### PR TITLE
refactor: improve context management with better token estimation and smarter trimming

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -27,16 +27,52 @@ logger = logging.getLogger(__name__)
 MAX_TOOL_ROUNDS = 5
 CONTEXT_QUERY_MAX_LENGTH = 100
 RATE_LIMIT_RETRY_DELAY = 2.0
-# Keep the most recent N messages (plus system prompt) when trimming for context length
-CONTEXT_TRIM_KEEP_RECENT = 4
+# Target token budget when trimming for context length (leave room for output tokens)
+CONTEXT_TRIM_TARGET_TOKENS = 80_000
 
 # Conservative default; most models support 128K+ but we leave room for output
 MAX_INPUT_TOKENS = 120_000
 
+# Per-message overhead tokens for role/delimiters/structural framing
+_MESSAGE_OVERHEAD_TOKENS = 4
+# Characters per token ratio for English text (slightly more accurate than 4.0)
+_CHARS_PER_TOKEN = 3.5
+
 
 def _estimate_tokens(messages: list[dict[str, Any]]) -> int:
-    """Rough token estimate: ~4 chars per token for English text."""
-    return sum(len(str(m.get("content", ""))) // 4 for m in messages)
+    """Estimate token count from messages, including tool call content and overhead.
+
+    Counts content from the ``content`` field and from any ``tool_calls`` entries
+    (function name + serialized arguments). Adds a small per-message overhead for
+    role and delimiter tokens.
+    """
+    total = 0
+    for m in messages:
+        # Per-message overhead (role, delimiters, structural tokens)
+        total += _MESSAGE_OVERHEAD_TOKENS
+
+        # Content field
+        content = m.get("content", "")
+        if content:
+            total += int(len(str(content)) / _CHARS_PER_TOKEN)
+
+        # Tool calls (assistant messages requesting tool use)
+        tool_calls = m.get("tool_calls")
+        if tool_calls and isinstance(tool_calls, list):
+            for tc in tool_calls:
+                func = tc.get("function") if isinstance(tc, dict) else getattr(tc, "function", None)
+                if func is None:
+                    continue
+                name = func.get("name", "") if isinstance(func, dict) else getattr(func, "name", "")
+                args = (
+                    func.get("arguments", "")
+                    if isinstance(func, dict)
+                    else getattr(func, "arguments", "")
+                )
+                total += int(len(str(name)) / _CHARS_PER_TOKEN)
+                total += int(len(str(args)) / _CHARS_PER_TOKEN)
+
+    return total
 
 
 def _format_validation_error(tool_name: str, exc: ValidationError, tool: Tool | None = None) -> str:
@@ -235,15 +271,78 @@ class BackshopAgent:
     @staticmethod
     def _trim_messages(
         messages: list[Any],
+        target_tokens: int = CONTEXT_TRIM_TARGET_TOKENS,
     ) -> list[Any]:
-        """Trim conversation messages to fit within context limits.
+        """Trim conversation messages to fit within a token budget.
 
-        Keeps the system prompt (first message) and the most recent messages.
+        Keeps the system prompt (first message) and removes the oldest
+        conversation messages until the estimated token count is at or below
+        *target_tokens*. Tool-call / tool-result pairs are treated as atomic
+        units: an assistant message containing ``tool_calls`` is never removed
+        without also removing the corresponding ``tool`` role messages that
+        follow it (and vice-versa).
         """
-        if len(messages) <= CONTEXT_TRIM_KEEP_RECENT + 1:
+        if len(messages) <= 2:
             return messages
-        # system prompt + last N messages
-        return [messages[0], *messages[-(CONTEXT_TRIM_KEEP_RECENT):]]
+
+        if _estimate_tokens(messages) <= target_tokens:
+            return messages
+
+        # Separate the system prompt from the conversation body.
+        system = messages[0]
+        body = list(messages[1:])
+
+        # Group the body into "blocks" that must be removed together.
+        # A block is either:
+        #   - A single message (user or assistant without tool_calls)
+        #   - An assistant message with tool_calls + all immediately following
+        #     tool-role messages (the paired results)
+        blocks: list[list[Any]] = []
+        i = 0
+        while i < len(body):
+            msg = body[i]
+            tc = (
+                msg.get("tool_calls") if isinstance(msg, dict) else getattr(msg, "tool_calls", None)
+            )
+            has_tool_calls = bool(tc)
+            role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+            if role == "assistant" and has_tool_calls:
+                # Collect this assistant message and all consecutive tool results
+                block: list[Any] = [msg]
+                j = i + 1
+                while j < len(body):
+                    next_msg = body[j]
+                    next_role = (
+                        next_msg.get("role")
+                        if isinstance(next_msg, dict)
+                        else getattr(next_msg, "role", None)
+                    )
+                    if next_role == "tool":
+                        block.append(next_msg)
+                        j += 1
+                    else:
+                        break
+                blocks.append(block)
+                i = j
+            else:
+                blocks.append([msg])
+                i += 1
+
+        # Remove blocks from the front (oldest) until we fit the budget,
+        # but always keep at least the last block so we never return only the
+        # system prompt.
+        while len(blocks) > 1:
+            remaining = [system]
+            for blk in blocks:
+                remaining.extend(blk)
+            if _estimate_tokens(remaining) <= target_tokens:
+                break
+            blocks.pop(0)
+
+        result: list[Any] = [system]
+        for blk in blocks:
+            result.extend(blk)
+        return result
 
     def _validate_tool_args(
         self, tool: Tool, tool_args: dict[str, Any]

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,7 +11,7 @@ from any_llm import (
 from sqlalchemy.orm import Session
 
 from backend.app.agent.core import (
-    CONTEXT_TRIM_KEEP_RECENT,
+    CONTEXT_TRIM_TARGET_TOKENS,
     MAX_INPUT_TOKENS,
     BackshopAgent,
     _estimate_tokens,
@@ -447,29 +447,99 @@ async def test_agent_rate_limit_retry_failure_propagates(
 
 
 def test_estimate_tokens_returns_reasonable_estimate() -> None:
-    """_estimate_tokens should return a rough char-based token count."""
+    """_estimate_tokens should return a char-based token count with per-message overhead."""
     messages = [
-        {"role": "system", "content": "Hello world"},  # 11 chars -> 2 tokens
-        {"role": "user", "content": "How are you?"},  # 12 chars -> 3 tokens
+        {"role": "system", "content": "Hello world"},  # 11 chars / 3.5 = 3 + 4 overhead = 7
+        {"role": "user", "content": "How are you?"},  # 12 chars / 3.5 = 3 + 4 overhead = 7
     ]
     result = _estimate_tokens(messages)
-    # 11 // 4 + 12 // 4 = 2 + 3 = 5
-    assert result == 5
+    # int(11/3.5) + 4 + int(12/3.5) + 4 = 3 + 4 + 3 + 4 = 14
+    assert result == 14
 
 
 def test_estimate_tokens_handles_empty_messages() -> None:
-    """_estimate_tokens should handle empty content gracefully."""
+    """_estimate_tokens should handle empty content, counting only overhead."""
     messages: list[dict[str, object]] = [
         {"role": "system", "content": ""},
         {"role": "user"},  # no content key at all
     ]
     result = _estimate_tokens(messages)
-    assert result == 0
+    # 2 messages x 4 overhead tokens each = 8
+    assert result == 8
 
 
 def test_estimate_tokens_handles_empty_list() -> None:
     """_estimate_tokens should return 0 for an empty message list."""
     assert _estimate_tokens([]) == 0
+
+
+def test_estimate_tokens_counts_tool_call_content() -> None:
+    """_estimate_tokens should include tool_calls function names and arguments."""
+    messages: list[dict[str, object]] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "save_fact",
+                        "arguments": '{"key": "rate", "value": "$75/hr"}',
+                    },
+                }
+            ],
+        },
+    ]
+    result = _estimate_tokens(messages)
+
+    # Overhead: 4 tokens
+    # content is None -> 0
+    # tool_calls: "save_fact" = 9 chars -> int(9/3.5) = 2
+    #   arguments = 34 chars -> int(34/3.5) = 9
+    # Total = 4 + 0 + 2 + 9 = 15
+    assert result == 15
+
+    # Compare with a message that has no tool_calls -- should be less
+    plain = [{"role": "assistant", "content": None}]
+    assert _estimate_tokens(plain) < result
+
+
+def test_trim_messages_preserves_tool_call_result_pairs() -> None:
+    """Trimming should never orphan a tool result by removing its tool_call."""
+    system = {"role": "system", "content": "x" * 3500}
+    user1 = {"role": "user", "content": "x" * 3500}
+    assistant_tc = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "function": {"name": "save_fact", "arguments": "{}"},
+            }
+        ],
+    }
+    tool_result = {"role": "tool", "tool_call_id": "call_1", "content": "x" * 3500}
+    user2 = {"role": "user", "content": "Final question"}
+
+    messages: list[dict[str, object]] = [
+        system,
+        user1,
+        assistant_tc,
+        tool_result,
+        user2,
+    ]
+
+    # Use a small budget that forces trimming of some messages
+    trimmed = BackshopAgent._trim_messages(messages, target_tokens=5000)
+
+    # The trimmed result should never contain tool_result without assistant_tc
+    has_tool_msg = any(m.get("role") == "tool" for m in trimmed)
+    has_tc_msg = any(m.get("role") == "assistant" and m.get("tool_calls") for m in trimmed)
+
+    if has_tool_msg:
+        assert has_tc_msg, "Tool result present without its tool_call assistant message"
+    if has_tc_msg:
+        assert has_tool_msg, "Tool call assistant message present without its tool result"
 
 
 @pytest.mark.asyncio()
@@ -497,11 +567,12 @@ async def test_agent_trims_context_on_context_length_exceeded(
     assert response.reply_text == "Trimmed and retried!"
     assert mock_acompletion.call_count == 2
 
-    # Verify the retry call used trimmed messages
+    # Verify the retry call used trimmed messages within the token budget
     retry_call = mock_acompletion.call_args_list[1]
     retry_messages = retry_call.kwargs["messages"]
-    # Should be system + CONTEXT_TRIM_KEEP_RECENT messages
-    assert len(retry_messages) == CONTEXT_TRIM_KEEP_RECENT + 1
+    assert _estimate_tokens(retry_messages) <= CONTEXT_TRIM_TARGET_TOKENS
+    # System prompt should always be preserved
+    assert retry_messages[0]["role"] == "system"
 
 
 @pytest.mark.asyncio()
@@ -617,19 +688,26 @@ def test_trim_messages_preserves_short_conversation() -> None:
 
 
 def test_trim_messages_keeps_system_and_recent() -> None:
-    """Long conversations should be trimmed to system + most recent N messages."""
+    """Long conversations should be trimmed to fit within the token budget."""
+    # Each message: ~1143 content tokens + 4 overhead = ~1147 tokens
+    # With a small budget, most messages should be trimmed
+    big_content = "x" * 4000
     messages: list[dict[str, object]] = [
         {"role": "system", "content": "System prompt"},
         *[
-            {"role": "user" if i % 2 == 0 else "assistant", "content": f"Msg {i}"}
+            {"role": "user" if i % 2 == 0 else "assistant", "content": big_content}
             for i in range(20)
         ],
     ]
-    trimmed = BackshopAgent._trim_messages(messages)
-    assert len(trimmed) == CONTEXT_TRIM_KEEP_RECENT + 1
+    # Use a small token budget to force trimming
+    trimmed = BackshopAgent._trim_messages(messages, target_tokens=5000)
     assert trimmed[0]["role"] == "system"
+    # Should have been trimmed significantly
+    assert len(trimmed) < len(messages)
     # Last message should be the most recent one
     assert trimmed[-1] == messages[-1]
+    # Should fit within the target budget
+    assert _estimate_tokens(trimmed) <= 5000
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- Replace fixed `CONTEXT_TRIM_KEEP_RECENT = 4` with token-budget-aware `CONTEXT_TRIM_TARGET_TOKENS = 80_000`
- Improve `_estimate_tokens()` to count tool_call content (function names + arguments), use 3.5 chars/token ratio, and add 4-token per-message overhead
- Rewrite `_trim_messages()` to remove oldest message blocks until under token budget, preserving tool_call/tool_result pairs as atomic units

## Test plan
- [x] Updated `test_estimate_tokens_returns_reasonable_estimate` for new ratio and overhead
- [x] Updated `test_estimate_tokens_handles_empty_messages` to account for overhead tokens
- [x] Added `test_estimate_tokens_counts_tool_call_content` verifying tool_calls are counted
- [x] Added `test_trim_messages_preserves_tool_call_result_pairs` verifying pairs are never orphaned
- [x] Updated `test_trim_messages_keeps_system_and_recent` for token-budget approach
- [x] Updated `test_agent_trims_context_on_context_length_exceeded` for budget-based assertions
- [x] All 512 tests pass, lint clean, format clean, type check clean

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)