### PR TITLE
fix: add diagnostic logging throughout media pipeline

### DIFF
--- a/backend/app/media/download.py
+++ b/backend/app/media/download.py
@@ -1,9 +1,12 @@
 import datetime
+import logging
 from dataclasses import dataclass
 
 import httpx
 
 from backend.app.config import settings
+
+logger = logging.getLogger(__name__)
 
 MIME_EXTENSIONS: dict[str, str] = {
     "image/jpeg": ".jpg",
@@ -60,6 +63,8 @@ async def download_telegram_media(
     token = bot_token or settings.telegram_bot_token
     api_base = f"https://api.telegram.org/bot{token}"
 
+    logger.info("Downloading Telegram media: file_id=%s", file_id)
+
     async with httpx.AsyncClient() as client:
         # Step 1: get file path
         resp = await client.get(f"{api_base}/getFile", params={"file_id": file_id}, timeout=30.0)
@@ -72,6 +77,13 @@ async def download_telegram_media(
         download.raise_for_status()
 
     mime_type = download.headers.get("content-type", "application/octet-stream").split(";")[0]
+    size_bytes = len(download.content)
+    logger.info(
+        "Download complete: file_id=%s, mime_type=%s, size=%d bytes",
+        file_id,
+        mime_type,
+        size_bytes,
+    )
     filename = _generate_filename(mime_type)
 
     return DownloadedMedia(

--- a/backend/app/media/pipeline.py
+++ b/backend/app/media/pipeline.py
@@ -29,13 +29,16 @@ async def _process_single_media(
 ) -> ProcessedMedia:
     """Process a single media item based on its type."""
     category = classify_media(media.mime_type)
+    logger.debug("Media classified: %s → %s", media.mime_type, category)
     extracted_text = ""
 
     if category == "image":
         try:
             extracted_text = await analyze_image(media.content, media.mime_type, context=context)
         except Exception:
-            logger.warning("Vision analysis failed for media: %s", media.original_url)
+            logger.exception(
+                "Vision analysis failed for %s (mime_type=%s)", media.original_url, media.mime_type
+            )
             extracted_text = "[Photo — vision analysis not available]"
     elif category == "audio":
         try:

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -1,8 +1,11 @@
 import base64
+import logging
 
 from any_llm import acompletion
 
 from backend.app.config import settings
+
+logger = logging.getLogger(__name__)
 
 VISION_SYSTEM_PROMPT = (
     "You are analyzing an image sent by a contractor. "
@@ -14,6 +17,9 @@ VISION_SYSTEM_PROMPT = (
 
 async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -> str:
     """Send an image to a vision LLM and get a text description."""
+    logger.info(
+        "Sending image to vision LLM: mime_type=%s, size=%d bytes", mime_type, len(image_bytes)
+    )
     b64_image = base64.b64encode(image_bytes).decode("utf-8")
     data_url = f"data:{mime_type};base64,{b64_image}"
 
@@ -33,4 +39,5 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
         ],
         max_tokens=1000,
     )
+    logger.debug("Vision LLM response received for mime_type=%s", mime_type)
     return response.choices[0].message.content

--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -118,6 +118,12 @@ def _extract_telegram_media(
         doc_mime = doc.get("mime_type", "application/octet-stream")
         media.append((doc["file_id"], doc_mime))
 
+    if media:
+        logger.debug(
+            "Extracted %d media item(s): %s",
+            len(media),
+            [(file_id, mime_type) for file_id, mime_type in media],
+        )
     return media
 
 


### PR DESCRIPTION
## Summary
- Add INFO-level logging in `download.py` for file_id at download start and mime_type/size on completion
- Add INFO-level logging in `vision.py` before sending image to LLM (mime_type, size) and DEBUG on response
- Add DEBUG-level logging in `pipeline.py` for media classification and upgrade `logger.warning` to `logger.exception` in the vision analysis error handler to capture full tracebacks
- Add DEBUG-level logging in `telegram_webhook.py` for extracted media items (count, file_ids, mime_types)

Fixes #145

## Test plan
- [x] All 274 passing tests still pass (13 pre-existing failures on main, unrelated)
- [x] Ruff lint passes
- [x] Ruff format passes
- [ ] Deploy to staging and send a photo via Telegram — verify logs show file_id, mime_type, size at each pipeline step
- [ ] Send an unsupported file type and verify the full traceback appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)