### PR TITLE
refactor: group PDF layout magic numbers into constants

### DIFF
--- a/backend/app/services/pdf_service.py
+++ b/backend/app/services/pdf_service.py
@@ -8,6 +8,19 @@ from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import inch
 from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
+# PDF Layout Constants
+PDF_MARGIN = 0.75 * inch
+PDF_TITLE_FONT_SIZE = 24
+PDF_BODY_FONT_SIZE = 10
+PDF_SPACER_SMALL = 12
+PDF_SPACER_LARGE = 24
+PDF_LINE_ITEM_COLUMNS = [3.5 * inch, 0.75 * inch, 1.25 * inch, 1.25 * inch]
+PDF_TOTALS_COLUMNS = [5.0 * inch, 1.75 * inch]
+PDF_HEADER_BG_COLOR = "#333333"
+PDF_ROW_ALT_COLOR = "#F5F5F5"
+PDF_CELL_PADDING = 6
+PDF_TOTALS_CELL_PADDING = 4
+
 
 @dataclass
 class EstimatePDFData:
@@ -33,10 +46,10 @@ def _build_pdf(data: EstimatePDFData) -> bytes:
     doc = SimpleDocTemplate(
         buf,
         pagesize=letter,
-        leftMargin=0.75 * inch,
-        rightMargin=0.75 * inch,
-        topMargin=0.75 * inch,
-        bottomMargin=0.75 * inch,
+        leftMargin=PDF_MARGIN,
+        rightMargin=PDF_MARGIN,
+        topMargin=PDF_MARGIN,
+        bottomMargin=PDF_MARGIN,
     )
     styles = getSampleStyleSheet()
     elements: list[object] = []
@@ -44,11 +57,11 @@ def _build_pdf(data: EstimatePDFData) -> bytes:
     title_style = ParagraphStyle(
         "EstimateTitle",
         parent=styles["Title"],
-        fontSize=24,
-        spaceAfter=12,
+        fontSize=PDF_TITLE_FONT_SIZE,
+        spaceAfter=PDF_SPACER_SMALL,
     )
     elements.append(Paragraph("ESTIMATE", title_style))
-    elements.append(Spacer(1, 12))
+    elements.append(Spacer(1, PDF_SPACER_SMALL))
 
     # Contractor info
     info_style = styles["Normal"]
@@ -57,12 +70,12 @@ def _build_pdf(data: EstimatePDFData) -> bytes:
         elements.append(Paragraph(data.contractor_trade, info_style))
     if data.contractor_phone:
         elements.append(Paragraph(data.contractor_phone, info_style))
-    elements.append(Spacer(1, 12))
+    elements.append(Spacer(1, PDF_SPACER_SMALL))
 
     # Date and estimate number
     elements.append(Paragraph(f"Date: {data.estimate_date}", info_style))
     elements.append(Paragraph(f"Estimate #: {data.estimate_number}", info_style))
-    elements.append(Spacer(1, 12))
+    elements.append(Spacer(1, PDF_SPACER_SMALL))
 
     # Client info
     if data.client_name:
@@ -70,12 +83,12 @@ def _build_pdf(data: EstimatePDFData) -> bytes:
     if data.client_address:
         elements.append(Paragraph(data.client_address, info_style))
     if data.client_name or data.client_address:
-        elements.append(Spacer(1, 12))
+        elements.append(Spacer(1, PDF_SPACER_SMALL))
 
     # Description
     if data.description:
         elements.append(Paragraph(f"<b>Description:</b> {data.description}", info_style))
-        elements.append(Spacer(1, 12))
+        elements.append(Spacer(1, PDF_SPACER_SMALL))
 
     # Line items table
     table_data: list[list[str]] = [["Description", "Qty", "Rate", "Total"]]
@@ -89,25 +102,30 @@ def _build_pdf(data: EstimatePDFData) -> bytes:
             ]
         )
 
