### PR TITLE
feat: message router for end-to-end processing

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -1,0 +1,101 @@
+import logging
+
+from sqlalchemy.orm import Session
+
+from backend.app.agent.core import AgentResponse, BackshopAgent
+from backend.app.agent.tools.memory_tools import create_memory_tools
+from backend.app.agent.tools.twilio_tools import create_twilio_tools
+from backend.app.media.download import DownloadedMedia, download_twilio_media
+from backend.app.media.pipeline import process_message_media
+from backend.app.models import Contractor, Message
+from backend.app.services.twilio_service import TwilioService
+
+logger = logging.getLogger(__name__)
+
+HISTORY_LIMIT = 20
+
+
+async def handle_inbound_message(
+    db: Session,
+    contractor: Contractor,
+    message: Message,
+    media_urls: list[tuple[str, str]],
+    twilio_service: TwilioService,
+) -> AgentResponse:
+    """Full message processing pipeline.
+
+    1. Download media from Twilio URLs (if any)
+    2. Run media pipeline (vision, audio, PDF extraction)
+    3. Build combined context (text + processed media)
+    4. Load conversation history
+    5. Initialize agent with tools
+    6. Process message through agent
+    7. Agent sends reply via tools or returns reply text
+    """
+    # Step 1: Download media
+    downloaded_media: list[DownloadedMedia] = []
+    for url, _mime_type in media_urls:
+        try:
+            media = await download_twilio_media(url)
+            downloaded_media.append(media)
+        except Exception:
+            logger.exception("Failed to download media: %s", url)
+
+    # Step 2: Run media pipeline
+    pipeline_result = await process_message_media(message.body, downloaded_media)
+
+    # Step 3: Combined context is ready in pipeline_result.combined_context
+
+    # Step 4: Load conversation history
+    conversation_history = _load_conversation_history(db, message.conversation_id)
+
+    # Step 5: Initialize agent with tools
+    agent = BackshopAgent(db=db, contractor=contractor)
+    tools = create_memory_tools(db, contractor.id)
+    tools.extend(create_twilio_tools(twilio_service, to_number=contractor.phone))
+    agent.register_tools(tools)
+
+    # Step 6: Process message
+    response = await agent.process_message(
+        message_context=pipeline_result.combined_context,
+        conversation_history=conversation_history,
+    )
+
+    # Step 7: If agent didn't explicitly call send_reply, send the reply text
+    sent_reply = any(tc.get("name") == "send_reply" for tc in response.tool_calls)
+    if not sent_reply and response.reply_text:
+        try:
+            await twilio_service.send_sms(to=contractor.phone, body=response.reply_text)
+        except Exception:
+            logger.exception("Failed to send reply SMS")
+
+    # Store outbound message
+    if response.reply_text:
+        outbound = Message(
+            conversation_id=message.conversation_id,
+            direction="outbound",
+            body=response.reply_text,
+        )
+        db.add(outbound)
+        db.commit()
+
+    return response
+
+
+def _load_conversation_history(db: Session, conversation_id: int) -> list[dict[str, str]]:
+    """Load recent messages from the conversation for context."""
+    messages = (
+        db.query(Message)
+        .filter(Message.conversation_id == conversation_id)
+        .order_by(Message.created_at.desc())
+        .limit(HISTORY_LIMIT)
+        .all()
+    )
+    # Reverse to chronological order, skip the current (most recent) message
+    messages = list(reversed(messages))[:-1] if len(messages) > 1 else []
+
+    history: list[dict[str, str]] = []
+    for msg in messages:
+        role = "user" if msg.direction == "inbound" else "assistant"
+        history.append({"role": role, "content": msg.body})
+    return history

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -1,0 +1,156 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.router import handle_inbound_message
+from backend.app.models import Contractor, Conversation, Message
+from backend.app.services.twilio_service import TwilioService
+from tests.mocks.llm import make_text_response
+
+
+@pytest.fixture()
+def conversation(db_session: Session, test_contractor: Contractor) -> Conversation:
+    conv = Conversation(contractor_id=test_contractor.id)
+    db_session.add(conv)
+    db_session.commit()
+    db_session.refresh(conv)
+    return conv
+
+
+@pytest.fixture()
+def inbound_message(db_session: Session, conversation: Conversation) -> Message:
+    msg = Message(
+        conversation_id=conversation.id,
+        direction="inbound",
+        body="I need a quote for a 12x12 deck",
+    )
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+    return msg
+
+
+@pytest.fixture()
+def mock_twilio() -> TwilioService:
+    service = TwilioService.__new__(TwilioService)
+    service.client = MagicMock()
+    service.from_number = "+15559876543"
+    mock_msg = MagicMock()
+    mock_msg.sid = "SM_test"
+    service.client.messages.create.return_value = mock_msg
+    return service
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_text_only_message(
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    inbound_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """Text-only message should go through agent and produce reply."""
+    mock_acompletion.return_value = make_text_response("I can help with that deck estimate!")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=inbound_message,
+        media_urls=[],
+        twilio_service=mock_twilio,
+    )
+
+    assert response.reply_text == "I can help with that deck estimate!"
+    # Should have sent reply SMS
+    mock_twilio.client.messages.create.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.media.pipeline.analyze_image", new_callable=AsyncMock)
+@patch("backend.app.agent.router.download_twilio_media", new_callable=AsyncMock)
+async def test_mms_with_photo(
+    mock_download: AsyncMock,
+    mock_vision: AsyncMock,
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    inbound_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """MMS with photo should download, process via vision, then agent."""
+    from backend.app.media.download import DownloadedMedia
+
+    mock_download.return_value = DownloadedMedia(
+        content=b"fake-image",
+        mime_type="image/jpeg",
+        original_url="https://api.twilio.com/media/test.jpg",
+        filename="photo.jpg",
+    )
+    mock_vision.return_value = "A 12x12 composite deck area."
+    mock_acompletion.return_value = make_text_response("Looks like a great deck project!")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=inbound_message,
+        media_urls=[("https://api.twilio.com/media/test.jpg", "image/jpeg")],
+        twilio_service=mock_twilio,
+    )
+
+    assert response.reply_text == "Looks like a great deck project!"
+    mock_download.assert_called_once()
+    mock_vision.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_stores_outbound_message(
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    inbound_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """Agent reply should be stored as outbound message."""
+    mock_acompletion.return_value = make_text_response("Reply stored!")  # type: ignore[union-attr]
+
+    await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=inbound_message,
+        media_urls=[],
+        twilio_service=mock_twilio,
+    )
+
+    outbound = db_session.query(Message).filter(Message.direction == "outbound").first()
+    assert outbound is not None
+    assert outbound.body == "Reply stored!"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.agent.router.download_twilio_media", new_callable=AsyncMock)
+async def test_media_download_failure_still_processes_text(
+    mock_download: AsyncMock,
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    inbound_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """If media download fails, agent should still process text."""
+    mock_download.side_effect = Exception("Download failed")
+    mock_acompletion.return_value = make_text_response("Got your text!")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=inbound_message,
+        media_urls=[("https://api.twilio.com/media/fail.jpg", "image/jpeg")],
+        twilio_service=mock_twilio,
+    )
+
+    assert response.reply_text == "Got your text!"


### PR DESCRIPTION
## Description
Add `handle_inbound_message` in `backend/app/agent/router.py` that wires the full inbound message pipeline:

1. Download media from Twilio URLs
2. Run media pipeline (vision, audio, PDF extraction)
3. Load conversation history
4. Initialize agent with memory + Twilio tools
5. Process message through agent
6. Send reply SMS (if agent didn't use `send_reply` tool)
7. Store outbound message

Also adds `_load_conversation_history` helper for fetching recent messages.

Fixes #17

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code for implementation and tests)
- [ ] No AI used