### PR TITLE
refactor: replace magic tool name strings with tool tags/metadata

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.memory import build_memory_context
 from backend.app.agent.profile import build_soul_prompt, get_missing_optional_fields
-from backend.app.agent.tools.base import Tool, ToolResult, tool_to_openai_schema
+from backend.app.agent.tools.base import Tool, ToolResult, ToolTags, tool_to_openai_schema
 from backend.app.config import settings
 from backend.app.models import Contractor
 
@@ -203,6 +203,11 @@ class BackshopAgent:
         # system prompt + last N messages
         return [messages[0], *messages[-(CONTEXT_TRIM_KEEP_RECENT):]]
 
+    def _get_tool_tags(self, tool_name: str) -> set[str]:
+        """Look up the tags for a registered tool by name."""
+        tool = self._tools_by_name.get(tool_name)
+        return tool.tags if tool else set()
+
     async def process_message(
         self,
         message_context: str,
@@ -289,6 +294,7 @@ class BackshopAgent:
                     continue
 
                 tool_func = self._find_tool(tool_name)
+                tool_tags = self._get_tool_tags(tool_name)
                 result_str = ""
                 is_error = False
                 if tool_func:
@@ -312,9 +318,10 @@ class BackshopAgent:
                                 "args": tool_args,
                                 "result": result_str,
                                 "is_error": is_error,
+                                "tags": tool_tags,
                             }
                         )
-                        if tool_name == "save_fact":
+                        if ToolTags.SAVES_MEMORY in tool_tags:
                             memories_saved.append(tool_args)
                     except Exception:
                         logger.exception("Tool call failed: %s", tool_name)
@@ -336,7 +343,7 @@ class BackshopAgent:
 
             messages.extend(tool_results)
         else:
-            # Max rounds reached — use last response content
+            # Max rounds reached -- use last response content
             reply_text = choice.message.content or ""
 
         return AgentResponse(

--- a/backend/app/agent/onboarding.py
+++ b/backend/app/agent/onboarding.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from backend.app.agent.core import AgentResponse
 from backend.app.agent.profile import build_onboarding_prompt
+from backend.app.agent.tools.base import ToolTags
 from backend.app.models import Contractor
 
 logger = logging.getLogger(__name__)
@@ -132,9 +133,9 @@ def _match_profile_field(key: str) -> str | None:
 def extract_profile_updates(agent_response: AgentResponse) -> dict[str, Any]:
     """Extract profile field updates from agent tool calls during onboarding.
 
-    Looks at save_fact calls and maps known categories to profile fields.
-    Uses exact key lookup as the fast path, then falls back to fuzzy keyword
-    matching for synonym keys the LLM might use.
+    Looks at tool calls tagged with SAVES_MEMORY and maps known categories
+    to profile fields. Uses exact key lookup as the fast path, then falls
+    back to fuzzy keyword matching for synonym keys the LLM might use.
     """
     updates: dict[str, Any] = {}
 
@@ -156,7 +157,7 @@ def extract_profile_updates(agent_response: AgentResponse) -> dict[str, Any]:
     }
 
     for tc in agent_response.tool_calls:
-        if tc.get("name") != "save_fact":
+        if ToolTags.SAVES_MEMORY not in tc.get("tags", set()):
             continue
         args = tc.get("args", {})
         key = str(args.get("key", "")).lower().strip()

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -11,6 +11,7 @@ from backend.app.agent.onboarding import (
     is_onboarding_needed,
 )
 from backend.app.agent.profile import update_contractor_profile
+from backend.app.agent.tools.base import ToolTags
 from backend.app.agent.tools.checklist_tools import create_checklist_tools
 from backend.app.agent.tools.estimate_tools import create_estimate_tools
 from backend.app.agent.tools.file_tools import auto_save_media, create_file_tools
