### PR TITLE
fix: only pass user parameter to acompletion for OpenAI provider

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -91,7 +91,9 @@ class BackshopAgent:
 
         tool_schemas = [tool_to_openai_schema(t) for t in self.tools] if self.tools else None
 
-        llm_kwargs: dict[str, object] = {"user": str(self.contractor.id)}
+        llm_kwargs: dict[str, object] = {}
+        if settings.llm_provider == "openai":
+            llm_kwargs["user"] = str(self.contractor.id)
         if temperature is not None:
             llm_kwargs["temperature"] = temperature
 

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -332,6 +332,10 @@ async def evaluate_heartbeat_need(
     model = settings.heartbeat_model or settings.llm_model
     provider = settings.heartbeat_provider or settings.llm_provider
 
+    llm_kwargs: dict[str, object] = {}
+    if provider == "openai":
+        llm_kwargs["user"] = str(contractor.id)
+
     response = await acompletion(
         model=model,
         provider=provider,
@@ -341,7 +345,7 @@ async def evaluate_heartbeat_need(
             {"role": "user", "content": "Compose a proactive message based on the flags above."},
         ],
         max_tokens=settings.llm_max_tokens_heartbeat,
-        user=str(contractor.id),
+        **llm_kwargs,
     )
     raw = response.choices[0].message.content or ""
     raw = _strip_code_fences(raw)

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -35,7 +35,7 @@ async def analyze_image(
     logger.info("Using vision model: %s (provider=%s)", model, settings.llm_provider)
 
     llm_kwargs: dict[str, object] = {}
-    if user is not None:
+    if user is not None and settings.llm_provider == "openai":
         llm_kwargs["user"] = user
 
     response = await acompletion(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -81,18 +81,49 @@ async def test_agent_does_not_pass_api_key(
 
 
 @pytest.mark.asyncio()
+@patch("backend.app.agent.core.settings")
 @patch("backend.app.agent.core.acompletion")
 async def test_agent_passes_user_parameter(
-    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+    mock_acompletion: object,
+    mock_settings: object,
+    db_session: Session,
+    test_contractor: Contractor,
 ) -> None:
-    """acompletion should be called with user=contractor.id for per-user tracking."""
+    """acompletion should be called with user=contractor.id when provider is openai."""
     mock_acompletion.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
+    mock_settings.llm_provider = "openai"  # type: ignore[attr-defined]
+    mock_settings.llm_model = "gpt-4o"  # type: ignore[attr-defined]
+    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
+    mock_settings.llm_max_tokens_agent = 500  # type: ignore[attr-defined]
 
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
     await agent.process_message("Hello")
 
     call_args = mock_acompletion.call_args  # type: ignore[union-attr]
     assert call_args.kwargs["user"] == str(test_contractor.id)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.settings")
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_omits_user_for_non_openai_provider(
+    mock_acompletion: object,
+    mock_settings: object,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """acompletion should NOT pass user param when provider is not openai (e.g. anthropic)."""
+    mock_acompletion.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
+    mock_settings.llm_provider = "anthropic"  # type: ignore[attr-defined]
+    mock_settings.llm_model = "claude-haiku-4-5-20251001"  # type: ignore[attr-defined]
+    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
+    mock_settings.llm_max_tokens_agent = 500  # type: ignore[attr-defined]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    await agent.process_message("Hello")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    assert "user" not in call_args.kwargs
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description
Anthropic's API does not accept a `user` keyword argument — passing it causes `TypeError: AsyncMessages.create() got an unexpected keyword argument 'user'`. This broke all integration tests after PR #193 added the `user` parameter.

This PR guards the `user` parameter behind a provider check (`llm_provider == "openai"`) in all three call sites:
- `agent/core.py` (agent loop)
- `agent/heartbeat.py` (heartbeat evaluation)
- `media/vision.py` (image analysis)

Also adds a regression test verifying `user` is omitted for non-OpenAI providers.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — diagnosed CI failure and implemented the fix)
- [ ] No AI used