### PR TITLE
fix: include send_media_reply in duplicate-send check

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -147,8 +147,9 @@ async def handle_inbound_message(
                 contractor.onboarding_complete = True
                 db.commit()
 
-    # Step 7: If agent didn't explicitly call send_reply, send the reply text
-    sent_reply = any(tc.get("name") == "send_reply" for tc in response.tool_calls)
+    # Step 7: If agent didn't explicitly call send_reply/send_media_reply, send the reply text
+    REPLY_TOOL_NAMES = {"send_reply", "send_media_reply"}
+    sent_reply = any(tc.get("name") in REPLY_TOOL_NAMES for tc in response.tool_calls)
     if not sent_reply and response.reply_text:
         try:
             await messaging_service.send_text(to=to_address, body=response.reply_text)

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6,7 +7,7 @@ from sqlalchemy.orm import Session
 from backend.app.agent.router import handle_inbound_message
 from backend.app.models import Contractor, Conversation, Message
 from backend.app.services.messaging import MessagingService
-from tests.mocks.llm import make_text_response
+from tests.mocks.llm import make_text_response, make_tool_call_response
 from tests.mocks.storage import MockStorageBackend
 
 
@@ -608,3 +609,43 @@ async def test_pipeline_failure_without_downloaded_media_skips_vision_note(
     # but NOT the "Vision analysis was unavailable" note (that requires downloaded_media)
     assert "couldn't download" in inbound_message.processed_context.lower()
     assert "Vision analysis was unavailable" not in inbound_message.processed_context
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_send_media_reply_suppresses_duplicate_text(
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    inbound_message: Message,
+    mock_messaging: MessagingService,
+) -> None:
+    """When agent calls send_media_reply, the router should NOT also send_text."""
+    # LLM calls send_media_reply tool
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_media",
+                "name": "send_media_reply",
+                "arguments": json.dumps(
+                    {"message": "Here's your file!", "media_url": "https://example.com/file.pdf"}
+                ),
+            }
+        ]
+    )
+    # Follow-up LLM produces text that would duplicate the media reply
+    followup_response = make_text_response("I've uploaded your photo!")
+
+    mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=inbound_message,
+        media_urls=[],
+        messaging_service=mock_messaging,
+    )
+
+    # The router should detect send_media_reply and suppress the extra send_text
+    mock_messaging.send_text.assert_not_called()  # type: ignore[union-attr]
+    assert response.reply_text == "I've uploaded your photo!"


### PR DESCRIPTION
## Description
The router only checked for `send_reply` when deciding whether to suppress the fallback `send_text()` call. When the agent sent a media reply via `send_media_reply`, the contractor received a duplicate text message. Now both `send_reply` and `send_media_reply` suppress the fallback.

Fixes #168

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented fix and tests)
- [ ] No AI used