### PR TITLE
refactor: add structured ToolResult type with self-correction hints

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.memory import build_memory_context
 from backend.app.agent.profile import build_soul_prompt, get_missing_optional_fields
-from backend.app.agent.tools.base import Tool, tool_to_openai_schema
+from backend.app.agent.tools.base import Tool, ToolResult, tool_to_openai_schema
 from backend.app.config import settings
 from backend.app.models import Contractor
 
@@ -290,23 +290,38 @@ class BackshopAgent:
 
                 tool_func = self._find_tool(tool_name)
                 result_str = ""
+                is_error = False
                 if tool_func:
                     try:
                         result = await tool_func(**tool_args)
-                        result_str = str(result)
-                        actions_taken.append(f"Called {tool_name}")
+                        if isinstance(result, ToolResult):
+                            result_str = result.content
+                            is_error = result.is_error
+                        else:
+                            result_str = str(result)
+                        if is_error:
+                            result_str += (
+                                "\n\n[Analyze the error above and try a different approach.]"
+                            )
+                            actions_taken.append(f"Failed: {tool_name}")
+                        else:
+                            actions_taken.append(f"Called {tool_name}")
                         tool_call_records.append(
                             {
                                 "name": tool_name,
                                 "args": tool_args,
                                 "result": result_str,
+                                "is_error": is_error,
                             }
                         )
                         if tool_name == "save_fact":
                             memories_saved.append(tool_args)
                     except Exception:
                         logger.exception("Tool call failed: %s", tool_name)
-                        result_str = f"Error: tool {tool_name} failed"
+                        result_str = (
+                            f"Error: tool {tool_name} failed"
+                            "\n\n[Analyze the error above and try a different approach.]"
+                        )
                         actions_taken.append(f"Failed: {tool_name}")
                 else:
                     result_str = f"Error: unknown tool {tool_name}"

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -4,6 +4,14 @@ from typing import Any
 
 
 @dataclass
+class ToolResult:
+    """Structured result from a tool execution."""
+
+    content: str
+    is_error: bool = False
+
+
+@dataclass
 class Tool:
     """A tool that the agent can call."""
 

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy.orm import Session
 
-from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.models import HeartbeatChecklistItem
 
 VALID_CHECKLIST_SCHEDULES = ("daily", "weekdays", "once")
@@ -14,10 +14,13 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
     async def add_checklist_item(
         description: str,
         schedule: str = "daily",
-    ) -> str:
+    ) -> ToolResult:
         """Add an item to the contractor's heartbeat checklist."""
         if schedule not in VALID_CHECKLIST_SCHEDULES:
