### PR TITLE
fix: make docker-compose .env optional and remove --reload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,13 +22,14 @@ services:
     environment:
       DATABASE_URL: postgresql://backshop:backshop@db:5432/backshop
     env_file:
-      - .env
+      - path: .env
+        required: false
     depends_on:
       db:
         condition: service_healthy
     command: >
       sh -c "uv run alembic upgrade head &&
-             uv run uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 --reload"
+             uv run uvicorn backend.app.main:app --host 0.0.0.0 --port 8000"
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- Made `.env` file optional in docker-compose.yml (`required: false`) so `docker compose up` works without a local `.env` file
- Removed `--reload` flag from uvicorn command — it requires `watchfiles` and isn't suitable for container deployment

## Test plan
- [x] docker-compose.yml syntax validated
- [x] `.env` file marked as optional with `required: false` (Compose v2.17+)
- [ ] `docker compose build` succeeds (requires Docker — not available in sandbox)
- [ ] `docker compose up` starts app + DB (requires Docker)
- [ ] Health endpoint accessible at `localhost:8000/api/health`

Note: Docker is not available in this sandbox. The configuration was reviewed for correctness but could not be tested end-to-end.

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)