### PR TITLE
feat: add Telegram chat ID allowlist for demo auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ PREMIUM_PLUGIN=
 MESSAGING_PROVIDER=telegram
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
+# Comma-separated list of allowed Telegram chat IDs (empty = allow all)
+# TELEGRAM_ALLOWED_CHAT_IDS=123456789,987654321
 
 # E2E testing: Telegram chat_id to send test messages to
 TELEGRAM_TEST_CHAT_ID=

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     messaging_provider: str = "telegram"
     telegram_bot_token: str = ""
     telegram_webhook_secret: str = ""
+    telegram_allowed_chat_ids: str = ""  # Comma-separated allowlist; empty = allow all
 
     # LLM
     llm_provider: str = "openai"

--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -140,6 +140,13 @@ async def telegram_inbound(
     text = msg.get("text", "")
     update_id = str(update.get("update_id", ""))
 
+    # Allowlist gate: reject unknown chat IDs when allowlist is configured
+    if settings.telegram_allowed_chat_ids:
+        allowed = {cid.strip() for cid in settings.telegram_allowed_chat_ids.split(",")}
+        if chat_id not in allowed:
+            logger.info("Chat %s not in allowlist, ignoring", chat_id)
+            return JSONResponse(content={"ok": True})
+
     # Extract media
     media_items = _extract_telegram_media(update)
     media_urls: list[tuple[str, str]] = media_items

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -225,3 +225,59 @@ def test_webhook_non_message_update_returns_200(client: TestClient) -> None:
     response = client.post("/api/webhooks/telegram", json=payload)
     assert response.status_code == 200
     assert response.json() == {"ok": True}
+
+
+# -- Allowlist gating tests --
+
+
+def test_allowlist_rejects_unlisted_chat_id(client: TestClient, db_session: Session) -> None:
+    """Messages from a chat_id not in the allowlist should be silently ignored."""
+    with (
+        patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h,
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
+            "111,222",
+        ),
+    ):
+        payload = make_telegram_update_payload(chat_id=999, text="Hi")
+        response = client.post("/api/webhooks/telegram", json=payload)
+
+    assert response.status_code == 200
+    mock_h.assert_not_called()
+    assert db_session.query(Message).count() == 0
+
+
+def test_allowlist_accepts_listed_chat_id(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Messages from a chat_id on the allowlist should be processed normally."""
+    chat_id = test_contractor.channel_identifier
+    with (
+        patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h,
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
+            f"111,{chat_id},333",
+        ),
+    ):
+        payload = make_telegram_update_payload(chat_id=int(chat_id), text="Hello")
+        response = client.post("/api/webhooks/telegram", json=payload)
+
+    assert response.status_code == 200
+    mock_h.assert_called_once()
+    assert db_session.query(Message).count() == 1
+
+
+def test_allowlist_empty_allows_all(client: TestClient, db_session: Session) -> None:
+    """Empty allowlist (default) should allow all chat IDs."""
+    with (
+        patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h,
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
+            "",
+        ),
+    ):
+        payload = make_telegram_update_payload(chat_id=777777, text="Hi")
+        response = client.post("/api/webhooks/telegram", json=payload)
+
+    assert response.status_code == 200
+    mock_h.assert_called_once()


### PR DESCRIPTION
## Description

Adds a simple `TELEGRAM_ALLOWED_CHAT_IDS` env var (comma-separated) that gates the Telegram webhook. Messages from unlisted chat IDs are silently ignored — no contractor record is created, no agent pipeline runs. Empty (default) allows all users for backwards compatibility.

Full multi-tenant auth via the premium plugin architecture is tracked in #100.

Fixes #99

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented allowlist gate, tests, and config)
- [ ] No AI used