### PR TITLE
refactor: make rate limiting configurable via Settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     # Whisper
     whisper_model_size: str = "base"
 
+    # Rate limiting
+    webhook_rate_limit_max_requests: int = 30
+    webhook_rate_limit_window_seconds: int = 60
+
     # HTTP timeouts
     http_timeout_seconds: float = 30.0
     cloudflared_metrics_timeout_seconds: float = 5.0

--- a/backend/app/services/rate_limiter.py
+++ b/backend/app/services/rate_limiter.py
@@ -11,6 +11,8 @@ from collections import defaultdict
 
 from fastapi import HTTPException, Request
 
+from backend.app.config import settings
+
 
 class InMemoryRateLimiter:
     """Sliding-window rate limiter that tracks request counts per key (IP address).
@@ -66,7 +68,10 @@ class InMemoryRateLimiter:
 
 # Singleton instance used by the webhook endpoint.
 # 30 requests per 60 seconds per IP address.
-webhook_rate_limiter = InMemoryRateLimiter(max_requests=30, window_seconds=60)
+webhook_rate_limiter = InMemoryRateLimiter(
+    max_requests=settings.webhook_rate_limit_max_requests,
+    window_seconds=settings.webhook_rate_limit_window_seconds,
+)
 
 
 def check_webhook_rate_limit(request: Request) -> None:


### PR DESCRIPTION
## Description
Adds `webhook_rate_limit_max_requests` (30) and `webhook_rate_limit_window_seconds` (60) to Settings. Wires them into the webhook rate limiter singleton.

Fixes #153

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used