### PR TITLE
refactor: extract minor constants (startup delay, slug lengths, headers, labels)

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -14,6 +14,7 @@ from backend.app.models import Contractor
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_ROUNDS = 5
+CONTEXT_QUERY_MAX_LENGTH = 100
 
 SYSTEM_PROMPT_TEMPLATE = """You are Backshop, an AI assistant for solo contractors.
 
@@ -64,7 +65,9 @@ class BackshopAgent:
         """Build the full system prompt with soul + memory."""
         soul_prompt = build_soul_prompt(self.contractor)
         memory_context = await build_memory_context(
-            self.db, self.contractor.id, query=message_context[:100] if message_context else None
+            self.db,
+            self.contractor.id,
+            query=message_context[:CONTEXT_QUERY_MAX_LENGTH] if message_context else None,
         )
         return SYSTEM_PROMPT_TEMPLATE.format(
             contractor_name=self.contractor.name or "Contractor",

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -13,6 +13,9 @@ from backend.app.services.storage_service import StorageBackend
 
 logger = logging.getLogger(__name__)
 
+DESCRIPTION_SLUG_MAX_LENGTH = 40
+FILENAME_SLUG_MAX_LENGTH = 30
+
 # Category to folder mapping
 CATEGORY_FOLDERS: dict[str, str] = {
     "job_photo": "Job Photos",
@@ -22,7 +25,7 @@ CATEGORY_FOLDERS: dict[str, str] = {
 }
 
 
-def _slugify(text: str, max_length: int = 40) -> str:
+def _slugify(text: str, max_length: int = DESCRIPTION_SLUG_MAX_LENGTH) -> str:
     """Convert text to a filesystem-safe slug."""
     slug = text.lower().strip()
     slug = re.sub(r"[^\w\s-]", "", slug)
@@ -59,7 +62,7 @@ def _build_filename(
     base = fallback_names.get(category, "file")
 
     if description and description.strip():
-        base = _slugify(description, max_length=30)
+        base = _slugify(description, max_length=FILENAME_SLUG_MAX_LENGTH)
 
     return f"{base}_{index:03d}.{extension}"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,8 @@ logging.basicConfig(
 logging.getLogger("backend").setLevel(settings.log_level.upper())
 logger = logging.getLogger(__name__)
 
+STARTUP_DELAY_SECONDS = 3
+
 
 async def _auto_register_webhook() -> None:
     """Discover Cloudflare Tunnel URL and register Telegram webhook.
@@ -34,7 +36,7 @@ async def _auto_register_webhook() -> None:
     Telegram's DNS may not resolve them immediately.
     """
     # Small delay to ensure Uvicorn is accepting connections.
-    await asyncio.sleep(3)
+    await asyncio.sleep(STARTUP_DELAY_SECONDS)
     tunnel_url = await discover_tunnel_url()
     if not tunnel_url:
         logger.debug("Cloudflare tunnel not detected — skipping webhook auto-registration")

--- a/backend/app/media/download.py
+++ b/backend/app/media/download.py
@@ -9,6 +9,8 @@ from backend.app.config import TELEGRAM_API_BASE, settings
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_MIME_TYPE = "application/octet-stream"
+
 MIME_EXTENSIONS: dict[str, str] = {
     "image/jpeg": ".jpg",
     "image/png": ".png",
@@ -86,11 +88,11 @@ async def download_telegram_media(
         )
         download.raise_for_status()
 
-    mime_type = download.headers.get("content-type", "application/octet-stream").split(";")[0]
+    mime_type = download.headers.get("content-type", DEFAULT_MIME_TYPE).split(";")[0]
 
     # Telegram's file download endpoint often returns application/octet-stream
     # regardless of the actual file type.  Infer from the file path extension.
-    if mime_type == "application/octet-stream":
+    if mime_type == DEFAULT_MIME_TYPE:
         ext = os.path.splitext(file_path)[1].lower()
         inferred = _EXTENSION_TO_MIME.get(ext)
         if inferred:

--- a/backend/app/media/pipeline.py
+++ b/backend/app/media/pipeline.py
@@ -14,6 +14,14 @@ AUDIO_FALLBACK = "[Audio file - transcription not available (faster-whisper not 
 VIDEO_FALLBACK = "[Video file - transcription not available (faster-whisper not installed)]"
 VIDEO_ERROR_FALLBACK = "[Video file - transcription not available]"
 
+# Media type display labels used in combined context output
+MEDIA_TYPE_LABELS: dict[str, str] = {
+    "image": "Photo",
+    "audio": "Voice note",
+    "video": "Video",
+    "pdf": "Document",
+}
+
 
 @dataclass
 class ProcessedMedia:
@@ -103,10 +111,7 @@ async def process_message_media(
 
 def _format_label(category: str, index: int) -> str:
     """Format a label for a media item in the combined context."""
-    labels = {
-        "image": f"Photo {index}",
-        "audio": "Voice note",
-        "video": f"Video {index}",
-        "pdf": f"Document {index}",
-    }
-    return labels.get(category, f"Attachment {index}")
+    label = MEDIA_TYPE_LABELS.get(category, "Attachment")
+    if label == "Voice note":
+        return label
+    return f"{label} {index}"

--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -18,6 +18,8 @@ from backend.app.services.rate_limiter import check_webhook_rate_limit
 
 logger = logging.getLogger(__name__)
 
+TELEGRAM_SECRET_HEADER = "X-Telegram-Bot-Api-Secret-Token"
+
 router = APIRouter()
 
 
@@ -25,7 +27,7 @@ def _validate_webhook_secret(request: Request) -> None:
     """Validate the Telegram webhook secret token header."""
     if not settings.telegram_webhook_secret:
         return
-    header = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+    header = request.headers.get(TELEGRAM_SECRET_HEADER, "")
     if header != settings.telegram_webhook_secret:
         logger.warning("Invalid Telegram webhook secret")
         # Still return 200 to avoid Telegram retries, but log the warning.


### PR DESCRIPTION
## Description
Extract a collection of hardcoded values to named module-level constants for code clarity:

- `STARTUP_DELAY_SECONDS = 3` in `main.py`
- `DESCRIPTION_SLUG_MAX_LENGTH = 40`, `FILENAME_SLUG_MAX_LENGTH = 30` in `file_tools.py`
- `TELEGRAM_SECRET_HEADER` in `telegram_webhook.py`
- `CONTEXT_QUERY_MAX_LENGTH = 100` in `core.py`
- `DEFAULT_MIME_TYPE = "application/octet-stream"` in `download.py`
- `MEDIA_TYPE_LABELS` dict in `pipeline.py`

Fixes #164

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code — implemented the change and ran all checks)
- [ ] No AI used