### PR TITLE
fix: add rate limiting to webhook endpoint

### DIFF
--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -13,6 +13,7 @@ from backend.app.config import settings
 from backend.app.database import get_db
 from backend.app.models import Contractor, Conversation, Message
 from backend.app.services.messaging import MessagingService, get_messaging_service
+from backend.app.services.rate_limiter import check_webhook_rate_limit
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +124,7 @@ def _extract_telegram_media(
 @router.post("/webhooks/telegram")
 async def telegram_inbound(
     request: Request,
+    _rate_limit: None = Depends(check_webhook_rate_limit),
     db: Session = Depends(get_db),
     messaging_service: MessagingService = Depends(get_messaging_service),
 ) -> JSONResponse:

--- a/backend/app/services/rate_limiter.py
+++ b/backend/app/services/rate_limiter.py
@@ -1,0 +1,74 @@
+"""Simple in-memory rate limiter for webhook endpoints.
+
+This is a per-process in-memory implementation using a sliding window counter.
+It is suitable for single-process deployments. For production deployments with
+multiple workers/processes, replace this with a distributed rate limiter backed
+by Redis or similar shared storage.
+"""
+
+import time
+from collections import defaultdict
+
+from fastapi import HTTPException, Request
+
+
+class InMemoryRateLimiter:
+    """Sliding-window rate limiter that tracks request counts per key (IP address).
+
+    Args:
+        max_requests: Maximum number of requests allowed within the window.
+        window_seconds: Duration of the sliding window in seconds.
+    """
+
+    def __init__(self, max_requests: int = 30, window_seconds: int = 60) -> None:
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        # key -> list of timestamps
+        self._requests: dict[str, list[float]] = defaultdict(list)
+
+    def _get_client_ip(self, request: Request) -> str:
+        """Extract client IP from request, respecting X-Forwarded-For."""
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            # First IP in the chain is the original client
+            return forwarded.split(",")[0].strip()
+        client = request.client
+        if client:
+            return client.host
+        return "unknown"
+
+    def _prune(self, key: str, now: float) -> None:
+        """Remove timestamps outside the current window."""
+        cutoff = now - self.window_seconds
+        timestamps = self._requests[key]
+        # Find first index within the window
+        i = 0
+        while i < len(timestamps) and timestamps[i] < cutoff:
+            i += 1
+        if i > 0:
+            self._requests[key] = timestamps[i:]
+
+    def check(self, request: Request) -> None:
+        """Check rate limit for the given request. Raises 429 if exceeded."""
+        key = self._get_client_ip(request)
+        now = time.monotonic()
+        self._prune(key, now)
+
+        if len(self._requests[key]) >= self.max_requests:
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+        self._requests[key].append(now)
+
+    def reset(self) -> None:
+        """Clear all tracked requests. Useful for testing."""
+        self._requests.clear()
+
+
+# Singleton instance used by the webhook endpoint.
+# 30 requests per 60 seconds per IP address.
+webhook_rate_limiter = InMemoryRateLimiter(max_requests=30, window_seconds=60)
+
+
+def check_webhook_rate_limit(request: Request) -> None:
+    """FastAPI dependency that enforces rate limiting on the webhook endpoint."""
+    webhook_rate_limiter.check(request)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from backend.app.database import Base, get_db
 from backend.app.main import app
 from backend.app.models import Contractor
 from backend.app.services.messaging import MessagingService, get_messaging_service
+from backend.app.services.rate_limiter import webhook_rate_limiter
 
 
 @pytest.fixture()
@@ -71,6 +72,7 @@ def client(
     def _override_get_messaging_service() -> Generator[MessagingService]:
         yield mock_messaging_service
 
+    webhook_rate_limiter.reset()
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_current_user] = _override_get_current_user
     app.dependency_overrides[get_messaging_service] = _override_get_messaging_service

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,230 @@
+"""Tests for webhook rate limiting."""
+
+import time
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, Request
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.app.agent.core import AgentResponse
+from backend.app.auth.dependencies import get_current_user
+from backend.app.database import Base, get_db
+from backend.app.main import app
+from backend.app.models import Contractor
+from backend.app.services.messaging import MessagingService, get_messaging_service
+from backend.app.services.rate_limiter import InMemoryRateLimiter, check_webhook_rate_limit
+from tests.mocks.telegram import make_telegram_update_payload
+
+_MOCK_AGENT_RESPONSE = AgentResponse(reply_text="Mock reply")
+_PATCH_HANDLE = "backend.app.routers.telegram_webhook.handle_inbound_message"
+
+
+def _make_scope(
+    client_ip: str = "127.0.0.1",
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> dict:
+    """Build a minimal ASGI scope for testing."""
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/test",
+        "headers": headers or [],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": (client_ip, 12345),
+    }
+
+
+@pytest.fixture()
+def _rate_limited_client() -> Generator[TestClient]:
+    """TestClient that does NOT override the rate limiter, so rate limiting is active."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    contractor = Contractor(
+        user_id="rl-test-user",
+        name="RL Test",
+        phone="+15559999999",
+        trade="Electrician",
+        location="Seattle, WA",
+        channel_identifier="777777",
+        preferred_channel="telegram",
+    )
+    session.add(contractor)
+    session.commit()
+    session.refresh(contractor)
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    def _override_get_current_user() -> Contractor:
+        return contractor
+
+    mock_messaging = MagicMock(spec=MessagingService)
+    mock_messaging.send_text = AsyncMock(return_value="mock_msg_id")
+    mock_messaging.send_media = AsyncMock(return_value="mock_msg_id")
+    mock_messaging.send_message = AsyncMock(return_value="mock_msg_id")
+
+    def _override_get_messaging_service() -> Generator[MessagingService]:
+        yield mock_messaging
+
+    # Reset the rate limiter before each test that uses this fixture
+    from backend.app.services.rate_limiter import webhook_rate_limiter
+
+    webhook_rate_limiter.reset()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    app.dependency_overrides[get_messaging_service] = _override_get_messaging_service
+    # Explicitly remove rate limiter override so the real one is used
+    app.dependency_overrides.pop(check_webhook_rate_limit, None)
+
+    with patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"), TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+    webhook_rate_limiter.reset()
+    session.close()
+
+
+class TestInMemoryRateLimiter:
+    """Unit tests for the InMemoryRateLimiter class."""
+
+    def test_allows_requests_under_limit(self) -> None:
+        """Requests under the max limit should be allowed."""
+        limiter = InMemoryRateLimiter(max_requests=5, window_seconds=60)
+
+        for _ in range(5):
+            request = Request(_make_scope())
+            limiter.check(request)  # Should not raise
+
+    def test_blocks_requests_over_limit(self) -> None:
+        """Requests exceeding the max limit should raise 429."""
+        limiter = InMemoryRateLimiter(max_requests=3, window_seconds=60)
+
+        for _ in range(3):
+            request = Request(_make_scope())
+            limiter.check(request)
+
+        # 4th request should be blocked
+        request = Request(_make_scope())
+        with pytest.raises(HTTPException) as exc_info:
+            limiter.check(request)
+        assert exc_info.value.status_code == 429
+
+    def test_window_expiry_allows_new_requests(self) -> None:
+        """After the window expires, new requests should be allowed."""
+        limiter = InMemoryRateLimiter(max_requests=2, window_seconds=1)
+
+        # Fill the window
+        for _ in range(2):
+            request = Request(_make_scope())
+            limiter.check(request)
+
+        # Wait for the window to expire
+        time.sleep(1.1)
+
+        # Should be allowed again
+        request = Request(_make_scope())
+        limiter.check(request)  # Should not raise
+
+    def test_different_ips_tracked_independently(self) -> None:
+        """Different IPs should have independent rate limits."""
+        limiter = InMemoryRateLimiter(max_requests=2, window_seconds=60)
+
+        # IP A uses 2 requests
+        for _ in range(2):
+            limiter.check(Request(_make_scope(client_ip="10.0.0.1")))
+
+        # IP B should still be allowed
+        limiter.check(Request(_make_scope(client_ip="10.0.0.2")))  # Should not raise
+
+    def test_x_forwarded_for_header(self) -> None:
+        """Should use X-Forwarded-For header when present."""
+        limiter = InMemoryRateLimiter(max_requests=2, window_seconds=60)
+
+        # Requests from different socket IPs but same X-Forwarded-For
+        for i in range(2):
+            scope = _make_scope(
+                client_ip=f"10.0.0.{i}",
+                headers=[(b"x-forwarded-for", b"203.0.113.50, 70.41.3.18")],
+            )
+            limiter.check(Request(scope))
+
+        # 3rd request from same forwarded IP should be blocked
+        scope = _make_scope(
+            client_ip="10.0.0.99",
+            headers=[(b"x-forwarded-for", b"203.0.113.50, 70.41.3.18")],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            limiter.check(Request(scope))
+        assert exc_info.value.status_code == 429
+
+    def test_reset_clears_state(self) -> None:
+        """reset() should clear all tracked requests."""
+        limiter = InMemoryRateLimiter(max_requests=2, window_seconds=60)
+
+        for _ in range(2):
+            limiter.check(Request(_make_scope()))
+
+        limiter.reset()
+
+        # Should be allowed again after reset
+        limiter.check(Request(_make_scope()))  # Should not raise
+
+
+class TestWebhookRateLimiting:
+    """Integration tests: rate limiting on the actual webhook endpoint."""
+
+    def test_requests_under_limit_succeed(self, _rate_limited_client: TestClient) -> None:
+        """Requests under the rate limit should return 200."""
+        with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+            for i in range(5):
+                payload = make_telegram_update_payload(
+                    chat_id=777777,
+                    text=f"Message {i}",
+                    message_id=1000 + i,
+                )
+                response = _rate_limited_client.post("/api/webhooks/telegram", json=payload)
+                assert response.status_code == 200
+
+    def test_requests_over_limit_return_429(self, _rate_limited_client: TestClient) -> None:
+        """Requests exceeding the rate limit should return 429."""
+        from backend.app.services.rate_limiter import webhook_rate_limiter
+
+        # Use a small limit for testing
+        original_max = webhook_rate_limiter.max_requests
+        webhook_rate_limiter.max_requests = 3
+
+        try:
+            with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+                # First 3 should succeed
+                for i in range(3):
+                    payload = make_telegram_update_payload(
+                        chat_id=777777,
+                        text=f"Message {i}",
+                        message_id=2000 + i,
+                    )
+                    response = _rate_limited_client.post("/api/webhooks/telegram", json=payload)
+                    assert response.status_code == 200
+
+                # 4th should be rate-limited
+                payload = make_telegram_update_payload(
+                    chat_id=777777,
+                    text="Too many",
+                    message_id=2003,
+                )
+                response = _rate_limited_client.post("/api/webhooks/telegram", json=payload)
+                assert response.status_code == 429
+        finally:
+            webhook_rate_limiter.max_requests = original_max


### PR DESCRIPTION
## Summary

- Adds per-IP in-memory rate limiting (30 requests per 60 seconds) to `POST /api/webhooks/telegram` to prevent abuse and expensive LLM call floods
- New `InMemoryRateLimiter` class in `backend/app/services/rate_limiter.py` using a sliding window counter
- Applied as a `FastAPI Depends()` on the webhook endpoint; returns HTTP 429 when limit exceeded
- Respects `X-Forwarded-For` header for correct client IP behind proxies

Note: This is a per-process in-memory implementation. Production deployments with multiple workers should use Redis or similar for distributed rate limiting (documented in code comments).

Fixes #126

## Test plan

- [x] Unit tests for `InMemoryRateLimiter`: under-limit allows, over-limit returns 429, window expiry resets, independent per-IP tracking, X-Forwarded-For support, reset clears state
- [x] Integration tests: requests under limit succeed (200), requests over limit return 429
- [x] Existing tests unaffected (rate limiter reset between tests via conftest fixture)
- [x] `uv run ruff check backend/ tests/` passes
- [x] `uv run ruff format --check backend/ tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)