### PR TITLE
feat: add onboarding progress signal and completion message

### DIFF
--- a/backend/app/agent/profile.py
+++ b/backend/app/agent/profile.py
@@ -69,6 +69,10 @@ def build_onboarding_prompt() -> str:
         "immediately save it using the save_fact tool. Use keys like 'name', 'trade', "
         "'location', 'hourly_rate', or 'business_hours'. Do not wait — save each "
         "piece of information as soon as you learn it.\n\n"
+        "After collecting and saving information, briefly confirm what you've saved "
+        "so the contractor knows you got it right. For example: \"Great, I've got you "
+        'down as Jake, a plumber in Portland." When you still need more information, '
+        "mention what's missing naturally in conversation.\n\n"
         "Be conversational and warm. Don't ask all questions at once — "
         "let the conversation flow naturally. Start by introducing yourself "
         "and asking their name and what kind of work they do."

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -103,8 +103,8 @@ async def handle_inbound_message(
     conversation_history = await load_conversation_history(db, message.conversation_id)
 
     # Step 5: Initialize agent with tools
-    onboarding = is_onboarding_needed(contractor)
-    system_prompt_override = build_onboarding_system_prompt(contractor) if onboarding else None
+    was_onboarding = is_onboarding_needed(contractor)
+    system_prompt_override = build_onboarding_system_prompt(contractor) if was_onboarding else None
 
     agent = BackshopAgent(db=db, contractor=contractor)
     tools = create_memory_tools(db, contractor.id)
@@ -148,7 +148,7 @@ async def handle_inbound_message(
         response = AgentResponse(reply_text=AGENT_ERROR_FALLBACK)
 
     # Step 6b: If onboarding, extract profile updates from tool calls
-    if onboarding:
+    if was_onboarding:
         profile_updates = extract_profile_updates(response)
         if profile_updates:
             await update_contractor_profile(db, contractor, profile_updates)
@@ -157,6 +157,22 @@ async def handle_inbound_message(
             if not is_onboarding_needed(contractor):
                 contractor.onboarding_complete = True
                 db.commit()
+
+        # Append completion summary when onboarding transitions to complete
+        if contractor.onboarding_complete:
+            parts = [f"Name: {contractor.name}", f"Trade: {contractor.trade}"]
+            if contractor.location:
+                parts.append(f"Location: {contractor.location}")
+            if contractor.hourly_rate:
+                parts.append(f"Rate: ${contractor.hourly_rate:.0f}/hour")
+            summary = "\n".join(f"- {p}" for p in parts)
+            completion_note = (
+                "\n\nSetup complete! Here's what I know about you:\n"
+                f"{summary}\n\n"
+                "You can update any of this anytime. I'm ready to help!"
+            )
+            if response.reply_text:
+                response.reply_text += completion_note
 
     # Step 7: If agent didn't explicitly call send_reply/send_media_reply, send the reply text
     REPLY_TOOL_NAMES = {"send_reply", "send_media_reply"}

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -311,3 +311,158 @@ async def test_complete_profile_uses_normal_prompt(
     system_msg = call_args.kwargs["messages"][0]["content"]
     # Normal prompt should NOT contain onboarding text
     assert "new contractor" not in system_msg
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_onboarding_completion_message_appended(
+    mock_acompletion: object,
+    db_session: Session,
+    mock_messaging: MessagingService,
+) -> None:
+    """Completion summary should be appended when onboarding transitions to complete."""
+    # Contractor with no name/trade — needs onboarding
+    contractor = Contractor(
+        user_id="completing-user",
+        phone="+15550008888",
+        channel_identifier="888888888",
+    )
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+
+    conv = Conversation(contractor_id=contractor.id)
+    db_session.add(conv)
+    db_session.commit()
+    db_session.refresh(conv)
+    msg = Message(conversation_id=conv.id, direction="inbound", body="I'm Jake, I'm a plumber")
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+
+    # Simulate agent saving name and trade (completing required fields)
+    tool_calls = [
+        {
+            "name": "save_fact",
+            "arguments": '{"key": "name", "value": "Jake"}',
+        },
+        {
+            "name": "save_fact",
+            "arguments": '{"key": "trade", "value": "Plumber"}',
+        },
+    ]
+    from tests.mocks.llm import make_tool_call_response
+
+    # First call: tool calls to save name/trade; second call: text reply
+    mock_acompletion.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(tool_calls, content=None),
+        make_text_response("Great to meet you, Jake!"),
+    ]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=contractor,
+        message=msg,
+        media_urls=[],
+        messaging_service=mock_messaging,
+    )
+
+    assert "Setup complete!" in response.reply_text
+    assert "- Name: Jake" in response.reply_text
+    assert "- Trade: Plumber" in response.reply_text
+    assert "You can update any of this anytime" in response.reply_text
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_onboarding_completion_message_includes_optional_fields(
+    mock_acompletion: object,
+    db_session: Session,
+    mock_messaging: MessagingService,
+) -> None:
+    """Completion summary should include location and rate when available."""
+    # Contractor with location already set, still needs name+trade
+    contractor = Contractor(
+        user_id="optional-fields-user",
+        phone="+15550009999",
+        channel_identifier="999999998",
+        location="Portland, OR",
+        hourly_rate=85.0,
+    )
+    db_session.add(contractor)
+    db_session.commit()
+    db_session.refresh(contractor)
+
+    conv = Conversation(contractor_id=contractor.id)
+    db_session.add(conv)
+    db_session.commit()
+    db_session.refresh(conv)
+    msg = Message(conversation_id=conv.id, direction="inbound", body="I'm Sarah, electrician")
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+
+    tool_calls = [
+        {
+            "name": "save_fact",
+            "arguments": '{"key": "name", "value": "Sarah"}',
+        },
+        {
+            "name": "save_fact",
+            "arguments": '{"key": "trade", "value": "Electrician"}',
+        },
+    ]
+    from tests.mocks.llm import make_tool_call_response
+
+    mock_acompletion.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(tool_calls, content=None),
+        make_text_response("Welcome aboard, Sarah!"),
+    ]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=contractor,
+        message=msg,
+        media_urls=[],
+        messaging_service=mock_messaging,
+    )
+
+    assert "Setup complete!" in response.reply_text
+    assert "- Name: Sarah" in response.reply_text
+    assert "- Trade: Electrician" in response.reply_text
+    assert "- Location: Portland, OR" in response.reply_text
+    assert "- Rate: $85/hour" in response.reply_text
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_no_completion_message_when_already_onboarded(
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+    mock_messaging: MessagingService,
+) -> None:
+    """Completion message should NOT be appended for already-onboarded contractors."""
+    conv = Conversation(contractor_id=test_contractor.id)
+    db_session.add(conv)
+    db_session.commit()
+    db_session.refresh(conv)
+    msg = Message(
+        conversation_id=conv.id, direction="inbound", body="Can you help me with an estimate?"
+    )
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+
+    mock_acompletion.return_value = make_text_response("Sure, I can help!")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        db=db_session,
+        contractor=test_contractor,
+        message=msg,
+        media_urls=[],
+        messaging_service=mock_messaging,
+    )
+
+    assert response.reply_text == "Sure, I can help!"
+    assert "Setup complete!" not in response.reply_text

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -68,3 +68,10 @@ def test_build_onboarding_prompt() -> None:
     assert "name" in prompt.lower()
     assert "trade" in prompt.lower()
     assert "rate" in prompt.lower()
+
+
+def test_build_onboarding_prompt_includes_confirmation_instruction() -> None:
+    """Onboarding prompt should instruct agent to confirm saved info."""
+    prompt = build_onboarding_prompt()
+    assert "confirm what you've saved" in prompt
+    assert "what's missing" in prompt.lower()


### PR DESCRIPTION
## Summary
- Update onboarding prompt to instruct agent to confirm saved info during collection
- Append completion summary when onboarding transitions to complete
- Summary shows name, trade, location, and rate (when available)

## Test plan
- [x] Onboarding prompt includes confirmation instruction
- [x] Completion message appended on transition
- [x] Not appended when already onboarded
- [x] Summary includes available fields
- [x] All existing tests pass (330 passed)

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)