### PR TITLE
fix: prevent path traversal in LocalFileStorage

### DIFF
--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -136,24 +136,34 @@ class LocalFileStorage(StorageBackend):
     """Local filesystem storage for development and demos."""
 
     def __init__(self, base_dir: str = settings.file_storage_base_dir) -> None:
-        self.base_dir = Path(base_dir)
+        self.base_dir = Path(base_dir).resolve()
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
+    def _safe_path(self, *segments: str) -> Path:
+        """Resolve path segments under base_dir, rejecting traversal attempts."""
+        result = self.base_dir
+        for seg in segments:
+            result = result / seg.lstrip("/")
+        resolved = result.resolve()
+        if not str(resolved).startswith(str(self.base_dir)):
+            msg = f"Path escapes storage directory: {'/'.join(segments)}"
+            raise ValueError(msg)
+        return resolved
+
     async def upload_file(self, file_bytes: bytes, path: str, filename: str) -> str:
-        folder = self.base_dir / path.lstrip("/")
-        folder.mkdir(parents=True, exist_ok=True)
-        file_path = folder / filename
+        file_path = self._safe_path(path, filename)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
         logger.info("Saving to local storage: %s (%d bytes)", file_path, len(file_bytes))
         await asyncio.to_thread(file_path.write_bytes, file_bytes)
-        return f"file://{file_path.resolve()}"
+        return f"file://{file_path}"
 
     async def create_folder(self, path: str) -> str:
-        folder = self.base_dir / path.lstrip("/")
+        folder = self._safe_path(path)
         folder.mkdir(parents=True, exist_ok=True)
         return str(folder)
 
     async def list_folder(self, path: str) -> list[dict[str, str]]:
-        folder = self.base_dir / path.lstrip("/")
+        folder = self._safe_path(path)
         if not folder.exists():
             return []
         return [{"name": f.name, "path": str(f)} for f in folder.iterdir() if f.is_file()]

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -138,6 +138,47 @@ async def test_local_list_folder_empty(local_storage: LocalFileStorage) -> None:
 
 
 # ---------------------------------------------------------------------------
+# LocalFileStorage path-traversal tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_local_upload_rejects_path_traversal(local_storage: LocalFileStorage) -> None:
+    """upload_file should reject path containing '..' that escapes base_dir."""
+    with pytest.raises(ValueError, match="Path escapes storage directory"):
+        await local_storage.upload_file(b"evil", "../../etc", "passwd")
+
+
+@pytest.mark.asyncio()
+async def test_local_upload_rejects_filename_traversal(local_storage: LocalFileStorage) -> None:
+    """upload_file should reject filename containing '..' that escapes base_dir."""
+    with pytest.raises(ValueError, match="Path escapes storage directory"):
+        await local_storage.upload_file(b"evil", "/safe", "../../etc/passwd")
+
+
+@pytest.mark.asyncio()
+async def test_local_create_folder_rejects_traversal(local_storage: LocalFileStorage) -> None:
+    """create_folder should reject paths that escape base_dir."""
+    with pytest.raises(ValueError, match="Path escapes storage directory"):
+        await local_storage.create_folder("../../tmp/evil")
+
+
+@pytest.mark.asyncio()
+async def test_local_list_folder_rejects_traversal(local_storage: LocalFileStorage) -> None:
+    """list_folder should reject paths that escape base_dir."""
+    with pytest.raises(ValueError, match="Path escapes storage directory"):
+        await local_storage.list_folder("../../../etc")
+
+
+@pytest.mark.asyncio()
+async def test_local_safe_relative_path_allowed(local_storage: LocalFileStorage) -> None:
+    """Paths that resolve inside base_dir (e.g. 'a/../b') should be allowed."""
+    url = await local_storage.upload_file(b"ok", "a/../b", "file.txt")
+    assert "file.txt" in url
+    assert (local_storage.base_dir / "b" / "file.txt").exists()
+
+
+# ---------------------------------------------------------------------------
 # DropboxStorage tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

`LocalFileStorage.upload_file()`, `create_folder()`, and `list_folder()` only stripped leading `/` from the path parameter via `path.lstrip("/")`. This did not prevent directory traversal sequences like `../../etc/`. An attacker who could influence the path or filename (e.g. via prompt injection into an LLM tool call) could write/read files outside the intended base directory.

**Fix**: Add `_safe_path()` method that resolves the final path and verifies it stays under `base_dir`. Apply it to all three methods. Resolve `base_dir` at init time so comparisons are stable.

Fixes #238

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the vulnerability and implemented the fix with 5 regression tests)
- [ ] No AI used