### PR TITLE
feat: conversation continuity with session management

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -1,0 +1,87 @@
+"""Conversation context loading and session management."""
+
+import datetime
+import logging
+
+from sqlalchemy.orm import Session
+
+from backend.app.models import Conversation, Message
+
+logger = logging.getLogger(__name__)
+
+CONVERSATION_TIMEOUT_HOURS = 4
+DEFAULT_HISTORY_LIMIT = 20
+
+
+async def load_conversation_history(
+    db: Session,
+    conversation_id: int,
+    limit: int = DEFAULT_HISTORY_LIMIT,
+) -> list[dict[str, str]]:
+    """Load recent messages formatted for LLM context.
+
+    Returns list of {"role": "user"/"assistant", "content": "..."} dicts.
+    Messages are returned in chronological order, excluding the most recent
+    (which is the current message being processed).
+    """
+    messages = (
+        db.query(Message)
+        .filter(Message.conversation_id == conversation_id)
+        .order_by(Message.id.desc())
+        .limit(limit)
+        .all()
+    )
+    # Reverse to chronological order, skip the current (most recent) message
+    messages = list(reversed(messages))[:-1] if len(messages) > 1 else []
+
+    history: list[dict[str, str]] = []
+    for msg in messages:
+        role = "user" if msg.direction == "inbound" else "assistant"
+        # Prefer processed context (includes media descriptions) over raw body
+        content = msg.processed_context if msg.processed_context else msg.body
+        history.append({"role": role, "content": content})
+    return history
+
+
+async def get_or_create_conversation(
+    db: Session,
+    contractor_id: int,
+    twilio_sid: str | None = None,
+    timeout_hours: int = CONVERSATION_TIMEOUT_HOURS,
+) -> tuple[Conversation, bool]:
+    """Get active conversation or create new one.
+
+    A conversation is "active" if the last message was within the timeout window.
+    Returns (conversation, is_new).
+    """
+    cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=timeout_hours)
+
+    # Look for an active conversation within the timeout window
+    active = (
+        db.query(Conversation)
+        .filter(
+            Conversation.contractor_id == contractor_id,
+            Conversation.is_active.is_(True),
+            Conversation.last_message_at >= cutoff,
+        )
+        .order_by(Conversation.last_message_at.desc())
+        .first()
+    )
+
+    if active:
+        # Update last_message_at timestamp
+        active.last_message_at = datetime.datetime.now(datetime.UTC)
+        db.commit()
+        db.refresh(active)
+        return active, False
+
+    # Create a new conversation
+    conversation = Conversation(
+        contractor_id=contractor_id,
+        twilio_sid=twilio_sid or "",
+        is_active=True,
+    )
+    db.add(conversation)
+    db.commit()
+    db.refresh(conversation)
+    return conversation, True

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -2,6 +2,7 @@ import logging
 
 from sqlalchemy.orm import Session
 
