### PR TITLE
refactor: centralize LLM token limits into Settings

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -107,7 +107,7 @@ class BackshopAgent:
                 api_base=settings.llm_api_base,
                 messages=messages,
                 tools=tool_schemas,
-                max_tokens=500,
+                max_tokens=settings.llm_max_tokens_agent,
                 **llm_kwargs,
             )
 

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -340,7 +340,7 @@ async def evaluate_heartbeat_need(
             {"role": "system", "content": prompt},
             {"role": "user", "content": "Compose a proactive message based on the flags above."},
         ],
-        max_tokens=300,
+        max_tokens=settings.llm_max_tokens_heartbeat,
         user=str(contractor.id),
     )
     raw = response.choices[0].message.content or ""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,6 +21,9 @@ class Settings(BaseSettings):
     llm_model: str = "gpt-4o"
     llm_api_base: str | None = None
     vision_model: str = ""  # empty = fall back to llm_model
+    llm_max_tokens_agent: int = 500
+    llm_max_tokens_heartbeat: int = 300
+    llm_max_tokens_vision: int = 1000
 
     # Storage
     storage_provider: str = "local"  # "local", "dropbox", or "google_drive"

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -46,7 +46,7 @@ async def analyze_image(
             {"role": "system", "content": VISION_SYSTEM_PROMPT},
             {"role": "user", "content": user_content},
         ],
-        max_tokens=1000,
+        max_tokens=settings.llm_max_tokens_vision,
         **llm_kwargs,
     )
     logger.debug("Vision LLM response received for mime_type=%s", mime_type)


### PR DESCRIPTION
## Description
Adds `llm_max_tokens_agent` (500), `llm_max_tokens_heartbeat` (300), and `llm_max_tokens_vision` (1000) to Settings so token limits can be tuned per environment via env vars.

Fixes #151

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used