### PR TITLE
refactor: reuse TELEGRAM_API_BASE constant in media/download.py

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,3 +43,5 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+TELEGRAM_API_BASE = "https://api.telegram.org"

--- a/backend/app/media/download.py
+++ b/backend/app/media/download.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import httpx
 
-from backend.app.config import settings
+from backend.app.config import TELEGRAM_API_BASE, settings
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ async def download_telegram_media(
     Flow: file_id -> GET /bot{token}/getFile -> file_path -> download bytes.
     """
     token = bot_token or settings.telegram_bot_token
-    api_base = f"https://api.telegram.org/bot{token}"
+    api_base = f"{TELEGRAM_API_BASE}/bot{token}"
 
     logger.info("Downloading Telegram media: file_id=%s", file_id)
 
@@ -76,7 +76,7 @@ async def download_telegram_media(
         file_path = resp.json()["result"]["file_path"]
 
         # Step 2: download the file
-        file_url = f"https://api.telegram.org/file/bot{token}/{file_path}"
+        file_url = f"{TELEGRAM_API_BASE}/file/bot{token}/{file_path}"
         download = await client.get(file_url, follow_redirects=True, timeout=30.0)
         download.raise_for_status()
 

--- a/backend/app/services/webhook.py
+++ b/backend/app/services/webhook.py
@@ -7,10 +7,11 @@ from urllib.parse import urlparse
 
 import httpx
 
+from backend.app.config import TELEGRAM_API_BASE
+
 logger = logging.getLogger(__name__)
 
 CLOUDFLARED_METRICS_URL = "http://tunnel:2000/quicktunnel"
-TELEGRAM_API_BASE = "https://api.telegram.org"
 
 
 async def discover_tunnel_url(


### PR DESCRIPTION
## Description
Moves `TELEGRAM_API_BASE` to `config.py` as a shared constant and imports it in both `webhook.py` and `download.py`, eliminating duplicated inline URL strings.

Fixes #160

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used