### PR TITLE
fix: use canonical get_or_create_conversation in webhook

### DIFF
--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -8,10 +8,11 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from starlette.background import BackgroundTask
 
+from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.router import handle_inbound_message
 from backend.app.config import settings
 from backend.app.database import get_db
-from backend.app.models import Contractor, Conversation, Message
+from backend.app.models import Contractor, Message
 from backend.app.services.messaging import MessagingService, get_messaging_service
 from backend.app.services.rate_limiter import check_webhook_rate_limit
 
@@ -49,21 +50,6 @@ def _get_or_create_contractor(db: Session, chat_id: str) -> Contractor:
         db.commit()
         db.refresh(contractor)
     return contractor
-
-
-def _get_or_create_conversation(db: Session, contractor: Contractor) -> Conversation:
-    """Get the active conversation or create a new one."""
-    conversation = (
-        db.query(Conversation)
-        .filter(Conversation.contractor_id == contractor.id, Conversation.is_active.is_(True))
-        .first()
-    )
-    if conversation is None:
-        conversation = Conversation(contractor_id=contractor.id)
-        db.add(conversation)
-        db.commit()
-        db.refresh(conversation)
-    return conversation
 
 
 async def _process_message_background(
@@ -187,7 +173,7 @@ async def telegram_inbound(
             return JSONResponse(content={"ok": True})
 
     contractor = _get_or_create_contractor(db, chat_id)
-    conversation = _get_or_create_conversation(db, contractor)
+    conversation, _is_new = await get_or_create_conversation(db, contractor.id)
 
     message = Message(
         conversation_id=conversation.id,

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -217,3 +217,11 @@ async def test_get_or_create_conversation_custom_timeout(
     # With 3-hour timeout, should reuse
     conv, is_new = await get_or_create_conversation(db_session, test_contractor.id, timeout_hours=3)
     assert is_new is False
+
+
+def test_webhook_uses_canonical_get_or_create_conversation() -> None:
+    """Webhook should use context.get_or_create_conversation, not a local duplicate."""
+    from backend.app.routers import telegram_webhook
+
+    # The local _get_or_create_conversation should no longer exist
+    assert not hasattr(telegram_webhook, "_get_or_create_conversation")


### PR DESCRIPTION
## Description
The webhook had its own `_get_or_create_conversation` that didn't check the conversation timeout or update `last_message_at`. Conversations in the main message flow never timed out and grew unbounded. Now uses the canonical `get_or_create_conversation` from `context.py` which respects the 4-hour timeout and updates timestamps.

Fixes #170

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented fix and tests)
- [ ] No AI used