### PR TITLE
refactor: deduplicate estimates path via Settings

### DIFF
--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -7,10 +7,11 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool
+from backend.app.config import settings
 from backend.app.models import Contractor, Estimate, EstimateLineItem
 from backend.app.services.pdf_service import EstimatePDFData, generate_estimate_pdf
 
-PDF_DIR = Path("data/estimates")
+PDF_DIR = Path(settings.pdf_storage_dir)
 ESTIMATE_NUMBER_FORMAT = "EST-{:04d}"
 
 logger = logging.getLogger(__name__)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
     storage_provider: str = "local"  # "local", "dropbox", or "google_drive"
     dropbox_access_token: str = ""
     google_drive_credentials_json: str = ""
+    pdf_storage_dir: str = "data/estimates"
 
     # Whisper
     whisper_model_size: str = "base"

--- a/backend/app/routers/estimates.py
+++ b/backend/app/routers/estimates.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.auth.dependencies import get_current_user
 from backend.app.auth.scoping import get_user_estimate
+from backend.app.config import settings
 from backend.app.database import get_db
 from backend.app.models import Contractor
 
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-PDF_DIR = Path("data/estimates")
+PDF_DIR = Path(settings.pdf_storage_dir)
 
 
 @router.get("/estimates/{estimate_id}/pdf")


### PR DESCRIPTION
## Description
Adds `pdf_storage_dir` to Settings (`data/estimates` default). Both `estimate_tools.py` and the `estimates.py` router now reference this single setting.

Fixes #154

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used