### PR TITLE
fix: handle faster-whisper optional dependency gracefully

### DIFF
--- a/backend/app/media/pipeline.py
+++ b/backend/app/media/pipeline.py
@@ -34,11 +34,22 @@ async def _process_single_media(
     if category == "image":
         extracted_text = await analyze_image(media.content, media.mime_type, context=context)
     elif category == "audio":
-        extracted_text = await transcribe_audio(media.content, media.mime_type)
+        try:
+            extracted_text = await transcribe_audio(media.content, media.mime_type)
+        except ImportError:
+            logger.warning("faster-whisper not installed, skipping audio transcription")
+            extracted_text = (
+                "[Audio file - transcription not available (faster-whisper not installed)]"
+            )
     elif category == "video":
         # Future: extract audio track. For now, try audio transcription.
         try:
             extracted_text = await transcribe_audio(media.content, media.mime_type)
+        except ImportError:
+            logger.warning("faster-whisper not installed, skipping video transcription")
+            extracted_text = (
+                "[Video file - transcription not available (faster-whisper not installed)]"
+            )
         except Exception:
             logger.warning("Could not process video file: %s", media.original_url)
             extracted_text = "[Video file - transcription not available]"

--- a/tests/test_media_pipeline.py
+++ b/tests/test_media_pipeline.py
@@ -79,3 +79,17 @@ async def test_process_unknown_media_type() -> None:
     result = await process_message_media("", [_make_media("application/octet-stream")])
     assert len(result.media_results) == 1
     assert result.media_results[0].category == "unknown"
+
+
+@pytest.mark.asyncio()
+@patch(
+    "backend.app.media.pipeline.transcribe_audio",
+    new_callable=AsyncMock,
+    side_effect=ImportError("faster-whisper not installed"),
+)
+async def test_audio_graceful_when_whisper_missing(mock_audio: AsyncMock) -> None:
+    """Audio processing should degrade gracefully when faster-whisper is not installed."""
+    result = await process_message_media("Voice memo", [_make_media("audio/ogg")])
+    assert len(result.media_results) == 1
+    assert "not available" in result.media_results[0].extracted_text
+    assert "faster-whisper" in result.media_results[0].extracted_text


### PR DESCRIPTION
## Summary
- Audio/video transcription in the media pipeline now catches `ImportError` when `faster-whisper` is not installed
- Returns a descriptive fallback message instead of crashing the pipeline
- Allows the demo to work without `faster-whisper` (images still get vision analysis)

## Test plan
- [x] New test `test_audio_graceful_when_whisper_missing` verifies graceful degradation
- [x] All existing media pipeline tests still pass
- [x] Lint and format clean

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)