### PR TITLE
fix: remove empty keys from rate limiter after window expiry

### DIFF
--- a/backend/app/services/rate_limiter.py
+++ b/backend/app/services/rate_limiter.py
@@ -49,6 +49,8 @@ class InMemoryRateLimiter:
             i += 1
         if i > 0:
             self._requests[key] = timestamps[i:]
+        if not self._requests[key]:
+            del self._requests[key]
 
     def check(self, request: Request) -> None:
         """Check rate limit for the given request. Raises 429 if exceeded."""

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -170,6 +170,21 @@ class TestInMemoryRateLimiter:
             limiter.check(Request(scope))
         assert exc_info.value.status_code == 429
 
+    def test_expired_keys_removed_from_dict(self) -> None:
+        """After all timestamps expire and the key is pruned, it should be removed."""
+        limiter = InMemoryRateLimiter(max_requests=5, window_seconds=1)
+
+        limiter.check(Request(_make_scope(client_ip="10.0.0.1")))
+        assert "10.0.0.1" in limiter._requests
+
+        # Wait for the window to expire
+        time.sleep(1.1)
+
+        # Manually prune the expired key — this simulates what happens when
+        # the same IP makes another request after the window expires
+        limiter._prune("10.0.0.1", time.monotonic())
+        assert "10.0.0.1" not in limiter._requests
+
     def test_reset_clears_state(self) -> None:
         """reset() should clear all tracked requests."""
         limiter = InMemoryRateLimiter(max_requests=2, window_seconds=60)


### PR DESCRIPTION
## Summary
- `InMemoryRateLimiter._prune()` now deletes dictionary keys when all timestamps have expired, preventing unbounded memory growth from many distinct IPs
- Added `test_expired_keys_removed_from_dict` regression test

## Test plan
- [x] `uv run pytest tests/test_rate_limiter.py -v` — all 9 tests pass
- [x] `uv run ruff check backend/ tests/` — clean
- [x] `uv run ruff format --check backend/ tests/` — clean

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)