### PR TITLE
refactor: make Whisper device and compute type configurable

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,6 +33,8 @@ class Settings(BaseSettings):
 
     # Whisper
     whisper_model_size: str = "base"
+    whisper_device: str = "cpu"
+    whisper_compute_type: str = "int8"
 
     # Conversation & memory
     conversation_timeout_hours: int = 4

--- a/backend/app/media/audio.py
+++ b/backend/app/media/audio.py
@@ -31,7 +31,11 @@ def _transcribe_sync(audio_bytes: bytes) -> str:
         )
         raise ImportError(msg) from None
 
-    model = WhisperModel(settings.whisper_model_size, device="cpu", compute_type="int8")
+    model = WhisperModel(
+        settings.whisper_model_size,
+        device=settings.whisper_device,
+        compute_type=settings.whisper_compute_type,
+    )
 
     with tempfile.NamedTemporaryFile(suffix=".ogg", delete=True) as tmp:
         tmp.write(audio_bytes)


### PR DESCRIPTION
## Description
Move hardcoded `device="cpu"` and `compute_type="int8"` from `audio.py` into `Settings` as `whisper_device` and `whisper_compute_type`, making them overridable via environment variables (`WHISPER_DEVICE`, `WHISPER_COMPUTE_TYPE`).

Fixes #157

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented the change and ran all checks)
- [ ] No AI used