### PR TITLE
fix: warn when TELEGRAM_WEBHOOK_SECRET is not configured

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,6 +55,12 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     """Start/stop background services."""
     heartbeat_scheduler.start()
 
+    if settings.telegram_bot_token and not settings.telegram_webhook_secret:
+        logger.warning(
+            "TELEGRAM_WEBHOOK_SECRET is not set — webhook endpoint is unprotected. "
+            "Set TELEGRAM_WEBHOOK_SECRET to enable request validation."
+        )
+
     # Fire-and-forget: register webhook after the server is ready.
     webhook_task: asyncio.Task[None] | None = None
     if settings.telegram_bot_token:

--- a/tests/test_webhook_secret_warning.py
+++ b/tests/test_webhook_secret_warning.py
@@ -1,0 +1,112 @@
+"""Test that a warning is logged when TELEGRAM_WEBHOOK_SECRET is not configured."""
+
+import logging
+from collections.abc import Generator
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.app.database import Base, get_db
+from backend.app.main import app
+
+
+def test_warns_when_webhook_secret_not_set(caplog: "logging.LogCaptureFixture") -> None:
+    """Startup should log a warning when bot token is set but webhook secret is empty."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.telegram_bot_token = "fake-bot-token"
+        mock_settings.telegram_webhook_secret = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
+            pass
+
+    assert any("TELEGRAM_WEBHOOK_SECRET is not set" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_no_warning_when_webhook_secret_set(caplog: "logging.LogCaptureFixture") -> None:
+    """No warning should be logged when webhook secret is configured."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.telegram_bot_token = "fake-bot-token"
+        mock_settings.telegram_webhook_secret = "my-secret"
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
+            pass
+
+    assert not any("TELEGRAM_WEBHOOK_SECRET is not set" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_no_warning_when_bot_token_not_set(caplog: "logging.LogCaptureFixture") -> None:
+    """No warning when bot token is empty (Telegram not configured at all)."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.telegram_bot_token = ""
+        mock_settings.telegram_webhook_secret = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
+            pass
+
+    assert not any("TELEGRAM_WEBHOOK_SECRET is not set" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- Log a warning at startup when `TELEGRAM_WEBHOOK_SECRET` is not set but `TELEGRAM_BOT_TOKEN` is configured
- Helps developers notice their webhook endpoint is unprotected

## Test plan
- [x] New test verifies warning is logged when secret is empty
- [x] New test verifies no warning when secret is set
- [x] New test verifies no warning when bot token is not set
- [x] Existing tests pass (13 pre-existing failures unrelated to this change)
- [x] Lint/format pass

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)