### PR TITLE
feat: add TwilioService dependency injection for webhook

### DIFF
--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -8,6 +8,7 @@ from twilio.request_validator import RequestValidator
 from backend.app.config import settings
 from backend.app.database import get_db
 from backend.app.models import Contractor, Conversation, Message
+from backend.app.services.twilio_service import TwilioService, get_twilio_service
 
 router = APIRouter()
 
@@ -67,7 +68,11 @@ def _get_or_create_conversation(db: Session, contractor: Contractor) -> Conversa
 
 
 @router.post("/webhooks/twilio/inbound")
-async def twilio_inbound(request: Request, db: Session = Depends(get_db)) -> Response:
+async def twilio_inbound(
+    request: Request,
+    db: Session = Depends(get_db),
+    twilio_service: TwilioService = Depends(get_twilio_service),
+) -> Response:
     """Receive inbound SMS/MMS from Twilio."""
     form_data = dict(await request.form())
     # Ensure all values are strings

--- a/backend/app/services/twilio_service.py
+++ b/backend/app/services/twilio_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Generator
 
 from twilio.rest import Client as TwilioClient
 
@@ -52,6 +53,6 @@ class TwilioService:
         return message.sid
 
 
-def get_twilio_service() -> TwilioService:
-    """FastAPI dependency for TwilioService."""
-    return TwilioService()
+def get_twilio_service() -> Generator[TwilioService]:
+    """FastAPI dependency for TwilioService (overridable in tests)."""
+    yield TwilioService()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,6 +10,7 @@ from sqlalchemy.pool import StaticPool
 from backend.app.database import Base, get_db
 from backend.app.main import app
 from backend.app.models import Contractor
+from backend.app.services.twilio_service import TwilioService, get_twilio_service
 
 
 @pytest.fixture()
@@ -42,13 +44,29 @@ def test_contractor(db_session: Session) -> Contractor:
 
 
 @pytest.fixture()
-def client(db_session: Session, test_contractor: Contractor) -> Generator[TestClient]:
-    """FastAPI test client with overridden DB and auth."""
+def mock_twilio_service() -> TwilioService:
+    """Mock TwilioService that doesn't hit real Twilio."""
+    service = MagicMock(spec=TwilioService)
+    service.send_sms = AsyncMock(return_value="SM_mock_sid")
+    service.send_mms = AsyncMock(return_value="SM_mock_sid")
+    service.send_message = AsyncMock(return_value="SM_mock_sid")
+    return service
+
+
+@pytest.fixture()
+def client(
+    db_session: Session, test_contractor: Contractor, mock_twilio_service: TwilioService
+) -> Generator[TestClient]:
+    """FastAPI test client with overridden DB, auth, and Twilio."""
 
     def _override_get_db() -> Generator[Session]:
         yield db_session
 
+    def _override_get_twilio_service() -> Generator[TwilioService]:
+        yield mock_twilio_service
+
     app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_twilio_service] = _override_get_twilio_service
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from backend.app.models import Contractor, Conversation, Message
+from backend.app.services.twilio_service import TwilioService
 from tests.mocks.twilio import make_twilio_webhook_payload
 
 
@@ -75,3 +78,16 @@ def test_inbound_webhook_creates_conversation(
     )
     assert len(conversations) == 1
     assert conversations[0].is_active is True
+
+
+def test_twilio_service_injected_via_depends(
+    client: TestClient, mock_twilio_service: TwilioService
+) -> None:
+    """TwilioService should be injected via Depends and overridable in tests."""
+    # The mock_twilio_service fixture is injected via dependency override in conftest.
+    # If DI is wired correctly, the endpoint succeeds with the mock (no real Twilio call).
+    payload = make_twilio_webhook_payload()
+    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    assert response.status_code == 200
+    # Verify the mock is indeed a MagicMock (not a real TwilioService)
+    assert isinstance(mock_twilio_service, MagicMock)


### PR DESCRIPTION
## Description
Make `get_twilio_service()` a proper FastAPI generator dependency (matching the `get_db()` pattern) so it can be overridden in tests. Add it as `Depends()` to the webhook endpoint. Update test conftest to override with a mock TwilioService for all test client usage.

Fixes #54

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used