### PR TITLE
feat: add LocalFileStorage backend and storage test coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,10 @@ ANTHROPIC_API_KEY=
 # instead of individual provider keys above. See https://any-llm.ai
 # ANY_LLM_KEY=
 
-# Storage ("dropbox" or "google_drive")
-STORAGE_PROVIDER=dropbox
+# Storage — "local" (default, no setup needed), "dropbox", or "google_drive"
+# Local storage saves files to data/storage/ on disk.
+# See README.md "File Storage Setup" for Dropbox/Google Drive configuration.
+STORAGE_PROVIDER=local
 DROPBOX_ACCESS_TOKEN=
 GOOGLE_DRIVE_CREDENTIALS_JSON=
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,6 +21,19 @@ uv run ruff format --check backend/ tests/
 
 Tests use in-memory SQLite — no database setup needed.
 
+## File Storage
+
+The default storage provider is `local`, which saves uploaded files to `data/storage/` on disk. No cloud credentials are needed — file cataloging works out of the box in development.
+
+```bash
+# Uploaded files appear here:
+ls data/storage/
+```
+
+To test with Dropbox or Google Drive, set `STORAGE_PROVIDER` and the corresponding credentials in `.env`. See the [README](README.md#file-storage-setup) for setup instructions.
+
+In tests, all storage is mocked via `MockStorageBackend` in `tests/mocks/storage.py` — no real filesystem or cloud calls are made.
+
 ## Troubleshooting
 
 ### Docker build fails with dependency errors

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Edit `.env` and fill in the required credentials:
 | `TELEGRAM_BOT_TOKEN` | Yes | Telegram bot token from @BotFather |
 | `LLM_PROVIDER` | No | LLM provider name (default: `openai`) |
 | `LLM_MODEL` | No | Model to use (default: `gpt-4o`) |
-| `STORAGE_PROVIDER` | No | `dropbox` or `google_drive` for file cataloging |
+| `STORAGE_PROVIDER` | No | `local` (default), `dropbox`, or `google_drive` for file cataloging |
 | `DROPBOX_ACCESS_TOKEN` | No | Dropbox token (if using Dropbox storage) |
 | `TELEGRAM_ALLOWED_CHAT_IDS` | No | Comma-separated allowlist of Telegram chat IDs (empty = allow all) |
 | `TELEGRAM_ALLOWED_USERNAMES` | No | Comma-separated allowlist of Telegram usernames (empty = allow all) |
@@ -114,6 +114,54 @@ If you set a `secret_token`, also set `TELEGRAM_WEBHOOK_SECRET` in your `.env`.
 ### 5. Test it
 
 Send a message to your bot on Telegram. Backshop will respond as an AI assistant ready to help with estimates, job tracking, and more.
+
+## File Storage Setup
+
+Backshop can catalog job photos, estimates, and documents to a storage backend. Three providers are supported:
+
+### Local (default)
+
+Works out of the box — no configuration needed. Files are saved to `data/storage/` on disk.
+
+```
+data/storage/
+├── Job Photos/
+│   └── 2026-02-28/
+│       ├── site-front.jpg
+│       └── site-back.jpg
+└── Estimates/
+    └── EST-001.pdf
+```
+
+This is ideal for development and demos. Set `STORAGE_PROVIDER=local` (or leave it unset — it's the default).
+
+### Dropbox
+
+1. Go to the [Dropbox App Console](https://www.dropbox.com/developers/apps) and create a new app
+2. Choose **Scoped access** and **Full Dropbox** (or **App folder** for sandboxed access)
+3. Under **Permissions**, enable: `files.content.write`, `files.content.read`, `sharing.write`, `sharing.read`
+4. Generate an **access token** on the app's settings page
+5. Set environment variables:
+
+```bash
+STORAGE_PROVIDER=dropbox
+DROPBOX_ACCESS_TOKEN=sl.xxxxx...
+```
+
+### Google Drive
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/) and create a project
+2. Enable the **Google Drive API**
+3. Create **OAuth 2.0 credentials** (Desktop app type)
+4. Complete the OAuth flow to get a credentials JSON
+5. Set environment variables:
+
+```bash
+STORAGE_PROVIDER=google_drive
+GOOGLE_DRIVE_CREDENTIALS_JSON='{"token": "...", "refresh_token": "...", ...}'
+```
+
+> **Multi-tenant note**: Storage is currently global — one storage account per deployment. Future versions will support per-contractor storage credentials so each contractor's files go to their own cloud account.
 
 ## Contributing
 

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -96,9 +96,17 @@ async def handle_inbound_message(
     tools.extend(create_estimate_tools(db, contractor))
 
     # Wire file tools if storage is configured
+    # TODO(multi-tenant): pass contractor to get_storage_service()
     try:
-        storage_token = settings.dropbox_access_token or settings.google_drive_credentials_json
-        if storage_token:
+        has_storage = (
+            settings.storage_provider == "local"
+            or (settings.storage_provider == "dropbox" and settings.dropbox_access_token)
+            or (
+                settings.storage_provider == "google_drive"
+                and settings.google_drive_credentials_json
+            )
+        )
+        if has_storage:
             storage = get_storage_service()
             pending_media = {m.original_url: m.content for m in downloaded_media if m.content}
             tools.extend(create_file_tools(db, contractor, storage, pending_media))

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     vision_model: str = "gpt-4o"
 
     # Storage
-    storage_provider: str = "dropbox"  # "dropbox" or "google_drive"
+    storage_provider: str = "local"  # "local", "dropbox", or "google_drive"
     dropbox_access_token: str = ""
     google_drive_credentials_json: str = ""
 

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import io
 import json
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 import dropbox
 
@@ -10,7 +13,16 @@ from backend.app.config import Settings, settings
 
 
 class StorageBackend(ABC):
-    """Abstract base for file storage providers."""
+    """Abstract base for file storage providers.
+
+    Each implementation handles a single storage destination (Dropbox, Google
+    Drive, local filesystem, etc.).  The interface is intentionally minimal so
+    that adding new backends is straightforward.
+
+    Multi-tenant note: today one backend instance is shared across all
+    contractors.  A future iteration will allow per-contractor credentials so
+    each contractor's files go to their own cloud account.
+    """
 
     @abstractmethod
     async def upload_file(self, file_bytes: bytes, path: str, filename: str) -> str:
@@ -110,10 +122,47 @@ class GoogleDriveStorage(StorageBackend):
         return files
 
 
-def get_storage_service(svc_settings: Settings | None = None) -> StorageBackend:
-    """Factory: return the configured storage backend."""
+class LocalFileStorage(StorageBackend):
+    """Local filesystem storage for development and demos."""
+
+    def __init__(self, base_dir: str = "data/storage") -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    async def upload_file(self, file_bytes: bytes, path: str, filename: str) -> str:
+        folder = self.base_dir / path.lstrip("/")
+        folder.mkdir(parents=True, exist_ok=True)
+        file_path = folder / filename
+        await asyncio.to_thread(file_path.write_bytes, file_bytes)
+        return f"file://{file_path.resolve()}"
+
+    async def create_folder(self, path: str) -> str:
+        folder = self.base_dir / path.lstrip("/")
+        folder.mkdir(parents=True, exist_ok=True)
+        return str(folder)
+
+    async def list_folder(self, path: str) -> list[dict[str, str]]:
+        folder = self.base_dir / path.lstrip("/")
+        if not folder.exists():
+            return []
+        return [{"name": f.name, "path": str(f)} for f in folder.iterdir() if f.is_file()]
+
+
+def get_storage_service(
+    svc_settings: Settings | None = None,
+    contractor: object | None = None,
+) -> StorageBackend:
+    """Factory: return the configured storage backend.
+
+    Args:
+        svc_settings: Override the global settings (useful in tests).
+        contractor: Reserved for future multi-tenant support where each
+            contractor may have their own storage credentials.
+    """
     s = svc_settings or settings
-    if s.storage_provider == "dropbox":
+    if s.storage_provider == "local":
+        return LocalFileStorage()
+    elif s.storage_provider == "dropbox":
         return DropboxStorage(s.dropbox_access_token)
     elif s.storage_provider == "google_drive":
         return GoogleDriveStorage(s.google_drive_credentials_json)

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -193,6 +193,7 @@ async def test_file_tools_wired_when_storage_configured(
     mock_messaging: MessagingService,
 ) -> None:
     """File tools should be registered when storage credentials are set."""
+    mock_settings.storage_provider = "dropbox"
     mock_settings.dropbox_access_token = "test-token"
     mock_settings.google_drive_credentials_json = ""
     mock_settings.llm_model = "gpt-4o"
@@ -224,6 +225,7 @@ async def test_file_tools_skipped_when_no_storage(
     mock_messaging: MessagingService,
 ) -> None:
     """File tools should be skipped gracefully when storage not configured."""
+    mock_settings.storage_provider = "dropbox"
     mock_settings.dropbox_access_token = ""
     mock_settings.google_drive_credentials_json = ""
     mock_settings.llm_model = "gpt-4o"

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -1,6 +1,18 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+from backend.app.services.storage_service import (
+    DropboxStorage,
+    GoogleDriveStorage,
+    LocalFileStorage,
+    get_storage_service,
+)
 from tests.mocks.storage import MockStorageBackend
+
+# ---------------------------------------------------------------------------
+# MockStorageBackend tests (existing)
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -47,11 +59,294 @@ async def test_list_empty_folder(storage: MockStorageBackend) -> None:
 
 def test_get_storage_service_invalid_provider() -> None:
     """get_storage_service should raise ValueError for unknown provider."""
-    from unittest.mock import MagicMock
-
-    from backend.app.services.storage_service import get_storage_service
-
     mock_settings = MagicMock()
     mock_settings.storage_provider = "invalid"
     with pytest.raises(ValueError, match="Unknown storage provider"):
         get_storage_service(mock_settings)
+
+
+# ---------------------------------------------------------------------------
+# Factory tests
+# ---------------------------------------------------------------------------
+
+
+def test_factory_returns_local() -> None:
+    """Factory should return LocalFileStorage for 'local' provider."""
+    mock_settings = MagicMock()
+    mock_settings.storage_provider = "local"
+    result = get_storage_service(mock_settings)
+    assert isinstance(result, LocalFileStorage)
+
+
+def test_factory_returns_dropbox() -> None:
+    """Factory should return DropboxStorage for 'dropbox' provider."""
+    mock_settings = MagicMock()
+    mock_settings.storage_provider = "dropbox"
+    mock_settings.dropbox_access_token = "fake-token"
+    with patch("backend.app.services.storage_service.dropbox.Dropbox"):
+        result = get_storage_service(mock_settings)
+    assert isinstance(result, DropboxStorage)
+
+
+# ---------------------------------------------------------------------------
+# LocalFileStorage tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def local_storage(tmp_path: object) -> LocalFileStorage:
+    return LocalFileStorage(base_dir=str(tmp_path))
+
+
+@pytest.mark.asyncio()
+async def test_local_upload_writes_file(local_storage: LocalFileStorage) -> None:
+    """LocalFileStorage should write bytes to disk and return a file:// URL."""
+    url = await local_storage.upload_file(b"photo-bytes", "/Job Photos", "site.jpg")
+    assert url.startswith("file://")
+    assert "site.jpg" in url
+    # Verify the file was actually written
+    written = local_storage.base_dir / "Job Photos" / "site.jpg"
+    assert written.read_bytes() == b"photo-bytes"
+
+
+@pytest.mark.asyncio()
+async def test_local_create_folder(local_storage: LocalFileStorage) -> None:
+    """LocalFileStorage should create the directory on disk."""
+    result = await local_storage.create_folder("/projects/2026")
+    folder = local_storage.base_dir / "projects" / "2026"
+    assert folder.is_dir()
+    assert result == str(folder)
+
+
+@pytest.mark.asyncio()
+async def test_local_list_folder(local_storage: LocalFileStorage) -> None:
+    """LocalFileStorage should list files in the directory."""
+    await local_storage.upload_file(b"a", "/docs", "a.txt")
+    await local_storage.upload_file(b"b", "/docs", "b.txt")
+
+    files = await local_storage.list_folder("/docs")
+    assert len(files) == 2
+    names = {f["name"] for f in files}
+    assert names == {"a.txt", "b.txt"}
+
+
+@pytest.mark.asyncio()
+async def test_local_list_folder_empty(local_storage: LocalFileStorage) -> None:
+    """LocalFileStorage should return [] for a non-existent folder."""
+    files = await local_storage.list_folder("/nonexistent")
+    assert files == []
+
+
+# ---------------------------------------------------------------------------
+# DropboxStorage tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_dbx_client() -> MagicMock:
+    client = MagicMock()
+    # Default: shared link creation succeeds
+    shared_link = MagicMock()
+    shared_link.url = "https://dropbox.com/s/abc/file.pdf?dl=0"
+    client.sharing_create_shared_link_with_settings.return_value = shared_link
+    # Default: list_folder returns entries
+    entry = MagicMock()
+    entry.name = "photo.jpg"
+    entry.path_display = "/photos/photo.jpg"
+    folder_result = MagicMock()
+    folder_result.entries = [entry]
+    client.files_list_folder.return_value = folder_result
+    return client
+
+
+@pytest.fixture()
+def dropbox_storage(mock_dbx_client: MagicMock) -> DropboxStorage:
+    with patch(
+        "backend.app.services.storage_service.dropbox.Dropbox", return_value=mock_dbx_client
+    ):
+        s = DropboxStorage(access_token="fake-token")
+    return s
+
+
+def test_dropbox_constructor(mock_dbx_client: MagicMock) -> None:
+    """DropboxStorage should create a Dropbox client with the token."""
+    with patch(
+        "backend.app.services.storage_service.dropbox.Dropbox", return_value=mock_dbx_client
+    ) as mock_cls:
+        DropboxStorage(access_token="my-token")
+    mock_cls.assert_called_once_with("my-token")
+
+
+@pytest.mark.asyncio()
+async def test_dropbox_upload_creates_shared_link(
+    dropbox_storage: DropboxStorage, mock_dbx_client: MagicMock
+) -> None:
+    """upload_file should call files_upload and return the shared link URL."""
+    url = await dropbox_storage.upload_file(b"data", "/docs", "file.pdf")
+    mock_dbx_client.files_upload.assert_called_once()
+    mock_dbx_client.sharing_create_shared_link_with_settings.assert_called_once_with(
+        "/docs/file.pdf"
+    )
+    assert url == "https://dropbox.com/s/abc/file.pdf?dl=0"
+
+
+@pytest.mark.asyncio()
+async def test_dropbox_upload_existing_link_fallback(
+    dropbox_storage: DropboxStorage, mock_dbx_client: MagicMock
+) -> None:
+    """When shared link creation fails, should fall back to list_shared_links."""
+    import dropbox as dbx_mod
+
+    mock_dbx_client.sharing_create_shared_link_with_settings.side_effect = (
+        dbx_mod.exceptions.ApiError("", None, None, None)
+    )
+    existing_link = MagicMock()
+    existing_link.url = "https://dropbox.com/s/existing/file.pdf?dl=0"
+    links_result = MagicMock()
+    links_result.links = [existing_link]
+    mock_dbx_client.sharing_list_shared_links.return_value = links_result
+
+    url = await dropbox_storage.upload_file(b"data", "/docs", "file.pdf")
+    assert url == "https://dropbox.com/s/existing/file.pdf?dl=0"
+
+
+@pytest.mark.asyncio()
+async def test_dropbox_upload_no_links_fallback(
+    dropbox_storage: DropboxStorage, mock_dbx_client: MagicMock
+) -> None:
+    """When both create and list fail, should return the file path."""
+    import dropbox as dbx_mod
+
+    mock_dbx_client.sharing_create_shared_link_with_settings.side_effect = (
+        dbx_mod.exceptions.ApiError("", None, None, None)
+    )
+    links_result = MagicMock()
+    links_result.links = []
+    mock_dbx_client.sharing_list_shared_links.return_value = links_result
+
+    url = await dropbox_storage.upload_file(b"data", "/docs", "file.pdf")
+    assert url == "/docs/file.pdf"
+
+
+@pytest.mark.asyncio()
+async def test_dropbox_create_folder(
+    dropbox_storage: DropboxStorage, mock_dbx_client: MagicMock
+) -> None:
+    """create_folder should call files_create_folder_v2 and return path."""
+    result = await dropbox_storage.create_folder("/Job Photos")
+    mock_dbx_client.files_create_folder_v2.assert_called_once_with("/Job Photos")
+    assert result == "/Job Photos"
+
+
+@pytest.mark.asyncio()
+async def test_dropbox_create_folder_already_exists(
+    dropbox_storage: DropboxStorage, mock_dbx_client: MagicMock
+) -> None:
+    """create_folder should suppress ApiError if folder already exists."""
+    import dropbox as dbx_mod
+
+    mock_dbx_client.files_create_folder_v2.side_effect = dbx_mod.exceptions.ApiError(
+        "", None, None, None
+    )
+    result = await dropbox_storage.create_folder("/existing")
+    assert result == "/existing"
+
+
+@pytest.mark.asyncio()
+async def test_dropbox_list_folder(
+    dropbox_storage: DropboxStorage, mock_dbx_client: MagicMock
+) -> None:
+    """list_folder should return entries as [{name, path}] dicts."""
+    files = await dropbox_storage.list_folder("/photos")
+    mock_dbx_client.files_list_folder.assert_called_once_with("/photos")
+    assert files == [{"name": "photo.jpg", "path": "/photos/photo.jpg"}]
+
+
+# ---------------------------------------------------------------------------
+# GoogleDriveStorage tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_drive_service() -> MagicMock:
+    service = MagicMock()
+    # files().create().execute() returns metadata
+    create_result = {"id": "file-123", "webViewLink": "https://drive.google.com/file/d/123/view"}
+    service.files.return_value.create.return_value.execute.return_value = create_result
+    # files().list().execute() returns file list
+    list_result = {
+        "files": [
+            {"id": "f1", "name": "photo.jpg", "webViewLink": "https://drive.google.com/f1"},
+            {"id": "f2", "name": "doc.pdf", "webViewLink": "https://drive.google.com/f2"},
+        ]
+    }
+    service.files.return_value.list.return_value.execute.return_value = list_result
+    return service
+
+
+@pytest.fixture()
+def gdrive_storage(mock_drive_service: MagicMock) -> GoogleDriveStorage:
+    s = GoogleDriveStorage(credentials_json='{"token": "fake"}')
+    s._service = mock_drive_service
+    return s
+
+
+@pytest.mark.asyncio()
+async def test_gdrive_upload_returns_web_link(
+    gdrive_storage: GoogleDriveStorage, mock_drive_service: MagicMock
+) -> None:
+    """upload_file should return the webViewLink from Google Drive."""
+    url = await gdrive_storage.upload_file(b"data", "folder-id", "doc.pdf")
+    assert url == "https://drive.google.com/file/d/123/view"
+    mock_drive_service.files.return_value.create.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_gdrive_upload_fallback_to_id(
+    gdrive_storage: GoogleDriveStorage, mock_drive_service: MagicMock
+) -> None:
+    """When webViewLink is missing, should fall back to file id."""
+    mock_drive_service.files.return_value.create.return_value.execute.return_value = {
+        "id": "file-456"
+    }
+    url = await gdrive_storage.upload_file(b"data", "folder-id", "doc.pdf")
+    assert url == "file-456"
+
+
+@pytest.mark.asyncio()
+async def test_gdrive_create_folder_returns_id(
+    gdrive_storage: GoogleDriveStorage, mock_drive_service: MagicMock
+) -> None:
+    """create_folder should create a folder and return its id."""
+    mock_drive_service.files.return_value.create.return_value.execute.return_value = {
+        "id": "folder-789"
+    }
+    result = await gdrive_storage.create_folder("/Job Photos/2026")
+    assert result == "folder-789"
+
+
+@pytest.mark.asyncio()
+async def test_gdrive_create_folder_uses_path_segment(
+    gdrive_storage: GoogleDriveStorage, mock_drive_service: MagicMock
+) -> None:
+    """create_folder should use the last path segment as the folder name."""
+    mock_drive_service.files.return_value.create.return_value.execute.return_value = {
+        "id": "folder-x"
+    }
+    await gdrive_storage.create_folder("/Job Photos/2026-02-28")
+    call_args = mock_drive_service.files.return_value.create.call_args
+    body = call_args[1]["body"] if "body" in call_args[1] else call_args[0][0]
+    assert body["name"] == "2026-02-28"
+    assert body["mimeType"] == "application/vnd.google-apps.folder"
+
+
+@pytest.mark.asyncio()
+async def test_gdrive_list_folder(
+    gdrive_storage: GoogleDriveStorage, mock_drive_service: MagicMock
+) -> None:
+    """list_folder should query with parent and return [{name, path}] dicts."""
+    files = await gdrive_storage.list_folder("folder-id")
+    assert len(files) == 2
+    assert files[0] == {"name": "photo.jpg", "path": "https://drive.google.com/f1"}
+    assert files[1] == {"name": "doc.pdf", "path": "https://drive.google.com/f2"}
+    mock_drive_service.files.return_value.list.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.84.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
+]
+
+[[package]]
 name = "any-agent"
 version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -72,6 +91,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9f/e3ae51bd4724b7a4019e935b19a877f31c040095f0f745aad7b17f904811/any_llm_sdk-1.8.6.tar.gz", hash = "sha256:ef6fd798bde3f39e85170a909fd86931399f95bd8efb8316235a2c58d47816a8", size = 133852, upload-time = "2026-02-25T15:37:36.207Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/68/14b09d305eef4c302a751c5fd45e8668c1fd8bccc8156d373c2a6cd3c4aa/any_llm_sdk-1.8.6-py3-none-any.whl", hash = "sha256:0f6cf178f9b736c9bb3d5d618709065361f3a0fb1094f2c71281c50631050aed", size = 189023, upload-time = "2026-02-25T15:37:34.528Z" },
+]
+
+[package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
 ]
 
 [[package]]
@@ -153,7 +177,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "any-agent" },
-    { name = "any-llm-sdk" },
+    { name = "any-llm-sdk", extra = ["anthropic"] },
     { name = "dropbox" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
@@ -185,7 +209,7 @@ whisper = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "any-agent", specifier = ">=1.18" },
-    { name = "any-llm-sdk", specifier = ">=1.8" },
+    { name = "any-llm-sdk", extras = ["anthropic"], specifier = ">=1.8" },
     { name = "dropbox", specifier = ">=12.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "faster-whisper", marker = "extra == 'whisper'", specifier = ">=1.0" },
@@ -502,6 +526,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `LocalFileStorage` backend for development/demos — file cataloging works out of the box with no cloud credentials
- Change default `storage_provider` from `"dropbox"` to `"local"` so it works without configuration
- Add 18 new tests covering `DropboxStorage`, `GoogleDriveStorage`, `LocalFileStorage`, and the factory (23 storage tests total)
- Update router storage gate to handle local provider (no token check needed)
- Add File Storage Setup documentation to README, DEVELOPMENT.md, and .env.example
- Prep for multi-tenant storage (optional `contractor` param on factory, docstrings, TODO)

## Test plan
- [x] All 206 tests pass (`uv run pytest -v`)
- [x] Ruff check clean (`uv run ruff check backend/ tests/`)
- [x] Ruff format clean (`uv run ruff format --check backend/ tests/`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)