### PR TITLE
refactor: promote conversation/memory limits to Settings

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -5,12 +5,13 @@ import logging
 
 from sqlalchemy.orm import Session
 
+from backend.app.config import settings
 from backend.app.models import Conversation, Message
 
 logger = logging.getLogger(__name__)
 
-CONVERSATION_TIMEOUT_HOURS = 4
-DEFAULT_HISTORY_LIMIT = 20
+CONVERSATION_TIMEOUT_HOURS = settings.conversation_timeout_hours
+DEFAULT_HISTORY_LIMIT = settings.conversation_history_limit
 
 
 async def load_conversation_history(

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -94,7 +94,7 @@ def _strip_code_fences(text: str) -> str:
     return stripped
 
 
-STALE_ESTIMATE_HOURS = 24
+STALE_ESTIMATE_HOURS = settings.heartbeat_stale_estimate_hours
 CHECKLIST_DAILY_INTERVAL_HOURS = 20
 HEARTBEAT_RECENT_MESSAGES_COUNT = 5
 WEEKDAY_FRIDAY = 4  # Monday=0 … Friday=4

--- a/backend/app/agent/memory.py
+++ b/backend/app/agent/memory.py
@@ -1,6 +1,7 @@
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from backend.app.config import settings
 from backend.app.models import Client, Memory
 
 
@@ -46,7 +47,7 @@ async def recall_memories(
     contractor_id: int,
     query: str,
     category: str | None = None,
-    limit: int = 20,
+    limit: int = settings.memory_recall_limit,
 ) -> list[Memory]:
     """Recall memories relevant to a query using keyword matching (ILIKE)."""
     q = db.query(Memory).filter(Memory.contractor_id == contractor_id)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,12 @@ class Settings(BaseSettings):
     # Whisper
     whisper_model_size: str = "base"
 
+    # Conversation & memory
+    conversation_timeout_hours: int = 4
+    conversation_history_limit: int = 20
+    memory_recall_limit: int = 20
+    heartbeat_stale_estimate_hours: int = 24
+
     # Rate limiting
     webhook_rate_limit_max_requests: int = 30
     webhook_rate_limit_window_seconds: int = 60


### PR DESCRIPTION
## Description
Adds `conversation_timeout_hours` (4), `conversation_history_limit` (20), `memory_recall_limit` (20), and `heartbeat_stale_estimate_hours` (24) to Settings so they can be tuned per environment.

Fixes #155

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used