### PR TITLE
fix: harden TelegramMessagingService chat_id parsing and media handling

### DIFF
--- a/backend/app/services/telegram_service.py
+++ b/backend/app/services/telegram_service.py
@@ -17,9 +17,19 @@ class TelegramMessagingService:
         self.bot = Bot(token=token)
         self._token = token
 
+    @staticmethod
+    def _parse_chat_id(to: str) -> int:
+        """Parse a Telegram chat_id from a string, stripping phone-number prefixes."""
+        cleaned = to.lstrip("+")
+        try:
+            return int(cleaned)
+        except (ValueError, TypeError) as exc:
+            msg = f"Invalid Telegram chat_id: {to!r}"
+            raise ValueError(msg) from exc
+
     async def send_text(self, to: str, body: str) -> str:
         """Send a text message. *to* is a Telegram chat_id."""
-        msg = await self.bot.send_message(chat_id=int(to), text=body)
+        msg = await self.bot.send_message(chat_id=self._parse_chat_id(to), text=body)
         return str(msg.message_id)
 
     async def send_media(self, to: str, body: str, media_url: str) -> str:
@@ -27,7 +37,7 @@ class TelegramMessagingService:
 
         Supports both HTTP(S) URLs and local file paths.
         """
-        chat_id = int(to)
+        chat_id = self._parse_chat_id(to)
 
         local_path = Path(media_url)
         if local_path.is_file():
@@ -40,12 +50,12 @@ class TelegramMessagingService:
                     media_url, follow_redirects=True, timeout=settings.http_timeout_seconds
                 )
                 resp.raise_for_status()
-            content_type = resp.headers.get("content-type", "application/octet-stream").split(";")[
-                0
-            ]
-            ext = mimetypes.guess_extension(content_type) or ".bin"
-            filename = f"file{ext}"
-            data = resp.content
+                content_type = resp.headers.get("content-type", "application/octet-stream").split(
+                    ";"
+                )[0]
+                ext = mimetypes.guess_extension(content_type) or ".bin"
+                filename = f"file{ext}"
+                data = resp.content
 
         if content_type.startswith("image/"):
             msg = await self.bot.send_photo(
@@ -61,7 +71,8 @@ class TelegramMessagingService:
         """Send text or media based on whether media_urls is provided."""
         if media_urls:
             last_id = ""
-            for url in media_urls:
-                last_id = await self.send_media(to, body, url)
+            for i, url in enumerate(media_urls):
+                caption = body if i == 0 else ""
+                last_id = await self.send_media(to, caption, url)
             return last_id
         return await self.send_text(to, body)

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -4,6 +4,26 @@ import pytest
 
 from backend.app.services.telegram_service import TelegramMessagingService
 
+# ---------------------------------------------------------------------------
+# _parse_chat_id
+# ---------------------------------------------------------------------------
+
+
+class TestParseChatId:
+    def test_plain_numeric(self) -> None:
+        assert TelegramMessagingService._parse_chat_id("123456789") == 123456789
+
+    def test_strips_plus_prefix(self) -> None:
+        assert TelegramMessagingService._parse_chat_id("+15551234567") == 15551234567
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid Telegram chat_id"):
+            TelegramMessagingService._parse_chat_id("")
+
+    def test_non_numeric_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid Telegram chat_id"):
+            TelegramMessagingService._parse_chat_id("not-a-number")
+
 
 @pytest.fixture()
 def mock_bot() -> MagicMock:
@@ -98,3 +118,34 @@ async def test_send_message_text_only(
     msg_id = await telegram_service.send_message(to="123456789", body="Hello")
     assert msg_id == "42"
     mock_bot.send_message.assert_called_once_with(chat_id=123456789, text="Hello")
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.services.telegram_service.httpx.AsyncClient")
+async def test_send_message_multi_media_caption_once(
+    mock_client_class: MagicMock,
+    telegram_service: TelegramMessagingService,
+    mock_bot: MagicMock,
+) -> None:
+    """send_message with multiple media URLs should only caption the first."""
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": "image/jpeg"}
+    mock_response.content = b"fake-image-data"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    await telegram_service.send_message(
+        to="123456789",
+        body="Here are the photos",
+        media_urls=["https://example.com/a.jpg", "https://example.com/b.jpg"],
+    )
+
+    calls = mock_bot.send_photo.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["caption"] == "Here are the photos"
+    assert calls[1].kwargs["caption"] == ""


### PR DESCRIPTION
## Summary
- Extract `_parse_chat_id()` static method that strips leading `+` prefix and raises clear `ValueError` for non-numeric inputs
- Move `resp.headers`/`resp.content` access inside the `async with httpx.AsyncClient()` block in `send_media`
- Only attach body caption to the first media item in `send_message` multi-media loop

## Test plan
- [x] Added `TestParseChatId` with 4 tests (plain numeric, `+` prefix, empty, non-numeric)
- [x] Added `test_send_message_multi_media_caption_once` regression test
- [x] `uv run pytest tests/test_telegram_service.py -v` — all 9 tests pass
- [x] `uv run ruff check backend/ tests/` — clean
- [x] `uv run ruff format --check backend/ tests/` — clean

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)