### PR TITLE
fix: replace deprecated get_event_loop and handle naive checklist datetimes

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -298,7 +298,10 @@ def _is_checklist_item_due(
     if item.last_triggered_at is None:
         return True
 
-    elapsed = now - item.last_triggered_at
+    last = item.last_triggered_at
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=datetime.UTC)
+    elapsed = now - last
 
     if item.schedule == "once":
         # Already triggered once -> not due again
@@ -494,7 +497,7 @@ class HeartbeatScheduler:
             return
         if self._task is not None and not self._task.done():
             return
-        self._task = asyncio.get_event_loop().create_task(self._run())
+        self._task = asyncio.get_running_loop().create_task(self._run())
         logger.info(
             "Heartbeat started (interval=%dm, max_daily=%d)",
             settings.heartbeat_interval_minutes,

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -512,6 +512,20 @@ class TestIsChecklistItemDue:
         )
         assert _is_checklist_item_due(item, monday) is True
 
+    def test_naive_last_triggered_at(self) -> None:
+        """Timezone-naive last_triggered_at (from SQLite) should not raise TypeError."""
+        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
+        # SQLite returns naive datetimes — simulate that here
+        naive_last = datetime.datetime(2025, 6, 14, 8, 0)
+        item = HeartbeatChecklistItem(
+            contractor_id=1,
+            description="Test",
+            schedule="daily",
+            last_triggered_at=naive_last,
+        )
+        # Should not raise TypeError and should be due (>20h elapsed)
+        assert _is_checklist_item_due(item, now) is True
+
 
 # ---------------------------------------------------------------------------
 # _strip_code_fences


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in `HeartbeatScheduler.start()` — the deprecated API emits warnings in Python 3.10+ and is scheduled for removal
- Normalize timezone-naive `last_triggered_at` in `_is_checklist_item_due()` before datetime arithmetic — SQLite returns naive datetimes which would cause `TypeError` when compared with aware `now`

## Test plan
- [x] Added `test_naive_last_triggered_at` regression test — verifies no TypeError with naive datetimes
- [x] `uv run pytest tests/test_heartbeat.py -v` — all 58 tests pass
- [x] `uv run ruff check backend/ tests/` — clean
- [x] `uv run ruff format --check backend/ tests/` — clean

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)