### PR TITLE
refactor: extract webhook retry/polling constants

### DIFF
--- a/backend/app/services/webhook.py
+++ b/backend/app/services/webhook.py
@@ -12,11 +12,15 @@ from backend.app.config import TELEGRAM_API_BASE
 logger = logging.getLogger(__name__)
 
 CLOUDFLARED_METRICS_URL = "http://tunnel:2000/quicktunnel"
+TUNNEL_DISCOVERY_MAX_RETRIES = 10
+TUNNEL_DISCOVERY_RETRY_DELAY = 2.0
+DNS_RESOLUTION_MAX_RETRIES = 30
+DNS_RESOLUTION_RETRY_DELAY = 2.0
 
 
 async def discover_tunnel_url(
-    max_retries: int = 10,
-    delay: float = 2.0,
+    max_retries: int = TUNNEL_DISCOVERY_MAX_RETRIES,
+    delay: float = TUNNEL_DISCOVERY_RETRY_DELAY,
     metrics_url: str = CLOUDFLARED_METRICS_URL,
 ) -> str | None:
     """Poll cloudflared metrics API for the quick-tunnel hostname.
@@ -44,8 +48,8 @@ async def discover_tunnel_url(
 
 async def wait_for_dns(
     url: str,
-    max_retries: int = 30,
-    delay: float = 2.0,
+    max_retries: int = DNS_RESOLUTION_MAX_RETRIES,
+    delay: float = DNS_RESOLUTION_RETRY_DELAY,
 ) -> bool:
     """Wait until the hostname in *url* is DNS-resolvable.
 


### PR DESCRIPTION
## Description
Extracts inline retry counts and delay values in `webhook.py` to named module-level constants: `TUNNEL_DISCOVERY_MAX_RETRIES`, `TUNNEL_DISCOVERY_RETRY_DELAY`, `DNS_RESOLUTION_MAX_RETRIES`, `DNS_RESOLUTION_RETRY_DELAY`.

Fixes #156

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used