### PR TITLE
fix: give webhook background task its own DB session

### DIFF
--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -11,7 +11,7 @@ from starlette.background import BackgroundTask
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.router import handle_inbound_message
 from backend.app.config import settings
-from backend.app.database import get_db
+from backend.app.database import SessionLocal, get_db
 from backend.app.models import Contractor, Message
 from backend.app.services.messaging import MessagingService, get_messaging_service
 from backend.app.services.rate_limiter import check_webhook_rate_limit
@@ -55,14 +55,27 @@ def _get_or_create_contractor(db: Session, chat_id: str) -> Contractor:
 
 
 async def _process_message_background(
-    db: Session,
-    contractor: Contractor,
-    message: Message,
+    contractor_id: int,
+    message_id: int,
     media_urls: list[tuple[str, str]],
     messaging_service: MessagingService,
 ) -> None:
-    """Run the agent pipeline as a background task."""
+    """Run the agent pipeline as a background task.
+
+    Creates its own DB session rather than sharing the request-scoped one,
+    which would be closed by the time this task executes.
+    """
+    db: Session = SessionLocal()
     try:
+        contractor = db.get(Contractor, contractor_id)
+        message = db.get(Message, message_id)
+        if contractor is None or message is None:
+            logger.error(
+                "Background task: contractor %d or message %d not found",
+                contractor_id,
+                message_id,
+            )
+            return
         await handle_inbound_message(
             db=db,
             contractor=contractor,
@@ -72,10 +85,12 @@ async def _process_message_background(
         )
     except Exception:
         logger.exception(
-            "Agent pipeline failed for message %d from chat %s",
-            message.id,
-            contractor.channel_identifier,
+            "Agent pipeline failed for message %d (contractor %d)",
+            message_id,
+            contractor_id,
         )
+    finally:
+        db.close()
 
 
 def _extract_telegram_media(
@@ -190,9 +205,8 @@ async def telegram_inbound(
 
     task = BackgroundTask(
         _process_message_background,
-        db=db,
-        contractor=contractor,
-        message=message,
+        contractor_id=contractor.id,
+        message_id=message.id,
         media_urls=media_urls,
         messaging_service=messaging_service,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,10 +72,21 @@ def client(
     def _override_get_messaging_service() -> Generator[MessagingService]:
         yield mock_messaging_service
 
+    # Build a sessionmaker bound to the test engine so background tasks
+    # (which call SessionLocal() directly) share the same in-memory DB.
+    test_session_factory = sessionmaker(bind=db_session.get_bind())
+
     webhook_rate_limiter.reset()
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_current_user] = _override_get_current_user
     app.dependency_overrides[get_messaging_service] = _override_get_messaging_service
-    with patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"), TestClient(app) as c:
+    with (
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.routers.telegram_webhook.SessionLocal", test_session_factory),
+        # Prevent .env allowlist settings from leaking into tests
+        patch("backend.app.routers.telegram_webhook.settings.telegram_allowed_chat_ids", ""),
+        patch("backend.app.routers.telegram_webhook.settings.telegram_allowed_usernames", ""),
+        TestClient(app) as c,
+    ):
         yield c
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `_process_message_background` now creates its own `SessionLocal()` session instead of receiving the request-scoped session, which gets closed before the background task executes
- Background task receives `contractor_id` and `message_id` (ints) and re-queries the entities in its own session
- Test fixture patches `SessionLocal` in the webhook module to use the test engine, and clears allowlist settings to prevent `.env` leakage

## Test plan
- [x] `uv run pytest tests/test_telegram_webhook.py -v` — all 23 tests pass
- [x] `uv run pytest -v` — all 307 tests pass
- [x] `uv run ruff check backend/ tests/` — clean
- [x] `uv run ruff format --check backend/ tests/` — clean

Fixes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)