### PR TITLE
feat: auth plugin infrastructure

### DIFF
--- a/backend/app/auth/base.py
+++ b/backend/app/auth/base.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from backend.app.models import Contractor
+
+
+class AuthBackend(ABC):
+    @abstractmethod
+    def get_auth_config(self) -> dict[str, Any]:
+        """Return auth config for the frontend."""
+
+    @abstractmethod
+    def authenticate_login(self, db: Session, credentials: dict[str, str]) -> Contractor:
+        """Validate credentials and return Contractor."""
+
+    def on_contractor_created(self, db: Session, contractor: Contractor) -> None:  # noqa: B027
+        """Hook called after new contractor creation. Override to seed data."""

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,0 +1,27 @@
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from backend.app.database import get_db
+from backend.app.models import Contractor
+
+LOCAL_USER_ID = "local@backshop.local"
+
+
+def _get_or_create_local_contractor(db: Session) -> Contractor:
+    contractor = db.query(Contractor).filter(Contractor.user_id == LOCAL_USER_ID).first()
+    if contractor is None:
+        contractor = Contractor(
+            user_id=LOCAL_USER_ID,
+            name="Local Contractor",
+            phone="",
+            trade="",
+        )
+        db.add(contractor)
+        db.commit()
+        db.refresh(contractor)
+    return contractor
+
+
+def get_current_user(db: Session = Depends(get_db)) -> Contractor:
+    """OSS mode: return the single local contractor, no auth required."""
+    return _get_or_create_local_contractor(db)

--- a/backend/app/auth/loader.py
+++ b/backend/app/auth/loader.py
@@ -1,0 +1,18 @@
+import importlib
+
+from backend.app.auth.base import AuthBackend
+from backend.app.config import settings
+
+_backend: AuthBackend | None = None
+_loaded: bool = False
+
+
+def get_auth_backend() -> AuthBackend | None:
+    global _backend, _loaded
+    if _loaded:
+        return _backend
+    if settings.premium_plugin:
+        module = importlib.import_module(settings.premium_plugin)
+        _backend = module.get_auth_backend()
+    _loaded = True
+    return _backend

--- a/backend/app/auth/scoping.py
+++ b/backend/app/auth/scoping.py
@@ -1,0 +1,48 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend.app.models import Client, Contractor, Estimate, Memory
+
+
+def get_user_contractor(db: Session, user: Contractor, contractor_id: int) -> Contractor:
+    """Get a contractor by ID, scoped to the current user. Returns 404 on mismatch."""
+    contractor = (
+        db.query(Contractor)
+        .filter(Contractor.id == contractor_id, Contractor.user_id == user.user_id)
+        .first()
+    )
+    if not contractor:
+        raise HTTPException(status_code=404, detail="Contractor not found")
+    return contractor
+
+
+def get_user_client(db: Session, user: Contractor, client_id: int) -> Client:
+    """Get a client by ID, scoped to the current user's contractor."""
+    client = (
+        db.query(Client).filter(Client.id == client_id, Client.contractor_id == user.id).first()
+    )
+    if not client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return client
+
+
+def get_user_estimate(db: Session, user: Contractor, estimate_id: int) -> Estimate:
+    """Get an estimate by ID, scoped to the current user's contractor."""
+    estimate = (
+        db.query(Estimate)
+        .filter(Estimate.id == estimate_id, Estimate.contractor_id == user.id)
+        .first()
+    )
+    if not estimate:
+        raise HTTPException(status_code=404, detail="Estimate not found")
+    return estimate
+
+
+def get_user_memory(db: Session, user: Contractor, memory_id: int) -> Memory:
+    """Get a memory by ID, scoped to the current user's contractor."""
+    memory = (
+        db.query(Memory).filter(Memory.id == memory_id, Memory.contractor_id == user.id).first()
+    )
+    if not memory:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return memory

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.app.config import settings
-from backend.app.routers import health
+from backend.app.routers import auth, health
 
 app = FastAPI(title="Backshop", version="0.1.0")
 
@@ -15,3 +15,4 @@ app.add_middleware(
 )
 
 app.include_router(health.router, prefix="/api")
+app.include_router(auth.router, prefix="/api")

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from fastapi import APIRouter
+
+from backend.app.auth.loader import get_auth_backend
+
+router = APIRouter()
+
+
+@router.get("/auth/config")
+async def auth_config() -> dict[str, Any]:
+    backend = get_auth_backend()
+    if backend is None:
+        return {"method": "none", "required": False}
+    return backend.get_auth_config()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,59 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from backend.app.auth.dependencies import LOCAL_USER_ID, _get_or_create_local_contractor
+from backend.app.auth.scoping import get_user_contractor
+from backend.app.models import Contractor
+
+
+def test_get_current_user_creates_local_contractor(db_session: Session) -> None:
+    """OSS mode should auto-create a local contractor."""
+    contractor = _get_or_create_local_contractor(db_session)
+    assert contractor.user_id == LOCAL_USER_ID
+    assert contractor.name == "Local Contractor"
+    assert contractor.id is not None
+
+
+def test_get_current_user_returns_same_contractor(db_session: Session) -> None:
+    """Calling twice should return the same contractor."""
+    c1 = _get_or_create_local_contractor(db_session)
+    c2 = _get_or_create_local_contractor(db_session)
+    assert c1.id == c2.id
+
+
+def test_auth_config_returns_none_mode(client: TestClient) -> None:
+    """OSS mode should return method=none."""
+    response = client.get("/api/auth/config")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"method": "none", "required": False}
+
+
+def test_scoping_returns_404_for_wrong_user(db_session: Session) -> None:
+    """Scoping should return 404 when contractor doesn't belong to user."""
+    # Create two contractors with different user_ids
+    contractor1 = Contractor(user_id="user-1", name="Contractor 1")
+    contractor2 = Contractor(user_id="user-2", name="Contractor 2")
+    db_session.add_all([contractor1, contractor2])
+    db_session.commit()
+    db_session.refresh(contractor1)
+    db_session.refresh(contractor2)
+
+    # User 1 should not be able to access contractor 2
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        get_user_contractor(db_session, contractor1, contractor2.id)
+    assert exc_info.value.status_code == 404
+
+
+def test_scoping_returns_contractor_for_correct_user(db_session: Session) -> None:
+    """Scoping should return contractor when user_id matches."""
+    contractor = Contractor(user_id="user-1", name="My Contractor")
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+
+    result = get_user_contractor(db_session, contractor, contractor.id)
+    assert result.id == contractor.id


### PR DESCRIPTION
## Summary
- AuthBackend ABC for premium plugins to implement
- Singleton plugin loader reading PREMIUM_PLUGIN env var
- `get_current_user` dependency (auto-creates local contractor in OSS mode)
- Row-level scoping helpers (`get_user_contractor`, `get_user_client`, etc.) returning 404 on ownership mismatch
- `GET /api/auth/config` endpoint returning `{"method": "none", "required": false}` in OSS mode

Fixes #2

## Test plan
- [x] `get_current_user` auto-creates local contractor
- [x] Calling twice returns same contractor
- [x] Auth config returns `method: none`
- [x] Scoping returns 404 for wrong user
- [x] All tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)