### PR TITLE
fix: validate estimate line item quantities and prices

### DIFF
--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -42,8 +42,15 @@ def create_estimate_tools(
         processed_items: list[dict[str, object]] = []
         subtotal = 0.0
         for item in line_items:
-            qty = float(item.get("quantity", 1))
-            price = float(item.get("unit_price", 0))
+            try:
+                qty = float(item.get("quantity", 1))
+                price = float(item.get("unit_price", 0))
+            except (ValueError, TypeError) as exc:
+                return f"Error: invalid line item values — {exc}"
+
+            if qty < 0 or price < 0:
+                return "Error: quantity and unit_price must not be negative."
+
             total = qty * price
             subtotal += total
             processed_items.append(

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -158,6 +158,62 @@ async def test_generate_estimate_custom_terms(
     assert "EST-0001" in result
 
 
+@pytest.mark.asyncio()
+async def test_generate_estimate_rejects_negative_quantity(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Negative quantity should return an error instead of creating a record."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result = await generate(
+        description="Bad estimate",
+        line_items=[{"description": "Work", "quantity": -5, "unit_price": 100.00}],
+    )
+
+    assert "Error" in result
+    assert "negative" in result.lower()
+    assert db_session.query(Estimate).count() == 0
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_rejects_negative_price(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Negative unit_price should return an error."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result = await generate(
+        description="Bad estimate",
+        line_items=[{"description": "Work", "quantity": 1, "unit_price": -50.00}],
+    )
+
+    assert "Error" in result
+    assert "negative" in result.lower()
+    assert db_session.query(Estimate).count() == 0
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_rejects_non_numeric_values(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Non-numeric quantity/price should return an error."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    result = await generate(
+        description="Bad estimate",
+        line_items=[{"description": "Work", "quantity": "abc", "unit_price": 100.00}],
+    )
+
+    assert "Error" in result
+    assert db_session.query(Estimate).count() == 0
+
+
 def test_serve_estimate_pdf_endpoint(
     client: TestClient, db_session: Session, test_contractor: Contractor, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Description

`generate_estimate()` converted line item values to `float()` without checking for negative numbers or non-numeric strings. Negative values create invalid estimates with negative totals, and non-numeric values crash with an unhandled `ValueError`.

**Fix:** Add validation to reject negative quantities/prices and catch `ValueError`/`TypeError` from `float()` conversion, returning a descriptive error string to the agent instead of crashing.

Fixes #241

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the vulnerability and implemented the fix with 3 regression tests)
- [ ] No AI used