### PR TITLE
refactor: extract estimate status values and checklist schedules to constants

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.memory import build_memory_context
 from backend.app.agent.profile import build_soul_prompt
+from backend.app.agent.tools.estimate_tools import EstimateStatus
 from backend.app.config import settings
 from backend.app.database import SessionLocal
 from backend.app.models import (
@@ -220,7 +221,7 @@ def run_cheap_checks(
         db.query(Estimate)
         .filter(
             Estimate.contractor_id == contractor.id,
-            Estimate.status == "draft",
+            Estimate.status == EstimateStatus.DRAFT,
             Estimate.created_at <= cutoff,
         )
         .all()

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import Session
 from backend.app.agent.tools.base import Tool
 from backend.app.models import HeartbeatChecklistItem
 
+VALID_CHECKLIST_SCHEDULES = ("daily", "weekdays", "once")
+
 
 def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
     """Create checklist-related tools for the agent."""
@@ -14,7 +16,7 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
         schedule: str = "daily",
     ) -> str:
         """Add an item to the contractor's heartbeat checklist."""
-        if schedule not in ("daily", "weekdays", "once"):
+        if schedule not in VALID_CHECKLIST_SCHEDULES:
             return f"Invalid schedule '{schedule}'. Use: daily, weekdays, or once."
         item = HeartbeatChecklistItem(
             contractor_id=contractor_id,
@@ -76,7 +78,7 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
                     },
                     "schedule": {
                         "type": "string",
-                        "enum": ["daily", "weekdays", "once"],
+                        "enum": list(VALID_CHECKLIST_SCHEDULES),
                         "description": "How often to check (default: daily)",
                     },
                 },

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -11,14 +11,20 @@ from backend.app.models import Contractor, Estimate, EstimateLineItem
 from backend.app.services.pdf_service import EstimatePDFData, generate_estimate_pdf
 
 PDF_DIR = Path("data/estimates")
+ESTIMATE_NUMBER_FORMAT = "EST-{:04d}"
 
 logger = logging.getLogger(__name__)
+
+
+class EstimateStatus:
+    DRAFT = "draft"
+    SENT = "sent"
 
 
 def _next_estimate_number(db: Session, contractor_id: int) -> str:
     """Generate the next sequential estimate number for a contractor."""
     count = db.query(Estimate).filter(Estimate.contractor_id == contractor_id).count()
-    return f"EST-{count + 1:04d}"
+    return ESTIMATE_NUMBER_FORMAT.format(count + 1)
 
 
 def create_estimate_tools(
@@ -62,7 +68,7 @@ def create_estimate_tools(
             contractor_id=contractor.id,
             description=description,
             total_amount=total_amount,
-            status="draft",
+            status=EstimateStatus.DRAFT,
         )
         db.add(estimate)
         db.flush()  # Get the ID before adding line items
@@ -105,7 +111,7 @@ def create_estimate_tools(
 
         # Update estimate with PDF URL (served by /api/estimates/{id}/pdf)
         estimate.pdf_url = f"/api/estimates/{estimate.id}/pdf"
-        estimate.status = "sent"
+        estimate.status = EstimateStatus.SENT
         db.commit()
 
         return (


### PR DESCRIPTION
## Description
- Added `EstimateStatus` class with `DRAFT` and `SENT` constants in `estimate_tools.py`
- Extracted `ESTIMATE_NUMBER_FORMAT` constant for the `EST-{:04d}` pattern
- Extracted `VALID_CHECKLIST_SCHEDULES` tuple in `checklist_tools.py`
- Updated `heartbeat.py` to use `EstimateStatus.DRAFT` instead of inline string

Fixes #161

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used