### PR TITLE
refactor: improve tool error feedback for LLM self-correction

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -39,13 +39,45 @@ def _estimate_tokens(messages: list[dict[str, Any]]) -> int:
     return sum(len(str(m.get("content", ""))) // 4 for m in messages)
 
 
-def _format_validation_error(tool_name: str, exc: ValidationError) -> str:
+def _format_validation_error(tool_name: str, exc: ValidationError, tool: Tool | None = None) -> str:
     """Format a Pydantic ValidationError into a structured message for the LLM."""
     error_lines: list[str] = [f"Validation error for {tool_name}:"]
     for err in exc.errors():
         loc = " -> ".join(str(part) for part in err["loc"])
         error_lines.append(f"  {loc}: {err['msg']} (type={err['type']})")
+
+    if tool is not None:
+        schema_summary = _summarize_tool_params(tool)
+        if schema_summary:
+            error_lines.append(f"\nExpected parameters: {schema_summary}")
+
     return "\n".join(error_lines)
+
+
+def _summarize_tool_params(tool: Tool) -> str:
+    """Build a concise parameter summary string from a tool's schema."""
+    if tool.params_model is not None:
+        schema = tool.params_model.model_json_schema()
+    elif tool.parameters:
+        schema = tool.parameters
+    else:
+        return ""
+
+    props = schema.get("properties", {})
+    required = set(schema.get("required", []))
+    if not props:
+        return ""
+
+    parts: list[str] = []
+    for name, info in props.items():
+        ptype = info.get("type", "any")
+        req = "required" if name in required else "optional"
+        default = info.get("default")
+        if default is not None:
+            parts.append(f'"{name}": {ptype} ({req}, default: {default})')
+        else:
+            parts.append(f'"{name}": {ptype} ({req})')
+    return "{" + ", ".join(parts) + "}"
 
 
 SYSTEM_PROMPT_TEMPLATE = """You are Backshop, an AI assistant for solo contractors.
@@ -230,7 +262,7 @@ class BackshopAgent:
             validated = tool.params_model.model_validate(tool_args)
             return validated.model_dump(), None
         except ValidationError as exc:
-            return tool_args, _format_validation_error(tool.name, exc)
+            return tool_args, _format_validation_error(tool.name, exc, tool)
 
     def _get_tool_tags(self, tool_name: str) -> set[str]:
         """Look up the tags for a registered tool by name."""
@@ -395,7 +427,12 @@ class BackshopAgent:
                         )
                         actions_taken.append(f"Failed: {tool_name}")
                 else:
-                    result_str = f"Error: unknown tool {tool_name}"
+                    available = ", ".join(sorted(self._tools_by_name.keys()))
+                    result_str = (
+                        f'Error: unknown tool "{tool_name}".'
+                        f" Available tools: {available}"
+                        "\n\n[Analyze the error above and try a different approach.]"
+                    )
 
                 tool_results.append(
                     {

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -888,3 +888,105 @@ async def test_tool_exception_appends_hint(
     response = await agent.process_message("test", system_prompt_override="system")
 
     assert any("Failed: bad_tool" in a for a in response.actions_taken)
+
+
+# ---------------------------------------------------------------------------
+# Tool error feedback tests (issue #292)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_unknown_tool_error_lists_available_tools(
+    mock_acompletion: AsyncMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Unknown tool error should list all registered tool names."""
+
+    async def dummy(**kwargs: object) -> str:
+        return "ok"
+
+    tools = [
+        Tool(name="save_fact", description="Save a fact", function=dummy, parameters={}),
+        Tool(name="recall_facts", description="Recall facts", function=dummy, parameters={}),
+    ]
+
+    # LLM calls a tool that doesn't exist
+    mock_acompletion.side_effect = [
+        make_tool_call_response(
+            tool_calls=[
+                {"id": "call_1", "name": "save_notes", "arguments": json.dumps({"text": "hi"})}
+            ]
+        ),
+        make_text_response("Let me try again."),
+    ]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools(tools)
+    await agent.process_message("test", system_prompt_override="system")
+
+    # Check the tool result sent back to the LLM
+    followup_call = mock_acompletion.call_args_list[1]
+    messages = followup_call.kwargs["messages"]
+    tool_msg = next(m for m in messages if m.get("role") == "tool")
+    content = tool_msg["content"]
+
+    assert 'unknown tool "save_notes"' in content
+    assert "save_fact" in content
+    assert "recall_facts" in content
+    assert "[Analyze the error" in content
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_validation_error_includes_expected_schema(
+    mock_acompletion: AsyncMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Validation errors should include the expected parameter schema."""
+    from pydantic import BaseModel
+
+    class FactParams(BaseModel):
+        key: str
+        value: str
+        category: str = "general"
+
+    async def save_fact(**kwargs: object) -> str:
+        return "saved"
+
+    tool = Tool(
+        name="save_fact",
+        description="Save a fact",
+        function=save_fact,
+        parameters={},
+        params_model=FactParams,
+    )
+
+    # LLM calls save_fact with missing required fields
+    mock_acompletion.side_effect = [
+        make_tool_call_response(
+            tool_calls=[
+                {"id": "call_1", "name": "save_fact", "arguments": json.dumps({"category": "job"})}
+            ]
+        ),
+        make_text_response("Let me fix that."),
+    ]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    await agent.process_message("test", system_prompt_override="system")
+
+    # Check the tool result sent back to the LLM
+    followup_call = mock_acompletion.call_args_list[1]
+    messages = followup_call.kwargs["messages"]
+    tool_msg = next(m for m in messages if m.get("role") == "tool")
+    content = tool_msg["content"]
+
+    assert "Validation error for save_fact" in content
+    assert "Expected parameters:" in content
+    assert '"key": string (required)' in content
+    assert '"value": string (required)' in content
+    assert '"category": string (optional, default: general)' in content
+    assert "[Analyze the error" in content


### PR DESCRIPTION
## Description
Improves error messages returned to the LLM when tool calls fail, enabling faster self-correction:

- **Unknown tool errors** now list all available tool names so the model can pick the right one in one retry
- **Validation errors** now include a concise summary of the expected parameter schema (field names, types, required/optional, defaults)

Both patterns are inspired by nanobot's self-correction approach.

Fixes #292

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)