### PR TITLE
feat: switch integration tests from LM Studio to Claude Haiku

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,41 +40,17 @@ jobs:
       - run: uv sync --all-extras
       - run: uv run pytest -m e2e -v --timeout=60
 
-  integration-lmstudio:
+  integration:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     env:
       DATABASE_URL: "sqlite:///:memory:"
-      LLM_PROVIDER: lmstudio
-      LLM_MODEL: google/gemma-3-4b
-      LLM_API_BASE: "http://localhost:1234/v1"
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
       - run: uv sync --all-extras
-
-      - name: Install LM Studio CLI
-        run: curl -fsSL https://lmstudio.ai/install.sh | bash
-
-      - name: Cache LM Studio models
-        uses: actions/cache@v4
-        with:
-          path: ~/.lmstudio
-          key: lmstudio-gemma-3-4b-${{ hashFiles('pyproject.toml') }}
-
-      - name: Download model
-        run: lms get google/gemma-3-4b --yes
-
-      - name: Start LM Studio server
-        run: |
-          lms load google/gemma-3-4b --yes &
-          lms server start
-
-      - name: Wait for LM Studio
-        run: timeout 120 bash -c 'until curl -s http://localhost:1234/v1/models >/dev/null; do sleep 1; done'
-
-      - name: Run integration tests
-        run: uv run pytest -m integration -v --timeout=120
+      - run: uv run pytest -m integration -v --timeout=120
 
   migration-check:
     runs-on: ubuntu-latest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,7 @@
-"""Shared fixtures for integration tests that hit a local LLM server."""
+"""Shared fixtures for integration tests that hit a real LLM API."""
 
 import os
 
-import httpx
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -11,21 +10,11 @@ from sqlalchemy.pool import StaticPool
 from backend.app.database import Base
 from backend.app.models import Contractor
 
-_LMSTUDIO_URL = "http://localhost:1234/v1"
+_ANTHROPIC_MODEL = "claude-haiku-4-5-latest"
 
-
-def _lmstudio_available() -> bool:
-    """Check if LM Studio is reachable."""
-    try:
-        resp = httpx.get(f"{_LMSTUDIO_URL}/models", timeout=2)
-        return resp.status_code == 200
-    except httpx.ConnectError:
-        return False
-
-
-skip_without_lmstudio = pytest.mark.skipif(
-    not _lmstudio_available(),
-    reason="LM Studio not available at localhost:1234",
+skip_without_anthropic_key = pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set",
 )
 
 
@@ -75,9 +64,3 @@ def onboarded_contractor(integration_db: Session) -> Contractor:
     integration_db.commit()
     integration_db.refresh(contractor)
     return contractor
-
-
-@pytest.fixture()
-def lmstudio_model() -> str:
-    """The model loaded in LM Studio (override via LLM_MODEL env var)."""
-    return os.environ.get("LLM_MODEL", "google/gemma-3-4b")

--- a/tests/integration/test_heartbeat_integration.py
+++ b/tests/integration/test_heartbeat_integration.py
@@ -3,9 +3,8 @@
 Verifies that evaluate_heartbeat_need() returns valid JSON from a real
 model and that the full heartbeat pipeline handles real LLM responses.
 
-Requires LM Studio running locally:
-    1. Start LM Studio and load a model
-    2. uv run pytest -m integration -v --timeout=120
+Requires ANTHROPIC_API_KEY set in environment:
+    ANTHROPIC_API_KEY=sk-... uv run pytest -m integration -v --timeout=120
 """
 
 from unittest.mock import patch
@@ -16,21 +15,20 @@ from sqlalchemy.orm import Session
 from backend.app.agent.heartbeat import evaluate_heartbeat_need
 from backend.app.models import Contractor, Conversation, Estimate, Message
 
-from .conftest import _LMSTUDIO_URL, skip_without_lmstudio
+from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
 
 
 @pytest.mark.integration()
-@skip_without_lmstudio
+@skip_without_anthropic_key
 async def test_heartbeat_evaluate_returns_valid_action(
     integration_db: Session,
     onboarded_contractor: Contractor,
-    lmstudio_model: str,
 ) -> None:
     """evaluate_heartbeat_need() should return a valid HeartbeatAction from a real LLM."""
     with patch("backend.app.agent.heartbeat.settings") as mock_settings:
-        mock_settings.llm_provider = "lmstudio"
-        mock_settings.llm_model = lmstudio_model
-        mock_settings.llm_api_base = _LMSTUDIO_URL
+        mock_settings.llm_provider = "anthropic"
+        mock_settings.llm_model = _ANTHROPIC_MODEL
+        mock_settings.llm_api_base = None
 
         action = await evaluate_heartbeat_need(integration_db, onboarded_contractor)
 
@@ -41,11 +39,10 @@ async def test_heartbeat_evaluate_returns_valid_action(
 
 
 @pytest.mark.integration()
-@skip_without_lmstudio
+@skip_without_anthropic_key
 async def test_heartbeat_evaluate_with_context(
     integration_db: Session,
     onboarded_contractor: Contractor,
-    lmstudio_model: str,
 ) -> None:
     """Heartbeat should handle a contractor with real conversation history and pending estimates."""
     # Set up conversation with messages
@@ -77,9 +74,9 @@ async def test_heartbeat_evaluate_with_context(
     integration_db.commit()
 
     with patch("backend.app.agent.heartbeat.settings") as mock_settings:
-        mock_settings.llm_provider = "lmstudio"
-        mock_settings.llm_model = lmstudio_model
-        mock_settings.llm_api_base = _LMSTUDIO_URL
+        mock_settings.llm_provider = "anthropic"
+        mock_settings.llm_model = _ANTHROPIC_MODEL
+        mock_settings.llm_api_base = None
 
         action = await evaluate_heartbeat_need(integration_db, onboarded_contractor)
 

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -1,11 +1,10 @@
 """Integration tests that exercise the real acompletion() call path.
 
