### PR TITLE
feat: process inbound messages in background task

### DIFF
--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -4,6 +4,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
+from starlette.background import BackgroundTask
 from twilio.request_validator import RequestValidator
 
 from backend.app.agent.router import handle_inbound_message
@@ -71,6 +72,34 @@ def _get_or_create_conversation(db: Session, contractor: Contractor) -> Conversa
     return conversation
 
 
+async def _process_message_background(
+    db: Session,
+    contractor: Contractor,
+    message: Message,
+    media_urls: list[tuple[str, str]],
+    twilio_service: TwilioService,
+) -> None:
+    """Run the agent pipeline as a background task.
+
+    Starlette runs this after the HTTP response body is sent but before
+    the dependency cleanup (db.close()), so the db session is still valid.
+    """
+    try:
+        await handle_inbound_message(
+            db=db,
+            contractor=contractor,
+            message=message,
+            media_urls=media_urls,
+            twilio_service=twilio_service,
+        )
+    except Exception:
+        logger.exception(
+            "Agent pipeline failed for message %d from %s",
+            message.id,
+            contractor.phone,
+        )
+
+
 @router.post("/webhooks/twilio/inbound")
 async def twilio_inbound(
     request: Request,
@@ -111,20 +140,16 @@ async def twilio_inbound(
     db.commit()
     db.refresh(message)
 
-    # Process through agent pipeline (media → LLM → reply SMS)
-    try:
-        await handle_inbound_message(
-            db=db,
-            contractor=contractor,
-            message=message,
-            media_urls=media_urls,
-            twilio_service=twilio_service,
-        )
-    except Exception:
-        logger.exception(
-            "Agent pipeline failed for message %d from %s",
-            message.id,
-            phone,
-        )
-
-    return Response(content=TWIML_EMPTY, media_type="application/xml")
+    # Return 200 immediately; process through agent pipeline in background.
+    # Twilio expects a response within 15 seconds. Starlette's BackgroundTask
+    # runs after the response body is sent but within the ASGI lifecycle,
+    # so the db session (from Depends) is still open.
+    task = BackgroundTask(
+        _process_message_background,
+        db=db,
+        contractor=contractor,
+        message=message,
+        media_urls=media_urls,
+        twilio_service=twilio_service,
+    )
+    return Response(content=TWIML_EMPTY, media_type="application/xml", background=task)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -146,7 +146,7 @@ def test_twilio_service_injected_via_depends(
 def test_webhook_calls_handle_inbound_message(
     client: TestClient, db_session: Session, test_contractor: Contractor
 ) -> None:
-    """Webhook should call handle_inbound_message after storing the message."""
+    """Webhook should call handle_inbound_message via background task after storing the message."""
     with patch(
         _PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE
     ) as mock_handle:


### PR DESCRIPTION
## Summary
- Webhook now returns 200 immediately after storing the inbound message
- Agent pipeline (media download, LLM call, tool execution, SMS reply) runs as a Starlette `BackgroundTask`
- Prevents Twilio webhook timeouts (15 second limit)
- Background task errors are caught and logged, not lost
- DB session from `Depends(get_db)` remains valid during the background task (Starlette runs it before dependency cleanup)

## Test plan
- [x] All 12 webhook tests pass (BackgroundTask completes within TestClient lifecycle)
- [x] All 3 integration tests pass
- [x] Full test suite: 152 passed
- [x] Lint and format clean

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)