### PR TITLE
refactor: create comprehensive domain enums for status fields

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -6,6 +6,7 @@ import logging
 from sqlalchemy.orm import Session
 
 from backend.app.config import settings
+from backend.app.enums import MessageDirection
 from backend.app.models import Conversation, Message
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ async def load_conversation_history(
 
     history: list[dict[str, str]] = []
     for msg in messages:
-        role = "user" if msg.direction == "inbound" else "assistant"
+        role = "user" if msg.direction == MessageDirection.INBOUND else "assistant"
         # Prefer processed context (includes media descriptions) over raw body
         content = msg.processed_context if msg.processed_context else msg.body
         history.append({"role": role, "content": content})

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -24,9 +24,14 @@ from sqlalchemy.orm import Session
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.memory import build_memory_context
 from backend.app.agent.profile import build_soul_prompt
-from backend.app.agent.tools.estimate_tools import EstimateStatus
 from backend.app.config import settings
 from backend.app.database import SessionLocal
+from backend.app.enums import (
+    ChecklistSchedule,
+    ChecklistStatus,
+    EstimateStatus,
+    MessageDirection,
+)
 from backend.app.models import (
     Contractor,
     Conversation,
@@ -258,7 +263,7 @@ def run_cheap_checks(
         db.query(HeartbeatChecklistItem)
         .filter(
             HeartbeatChecklistItem.contractor_id == contractor.id,
-            HeartbeatChecklistItem.status == "active",
+            HeartbeatChecklistItem.status == ChecklistStatus.ACTIVE,
         )
         .all()
     )
@@ -282,7 +287,7 @@ def run_cheap_checks(
         .join(Conversation, Message.conversation_id == Conversation.id)
         .filter(
             Conversation.contractor_id == contractor.id,
-            Message.direction == "inbound",
+            Message.direction == MessageDirection.INBOUND,
         )
         .order_by(Message.created_at.desc())
         .first()
@@ -311,7 +316,7 @@ def _is_checklist_item_due(
 ) -> bool:
     """Determine whether a checklist item should fire on this tick."""
     # Weekday gate applies regardless of trigger history
-    if item.schedule == "weekdays" and now.weekday() > WEEKDAY_FRIDAY:
+    if item.schedule == ChecklistSchedule.WEEKDAYS and now.weekday() > WEEKDAY_FRIDAY:
         return False
 
     # Never triggered -> due (for daily/weekdays/once)
@@ -323,7 +328,7 @@ def _is_checklist_item_due(
         last = last.replace(tzinfo=datetime.UTC)
     elapsed = now - last
 
-    if item.schedule == "once":
+    if item.schedule == ChecklistSchedule.ONCE:
         # Already triggered once -> not due again
         return False
     # Default: "daily" or "weekdays" (weekday gate already passed above)
@@ -355,7 +360,7 @@ async def build_heartbeat_context(
     )
     recent_lines: list[str] = []
     for msg in reversed(recent):
-        direction = "Contractor" if msg.direction == "inbound" else "Backshop"
+        direction = "Contractor" if msg.direction == MessageDirection.INBOUND else "Backshop"
         recent_lines.append(f"[{direction}] {msg.body}")
 
     return {
@@ -538,7 +543,7 @@ async def run_heartbeat_for_contractor(
     conv, _ = await get_or_create_conversation(db, contractor.id)
     outbound = Message(
         conversation_id=conv.id,
-        direction="outbound",
+        direction=MessageDirection.OUTBOUND,
         body=action.message,
     )
     db.add(outbound)
@@ -548,8 +553,8 @@ async def run_heartbeat_for_contractor(
     now = datetime.datetime.now(datetime.UTC)
     for item in check_result.due_checklist_items:
         item.last_triggered_at = now
-        if item.schedule == "once":
-            item.status = "completed"
+        if item.schedule == ChecklistSchedule.ONCE:
+            item.status = ChecklistStatus.COMPLETED
     if check_result.due_checklist_items:
         db.commit()
 

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -20,6 +20,7 @@ from backend.app.agent.tools.profile_tools import (
     extract_profile_updates_from_tool_calls,
 )
 from backend.app.config import settings
+from backend.app.enums import MessageDirection
 from backend.app.media.download import DownloadedMedia, download_telegram_media
 from backend.app.media.pipeline import process_message_media
 from backend.app.models import Contractor, Message
@@ -239,7 +240,7 @@ async def handle_inbound_message(
     if response.reply_text and not response.is_error_fallback:
         outbound = Message(
             conversation_id=message.conversation_id,
-            direction="outbound",
+            direction=MessageDirection.OUTBOUND,
             body=response.reply_text,
         )
         db.add(outbound)

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -6,9 +6,8 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.enums import ChecklistSchedule, ChecklistStatus
 from backend.app.models import HeartbeatChecklistItem
-
-VALID_CHECKLIST_SCHEDULES = ("daily", "weekdays", "once")
 
 
 class AddChecklistItemParams(BaseModel):
@@ -16,7 +15,7 @@ class AddChecklistItemParams(BaseModel):
 
     description: str = Field(description="What to check or remind about")
     schedule: Literal["daily", "weekdays", "once"] = Field(
-        default="daily",
+        default=ChecklistSchedule.DAILY,
         description="How often to check (default: daily)",
     )
 
@@ -36,10 +35,10 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
 
     async def add_checklist_item(
         description: str,
-        schedule: str = "daily",
+        schedule: str = ChecklistSchedule.DAILY,
     ) -> ToolResult:
         """Add an item to the contractor's heartbeat checklist."""
-        if schedule not in VALID_CHECKLIST_SCHEDULES:
+        if schedule not in list(ChecklistSchedule):
             return ToolResult(
                 content=f"Invalid schedule '{schedule}'. Use: daily, weekdays, or once.",
                 is_error=True,
@@ -60,7 +59,7 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
             db.query(HeartbeatChecklistItem)
             .filter(
                 HeartbeatChecklistItem.contractor_id == contractor_id,
-                HeartbeatChecklistItem.status == "active",
+                HeartbeatChecklistItem.status == ChecklistStatus.ACTIVE,
             )
             .order_by(HeartbeatChecklistItem.id)
             .all()

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.agent.tools.file_tools import build_folder_path
 from backend.app.config import settings
+from backend.app.enums import EstimateStatus
 from backend.app.models import Contractor, Estimate, EstimateLineItem
 from backend.app.services.pdf_service import EstimatePDFData, generate_estimate_pdf
 from backend.app.services.storage_service import StorageBackend
@@ -19,11 +20,6 @@ PDF_BASE_DIR = Path(settings.pdf_storage_dir)
 ESTIMATE_NUMBER_FORMAT = "EST-{:04d}"
 
 logger = logging.getLogger(__name__)
-
-
-class EstimateStatus:
-    DRAFT = "draft"
-    SENT = "sent"
 
 
 class EstimateLineItemParams(BaseModel):

--- a/backend/app/enums.py
+++ b/backend/app/enums.py
@@ -1,0 +1,27 @@
+"""Domain enums for status and direction fields."""
+
+from enum import StrEnum
+
+
+class MessageDirection(StrEnum):
+    INBOUND = "inbound"
+    OUTBOUND = "outbound"
+
+
+class EstimateStatus(StrEnum):
+    DRAFT = "draft"
+    SENT = "sent"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+class ChecklistStatus(StrEnum):
+    ACTIVE = "active"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+
+
+class ChecklistSchedule(StrEnum):
+    DAILY = "daily"
+    WEEKDAYS = "weekdays"
+    ONCE = "once"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -4,6 +4,7 @@ from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Te
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.app.database import Base
+from backend.app.enums import ChecklistSchedule, ChecklistStatus, EstimateStatus
 
 
 class Contractor(Base):
@@ -125,7 +126,7 @@ class Estimate(Base):
     description: Mapped[str] = mapped_column(Text, default="")
     total_amount: Mapped[float] = mapped_column(Float, default=0.0)
     status: Mapped[str] = mapped_column(
-        String(20), default="draft"
+        String(20), default=EstimateStatus.DRAFT
     )  # draft, sent, accepted, rejected
     pdf_url: Mapped[str] = mapped_column(String(500), default="")
     created_at: Mapped[datetime.datetime] = mapped_column(
@@ -177,12 +178,16 @@ class HeartbeatChecklistItem(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     contractor_id: Mapped[int] = mapped_column(Integer, ForeignKey("contractors.id"), index=True)
     description: Mapped[str] = mapped_column(Text)
-    schedule: Mapped[str] = mapped_column(String(50), default="daily")  # daily, weekdays, once
+    schedule: Mapped[str] = mapped_column(
+        String(50), default=ChecklistSchedule.DAILY
+    )  # daily, weekdays, once
     active_hours: Mapped[str] = mapped_column(String(255), default="")  # e.g. "7am-5pm"
     last_triggered_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
-    status: Mapped[str] = mapped_column(String(20), default="active")  # active, paused, completed
+    status: Mapped[str] = mapped_column(
+        String(20), default=ChecklistStatus.ACTIVE
+    )  # active, paused, completed
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -12,6 +12,7 @@ from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.router import handle_inbound_message
 from backend.app.config import settings
 from backend.app.database import SessionLocal, get_db
+from backend.app.enums import MessageDirection
 from backend.app.models import Contractor, Message
 from backend.app.services.messaging import MessagingService, get_messaging_service
 from backend.app.services.rate_limiter import check_webhook_rate_limit
@@ -209,7 +210,7 @@ async def telegram_inbound(
 
     message = Message(
         conversation_id=conversation.id,
-        direction="inbound",
+        direction=MessageDirection.INBOUND,
         external_message_id=external_id or None,
         body=text,
         media_urls_json=json.dumps([file_id for file_id, _mime in media_items]),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,6 +2,8 @@ import datetime
 
 from pydantic import BaseModel
 
+from backend.app.enums import EstimateStatus
+
 
 class HealthResponse(BaseModel):
     status: str
@@ -73,7 +75,7 @@ class EstimateLineItemBase(BaseModel):
 class EstimateBase(BaseModel):
     description: str = ""
     total_amount: float = 0.0
-    status: str = "draft"
+    status: str = EstimateStatus.DRAFT
 
 
 class EstimateResponse(EstimateBase):


### PR DESCRIPTION
## Description

Creates a centralized `backend/app/enums.py` module with `StrEnum` classes for all domain status and direction fields, replacing scattered magic strings:

- **`MessageDirection`**: `INBOUND`, `OUTBOUND`
- **`EstimateStatus`**: `DRAFT`, `SENT`, `ACCEPTED`, `REJECTED`
- **`ChecklistStatus`**: `ACTIVE`, `PAUSED`, `COMPLETED`
- **`ChecklistSchedule`**: `DAILY`, `WEEKDAYS`, `ONCE`

Updated all source files to use enum members instead of bare strings:
- `backend/app/agent/context.py`
- `backend/app/agent/heartbeat.py`
- `backend/app/agent/router.py`
- `backend/app/agent/tools/estimate_tools.py` (removed partial `EstimateStatus` class)
- `backend/app/agent/tools/checklist_tools.py` (removed `VALID_CHECKLIST_SCHEDULES` tuple)
- `backend/app/routers/telegram_webhook.py`
- `backend/app/models.py`
- `backend/app/schemas.py`

Since `StrEnum` members compare equal to their string values, all existing tests pass without modification.

Fixes #293

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.6 via Claude Code)
- [ ] No AI used