### PR TITLE
fix: pass contractor ID to vision analysis for OpenAI user tracking

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -77,7 +77,9 @@ async def handle_inbound_message(
         media_notes.append(MEDIA_DOWNLOAD_ERROR)
 
     try:
-        pipeline_result = await process_message_media(message.body, downloaded_media)
+        pipeline_result = await process_message_media(
+            message.body, downloaded_media, user=str(contractor.id)
+        )
     except Exception:
         logger.exception(
             "Media pipeline failed for message %d, contractor %d",

--- a/backend/app/media/pipeline.py
+++ b/backend/app/media/pipeline.py
@@ -39,7 +39,7 @@ class PipelineResult:
 
 
 async def _process_single_media(
-    media: DownloadedMedia, index: int, context: str = ""
+    media: DownloadedMedia, index: int, context: str = "", user: str | None = None
 ) -> ProcessedMedia:
     """Process a single media item based on its type."""
     category = classify_media(media.mime_type)
@@ -48,7 +48,9 @@ async def _process_single_media(
 
     if category == "image":
         try:
-            extracted_text = await analyze_image(media.content, media.mime_type, context=context)
+            extracted_text = await analyze_image(
+                media.content, media.mime_type, context=context, user=user
+            )
         except Exception:
             logger.exception(
                 "Vision analysis failed for %s (mime_type=%s)", media.original_url, media.mime_type
@@ -85,10 +87,13 @@ async def _process_single_media(
 async def process_message_media(
     text_body: str,
     media_items: list[DownloadedMedia],
+    user: str | None = None,
 ) -> PipelineResult:
     """Process all media in a message and combine into unified context."""
     logger.info("Processing %d media item(s)", len(media_items))
-    tasks = [_process_single_media(m, i, context=text_body) for i, m in enumerate(media_items)]
+    tasks = [
+        _process_single_media(m, i, context=text_body, user=user) for i, m in enumerate(media_items)
+    ]
     media_results = await asyncio.gather(*tasks)
     media_results = list(media_results)
     logger.info(

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -102,6 +102,9 @@ async def test_message_with_photo(
     assert response.reply_text == "Looks like a great deck project!"
     mock_download.assert_called_once()
     mock_vision.assert_called_once()
+    # Verify user (contractor ID) is passed for OpenAI tracking
+    call_kwargs = mock_vision.call_args
+    assert call_kwargs.kwargs.get("user") == str(test_contractor.id)
 
 
 @pytest.mark.asyncio()

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -74,6 +74,46 @@ async def test_analyze_image_does_not_pass_api_key(mock_acompletion: object) -> 
 @pytest.mark.asyncio()
 @patch("backend.app.media.vision.acompletion")
 @patch("backend.app.media.vision.settings")
+async def test_analyze_image_passes_user_for_openai(
+    mock_settings: object, mock_acompletion: object
+) -> None:
+    """When provider is openai and user is set, user should be passed to acompletion."""
+    mock_settings.vision_model = "gpt-4o"  # type: ignore[attr-defined]
+    mock_settings.llm_model = "gpt-4o"  # type: ignore[attr-defined]
+    mock_settings.llm_provider = "openai"  # type: ignore[attr-defined]
+    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
+    mock_settings.llm_max_tokens_vision = 1024  # type: ignore[attr-defined]
+    mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]
+
+    await analyze_image(b"fake-jpeg-bytes", "image/jpeg", user="42")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    assert call_args.kwargs["user"] == "42"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.media.vision.acompletion")
+@patch("backend.app.media.vision.settings")
+async def test_analyze_image_omits_user_for_non_openai(
+    mock_settings: object, mock_acompletion: object
+) -> None:
+    """When provider is not openai, user should NOT be passed."""
+    mock_settings.vision_model = ""  # type: ignore[attr-defined]
+    mock_settings.llm_model = "claude-haiku-4-5-20251001"  # type: ignore[attr-defined]
+    mock_settings.llm_provider = "anthropic"  # type: ignore[attr-defined]
+    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
+    mock_settings.llm_max_tokens_vision = 1024  # type: ignore[attr-defined]
+    mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]
+
+    await analyze_image(b"fake-jpeg-bytes", "image/jpeg", user="42")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    assert "user" not in call_args.kwargs
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.media.vision.acompletion")
+@patch("backend.app.media.vision.settings")
 async def test_analyze_image_falls_back_to_llm_model(
     mock_settings: object, mock_acompletion: object
 ) -> None:


### PR DESCRIPTION
## Description

The media pipeline called `analyze_image()` without the `user` parameter, so OpenAI vision requests lacked contractor attribution for billing and quota tracking. The agent's `process_message()` already passes `user` correctly, but vision analysis did not.

**Fix:** Thread `user` (contractor ID as string) through `process_message_media()` and `_process_single_media()` to `analyze_image()`, matching the pattern already used in `core.py`.

Fixes #246

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the inconsistency and implemented the fix with 3 regression tests)
- [ ] No AI used