### PR TITLE
fix: preserve media content_type in webhook extraction

### DIFF
--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -83,7 +83,7 @@ async def twilio_inbound(
     phone = form_data.get("From", "")
     body = form_data.get("Body", "")
     media = _extract_media(form_data)
-    media_urls = [m["url"] for m in media]
+    media_urls: list[tuple[str, str]] = [(m["url"], m["content_type"]) for m in media]
 
     contractor = _get_or_create_contractor(db, phone)
     conversation = _get_or_create_conversation(db, contractor)
@@ -92,7 +92,7 @@ async def twilio_inbound(
         conversation_id=conversation.id,
         direction="inbound",
         body=body,
-        media_urls_json=json.dumps(media_urls),
+        media_urls_json=json.dumps([url for url, _ct in media_urls]),
     )
     db.add(message)
     db.commit()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from backend.app.models import Contractor, Conversation, Message
+from backend.app.routers.webhooks import _extract_media
 from backend.app.services.twilio_service import TwilioService
 from tests.mocks.twilio import make_twilio_webhook_payload
 
@@ -78,6 +79,43 @@ def test_inbound_webhook_creates_conversation(
     )
     assert len(conversations) == 1
     assert conversations[0].is_active is True
+
+
+def test_extract_media_preserves_content_type() -> None:
+    """_extract_media should return url and content_type for each media item."""
+    form_data = {
+        "NumMedia": "2",
+        "MediaUrl0": "https://api.twilio.com/media1.jpg",
+        "MediaContentType0": "image/jpeg",
+        "MediaUrl1": "https://api.twilio.com/media2.pdf",
+        "MediaContentType1": "application/pdf",
+    }
+    result = _extract_media(form_data)
+    assert len(result) == 2
+    assert result[0]["url"] == "https://api.twilio.com/media1.jpg"
+    assert result[0]["content_type"] == "image/jpeg"
+    assert result[1]["url"] == "https://api.twilio.com/media2.pdf"
+    assert result[1]["content_type"] == "application/pdf"
+
+
+def test_media_urls_as_tuples_with_content_type(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """media_urls should be (url, content_type) tuples, not bare URLs."""
+    payload = make_twilio_webhook_payload(
+        from_number=test_contractor.phone,
+        body="Photo of the job",
+        num_media=1,
+        media_urls=["https://api.twilio.com/media1.jpg"],
+        media_types=["image/jpeg"],
+    )
+    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    assert response.status_code == 200
+
+    # media_urls_json should still store just URLs for DB storage
+    messages = db_session.query(Message).all()
+    assert len(messages) == 1
+    assert "media1.jpg" in messages[0].media_urls_json
 
 
 def test_twilio_service_injected_via_depends(


### PR DESCRIPTION
## Description
Change `media_urls` from bare URL strings to `(url, content_type)` tuples so MIME types from Twilio are passed downstream to `handle_inbound_message()`. The DB still stores just URLs in `media_urls_json` for backward compatibility.

Fixes #57

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used