### PR TITLE
fix: use regex-based rate parsing for robust hourly rate extraction

### DIFF
--- a/backend/app/agent/onboarding.py
+++ b/backend/app/agent/onboarding.py
@@ -1,11 +1,14 @@
 """Onboarding conversation logic for new contractors."""
 
-import contextlib
+import logging
+import re
 from typing import Any
 
 from backend.app.agent.core import AgentResponse
 from backend.app.agent.profile import build_onboarding_prompt
 from backend.app.models import Contractor
+
+logger = logging.getLogger(__name__)
 
 # Fields that indicate a contractor has completed onboarding
 REQUIRED_PROFILE_FIELDS = {"name", "trade"}
@@ -59,6 +62,26 @@ def build_onboarding_system_prompt(contractor: Contractor) -> str:
     return "".join(parts)
 
 
+def _parse_rate(value: str) -> float | None:
+    """Extract a numeric rate from natural-language rate descriptions.
+
+    Handles formats like "$85/hr", "$85/hour", "$85 per hour", "$85 an hour",
+    "85 dollars", "$85.50", "$50-75/hr" (extracts first number), "$4500 per project",
+    "Usually around $80", etc.
+
+    Returns None for non-numeric values like "not sure" or "varies".
+    """
+    cleaned = str(value).replace(",", "").strip()
+
+    # Try to find a dollar amount or plain number
+    # Handles: $85, $85/hr, $85.50, 85, 85.00, etc.
+    match = re.search(r"\$?\s*(\d+(?:\.\d+)?)", cleaned)
+    if match:
+        return float(match.group(1))
+
+    return None
+
+
 def extract_profile_updates(agent_response: AgentResponse) -> dict[str, Any]:
     """Extract profile field updates from agent tool calls during onboarding.
 
@@ -90,8 +113,11 @@ def extract_profile_updates(agent_response: AgentResponse) -> dict[str, Any]:
         if key in key_to_field:
             field = key_to_field[key]
             if field == "hourly_rate":
-                with contextlib.suppress(ValueError):
-                    updates[field] = float(str(value).replace("$", "").replace("/hr", "").strip())
+                parsed = _parse_rate(str(value))
+                if parsed is not None:
+                    updates[field] = parsed
+                else:
+                    logger.warning("Could not parse hourly rate from value: %r", value)
             else:
                 updates[field] = str(value)
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.core import AgentResponse
 from backend.app.agent.onboarding import (
+    _parse_rate,
     build_onboarding_system_prompt,
     extract_profile_updates,
     is_onboarding_needed,
@@ -174,9 +175,106 @@ def test_extract_profile_updates_invalid_rate() -> None:
     assert "hourly_rate" not in updates
 
 
+# --- _parse_rate unit tests ---
+
+
+@pytest.mark.parametrize(
+    ("input_value", "expected"),
+    [
+        ("$85/hr", 85.0),
+        ("$85/hour", 85.0),
+        ("$85 per hour", 85.0),
+        ("$85 an hour", 85.0),
+        ("85 dollars", 85.0),
+        ("$85.50", 85.5),
+        ("$85.50/hr", 85.5),
+        ("85", 85.0),
+        ("85.00", 85.0),
+        ("$50-75/hr", 50.0),
+        ("$4500 per project", 4500.0),
+        ("$4,500 per project", 4500.0),
+        ("Usually around $80", 80.0),
+        ("$125/hour for electrical", 125.0),
+        ("  $65 /hr  ", 65.0),
+    ],
+)
+def test_parse_rate_valid_formats(input_value: str, expected: float) -> None:
+    """_parse_rate should extract numeric rate from various natural-language formats."""
+    assert _parse_rate(input_value) == expected
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        "not sure",
+        "varies",
+        "depends on the job",
+        "TBD",
+        "",
+    ],
+)
+def test_parse_rate_invalid_returns_none(input_value: str) -> None:
+    """_parse_rate should return None for non-numeric values."""
+    assert _parse_rate(input_value) is None
+
+
+# --- extract_profile_updates with various rate formats ---
+
+
+@pytest.mark.parametrize(
+    ("rate_value", "expected_rate"),
+    [
+        ("$85/hour", 85.0),
+        ("$85 per hour", 85.0),
+        ("$85 an hour", 85.0),
+        ("85 dollars", 85.0),
+        ("$85.50", 85.5),
+        ("$50-75/hr", 50.0),
+        ("$4,500 per project", 4500.0),
+        ("Usually around $80", 80.0),
+    ],
+)
+def test_extract_profile_updates_various_rate_formats(
+    rate_value: str, expected_rate: float
+) -> None:
+    """extract_profile_updates should handle various rate formats via _parse_rate."""
+    response = AgentResponse(
+        reply_text="Got it!",
+        tool_calls=[
+            {
+                "name": "save_fact",
+                "args": {"key": "hourly_rate", "value": rate_value},
+                "result": "ok",
+            },
+        ],
+    )
+    updates = extract_profile_updates(response)
+    assert updates["hourly_rate"] == expected_rate
+
+
+def test_extract_profile_updates_invalid_rate_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Should log a warning when rate parsing fails."""
+    response = AgentResponse(
+        reply_text="Got it!",
+        tool_calls=[
+            {
+                "name": "save_fact",
+                "args": {"key": "hourly_rate", "value": "varies"},
+                "result": "ok",
+            },
+        ],
+    )
+    with caplog.at_level("WARNING", logger="backend.app.agent.onboarding"):
+        updates = extract_profile_updates(response)
+    assert "hourly_rate" not in updates
+    assert "Could not parse hourly rate" in caplog.text
+
+
 @pytest.fixture()
 def new_contractor(db_session: Session) -> Contractor:
-    """Contractor with no profile — needs onboarding."""
+    """Contractor with no profile -- needs onboarding."""
     contractor = Contractor(
         user_id="new-user-onboard",
         phone="+15559999999",


### PR DESCRIPTION
## Summary
- Replace brittle string replacement rate parsing with regex-based extraction
- Handles common formats: "$85/hour", "$85 per hour", "$85 an hour", "85 dollars", etc.
- Add warning log when rate parsing fails instead of silent suppression
- For ranges like "$50-75/hr", extracts the first number

## Test plan
- [x] Unit tests for `_parse_rate()` with 15 valid format variations
- [x] Parametrized tests for invalid/non-numeric values (5 cases)
- [x] Integration tests through `extract_profile_updates()` with 8 rate formats
- [x] Test that warning is logged on parse failure
- [x] All existing tests pass (362 total)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)