### PR TITLE
feat: agent tools - memory

### DIFF
--- a/backend/app/agent/tools/memory_tools.py
+++ b/backend/app/agent/tools/memory_tools.py
@@ -1,0 +1,78 @@
+from sqlalchemy.orm import Session
+
+from backend.app.agent.memory import delete_memory, recall_memories, save_memory
+from backend.app.agent.tools.base import Tool
+
+
+def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
+    """Create memory-related tools for the agent."""
+
+    async def save_fact(key: str, value: str, category: str = "general") -> str:
+        """Save a fact to memory."""
+        memory = await save_memory(db, contractor_id, key=key, value=value, category=category)
+        return f"Saved: {memory.key} = {memory.value}"
+
+    async def recall_facts(query: str, category: str | None = None) -> str:
+        """Search memory for facts matching a query."""
+        memories = await recall_memories(db, contractor_id, query=query, category=category)
+        if not memories:
+            return "No matching facts found."
+        lines = [f"- {m.key}: {m.value}" for m in memories]
+        return "\n".join(lines)
+
+    async def forget_fact(key: str) -> str:
+        """Delete a fact from memory."""
+        deleted = await delete_memory(db, contractor_id, key=key)
+        if deleted:
+            return f"Deleted: {key}"
+        return f"Not found: {key}"
+
+    return [
+        Tool(
+            name="save_fact",
+            description="Save a key-value fact to the contractor's memory. Use for pricing, client info, preferences, etc.",
+            function=save_fact,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "key": {"type": "string", "description": "Short identifier for the fact"},
+                    "value": {"type": "string", "description": "The fact value to remember"},
+                    "category": {
+                        "type": "string",
+                        "enum": ["pricing", "client", "job", "general"],
+                        "description": "Category for the fact",
+                    },
+                },
+                "required": ["key", "value"],
+            },
+        ),
+        Tool(
+            name="recall_facts",
+            description="Search the contractor's memory for facts matching a query.",
+            function=recall_facts,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query"},
+                    "category": {
+                        "type": "string",
+                        "enum": ["pricing", "client", "job", "general"],
+                        "description": "Optional category filter",
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="forget_fact",
+            description="Delete a fact from memory by key.",
+            function=forget_fact,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "key": {"type": "string", "description": "Key of the fact to delete"},
+                },
+                "required": ["key"],
+            },
+        ),
+    ]

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -1,0 +1,58 @@
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.tools.memory_tools import create_memory_tools
+from backend.app.models import Contractor
+
+
+@pytest.mark.asyncio()
+async def test_save_fact_tool(db_session: Session, test_contractor: Contractor) -> None:
+    """save_fact tool should save a memory and return confirmation."""
+    tools = create_memory_tools(db_session, test_contractor.id)
+    save_fact = tools[0].function
+    result = await save_fact(key="deck_rate", value="$35/sqft", category="pricing")
+    assert "Saved" in result
+    assert "deck_rate" in result
+
+
+@pytest.mark.asyncio()
+async def test_recall_facts_tool(db_session: Session, test_contractor: Contractor) -> None:
+    """recall_facts tool should find saved memories."""
+    tools = create_memory_tools(db_session, test_contractor.id)
+    save_fact = tools[0].function
+    recall_facts = tools[1].function
+
+    await save_fact(key="deck_rate", value="$35/sqft")
+    result = await recall_facts(query="deck")
+    assert "deck_rate" in result
+    assert "$35/sqft" in result
+
+
+@pytest.mark.asyncio()
+async def test_recall_facts_empty(db_session: Session, test_contractor: Contractor) -> None:
+    """recall_facts should return message when no facts found."""
+    tools = create_memory_tools(db_session, test_contractor.id)
+    recall_facts = tools[1].function
+    result = await recall_facts(query="nonexistent")
+    assert "No matching facts" in result
+
+
+@pytest.mark.asyncio()
+async def test_forget_fact_tool(db_session: Session, test_contractor: Contractor) -> None:
+    """forget_fact tool should delete a memory."""
+    tools = create_memory_tools(db_session, test_contractor.id)
+    save_fact = tools[0].function
+    forget_fact = tools[2].function
+
+    await save_fact(key="temp", value="temporary")
+    result = await forget_fact(key="temp")
+    assert "Deleted" in result
+
+
+@pytest.mark.asyncio()
+async def test_forget_fact_not_found(db_session: Session, test_contractor: Contractor) -> None:
+    """forget_fact should handle missing keys."""
+    tools = create_memory_tools(db_session, test_contractor.id)
+    forget_fact = tools[2].function
+    result = await forget_fact(key="nonexistent")
+    assert "Not found" in result


### PR DESCRIPTION
## Summary
- save_fact, recall_facts, forget_fact tools for the agent
- OpenAI function calling schema for each tool
- Tools use the memory system from #12

Fixes #15

## Test plan
- [x] save_fact saves and confirms
- [x] recall_facts finds matching memories
- [x] recall_facts handles empty results
- [x] forget_fact deletes and confirms
- [x] forget_fact handles missing keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)