### PR TITLE
fix: add authentication to PDF estimate endpoint

### DIFF
--- a/backend/app/routers/estimates.py
+++ b/backend/app/routers/estimates.py
@@ -3,8 +3,14 @@
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
+from backend.app.auth.dependencies import get_current_user
+from backend.app.auth.scoping import get_user_estimate
+from backend.app.database import get_db
+from backend.app.models import Contractor
 
 logger = logging.getLogger(__name__)
 
@@ -14,8 +20,15 @@ PDF_DIR = Path("data/estimates")
 
 
 @router.get("/estimates/{estimate_id}/pdf")
-async def serve_estimate_pdf(estimate_id: int) -> Response:
+async def serve_estimate_pdf(
+    estimate_id: int,
+    db: Session = Depends(get_db),
+    current_user: Contractor = Depends(get_current_user),
+) -> Response:
     """Serve a generated estimate PDF by estimate ID."""
+    # Verify the estimate exists and belongs to the current user
+    get_user_estimate(db, current_user, estimate_id)
+
     pdf_path = PDF_DIR / f"{estimate_id}.pdf"
     if not pdf_path.exists():
         raise HTTPException(status_code=404, detail="Estimate PDF not found")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from backend.app.auth.dependencies import get_current_user
 from backend.app.database import Base, get_db
 from backend.app.main import app
 from backend.app.models import Contractor
@@ -64,10 +65,14 @@ def client(
     def _override_get_db() -> Generator[Session]:
         yield db_session
 
+    def _override_get_current_user() -> Contractor:
+        return test_contractor
+
     def _override_get_messaging_service() -> Generator[MessagingService]:
         yield mock_messaging_service
 
     app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_get_current_user
     app.dependency_overrides[get_messaging_service] = _override_get_messaging_service
     with patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"), TestClient(app) as c:
         yield c

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -173,16 +173,28 @@ def test_next_estimate_number_increments(
     assert _next_estimate_number(db_session, test_contractor.id) == "EST-0002"
 
 
-def test_serve_estimate_pdf_endpoint(client: TestClient) -> None:
-    """GET /api/estimates/{id}/pdf should serve existing PDF."""
-    # Create a test PDF file
+def test_serve_estimate_pdf_endpoint(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """GET /api/estimates/{id}/pdf should serve existing PDF for authenticated owner."""
+    # Create an estimate record owned by the test contractor
+    estimate = Estimate(
+        contractor_id=test_contractor.id,
+        description="Test estimate",
+        total_amount=500.0,
+    )
+    db_session.add(estimate)
+    db_session.commit()
+    db_session.refresh(estimate)
+
+    # Create a test PDF file matching the estimate ID
     pdf_dir = Path("data/estimates")
     pdf_dir.mkdir(parents=True, exist_ok=True)
-    test_pdf = pdf_dir / "999.pdf"
+    test_pdf = pdf_dir / f"{estimate.id}.pdf"
     test_pdf.write_bytes(b"%PDF-1.4 test content")
 
     try:
-        response = client.get("/api/estimates/999/pdf")
+        response = client.get(f"/api/estimates/{estimate.id}/pdf")
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/pdf"
         assert b"%PDF-1.4" in response.content
@@ -191,6 +203,57 @@ def test_serve_estimate_pdf_endpoint(client: TestClient) -> None:
 
 
 def test_serve_estimate_pdf_not_found(client: TestClient) -> None:
-    """GET /api/estimates/{id}/pdf should return 404 for missing PDF."""
+    """GET /api/estimates/{id}/pdf should return 404 for missing estimate."""
     response = client.get("/api/estimates/99999/pdf")
     assert response.status_code == 404
+
+
+def test_serve_estimate_pdf_other_user_rejected(client: TestClient, db_session: Session) -> None:
+    """GET /api/estimates/{id}/pdf should return 404 for another user's estimate."""
+    # Create a different contractor
+    other_contractor = Contractor(
+        user_id="other-user-999",
+        name="Other Contractor",
+        phone="+15559999999",
+        trade="Electrician",
+    )
+    db_session.add(other_contractor)
+    db_session.commit()
+    db_session.refresh(other_contractor)
+
+    # Create an estimate owned by the other contractor
+    estimate = Estimate(
+        contractor_id=other_contractor.id,
+        description="Other user's estimate",
+        total_amount=1000.0,
+    )
+    db_session.add(estimate)
+    db_session.commit()
+    db_session.refresh(estimate)
+
+    # Create the PDF file so we can verify auth blocks access, not file absence
+    pdf_dir = Path("data/estimates")
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    test_pdf = pdf_dir / f"{estimate.id}.pdf"
+    test_pdf.write_bytes(b"%PDF-1.4 secret content")
+
+    try:
+        response = client.get(f"/api/estimates/{estimate.id}/pdf")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Estimate not found"
+    finally:
+        test_pdf.unlink()
+
+
+def test_serve_estimate_pdf_requires_auth_dependency() -> None:
+    """The PDF endpoint must declare get_current_user as a dependency."""
+    import inspect
+
+    from backend.app.auth.dependencies import get_current_user
+    from backend.app.routers.estimates import serve_estimate_pdf
+
+    sig = inspect.signature(serve_estimate_pdf)
+    dependencies = {
+        p.default.dependency for p in sig.parameters.values() if hasattr(p.default, "dependency")
+    }
+    assert get_current_user in dependencies, "serve_estimate_pdf must use Depends(get_current_user)"


### PR DESCRIPTION
## Summary
- Add `Depends(get_current_user)` and `Depends(get_db)` to `GET /api/estimates/{estimate_id}/pdf` so the endpoint requires authentication
- Use existing `get_user_estimate()` scoping function to verify the estimate belongs to the requesting user, returning 404 for unauthorized access
- Override `get_current_user` in the test client fixture (`conftest.py`) to ensure consistent auth behavior across tests

## Test plan
- [x] Authenticated user can download their own estimate PDF (updated existing test)
- [x] Returns 404 when estimate doesn't exist (existing test, still passes)
- [x] Returns 404 when authenticated user tries to access another user's estimate (new regression test)
- [x] Structural test verifies `get_current_user` dependency is wired into the endpoint (new regression test)
- [x] All 12 estimate tests pass
- [x] Ruff lint and format checks pass

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)