### PR TITLE
refactor: switch to dict-based tool registry for O(1) lookup

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -86,10 +86,16 @@ class BackshopAgent:
         self.db = db
         self.contractor = contractor
         self.tools: list[Tool] = []
+        self._tools_by_name: dict[str, Tool] = {}
 
     def register_tools(self, tools: list[Tool]) -> None:
         """Register available tools for this agent session."""
         self.tools = tools
+        self._tools_by_name = {}
+        for tool in tools:
+            if tool.name in self._tools_by_name:
+                logger.warning("Duplicate tool name registered: %s", tool.name)
+            self._tools_by_name[tool.name] = tool
 
     async def _build_system_prompt(self, message_context: str) -> str:
         """Build the full system prompt with soul + memory."""
@@ -326,7 +332,5 @@ class BackshopAgent:
 
     def _find_tool(self, name: str) -> Callable[..., Any] | None:
         """Find a registered tool by name."""
-        for tool in self.tools:
-            if tool.name == name:
-                return tool.function
-        return None
+        tool = self._tools_by_name.get(name)
+        return tool.function if tool else None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -681,3 +681,50 @@ async def test_agent_logs_warning_when_trimming(
         )
 
     assert any("Trimmed" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Dict-based tool registry tests (issue #282)
+# ---------------------------------------------------------------------------
+
+
+def test_register_tools_builds_dict_lookup(
+    db_session: Session, test_contractor: Contractor
+) -> None:
+    """register_tools should build a dict for O(1) lookup by name."""
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+
+    async def dummy(**kwargs: object) -> str:
+        return "ok"
+
+    tools = [
+        Tool(name="tool_a", description="A", function=dummy, parameters={}),
+        Tool(name="tool_b", description="B", function=dummy, parameters={}),
+    ]
+    agent.register_tools(tools)
+
+    assert agent._find_tool("tool_a") is not None
+    assert agent._find_tool("tool_b") is not None
+    assert agent._find_tool("nonexistent") is None
+
+
+def test_register_tools_warns_on_duplicate_name(
+    db_session: Session,
+    test_contractor: Contractor,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Registering tools with duplicate names should log a warning."""
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+
+    async def dummy(**kwargs: object) -> str:
+        return "ok"
+
+    tools = [
+        Tool(name="dupe", description="First", function=dummy, parameters={}),
+        Tool(name="dupe", description="Second", function=dummy, parameters={}),
+    ]
+
+    with caplog.at_level("WARNING", logger="backend.app.agent.core"):
+        agent.register_tools(tools)
+
+    assert any("Duplicate tool name" in record.message for record in caplog.records)


### PR DESCRIPTION
## Description

Replace linear-scan tool dispatch with dict-based O(1) lookup in `BackshopAgent`. The `register_tools()` method now builds a `_tools_by_name` dict at registration time and `_find_tool()` uses `dict.get()`. Also adds duplicate tool name detection (logs a warning) to catch configuration errors early.

Fixes #282

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)