### PR TITLE
feat: onboarding conversation for new contractors

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -67,9 +67,10 @@ class BackshopAgent:
         self,
         message_context: str,
         conversation_history: list[dict[str, str]] | None = None,
+        system_prompt_override: str | None = None,
     ) -> AgentResponse:
         """Process a message through the agent loop."""
-        system_prompt = await self._build_system_prompt(message_context)
+        system_prompt = system_prompt_override or await self._build_system_prompt(message_context)
 
         messages: list[dict[str, object]] = [{"role": "system", "content": system_prompt}]
 

--- a/backend/app/agent/onboarding.py
+++ b/backend/app/agent/onboarding.py
@@ -1,0 +1,85 @@
+"""Onboarding conversation logic for new contractors."""
+
+import contextlib
+from typing import Any
+
+from backend.app.agent.core import AgentResponse
+from backend.app.agent.profile import build_onboarding_prompt
+from backend.app.models import Contractor
+
+# Fields that indicate a contractor has completed onboarding
+REQUIRED_PROFILE_FIELDS = {"name", "trade"}
+
+
+def is_onboarding_needed(contractor: Contractor) -> bool:
+    """Check if contractor needs onboarding (missing critical profile fields)."""
+    for field in REQUIRED_PROFILE_FIELDS:
+        value = getattr(contractor, field, None)
+        if not value or not str(value).strip():
+            return True
+    return False
+
+
+def build_onboarding_system_prompt(contractor: Contractor) -> str:
+    """Build system prompt for onboarding mode.
+
+    Wraps the base onboarding prompt with any partial profile info
+    already collected so the agent doesn't re-ask known fields.
+    """
+    base = build_onboarding_prompt()
+
+    known: list[str] = []
+    if contractor.name and contractor.name.strip():
+        known.append(f"- Name: {contractor.name}")
+    if contractor.trade and contractor.trade.strip():
+        known.append(f"- Trade: {contractor.trade}")
+    if contractor.location and contractor.location.strip():
+        known.append(f"- Location: {contractor.location}")
+    if contractor.hourly_rate:
+        known.append(f"- Rate: ${contractor.hourly_rate:.0f}/hour")
+    if contractor.business_hours and contractor.business_hours.strip():
+        known.append(f"- Business hours: {contractor.business_hours}")
+
+    if known:
+        return base + "\n\nYou already know:\n" + "\n".join(known) + "\n\nDon't re-ask these."
+
+    return base
+
+
+def extract_profile_updates(agent_response: AgentResponse) -> dict[str, Any]:
+    """Extract profile field updates from agent tool calls during onboarding.
+
+    Looks at save_fact calls and maps known categories to profile fields.
+    """
+    updates: dict[str, Any] = {}
+
+    # Map memory keys to profile fields
+    key_to_field: dict[str, str] = {
+        "name": "name",
+        "contractor_name": "name",
+        "trade": "trade",
+        "location": "location",
+        "city": "location",
+        "region": "location",
+        "hourly_rate": "hourly_rate",
+        "rate": "hourly_rate",
+        "business_hours": "business_hours",
+        "hours": "business_hours",
+    }
+
+    for tc in agent_response.tool_calls:
+        if tc.get("name") != "save_fact":
+            continue
+        args = tc.get("args", {})
+        key = str(args.get("key", "")).lower().strip()
+        value = args.get("value", "")
+
+        if key in key_to_field:
+            field = key_to_field[key]
+            if field == "hourly_rate":
+                with contextlib.suppress(ValueError):
+                    updates[field] = float(str(value).replace("$", "").replace("/hr", "").strip())
+            else:
+                updates[field] = str(value)
+
+    return updates

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -3,6 +3,12 @@ import logging
 from sqlalchemy.orm import Session
 
 from backend.app.agent.core import AgentResponse, BackshopAgent
+from backend.app.agent.onboarding import (
+    build_onboarding_system_prompt,
+    extract_profile_updates,
+    is_onboarding_needed,
+)
+from backend.app.agent.profile import update_contractor_profile
 from backend.app.agent.tools.memory_tools import create_memory_tools
 from backend.app.agent.tools.twilio_tools import create_twilio_tools
 from backend.app.media.download import DownloadedMedia, download_twilio_media
