### PR TITLE
fix: guard JSON parsing of tool call arguments

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -123,7 +123,23 @@ class BackshopAgent:
             tool_results: list[dict[str, str]] = []
             for tool_call in choice.message.tool_calls:
                 tool_name = tool_call.function.name
-                tool_args = json.loads(tool_call.function.arguments)
+                try:
+                    tool_args = json.loads(tool_call.function.arguments)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Malformed tool arguments for %s: %s",
+                        tool_name,
+                        tool_call.function.arguments[:200],
+                    )
+                    tool_results.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tool_call.id,
+                            "content": f"Error: malformed arguments for {tool_name}",
+                        }
+                    )
+                    actions_taken.append(f"Failed: {tool_name} (bad args)")
+                    continue
 
                 tool_func = self._find_tool(tool_name)
                 result_str = ""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -282,3 +282,45 @@ async def test_agent_tool_loop_respects_max_rounds(
 
     # Should still return a reply (from the last response's content)
     assert response.reply_text == "Still thinking..."
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_handles_malformed_tool_arguments(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Agent should gracefully handle malformed JSON in tool call arguments."""
+    # LLM returns a tool call with invalid JSON arguments
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_bad",
+                "name": "save_fact",
+                "arguments": "{invalid json!!!",
+            }
+        ]
+    )
+    followup_response = make_text_response("Sorry, I had trouble with that.")
+
+    mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
+
+    mock_save = AsyncMock(return_value="saved")
+    tool = Tool(
+        name="save_fact",
+        description="Save a fact",
+        function=mock_save,
+        parameters={"type": "object", "properties": {"key": {}, "value": {}}},
+    )
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("My rate is $75/hour")
+
+    # Tool should NOT have been called (args were unparseable)
+    mock_save.assert_not_called()
+
+    # Agent should still produce a reply (not crash)
+    assert response.reply_text == "Sorry, I had trouble with that."
+
+    # The failure should be recorded in actions_taken
+    assert any("bad args" in a for a in response.actions_taken)


### PR DESCRIPTION
## Description
Wraps `json.loads(tool_call.function.arguments)` in a `try/except json.JSONDecodeError` so malformed JSON from the LLM doesn't crash the entire agent loop. Instead, logs a warning, returns an error tool result to the LLM, and continues processing remaining tool calls in the batch.

Fixes #169

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented fix and tests)
- [ ] No AI used