### PR TITLE
Fix vision model fallback for non-OpenAI providers

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     llm_provider: str = "openai"
     llm_model: str = "gpt-4o"
     llm_api_base: str | None = None
-    vision_model: str = "gpt-4o"
+    vision_model: str = ""  # empty = fall back to llm_model
 
     # Storage
     storage_provider: str = "local"  # "local", "dropbox", or "google_drive"

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -29,8 +29,11 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
     if context:
         user_content.insert(0, {"type": "text", "text": context})
 
+    model = settings.vision_model or settings.llm_model
+    logger.info("Using vision model: %s (provider=%s)", model, settings.llm_provider)
+
     response = await acompletion(
-        model=settings.vision_model,
+        model=model,
         provider=settings.llm_provider,
         api_base=settings.llm_api_base,
         messages=[

--- a/tests/integration/test_vision_integration.py
+++ b/tests/integration/test_vision_integration.py
@@ -60,6 +60,7 @@ async def test_analyze_image_returns_description() -> None:
 
     with patch("backend.app.media.vision.settings") as mock_settings:
         mock_settings.vision_model = _VISION_MODEL
+        mock_settings.llm_model = _VISION_MODEL
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
 
@@ -77,6 +78,7 @@ async def test_analyze_image_with_context() -> None:
 
     with patch("backend.app.media.vision.settings") as mock_settings:
         mock_settings.vision_model = _VISION_MODEL
+        mock_settings.llm_model = _VISION_MODEL
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
 
@@ -105,6 +107,7 @@ async def test_pipeline_processes_real_image() -> None:
 
     with patch("backend.app.media.vision.settings") as mock_settings:
         mock_settings.vision_model = _VISION_MODEL
+        mock_settings.llm_model = _VISION_MODEL
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
 
@@ -136,6 +139,7 @@ async def test_mime_mismatch_raises_error() -> None:
         pytest.raises(Exception, match=r"image/jpeg.*image/png|invalid_request_error"),
     ):
         mock_settings.vision_model = _VISION_MODEL
+        mock_settings.llm_model = _VISION_MODEL
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
 

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -55,3 +55,22 @@ async def test_analyze_image_does_not_pass_api_key(mock_acompletion: object) -> 
 
     call_args = mock_acompletion.call_args  # type: ignore[union-attr]
     assert "api_key" not in call_args.kwargs
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.media.vision.acompletion")
+@patch("backend.app.media.vision.settings")
+async def test_analyze_image_falls_back_to_llm_model(
+    mock_settings: object, mock_acompletion: object
+) -> None:
+    """When vision_model is empty, should fall back to llm_model."""
+    mock_settings.vision_model = ""  # type: ignore[attr-defined]
+    mock_settings.llm_model = "claude-haiku-4-5-20251001"  # type: ignore[attr-defined]
+    mock_settings.llm_provider = "anthropic"  # type: ignore[attr-defined]
+    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
+    mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]
+
+    await analyze_image(b"fake-jpeg-bytes", "image/jpeg")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    assert call_args.kwargs["model"] == "claude-haiku-4-5-20251001"


### PR DESCRIPTION
## Description

`vision_model` was hardcoded to `gpt-4o`, which breaks image processing for anyone using Anthropic or any non-OpenAI provider. The vision call would try to use model `gpt-4o` on the Anthropic API and fail with an API error.

**Root cause of #145** — this is why sending photos to the bot via Telegram fails with "I'm having trouble processing it."

**Fix**: `vision_model` now defaults to empty string, and `vision.py` resolves it as `settings.vision_model or settings.llm_model` — matching the pattern already used by `heartbeat_model`.

**Changes:**
- `config.py`: Default `vision_model` to `""` with comment "empty = fall back to llm_model"
- `vision.py`: Resolve `model = settings.vision_model or settings.llm_model` before calling `acompletion()`
- `test_vision.py`: New test `test_analyze_image_falls_back_to_llm_model` verifying fallback
- `test_vision_integration.py`: Add `llm_model` to mock settings for completeness

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (written by Claude Code)
- [ ] No AI used