### PR TITLE
feat: persist estimate PDFs and serve via endpoint

### DIFF
--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -2,12 +2,15 @@
 
 import datetime
 import logging
+from pathlib import Path
 
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool
 from backend.app.models import Contractor, Estimate, EstimateLineItem
 from backend.app.services.pdf_service import EstimatePDFData, generate_estimate_pdf
+
+PDF_DIR = Path("data/estimates")
 
 logger = logging.getLogger(__name__)
 
@@ -95,15 +98,20 @@ def create_estimate_tools(
 
         pdf_bytes = await generate_estimate_pdf(pdf_data)
 
-        # Store PDF reference (in Phase 0, just record that it was generated)
-        estimate.pdf_url = f"estimate://{estimate_number}.pdf"
+        # Save PDF to local storage
+        PDF_DIR.mkdir(parents=True, exist_ok=True)
+        pdf_path = PDF_DIR / f"{estimate.id}.pdf"
+        pdf_path.write_bytes(pdf_bytes)
+
+        # Update estimate with PDF URL (served by /api/estimates/{id}/pdf)
+        estimate.pdf_url = f"/api/estimates/{estimate.id}/pdf"
         estimate.status = "sent"
         db.commit()
 
         return (
             f"Estimate {estimate_number} generated for ${total_amount:,.2f}. "
             f"{len(processed_items)} line item(s). "
-            f"PDF is {len(pdf_bytes)} bytes."
+            f"PDF available at {estimate.pdf_url}"
         )
 
     return [

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.app.config import settings
-from backend.app.routers import auth, health, webhooks
+from backend.app.routers import auth, estimates, health, webhooks
 
 app = FastAPI(title="Backshop", version="0.1.0")
 
@@ -17,3 +17,4 @@ app.add_middleware(
 app.include_router(health.router, prefix="/api")
 app.include_router(auth.router, prefix="/api")
 app.include_router(webhooks.router, prefix="/api")
+app.include_router(estimates.router, prefix="/api")

--- a/backend/app/routers/estimates.py
+++ b/backend/app/routers/estimates.py
@@ -1,0 +1,27 @@
+"""Endpoints for estimate PDF serving."""
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+PDF_DIR = Path("data/estimates")
+
+
+@router.get("/estimates/{estimate_id}/pdf")
+async def serve_estimate_pdf(estimate_id: int) -> Response:
+    """Serve a generated estimate PDF by estimate ID."""
+    pdf_path = PDF_DIR / f"{estimate_id}.pdf"
+    if not pdf_path.exists():
+        raise HTTPException(status_code=404, detail="Estimate PDF not found")
+
+    return Response(
+        content=pdf_path.read_bytes(),
+        media_type="application/pdf",
+        headers={"Content-Disposition": f"inline; filename=estimate-{estimate_id}.pdf"},
+    )

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.estimate_tools import _next_estimate_number, create_estimate_tools
@@ -73,12 +76,19 @@ async def test_generate_estimate_pdf_generated(
         line_items=[{"description": "Service call", "quantity": 1, "unit_price": 150.00}],
     )
 
-    # Result mentions PDF size
-    assert "PDF is" in result
-    # Extract bytes count from "PDF is N bytes"
-    parts = result.split("PDF is ")[1].split(" bytes")[0]
-    pdf_size = int(parts)
-    assert pdf_size > 0
+    # Result mentions PDF URL
+    assert "/api/estimates/" in result
+    assert "/pdf" in result
+
+    # Verify PDF file was actually written
+    from pathlib import Path
+
+    estimate = db_session.query(Estimate).first()
+    pdf_path = Path(f"data/estimates/{estimate.id}.pdf")
+    assert pdf_path.exists()
+    assert pdf_path.stat().st_size > 0
+    # Clean up
+    pdf_path.unlink()
 
 
 @pytest.mark.asyncio()
@@ -161,3 +171,26 @@ def test_next_estimate_number_increments(
     )
     db_session.commit()
     assert _next_estimate_number(db_session, test_contractor.id) == "EST-0002"
+
+
+def test_serve_estimate_pdf_endpoint(client: TestClient) -> None:
+    """GET /api/estimates/{id}/pdf should serve existing PDF."""
+    # Create a test PDF file
+    pdf_dir = Path("data/estimates")
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    test_pdf = pdf_dir / "999.pdf"
+    test_pdf.write_bytes(b"%PDF-1.4 test content")
+
+    try:
+        response = client.get("/api/estimates/999/pdf")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/pdf"
+        assert b"%PDF-1.4" in response.content
+    finally:
+        test_pdf.unlink()
+
+
+def test_serve_estimate_pdf_not_found(client: TestClient) -> None:
+    """GET /api/estimates/{id}/pdf should return 404 for missing PDF."""
+    response = client.get("/api/estimates/99999/pdf")
+    assert response.status_code == 404


### PR DESCRIPTION
## Description
Save generated PDF bytes to `data/estimates/{id}.pdf` and add a `GET /api/estimates/{id}/pdf` endpoint to serve them. Update estimate record with real `pdf_url`. This enables future MMS sending of PDFs.

Fixes #59

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used