### PR TITLE
fix: restrict CORS allow_origins default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
 # Database (auto-configured in Docker Compose; set for local development)
 DATABASE_URL=postgresql://backshop:backshop@localhost:5432/backshop
 
-# CORS
-CORS_ORIGINS=*
+# CORS — comma-separated list of allowed origins (no wildcard with credentials)
+# Default: http://localhost:3000,http://localhost:8000 (local dev only)
+# Production: set to your actual frontend origin(s)
+CORS_ORIGINS=http://localhost:3000,http://localhost:8000
 
 # Auth
 JWT_SECRET=change-me-in-production

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,7 +3,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str = "postgresql://backshop:backshop@localhost:5432/backshop"
-    cors_origins: str = "*"
+    cors_origins: str = "http://localhost:3000,http://localhost:8000"
     jwt_secret: str = "change-me-in-production"
     jwt_expiry_minutes: int = 15
     premium_plugin: str | None = None

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,27 @@
+from backend.app.config import Settings
+
+
+def test_default_cors_origins_are_restrictive() -> None:
+    """Default CORS origins must not be the wildcard '*'."""
+    s = Settings(
+        _env_file=None,
+        database_url="sqlite://",
+        telegram_bot_token="",
+        telegram_webhook_secret="",
+    )
+    origins = s.cors_origins.split(",")
+    assert "*" not in origins, "Default CORS origins must not contain '*'"
+    assert all(o.startswith("http") for o in origins), "Each origin must be a valid URL"
+
+
+def test_cors_origins_can_be_overridden() -> None:
+    """Operators can still set explicit origins via env/config."""
+    s = Settings(
+        _env_file=None,
+        database_url="sqlite://",
+        cors_origins="https://app.example.com,https://admin.example.com",
+        telegram_bot_token="",
+        telegram_webhook_secret="",
+    )
+    origins = s.cors_origins.split(",")
+    assert origins == ["https://app.example.com", "https://admin.example.com"]


### PR DESCRIPTION
## Summary

- Changed `cors_origins` default in `Settings` from `"*"` to `"http://localhost:3000,http://localhost:8000"` so the API is not wide-open by default
- Updated `.env.example` with the new default and documentation comments explaining configuration
- Added regression tests verifying the default is restrictive and that explicit overrides still work

Fixes #124

## Test plan

- [x] `test_default_cors_origins_are_restrictive` — verifies the Settings default does not contain `"*"` and all origins are valid URLs
- [x] `test_cors_origins_can_be_overridden` — verifies operators can still set custom origins via config
- [x] Existing test suite passes (pre-existing failures in integration tests are unrelated)
- [x] `ruff check` and `ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)