### PR TITLE
fix: add max-size check on downloaded media to prevent memory exhaustion

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     webhook_rate_limit_max_requests: int = 30
     webhook_rate_limit_window_seconds: int = 60
 
+    # Media
+    max_media_size_bytes: int = 20_971_520  # 20 MB
+
     # HTTP timeouts
     http_timeout_seconds: float = 30.0
     cloudflared_metrics_timeout_seconds: float = 5.0

--- a/backend/app/media/download.py
+++ b/backend/app/media/download.py
@@ -100,6 +100,13 @@ async def download_telegram_media(
             mime_type = inferred
 
     size_bytes = len(download.content)
+    if size_bytes > settings.max_media_size_bytes:
+        msg = (
+            f"Media file too large: {size_bytes} bytes "
+            f"(limit {settings.max_media_size_bytes} bytes)"
+        )
+        raise ValueError(msg)
+
     logger.info(
         "Download complete: file_id=%s, mime_type=%s, size=%d bytes",
         file_id,

--- a/tests/test_media_download.py
+++ b/tests/test_media_download.py
@@ -123,6 +123,38 @@ async def test_download_keeps_octet_stream_for_unknown_extension() -> None:
 
 
 @pytest.mark.asyncio()
+@patch("backend.app.media.download.settings")
+async def test_download_rejects_oversized_media(mock_settings: object) -> None:
+    """Files exceeding max_media_size_bytes should raise ValueError."""
+    mock_settings.telegram_bot_token = "TOKEN"  # type: ignore[attr-defined]
+    mock_settings.http_timeout_seconds = 30.0  # type: ignore[attr-defined]
+    mock_settings.max_media_size_bytes = 100  # type: ignore[attr-defined]
+
+    get_file_response = httpx.Response(
+        200,
+        json={"ok": True, "result": {"file_id": "abc123", "file_path": "photos/big.jpg"}},
+        request=httpx.Request("GET", "https://api.telegram.org/botTOKEN/getFile"),
+    )
+    # 200 bytes > 100 byte limit
+    download_response = httpx.Response(
+        200,
+        content=b"x" * 200,
+        headers={"content-type": "image/jpeg"},
+        request=httpx.Request("GET", "https://api.telegram.org/file/botTOKEN/photos/big.jpg"),
+    )
+
+    with patch("backend.app.media.download.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [get_file_response, download_response]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(ValueError, match="Media file too large"):
+            await download_telegram_media("abc123", bot_token="TOKEN")
+
+
+@pytest.mark.asyncio()
 async def test_download_telegram_media_error() -> None:
     """download_telegram_media should raise on HTTP error."""
     error_response = httpx.Response(


### PR DESCRIPTION
## Summary
- Add `max_media_size_bytes` setting to `config.py` (default 20 MB)
- Check `len(download.content)` in `download_telegram_media` and raise `ValueError` when exceeded
- Prevents concurrent large file downloads from exhausting process memory

## Test plan
- [x] Added `test_download_rejects_oversized_media` regression test (sets 100-byte limit, sends 200 bytes)
- [x] `uv run pytest tests/test_media_download.py -v` — all 10 tests pass
- [x] `uv run ruff check backend/ tests/` — clean
- [x] `uv run ruff format --check backend/ tests/` — clean

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)