### PR TITLE
feat: add proactive messaging section to agent system prompt

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -31,6 +31,13 @@ SYSTEM_PROMPT_TEMPLATE = """You are Backshop, an AI assistant for solo contracto
 - Always be helpful, friendly, and professional.
 - Keep SMS replies under 160 characters when possible (single SMS segment).
 
+## Proactive Messaging
+You will proactively reach out during business hours when something needs attention:
+- A draft estimate has been sitting unsent for over 24 hours
+- A scheduled checklist item is due
+- A follow-up reminder or deadline is approaching
+- You haven't heard from the contractor in a few days
+
 ## Recall Behavior
 When the contractor asks a question about their business, clients, or past work:
 1. Use recall_facts to search your memory for relevant information.


### PR DESCRIPTION
## Description

The agent's system prompt (`SYSTEM_PROMPT_TEMPLATE` in `core.py`) had no mention of the heartbeat/proactive messaging feature. When contractors asked "when will you message me?" the bot gave a generic capability list instead of explaining the proactive behavior.

Adds a `## Proactive Messaging` section listing the four triggers:
- Stale draft estimates (>24h)
- Due checklist items
- Follow-up reminders/deadlines
- Contractor idle for several days

Fixes #211

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)