-    col_widths = [3.5 * inch, 0.75 * inch, 1.25 * inch, 1.25 * inch]
+    col_widths = PDF_LINE_ITEM_COLUMNS
     table = Table(table_data, colWidths=col_widths)
     table.setStyle(
         TableStyle(
             [
-                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#333333")),
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor(PDF_HEADER_BG_COLOR)),
                 ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
                 ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
-                ("FONTSIZE", (0, 0), (-1, -1), 10),
+                ("FONTSIZE", (0, 0), (-1, -1), PDF_BODY_FONT_SIZE),
                 ("ALIGN", (1, 0), (-1, -1), "RIGHT"),
                 ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
-                ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#F5F5F5")]),
-                ("TOPPADDING", (0, 0), (-1, -1), 6),
-                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                (
+                    "ROWBACKGROUNDS",
+                    (0, 1),
+                    (-1, -1),
+                    [colors.white, colors.HexColor(PDF_ROW_ALT_COLOR)],
+                ),
+                ("TOPPADDING", (0, 0), (-1, -1), PDF_CELL_PADDING),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), PDF_CELL_PADDING),
             ]
         )
     )
     elements.append(table)
-    elements.append(Spacer(1, 12))
+    elements.append(Spacer(1, PDF_SPACER_SMALL))
 
     # Totals
     totals_data: list[list[str]] = [["Subtotal:", f"${data.subtotal:,.2f}"]]
@@ -115,16 +133,16 @@ def _build_pdf(data: EstimatePDFData) -> bytes:
         totals_data.append([f"Tax ({data.tax_rate}%):", f"${data.tax_amount:,.2f}"])
     totals_data.append(["Total:", f"${data.total:,.2f}"])
 
-    totals_table = Table(totals_data, colWidths=[5.0 * inch, 1.75 * inch])
+    totals_table = Table(totals_data, colWidths=PDF_TOTALS_COLUMNS)
     totals_table.setStyle(
         TableStyle(
             [
                 ("ALIGN", (0, 0), (-1, -1), "RIGHT"),
                 ("FONTNAME", (-1, -1), (-1, -1), "Helvetica-Bold"),
-                ("FONTSIZE", (0, 0), (-1, -1), 10),
+                ("FONTSIZE", (0, 0), (-1, -1), PDF_BODY_FONT_SIZE),
                 ("LINEABOVE", (0, -1), (-1, -1), 1, colors.black),
-                ("TOPPADDING", (0, 0), (-1, -1), 4),
-                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+                ("TOPPADDING", (0, 0), (-1, -1), PDF_TOTALS_CELL_PADDING),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), PDF_TOTALS_CELL_PADDING),
             ]
         )
     )
@@ -132,7 +150,7 @@ def _build_pdf(data: EstimatePDFData) -> bytes:
 
     # Terms
     if data.terms:
-        elements.append(Spacer(1, 24))
+        elements.append(Spacer(1, PDF_SPACER_LARGE))
         elements.append(Paragraph("<b>Terms:</b>", info_style))
         elements.append(Paragraph(data.terms, info_style))
 


### PR DESCRIPTION
## Description
Extract ~20 hardcoded numeric values for margins, font sizes, spacer heights, column widths, colors, and cell padding into named constants at the top of `pdf_service.py` for better maintainability.

Constants added: `PDF_MARGIN`, `PDF_TITLE_FONT_SIZE`, `PDF_BODY_FONT_SIZE`, `PDF_SPACER_SMALL`, `PDF_SPACER_LARGE`, `PDF_LINE_ITEM_COLUMNS`, `PDF_TOTALS_COLUMNS`, `PDF_HEADER_BG_COLOR`, `PDF_ROW_ALT_COLOR`, `PDF_CELL_PADDING`, `PDF_TOTALS_CELL_PADDING`.

Fixes #162

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented the change and ran all checks)
- [ ] No AI used