@@ -63,7 +64,7 @@ async def handle_inbound_message(
     to_address = contractor.channel_identifier or contractor.phone
     if not to_address:
         logger.error(
-            "Contractor %d has no channel_identifier or phone — cannot send replies",
+            "Contractor %d has no channel_identifier or phone -- cannot send replies",
             contractor.id,
         )
         return AgentResponse(reply_text="")
@@ -219,9 +220,8 @@ async def handle_inbound_message(
         contractor.onboarding_complete = True
         db.commit()
 
-    # Step 7: If agent didn't explicitly call send_reply/send_media_reply, send the reply text
-    REPLY_TOOL_NAMES = {"send_reply", "send_media_reply"}
-    sent_reply = any(tc.get("name") in REPLY_TOOL_NAMES for tc in response.tool_calls)
+    # Step 7: If agent didn't explicitly call a reply tool, send the reply text
+    sent_reply = any(ToolTags.SENDS_REPLY in tc.get("tags", set()) for tc in response.tool_calls)
     if not sent_reply and response.reply_text:
         try:
             await messaging_service.send_text(to=to_address, body=response.reply_text)

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -1,6 +1,13 @@
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+
+
+class ToolTags:
+    """Constants for cross-cutting tool metadata tags."""
+
+    SENDS_REPLY = "sends_reply"
+    SAVES_MEMORY = "saves_memory"
 
 
 @dataclass
@@ -19,6 +26,7 @@ class Tool:
     description: str
     function: Callable[..., Any]
     parameters: dict[str, Any]
+    tags: set[str] = field(default_factory=set)
 
 
 def tool_to_openai_schema(tool: Tool) -> dict[str, Any]:

--- a/backend/app/agent/tools/memory_tools.py
+++ b/backend/app/agent/tools/memory_tools.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
 from backend.app.agent.memory import delete_memory, recall_memories, save_memory
-from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.agent.tools.base import Tool, ToolResult, ToolTags
 
 
 def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
@@ -45,6 +45,7 @@ def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
                 },
                 "required": ["key", "value"],
             },
+            tags={ToolTags.SAVES_MEMORY},
         ),
         Tool(
             name="recall_facts",

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -1,4 +1,4 @@
-from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.agent.tools.base import Tool, ToolResult, ToolTags
 from backend.app.services.messaging import MessagingService
 
 
@@ -33,6 +33,7 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
                 },
                 "required": ["message"],
             },
+            tags={ToolTags.SENDS_REPLY},
         ),
         Tool(
             name="send_media_reply",
@@ -49,5 +50,6 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
                 },
                 "required": ["message", "media_url"],
             },
+            tags={ToolTags.SENDS_REPLY},
         ),
     ]

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -15,6 +15,7 @@ from backend.app.agent.onboarding import (
 )
 from backend.app.agent.profile import get_missing_optional_fields
 from backend.app.agent.router import handle_inbound_message
+from backend.app.agent.tools.base import ToolTags
 from backend.app.models import Contractor, Conversation, Message
 from backend.app.services.messaging import MessagingService
 from tests.mocks.llm import make_text_response, make_tool_call_response
