### PR TITLE
fix: derive estimate number from database ID to prevent race condition

### DIFF
--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -22,12 +22,6 @@ class EstimateStatus:
     SENT = "sent"
 
 
-def _next_estimate_number(db: Session, contractor_id: int) -> str:
-    """Generate the next sequential estimate number for a contractor."""
-    count = db.query(Estimate).filter(Estimate.contractor_id == contractor_id).count()
-    return ESTIMATE_NUMBER_FORMAT.format(count + 1)
-
-
 def create_estimate_tools(
     db: Session,
     contractor: Contractor,
@@ -42,7 +36,6 @@ def create_estimate_tools(
         terms: str | None = None,
     ) -> str:
         """Generate a professional estimate PDF and return summary."""
-        estimate_number = _next_estimate_number(db, contractor.id)
         today = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")
 
         # Calculate totals
@@ -73,6 +66,8 @@ def create_estimate_tools(
         )
         db.add(estimate)
         db.flush()  # Get the ID before adding line items
+
+        estimate_number = ESTIMATE_NUMBER_FORMAT.format(estimate.id)
 
         for item in processed_items:
             line_item = EstimateLineItem(

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from backend.app.agent.tools.estimate_tools import _next_estimate_number, create_estimate_tools
+from backend.app.agent.tools.estimate_tools import create_estimate_tools
 from backend.app.models import Contractor, Estimate, EstimateLineItem
 
 
@@ -147,30 +147,6 @@ async def test_generate_estimate_custom_terms(
     )
 
     assert "EST-0001" in result
-
-
-def test_next_estimate_number_empty(
-    db_session: Session,
-    test_contractor: Contractor,
-) -> None:
-    """First estimate should be EST-0001."""
-    assert _next_estimate_number(db_session, test_contractor.id) == "EST-0001"
-
-
-def test_next_estimate_number_increments(
-    db_session: Session,
-    test_contractor: Contractor,
-) -> None:
-    """Estimate number should increment."""
-    db_session.add(
-        Estimate(
-            contractor_id=test_contractor.id,
-            description="Test",
-            total_amount=100.0,
-        )
-    )
-    db_session.commit()
-    assert _next_estimate_number(db_session, test_contractor.id) == "EST-0002"
 
 
 def test_serve_estimate_pdf_endpoint(


### PR DESCRIPTION
## Summary
- Remove `_next_estimate_number()` which used `count()` and was vulnerable to race conditions under concurrent estimate creation
- Derive estimate number from the auto-increment database ID after `db.flush()`, guaranteeing uniqueness
- Remove two unit tests for the deleted function; all remaining estimate tests still pass with ID-based numbering

## Test plan
- [x] `test_generate_estimate_sequential_numbers` verifies sequential numbering (EST-0001, EST-0002) still works via database IDs
- [x] `uv run pytest tests/test_estimates.py -v` — all 10 tests pass
- [x] `uv run ruff check backend/ tests/` — clean
- [x] `uv run ruff format --check backend/ tests/` — clean

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)