### PR TITLE
feat: add Telegram username allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 # Comma-separated list of allowed Telegram chat IDs (empty = allow all)
 # TELEGRAM_ALLOWED_CHAT_IDS=123456789,987654321
+# Comma-separated list of allowed Telegram usernames (empty = allow all)
+# If both are set, a message is allowed if EITHER matches.
+# TELEGRAM_ALLOWED_USERNAMES=alice,bob
 
 # E2E testing: Telegram chat_id to send test messages to
 TELEGRAM_TEST_CHAT_ID=

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Edit `.env` and fill in the required credentials:
 | `STORAGE_PROVIDER` | No | `dropbox` or `google_drive` for file cataloging |
 | `DROPBOX_ACCESS_TOKEN` | No | Dropbox token (if using Dropbox storage) |
 | `TELEGRAM_ALLOWED_CHAT_IDS` | No | Comma-separated allowlist of Telegram chat IDs (empty = allow all) |
+| `TELEGRAM_ALLOWED_USERNAMES` | No | Comma-separated allowlist of Telegram usernames (empty = allow all) |
 | `ANY_LLM_KEY` | No | any-llm.ai managed platform key (replaces individual provider keys) |
 
 *Set the API key env var for your chosen provider (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) — or set `ANY_LLM_KEY` to use the [any-llm.ai](https://any-llm.ai) managed platform as a key vault for all providers.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     telegram_bot_token: str = ""
     telegram_webhook_secret: str = ""
     telegram_allowed_chat_ids: str = ""  # Comma-separated allowlist; empty = allow all
+    telegram_allowed_usernames: str = ""  # Comma-separated @usernames; empty = allow all
 
     # LLM
     llm_provider: str = "openai"

--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -140,12 +140,28 @@ async def telegram_inbound(
     text = msg.get("text", "")
     update_id = str(update.get("update_id", ""))
 
-    # Allowlist gate: reject unknown chat IDs when allowlist is configured
+    # Allowlist gate: reject messages when allowlists are configured and neither matches
+    username = msg.get("from", {}).get("username", "")
+    chat_id_match = False
+    username_match = False
+
     if settings.telegram_allowed_chat_ids:
-        allowed = {cid.strip() for cid in settings.telegram_allowed_chat_ids.split(",")}
-        if chat_id not in allowed:
-            logger.info("Chat %s not in allowlist, ignoring", chat_id)
-            return JSONResponse(content={"ok": True})
+        allowed_ids = {cid.strip() for cid in settings.telegram_allowed_chat_ids.split(",")}
+        chat_id_match = chat_id in allowed_ids
+
+    if settings.telegram_allowed_usernames:
+        allowed_users = {
+            u.strip().lstrip("@").lower() for u in settings.telegram_allowed_usernames.split(",")
+        }
+        username_match = username.lower() in allowed_users if username else False
+
+    # If any allowlist is configured, at least one must match (OR logic)
+    any_allowlist_configured = bool(
+        settings.telegram_allowed_chat_ids or settings.telegram_allowed_usernames
+    )
+    if any_allowlist_configured and not (chat_id_match or username_match):
+        logger.info("Chat %s / @%s not in allowlist, ignoring", chat_id, username)
+        return JSONResponse(content={"ok": True})
 
     # Extract media
     media_items = _extract_telegram_media(update)

--- a/tests/mocks/telegram.py
+++ b/tests/mocks/telegram.py
@@ -9,15 +9,20 @@ def make_telegram_update_payload(
     document_file_id: str | None = None,
     document_mime_type: str = "application/pdf",
     first_name: str = "Test",
+    username: str | None = None,
 ) -> dict:
     """Build a realistic Telegram webhook Update JSON payload."""
+    from_obj: dict = {
+        "id": chat_id,
+        "is_bot": False,
+        "first_name": first_name,
+    }
+    if username is not None:
+        from_obj["username"] = username
+
     msg: dict = {
         "message_id": message_id,
-        "from": {
-            "id": chat_id,
-            "is_bot": False,
-            "first_name": first_name,
-        },
+        "from": from_obj,
         "chat": {
             "id": chat_id,
             "first_name": first_name,

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -238,6 +238,10 @@ def test_allowlist_rejects_unlisted_chat_id(client: TestClient, db_session: Sess
             "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
             "111,222",
         ),
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames",
+            "",
+        ),
     ):
         payload = make_telegram_update_payload(chat_id=999, text="Hi")
         response = client.post("/api/webhooks/telegram", json=payload)
@@ -258,6 +262,10 @@ def test_allowlist_accepts_listed_chat_id(
             "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
             f"111,{chat_id},333",
         ),
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames",
+            "",
+        ),
     ):
         payload = make_telegram_update_payload(chat_id=int(chat_id), text="Hello")
         response = client.post("/api/webhooks/telegram", json=payload)
