### PR TITLE
fix: agent tool loop sends results back to LLM

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -103,31 +103,56 @@ class BackshopAgent:
         tool_call_records: list[dict[str, object]] = []
 
         # Handle tool calls
-        if hasattr(choice.message, "tool_calls") and choice.message.tool_calls:
+        if getattr(choice.message, "tool_calls", None):
+            # Append the assistant message (with tool_calls) to conversation
+            messages.append(choice.message.model_dump())
+
+            tool_results: list[dict[str, str]] = []
             for tool_call in choice.message.tool_calls:
                 tool_name = tool_call.function.name
                 tool_args = json.loads(tool_call.function.arguments)
 
                 tool_func = self._find_tool(tool_name)
+                result_str = ""
                 if tool_func:
                     try:
                         result = await tool_func(**tool_args)
+                        result_str = str(result)
                         actions_taken.append(f"Called {tool_name}")
                         tool_call_records.append(
                             {
                                 "name": tool_name,
                                 "args": tool_args,
-                                "result": str(result),
+                                "result": result_str,
                             }
                         )
                         if tool_name == "save_fact":
                             memories_saved.append(tool_args)
                     except Exception:
                         logger.exception("Tool call failed: %s", tool_name)
+                        result_str = f"Error: tool {tool_name} failed"
                         actions_taken.append(f"Failed: {tool_name}")
+                else:
+                    result_str = f"Error: unknown tool {tool_name}"
 
-            # Get final response after tool calls
-            reply_text = choice.message.content or "Done."
+                tool_results.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": result_str,
+                    }
+                )
+
+            # Append tool results and make follow-up LLM call
+            messages.extend(tool_results)
+            followup = await acompletion(
+                model=settings.llm_model,
+                provider=settings.llm_provider,
+                api_key=settings.llm_api_key,
+                messages=messages,
+                max_tokens=500,
+            )
+            reply_text = followup.choices[0].message.content or ""
         else:
             reply_text = choice.message.content or ""
 

--- a/tests/mocks/llm.py
+++ b/tests/mocks/llm.py
@@ -13,10 +13,50 @@ def make_text_response(content: str = "I'll help you with that.") -> MagicMock:
     return _make_completion_response(content)
 
 
-def _make_completion_response(content: str) -> MagicMock:
-    """Build a mock ChatCompletion response."""
+def make_tool_call_response(
+    tool_calls: list[dict[str, str]],
+    content: str | None = None,
+) -> MagicMock:
+    """Build a mock ChatCompletion response with tool_calls.
+
+    Each tool_call dict should have: name, arguments (JSON string), and optionally id.
+    """
+    mock_tool_calls = []
+    for i, tc in enumerate(tool_calls):
+        mock_tc = MagicMock()
+        mock_tc.id = tc.get("id", f"call_{i}")
+        mock_tc.function.name = tc["name"]
+        mock_tc.function.arguments = tc["arguments"]
+        mock_tool_calls.append(mock_tc)
+
     msg = MagicMock()
     msg.content = content
+    msg.tool_calls = mock_tool_calls
+    msg.model_dump.return_value = {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+            }
+            for tc in mock_tool_calls
+        ],
+    }
+
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+def _make_completion_response(content: str) -> MagicMock:
+    """Build a mock ChatCompletion response (no tool calls)."""
+    msg = MagicMock()
+    msg.content = content
+    msg.tool_calls = None  # Explicitly no tool calls
     choice = MagicMock()
     choice.message = msg
     resp = MagicMock()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,11 +1,13 @@
-from unittest.mock import patch
+import json
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.orm import Session
 
 from backend.app.agent.core import BackshopAgent
+from backend.app.agent.tools.base import Tool
 from backend.app.models import Contractor
-from tests.mocks.llm import make_text_response
+from tests.mocks.llm import make_text_response, make_tool_call_response
 
 
 @pytest.mark.asyncio()
@@ -61,3 +63,90 @@ async def test_agent_system_prompt_includes_soul(
     call_args = mock_acompletion.call_args  # type: ignore[union-attr]
     system_prompt = call_args.kwargs["messages"][0]["content"]
     assert test_contractor.name in system_prompt
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_tool_loop_sends_results_back(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """After tool calls, agent should send results back to LLM for a follow-up response."""
+    # First call: LLM requests a tool call
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "name": "save_fact",
+                "arguments": json.dumps({"key": "hourly_rate", "value": "$75/hr"}),
+            }
+        ]
+    )
+    # Second call: LLM produces the final reply
+    followup_response = make_text_response("Got it, I'll remember your rate is $75/hour!")
+
+    mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
+
+    # Register a mock save_fact tool
+    mock_save = AsyncMock(return_value="Saved hourly_rate = $75/hr")
+    tool = Tool(
+        name="save_fact",
+        description="Save a fact",
+        function=mock_save,
+        parameters={"type": "object", "properties": {"key": {}, "value": {}}},
+    )
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("My rate is $75/hour")
+
+    # Verify the tool was called
+    mock_save.assert_called_once_with(key="hourly_rate", value="$75/hr")
+
+    # Verify follow-up LLM call was made (2 calls total)
+    assert mock_acompletion.call_count == 2  # type: ignore[union-attr]
+
+    # Verify the reply comes from the follow-up response, not "Done."
+    assert response.reply_text == "Got it, I'll remember your rate is $75/hour!"
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0]["name"] == "save_fact"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_tool_loop_includes_tool_results_in_followup(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Follow-up LLM call should include tool result messages."""
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_abc",
+                "name": "recall_facts",
+                "arguments": json.dumps({"query": "hourly rate"}),
+            }
+        ]
+    )
+    followup_response = make_text_response("Your hourly rate is $75.")
+
+    mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
+
+    mock_recall = AsyncMock(return_value="hourly_rate: $75/hr")
+    tool = Tool(
+        name="recall_facts",
+        description="Recall facts",
+        function=mock_recall,
+        parameters={"type": "object", "properties": {"query": {}}},
+    )
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    await agent.process_message("What's my rate?")
+
+    # Verify the follow-up call includes tool result messages
+    followup_call = mock_acompletion.call_args_list[1]  # type: ignore[union-attr]
+    messages = followup_call.kwargs["messages"]
+
+    # Should have: system, user, assistant (with tool_calls), tool result
+    tool_messages = [m for m in messages if m.get("role") == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["tool_call_id"] == "call_abc"
+    assert "hourly_rate: $75/hr" in tool_messages[0]["content"]


### PR DESCRIPTION
## Description
After executing tool calls, the agent now appends the assistant message and tool results to the conversation, then makes a follow-up `acompletion` call so the LLM can produce a meaningful reply incorporating tool results. Previously it returned "Done." from the empty original response.

Fixes #55

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used