### PR TITLE
fix: replace non-existent api_key with api_base in heartbeat

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -205,7 +205,7 @@ async def evaluate_heartbeat_need(db: Session, contractor: Contractor) -> Heartb
     response = await acompletion(
         model=settings.llm_model,
         provider=settings.llm_provider,
-        api_key=settings.llm_api_key,
+        api_base=settings.llm_api_base,
         messages=[
             {"role": "system", "content": prompt},
             {"role": "user", "content": "Evaluate whether to send a proactive message now."},

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -185,7 +185,7 @@ class TestEvaluateHeartbeatNeed:
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
         mock_settings.llm_provider = "openai"
-        mock_settings.llm_api_key = ""
+        mock_settings.llm_api_base = None
         mock_llm.return_value = _make_llm_response(
             json.dumps(
                 {
@@ -212,7 +212,7 @@ class TestEvaluateHeartbeatNeed:
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
         mock_settings.llm_provider = "openai"
-        mock_settings.llm_api_key = ""
+        mock_settings.llm_api_base = None
         mock_llm.return_value = _make_llm_response(
             json.dumps(
                 {
@@ -230,6 +230,29 @@ class TestEvaluateHeartbeatNeed:
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.acompletion")
+    async def test_passes_api_base_not_api_key(
+        self,
+        mock_llm: AsyncMock,
+        mock_settings: MagicMock,
+        db: Session,
+        contractor: Contractor,
+    ) -> None:
+        """Regression test: acompletion must receive api_base, not api_key."""
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_api_base = "http://localhost:1234/v1"
+        mock_llm.return_value = _make_llm_response(
+            json.dumps({"action": "no_action", "message": "", "reasoning": "test", "priority": 1})
+        )
+        await evaluate_heartbeat_need(db, contractor)
+        _, kwargs = mock_llm.call_args
+        assert "api_base" in kwargs
+        assert kwargs["api_base"] == "http://localhost:1234/v1"
+        assert "api_key" not in kwargs
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.settings")
+    @patch("backend.app.agent.heartbeat.acompletion")
     async def test_malformed_response(
         self,
         mock_llm: AsyncMock,
@@ -239,7 +262,7 @@ class TestEvaluateHeartbeatNeed:
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
         mock_settings.llm_provider = "openai"
-        mock_settings.llm_api_key = ""
+        mock_settings.llm_api_base = None
         mock_llm.return_value = _make_llm_response("I'm not sure what to do {broken json")
         action = await evaluate_heartbeat_need(db, contractor)
         assert action.action_type == "no_action"


### PR DESCRIPTION
## Description
The heartbeat evaluator passed `api_key=settings.llm_api_key` to `acompletion()`, but `llm_api_key` does not exist in the `Settings` class. This caused an `AttributeError` at runtime whenever the heartbeat tick fired. Changed to `api_base=settings.llm_api_base` to match the pattern in `core.py` and `vision.py`.

Fixes #93

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — identified bug during demo readiness audit, implemented fix and regression test)
- [ ] No AI used