### PR TITLE
refactor: use tool calling for heartbeat instead of JSON parsing

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -410,19 +410,26 @@ def _parse_tool_call_response(response: ChatCompletion) -> HeartbeatAction:
     try:
         data = json.loads(func.arguments)
     except (json.JSONDecodeError, TypeError):
-        logger.warning("Heartbeat tool call had malformed arguments: %s", func.arguments[:200])
+        logger.warning(
+            "Heartbeat tool call had malformed arguments: %s", (func.arguments or "")[:200]
+        )
         return HeartbeatAction(
             action_type="no_action",
             message="",
-            reasoning=f"Malformed tool arguments: {func.arguments[:100]}",
+            reasoning=f"Malformed tool arguments: {(func.arguments or '')[:100]}",
             priority=0,
         )
+
+    try:
+        priority = int(data.get("priority", 3))
+    except (ValueError, TypeError):
+        priority = 3
 
     return HeartbeatAction(
         action_type=data.get("action", "no_action"),
         message=data.get("message", ""),
         reasoning=data.get("reasoning", ""),
-        priority=int(data.get("priority", 3)),
+        priority=priority,
     )
 
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -676,6 +676,56 @@ class TestParseToolCallResponse:
         assert action.action_type == "no_action"
         assert "Malformed tool arguments" in action.reasoning
 
+    def test_none_arguments_does_not_crash(self) -> None:
+        """None func.arguments should not raise TypeError on slicing."""
+        func = MagicMock()
+        func.name = "compose_message"
+        func.arguments = None
+        tool_call = MagicMock()
+        tool_call.function = func
+        tool_call.id = "call_none_args"
+
+        msg = MagicMock()
+        msg.tool_calls = [tool_call]
+        msg.content = None
+        choice = MagicMock()
+        choice.message = msg
+        resp = MagicMock()
+        resp.choices = [choice]
+
+        action = _parse_tool_call_response(resp)
+        assert action.action_type == "no_action"
+        assert action.priority == 0
+
+    def test_non_numeric_priority_defaults_to_3(self) -> None:
+        """Non-numeric priority value should default to 3 instead of crashing."""
+        args = json.dumps(
+            {
+                "action": "send_message",
+                "message": "Hello",
+                "reasoning": "test",
+                "priority": "high",
+            }
+        )
+        func = MagicMock()
+        func.name = "compose_message"
+        func.arguments = args
+        tool_call = MagicMock()
+        tool_call.function = func
+        tool_call.id = "call_bad_priority"
+
+        msg = MagicMock()
+        msg.tool_calls = [tool_call]
+        msg.content = None
+        choice = MagicMock()
+        choice.message = msg
+        resp = MagicMock()
+        resp.choices = [choice]
+
+        action = _parse_tool_call_response(resp)
+        assert action.action_type == "send_message"
+        assert action.priority == 3
+
     def test_missing_optional_message_defaults_empty(self) -> None:
         """If the LLM omits the optional message field, it should default to empty."""
         args = json.dumps({"action": "no_action", "reasoning": "nothing", "priority": 2})


### PR DESCRIPTION
## Summary

- Replaces the fragile raw-JSON parsing in the heartbeat evaluator with the `compose_message` tool calling protocol
- Defines `COMPOSE_MESSAGE_TOOL` schema with `action`, `message`, `reasoning`, and `priority` parameters
- Adds `_parse_tool_call_response()` to extract `HeartbeatAction` from LLM tool call responses
- Removes `_strip_code_fences()` and `_CODE_FENCE_RE` regex (no longer needed)
- Updates `HEARTBEAT_SYSTEM_PROMPT` to instruct the LLM to use the tool instead of returning raw JSON
- Preserves fallback behavior: if the LLM returns text instead of calling the tool, defaults to `no_action`

## Test plan

- [x] All 518 existing tests pass (66 heartbeat-specific)
- [x] Added `TestComposeMessageToolSchema` (5 tests) validating tool schema structure
- [x] Added `TestParseToolCallResponse` (8 tests) covering: valid send/no_action, text fallback, wrong tool name, malformed arguments, missing optional fields, no-function edge case
- [x] Updated `TestEvaluateHeartbeatNeed` to use tool call mocks; added tests verifying `tools` parameter is passed to `acompletion` and system prompt no longer asks for raw JSON
- [x] Removed `TestStripCodeFences` (code under test was removed)
- [x] `ruff check` passes
- [x] `ruff format --check` passes

Fixes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)