### PR TITLE
refactor: add json-repair for LLM tool argument parsing

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1,10 +1,10 @@
 import asyncio
-import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+import json_repair
 from any_llm import (
     AuthenticationError,
     ContentFilterError,
@@ -305,8 +305,10 @@ class BackshopAgent:
                     continue
                 tool_name = func.name
                 try:
-                    tool_args = json.loads(func.arguments)
-                except json.JSONDecodeError:
+                    tool_args = json_repair.loads(func.arguments)
+                    if not isinstance(tool_args, dict):
+                        raise ValueError(f"Expected dict, got {type(tool_args).__name__}")
+                except (ValueError, TypeError):
                     logger.warning(
                         "Malformed tool arguments for %s: %s",
                         tool_name,

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-import json
 import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+import json_repair
 from any_llm import acompletion
 from any_llm.types.completion import ChatCompletion
 from sqlalchemy.orm import Session
@@ -408,8 +408,10 @@ def _parse_tool_call_response(response: ChatCompletion) -> HeartbeatAction:
         )
 
     try:
-        data = json.loads(func.arguments)
-    except (json.JSONDecodeError, TypeError):
+        data = json_repair.loads(func.arguments)
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected dict, got {type(data).__name__}")
+    except (ValueError, TypeError):
         logger.warning(
             "Heartbeat tool call had malformed arguments: %s", (func.arguments or "")[:200]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-multipart>=0.0.9",
     "httpx>=0.27",
     "any-llm-sdk[anthropic]>=1.8",
+    "json-repair>=0.30",
     "python-telegram-bot>=22.0",
     "reportlab>=4.0",
     "dropbox>=12.0",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -383,6 +383,43 @@ async def test_agent_handles_malformed_tool_arguments(
     assert any("bad args" in a for a in response.actions_taken)
 
 
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_repairs_slightly_malformed_json(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Agent should repair common LLM JSON mistakes like trailing commas."""
+    # LLM returns a tool call with a trailing comma (common LLM mistake)
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_repair",
+                "name": "save_fact",
+                "arguments": '{"key": "hourly_rate", "value": "$75/hr",}',
+            }
+        ]
+    )
+    followup_response = make_text_response("Got it!")
+
+    mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
+
+    mock_save = AsyncMock(return_value="Saved hourly_rate = $75/hr")
+    tool = Tool(
+        name="save_fact",
+        description="Save a fact",
+        function=mock_save,
+        parameters={"type": "object", "properties": {"key": {}, "value": {}}},
+    )
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("My rate is $75/hour")
+
+    # Tool SHOULD have been called despite the trailing comma
+    mock_save.assert_called_once_with(key="hourly_rate", value="$75/hr")
+    assert any("Called save_fact" in a for a in response.actions_taken)
+
+
 # ---------------------------------------------------------------------------
 # Typed LLM exception handling tests (issue #173)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Replace `json.loads()` with `json_repair.loads()` for parsing LLM tool call arguments in both the agent loop (`core.py`) and heartbeat engine (`heartbeat.py`). This tolerates common LLM JSON mistakes like trailing commas, single quotes, and missing closing braces instead of aborting the tool call and wasting a round.

Adds a type guard (`isinstance(tool_args, dict)`) to catch cases where json_repair produces a non-dict result from truly unrecoverable input.

Fixes #291

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)