### PR TITLE
docs: add TELEGRAM_ALLOWED_CHAT_IDS to README env var table

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Edit `.env` and fill in the required credentials:
 | `LLM_MODEL` | No | Model to use (default: `gpt-4o`) |
 | `STORAGE_PROVIDER` | No | `dropbox` or `google_drive` for file cataloging |
 | `DROPBOX_ACCESS_TOKEN` | No | Dropbox token (if using Dropbox storage) |
+| `TELEGRAM_ALLOWED_CHAT_IDS` | No | Comma-separated allowlist of Telegram chat IDs (empty = allow all) |
 | `ANY_LLM_KEY` | No | any-llm.ai managed platform key (replaces individual provider keys) |
 
 *Set the API key env var for your chosen provider (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) — or set `ANY_LLM_KEY` to use the [any-llm.ai](https://any-llm.ai) managed platform as a key vault for all providers.


### PR DESCRIPTION
## Description

Adds `TELEGRAM_ALLOWED_CHAT_IDS` to the README's environment variable table. This was added in #101 but only documented in `.env.example`.

Fixes #109

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used