### PR TITLE
feat: estimate generation tool with PDF output

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -9,6 +9,7 @@ from backend.app.agent.onboarding import (
     is_onboarding_needed,
 )
 from backend.app.agent.profile import update_contractor_profile
+from backend.app.agent.tools.estimate_tools import create_estimate_tools
 from backend.app.agent.tools.memory_tools import create_memory_tools
 from backend.app.agent.tools.twilio_tools import create_twilio_tools
 from backend.app.media.download import DownloadedMedia, download_twilio_media
@@ -62,6 +63,7 @@ async def handle_inbound_message(
     agent = BackshopAgent(db=db, contractor=contractor)
     tools = create_memory_tools(db, contractor.id)
     tools.extend(create_twilio_tools(twilio_service, to_number=contractor.phone))
+    tools.extend(create_estimate_tools(db, contractor))
     agent.register_tools(tools)
 
     # Step 6: Process message

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -1,0 +1,154 @@
+"""Estimate generation tools for the agent."""
+
+import datetime
+import logging
+
+from sqlalchemy.orm import Session
+
+from backend.app.agent.tools.base import Tool
+from backend.app.models import Contractor, Estimate, EstimateLineItem
+from backend.app.services.pdf_service import EstimatePDFData, generate_estimate_pdf
+
+logger = logging.getLogger(__name__)
+
+
+def _next_estimate_number(db: Session, contractor_id: int) -> str:
+    """Generate the next sequential estimate number for a contractor."""
+    count = db.query(Estimate).filter(Estimate.contractor_id == contractor_id).count()
+    return f"EST-{count + 1:04d}"
+
+
+def create_estimate_tools(
+    db: Session,
+    contractor: Contractor,
+) -> list[Tool]:
+    """Create estimate-related tools for the agent."""
+
+    async def generate_estimate(
+        description: str,
+        line_items: list[dict[str, object]],
+        client_name: str | None = None,
+        client_address: str | None = None,
+        terms: str | None = None,
+    ) -> str:
+        """Generate a professional estimate PDF and return summary."""
+        estimate_number = _next_estimate_number(db, contractor.id)
+        today = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")
+
+        # Calculate totals
+        processed_items: list[dict[str, object]] = []
+        subtotal = 0.0
+        for item in line_items:
+            qty = float(item.get("quantity", 1))
+            price = float(item.get("unit_price", 0))
+            total = qty * price
+            subtotal += total
+            processed_items.append(
+                {
+                    "description": str(item.get("description", "")),
+                    "quantity": qty,
+                    "unit_price": price,
+                    "total": total,
+                }
+            )
+
+        total_amount = subtotal
+
+        # Create database records
+        estimate = Estimate(
+            contractor_id=contractor.id,
+            description=description,
+            total_amount=total_amount,
+            status="draft",
+        )
+        db.add(estimate)
+        db.flush()  # Get the ID before adding line items
+
+        for item in processed_items:
+            line_item = EstimateLineItem(
+                estimate_id=estimate.id,
+                description=str(item["description"]),
+                quantity=float(item["quantity"]),
+                unit_price=float(item["unit_price"]),
+                total=float(item["total"]),
+            )
+            db.add(line_item)
+
+        db.commit()
+        db.refresh(estimate)
+
+        # Generate PDF
+        pdf_data = EstimatePDFData(
+            contractor_name=contractor.name or "Contractor",
+            contractor_phone=contractor.phone or "",
+            contractor_trade=contractor.trade or "",
+            description=description,
+            line_items=processed_items,
+            subtotal=subtotal,
+            total=total_amount,
+            estimate_date=today,
+            estimate_number=estimate_number,
+            client_name=client_name,
+            client_address=client_address,
+            terms=terms or "Payment due within 30 days of project completion.",
+        )
+
+        pdf_bytes = await generate_estimate_pdf(pdf_data)
+
+        # Store PDF reference (in Phase 0, just record that it was generated)
+        estimate.pdf_url = f"estimate://{estimate_number}.pdf"
+        estimate.status = "sent"
+        db.commit()
+
+        return (
+            f"Estimate {estimate_number} generated for ${total_amount:,.2f}. "
+            f"{len(processed_items)} line item(s). "
+            f"PDF is {len(pdf_bytes)} bytes."
+        )
+
+    return [
+        Tool(
+            name="generate_estimate",
+            description=(
+                "Generate a professional estimate PDF. Use when the contractor asks for "
+                "an estimate, quote, or bid. Include line items with description, quantity, "
+                "and unit_price."
+            ),
+            function=generate_estimate,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "Brief description of the work",
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "description": {"type": "string"},
+                                "quantity": {"type": "number", "default": 1},
+                                "unit_price": {"type": "number"},
+                            },
+                            "required": ["description", "unit_price"],
+                        },
+                        "description": "Line items for the estimate",
+                    },
+                    "client_name": {
+                        "type": "string",
+                        "description": "Client name (optional)",
+                    },
+                    "client_address": {
+                        "type": "string",
+                        "description": "Client address (optional)",
+                    },
+                    "terms": {
+                        "type": "string",
+                        "description": "Payment terms (optional)",
+                    },
+                },
+                "required": ["description", "line_items"],
+            },
+        ),
+    ]

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -1,0 +1,163 @@
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.tools.estimate_tools import _next_estimate_number, create_estimate_tools
+from backend.app.models import Contractor, Estimate, EstimateLineItem
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_creates_records(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """generate_estimate should create Estimate and EstimateLineItem records."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result = await generate(
+        description="12x12 composite deck build",
+        line_items=[
+            {"description": "Materials - Trex composite", "quantity": 1, "unit_price": 2400.00},
+            {"description": "Labor - deck build", "quantity": 24, "unit_price": 75.00},
+        ],
+    )
+
+    assert "EST-0001" in result
+    assert "$4,200.00" in result
+
+    estimate = (
+        db_session.query(Estimate).filter(Estimate.contractor_id == test_contractor.id).first()
+    )
+    assert estimate is not None
+    assert estimate.total_amount == 4200.00
+    assert estimate.status == "sent"
+    assert estimate.description == "12x12 composite deck build"
+
+    items = (
+        db_session.query(EstimateLineItem).filter(EstimateLineItem.estimate_id == estimate.id).all()
+    )
+    assert len(items) == 2
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_with_client_info(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """generate_estimate should include client info."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result = await generate(
+        description="Bathroom remodel",
+        line_items=[{"description": "Full remodel", "quantity": 1, "unit_price": 8500.00}],
+        client_name="John Johnson",
+        client_address="123 Oak St, Portland, OR",
+    )
+
+    assert "EST-0001" in result
+    assert "$8,500.00" in result
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_pdf_generated(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """generate_estimate should generate a PDF (nonzero bytes)."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result = await generate(
+        description="Quick fix",
+        line_items=[{"description": "Service call", "quantity": 1, "unit_price": 150.00}],
+    )
+
+    # Result mentions PDF size
+    assert "PDF is" in result
+    # Extract bytes count from "PDF is N bytes"
+    parts = result.split("PDF is ")[1].split(" bytes")[0]
+    pdf_size = int(parts)
+    assert pdf_size > 0
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_sequential_numbers(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Estimate numbers should be sequential per contractor."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result1 = await generate(
+        description="Job 1",
+        line_items=[{"description": "Work", "quantity": 1, "unit_price": 100.00}],
+    )
+    result2 = await generate(
+        description="Job 2",
+        line_items=[{"description": "Work", "quantity": 1, "unit_price": 200.00}],
+    )
+
+    assert "EST-0001" in result1
+    assert "EST-0002" in result2
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_single_line_item(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Estimate with single line item should work."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result = await generate(
+        description="Plumbing repair",
+        line_items=[{"description": "Fix leaking pipe", "quantity": 1, "unit_price": 350.00}],
+    )
+
+    assert "$350.00" in result
+    assert "1 line item" in result
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_custom_terms(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Custom terms should be accepted."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result = await generate(
+        description="Fence install",
+        line_items=[{"description": "Fence", "quantity": 1, "unit_price": 5000.00}],
+        terms="50% upfront, 50% on completion",
+    )
+
+    assert "EST-0001" in result
+
+
+def test_next_estimate_number_empty(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """First estimate should be EST-0001."""
+    assert _next_estimate_number(db_session, test_contractor.id) == "EST-0001"
+
+
+def test_next_estimate_number_increments(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Estimate number should increment."""
+    db_session.add(
+        Estimate(
+            contractor_id=test_contractor.id,
+            description="Test",
+            total_amount=100.0,
+        )
+    )
+    db_session.commit()
+    assert _next_estimate_number(db_session, test_contractor.id) == "EST-0002"


### PR DESCRIPTION
## Description
Add `generate_estimate` agent tool that creates professional estimates:

- Creates `Estimate` and `EstimateLineItem` database records
- Generates PDF via ReportLab with line items, totals, contractor info
- Sequential estimate numbering per contractor (EST-0001, EST-0002, etc.)
- Accepts optional client name/address and custom payment terms
- Registered in message router for use during agent conversations

Fixes #21

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code for implementation and tests)
- [ ] No AI used