### PR TITLE
refactor: remove provider-specific checks in favor of any-llm abstraction

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -306,9 +306,7 @@ class BackshopAgent:
 
         tool_schemas = [tool_to_openai_schema(t) for t in self.tools] if self.tools else None
 
-        llm_kwargs: dict[str, Any] = {}
-        if settings.llm_provider == "openai":
-            llm_kwargs["user"] = str(self.contractor.id)
+        llm_kwargs: dict[str, Any] = {"user": str(self.contractor.id)}
         if temperature is not None:
             llm_kwargs["temperature"] = temperature
 

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -456,9 +456,7 @@ async def evaluate_heartbeat_need(
     model = settings.heartbeat_model or settings.llm_model
     provider = settings.heartbeat_provider or settings.llm_provider
 
-    llm_kwargs: dict[str, Any] = {}
-    if provider == "openai":
-        llm_kwargs["user"] = str(contractor.id)
+    llm_kwargs: dict[str, Any] = {"user": str(contractor.id)}
 
     response = cast(
         ChatCompletion,

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -37,7 +37,7 @@ async def analyze_image(
     logger.info("Using vision model: %s (provider=%s)", model, settings.llm_provider)
 
     llm_kwargs: dict[str, Any] = {}
-    if user is not None and settings.llm_provider == "openai":
+    if user is not None:
         llm_kwargs["user"] = user
 
     response = cast(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -92,49 +92,20 @@ async def test_agent_does_not_pass_api_key(
 
 
 @pytest.mark.asyncio()
-@patch("backend.app.agent.core.settings")
 @patch("backend.app.agent.core.acompletion")
-async def test_agent_passes_user_parameter(
+async def test_agent_always_passes_user_parameter(
     mock_acompletion: object,
-    mock_settings: object,
     db_session: Session,
     test_contractor: Contractor,
 ) -> None:
-    """acompletion should be called with user=contractor.id when provider is openai."""
+    """acompletion should always be called with user=contractor.id regardless of provider."""
     mock_acompletion.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
-    mock_settings.llm_provider = "openai"  # type: ignore[attr-defined]
-    mock_settings.llm_model = "gpt-4o"  # type: ignore[attr-defined]
-    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
-    mock_settings.llm_max_tokens_agent = 500  # type: ignore[attr-defined]
 
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
     await agent.process_message("Hello")
 
     call_args = mock_acompletion.call_args  # type: ignore[union-attr]
     assert call_args.kwargs["user"] == str(test_contractor.id)
-
-
-@pytest.mark.asyncio()
-@patch("backend.app.agent.core.settings")
-@patch("backend.app.agent.core.acompletion")
-async def test_agent_omits_user_for_non_openai_provider(
-    mock_acompletion: object,
-    mock_settings: object,
-    db_session: Session,
-    test_contractor: Contractor,
-) -> None:
-    """acompletion should NOT pass user param when provider is not openai (e.g. anthropic)."""
-    mock_acompletion.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
-    mock_settings.llm_provider = "anthropic"  # type: ignore[attr-defined]
-    mock_settings.llm_model = "claude-haiku-4-5-20251001"  # type: ignore[attr-defined]
-    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
-    mock_settings.llm_max_tokens_agent = 500  # type: ignore[attr-defined]
-
-    agent = BackshopAgent(db=db_session, contractor=test_contractor)
-    await agent.process_message("Hello")
-
-    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
-    assert "user" not in call_args.kwargs
 
 
 @pytest.mark.asyncio()

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -73,16 +73,10 @@ async def test_analyze_image_does_not_pass_api_key(mock_acompletion: object) -> 
 
 @pytest.mark.asyncio()
 @patch("backend.app.media.vision.acompletion")
-@patch("backend.app.media.vision.settings")
-async def test_analyze_image_passes_user_for_openai(
-    mock_settings: object, mock_acompletion: object
+async def test_analyze_image_always_passes_user_when_provided(
+    mock_acompletion: object,
 ) -> None:
-    """When provider is openai and user is set, user should be passed to acompletion."""
-    mock_settings.vision_model = "gpt-4o"  # type: ignore[attr-defined]
-    mock_settings.llm_model = "gpt-4o"  # type: ignore[attr-defined]
-    mock_settings.llm_provider = "openai"  # type: ignore[attr-defined]
-    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
-    mock_settings.llm_max_tokens_vision = 1024  # type: ignore[attr-defined]
+    """When user is provided, it should always be passed to acompletion regardless of provider."""
     mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]
 
     await analyze_image(b"fake-jpeg-bytes", "image/jpeg", user="42")
@@ -93,19 +87,13 @@ async def test_analyze_image_passes_user_for_openai(
 
 @pytest.mark.asyncio()
 @patch("backend.app.media.vision.acompletion")
-@patch("backend.app.media.vision.settings")
-async def test_analyze_image_omits_user_for_non_openai(
-    mock_settings: object, mock_acompletion: object
+async def test_analyze_image_omits_user_when_not_provided(
+    mock_acompletion: object,
 ) -> None:
-    """When provider is not openai, user should NOT be passed."""
-    mock_settings.vision_model = ""  # type: ignore[attr-defined]
-    mock_settings.llm_model = "claude-haiku-4-5-20251001"  # type: ignore[attr-defined]
-    mock_settings.llm_provider = "anthropic"  # type: ignore[attr-defined]
-    mock_settings.llm_api_base = None  # type: ignore[attr-defined]
-    mock_settings.llm_max_tokens_vision = 1024  # type: ignore[attr-defined]
+    """When user is not provided, user should NOT be passed to acompletion."""
     mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]
 
-    await analyze_image(b"fake-jpeg-bytes", "image/jpeg", user="42")
+    await analyze_image(b"fake-jpeg-bytes", "image/jpeg")
 
     call_args = mock_acompletion.call_args  # type: ignore[union-attr]
     assert "user" not in call_args.kwargs


### PR DESCRIPTION
## Summary

- Always pass `user=str(contractor.id)` to `acompletion()` regardless of LLM provider, removing `if provider == "openai"` conditionals from `core.py`, `heartbeat.py`, and `vision.py`
- The any-llm SDK handles provider-specific parameter mapping and silently ignores unsupported params, so these checks were unnecessary coupling
- Consolidated the two provider-conditional test cases (one for OpenAI, one for non-OpenAI) into single tests that verify user is always passed

## Test plan

- [x] All 510 tests pass (`DATABASE_URL=sqlite:// uv run pytest -v`)
- [x] Ruff lint passes (`uv run ruff check backend/ tests/`)
- [x] Ruff format passes (`uv run ruff format --check backend/ tests/`)
- [x] Verified no remaining `if settings.llm_provider == "openai"` or `if provider == "openai"` checks in production code

Fixes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)