@@ -302,11 +303,13 @@ def test_extract_profile_updates_name_and_trade() -> None:
                 "name": "save_fact",
                 "args": {"key": "name", "value": "Mike Johnson"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
             {
                 "name": "save_fact",
                 "args": {"key": "trade", "value": "Electrician"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -324,6 +327,7 @@ def test_extract_profile_updates_hourly_rate() -> None:
                 "name": "save_fact",
                 "args": {"key": "hourly_rate", "value": "$85/hr"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -340,6 +344,7 @@ def test_extract_profile_updates_ignores_non_profile_facts() -> None:
                 "name": "save_fact",
                 "args": {"key": "favorite_color", "value": "blue"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -368,6 +373,7 @@ def test_extract_profile_updates_invalid_rate() -> None:
                 "name": "save_fact",
                 "args": {"key": "hourly_rate", "value": "depends on the job"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -445,6 +451,7 @@ def test_extract_profile_updates_various_rate_formats(
                 "name": "save_fact",
                 "args": {"key": "hourly_rate", "value": rate_value},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -463,6 +470,7 @@ def test_extract_profile_updates_invalid_rate_logs_warning(
                 "name": "save_fact",
                 "args": {"key": "hourly_rate", "value": "varies"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -570,6 +578,7 @@ def test_extract_profile_updates_fuzzy_profession_maps_to_trade() -> None:
                 "name": "save_fact",
                 "args": {"key": "profession", "value": "Plumber"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -586,6 +595,7 @@ def test_extract_profile_updates_fuzzy_area_maps_to_location() -> None:
                 "name": "save_fact",
                 "args": {"key": "service_area", "value": "Portland, OR"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -602,6 +612,7 @@ def test_extract_profile_updates_fuzzy_pricing_maps_to_hourly_rate() -> None:
                 "name": "save_fact",
                 "args": {"key": "pricing", "value": "$95"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -618,6 +629,7 @@ def test_extract_profile_updates_fuzzy_schedule_maps_to_business_hours() -> None
                 "name": "save_fact",
                 "args": {"key": "schedule", "value": "Mon-Fri 8am-5pm"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -634,6 +646,7 @@ def test_extract_profile_updates_fuzzy_full_name_maps_to_name() -> None:
                 "name": "save_fact",
                 "args": {"key": "full_name", "value": "Sarah Connor"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -653,6 +666,7 @@ def test_extract_profile_updates_communication_style_exact_key() -> None:
                 "name": "save_fact",
                 "args": {"key": "communication_style", "value": "casual and brief"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -671,6 +685,7 @@ def test_extract_profile_updates_communication_preference_exact_key() -> None:
                 "name": "save_fact",
                 "args": {"key": "communication_preference", "value": "formal and detailed"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -689,6 +704,7 @@ def test_extract_profile_updates_fuzzy_tone_maps_to_preferences() -> None:
                 "name": "save_fact",
                 "args": {"key": "preferred_tone", "value": "keep it short"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -708,6 +724,7 @@ def test_extract_profile_updates_soul_text_exact_key() -> None:
                     "value": "I specialize in custom decks.",
                 },
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -724,6 +741,7 @@ def test_extract_profile_updates_fuzzy_bio_maps_to_soul_text() -> None:
                 "name": "save_fact",
                 "args": {"key": "bio", "value": "20 years in the trade."},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -740,11 +758,13 @@ def test_extract_profile_updates_style_key_no_false_positive() -> None:
                 "name": "save_fact",
                 "args": {"key": "cabinet_style", "value": "shaker"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
             {
                 "name": "save_fact",
                 "args": {"key": "project_brief", "value": "deck replacement"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -758,26 +778,35 @@ def test_extract_profile_updates_exact_keys_still_work() -> None:
     response = AgentResponse(
         reply_text="All set!",
         tool_calls=[
-            {"name": "save_fact", "args": {"key": "name", "value": "Mike"}, "result": "ok"},
+            {
+                "name": "save_fact",
+                "args": {"key": "name", "value": "Mike"},
+                "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
+            },
             {
                 "name": "save_fact",
                 "args": {"key": "trade", "value": "Plumber"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
             {
                 "name": "save_fact",
                 "args": {"key": "location", "value": "Denver"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
             {
                 "name": "save_fact",
                 "args": {"key": "hourly_rate", "value": "$75"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
             {
                 "name": "save_fact",
                 "args": {"key": "business_hours", "value": "9-5"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )
@@ -798,11 +827,13 @@ def test_extract_profile_updates_fuzzy_does_not_match_unrelated() -> None:
                 "name": "save_fact",
                 "args": {"key": "favorite_color", "value": "blue"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
             {
                 "name": "save_fact",
                 "args": {"key": "username", "value": "mike42"},
                 "result": "ok",
+                "tags": {ToolTags.SAVES_MEMORY},
             },
         ],
     )

--- a/tests/test_tool_tags.py
+++ b/tests/test_tool_tags.py
@@ -1,0 +1,218 @@
+"""Tests for the ToolTags metadata system on the Tool dataclass."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.core import BackshopAgent
+from backend.app.agent.tools.base import Tool, ToolTags
+from backend.app.agent.tools.memory_tools import create_memory_tools
+from backend.app.agent.tools.messaging_tools import create_messaging_tools
+from backend.app.models import Contractor
+from tests.mocks.llm import make_text_response, make_tool_call_response
+
+# --- ToolTags constants ---
+
+
+def test_tool_tags_constants_are_strings() -> None:
+    """ToolTags constants should be plain strings for JSON serialization."""
+    assert isinstance(ToolTags.SENDS_REPLY, str)
+    assert isinstance(ToolTags.SAVES_MEMORY, str)
+
+
+def test_tool_tags_constants_are_distinct() -> None:
+    """Each tag constant should be unique."""
+    assert ToolTags.SENDS_REPLY != ToolTags.SAVES_MEMORY
+
+
+# --- Tool dataclass tags field ---
+
+
+def test_tool_default_tags_empty() -> None:
+    """Tools created without explicit tags should have an empty set."""
+    tool = Tool(
+        name="noop",
+        description="Does nothing",
+        function=lambda: None,
+        parameters={},
+    )
+    assert tool.tags == set()
+
+
+def test_tool_with_single_tag() -> None:
+    """A tool can be created with a single tag."""
+    tool = Tool(
+        name="save_fact",
+        description="Saves a memory",
+        function=lambda: None,
+        parameters={},
+        tags={ToolTags.SAVES_MEMORY},
+    )
+    assert ToolTags.SAVES_MEMORY in tool.tags
+    assert ToolTags.SENDS_REPLY not in tool.tags
+
+
+def test_tool_with_multiple_tags() -> None:
+    """A tool can have multiple tags."""
+    tool = Tool(
+        name="multi",
+        description="Multi-purpose",
+        function=lambda: None,
+        parameters={},
+        tags={ToolTags.SAVES_MEMORY, ToolTags.SENDS_REPLY},
+    )
+    assert ToolTags.SAVES_MEMORY in tool.tags
+    assert ToolTags.SENDS_REPLY in tool.tags
+
+
+def test_tool_tags_do_not_leak_between_instances() -> None:
+    """Each Tool instance should have its own tags set (no shared default)."""
+    tool_a = Tool(name="a", description="A", function=lambda: None, parameters={})
+    tool_b = Tool(name="b", description="B", function=lambda: None, parameters={})
+    tool_a.tags.add("custom")
+    assert "custom" not in tool_b.tags
+
+
+# --- Tool factory tags ---
+
+
+def test_memory_tools_save_fact_has_saves_memory_tag() -> None:
+    """save_fact tool from create_memory_tools should have SAVES_MEMORY tag."""
+    db = MagicMock()
+    tools = create_memory_tools(db, contractor_id=1)
+    save_fact = next(t for t in tools if t.name == "save_fact")
+    assert ToolTags.SAVES_MEMORY in save_fact.tags
+
+
+def test_memory_tools_recall_and_forget_have_no_special_tags() -> None:
+    """recall_facts and forget_fact should not have SAVES_MEMORY or SENDS_REPLY tags."""
+    db = MagicMock()
+    tools = create_memory_tools(db, contractor_id=1)
+    for tool in tools:
+        if tool.name in ("recall_facts", "forget_fact"):
+            assert ToolTags.SAVES_MEMORY not in tool.tags
+            assert ToolTags.SENDS_REPLY not in tool.tags
+
+
+def test_messaging_tools_have_sends_reply_tag() -> None:
+    """send_reply and send_media_reply should have SENDS_REPLY tag."""
+    messaging = MagicMock()
+    tools = create_messaging_tools(messaging, to_address="+15550001234")
+    for tool in tools:
+        assert ToolTags.SENDS_REPLY in tool.tags, f"{tool.name} missing SENDS_REPLY tag"
+
+
+def test_messaging_tools_do_not_have_saves_memory_tag() -> None:
+    """Messaging tools should not have SAVES_MEMORY tag."""
+    messaging = MagicMock()
+    tools = create_messaging_tools(messaging, to_address="+15550001234")
+    for tool in tools:
+        assert ToolTags.SAVES_MEMORY not in tool.tags
+
+
+# --- Agent core integration ---
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_tool_call_records_include_tags(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Tool call records in AgentResponse should include tags from the Tool definition."""
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "name": "save_fact",
+                "arguments": json.dumps({"key": "rate", "value": "$50/hr"}),
+            }
+        ]
+    )
+    followup_response = make_text_response("Got it!")
+    mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
+
+    mock_save = AsyncMock(return_value="Saved rate = $50/hr")
+    tool = Tool(
+        name="save_fact",
+        description="Save a fact",
+        function=mock_save,
+        parameters={"type": "object", "properties": {"key": {}, "value": {}}},
+        tags={ToolTags.SAVES_MEMORY},
+    )
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("My rate is $50/hour")
+
+    assert len(response.tool_calls) == 1
+    assert "tags" in response.tool_calls[0]
+    assert ToolTags.SAVES_MEMORY in response.tool_calls[0]["tags"]
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_memories_saved_uses_tags_not_name(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """memories_saved should be populated based on SAVES_MEMORY tag, not tool name."""
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "name": "custom_memory_saver",
+                "arguments": json.dumps({"key": "color", "value": "blue"}),
+            }
+        ]
+    )
+    followup_response = make_text_response("Noted!")
+    mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
+
+    mock_fn = AsyncMock(return_value="Saved")
+    tool = Tool(
+        name="custom_memory_saver",
+        description="Custom memory saver",
+        function=mock_fn,
+        parameters={"type": "object", "properties": {"key": {}, "value": {}}},
+        tags={ToolTags.SAVES_MEMORY},
+    )
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("My favorite color is blue")
+
+    assert len(response.memories_saved) == 1
+    assert response.memories_saved[0]["key"] == "color"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_untagged_tool_has_empty_tags(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Tool without tags should produce tool_call record with empty tags set."""
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "name": "some_tool",
+                "arguments": json.dumps({"q": "hello"}),
+            }
+        ]
+    )
+    followup_response = make_text_response("Done!")
+    mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
+
+    mock_fn = AsyncMock(return_value="ok")
+    tool = Tool(
+        name="some_tool",
+        description="A tool",
+        function=mock_fn,
+        parameters={"type": "object", "properties": {"q": {}}},
+    )
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("hello")
+
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0]["tags"] == set()
+    assert len(response.memories_saved) == 0


### PR DESCRIPTION
## Summary

- Added `tags: set[str]` field to the `Tool` dataclass and `ToolTags` constants (`SENDS_REPLY`, `SAVES_MEMORY`) for declarative cross-cutting metadata
- Replaced all hardcoded tool name string checks with tag-based checks:
  - `core.py`: `tool_name == "save_fact"` replaced with `ToolTags.SAVES_MEMORY in tool_tags`; tags included in `tool_call_records` for downstream consumers
  - `router.py`: `REPLY_TOOL_NAMES = {"send_reply", "send_media_reply"}` replaced with `ToolTags.SENDS_REPLY in tc.get("tags", set())`
  - `onboarding.py`: `tc.get("name") != "save_fact"` replaced with `ToolTags.SAVES_MEMORY not in tc.get("tags", set())`
- Tagged tools at creation time in `memory_tools.py` and `messaging_tools.py`
- Added 13 new tests covering ToolTags constants, Tool dataclass behavior, factory wiring, and agent integration

## Test plan

- [x] All 523 existing + new tests pass (`DATABASE_URL=sqlite:// uv run pytest -v`)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] No hardcoded tool name strings remain in core.py, router.py, or onboarding.py
- [x] Verified tools are correctly tagged via factory function tests
- [x] Verified `memories_saved` uses SAVES_MEMORY tag (not tool name) via integration test
- [x] Verified untagged tools get empty tags set in tool_call_records

Fixes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)