### PR TITLE
refactor: extract user-facing error/fallback messages to constants

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -24,6 +24,18 @@ from backend.app.services.storage_service import get_storage_service
 
 logger = logging.getLogger(__name__)
 
+# User-facing error/fallback messages
+AGENT_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
+MEDIA_DOWNLOAD_ERROR = (
+    "I couldn't download your attachment(s). The rest of your message came through fine."
+)
+VISION_UNAVAILABLE_NOTE = (
+    "Vision analysis was unavailable for the attached media. "
+    "The contractor may have sent a photo or document that could "
+    "not be analyzed. You can still help with their text message "
+    "and ask them to describe what the attachment shows."
+)
+
 
 async def handle_inbound_message(
     db: Session,
@@ -56,9 +68,7 @@ async def handle_inbound_message(
     # Step 2: Run media pipeline
     media_notes: list[str] = []
     if media_urls and not downloaded_media:
-        media_notes.append(
-            "I couldn't download your attachment(s). The rest of your message came through fine."
-        )
+        media_notes.append(MEDIA_DOWNLOAD_ERROR)
 
     try:
         pipeline_result = await process_message_media(message.body, downloaded_media)
@@ -70,12 +80,7 @@ async def handle_inbound_message(
         )
         pipeline_result = await process_message_media(message.body, [])
         if downloaded_media:
-            media_notes.append(
-                "Vision analysis was unavailable for the attached media. "
-                "The contractor may have sent a photo or document that could "
-                "not be analyzed. You can still help with their text message "
-                "and ask them to describe what the attachment shows."
-            )
+            media_notes.append(VISION_UNAVAILABLE_NOTE)
 
     # Step 3: Combined context (with any media failure notes)
     combined_context = pipeline_result.combined_context
@@ -132,9 +137,7 @@ async def handle_inbound_message(
             message.id,
             contractor.id,
         )
-        response = AgentResponse(
-            reply_text="I'm having trouble thinking right now. Can you try again in a moment?"
-        )
+        response = AgentResponse(reply_text=AGENT_ERROR_FALLBACK)
 
     # Step 6b: If onboarding, extract profile updates from tool calls
     if onboarding:

--- a/backend/app/media/pipeline.py
+++ b/backend/app/media/pipeline.py
@@ -8,6 +8,12 @@ from backend.app.media.vision import analyze_image
 
 logger = logging.getLogger(__name__)
 
+# Fallback messages when media processing is unavailable
+VISION_FALLBACK = "[Photo — vision analysis not available]"
+AUDIO_FALLBACK = "[Audio file - transcription not available (faster-whisper not installed)]"
+VIDEO_FALLBACK = "[Video file - transcription not available (faster-whisper not installed)]"
+VIDEO_ERROR_FALLBACK = "[Video file - transcription not available]"
+
 
 @dataclass
 class ProcessedMedia:
@@ -39,27 +45,23 @@ async def _process_single_media(
             logger.exception(
                 "Vision analysis failed for %s (mime_type=%s)", media.original_url, media.mime_type
             )
-            extracted_text = "[Photo — vision analysis not available]"
+            extracted_text = VISION_FALLBACK
     elif category == "audio":
         try:
             extracted_text = await transcribe_audio(media.content, media.mime_type)
         except ImportError:
             logger.warning("faster-whisper not installed, skipping audio transcription")
-            extracted_text = (
-                "[Audio file - transcription not available (faster-whisper not installed)]"
-            )
+            extracted_text = AUDIO_FALLBACK
     elif category == "video":
         # Future: extract audio track. For now, try audio transcription.
         try:
             extracted_text = await transcribe_audio(media.content, media.mime_type)
         except ImportError:
             logger.warning("faster-whisper not installed, skipping video transcription")
-            extracted_text = (
-                "[Video file - transcription not available (faster-whisper not installed)]"
-            )
+            extracted_text = VIDEO_FALLBACK
         except Exception:
             logger.warning("Could not process video file: %s", media.original_url)
-            extracted_text = "[Video file - transcription not available]"
+            extracted_text = VIDEO_ERROR_FALLBACK
     else:
         logger.info("Skipping unsupported media type: %s", media.mime_type)
         extracted_text = f"[{category.title()} file - processing not available]"


### PR DESCRIPTION
## Description
Move hardcoded error messages and media fallback strings into named constants at the top of `router.py` and `pipeline.py` for consistency and future i18n readiness.

**Constants added:**
- `router.py`: `AGENT_ERROR_FALLBACK`, `MEDIA_DOWNLOAD_ERROR`, `VISION_UNAVAILABLE_NOTE`
- `pipeline.py`: `VISION_FALLBACK`, `AUDIO_FALLBACK`, `VIDEO_FALLBACK`, `VIDEO_ERROR_FALLBACK`

Fixes #163

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented the change and ran all checks)
- [ ] No AI used