### PR TITLE
fix: remove dead get_or_create_contractor from profile.py

### DIFF
--- a/backend/app/agent/profile.py
+++ b/backend/app/agent/profile.py
@@ -5,23 +5,6 @@ from sqlalchemy.orm import Session
 from backend.app.models import Contractor
 
 
-async def get_or_create_contractor(
-    db: Session,
-    user_id: str,
-    phone: str,
-) -> tuple[Contractor, bool]:
-    """Get existing contractor or create new one. Returns (contractor, is_new)."""
-    contractor = db.query(Contractor).filter(Contractor.phone == phone).first()
-    if contractor:
-        return contractor, False
-
-    contractor = Contractor(user_id=user_id, phone=phone)
-    db.add(contractor)
-    db.commit()
-    db.refresh(contractor)
-    return contractor, True
-
-
 async def update_contractor_profile(
     db: Session,
     contractor: Contractor,

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -4,33 +4,9 @@ from sqlalchemy.orm import Session
 from backend.app.agent.profile import (
     build_onboarding_prompt,
     build_soul_prompt,
-    get_or_create_contractor,
     update_contractor_profile,
 )
 from backend.app.models import Contractor
-
-
-@pytest.mark.asyncio()
-async def test_get_or_create_contractor_new(db_session: Session) -> None:
-    """Should create a new contractor when phone not found."""
-    contractor, is_new = await get_or_create_contractor(
-        db_session, user_id="+15559999999", phone="+15559999999"
-    )
-    assert is_new is True
-    assert contractor.phone == "+15559999999"
-    assert contractor.id is not None
-
-
-@pytest.mark.asyncio()
-async def test_get_or_create_contractor_existing(
-    db_session: Session, test_contractor: Contractor
-) -> None:
-    """Should return existing contractor when phone matches."""
-    contractor, is_new = await get_or_create_contractor(
-        db_session, user_id=test_contractor.user_id, phone=test_contractor.phone
-    )
-    assert is_new is False
-    assert contractor.id == test_contractor.id
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description

Removes the dead `get_or_create_contractor` function from `profile.py` and its two tests. This phone-based lookup is leftover from the pre-Telegram era — the canonical version lives in `telegram_webhook.py` and looks up by `channel_identifier`. No production code called the removed function.

Fixes #220

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)