### PR TITLE
fix: validate empty messages in send_reply and send_media_reply tools

### DIFF
--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -7,11 +7,15 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
 
     async def send_reply(message: str) -> str:
         """Send a text reply to the contractor."""
+        if not message or not message.strip():
+            return "Error: message cannot be empty."
         msg_id = await messaging_service.send_text(to=to_address, body=message)
         return f"Sent message (ID: {msg_id})"
 
     async def send_media_reply(message: str, media_url: str) -> str:
         """Send a reply with a media attachment."""
+        if not media_url or not media_url.strip():
+            return "Error: media_url cannot be empty."
         msg_id = await messaging_service.send_media(
             to=to_address, body=message, media_url=media_url
         )

--- a/tests/test_messaging_tools.py
+++ b/tests/test_messaging_tools.py
@@ -27,6 +27,40 @@ async def test_send_reply_tool(mock_messaging_service: MessagingService) -> None
 
 
 @pytest.mark.asyncio()
+async def test_send_reply_rejects_empty_message(mock_messaging_service: MessagingService) -> None:
+    """send_reply should return error for empty messages."""
+    tools = create_messaging_tools(mock_messaging_service, to_address="123456789")
+    send_reply = tools[0].function
+    result = await send_reply(message="")
+    assert "Error" in result
+    mock_messaging_service.send_text.assert_not_called()  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio()
+async def test_send_reply_rejects_whitespace_message(
+    mock_messaging_service: MessagingService,
+) -> None:
+    """send_reply should return error for whitespace-only messages."""
+    tools = create_messaging_tools(mock_messaging_service, to_address="123456789")
+    send_reply = tools[0].function
+    result = await send_reply(message="   ")
+    assert "Error" in result
+    mock_messaging_service.send_text.assert_not_called()  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio()
+async def test_send_media_reply_rejects_empty_url(
+    mock_messaging_service: MessagingService,
+) -> None:
+    """send_media_reply should return error for empty media_url."""
+    tools = create_messaging_tools(mock_messaging_service, to_address="123456789")
+    send_media_reply = tools[1].function
+    result = await send_media_reply(message="Here's your file", media_url="")
+    assert "Error" in result
+    mock_messaging_service.send_media.assert_not_called()  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio()
 async def test_send_media_reply_tool(mock_messaging_service: MessagingService) -> None:
     """send_media_reply tool should send media with message."""
     tools = create_messaging_tools(mock_messaging_service, to_address="123456789")


### PR DESCRIPTION
## Description

`send_reply` accepted empty or whitespace-only messages, which Telegram's API rejects. `send_media_reply` similarly accepted empty media URLs. In both cases the error propagated as an unhandled exception from the messaging service.

**Fix:** Add early validation returning a descriptive error string to the agent, preventing the API call from being attempted.

Fixes #247

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the gap and implemented the fix with 3 regression tests)
- [ ] No AI used