### PR TITLE
fix: log warning when Telegram allowlists are empty

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,6 +61,16 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             "Set TELEGRAM_WEBHOOK_SECRET to enable request validation."
         )
 
+    if (
+        settings.telegram_bot_token
+        and not settings.telegram_allowed_chat_ids
+        and not settings.telegram_allowed_usernames
+    ):
+        logger.warning(
+            "No Telegram allowlist configured (TELEGRAM_ALLOWED_CHAT_IDS / "
+            "TELEGRAM_ALLOWED_USERNAMES) — bot will respond to all users."
+        )
+
     # Fire-and-forget: register webhook after the server is ready.
     webhook_task: asyncio.Task[None] | None = None
     if settings.telegram_bot_token:

--- a/tests/test_allowlist_empty_warning.py
+++ b/tests/test_allowlist_empty_warning.py
@@ -1,0 +1,155 @@
+"""Test that a warning is logged when Telegram allowlists are empty."""
+
+import logging
+from collections.abc import Generator
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.app.database import Base, get_db
+from backend.app.main import app
+
+
+def test_warns_when_both_allowlists_empty(caplog: "logging.LogCaptureFixture") -> None:
+    """Startup should warn when bot token is set but both allowlists are empty."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.telegram_bot_token = "fake-bot-token"
+        mock_settings.telegram_webhook_secret = "secret"
+        mock_settings.telegram_allowed_chat_ids = ""
+        mock_settings.telegram_allowed_usernames = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
+            pass
+
+    assert any("No Telegram allowlist configured" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_no_warning_when_chat_ids_set(caplog: "logging.LogCaptureFixture") -> None:
+    """No allowlist warning when TELEGRAM_ALLOWED_CHAT_IDS is configured."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.telegram_bot_token = "fake-bot-token"
+        mock_settings.telegram_webhook_secret = "secret"
+        mock_settings.telegram_allowed_chat_ids = "12345"
+        mock_settings.telegram_allowed_usernames = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
+            pass
+
+    assert not any("No Telegram allowlist configured" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_no_warning_when_usernames_set(caplog: "logging.LogCaptureFixture") -> None:
+    """No allowlist warning when TELEGRAM_ALLOWED_USERNAMES is configured."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.telegram_bot_token = "fake-bot-token"
+        mock_settings.telegram_webhook_secret = "secret"
+        mock_settings.telegram_allowed_chat_ids = ""
+        mock_settings.telegram_allowed_usernames = "contractor1"
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
+            pass
+
+    assert not any("No Telegram allowlist configured" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_no_allowlist_warning_when_bot_token_not_set(
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    """No allowlist warning when bot token is empty (Telegram not configured)."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.telegram_bot_token = ""
+        mock_settings.telegram_webhook_secret = ""
+        mock_settings.telegram_allowed_chat_ids = ""
+        mock_settings.telegram_allowed_usernames = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
+            pass
+
+    assert not any("No Telegram allowlist configured" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- Adds a startup WARNING log when `telegram_bot_token` is set but both `TELEGRAM_ALLOWED_CHAT_IDS` and `TELEGRAM_ALLOWED_USERNAMES` are empty, alerting developers that the bot will respond to all users
- No functional change to allowlist logic — purely informational logging

## Test plan

- [x] `test_warns_when_both_allowlists_empty` — verifies warning is logged when both allowlists are empty
- [x] `test_no_warning_when_chat_ids_set` — verifies no warning when chat IDs allowlist is configured
- [x] `test_no_warning_when_usernames_set` — verifies no warning when usernames allowlist is configured
- [x] `test_no_allowlist_warning_when_bot_token_not_set` — verifies no warning when bot token is empty (Telegram not configured)
- [x] Lint passes: `uv run ruff check backend/ tests/`
- [x] Format passes: `uv run ruff format --check backend/ tests/`

Fixes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)