### PR TITLE
feat: add webhook idempotency for duplicate prevention

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -99,6 +99,7 @@ class Message(Base):
         Integer, ForeignKey("conversations.id"), index=True
     )
     direction: Mapped[str] = mapped_column(String(20))  # inbound, outbound
+    twilio_sid: Mapped[str | None] = mapped_column(String(50), nullable=True, unique=True)
     body: Mapped[str] = mapped_column(Text, default="")
     media_urls_json: Mapped[str] = mapped_column(Text, default="[]")
     processed_context: Mapped[str] = mapped_column(Text, default="")

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -86,8 +86,16 @@ async def twilio_inbound(
 
     phone = form_data.get("From", "")
     body = form_data.get("Body", "")
+    message_sid = form_data.get("MessageSid", "")
     media = _extract_media(form_data)
     media_urls: list[tuple[str, str]] = [(m["url"], m["content_type"]) for m in media]
+
+    # Idempotency: skip duplicate messages from Twilio retries
+    if message_sid:
+        existing = db.query(Message).filter(Message.twilio_sid == message_sid).first()
+        if existing:
+            logger.info("Duplicate webhook for MessageSid=%s, skipping", message_sid)
+            return Response(content=TWIML_EMPTY, media_type="application/xml")
 
     contractor = _get_or_create_contractor(db, phone)
     conversation = _get_or_create_conversation(db, contractor)
@@ -95,6 +103,7 @@ async def twilio_inbound(
     message = Message(
         conversation_id=conversation.id,
         direction="inbound",
+        twilio_sid=message_sid or None,
         body=body,
         media_urls_json=json.dumps([url for url, _ct in media_urls]),
     )

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -202,3 +202,27 @@ def test_webhook_survives_handler_failure(
     assert response.status_code == 200
     messages = db_session.query(Message).all()
     assert len(messages) == 1
+
+
+def test_webhook_idempotency_skips_duplicate(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Duplicate webhook calls with same MessageSid should not create duplicate messages."""
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_twilio_webhook_payload(
+            from_number=test_contractor.phone,
+            body="First message",
+            message_sid="SM_unique_123",
+        )
+        # First call
+        response1 = client.post("/api/webhooks/twilio/inbound", data=payload)
+        # Second call (retry from Twilio)
+        response2 = client.post("/api/webhooks/twilio/inbound", data=payload)
+
+    assert response1.status_code == 200
+    assert response2.status_code == 200
+
+    # Only one message should exist
+    messages = db_session.query(Message).filter(Message.direction == "inbound").all()
+    assert len(messages) == 1
+    assert messages[0].twilio_sid == "SM_unique_123"


### PR DESCRIPTION
## Description
Add `twilio_sid` field to Message model and check for existing messages with the same MessageSid before processing. Twilio retries on timeout are now safely de-duplicated.

Fixes #61

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used