@@ -50,6 +56,9 @@ async def handle_inbound_message(
     conversation_history = _load_conversation_history(db, message.conversation_id)
 
     # Step 5: Initialize agent with tools
+    onboarding = is_onboarding_needed(contractor)
+    system_prompt_override = build_onboarding_system_prompt(contractor) if onboarding else None
+
     agent = BackshopAgent(db=db, contractor=contractor)
     tools = create_memory_tools(db, contractor.id)
     tools.extend(create_twilio_tools(twilio_service, to_number=contractor.phone))
@@ -59,7 +68,14 @@ async def handle_inbound_message(
     response = await agent.process_message(
         message_context=pipeline_result.combined_context,
         conversation_history=conversation_history,
+        system_prompt_override=system_prompt_override,
     )
+
+    # Step 6b: If onboarding, extract profile updates from tool calls
+    if onboarding:
+        profile_updates = extract_profile_updates(response)
+        if profile_updates:
+            await update_contractor_profile(db, contractor, profile_updates)
 
     # Step 7: If agent didn't explicitly call send_reply, send the reply text
     sent_reply = any(tc.get("name") == "send_reply" for tc in response.tool_calls)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,293 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.core import AgentResponse
+from backend.app.agent.onboarding import (
+    build_onboarding_system_prompt,
+    extract_profile_updates,
+    is_onboarding_needed,
+)
+from backend.app.agent.router import handle_inbound_message
+from backend.app.models import Contractor, Conversation, Message
+from backend.app.services.twilio_service import TwilioService
+from tests.mocks.llm import make_text_response
+
+
+def test_is_onboarding_needed_new_contractor(db_session: Session) -> None:
+    """New contractor with no name/trade should need onboarding."""
+    contractor = Contractor(user_id="new-user", phone="+15550001111")
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+
+    assert is_onboarding_needed(contractor) is True
+
+
+def test_is_onboarding_needed_partial_profile(db_session: Session) -> None:
+    """Contractor with name but no trade still needs onboarding."""
+    contractor = Contractor(user_id="partial-user", phone="+15550002222", name="Mike")
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+
+    assert is_onboarding_needed(contractor) is True
+
+
+def test_is_onboarding_needed_complete_profile(test_contractor: Contractor) -> None:
+    """Contractor with name and trade does not need onboarding."""
+    assert is_onboarding_needed(test_contractor) is False
+
+
+def test_is_onboarding_needed_empty_strings(db_session: Session) -> None:
+    """Empty strings should still trigger onboarding."""
+    contractor = Contractor(user_id="empty-user", phone="+15550003333", name="", trade="")
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+
+    assert is_onboarding_needed(contractor) is True
+
+
+def test_build_onboarding_system_prompt_new_contractor(db_session: Session) -> None:
+    """Onboarding prompt for new contractor should not include known info."""
+    contractor = Contractor(user_id="brand-new", phone="+15550004444")
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+
+    prompt = build_onboarding_system_prompt(contractor)
+    assert "Backshop" in prompt
+    assert "new contractor" in prompt
+    assert "You already know" not in prompt
+
+
+def test_build_onboarding_system_prompt_partial_profile(db_session: Session) -> None:
+    """Onboarding prompt should include already-known fields."""
+    contractor = Contractor(
+        user_id="partial-user",
+        phone="+15550005555",
+        name="Sarah",
+        location="Denver, CO",
+    )
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+
+    prompt = build_onboarding_system_prompt(contractor)
+    assert "You already know" in prompt
+    assert "Sarah" in prompt
+    assert "Denver" in prompt
+    assert "Don't re-ask" in prompt
+
+
+def test_extract_profile_updates_name_and_trade() -> None:
+    """Should extract name and trade from save_fact tool calls."""
+    response = AgentResponse(
+        reply_text="Nice to meet you!",
+        tool_calls=[
+            {"name": "save_fact", "args": {"key": "name", "value": "Mike Johnson"}, "result": "ok"},
+            {"name": "save_fact", "args": {"key": "trade", "value": "Electrician"}, "result": "ok"},
+        ],
+    )
+    updates = extract_profile_updates(response)
+    assert updates["name"] == "Mike Johnson"
+    assert updates["trade"] == "Electrician"
+
+
+def test_extract_profile_updates_hourly_rate() -> None:
+    """Should parse numeric hourly rate from save_fact."""
+    response = AgentResponse(
+        reply_text="Got it!",
+        tool_calls=[
+            {
+                "name": "save_fact",
+                "args": {"key": "hourly_rate", "value": "$85/hr"},
+                "result": "ok",
+            },
+        ],
+    )
+    updates = extract_profile_updates(response)
+    assert updates["hourly_rate"] == 85.0
+
+
+def test_extract_profile_updates_ignores_non_profile_facts() -> None:
+    """Should ignore save_fact calls that don't map to profile fields."""
+    response = AgentResponse(
+        reply_text="Got it!",
+        tool_calls=[
+            {
+                "name": "save_fact",
+                "args": {"key": "favorite_color", "value": "blue"},
+                "result": "ok",
+            },
+        ],
+    )
+    updates = extract_profile_updates(response)
+    assert updates == {}
+
+
+def test_extract_profile_updates_ignores_non_save_fact_tools() -> None:
+    """Should only look at save_fact tool calls."""
+    response = AgentResponse(
+        reply_text="Sent!",
+        tool_calls=[
+            {"name": "send_reply", "args": {"message": "Hello"}, "result": "ok"},
+        ],
+    )
+    updates = extract_profile_updates(response)
+    assert updates == {}
+
+
+def test_extract_profile_updates_invalid_rate() -> None:
+    """Should handle non-numeric rate values gracefully."""
+    response = AgentResponse(
+        reply_text="Got it!",
+        tool_calls=[
+            {
+                "name": "save_fact",
+                "args": {"key": "hourly_rate", "value": "depends on the job"},
+                "result": "ok",
+            },
+        ],
+    )
+    updates = extract_profile_updates(response)
+    assert "hourly_rate" not in updates
+
+
+@pytest.fixture()
+def new_contractor(db_session: Session) -> Contractor:
+    """Contractor with no profile — needs onboarding."""
+    contractor = Contractor(user_id="new-user-onboard", phone="+15559999999")
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+    return contractor
+
+
+@pytest.fixture()
+def onboarding_conversation(db_session: Session, new_contractor: Contractor) -> Conversation:
+    conv = Conversation(contractor_id=new_contractor.id)
+    db_session.add(conv)
+    db_session.commit()
+    db_session.refresh(conv)
+    return conv
+
+
+@pytest.fixture()
+def onboarding_message(db_session: Session, onboarding_conversation: Conversation) -> Message:
+    msg = Message(
+        conversation_id=onboarding_conversation.id,
+        direction="inbound",
+        body="Hey, I heard about Backshop",
+    )
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+    return msg
+
+
+@pytest.fixture()
+def mock_twilio() -> TwilioService:
+    service = TwilioService.__new__(TwilioService)
+    service.client = MagicMock()
+    service.from_number = "+15559876543"
+    mock_msg = MagicMock()
+    mock_msg.sid = "SM_test"
+    service.client.messages.create.return_value = mock_msg
+    return service
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_onboarding_uses_onboarding_prompt(
+    mock_acompletion: object,
+    db_session: Session,
+    new_contractor: Contractor,
+    onboarding_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """Router should use onboarding prompt for new contractors."""
+    mock_acompletion.return_value = make_text_response(  # type: ignore[union-attr]
+        "Welcome to Backshop! What's your name?"
+    )
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=new_contractor,
+        message=onboarding_message,
+        media_urls=[],
+        twilio_service=mock_twilio,
+    )
+
+    assert response.reply_text == "Welcome to Backshop! What's your name?"
+    # Verify the system prompt passed was the onboarding prompt
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    system_msg = call_args.kwargs["messages"][0]["content"]
+    assert "new contractor" in system_msg
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_onboarding_extracts_profile_updates(
+    mock_acompletion: object,
+    db_session: Session,
+    new_contractor: Contractor,
+    onboarding_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """Profile updates from onboarding should be saved to contractor record."""
+    # Simulate agent calling save_fact with name and trade
+    resp_mock = make_text_response("Nice to meet you, Mike!")
+    tool_call = MagicMock()
+    tool_call.function.name = "save_fact"
+    tool_call.function.arguments = '{"key": "name", "value": "Mike"}'
+    resp_mock.choices[0].message.tool_calls = [tool_call]
+    mock_acompletion.return_value = resp_mock  # type: ignore[union-attr]
+
+    await handle_inbound_message(
+        db=db_session,
+        contractor=new_contractor,
+        message=onboarding_message,
+        media_urls=[],
+        twilio_service=mock_twilio,
+    )
+
+    db_session.refresh(new_contractor)
+    assert new_contractor.name == "Mike"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_complete_profile_uses_normal_prompt(
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    mock_twilio: TwilioService,
+) -> None:
+    """Contractor with complete profile should use normal agent prompt."""
+    conv = Conversation(contractor_id=test_contractor.id)
+    db_session.add(conv)
+    db_session.commit()
+    db_session.refresh(conv)
+    msg = Message(conversation_id=conv.id, direction="inbound", body="How much for a deck?")
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+
+    mock_acompletion.return_value = make_text_response("Let me help with that estimate!")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=msg,
+        media_urls=[],
+        twilio_service=mock_twilio,
+    )
+
+    assert response.reply_text == "Let me help with that estimate!"
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    system_msg = call_args.kwargs["messages"][0]["content"]
+    # Normal prompt should NOT contain onboarding text
+    assert "new contractor" not in system_msg


### PR DESCRIPTION
## Description
Add onboarding flow that detects new contractors (missing name/trade) and uses a guided conversation prompt to collect profile information naturally.

- `is_onboarding_needed()`: checks if critical profile fields (name, trade) are populated
- `build_onboarding_system_prompt()`: builds onboarding prompt that includes already-known fields to avoid re-asking
- `extract_profile_updates()`: maps `save_fact` tool calls to contractor profile fields (name, trade, location, hourly_rate, business_hours)
- `BackshopAgent.process_message()`: now accepts `system_prompt_override` for onboarding mode
- Router integration: auto-detects onboarding mode and writes profile updates back to contractor record

Fixes #18

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code for implementation and tests)
- [ ] No AI used