### PR TITLE
fix: return early when contractor has no delivery address

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -60,6 +60,7 @@ async def handle_inbound_message(
             "Contractor %d has no channel_identifier or phone — cannot send replies",
             contractor.id,
         )
+        return AgentResponse(reply_text="")
 
     # Step 1: Download media
     downloaded_media: list[DownloadedMedia] = []

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -613,13 +613,13 @@ async def test_pipeline_failure_without_downloaded_media_skips_vision_note(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.acompletion")
-async def test_empty_to_address_logs_error(
+async def test_empty_to_address_returns_early(
     mock_acompletion: object,
     db_session: Session,
     inbound_message: Message,
     mock_messaging: MessagingService,
 ) -> None:
-    """Contractor with no channel_identifier or phone should log an error."""
+    """Contractor with no channel_identifier or phone should return early."""
     # Create contractor with empty delivery fields
     no_addr = Contractor(
         user_id="no-addr",
@@ -630,21 +630,18 @@ async def test_empty_to_address_logs_error(
     db_session.commit()
     db_session.refresh(no_addr)
 
-    mock_acompletion.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
-
-    with patch("backend.app.agent.router.logger") as mock_logger:
-        await handle_inbound_message(
-            db=db_session,
-            contractor=no_addr,
-            message=inbound_message,
-            media_urls=[],
-            messaging_service=mock_messaging,
-        )
-
-    mock_logger.error.assert_any_call(
-        "Contractor %d has no channel_identifier or phone — cannot send replies",
-        no_addr.id,
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=no_addr,
+        message=inbound_message,
+        media_urls=[],
+        messaging_service=mock_messaging,
     )
+
+    # Should return early without calling the LLM or sending any message
+    assert response.reply_text == ""
+    mock_acompletion.assert_not_called()  # type: ignore[union-attr]
+    mock_messaging.send_text.assert_not_called()  # type: ignore[union-attr]
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description

When a contractor has no `channel_identifier` or `phone`, `handle_inbound_message` logged an error but continued executing the full pipeline: downloading media, calling the LLM, and building messaging tools with `to_address=None`. This wasted LLM calls and caused failures downstream when trying to send replies.

**Fix:** Return an empty `AgentResponse` immediately after logging the error, avoiding all unnecessary processing.

Fixes #240

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the bug and implemented the fix with updated regression test)
- [ ] No AI used