### PR TITLE
feat: Docker single-command demo setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.venv/
+__pycache__/
+*.pyc
+.git/
+.github/
+.pytest_cache/
+.ruff_cache/
+tests/
+*.md
+.env
+.env.example
+.pre-commit-config.yaml

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Database
+# Database (auto-configured in Docker Compose; set for local development)
 DATABASE_URL=postgresql://backshop:backshop@localhost:5432/backshop
 
 # CORS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+# Install system dependencies (ffmpeg for audio processing)
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+# Install dependencies
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen
+
+# Copy application code
+COPY backend/ backend/
+COPY alembic/ alembic/
+COPY alembic.ini .
+
+EXPOSE 8000
+
+CMD ["uv", "run", "uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -21,7 +21,6 @@ from backend.app.services.twilio_service import TwilioService
 logger = logging.getLogger(__name__)
 
 
-
 async def handle_inbound_message(
     db: Session,
     contractor: Contractor,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: backshop
+      POSTGRES_USER: backshop
+      POSTGRES_PASSWORD: backshop
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U backshop"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: postgresql://backshop:backshop@db:5432/backshop
+    env_file:
+      - .env
+    depends_on:
+      db:
+        condition: service_healthy
+    command: >
+      sh -c "uv run alembic upgrade head &&
+             uv run uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 --reload"
+
+volumes:
+  pgdata:

--- a/scripts/setup-tunnel.sh
+++ b/scripts/setup-tunnel.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Set up a public tunnel for Twilio webhooks during local development.
+#
+# Usage:
+#   ./scripts/setup-tunnel.sh
+#
+# After running, copy the public URL and configure it in Twilio console:
+#   Phone Numbers > Active Numbers > (your number) > Messaging > Webhook
+#   Set to: https://<tunnel-url>/api/webhooks/twilio/inbound
+
+set -euo pipefail
+
+PORT="${PORT:-8000}"
+
+# Try ngrok first, then fall back to localtunnel
+if command -v ngrok &>/dev/null; then
+    echo "Starting ngrok tunnel on port $PORT..."
+    echo "Configure your Twilio webhook to: https://<ngrok-url>/api/webhooks/twilio/inbound"
+    ngrok http "$PORT"
+elif command -v npx &>/dev/null; then
+    echo "Starting localtunnel on port $PORT..."
+    echo "Configure your Twilio webhook to: https://<tunnel-url>/api/webhooks/twilio/inbound"
+    npx localtunnel --port "$PORT"
+else
+    echo "Error: Neither ngrok nor npx (for localtunnel) found."
+    echo ""
+    echo "Install one of:"
+    echo "  ngrok:       https://ngrok.com/download"
+    echo "  localtunnel: npm install -g localtunnel"
+    exit 1
+fi


### PR DESCRIPTION
## Description
Add Docker Compose setup for single-command demo deployment:

- `Dockerfile`: Python 3.11-slim base with ffmpeg (for audio), uv package manager
- `docker-compose.yml`: PostgreSQL 16 + app service with health checks, auto-migration on startup, hot reload for development
- `.dockerignore`: excludes dev files from Docker image
- `scripts/setup-tunnel.sh`: helper to set up ngrok or localtunnel for Twilio webhook development
- `.env.example`: updated with Docker Compose context

Quick start: `cp .env.example .env && docker compose up`

Fixes #26

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code for implementation)
- [ ] No AI used