### PR TITLE
fix: save processed_context to Message after media pipeline

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -74,6 +74,10 @@ async def handle_inbound_message(
     if media_notes:
         combined_context += "\n\n[System note: " + " ".join(media_notes) + "]"
 
+    # Persist processed context for conversation history
+    message.processed_context = combined_context
+    db.commit()
+
     # Step 4: Load conversation history
     conversation_history = await load_conversation_history(db, message.conversation_id)
 

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -154,3 +154,28 @@ async def test_media_download_failure_still_processes_text(
     )
 
     assert response.reply_text == "Got your text!"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_processed_context_saved_to_message(
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    inbound_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """processed_context should be saved to the Message after media pipeline."""
+    mock_acompletion.return_value = make_text_response("Got it!")  # type: ignore[union-attr]
+
+    await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=inbound_message,
+        media_urls=[],
+        twilio_service=mock_twilio,
+    )
+
+    db_session.refresh(inbound_message)
+    assert inbound_message.processed_context is not None
+    assert inbound_message.body in inbound_message.processed_context


### PR DESCRIPTION
## Description
Persist the media pipeline's combined_context to `Message.processed_context` so that `load_conversation_history()` can include rich media context (vision descriptions, audio transcriptions) in subsequent LLM calls.

Fixes #56

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used