-            return f"Invalid schedule '{schedule}'. Use: daily, weekdays, or once."
+            return ToolResult(
+                content=f"Invalid schedule '{schedule}'. Use: daily, weekdays, or once.",
+                is_error=True,
+            )
         item = HeartbeatChecklistItem(
             contractor_id=contractor_id,
             description=description,
@@ -26,9 +29,9 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
         db.add(item)
         db.commit()
         db.refresh(item)
-        return f"Added to checklist (#{item.id}, {schedule}): {description}"
+        return ToolResult(content=f"Added to checklist (#{item.id}, {schedule}): {description}")
 
-    async def list_checklist_items() -> str:
+    async def list_checklist_items() -> ToolResult:
         """List all active checklist items."""
         items = (
             db.query(HeartbeatChecklistItem)
@@ -40,11 +43,11 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
             .all()
         )
         if not items:
-            return "No active checklist items."
+            return ToolResult(content="No active checklist items.")
         lines = [f"- #{item.id}: {item.description} ({item.schedule})" for item in items]
-        return "\n".join(lines)
+        return ToolResult(content="\n".join(lines))
 
-    async def remove_checklist_item(item_id: int) -> str:
+    async def remove_checklist_item(item_id: int) -> ToolResult:
         """Remove a checklist item by ID."""
         item = (
             db.query(HeartbeatChecklistItem)
@@ -55,10 +58,10 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
             .first()
         )
         if not item:
-            return f"Checklist item #{item_id} not found."
+            return ToolResult(content=f"Checklist item #{item_id} not found.", is_error=True)
         db.delete(item)
         db.commit()
-        return f"Removed checklist item #{item_id}: {item.description}"
+        return ToolResult(content=f"Removed checklist item #{item_id}: {item.description}")
 
     return [
         Tool(

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
-from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.agent.tools.file_tools import build_folder_path
 from backend.app.config import settings
 from backend.app.models import Contractor, Estimate, EstimateLineItem
@@ -38,7 +38,7 @@ def create_estimate_tools(
         client_name: str | None = None,
         client_address: str | None = None,
         terms: str | None = None,
-    ) -> str:
+    ) -> ToolResult:
         """Generate a professional estimate PDF and return summary."""
         today = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")
 
@@ -50,10 +50,13 @@ def create_estimate_tools(
                 qty = float(item.get("quantity", 1))
                 price = float(item.get("unit_price", 0))
             except (ValueError, TypeError) as exc:
-                return f"Error: invalid line item values — {exc}"
+                return ToolResult(content=f"Error: invalid line item values: {exc}", is_error=True)
 
             if qty < 0 or price < 0:
-                return "Error: quantity and unit_price must not be negative."
+                return ToolResult(
+                    content="Error: quantity and unit_price must not be negative.",
+                    is_error=True,
+                )
 
             total = qty * price
             subtotal += total
@@ -133,11 +136,13 @@ def create_estimate_tools(
         estimate.pdf_url = str(pdf_path)
         db.commit()
 
-        return (
-            f"Estimate {estimate_number} generated for ${total_amount:,.2f}. "
-            f"{len(processed_items)} line item(s). "
-            f"PDF saved at {pdf_path}. "
-            f"Use send_media_reply to send it to the contractor."
+        return ToolResult(
+            content=(
+                f"Estimate {estimate_number} generated for ${total_amount:,.2f}. "
+                f"{len(processed_items)} line item(s). "
+                f"PDF saved at {pdf_path}. "
+                f"Use send_media_reply to send it to the contractor."
+            )
         )
 
     return [

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -6,7 +6,7 @@ import re
 
 from sqlalchemy.orm import Session
 
-from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.media.download import MIME_EXTENSIONS, DownloadedMedia
 from backend.app.models import Contractor, MediaFile
 from backend.app.services.storage_service import StorageBackend
@@ -173,7 +173,7 @@ def create_file_tools(
         client_address: str | None = None,
         original_url: str | None = None,
         mime_type: str = "image/jpeg",
-    ) -> str:
+    ) -> ToolResult:
         """Upload a file to the contractor's cloud storage."""
         # Determine file content
         file_bytes = b""
@@ -187,7 +187,7 @@ def create_file_tools(
 
         if not file_bytes:
             logger.warning("upload_to_storage called but no file content available")
-            return "No file content available to upload."
+            return ToolResult(content="No file content available to upload.", is_error=True)
 
         logger.info(
             "Cataloging file: category=%s, mime=%s, size=%d bytes",
@@ -231,7 +231,7 @@ def create_file_tools(
         db.commit()
 
         logger.info("File cataloged: %s/%s -> %s", folder_path, filename, storage_url)
-        return f"Uploaded {filename} to {folder_path}/ ({storage_url})"
+        return ToolResult(content=f"Uploaded {filename} to {folder_path}/ ({storage_url})")
 
     async def organize_file(
         original_url: str,
@@ -239,7 +239,7 @@ def create_file_tools(
         client_name: str | None = None,
         client_address: str | None = None,
         description: str = "",
-    ) -> str:
+    ) -> ToolResult:
         """Move an auto-saved file from Unsorted into the correct client folder."""
         # Look up the MediaFile record
         media_file = (
@@ -251,26 +251,29 @@ def create_file_tools(
             .first()
         )
         if media_file is None:
-            return f"File not found for URL: {original_url}"
+            return ToolResult(content=f"File not found for URL: {original_url}", is_error=True)
 
         current_path = media_file.storage_path  # e.g. /Unsorted/2026-03-02/file_001.jpg
         new_folder = build_folder_path(file_category, client_name, client_address)
 
         # Guard: without client context the file would just move within Unsorted
         if new_folder.startswith("/Unsorted"):
-            return (
-                "Error: client_name or client_address is required to organize a file. "
-                "Please provide at least one so the file can be moved to a client folder."
+            return ToolResult(
+                content=(
+                    "Error: client_name or client_address is required to organize a file. "
+                    "Please provide at least one so the file can be moved to a client folder."
+                ),
+                is_error=True,
             )
 
         # Check if already in a client folder (not Unsorted)
         if not current_path.startswith("/Unsorted/"):
-            return f"File is already organized at {current_path}"
+            return ToolResult(content=f"File is already organized at {current_path}")
 
         # Parse current path into folder and filename
         parts = current_path.rsplit("/", 1)
         if len(parts) != 2:
-            return f"Cannot parse storage path: {current_path}"
+            return ToolResult(content=f"Cannot parse storage path: {current_path}", is_error=True)
         old_folder, old_filename = parts
 
         # Build new filename
@@ -304,7 +307,7 @@ def create_file_tools(
             new_folder,
             new_filename,
         )
-        return f"Moved {old_filename} to {new_folder}/{new_filename}"
+        return ToolResult(content=f"Moved {old_filename} to {new_folder}/{new_filename}")
 
     return [
         Tool(

--- a/backend/app/agent/tools/memory_tools.py
+++ b/backend/app/agent/tools/memory_tools.py
@@ -1,31 +1,31 @@
 from sqlalchemy.orm import Session
 
 from backend.app.agent.memory import delete_memory, recall_memories, save_memory
-from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.base import Tool, ToolResult
 
 
 def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
     """Create memory-related tools for the agent."""
 
-    async def save_fact(key: str, value: str, category: str = "general") -> str:
+    async def save_fact(key: str, value: str, category: str = "general") -> ToolResult:
         """Save a fact to memory."""
         memory = await save_memory(db, contractor_id, key=key, value=value, category=category)
-        return f"Saved: {memory.key} = {memory.value}"
+        return ToolResult(content=f"Saved: {memory.key} = {memory.value}")
 
-    async def recall_facts(query: str, category: str | None = None) -> str:
+    async def recall_facts(query: str, category: str | None = None) -> ToolResult:
         """Search memory for facts matching a query."""
         memories = await recall_memories(db, contractor_id, query=query, category=category)
         if not memories:
-            return "No matching facts found."
+            return ToolResult(content="No matching facts found.")
         lines = [f"- {m.key}: {m.value}" for m in memories]
-        return "\n".join(lines)
+        return ToolResult(content="\n".join(lines))
 
-    async def forget_fact(key: str) -> str:
+    async def forget_fact(key: str) -> ToolResult:
         """Delete a fact from memory."""
         deleted = await delete_memory(db, contractor_id, key=key)
         if deleted:
-            return f"Deleted: {key}"
-        return f"Not found: {key}"
+            return ToolResult(content=f"Deleted: {key}")
+        return ToolResult(content=f"Not found: {key}", is_error=True)
 
     return [
         Tool(

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -1,25 +1,25 @@
-from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.services.messaging import MessagingService
 
 
 def create_messaging_tools(messaging_service: MessagingService, to_address: str) -> list[Tool]:
     """Create messaging tools for the agent."""
 
-    async def send_reply(message: str) -> str:
+    async def send_reply(message: str) -> ToolResult:
         """Send a text reply to the contractor."""
         if not message or not message.strip():
-            return "Error: message cannot be empty."
+            return ToolResult(content="Error: message cannot be empty.", is_error=True)
         msg_id = await messaging_service.send_text(to=to_address, body=message)
-        return f"Sent message (ID: {msg_id})"
+        return ToolResult(content=f"Sent message (ID: {msg_id})")
 
-    async def send_media_reply(message: str, media_url: str) -> str:
+    async def send_media_reply(message: str, media_url: str) -> ToolResult:
         """Send a reply with a media attachment."""
         if not media_url or not media_url.strip():
-            return "Error: media_url cannot be empty."
+            return ToolResult(content="Error: media_url cannot be empty.", is_error=True)
         msg_id = await messaging_service.send_media(
             to=to_address, body=message, media_url=media_url
         )
-        return f"Sent media message (ID: {msg_id})"
+        return ToolResult(content=f"Sent media message (ID: {msg_id})")
 
     return [
         Tool(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -16,7 +16,7 @@ from backend.app.agent.core import (
     BackshopAgent,
     _estimate_tokens,
 )
-from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.models import Contractor
 from tests.mocks.llm import make_text_response, make_tool_call_response
 
@@ -728,3 +728,126 @@ def test_register_tools_warns_on_duplicate_name(
         agent.register_tools(tools)
 
     assert any("Duplicate tool name" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Structured ToolResult tests (issue #280)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_tool_result_error_appends_hint(
+    mock_acompletion: AsyncMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """When a tool returns ToolResult(is_error=True), a hint is appended."""
+
+    async def failing_tool(**kwargs: object) -> ToolResult:
+        return ToolResult(content="Error: item not found", is_error=True)
+
+    tool = Tool(name="do_thing", description="test", function=failing_tool, parameters={})
+
+    mock_acompletion.side_effect = [
+        make_tool_call_response(
+            tool_calls=[{"id": "call_1", "name": "do_thing", "arguments": json.dumps({})}]
+        ),
+        make_text_response("I'll try something else."),
+    ]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("test", system_prompt_override="system")
+
+    # The hint should have been appended to the error result
+    assert any("Failed: do_thing" in a for a in response.actions_taken)
+    assert response.tool_calls[0]["is_error"] is True
+    assert "[Analyze the error" in response.tool_calls[0]["result"]
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_tool_result_success_no_hint(
+    mock_acompletion: AsyncMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """When a tool returns ToolResult(is_error=False), no hint is appended."""
+
+    async def ok_tool(**kwargs: object) -> ToolResult:
+        return ToolResult(content="Done!")
+
+    tool = Tool(name="do_thing", description="test", function=ok_tool, parameters={})
+
+    mock_acompletion.side_effect = [
+        make_tool_call_response(
+            tool_calls=[{"id": "call_1", "name": "do_thing", "arguments": json.dumps({})}]
+        ),
+        make_text_response("Great!"),
+    ]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("test", system_prompt_override="system")
+
+    assert any("Called do_thing" in a for a in response.actions_taken)
+    assert response.tool_calls[0]["is_error"] is False
+    assert "[Analyze the error" not in response.tool_calls[0]["result"]
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_plain_string_return_backward_compat(
+    mock_acompletion: AsyncMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Tools returning plain strings should still work (backward compatibility)."""
+
+    async def legacy_tool(**kwargs: object) -> str:
+        return "Legacy result"
+
+    tool = Tool(name="old_tool", description="test", function=legacy_tool, parameters={})
+
+    mock_acompletion.side_effect = [
+        make_tool_call_response(
+            tool_calls=[{"id": "call_1", "name": "old_tool", "arguments": json.dumps({})}]
+        ),
+        make_text_response("Ok!"),
+    ]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("test", system_prompt_override="system")
+
+    assert any("Called old_tool" in a for a in response.actions_taken)
+    assert response.tool_calls[0]["result"] == "Legacy result"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_tool_exception_appends_hint(
+    mock_acompletion: AsyncMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """When a tool raises an exception, a self-correction hint is appended."""
+
+    async def crashing_tool(**kwargs: object) -> ToolResult:
+        raise RuntimeError("Something broke")
+
+    tool = Tool(name="bad_tool", description="test", function=crashing_tool, parameters={})
+
+    mock_acompletion.side_effect = [
+        make_tool_call_response(
+            tool_calls=[{"id": "call_1", "name": "bad_tool", "arguments": json.dumps({})}]
+        ),
+        make_text_response("Let me try another way."),
+    ]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("test", system_prompt_override="system")
+
+    assert any("Failed: bad_tool" in a for a in response.actions_taken)

--- a/tests/test_checklist_tools.py
+++ b/tests/test_checklist_tools.py
@@ -13,9 +13,10 @@ async def test_add_checklist_item(db_session: Session, test_contractor: Contract
     tools = create_checklist_tools(db_session, test_contractor.id)
     add_item = tools[0].function
     result = await add_item(description="Check material prices", schedule="daily")
-    assert "Added to checklist" in result
-    assert "material prices" in result
-    assert "daily" in result
+    assert "Added to checklist" in result.content
+    assert "material prices" in result.content
+    assert "daily" in result.content
+    assert result.is_error is False
 
     # Verify in DB
     items = db_session.query(HeartbeatChecklistItem).all()
@@ -47,7 +48,8 @@ async def test_add_checklist_item_invalid_schedule(
     tools = create_checklist_tools(db_session, test_contractor.id)
     add_item = tools[0].function
     result = await add_item(description="Bad schedule", schedule="hourly")
-    assert "Invalid schedule" in result
+    assert "Invalid schedule" in result.content
+    assert result.is_error is True
 
     items = db_session.query(HeartbeatChecklistItem).all()
     assert len(items) == 0
@@ -64,10 +66,10 @@ async def test_list_checklist_items(db_session: Session, test_contractor: Contra
     await add_item(description="Review quotes", schedule="weekdays")
 
     result = await list_items()
-    assert "Check inbox" in result
-    assert "Review quotes" in result
-    assert "daily" in result
-    assert "weekdays" in result
+    assert "Check inbox" in result.content
+    assert "Review quotes" in result.content
+    assert "daily" in result.content
+    assert "weekdays" in result.content
 
 
 @pytest.mark.asyncio()
@@ -76,7 +78,7 @@ async def test_list_checklist_items_empty(db_session: Session, test_contractor: 
     tools = create_checklist_tools(db_session, test_contractor.id)
     list_items = tools[1].function
     result = await list_items()
-    assert "No active checklist items" in result
+    assert "No active checklist items" in result.content
 
 
 @pytest.mark.asyncio()
@@ -94,7 +96,7 @@ async def test_list_excludes_paused(db_session: Session, test_contractor: Contra
     tools = create_checklist_tools(db_session, test_contractor.id)
     list_items = tools[1].function
     result = await list_items()
-    assert "No active checklist items" in result
+    assert "No active checklist items" in result.content
 
 
 @pytest.mark.asyncio()
@@ -110,8 +112,9 @@ async def test_remove_checklist_item(db_session: Session, test_contractor: Contr
     assert item is not None
 
     result = await remove_item(item_id=item.id)
-    assert "Removed" in result
-    assert "To remove" in result
+    assert "Removed" in result.content
+    assert "To remove" in result.content
+    assert result.is_error is False
 
     items = db_session.query(HeartbeatChecklistItem).all()
     assert len(items) == 0
@@ -125,7 +128,8 @@ async def test_remove_checklist_item_not_found(
     tools = create_checklist_tools(db_session, test_contractor.id)
     remove_item = tools[2].function
     result = await remove_item(item_id=999)
-    assert "not found" in result
+    assert "not found" in result.content
+    assert result.is_error is True
 
 
 @pytest.mark.asyncio()
@@ -150,7 +154,8 @@ async def test_remove_scoped_to_contractor(
     tools = create_checklist_tools(db_session, test_contractor.id)
     remove_item = tools[2].function
     result = await remove_item(item_id=item.id)
-    assert "not found" in result
+    assert "not found" in result.content
+    assert result.is_error is True
 
     # Item should still exist
     remaining = db_session.query(HeartbeatChecklistItem).all()

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -40,8 +40,9 @@ async def test_generate_estimate_creates_records(
         ],
     )
 
-    assert "EST-0001" in result
-    assert "$4,200.00" in result
+    assert "EST-0001" in result.content
+    assert "$4,200.00" in result.content
+    assert result.is_error is False
 
     estimate = (
         db_session.query(Estimate).filter(Estimate.contractor_id == test_contractor.id).first()
@@ -73,8 +74,8 @@ async def test_generate_estimate_with_client_info(
         client_address="123 Oak St, Portland, OR",
     )
 
-    assert "EST-0001" in result
-    assert "$8,500.00" in result
+    assert "EST-0001" in result.content
+    assert "$8,500.00" in result.content
 
 
 @pytest.mark.asyncio()
@@ -92,7 +93,7 @@ async def test_generate_estimate_pdf_generated(
         line_items=[{"description": "Service call", "quantity": 1, "unit_price": 150.00}],
     )
 
-    assert ".pdf" in result
+    assert ".pdf" in result.content
 
     # Verify PDF file was actually written in the temp directory (per-contractor subdir)
     estimate = db_session.query(Estimate).first()
@@ -120,8 +121,8 @@ async def test_generate_estimate_sequential_numbers(
         line_items=[{"description": "Work", "quantity": 1, "unit_price": 200.00}],
     )
 
-    assert "EST-0001" in result1
-    assert "EST-0002" in result2
+    assert "EST-0001" in result1.content
+    assert "EST-0002" in result2.content
 
 
 @pytest.mark.asyncio()
@@ -138,8 +139,8 @@ async def test_generate_estimate_single_line_item(
         line_items=[{"description": "Fix leaking pipe", "quantity": 1, "unit_price": 350.00}],
     )
 
-    assert "$350.00" in result
-    assert "1 line item" in result
+    assert "$350.00" in result.content
+    assert "1 line item" in result.content
 
 
 @pytest.mark.asyncio()
@@ -157,7 +158,7 @@ async def test_generate_estimate_custom_terms(
         terms="50% upfront, 50% on completion",
     )
 
-    assert "EST-0001" in result
+    assert "EST-0001" in result.content
 
 
 @pytest.mark.asyncio()
@@ -174,8 +175,9 @@ async def test_generate_estimate_rejects_negative_quantity(
         line_items=[{"description": "Work", "quantity": -5, "unit_price": 100.00}],
     )
 
-    assert "Error" in result
-    assert "negative" in result.lower()
+    assert "Error" in result.content
+    assert "negative" in result.content.lower()
+    assert result.is_error is True
     assert db_session.query(Estimate).count() == 0
 
 
@@ -193,8 +195,9 @@ async def test_generate_estimate_rejects_negative_price(
         line_items=[{"description": "Work", "quantity": 1, "unit_price": -50.00}],
     )
 
-    assert "Error" in result
-    assert "negative" in result.lower()
+    assert "Error" in result.content
+    assert "negative" in result.content.lower()
+    assert result.is_error is True
     assert db_session.query(Estimate).count() == 0
 
 
@@ -212,7 +215,8 @@ async def test_generate_estimate_rejects_non_numeric_values(
         line_items=[{"description": "Work", "quantity": "abc", "unit_price": 100.00}],
     )
 
-    assert "Error" in result
+    assert "Error" in result.content
+    assert result.is_error is True
     assert db_session.query(Estimate).count() == 0
 
 
@@ -343,7 +347,7 @@ async def test_generate_estimate_no_storage_still_saves_locally(
         line_items=[{"description": "Work", "quantity": 1, "unit_price": 100.00}],
     )
 
-    assert "EST-0001" in result
+    assert "EST-0001" in result.content
     estimate = db_session.query(Estimate).first()
     assert estimate is not None
     pdf_path = tmp_path / "estimates" / str(test_contractor.id) / f"{estimate.id}.pdf"
@@ -389,8 +393,8 @@ async def test_generate_estimate_cloud_upload_failure_does_not_kill_call(
     )
 
     # The estimate should still succeed with the local PDF
-    assert "EST-0001" in result
-    assert "$2,000.00" in result
+    assert "EST-0001" in result.content
+    assert "$2,000.00" in result.content
 
     # Verify local PDF was saved
     estimate = db_session.query(Estimate).first()

--- a/tests/test_file_cataloging.py
+++ b/tests/test_file_cataloging.py
@@ -137,8 +137,9 @@ async def test_upload_creates_media_file_record(
         original_url="https://example.com/media/photo.jpg",
     )
 
-    assert "Uploaded" in result
-    assert "damaged_deck_railing_001.jpg" in result
+    assert "Uploaded" in result.content
+    assert "damaged_deck_railing_001.jpg" in result.content
+    assert result.is_error is False
 
     media_file = (
         db_session.query(MediaFile).filter(MediaFile.contractor_id == test_contractor.id).first()
@@ -214,7 +215,8 @@ async def test_upload_no_media_returns_error(
     upload = tools[0].function
 
     result = await upload(file_category="job_photo")
-    assert "No file content" in result
+    assert "No file content" in result.content
+    assert result.is_error is True
 
 
 @pytest.mark.asyncio()
@@ -233,7 +235,8 @@ async def test_upload_uses_first_media_if_no_url(
     upload = tools[0].function
 
     result = await upload(file_category="job_photo", description="Auto selected")
-    assert "Uploaded" in result
+    assert "Uploaded" in result.content
+    assert result.is_error is False
     assert len(storage.files) == 1
 
 
@@ -266,8 +269,8 @@ async def test_upload_sequential_indexing(
         client_name="Test Client",
     )
 
-    assert "_001." in result1
-    assert "_002." in result2
+    assert "_001." in result1.content
+    assert "_002." in result2.content
 
 
 @pytest.mark.asyncio()
@@ -423,9 +426,10 @@ async def test_organize_file_moves_to_client_folder(
         description="Front porch damage",
     )
 
-    assert "Moved" in result
-    assert "John Smith - 116 Virginia Ave" in result
-    assert "front_porch_damage_001.jpg" in result
+    assert "Moved" in result.content
+    assert "John Smith - 116 Virginia Ave" in result.content
+    assert "front_porch_damage_001.jpg" in result.content
+    assert result.is_error is False
 
     # Verify DB record updated
     db_session.refresh(media_file)
@@ -453,7 +457,8 @@ async def test_organize_file_not_found(
         file_category="job_photo",
         client_name="Jane",
     )
-    assert "File not found" in result
+    assert "File not found" in result.content
+    assert result.is_error is True
 
 
 @pytest.mark.asyncio()
@@ -481,7 +486,7 @@ async def test_organize_file_already_in_client_folder(
         file_category="job_photo",
         client_name="Jane",
     )
-    assert "already organized" in result
+    assert "already organized" in result.content
 
 
 @pytest.mark.asyncio()
@@ -508,5 +513,6 @@ async def test_organize_file_without_client_returns_error(
         original_url="tg_file_id_789",
         file_category="job_photo",
     )
-    assert "Error" in result
-    assert "client_name or client_address is required" in result
+    assert "Error" in result.content
+    assert "client_name or client_address is required" in result.content
+    assert result.is_error is True

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -11,8 +11,9 @@ async def test_save_fact_tool(db_session: Session, test_contractor: Contractor) 
     tools = create_memory_tools(db_session, test_contractor.id)
     save_fact = tools[0].function
     result = await save_fact(key="deck_rate", value="$35/sqft", category="pricing")
-    assert "Saved" in result
-    assert "deck_rate" in result
+    assert "Saved" in result.content
+    assert "deck_rate" in result.content
+    assert result.is_error is False
 
 
 @pytest.mark.asyncio()
@@ -24,8 +25,8 @@ async def test_recall_facts_tool(db_session: Session, test_contractor: Contracto
 
     await save_fact(key="deck_rate", value="$35/sqft")
     result = await recall_facts(query="deck")
-    assert "deck_rate" in result
-    assert "$35/sqft" in result
+    assert "deck_rate" in result.content
+    assert "$35/sqft" in result.content
 
 
 @pytest.mark.asyncio()
@@ -34,7 +35,7 @@ async def test_recall_facts_empty(db_session: Session, test_contractor: Contract
     tools = create_memory_tools(db_session, test_contractor.id)
     recall_facts = tools[1].function
     result = await recall_facts(query="nonexistent")
-    assert "No matching facts" in result
+    assert "No matching facts" in result.content
 
 
 @pytest.mark.asyncio()
@@ -46,13 +47,15 @@ async def test_forget_fact_tool(db_session: Session, test_contractor: Contractor
 
     await save_fact(key="temp", value="temporary")
     result = await forget_fact(key="temp")
-    assert "Deleted" in result
+    assert "Deleted" in result.content
+    assert result.is_error is False
 
 
 @pytest.mark.asyncio()
 async def test_forget_fact_not_found(db_session: Session, test_contractor: Contractor) -> None:
-    """forget_fact should handle missing keys."""
+    """forget_fact should handle missing keys with is_error=True."""
     tools = create_memory_tools(db_session, test_contractor.id)
     forget_fact = tools[2].function
     result = await forget_fact(key="nonexistent")
-    assert "Not found" in result
+    assert "Not found" in result.content
+    assert result.is_error is True

--- a/tests/test_messaging_tools.py
+++ b/tests/test_messaging_tools.py
@@ -20,7 +20,8 @@ async def test_send_reply_tool(mock_messaging_service: MessagingService) -> None
     tools = create_messaging_tools(mock_messaging_service, to_address="123456789")
     send_reply = tools[0].function
     result = await send_reply(message="Your estimate is ready!")
-    assert "msg_42" in result
+    assert "msg_42" in result.content
+    assert result.is_error is False
     mock_messaging_service.send_text.assert_called_once_with(  # type: ignore[union-attr]
         to="123456789", body="Your estimate is ready!"
     )
@@ -32,7 +33,8 @@ async def test_send_reply_rejects_empty_message(mock_messaging_service: Messagin
     tools = create_messaging_tools(mock_messaging_service, to_address="123456789")
     send_reply = tools[0].function
     result = await send_reply(message="")
-    assert "Error" in result
+    assert "Error" in result.content
+    assert result.is_error is True
     mock_messaging_service.send_text.assert_not_called()  # type: ignore[union-attr]
 
 
@@ -44,7 +46,8 @@ async def test_send_reply_rejects_whitespace_message(
     tools = create_messaging_tools(mock_messaging_service, to_address="123456789")
     send_reply = tools[0].function
     result = await send_reply(message="   ")
-    assert "Error" in result
+    assert "Error" in result.content
+    assert result.is_error is True
     mock_messaging_service.send_text.assert_not_called()  # type: ignore[union-attr]
 
 
@@ -56,7 +59,8 @@ async def test_send_media_reply_rejects_empty_url(
     tools = create_messaging_tools(mock_messaging_service, to_address="123456789")
     send_media_reply = tools[1].function
     result = await send_media_reply(message="Here's your file", media_url="")
-    assert "Error" in result
+    assert "Error" in result.content
+    assert result.is_error is True
     mock_messaging_service.send_media.assert_not_called()  # type: ignore[union-attr]
 
 
@@ -68,7 +72,8 @@ async def test_send_media_reply_tool(mock_messaging_service: MessagingService) -
     result = await send_media_reply(
         message="Here's your estimate", media_url="https://example.com/estimate.pdf"
     )
-    assert "msg_43" in result
+    assert "msg_43" in result.content
+    assert result.is_error is False
     mock_messaging_service.send_media.assert_called_once_with(  # type: ignore[union-attr]
         to="123456789", body="Here's your estimate", media_url="https://example.com/estimate.pdf"
     )


### PR DESCRIPTION
## Summary
- All tool functions now return a `ToolResult` dataclass (`content: str`, `is_error: bool = False`) instead of plain strings
- Agent loop inspects `is_error` to append self-correction hints that guide the LLM toward alternative approaches on failure
- Backward compatible: plain string returns are still handled via `str()` coercion
- Updated all 5 tool modules (memory, messaging, checklist, estimate, file) and all corresponding tests

## Test plan
- [x] All 510 tests pass
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] New tests for ToolResult handling in agent loop (error hint, success no-hint, backward compat, exception hint)
- [x] All existing tool tests updated to assert on `result.content` and `result.is_error`

Fixes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)