### PR TITLE
fix: add missing mock settings to integration tests

### DIFF
--- a/tests/integration/test_estimate_integration.py
+++ b/tests/integration/test_estimate_integration.py
@@ -31,6 +31,7 @@ async def test_estimate_generation_roundtrip(
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_agent = 500
 
         agent = BackshopAgent(db=integration_db, contractor=integration_contractor)
         tools = create_estimate_tools(integration_db, integration_contractor)

--- a/tests/integration/test_heartbeat_integration.py
+++ b/tests/integration/test_heartbeat_integration.py
@@ -31,6 +31,7 @@ async def test_heartbeat_evaluate_returns_valid_action(
         mock_settings.llm_api_base = None
         mock_settings.heartbeat_provider = None
         mock_settings.heartbeat_model = None
+        mock_settings.llm_max_tokens_heartbeat = 300
 
         action = await evaluate_heartbeat_need(
             integration_db, onboarded_contractor, ["Test flag: check-in needed"]
@@ -83,6 +84,7 @@ async def test_heartbeat_evaluate_with_context(
         mock_settings.llm_api_base = None
         mock_settings.heartbeat_provider = None
         mock_settings.heartbeat_model = None
+        mock_settings.llm_max_tokens_heartbeat = 300
 
         action = await evaluate_heartbeat_need(
             integration_db,

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -29,6 +29,7 @@ async def test_agent_returns_nonempty_reply(
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_agent = 500
 
         agent = BackshopAgent(db=integration_db, contractor=integration_contractor)
         response = await agent.process_message(
@@ -51,6 +52,7 @@ async def test_agent_message_format_accepted(
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_agent = 500
 
         agent = BackshopAgent(db=integration_db, contractor=integration_contractor)
         history = [

--- a/tests/integration/test_memory_integration.py
+++ b/tests/integration/test_memory_integration.py
@@ -30,6 +30,7 @@ async def test_memory_save_via_llm(
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_agent = 500
 
         agent = BackshopAgent(db=integration_db, contractor=integration_contractor)
         tools = create_memory_tools(integration_db, integration_contractor.id)
@@ -65,6 +66,7 @@ async def test_memory_save_then_recall(
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_agent = 500
 
         agent = BackshopAgent(db=integration_db, contractor=integration_contractor)
         tools = create_memory_tools(integration_db, integration_contractor.id)

--- a/tests/integration/test_onboarding_integration.py
+++ b/tests/integration/test_onboarding_integration.py
@@ -47,6 +47,7 @@ async def test_onboarding_extracts_profile_from_intro(
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_agent = 500
 
         agent = BackshopAgent(db=integration_db, contractor=contractor)
         tools = create_memory_tools(integration_db, contractor.id)

--- a/tests/integration/test_vision_integration.py
+++ b/tests/integration/test_vision_integration.py
@@ -63,6 +63,7 @@ async def test_analyze_image_returns_description() -> None:
         mock_settings.llm_model = _VISION_MODEL
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_vision = 1000
 
         result = await analyze_image(png_bytes, "image/png")
 
@@ -81,6 +82,7 @@ async def test_analyze_image_with_context() -> None:
         mock_settings.llm_model = _VISION_MODEL
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_vision = 1000
 
         result = await analyze_image(
             png_bytes,
@@ -110,6 +112,7 @@ async def test_pipeline_processes_real_image() -> None:
         mock_settings.llm_model = _VISION_MODEL
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_vision = 1000
 
         result = await process_message_media(
             text_body="Here's a photo of the job site",
@@ -142,6 +145,7 @@ async def test_mime_mismatch_raises_error() -> None:
         mock_settings.llm_model = _VISION_MODEL
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_vision = 1000
 
         # PNG bytes declared as JPEG — Claude validates and rejects this
         await analyze_image(png_bytes, "image/jpeg")


### PR DESCRIPTION
## Description
Integration tests that mock `settings` were missing `llm_max_tokens_agent`, `llm_max_tokens_heartbeat`, and `llm_max_tokens_vision`. Since the mocks use `MagicMock`, these missing fields returned `MagicMock` objects instead of integers, causing the real LLM API to receive invalid `max_tokens` values. This resulted in short responses without tool calls, failing the integration tests.

This was introduced when hardcoded max_tokens values were promoted to Settings in PR #198.

**Files updated:**
- `tests/integration/test_estimate_integration.py` — added `llm_max_tokens_agent = 500`
- `tests/integration/test_memory_integration.py` — added `llm_max_tokens_agent = 500`
- `tests/integration/test_onboarding_integration.py` — added `llm_max_tokens_agent = 500`
- `tests/integration/test_llm_integration.py` — added `llm_max_tokens_agent = 500`
- `tests/integration/test_heartbeat_integration.py` — added `llm_max_tokens_heartbeat = 300`
- `tests/integration/test_vision_integration.py` — added `llm_max_tokens_vision = 1000`

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — diagnosed root cause from CI logs and fixed all 6 test files)
- [ ] No AI used