### PR TITLE
fix: infer MIME type from Telegram file path when response returns octet-stream

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    log_level: str = "INFO"
     database_url: str = "postgresql://backshop:backshop@localhost:5432/backshop"
     cors_origins: str = "http://localhost:3000,http://localhost:8000"
     jwt_secret: str = "change-me-in-production"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,13 @@ from backend.app.services.webhook import (
     wait_for_dns,
 )
 
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
+)
+# Only the app's own loggers get the configured level; third-party libraries
+# (httpcore, httpx, telegram, etc.) stay at WARNING to avoid noise.
+logging.getLogger("backend").setLevel(settings.log_level.upper())
 logger = logging.getLogger(__name__)
 
 

--- a/backend/app/media/download.py
+++ b/backend/app/media/download.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 from dataclasses import dataclass
 
 import httpx
@@ -22,6 +23,9 @@ MIME_EXTENSIONS: dict[str, str] = {
     "video/3gpp": ".3gp",
     "application/pdf": ".pdf",
 }
+
+# Reverse lookup: extension -> MIME type (e.g. ".jpg" -> "image/jpeg")
+_EXTENSION_TO_MIME: dict[str, str] = {ext: mime for mime, ext in MIME_EXTENSIONS.items()}
 
 
 @dataclass
@@ -77,6 +81,16 @@ async def download_telegram_media(
         download.raise_for_status()
 
     mime_type = download.headers.get("content-type", "application/octet-stream").split(";")[0]
+
+    # Telegram's file download endpoint often returns application/octet-stream
+    # regardless of the actual file type.  Infer from the file path extension.
+    if mime_type == "application/octet-stream":
+        ext = os.path.splitext(file_path)[1].lower()
+        inferred = _EXTENSION_TO_MIME.get(ext)
+        if inferred:
+            logger.debug("Inferred MIME type %s from file path extension %s", inferred, ext)
+            mime_type = inferred
+
     size_bytes = len(download.content)
     logger.info(
         "Download complete: file_id=%s, mime_type=%s, size=%d bytes",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - 1.1.1.1
     environment:
       DATABASE_URL: postgresql://backshop:backshop@db:5432/backshop
+      LOG_LEVEL: debug
     env_file:
       - path: .env
         required: false
@@ -32,7 +33,8 @@ services:
         condition: service_healthy
     command: >
       sh -c "uv run alembic upgrade head &&
-             uv run uvicorn backend.app.main:app --host 0.0.0.0 --port 8000"
+             uv run uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
+             --log-level $${LOG_LEVEL:-info}"
 
   tunnel:
     image: cloudflare/cloudflared:latest

--- a/tests/test_media_download.py
+++ b/tests/test_media_download.py
@@ -68,6 +68,61 @@ async def test_download_telegram_media() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_download_infers_mime_from_file_path_when_octet_stream() -> None:
+    """When Telegram returns application/octet-stream, infer MIME from file path extension."""
+    get_file_response = httpx.Response(
+        200,
+        json={"ok": True, "result": {"file_id": "abc123", "file_path": "photos/file_1.jpg"}},
+        request=httpx.Request("GET", "https://api.telegram.org/botTOKEN/getFile"),
+    )
+    download_response = httpx.Response(
+        200,
+        content=b"fake-image-bytes",
+        headers={"content-type": "application/octet-stream"},
+        request=httpx.Request("GET", "https://api.telegram.org/file/botTOKEN/photos/file_1.jpg"),
+    )
+
+    with patch("backend.app.media.download.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [get_file_response, download_response]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        result = await download_telegram_media("abc123", bot_token="TOKEN")
+
+    assert result.mime_type == "image/jpeg"
+    assert result.filename.endswith(".jpg")
+
+
+@pytest.mark.asyncio()
+async def test_download_keeps_octet_stream_for_unknown_extension() -> None:
+    """When extension is unrecognised, keep application/octet-stream as-is."""
+    get_file_response = httpx.Response(
+        200,
+        json={"ok": True, "result": {"file_id": "abc123", "file_path": "documents/file_0.xyz"}},
+        request=httpx.Request("GET", "https://api.telegram.org/botTOKEN/getFile"),
+    )
+    download_response = httpx.Response(
+        200,
+        content=b"some-bytes",
+        headers={"content-type": "application/octet-stream"},
+        request=httpx.Request("GET", "https://api.telegram.org/file/botTOKEN/documents/file_0.xyz"),
+    )
+
+    with patch("backend.app.media.download.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [get_file_response, download_response]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        result = await download_telegram_media("abc123", bot_token="TOKEN")
+
+    assert result.mime_type == "application/octet-stream"
+
+
+@pytest.mark.asyncio()
 async def test_download_telegram_media_error() -> None:
     """download_telegram_media should raise on HTTP error."""
     error_response = httpx.Response(


### PR DESCRIPTION
## Description
Telegram's file download endpoint returns `Content-Type: application/octet-stream` regardless of the actual file type. This caused the media pipeline to classify photos as "unknown" and skip vision analysis entirely — the contractor saw "I'm having trouble processing that file" instead of getting their photo analyzed.

**Root cause:** `download_telegram_media()` trusted the HTTP response content-type, but Telegram always returns `application/octet-stream` for file downloads.

**Fix:** When the response MIME type is `application/octet-stream`, infer the real type from the file path extension returned by Telegram's `getFile` API (e.g., `photos/file_1.jpg` → `image/jpeg`). Uses a reverse lookup of the existing `MIME_EXTENSIONS` dict.

Also adds configurable logging infrastructure:
- `LOG_LEVEL` setting in `config.py` (defaults to `INFO`)
- `logging.basicConfig()` in `main.py` with third-party noise suppression (`httpcore`, `httpx`, `telegram` stay at WARNING)
- Debug logging enabled by default in `docker-compose.yml`

Fixes #165

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — identified bug from debug logs, implemented fix and regression tests)
- [ ] No AI used