@@ -275,9 +283,120 @@ def test_allowlist_empty_allows_all(client: TestClient, db_session: Session) -> 
             "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
             "",
         ),
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames",
+            "",
+        ),
     ):
         payload = make_telegram_update_payload(chat_id=777777, text="Hi")
         response = client.post("/api/webhooks/telegram", json=payload)
 
     assert response.status_code == 200
     mock_h.assert_called_once()
+
+
+# -- Username allowlist tests --
+
+
+def test_username_allowlist_accepts_listed_user(client: TestClient, db_session: Session) -> None:
+    """Messages from a username on the allowlist should be processed."""
+    with (
+        patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h,
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
+            "",
+        ),
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames",
+            "alice,bob",
+        ),
+    ):
+        payload = make_telegram_update_payload(chat_id=555, text="Hi", username="alice")
+        response = client.post("/api/webhooks/telegram", json=payload)
+
+    assert response.status_code == 200
+    mock_h.assert_called_once()
+
+
+def test_username_allowlist_rejects_unlisted_user(client: TestClient, db_session: Session) -> None:
+    """Messages from a username NOT on the allowlist should be ignored."""
+    with (
+        patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h,
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
+            "",
+        ),
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames",
+            "alice,bob",
+        ),
+    ):
+        payload = make_telegram_update_payload(chat_id=555, text="Hi", username="eve")
+        response = client.post("/api/webhooks/telegram", json=payload)
+
+    assert response.status_code == 200
+    mock_h.assert_not_called()
+    assert db_session.query(Message).count() == 0
+
+
+def test_username_allowlist_strips_at_prefix(client: TestClient, db_session: Session) -> None:
+    """Usernames with @ prefix in config should still match."""
+    with (
+        patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h,
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
+            "",
+        ),
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames",
+            "@Alice, @Bob",
+        ),
+    ):
+        payload = make_telegram_update_payload(chat_id=555, text="Hi", username="alice")
+        response = client.post("/api/webhooks/telegram", json=payload)
+
+    assert response.status_code == 200
+    mock_h.assert_called_once()
+
+
+def test_username_or_chat_id_either_passes(client: TestClient, db_session: Session) -> None:
+    """If either chat_id OR username matches, the message should be allowed."""
+    with (
+        patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h,
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
+            "999",
+        ),
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames",
+            "alice",
+        ),
+    ):
+        # chat_id doesn't match (555 != 999), but username matches
+        payload = make_telegram_update_payload(chat_id=555, text="Hi", username="alice")
+        response = client.post("/api/webhooks/telegram", json=payload)
+
+    assert response.status_code == 200
+    mock_h.assert_called_once()
+
+
+def test_username_allowlist_no_username_in_payload(client: TestClient, db_session: Session) -> None:
+    """Messages without a username should be rejected when only username allowlist is set."""
+    with (
+        patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h,
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids",
+            "",
+        ),
+        patch(
+            "backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames",
+            "alice",
+        ),
+    ):
+        # No username in payload
+        payload = make_telegram_update_payload(chat_id=555, text="Hi")
+        response = client.post("/api/webhooks/telegram", json=payload)
+
+    assert response.status_code == 200
+    mock_h.assert_not_called()
+    assert db_session.query(Message).count() == 0


### PR DESCRIPTION
## Description

Add `TELEGRAM_ALLOWED_USERNAMES` as an alternative to `TELEGRAM_ALLOWED_CHAT_IDS` for gating Telegram access. When both are set, a message is allowed if EITHER matches (OR logic). Both empty = allow all (backwards compatible). Usernames are matched case-insensitively and `@` prefixes in config are stripped.

Fixes #112

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implementation, tests, documentation)
- [ ] No AI used