### PR TITLE
refactor: centralize HTTP timeout constants into Settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,6 +33,11 @@ class Settings(BaseSettings):
     # Whisper
     whisper_model_size: str = "base"
 
+    # HTTP timeouts
+    http_timeout_seconds: float = 30.0
+    cloudflared_metrics_timeout_seconds: float = 5.0
+    telegram_webhook_timeout_seconds: float = 10.0
+
     # Heartbeat
     heartbeat_enabled: bool = True
     heartbeat_interval_minutes: int = 30

--- a/backend/app/media/download.py
+++ b/backend/app/media/download.py
@@ -71,13 +71,19 @@ async def download_telegram_media(
 
     async with httpx.AsyncClient() as client:
         # Step 1: get file path
-        resp = await client.get(f"{api_base}/getFile", params={"file_id": file_id}, timeout=30.0)
+        resp = await client.get(
+            f"{api_base}/getFile",
+            params={"file_id": file_id},
+            timeout=settings.http_timeout_seconds,
+        )
         resp.raise_for_status()
         file_path = resp.json()["result"]["file_path"]
 
         # Step 2: download the file
         file_url = f"{TELEGRAM_API_BASE}/file/bot{token}/{file_path}"
-        download = await client.get(file_url, follow_redirects=True, timeout=30.0)
+        download = await client.get(
+            file_url, follow_redirects=True, timeout=settings.http_timeout_seconds
+        )
         download.raise_for_status()
 
     mime_type = download.headers.get("content-type", "application/octet-stream").split(";")[0]

--- a/backend/app/services/telegram_service.py
+++ b/backend/app/services/telegram_service.py
@@ -5,7 +5,7 @@ import mimetypes
 import httpx
 from telegram import Bot
 
-from backend.app.config import Settings
+from backend.app.config import Settings, settings
 
 
 class TelegramMessagingService:
@@ -25,7 +25,9 @@ class TelegramMessagingService:
         """Download *media_url* and send it as a document or photo."""
         chat_id = int(to)
         async with httpx.AsyncClient() as client:
-            resp = await client.get(media_url, follow_redirects=True, timeout=30.0)
+            resp = await client.get(
+                media_url, follow_redirects=True, timeout=settings.http_timeout_seconds
+            )
             resp.raise_for_status()
 
         content_type = resp.headers.get("content-type", "application/octet-stream").split(";")[0]

--- a/backend/app/services/webhook.py
+++ b/backend/app/services/webhook.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from backend.app.config import TELEGRAM_API_BASE
+from backend.app.config import TELEGRAM_API_BASE, settings
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,9 @@ async def discover_tunnel_url(
     for attempt in range(1, max_retries + 1):
         try:
             async with httpx.AsyncClient() as client:
-                resp = await client.get(metrics_url, timeout=5.0)
+                resp = await client.get(
+                    metrics_url, timeout=settings.cloudflared_metrics_timeout_seconds
+                )
                 resp.raise_for_status()
                 hostname = resp.json().get("hostname", "")
                 if hostname:
@@ -89,7 +91,9 @@ async def register_telegram_webhook(
 
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.post(url, json=payload, timeout=10.0)
+            resp = await client.post(
+                url, json=payload, timeout=settings.telegram_webhook_timeout_seconds
+            )
             data = resp.json()
             if data.get("ok"):
                 logger.info("Telegram webhook registered: %s", webhook_url)


### PR DESCRIPTION
## Description
Adds `http_timeout_seconds` (30.0), `cloudflared_metrics_timeout_seconds` (5.0), and `telegram_webhook_timeout_seconds` (10.0) to Settings. Replaces hardcoded timeout values across `download.py`, `telegram_service.py`, and `webhook.py`.

Fixes #152

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used