### PR TITLE
fix: heartbeat acompletion passes non-existent api_key setting

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -3,7 +3,7 @@
 Every ``heartbeat_interval_minutes`` the scheduler wakes up, iterates over
 onboarded contractors, and asks the LLM whether any proactive outreach is
 warranted.  Most ticks produce **no** outbound messages — only genuinely
-useful reminders or follow-ups trigger SMS.
+useful reminders or follow-ups trigger a message.
 """
 
 from __future__ import annotations
@@ -58,7 +58,7 @@ contractor needs a proactive check-in message RIGHT NOW.
   * Follow-up questions the contractor asked you to remind them about
   * Useful daily summary if there is something worth summarising
 - NEVER reach out just to say hi or ask how the day is going.
-- Keep the message under 160 characters (single SMS segment).
+- Keep the message under 160 characters.
 
 Respond with ONLY a JSON object (no markdown fences):
 {{"action": "send_message" | "no_action", "message": "...", "reasoning": "...", "priority": 1-5}}
@@ -205,7 +205,7 @@ async def evaluate_heartbeat_need(db: Session, contractor: Contractor) -> Heartb
     response = await acompletion(
         model=settings.llm_model,
         provider=settings.llm_provider,
-        api_key=settings.llm_api_key,
+        api_base=settings.llm_api_base,
         messages=[
             {"role": "system", "content": prompt},
             {"role": "user", "content": "Evaluate whether to send a proactive message now."},

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -185,7 +185,7 @@ class TestEvaluateHeartbeatNeed:
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
         mock_settings.llm_provider = "openai"
-        mock_settings.llm_api_key = ""
+        mock_settings.llm_api_base = None
         mock_llm.return_value = _make_llm_response(
             json.dumps(
                 {
@@ -212,7 +212,7 @@ class TestEvaluateHeartbeatNeed:
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
         mock_settings.llm_provider = "openai"
-        mock_settings.llm_api_key = ""
+        mock_settings.llm_api_base = None
         mock_llm.return_value = _make_llm_response(
             json.dumps(
                 {
@@ -239,7 +239,7 @@ class TestEvaluateHeartbeatNeed:
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
         mock_settings.llm_provider = "openai"
-        mock_settings.llm_api_key = ""
+        mock_settings.llm_api_base = None
         mock_llm.return_value = _make_llm_response("I'm not sure what to do {broken json")
         action = await evaluate_heartbeat_need(db, contractor)
         assert action.action_type == "no_action"


### PR DESCRIPTION
## Summary

- Replace `api_key=settings.llm_api_key` with `api_base=settings.llm_api_base` in heartbeat evaluator to match `core.py` and the current `Settings` class (which dropped `llm_api_key` during the Twilio→Telegram migration)
- Update test mocks from `llm_api_key` to `llm_api_base`
- Remove "SMS" references from heartbeat prompt (messaging is now channel-agnostic)

Closes #93

## Test plan

- [x] 180 tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)