### PR TITLE
feat: use any-llm.ai as the key vault

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,18 @@ TWILIO_TEST_TO_NUMBER=
 # LLM
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-4o
-LLM_API_KEY=
 VISION_MODEL=gpt-4o
+
+# LLM Provider API Keys — set the ones you want to use.
+# The any-llm SDK reads these from the environment automatically.
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+# GROQ_API_KEY=
+# GEMINI_API_KEY=
+
+# Any LLM Managed Platform (optional) — set this to use the any-llm.ai key vault
+# instead of individual provider keys above. See https://any-llm.ai
+# ANY_LLM_KEY=
 
 # Storage ("dropbox" or "google_drive")
 STORAGE_PROVIDER=dropbox

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Edit `.env` and fill in the required credentials:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `LLM_API_KEY` | Yes | API key for your LLM provider (OpenAI, Anthropic, etc.) |
+| `OPENAI_API_KEY` | Yes* | OpenAI API key (or set the key for your chosen provider) |
 | `TWILIO_ACCOUNT_SID` | Yes | Twilio account SID |
 | `TWILIO_AUTH_TOKEN` | Yes | Twilio auth token |
 | `TWILIO_PHONE_NUMBER` | Yes | Your Twilio phone number (e.g. `+15551234567`) |
@@ -26,6 +26,9 @@ Edit `.env` and fill in the required credentials:
 | `LLM_MODEL` | No | Model to use (default: `gpt-4o`) |
 | `STORAGE_PROVIDER` | No | `dropbox` or `google_drive` for file cataloging |
 | `DROPBOX_ACCESS_TOKEN` | No | Dropbox token (if using Dropbox storage) |
+| `ANY_LLM_KEY` | No | any-llm.ai managed platform key (replaces individual provider keys) |
+
+*Set the API key env var for your chosen provider (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) — or set `ANY_LLM_KEY` to use the [any-llm.ai](https://any-llm.ai) managed platform as a key vault for all providers.
 
 The `DATABASE_URL` is set automatically by Docker Compose — you don't need to change it.
 

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -91,7 +91,6 @@ class BackshopAgent:
         response = await acompletion(
             model=settings.llm_model,
             provider=settings.llm_provider,
-            api_key=settings.llm_api_key,
             messages=messages,
             tools=tool_schemas,
             max_tokens=500,
@@ -148,7 +147,6 @@ class BackshopAgent:
             followup = await acompletion(
                 model=settings.llm_model,
                 provider=settings.llm_provider,
-                api_key=settings.llm_api_key,
                 messages=messages,
                 max_tokens=500,
             )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,7 +17,6 @@ class Settings(BaseSettings):
     # LLM
     llm_provider: str = "openai"
     llm_model: str = "gpt-4o"
-    llm_api_key: str = ""
     vision_model: str = "gpt-4o"
 
     # Storage

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -26,7 +26,6 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
     response = await acompletion(
         model=settings.vision_model,
         provider=settings.llm_provider,
-        api_key=settings.llm_api_key,
         messages=[
             {"role": "system", "content": VISION_SYSTEM_PROMPT},
             {"role": "user", "content": user_content},

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -67,6 +67,21 @@ async def test_agent_system_prompt_includes_soul(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.acompletion")
+async def test_agent_does_not_pass_api_key(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """acompletion should be called without api_key so the SDK resolves keys from env."""
+    mock_acompletion.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    await agent.process_message("Hello")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    assert "api_key" not in call_args.kwargs
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
 async def test_agent_tool_loop_sends_results_back(
     mock_acompletion: object, db_session: Session, test_contractor: Contractor
 ) -> None:

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -200,7 +200,6 @@ async def test_file_tools_wired_when_storage_configured(
     mock_settings.google_drive_credentials_json = ""
     mock_settings.llm_model = "gpt-4o"
     mock_settings.llm_provider = "openai"
-    mock_settings.llm_api_key = "test-key"
     mock_get_storage.return_value = MockStorageBackend()
     mock_acompletion.return_value = make_text_response("File saved!")  # type: ignore[union-attr]
 
@@ -232,7 +231,6 @@ async def test_file_tools_skipped_when_no_storage(
     mock_settings.google_drive_credentials_json = ""
     mock_settings.llm_model = "gpt-4o"
     mock_settings.llm_provider = "openai"
-    mock_settings.llm_api_key = "test-key"
     mock_acompletion.return_value = make_text_response("No file tools!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -44,3 +44,14 @@ async def test_analyze_image_encodes_base64(mock_acompletion: object) -> None:
     image_parts = [p for p in user_content if p.get("type") == "image_url"]
     assert len(image_parts) == 1
     assert image_parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.media.vision.acompletion")
+async def test_analyze_image_does_not_pass_api_key(mock_acompletion: object) -> None:
+    """acompletion should be called without api_key so the SDK resolves keys from env."""
+    mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]
+    await analyze_image(b"fake-jpeg-bytes", "image/jpeg")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    assert "api_key" not in call_args.kwargs


### PR DESCRIPTION
## Description
Stop passing `api_key=` explicitly to `acompletion()` calls and let the any-llm SDK resolve credentials from environment variables automatically. This enables the `ANY_LLM_KEY` managed platform as a key vault (matching the porchsongs pattern) while also supporting standard per-provider env vars like `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`.

Fixes #81

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented the feature, wrote tests, updated docs)
- [ ] No AI used