### PR TITLE
feat: auto-register Telegram webhook via Cloudflare Tunnel + fix CI

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,15 @@ To test with Dropbox or Google Drive, set `STORAGE_PROVIDER` and the correspondi
 
 In tests, all storage is mocked via `MockStorageBackend` in `tests/mocks/storage.py` — no real filesystem or cloud calls are made.
 
+## Telegram Webhook (Auto-Registration)
+
+When using Docker Compose, the Telegram webhook is registered automatically on startup. The compose stack includes a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) service that creates a public HTTPS tunnel to the app. The app discovers the tunnel URL via cloudflared's metrics API and calls Telegram's `setWebhook`.
+
+- **No account required** — Cloudflare quick tunnels work without signup or auth tokens
+- **Tunnel URL** — A random `*.trycloudflare.com` URL is assigned on each start; check `docker compose logs tunnel` to see it
+
+If cloudflared is not running (e.g. running the app directly without Docker), webhook auto-registration is silently skipped.
+
 ## Troubleshooting
 
 ### Docker build fails with dependency errors

--- a/README.md
+++ b/README.md
@@ -95,25 +95,18 @@ curl http://localhost:8000/api/health
 # {"status":"ok"}
 ```
 
-### 4. Set up Telegram webhook
+### 4. Test it
 
-Create a bot via [@BotFather](https://t.me/BotFather) on Telegram. Then expose your server and set the webhook:
+The Telegram webhook is registered automatically — Docker Compose starts a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) alongside the app and calls `setWebhook` on startup. No account or auth token required. Just send a message to your bot on Telegram and Backshop will respond.
 
-```bash
-# Using ngrok
-ngrok http 8000
-
-# Set the webhook URL (replace with your tunnel URL and bot token)
-curl -X POST "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://<your-tunnel-url>/api/webhooks/telegram", "secret_token": "<optional-secret>"}'
-```
-
-If you set a `secret_token`, also set `TELEGRAM_WEBHOOK_SECRET` in your `.env`.
-
-### 5. Test it
-
-Send a message to your bot on Telegram. Backshop will respond as an AI assistant ready to help with estimates, job tracking, and more.
+> **Manual fallback**: If you need to register the webhook manually (e.g. when running without Docker), start a tunnel yourself and call `setWebhook`:
+> ```bash
+> cloudflared tunnel --url http://localhost:8000
+> # Copy the https://*.trycloudflare.com URL from the output, then:
+> curl -X POST "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
+>   -H "Content-Type: application/json" \
+>   -d '{"url": "https://<your-tunnel-url>/api/webhooks/telegram"}'
+> ```
 
 ## File Storage Setup
 

--- a/alembic/versions/002_add_heartbeat_checklist_items.py
+++ b/alembic/versions/002_add_heartbeat_checklist_items.py
@@ -1,0 +1,47 @@
+"""Add heartbeat_checklist_items table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-02-28
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "heartbeat_checklist_items",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "contractor_id",
+            sa.Integer(),
+            sa.ForeignKey("contractors.id"),
+            index=True,
+            nullable=False,
+        ),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("schedule", sa.String(50), server_default="daily", nullable=False),
+        sa.Column("active_hours", sa.String(255), server_default="", nullable=False),
+        sa.Column("last_triggered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("status", sa.String(20), server_default="active", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("heartbeat_checklist_items")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -7,12 +8,32 @@ from fastapi.middleware.cors import CORSMiddleware
 from backend.app.agent.heartbeat import heartbeat_scheduler
 from backend.app.config import settings
 from backend.app.routers import auth, estimates, health, telegram_webhook
+from backend.app.services.webhook import discover_tunnel_url, register_telegram_webhook
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     """Start/stop background services."""
     heartbeat_scheduler.start()
+
+    # Auto-register Telegram webhook via Cloudflare Tunnel (local dev convenience).
+    if settings.telegram_bot_token:
+        tunnel_url = await discover_tunnel_url()
+        if tunnel_url:
+            webhook_url = f"{tunnel_url}/api/webhooks/telegram"
+            secret = settings.telegram_webhook_secret or None
+            ok = await register_telegram_webhook(
+                settings.telegram_bot_token, webhook_url, secret=secret
+            )
+            if ok:
+                logger.info("Telegram webhook auto-registered: %s", webhook_url)
+            else:
+                logger.warning("Failed to auto-register Telegram webhook")
+        else:
+            logger.debug("Cloudflare tunnel not detected — skipping webhook auto-registration")
+
     yield
     heartbeat_scheduler.stop()
 

--- a/backend/app/services/webhook.py
+++ b/backend/app/services/webhook.py
@@ -1,0 +1,65 @@
+"""Auto-discover Cloudflare Tunnel URL and register Telegram webhook."""
+
+import asyncio
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+CLOUDFLARED_METRICS_URL = "http://tunnel:2000/quicktunnel"
+TELEGRAM_API_BASE = "https://api.telegram.org"
+
+
+async def discover_tunnel_url(
+    max_retries: int = 10,
+    delay: float = 2.0,
+    metrics_url: str = CLOUDFLARED_METRICS_URL,
+) -> str | None:
+    """Poll cloudflared metrics API for the quick-tunnel hostname.
+
+    Returns the public HTTPS URL or ``None`` if cloudflared is unreachable
+    after *max_retries* attempts.
+    """
+    for attempt in range(1, max_retries + 1):
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(metrics_url, timeout=5.0)
+                resp.raise_for_status()
+                hostname = resp.json().get("hostname", "")
+                if hostname:
+                    return f"https://{hostname}"
+        except (httpx.HTTPError, KeyError):
+            pass
+        if attempt < max_retries:
+            logger.debug("cloudflared not ready (attempt %d/%d), retrying…", attempt, max_retries)
+            await asyncio.sleep(delay)
+
+    logger.debug("Cloudflare tunnel not found after %d attempts", max_retries)
+    return None
+
+
+async def register_telegram_webhook(
+    bot_token: str,
+    webhook_url: str,
+    secret: str | None = None,
+) -> bool:
+    """Call Telegram ``setWebhook`` and return ``True`` on success."""
+    url = f"{TELEGRAM_API_BASE}/bot{bot_token}/setWebhook"
+    payload: dict[str, str] = {"url": webhook_url}
+    if secret:
+        payload["secret_token"] = secret
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json=payload, timeout=10.0)
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("ok"):
+                logger.info("Telegram webhook registered: %s", webhook_url)
+                return True
+            logger.error("Telegram setWebhook failed: %s", data)
+            return False
+    except httpx.HTTPError:
+        logger.exception("Failed to register Telegram webhook")
+        return False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,11 @@ services:
       sh -c "uv run alembic upgrade head &&
              uv run uvicorn backend.app.main:app --host 0.0.0.0 --port 8000"
 
+  tunnel:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --no-autoupdate --url http://app:8000 --metrics 0.0.0.0:2000
+    depends_on:
+      - app
+
 volumes:
   pgdata:

--- a/scripts/setup-tunnel.sh
+++ b/scripts/setup-tunnel.sh
@@ -13,20 +13,20 @@ set -euo pipefail
 
 PORT="${PORT:-8000}"
 
-# Try ngrok first, then fall back to localtunnel
-if command -v ngrok &>/dev/null; then
-    echo "Starting ngrok tunnel on port $PORT..."
-    echo "Set your Telegram webhook to: https://<ngrok-url>/api/webhooks/telegram"
-    ngrok http "$PORT"
+# Try cloudflared first, then fall back to localtunnel
+if command -v cloudflared &>/dev/null; then
+    echo "Starting Cloudflare Tunnel on port $PORT..."
+    echo "Copy the https://*.trycloudflare.com URL from the output below."
+    cloudflared tunnel --url "http://localhost:$PORT"
 elif command -v npx &>/dev/null; then
     echo "Starting localtunnel on port $PORT..."
     echo "Set your Telegram webhook to: https://<tunnel-url>/api/webhooks/telegram"
     npx localtunnel --port "$PORT"
 else
-    echo "Error: Neither ngrok nor npx (for localtunnel) found."
+    echo "Error: Neither cloudflared nor npx (for localtunnel) found."
     echo ""
     echo "Install one of:"
-    echo "  ngrok:       https://ngrok.com/download"
+    echo "  cloudflared: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
     echo "  localtunnel: npm install -g localtunnel"
     exit 1
 fi

--- a/tests/integration/test_heartbeat_integration.py
+++ b/tests/integration/test_heartbeat_integration.py
@@ -30,7 +30,9 @@ async def test_heartbeat_evaluate_returns_valid_action(
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
 
-        action = await evaluate_heartbeat_need(integration_db, onboarded_contractor)
+        action = await evaluate_heartbeat_need(
+            integration_db, onboarded_contractor, ["Test flag: check-in needed"]
+        )
 
     assert action.action_type in ("send_message", "no_action")
     assert isinstance(action.reasoning, str)
@@ -78,7 +80,11 @@ async def test_heartbeat_evaluate_with_context(
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
 
-        action = await evaluate_heartbeat_need(integration_db, onboarded_contractor)
+        action = await evaluate_heartbeat_need(
+            integration_db,
+            onboarded_contractor,
+            ["Stale draft estimate: 12x12 composite deck build"],
+        )
 
     assert action.action_type in ("send_message", "no_action")
     # If LLM decides to send, the message should be non-empty

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -1,0 +1,122 @@
+"""Tests for Cloudflare Tunnel discovery and Telegram webhook registration."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from backend.app.services.webhook import discover_tunnel_url, register_telegram_webhook
+
+CLOUDFLARED_QUICKTUNNEL_RESPONSE = {
+    "hostname": "random-words.trycloudflare.com",
+}
+
+
+@pytest.mark.asyncio
+async def test_discover_tunnel_url_success() -> None:
+    """Returns HTTPS URL from cloudflared metrics API response."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.json.return_value = CLOUDFLARED_QUICKTUNNEL_RESPONSE
+
+    with patch("backend.app.services.webhook.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        url = await discover_tunnel_url(max_retries=1, delay=0.0)
+
+    assert url == "https://random-words.trycloudflare.com"
+
+
+@pytest.mark.asyncio
+async def test_discover_tunnel_url_retries_on_failure() -> None:
+    """Retries when cloudflared isn't ready, then succeeds."""
+    error_response = httpx.Response(status_code=502, request=httpx.Request("GET", "http://x"))
+
+    success_response = Mock()
+    success_response.status_code = 200
+    success_response.raise_for_status = Mock()
+    success_response.json.return_value = CLOUDFLARED_QUICKTUNNEL_RESPONSE
+
+    with patch("backend.app.services.webhook.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [
+            httpx.HTTPStatusError("bad", request=error_response.request, response=error_response),
+            success_response,
+        ]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        url = await discover_tunnel_url(max_retries=2, delay=0.0)
+
+    assert url == "https://random-words.trycloudflare.com"
+    assert mock_client.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_discover_tunnel_url_returns_none_after_max_retries() -> None:
+    """Returns None after exhausting retries."""
+    with patch("backend.app.services.webhook.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.ConnectError("refused")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        url = await discover_tunnel_url(max_retries=3, delay=0.0)
+
+    assert url is None
+    assert mock_client.get.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_register_webhook_success() -> None:
+    """Calls Telegram API and returns True on success."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.json.return_value = {"ok": True, "result": True}
+
+    with patch("backend.app.services.webhook.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = await register_telegram_webhook(
+            bot_token="123:ABC",
+            webhook_url="https://random-words.trycloudflare.com/api/webhooks/telegram",
+            secret="mysecret",
+        )
+
+    assert result is True
+    mock_client.post.assert_called_once()
+    call_kwargs = mock_client.post.call_args
+    assert call_kwargs.kwargs["json"]["url"] == (
+        "https://random-words.trycloudflare.com/api/webhooks/telegram"
+    )
+    assert call_kwargs.kwargs["json"]["secret_token"] == "mysecret"
+
+
+@pytest.mark.asyncio
+async def test_register_webhook_failure() -> None:
+    """Handles API error and returns False."""
+    with patch("backend.app.services.webhook.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = httpx.ConnectError("network error")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = await register_telegram_webhook(
+            bot_token="123:ABC",
+            webhook_url="https://random-words.trycloudflare.com/api/webhooks/telegram",
+        )
+
+    assert result is False


### PR DESCRIPTION
## Description

Add a Cloudflare Tunnel service to docker-compose that creates a public HTTPS tunnel to the app on startup. The app discovers the tunnel URL via cloudflared's `/quicktunnel` metrics API and automatically calls Telegram's `setWebhook` — zero manual steps needed for local dev.

Also fixes two CI failures on main from #120 merge:
- Missing Alembic migration for `heartbeat_checklist_items` table (`migration-check` job)
- Integration tests calling `evaluate_heartbeat_need()` without required `flags` arg (`integration` job)

Fixes #119

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implementation, tests, and docs)
- [ ] No AI used