### PR TITLE
fix: add anthropic package dependency for integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "psycopg2-binary>=2.9",
     "python-multipart>=0.0.9",
     "httpx>=0.27",
-    "any-llm-sdk>=1.8",
+    "any-llm-sdk[anthropic]>=1.8",
     "any-agent>=1.18",
     "python-telegram-bot>=22.0",
     "reportlab>=4.0",
@@ -54,6 +54,6 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
     "e2e: end-to-end tests that hit real external services (Telegram, etc.)",
-    "integration: integration tests that require a local LLM server (LM Studio)",
+    "integration: integration tests that call a real LLM API (requires ANTHROPIC_API_KEY)",
 ]
 addopts = "-m 'not e2e and not integration'"


### PR DESCRIPTION
## Description

`any-llm-sdk` needs the `[anthropic]` extra to use the Anthropic provider. Without it, all 5 integration tests fail with `ModuleNotFoundError: No module named 'anthropic'` in CI.

Changes `any-llm-sdk>=1.8` → `any-llm-sdk[anthropic]>=1.8` in `pyproject.toml` and updates the integration marker description from "LM Studio" to "Anthropic".

Fixes #104

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used