### PR TITLE
feat: media download from Twilio URLs

### DIFF
--- a/backend/app/media/download.py
+++ b/backend/app/media/download.py
@@ -1,0 +1,69 @@
+import datetime
+from dataclasses import dataclass
+
+import httpx
+
+from backend.app.config import settings
+
+MIME_EXTENSIONS: dict[str, str] = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "audio/ogg": ".ogg",
+    "audio/mp3": ".mp3",
+    "audio/mpeg": ".mp3",
+    "audio/amr": ".amr",
+    "video/mp4": ".mp4",
+    "video/3gpp": ".3gp",
+    "application/pdf": ".pdf",
+}
+
+
+@dataclass
+class DownloadedMedia:
+    content: bytes
+    mime_type: str
+    original_url: str
+    filename: str
+
+
+def classify_media(mime_type: str) -> str:
+    """Classify MIME type into processing category."""
+    if mime_type.startswith("image/"):
+        return "image"
+    if mime_type.startswith("audio/"):
+        return "audio"
+    if mime_type.startswith("video/"):
+        return "video"
+    if mime_type == "application/pdf":
+        return "pdf"
+    return "unknown"
+
+
+def _generate_filename(mime_type: str) -> str:
+    """Generate a filename from MIME type and timestamp."""
+    ext = MIME_EXTENSIONS.get(mime_type, ".bin")
+    timestamp = datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%d_%H%M%S")
+    return f"media_{timestamp}{ext}"
+
+
+async def download_twilio_media(
+    url: str,
+    twilio_auth: tuple[str, str] | None = None,
+) -> DownloadedMedia:
+    """Download media from a Twilio URL with authentication."""
+    auth = twilio_auth or (settings.twilio_account_sid, settings.twilio_auth_token)
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, auth=auth, follow_redirects=True, timeout=30.0)
+        response.raise_for_status()
+
+    mime_type = response.headers.get("content-type", "application/octet-stream").split(";")[0]
+    filename = _generate_filename(mime_type)
+
+    return DownloadedMedia(
+        content=response.content,
+        mime_type=mime_type,
+        original_url=url,
+        filename=filename,
+    )

--- a/tests/test_media_download.py
+++ b/tests/test_media_download.py
@@ -1,0 +1,89 @@
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from backend.app.media.download import (
+    DownloadedMedia,
+    classify_media,
+    download_twilio_media,
+)
+
+
+def test_classify_image_types() -> None:
+    assert classify_media("image/jpeg") == "image"
+    assert classify_media("image/png") == "image"
+    assert classify_media("image/gif") == "image"
+
+
+def test_classify_audio_types() -> None:
+    assert classify_media("audio/ogg") == "audio"
+    assert classify_media("audio/mp3") == "audio"
+    assert classify_media("audio/amr") == "audio"
+
+
+def test_classify_video_types() -> None:
+    assert classify_media("video/mp4") == "video"
+    assert classify_media("video/3gpp") == "video"
+
+
+def test_classify_pdf() -> None:
+    assert classify_media("application/pdf") == "pdf"
+
+
+def test_classify_unknown() -> None:
+    assert classify_media("application/octet-stream") == "unknown"
+    assert classify_media("text/plain") == "unknown"
+
+
+@pytest.mark.asyncio()
+async def test_download_twilio_media() -> None:
+    """download_twilio_media should fetch bytes with auth."""
+    mock_response = httpx.Response(
+        200,
+        content=b"fake-image-bytes",
+        headers={"content-type": "image/jpeg"},
+        request=httpx.Request("GET", "https://api.twilio.com/media/test.jpg"),
+    )
+
+    with patch("backend.app.media.download.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        result = await download_twilio_media(
+            "https://api.twilio.com/media/test.jpg",
+            twilio_auth=("AC123", "authtoken"),
+        )
+
+    assert isinstance(result, DownloadedMedia)
+    assert result.content == b"fake-image-bytes"
+    assert result.mime_type == "image/jpeg"
+    assert result.filename.endswith(".jpg")
+    mock_client.get.assert_called_once()
+    call_kwargs = mock_client.get.call_args
+    assert call_kwargs[1]["auth"] == ("AC123", "authtoken")
+
+
+@pytest.mark.asyncio()
+async def test_download_twilio_media_error() -> None:
+    """download_twilio_media should raise on HTTP error."""
+    mock_response = httpx.Response(
+        404,
+        request=httpx.Request("GET", "https://api.twilio.com/media/missing.jpg"),
+    )
+
+    with patch("backend.app.media.download.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await download_twilio_media(
+                "https://api.twilio.com/media/missing.jpg",
+                twilio_auth=("AC123", "authtoken"),
+            )


### PR DESCRIPTION
## Summary
- download_twilio_media fetches media files with HTTP Basic Auth via httpx
- classify_media categorizes MIME types into image/audio/video/pdf/unknown
- Generates timestamped filenames from MIME type

Fixes #8

## Test plan
- [x] All MIME type classifications correct
- [x] Download with auth credentials
- [x] HTTP error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)