### PR TITLE
fix: harden webhook against malformed Telegram updates

### DIFF
--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -107,19 +107,25 @@ def _extract_telegram_media(
     photos = msg.get("photo")
     if photos:
         largest = max(photos, key=lambda p: p.get("file_size", 0))
-        media.append((largest["file_id"], "image/jpeg"))
+        file_id = largest.get("file_id")
+        if file_id:
+            media.append((file_id, "image/jpeg"))
 
     # Voice note
     voice = msg.get("voice")
     if voice:
-        media.append((voice["file_id"], voice.get("mime_type", "audio/ogg")))
+        file_id = voice.get("file_id")
+        if file_id:
+            media.append((file_id, voice.get("mime_type", "audio/ogg")))
 
     # Document — preserve Telegram-provided MIME type so images sent as
     # documents (e.g. image/png) are correctly classified downstream
     doc = msg.get("document")
     if doc:
-        doc_mime = doc.get("mime_type", "application/octet-stream")
-        media.append((doc["file_id"], doc_mime))
+        file_id = doc.get("file_id")
+        if file_id:
+            doc_mime = doc.get("mime_type", "application/octet-stream")
+            media.append((file_id, doc_mime))
 
     if media:
         logger.debug(
@@ -143,13 +149,22 @@ async def telegram_inbound(
     except _InvalidSecret:
         return JSONResponse(content={"ok": True})
 
-    update: dict = await request.json()  # type: ignore[assignment]
+    try:
+        update: dict = await request.json()  # type: ignore[assignment]
+    except ValueError:
+        logger.warning("Telegram webhook received invalid JSON")
+        return JSONResponse(content={"ok": True})
+
     msg = update.get("message")
     if not msg:
         # Not a message update (could be edited_message, callback_query, etc.)
         return JSONResponse(content={"ok": True})
 
-    chat_id = str(msg["chat"]["id"])
+    chat = msg.get("chat") if isinstance(msg, dict) else None
+    if not chat or "id" not in chat:
+        logger.warning("Telegram message missing chat.id, ignoring")
+        return JSONResponse(content={"ok": True})
+    chat_id = str(chat["id"])
     text = msg.get("text", "")
     update_id = str(update.get("update_id", ""))
 

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -405,6 +405,64 @@ def test_username_allowlist_no_username_in_payload(client: TestClient, db_sessio
 # -- Regression tests for document MIME classification --
 
 
+def test_webhook_invalid_json_returns_200(client: TestClient) -> None:
+    """Invalid JSON body should return 200 without crashing."""
+    response = client.post(
+        "/api/webhooks/telegram",
+        content=b"not valid json",
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_webhook_missing_chat_id_returns_200(client: TestClient) -> None:
+    """Message without chat.id should return 200 without crashing."""
+    payload = {"update_id": 1, "message": {"text": "hello"}}
+    response = client.post("/api/webhooks/telegram", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_extract_media_skips_photo_without_file_id() -> None:
+    """Photos missing file_id should be skipped instead of crashing."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {
+        "message": {
+            "photo": [{"file_unique_id": "abc", "width": 90, "height": 90, "file_size": 1000}],
+        }
+    }
+    media = _extract_telegram_media(update)
+    assert media == []
+
+
+def test_extract_media_skips_voice_without_file_id() -> None:
+    """Voice notes missing file_id should be skipped."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {
+        "message": {
+            "voice": {"file_unique_id": "v1", "duration": 5},
+        }
+    }
+    media = _extract_telegram_media(update)
+    assert media == []
+
+
+def test_extract_media_skips_document_without_file_id() -> None:
+    """Documents missing file_id should be skipped."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {
+        "message": {
+            "document": {"file_unique_id": "d1", "file_name": "test.pdf"},
+        }
+    }
+    media = _extract_telegram_media(update)
+    assert media == []
+
+
 def test_extract_telegram_media_image_document_preserves_mime() -> None:
     """Images sent as documents should preserve their image/* MIME type."""
     from backend.app.routers.telegram_webhook import _extract_telegram_media


### PR DESCRIPTION
## Description

The Telegram webhook endpoint had several unguarded dictionary accesses that would crash on malformed payloads:

1. `await request.json()` could raise `ValueError` on invalid JSON
2. `msg["chat"]["id"]` would `KeyError` if `chat` key is missing
3. `largest["file_id"]`, `voice["file_id"]`, `doc["file_id"]` would `KeyError` if `file_id` is missing

Since Telegram expects 200 responses, unhandled exceptions cause retries and potential rate limit exhaustion.

**Fix:**
- Wrap `request.json()` in `try/except ValueError`
- Validate `chat.id` with `.get()` and return early if missing
- Use `.get()` for all `file_id` accesses in `_extract_telegram_media()` and skip entries without it

Fixes #239

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the vulnerability and implemented the fix with 5 regression tests)
- [ ] No AI used