### PR TITLE
fix: support multiple rounds of tool calls in agent loop

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -13,6 +13,8 @@ from backend.app.models import Contractor
 
 logger = logging.getLogger(__name__)
 
+MAX_TOOL_ROUNDS = 5
+
 SYSTEM_PROMPT_TEMPLATE = """You are Backshop, an AI assistant for solo contractors.
 
 ## About {contractor_name}
@@ -93,23 +95,28 @@ class BackshopAgent:
         if temperature is not None:
             llm_kwargs["temperature"] = temperature
 
-        response = await acompletion(
-            model=settings.llm_model,
-            provider=settings.llm_provider,
-            api_base=settings.llm_api_base,
-            messages=messages,
-            tools=tool_schemas,
-            max_tokens=500,
-            **llm_kwargs,
-        )
-
-        choice = response.choices[0]
         actions_taken: list[str] = []
         memories_saved: list[dict[str, str]] = []
         tool_call_records: list[dict[str, object]] = []
+        reply_text = ""
 
-        # Handle tool calls
-        if getattr(choice.message, "tool_calls", None):
+        for _round in range(MAX_TOOL_ROUNDS):
+            response = await acompletion(
+                model=settings.llm_model,
+                provider=settings.llm_provider,
+                api_base=settings.llm_api_base,
+                messages=messages,
+                tools=tool_schemas,
+                max_tokens=500,
+                **llm_kwargs,
+            )
+
+            choice = response.choices[0]
+
+            if not getattr(choice.message, "tool_calls", None):
+                reply_text = choice.message.content or ""
+                break
+
             # Append the assistant message (with tool_calls) to conversation
             messages.append(choice.message.model_dump())
 
@@ -149,17 +156,9 @@ class BackshopAgent:
                     }
                 )
 
-            # Append tool results and make follow-up LLM call
             messages.extend(tool_results)
-            followup = await acompletion(
-                model=settings.llm_model,
-                provider=settings.llm_provider,
-                api_base=settings.llm_api_base,
-                messages=messages,
-                max_tokens=500,
-            )
-            reply_text = followup.choices[0].message.content or ""
         else:
+            # Max rounds reached — use last response content
             reply_text = choice.message.content or ""
 
         return AgentResponse(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -165,3 +165,120 @@ async def test_agent_tool_loop_includes_tool_results_in_followup(
     assert len(tool_messages) == 1
     assert tool_messages[0]["tool_call_id"] == "call_abc"
     assert "hourly_rate: $75/hr" in tool_messages[0]["content"]
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_multi_round_tool_calls(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Agent should support multiple rounds of tool calls, not just one."""
+    # Round 1: LLM calls recall_facts
+    round1_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "recall_facts",
+                "arguments": json.dumps({"query": "deck pricing"}),
+            }
+        ]
+    )
+    # Round 2: LLM calls generate_estimate
+    round2_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_2",
+                "name": "generate_estimate",
+                "arguments": json.dumps({"description": "deck build"}),
+            }
+        ]
+    )
+    # Round 3: LLM produces final text reply
+    final_response = make_text_response("Here's your estimate for the deck build!")
+
+    mock_acompletion.side_effect = [round1_response, round2_response, final_response]  # type: ignore[union-attr]
+
+    mock_recall = AsyncMock(return_value="deck: $45/sqft")
+    mock_estimate = AsyncMock(return_value="Estimate PDF generated")
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools(
+        [
+            Tool(
+                name="recall_facts",
+                description="Recall facts",
+                function=mock_recall,
+                parameters={"type": "object", "properties": {"query": {}}},
+            ),
+            Tool(
+                name="generate_estimate",
+                description="Generate estimate",
+                function=mock_estimate,
+                parameters={"type": "object", "properties": {"description": {}}},
+            ),
+        ]
+    )
+
+    response = await agent.process_message("Look up deck pricing and generate an estimate")
+
+    # Both tools should have been called
+    mock_recall.assert_called_once()
+    mock_estimate.assert_called_once()
+
+    # 3 LLM calls total (round 1 + round 2 + final)
+    assert mock_acompletion.call_count == 3  # type: ignore[union-attr]
+
+    # Final reply comes from the text response
+    assert response.reply_text == "Here's your estimate for the deck build!"
+
+    # Both tool calls should be recorded
+    assert len(response.tool_calls) == 2
+    assert response.tool_calls[0]["name"] == "recall_facts"
+    assert response.tool_calls[1]["name"] == "generate_estimate"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_tool_loop_respects_max_rounds(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Agent should stop after MAX_TOOL_ROUNDS even if LLM keeps requesting tools."""
+    from backend.app.agent.core import MAX_TOOL_ROUNDS
+
+    # Create MAX_TOOL_ROUNDS responses that all request tool calls
+    tool_responses = [
+        make_tool_call_response(
+            tool_calls=[
+                {
+                    "id": f"call_{i}",
+                    "name": "recall_facts",
+                    "arguments": json.dumps({"query": f"round {i}"}),
+                }
+            ],
+            content="Still thinking...",
+        )
+        for i in range(MAX_TOOL_ROUNDS)
+    ]
+
+    mock_acompletion.side_effect = tool_responses  # type: ignore[union-attr]
+
+    mock_recall = AsyncMock(return_value="some result")
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools(
+        [
+            Tool(
+                name="recall_facts",
+                description="Recall facts",
+                function=mock_recall,
+                parameters={"type": "object", "properties": {"query": {}}},
+            ),
+        ]
+    )
+
+    response = await agent.process_message("Keep going forever")
+
+    # Should have made exactly MAX_TOOL_ROUNDS calls, not more
+    assert mock_acompletion.call_count == MAX_TOOL_ROUNDS  # type: ignore[union-attr]
+
+    # Should still return a reply (from the last response's content)
+    assert response.reply_text == "Still thinking..."


### PR DESCRIPTION
## Description
The agent loop previously only processed one round of tool calls. After executing tools and making a follow-up LLM call, any tool calls in the follow-up response were silently ignored. This broke multi-step workflows (e.g. recall → estimate).

Replaced the single if/else with a loop (max 5 rounds) that keeps calling `acompletion` with `tool_schemas` and `**llm_kwargs` until the LLM returns a text-only response or the round limit is reached.

Fixes #167

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented fix and tests)
- [ ] No AI used