-These tests require a local LM Studio server running on port 1234.
+These tests require ANTHROPIC_API_KEY set in the environment.
 They are skipped by default and only run via ``pytest -m integration``.
 
 Run locally:
-    1. Start LM Studio and load a model
-    2. uv run pytest -m integration -v --timeout=120
+    ANTHROPIC_API_KEY=sk-... uv run pytest -m integration -v --timeout=120
 """
 
 from unittest.mock import patch
@@ -16,21 +15,20 @@ from sqlalchemy.orm import Session
 from backend.app.agent.core import BackshopAgent
 from backend.app.models import Contractor
 
-from .conftest import _LMSTUDIO_URL, skip_without_lmstudio
+from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
 
 
 @pytest.mark.integration()
-@skip_without_lmstudio
+@skip_without_anthropic_key
 async def test_agent_returns_nonempty_reply(
     integration_db: Session,
     integration_contractor: Contractor,
-    lmstudio_model: str,
 ) -> None:
     """BackshopAgent.process_message() should return a non-empty reply from a real LLM."""
     with patch("backend.app.agent.core.settings") as mock_settings:
-        mock_settings.llm_provider = "lmstudio"
-        mock_settings.llm_model = lmstudio_model
-        mock_settings.llm_api_base = _LMSTUDIO_URL
+        mock_settings.llm_provider = "anthropic"
+        mock_settings.llm_model = _ANTHROPIC_MODEL
+        mock_settings.llm_api_base = None
 
         agent = BackshopAgent(db=integration_db, contractor=integration_contractor)
         response = await agent.process_message(
@@ -43,17 +41,16 @@ async def test_agent_returns_nonempty_reply(
 
 
 @pytest.mark.integration()
-@skip_without_lmstudio
+@skip_without_anthropic_key
 async def test_agent_message_format_accepted(
     integration_db: Session,
     integration_contractor: Contractor,
-    lmstudio_model: str,
 ) -> None:
     """The full system prompt + conversation history format should be accepted by a real LLM."""
     with patch("backend.app.agent.core.settings") as mock_settings:
-        mock_settings.llm_provider = "lmstudio"
-        mock_settings.llm_model = lmstudio_model
-        mock_settings.llm_api_base = _LMSTUDIO_URL
+        mock_settings.llm_provider = "anthropic"
+        mock_settings.llm_model = _ANTHROPIC_MODEL
+        mock_settings.llm_api_base = None
 
         agent = BackshopAgent(db=integration_db, contractor=integration_contractor)
         history = [
@@ -71,15 +68,14 @@ async def test_agent_message_format_accepted(
 
 
 @pytest.mark.integration()
-@skip_without_lmstudio
-async def test_acompletion_direct_call(lmstudio_model: str) -> None:
-    """Verify acompletion() works directly with lmstudio provider."""
+@skip_without_anthropic_key
+async def test_acompletion_direct_call() -> None:
+    """Verify acompletion() works directly with anthropic provider."""
     from any_llm import acompletion
 
     response = await acompletion(
-        model=lmstudio_model,
-        provider="lmstudio",
-        api_base=_LMSTUDIO_URL,
+        model=_ANTHROPIC_MODEL,
+        provider="anthropic",
         messages=[
             {"role": "system", "content": "Reply with exactly: HELLO"},
             {"role": "user", "content": "Say hello"},


### PR DESCRIPTION
## Description

Replaces LM Studio dependency in integration tests with the Anthropic API using `claude-haiku-4-5-latest`. The old CI job required installing the LM Studio CLI, downloading a model, and starting a local server (~25 lines). The new job just passes `ANTHROPIC_API_KEY` from secrets (~6 lines).

Fixes #102

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — updated integration test fixtures, test files, and CI workflow)
- [ ] No AI used