### PR TITLE
feat: wire webhook to message router

### DIFF
--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -1,14 +1,18 @@
 import json
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 from twilio.request_validator import RequestValidator
 
+from backend.app.agent.router import handle_inbound_message
 from backend.app.config import settings
 from backend.app.database import get_db
 from backend.app.models import Contractor, Conversation, Message
 from backend.app.services.twilio_service import TwilioService, get_twilio_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -96,5 +100,22 @@ async def twilio_inbound(
     )
     db.add(message)
     db.commit()
+    db.refresh(message)
+
+    # Process through agent pipeline (media → LLM → reply SMS)
+    try:
+        await handle_inbound_message(
+            db=db,
+            contractor=contractor,
+            message=message,
+            media_urls=media_urls,
+            twilio_service=twilio_service,
+        )
+    except Exception:
+        logger.exception(
+            "Agent pipeline failed for message %d from %s",
+            message.id,
+            phone,
+        )
 
     return Response(content=TWIML_EMPTY, media_type="application/xml")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,18 +1,24 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from backend.app.agent.core import AgentResponse
 from backend.app.models import Contractor, Conversation, Message
 from backend.app.routers.webhooks import _extract_media
 from backend.app.services.twilio_service import TwilioService
 from tests.mocks.twilio import make_twilio_webhook_payload
 
+# All webhook tests mock handle_inbound_message to avoid LLM calls
+_MOCK_AGENT_RESPONSE = AgentResponse(reply_text="Mock reply")
+_PATCH_HANDLE = "backend.app.routers.webhooks.handle_inbound_message"
+
 
 def test_inbound_webhook_returns_200(client: TestClient) -> None:
     """Valid webhook payload should return 200 with empty TwiML."""
-    payload = make_twilio_webhook_payload()
-    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_twilio_webhook_payload()
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
     assert response.status_code == 200
     assert "<Response/>" in response.text
 
@@ -21,11 +27,12 @@ def test_inbound_webhook_stores_message(
     client: TestClient, db_session: Session, test_contractor: Contractor
 ) -> None:
     """Inbound message should be stored in the database."""
-    payload = make_twilio_webhook_payload(
-        from_number=test_contractor.phone,
-        body="I need a quote for kitchen remodel",
-    )
-    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_twilio_webhook_payload(
+            from_number=test_contractor.phone,
+            body="I need a quote for kitchen remodel",
+        )
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
     assert response.status_code == 200
 
     messages = db_session.query(Message).all()
@@ -38,14 +45,18 @@ def test_inbound_webhook_extracts_media_urls(
     client: TestClient, db_session: Session, test_contractor: Contractor
 ) -> None:
     """Media URLs should be extracted and stored."""
-    payload = make_twilio_webhook_payload(
-        from_number=test_contractor.phone,
-        body="Here are the photos",
-        num_media=2,
-        media_urls=["https://api.twilio.com/media1.jpg", "https://api.twilio.com/media2.jpg"],
-        media_types=["image/jpeg", "image/jpeg"],
-    )
-    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_twilio_webhook_payload(
+            from_number=test_contractor.phone,
+            body="Here are the photos",
+            num_media=2,
+            media_urls=[
+                "https://api.twilio.com/media1.jpg",
+                "https://api.twilio.com/media2.jpg",
+            ],
+            media_types=["image/jpeg", "image/jpeg"],
+        )
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
     assert response.status_code == 200
 
     messages = db_session.query(Message).all()