+from backend.app.agent.context import load_conversation_history
 from backend.app.agent.core import AgentResponse, BackshopAgent
 from backend.app.agent.onboarding import (
     build_onboarding_system_prompt,
@@ -19,7 +20,6 @@ from backend.app.services.twilio_service import TwilioService
 
 logger = logging.getLogger(__name__)
 
-HISTORY_LIMIT = 20
 
 
 async def handle_inbound_message(
@@ -76,7 +76,7 @@ async def handle_inbound_message(
         combined_context += "\n\n[System note: " + " ".join(media_notes) + "]"
 
     # Step 4: Load conversation history
-    conversation_history = _load_conversation_history(db, message.conversation_id)
+    conversation_history = await load_conversation_history(db, message.conversation_id)
 
     # Step 5: Initialize agent with tools
     onboarding = is_onboarding_needed(contractor)
@@ -134,22 +134,3 @@ async def handle_inbound_message(
         db.commit()
 
     return response
-
-
-def _load_conversation_history(db: Session, conversation_id: int) -> list[dict[str, str]]:
-    """Load recent messages from the conversation for context."""
-    messages = (
-        db.query(Message)
-        .filter(Message.conversation_id == conversation_id)
-        .order_by(Message.created_at.desc())
-        .limit(HISTORY_LIMIT)
-        .all()
-    )
-    # Reverse to chronological order, skip the current (most recent) message
-    messages = list(reversed(messages))[:-1] if len(messages) > 1 else []
-
-    history: list[dict[str, str]] = []
-    for msg in messages:
-        role = "user" if msg.direction == "inbound" else "assistant"
-        history.append({"role": role, "content": msg.body})
-    return history

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -1,0 +1,219 @@
+import datetime
+
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.context import (
+    CONVERSATION_TIMEOUT_HOURS,
+    get_or_create_conversation,
+    load_conversation_history,
+)
+from backend.app.models import Contractor, Conversation, Message
+
+
+@pytest.fixture()
+def conversation(db_session: Session, test_contractor: Contractor) -> Conversation:
+    conv = Conversation(contractor_id=test_contractor.id)
+    db_session.add(conv)
+    db_session.commit()
+    db_session.refresh(conv)
+    return conv
+
+
+@pytest.mark.asyncio()
+async def test_load_history_chronological_order(
+    db_session: Session,
+    test_contractor: Contractor,
+    conversation: Conversation,
+) -> None:
+    """History should be in chronological order."""
+    for i in range(3):
+        msg = Message(
+            conversation_id=conversation.id,
+            direction="inbound" if i % 2 == 0 else "outbound",
+            body=f"Message {i}",
+        )
+        db_session.add(msg)
+    db_session.commit()
+
+    # Add the "current" message
+    current = Message(conversation_id=conversation.id, direction="inbound", body="Current")
+    db_session.add(current)
+    db_session.commit()
+
+    history = await load_conversation_history(db_session, conversation.id)
+    # Should exclude the current (most recent) message
+    assert len(history) == 3
+    assert history[0]["content"] == "Message 0"
+    assert history[1]["content"] == "Message 1"
+    assert history[2]["content"] == "Message 2"
+
+
+@pytest.mark.asyncio()
+async def test_load_history_roles(
+    db_session: Session,
+    conversation: Conversation,
+) -> None:
+    """Inbound = user, outbound = assistant."""
+    db_session.add(Message(conversation_id=conversation.id, direction="inbound", body="Hi"))
+    db_session.add(Message(conversation_id=conversation.id, direction="outbound", body="Hello!"))
+    db_session.add(Message(conversation_id=conversation.id, direction="inbound", body="Current"))
+    db_session.commit()
+
+    history = await load_conversation_history(db_session, conversation.id)
+    assert history[0]["role"] == "user"
+    assert history[1]["role"] == "assistant"
+
+
+@pytest.mark.asyncio()
+async def test_load_history_limit(
+    db_session: Session,
+    conversation: Conversation,
+) -> None:
+    """History should be limited to N messages."""
+    for i in range(10):
+        db_session.add(
+            Message(conversation_id=conversation.id, direction="inbound", body=f"Msg {i}")
+        )
+    db_session.commit()
+
+    history = await load_conversation_history(db_session, conversation.id, limit=5)
+    # 5 loaded, minus 1 for current = 4
+    assert len(history) == 4
+
+
+@pytest.mark.asyncio()
+async def test_load_history_prefers_processed_context(
+    db_session: Session,
+    conversation: Conversation,
+) -> None:
+    """History should use processed_context over raw body when available."""
+    msg = Message(
+        conversation_id=conversation.id,
+        direction="inbound",
+        body="Check this photo",
+        processed_context="[Text message]: 'Check this photo'\n[Photo 1]: A damaged deck railing",
+    )
+    db_session.add(msg)
+    # Add current message
+    db_session.add(Message(conversation_id=conversation.id, direction="inbound", body="Current"))
+    db_session.commit()
+
+    history = await load_conversation_history(db_session, conversation.id)
+    assert "damaged deck railing" in history[0]["content"]
+
+
+@pytest.mark.asyncio()
+async def test_load_history_empty_conversation(
+    db_session: Session,
+    conversation: Conversation,
+) -> None:
+    """Empty conversation should return empty history."""
+    history = await load_conversation_history(db_session, conversation.id)
+    assert history == []
+
+
+@pytest.mark.asyncio()
+async def test_load_history_single_message(
+    db_session: Session,
+    conversation: Conversation,
+) -> None:
+    """Single message (current) should return empty history."""
+    db_session.add(Message(conversation_id=conversation.id, direction="inbound", body="Only msg"))
+    db_session.commit()
+
+    history = await load_conversation_history(db_session, conversation.id)
+    assert history == []
+
+
+@pytest.mark.asyncio()
+async def test_get_or_create_conversation_new(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Should create a new conversation when none exists."""
+    conv, is_new = await get_or_create_conversation(db_session, test_contractor.id)
+    assert is_new is True
+    assert conv.contractor_id == test_contractor.id
+    assert conv.is_active is True
+
+
+@pytest.mark.asyncio()
+async def test_get_or_create_conversation_existing_active(
+    db_session: Session,
+    test_contractor: Contractor,
+    conversation: Conversation,
+) -> None:
+    """Should return existing active conversation within timeout."""
+    # Update last_message_at to be recent
+    conversation.last_message_at = datetime.datetime.now(datetime.UTC)
+    db_session.commit()
+
+    conv, is_new = await get_or_create_conversation(db_session, test_contractor.id)
+    assert is_new is False
+    assert conv.id == conversation.id
+
+
+@pytest.mark.asyncio()
+async def test_get_or_create_conversation_expired(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Should create new conversation when existing one has timed out."""
+    # Create an old conversation
+    old_conv = Conversation(
+        contractor_id=test_contractor.id,
+        is_active=True,
+    )
+    db_session.add(old_conv)
+    db_session.commit()
+
+    # Manually set last_message_at to past the timeout
+    old_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+        hours=CONVERSATION_TIMEOUT_HOURS + 1
+    )
+    old_conv.last_message_at = old_time
+    db_session.commit()
+
+    conv, is_new = await get_or_create_conversation(db_session, test_contractor.id)
+    assert is_new is True
+    assert conv.id != old_conv.id
+
+
+@pytest.mark.asyncio()
+async def test_get_or_create_conversation_with_twilio_sid(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """New conversation should store Twilio SID."""
+    conv, is_new = await get_or_create_conversation(
+        db_session, test_contractor.id, twilio_sid="SM_abc123"
+    )
+    assert is_new is True
+    assert conv.twilio_sid == "SM_abc123"
+
+
+@pytest.mark.asyncio()
+async def test_get_or_create_conversation_custom_timeout(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Custom timeout should be respected."""
+    # Create a conversation 2 hours old
+    conv1 = Conversation(contractor_id=test_contractor.id, is_active=True)
+    db_session.add(conv1)
+    db_session.commit()
+    conv1.last_message_at = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=2)
+    db_session.commit()
+
+    # With 1-hour timeout, should create new
+    conv, is_new = await get_or_create_conversation(db_session, test_contractor.id, timeout_hours=1)
+    assert is_new is True
+
+    # Clean up the new conversation for next assertion
+    db_session.delete(conv)
+    db_session.commit()
+
+    # With 3-hour timeout, should reuse
+    conv, is_new = await get_or_create_conversation(db_session, test_contractor.id, timeout_hours=3)
+    assert is_new is False


### PR DESCRIPTION
## Description
Add conversation context loading and session management:

- `load_conversation_history()`: loads recent messages for LLM context, preferring `processed_context` (includes media descriptions) over raw `body`
- `get_or_create_conversation()`: session management with configurable timeout (default 4 hours), auto-creates new conversation when existing one expires
- Router refactored to use shared context module

Fixes #25

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code for implementation and tests)
- [ ] No AI used