### PR TITLE
feat: pass user parameter to acompletion for per-contractor tracking

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -91,7 +91,7 @@ class BackshopAgent:
 
         tool_schemas = [tool_to_openai_schema(t) for t in self.tools] if self.tools else None
 
-        llm_kwargs: dict[str, object] = {}
+        llm_kwargs: dict[str, object] = {"user": str(self.contractor.id)}
         if temperature is not None:
             llm_kwargs["temperature"] = temperature
 

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -337,6 +337,7 @@ async def evaluate_heartbeat_need(
             {"role": "user", "content": "Compose a proactive message based on the flags above."},
         ],
         max_tokens=300,
+        user=str(contractor.id),
     )
     raw = response.choices[0].message.content or ""
     raw = _strip_code_fences(raw)

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -15,7 +15,9 @@ VISION_SYSTEM_PROMPT = (
 )
 
 
-async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -> str:
+async def analyze_image(
+    image_bytes: bytes, mime_type: str, context: str = "", user: str | None = None
+) -> str:
     """Send an image to a vision LLM and get a text description."""
     logger.info(
         "Sending image to vision LLM: mime_type=%s, size=%d bytes", mime_type, len(image_bytes)
@@ -32,6 +34,10 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
     model = settings.vision_model or settings.llm_model
     logger.info("Using vision model: %s (provider=%s)", model, settings.llm_provider)
 
+    llm_kwargs: dict[str, object] = {}
+    if user is not None:
+        llm_kwargs["user"] = user
+
     response = await acompletion(
         model=model,
         provider=settings.llm_provider,
@@ -41,6 +47,7 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
             {"role": "user", "content": user_content},
         ],
         max_tokens=1000,
+        **llm_kwargs,
     )
     logger.debug("Vision LLM response received for mime_type=%s", mime_type)
     return response.choices[0].message.content

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -82,6 +82,21 @@ async def test_agent_does_not_pass_api_key(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.acompletion")
+async def test_agent_passes_user_parameter(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """acompletion should be called with user=contractor.id for per-user tracking."""
+    mock_acompletion.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    await agent.process_message("Hello")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    assert call_args.kwargs["user"] == str(test_contractor.id)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
 async def test_agent_tool_loop_sends_results_back(
     mock_acompletion: object, db_session: Session, test_contractor: Contractor
 ) -> None:


### PR DESCRIPTION
## Description
Passes `user=str(contractor.id)` to all `acompletion()` calls so the LLM provider can attribute usage per contractor. This enables per-user rate limiting, cost tracking, and abuse monitoring at the provider level.

- `core.py`: Added to `llm_kwargs` dict (covers all rounds in the agent loop)
- `heartbeat.py`: Added directly to heartbeat evaluation call
- `vision.py`: Added as an optional parameter to `analyze_image()` (pipeline plumbing to pass contractor ID can be added later)

Fixes #175

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented fix and tests)
- [ ] No AI used