### PR TITLE
fix: keep estimate as draft until actually sent

### DIFF
--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -105,9 +105,8 @@ def create_estimate_tools(
         pdf_path = PDF_DIR / f"{estimate.id}.pdf"
         pdf_path.write_bytes(pdf_bytes)
 
-        # Update estimate with PDF path
+        # Update estimate with PDF path — stays as DRAFT until actually sent
         estimate.pdf_url = str(pdf_path)
-        estimate.status = EstimateStatus.SENT
         db.commit()
 
         return (

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -47,7 +47,7 @@ async def test_generate_estimate_creates_records(
     )
     assert estimate is not None
     assert estimate.total_amount == 4200.00
-    assert estimate.status == "sent"
+    assert estimate.status == "draft"
     assert estimate.description == "12x12 composite deck build"
 
     items = (


### PR DESCRIPTION
## Summary
- Remove premature `estimate.status = EstimateStatus.SENT` from `generate_estimate` — estimate now stays as `draft` after PDF generation
- The heartbeat's stale-estimate check queries for `status == 'draft'`, so unsent PDFs will now correctly be flagged if they sit for >24h

## Test plan
- [x] Updated `test_generate_estimate_creates_records` to assert `status == "draft"`
- [x] `uv run pytest tests/test_estimates.py tests/test_heartbeat.py -v` — all 68 tests pass
- [x] `uv run ruff check backend/ tests/` — clean
- [x] `uv run ruff format --check backend/ tests/` — clean

Fixes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)