### PR TITLE
feat: wire file cataloging tools into agent router

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -11,11 +11,14 @@ from backend.app.agent.onboarding import (
 )
 from backend.app.agent.profile import update_contractor_profile
 from backend.app.agent.tools.estimate_tools import create_estimate_tools
+from backend.app.agent.tools.file_tools import create_file_tools
 from backend.app.agent.tools.memory_tools import create_memory_tools
 from backend.app.agent.tools.twilio_tools import create_twilio_tools
+from backend.app.config import settings
 from backend.app.media.download import DownloadedMedia, download_twilio_media
 from backend.app.media.pipeline import process_message_media
 from backend.app.models import Contractor, Message
+from backend.app.services.storage_service import get_storage_service
 from backend.app.services.twilio_service import TwilioService
 
 logger = logging.getLogger(__name__)
@@ -89,6 +92,17 @@ async def handle_inbound_message(
     tools = create_memory_tools(db, contractor.id)
     tools.extend(create_twilio_tools(twilio_service, to_number=contractor.phone))
     tools.extend(create_estimate_tools(db, contractor))
+
+    # Wire file tools if storage is configured
+    try:
+        storage_token = settings.dropbox_access_token or settings.google_drive_credentials_json
+        if storage_token:
+            storage = get_storage_service()
+            pending_media = {m.original_url: m.content for m in downloaded_media if m.content}
+            tools.extend(create_file_tools(db, contractor, storage, pending_media))
+    except Exception:
+        logger.debug("Storage not configured, skipping file tools")
+
     agent.register_tools(tools)
 
     # Step 6: Process message through agent (with LLM failure fallback)

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -7,6 +7,7 @@ from backend.app.agent.router import handle_inbound_message
 from backend.app.models import Contractor, Conversation, Message
 from backend.app.services.twilio_service import TwilioService
 from tests.mocks.llm import make_text_response
+from tests.mocks.storage import MockStorageBackend
 
 
 @pytest.fixture()
@@ -179,3 +180,67 @@ async def test_processed_context_saved_to_message(
     db_session.refresh(inbound_message)
     assert inbound_message.processed_context is not None
     assert inbound_message.body in inbound_message.processed_context
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.agent.router.get_storage_service")
+@patch("backend.app.agent.router.settings")
+async def test_file_tools_wired_when_storage_configured(
+    mock_settings: MagicMock,
+    mock_get_storage: MagicMock,
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    inbound_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """File tools should be registered when storage credentials are set."""
+    mock_settings.dropbox_access_token = "test-token"
+    mock_settings.google_drive_credentials_json = ""
+    mock_settings.llm_model = "gpt-4o"
+    mock_settings.llm_provider = "openai"
+    mock_settings.llm_api_key = "test-key"
+    mock_get_storage.return_value = MockStorageBackend()
+    mock_acompletion.return_value = make_text_response("File saved!")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=inbound_message,
+        media_urls=[],
+        twilio_service=mock_twilio,
+    )
+
+    assert response.reply_text == "File saved!"
+    mock_get_storage.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.agent.router.settings")
+async def test_file_tools_skipped_when_no_storage(
+    mock_settings: MagicMock,
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    inbound_message: Message,
+    mock_twilio: TwilioService,
+) -> None:
+    """File tools should be skipped gracefully when storage not configured."""
+    mock_settings.dropbox_access_token = ""
+    mock_settings.google_drive_credentials_json = ""
+    mock_settings.llm_model = "gpt-4o"
+    mock_settings.llm_provider = "openai"
+    mock_settings.llm_api_key = "test-key"
+    mock_acompletion.return_value = make_text_response("No file tools!")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=inbound_message,
+        media_urls=[],
+        twilio_service=mock_twilio,
+    )
+
+    assert response.reply_text == "No file tools!"


### PR DESCRIPTION
## Description
Register file tools when storage credentials (Dropbox or Google Drive) are configured. Build `pending_media` dict from downloaded media so the `upload_to_storage` tool can access file content. Skip gracefully when storage is not configured.

Fixes #58

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used