### PR TITLE
fix: ensure analyze_image always returns str, not None

### DIFF
--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -50,4 +50,4 @@ async def analyze_image(
         **llm_kwargs,
     )
     logger.debug("Vision LLM response received for mime_type=%s", mime_type)
-    return response.choices[0].message.content
+    return response.choices[0].message.content or ""

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -48,6 +48,20 @@ async def test_analyze_image_encodes_base64(mock_acompletion: object) -> None:
 
 @pytest.mark.asyncio()
 @patch("backend.app.media.vision.acompletion")
+async def test_analyze_image_returns_empty_string_on_none_content(
+    mock_acompletion: object,
+) -> None:
+    """analyze_image should return '' when LLM content is None, not None."""
+    mock_acompletion.return_value = make_vision_response("")  # type: ignore[union-attr]
+    # Manually set content to None to simulate LLM returning null content
+    mock_acompletion.return_value.choices[0].message.content = None  # type: ignore[union-attr]
+    result = await analyze_image(b"fake-jpeg-bytes", "image/jpeg")
+    assert result == ""
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.media.vision.acompletion")
 async def test_analyze_image_does_not_pass_api_key(mock_acompletion: object) -> None:
     """acompletion should be called without api_key so the SDK resolves keys from env."""
     mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]


### PR DESCRIPTION
## Description

`analyze_image` could return `None` when the LLM content field was null, violating its `-> str` return type. Added `or ""` fallback and a regression test.

Fixes #218

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)