@@ -56,8 +67,9 @@ def test_inbound_webhook_extracts_media_urls(
 
 def test_inbound_webhook_creates_contractor_if_new(client: TestClient, db_session: Session) -> None:
     """Unknown phone number should create a new contractor."""
-    payload = make_twilio_webhook_payload(from_number="+15559999999", body="Hi")
-    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_twilio_webhook_payload(from_number="+15559999999", body="Hi")
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
     assert response.status_code == 200
 
     contractor = db_session.query(Contractor).filter(Contractor.phone == "+15559999999").first()
@@ -68,8 +80,9 @@ def test_inbound_webhook_creates_conversation(
     client: TestClient, db_session: Session, test_contractor: Contractor
 ) -> None:
     """Should create a conversation for the contractor."""
-    payload = make_twilio_webhook_payload(from_number=test_contractor.phone, body="Hello")
-    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_twilio_webhook_payload(from_number=test_contractor.phone, body="Hello")
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
     assert response.status_code == 200
 
     conversations = (
@@ -102,14 +115,15 @@ def test_media_urls_as_tuples_with_content_type(
     client: TestClient, db_session: Session, test_contractor: Contractor
 ) -> None:
     """media_urls should be (url, content_type) tuples, not bare URLs."""
-    payload = make_twilio_webhook_payload(
-        from_number=test_contractor.phone,
-        body="Photo of the job",
-        num_media=1,
-        media_urls=["https://api.twilio.com/media1.jpg"],
-        media_types=["image/jpeg"],
-    )
-    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_twilio_webhook_payload(
+            from_number=test_contractor.phone,
+            body="Photo of the job",
+            num_media=1,
+            media_urls=["https://api.twilio.com/media1.jpg"],
+            media_types=["image/jpeg"],
+        )
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
     assert response.status_code == 200
 
     # media_urls_json should still store just URLs for DB storage
@@ -122,10 +136,69 @@ def test_twilio_service_injected_via_depends(
     client: TestClient, mock_twilio_service: TwilioService
 ) -> None:
     """TwilioService should be injected via Depends and overridable in tests."""
-    # The mock_twilio_service fixture is injected via dependency override in conftest.
-    # If DI is wired correctly, the endpoint succeeds with the mock (no real Twilio call).
-    payload = make_twilio_webhook_payload()
-    response = client.post("/api/webhooks/twilio/inbound", data=payload)
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_twilio_webhook_payload()
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
     assert response.status_code == 200
-    # Verify the mock is indeed a MagicMock (not a real TwilioService)
     assert isinstance(mock_twilio_service, MagicMock)
+
+
+def test_webhook_calls_handle_inbound_message(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Webhook should call handle_inbound_message after storing the message."""
+    with patch(
+        _PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE
+    ) as mock_handle:
+        payload = make_twilio_webhook_payload(
+            from_number=test_contractor.phone,
+            body="Need a quote",
+        )
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
+
+    assert response.status_code == 200
+    mock_handle.assert_called_once()
+
+    # Verify the call args
+    call_kwargs = mock_handle.call_args
+    assert call_kwargs.kwargs["contractor"].phone == test_contractor.phone
+    assert call_kwargs.kwargs["message"].body == "Need a quote"
+    assert call_kwargs.kwargs["media_urls"] == []
+
+
+def test_webhook_calls_handle_with_media_tuples(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Webhook should pass media as (url, content_type) tuples to handler."""
+    with patch(
+        _PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE
+    ) as mock_handle:
+        payload = make_twilio_webhook_payload(
+            from_number=test_contractor.phone,
+            body="Photos",
+            num_media=1,
+            media_urls=["https://api.twilio.com/photo.jpg"],
+            media_types=["image/jpeg"],
+        )
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
+
+    assert response.status_code == 200
+    call_kwargs = mock_handle.call_args.kwargs
+    assert call_kwargs["media_urls"] == [("https://api.twilio.com/photo.jpg", "image/jpeg")]
+
+
+def test_webhook_survives_handler_failure(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Webhook should return 200 even if handle_inbound_message raises."""
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, side_effect=RuntimeError("LLM down")):
+        payload = make_twilio_webhook_payload(
+            from_number=test_contractor.phone,
+            body="Hello",
+        )
+        response = client.post("/api/webhooks/twilio/inbound", data=payload)
+
+    # Should still return 200 (message was stored, agent failure is logged)
+    assert response.status_code == 200
+    messages = db_session.query(Message).all()
+    assert len(messages) == 1


### PR DESCRIPTION
## Description
After storing the inbound message, the webhook now calls `handle_inbound_message()` which triggers the full pipeline: media download → media processing → agent LLM → SMS reply. Agent failures are caught and logged so the webhook always returns 200 to Twilio.

Fixes #53

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used