### PR TITLE
refactor: add default estimate terms and file storage dir to Settings

### DIFF
--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -100,7 +100,7 @@ def create_estimate_tools(
             estimate_number=estimate_number,
             client_name=client_name,
             client_address=client_address,
-            terms=terms or "Payment due within 30 days of project completion.",
+            terms=terms or settings.default_estimate_terms,
         )
 
         pdf_bytes = await generate_estimate_pdf(pdf_data)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,6 +30,8 @@ class Settings(BaseSettings):
     dropbox_access_token: str = ""
     google_drive_credentials_json: str = ""
     pdf_storage_dir: str = "data/estimates"
+    file_storage_base_dir: str = "data/storage"
+    default_estimate_terms: str = "Payment due within 30 days of project completion."
 
     # Whisper
     whisper_model_size: str = "base"

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -125,7 +125,7 @@ class GoogleDriveStorage(StorageBackend):
 class LocalFileStorage(StorageBackend):
     """Local filesystem storage for development and demos."""
 
-    def __init__(self, base_dir: str = "data/storage") -> None:
+    def __init__(self, base_dir: str = settings.file_storage_base_dir) -> None:
         self.base_dir = Path(base_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Description
Move hardcoded payment terms text (`"Payment due within 30 days of project completion."`) and local file storage base directory (`"data/storage"`) into `Settings` as `default_estimate_terms` and `file_storage_base_dir`, making them overridable via environment variables.

Fixes #158

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented the change and ran all checks)
- [ ] No AI used