### PR TITLE
refactor: add tool registry to decouple router from tool knowledge

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -10,14 +10,12 @@ from backend.app.agent.onboarding import (
     is_onboarding_needed,
 )
 from backend.app.agent.tools.base import ToolTags
-from backend.app.agent.tools.checklist_tools import create_checklist_tools
-from backend.app.agent.tools.estimate_tools import create_estimate_tools
-from backend.app.agent.tools.file_tools import auto_save_media, create_file_tools
-from backend.app.agent.tools.memory_tools import create_memory_tools
-from backend.app.agent.tools.messaging_tools import create_messaging_tools
-from backend.app.agent.tools.profile_tools import (
-    create_profile_tools,
-    extract_profile_updates_from_tool_calls,
+from backend.app.agent.tools.file_tools import auto_save_media
+from backend.app.agent.tools.profile_tools import extract_profile_updates_from_tool_calls
+from backend.app.agent.tools.registry import (
+    ToolContext,
+    default_registry,
+    ensure_tool_modules_imported,
 )
 from backend.app.config import settings
 from backend.app.enums import MessageDirection
@@ -28,6 +26,10 @@ from backend.app.services.messaging import MessagingService
 from backend.app.services.storage_service import StorageBackend, get_storage_service
 
 logger = logging.getLogger(__name__)
+
+# Ensure all tool modules register their factories with the default registry.
+# This must happen after all imports to avoid circular import issues.
+ensure_tool_modules_imported()
 
 # User-facing error/fallback messages
 AGENT_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
@@ -140,17 +142,16 @@ async def handle_inbound_message(
     system_prompt_override = build_onboarding_system_prompt(contractor) if was_onboarding else None
 
     agent = BackshopAgent(db=db, contractor=contractor)
-    tools = create_memory_tools(db, contractor.id)
-    tools.extend(create_messaging_tools(messaging_service, to_address=to_address))
-    tools.extend(create_estimate_tools(db, contractor, storage))
-    tools.extend(create_checklist_tools(db, contractor.id))
-    tools.extend(create_profile_tools(db, contractor))
-
-    # Wire file tools if storage is available
-    if storage:
-        pending_media = {m.original_url: m.content for m in downloaded_media if m.content}
-        tools.extend(create_file_tools(db, contractor, storage, pending_media))
-
+    pending_media = {m.original_url: m.content for m in downloaded_media if m.content}
+    context = ToolContext(
+        db=db,
+        contractor=contractor,
+        storage=storage,
+        messaging_service=messaging_service,
+        to_address=to_address,
+        downloaded_media=pending_media,
+    )
+    tools = default_registry.create_tools(context)
     agent.register_tools(tools)
 
     # Send typing indicator while processing (non-blocking on failure)

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.agent.tools.registry import ToolContext, ToolFactory, default_registry
 from backend.app.enums import ChecklistSchedule, ChecklistStatus
 from backend.app.models import HeartbeatChecklistItem
 
@@ -109,3 +110,10 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
             params_model=RemoveChecklistItemParams,
         ),
     ]
+
+
+def _factory(ctx: ToolContext) -> list[Tool]:
+    return create_checklist_tools(ctx.db, ctx.contractor.id)
+
+
+default_registry.register(ToolFactory(create=_factory))

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.agent.tools.file_tools import build_folder_path
+from backend.app.agent.tools.registry import ToolContext, ToolFactory, default_registry
 from backend.app.config import settings
 from backend.app.enums import EstimateStatus
 from backend.app.models import Contractor, Estimate, EstimateLineItem
@@ -174,3 +175,10 @@ def create_estimate_tools(
             params_model=GenerateEstimateParams,
         ),
     ]
+
+
+def _factory(ctx: ToolContext) -> list[Tool]:
+    return create_estimate_tools(ctx.db, ctx.contractor, ctx.storage)
+
+
+default_registry.register(ToolFactory(create=_factory))

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.agent.tools.registry import ToolContext, ToolFactory, default_registry
 from backend.app.media.download import MIME_EXTENSIONS, DownloadedMedia
 from backend.app.models import Contractor, MediaFile
 from backend.app.services.storage_service import StorageBackend
@@ -390,3 +391,11 @@ def create_file_tools(
             params_model=OrganizeFileParams,
         ),
     ]
+
+
+def _factory(ctx: ToolContext) -> list[Tool]:
+    assert ctx.storage is not None
+    return create_file_tools(ctx.db, ctx.contractor, ctx.storage, ctx.downloaded_media)
+
+
+default_registry.register(ToolFactory(create=_factory, requires_storage=True))

--- a/backend/app/agent/tools/memory_tools.py
+++ b/backend/app/agent/tools/memory_tools.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.memory import delete_memory, recall_memories, save_memory
 from backend.app.agent.tools.base import Tool, ToolResult, ToolTags
+from backend.app.agent.tools.registry import ToolContext, ToolFactory, default_registry
 
 
 class SaveFactParams(BaseModel):
@@ -81,3 +82,10 @@ def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
             params_model=ForgetFactParams,
         ),
     ]
+
+
+def _factory(ctx: ToolContext) -> list[Tool]:
+    return create_memory_tools(ctx.db, ctx.contractor.id)
+
+
+default_registry.register(ToolFactory(create=_factory))

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 
 from backend.app.agent.tools.base import Tool, ToolResult, ToolTags
+from backend.app.agent.tools.registry import ToolContext, ToolFactory, default_registry
 from backend.app.services.messaging import MessagingService
 
 
@@ -52,3 +53,11 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
             tags={ToolTags.SENDS_REPLY},
         ),
     ]
+
+
+def _factory(ctx: ToolContext) -> list[Tool]:
+    assert ctx.messaging_service is not None
+    return create_messaging_tools(ctx.messaging_service, to_address=ctx.to_address)
+
+
+default_registry.register(ToolFactory(create=_factory, requires_messaging=True))

--- a/backend/app/agent/tools/profile_tools.py
+++ b/backend/app/agent/tools/profile_tools.py
@@ -12,6 +12,7 @@ import re
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.agent.tools.registry import ToolContext, ToolFactory, default_registry
 from backend.app.models import Contractor
 
 logger = logging.getLogger(__name__)
@@ -201,3 +202,10 @@ def extract_profile_updates_from_tool_calls(
             updates["preferences_json"] = json.dumps({"communication_style": str(style)})
 
     return updates
+
+
+def _factory(ctx: ToolContext) -> list[Tool]:
+    return create_profile_tools(ctx.db, ctx.contractor)
+
+
+default_registry.register(ToolFactory(create=_factory))

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -1,0 +1,93 @@
+"""Tool registry for declarative tool registration.
+
+Provides a ToolRegistry that tool modules register with, decoupling the
+router from knowledge of individual tool modules and their dependencies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from backend.app.agent.tools.base import Tool
+from backend.app.models import Contractor
+from backend.app.services.messaging import MessagingService
+from backend.app.services.storage_service import StorageBackend
+
+
+@dataclass
+class ToolContext:
+    """Shared dependencies passed to tool factories."""
+
+    db: Session
+    contractor: Contractor
+    storage: StorageBackend | None = None
+    messaging_service: MessagingService | None = None
+    to_address: str = ""
+    downloaded_media: dict[str, bytes] = field(default_factory=dict)
+
+
+@dataclass
+class ToolFactory:
+    """Declarative tool factory with dependency requirements."""
+
+    create: Callable[[ToolContext], list[Tool]]
+    requires_storage: bool = False
+    requires_messaging: bool = False
+
+
+class ToolRegistry:
+    """Registry of tool factories.
+
+    Tool modules register their factories at import time. The router
+    creates a ToolContext and calls create_tools() to get all tools,
+    without needing to know about individual tool modules.
+    """
+
+    def __init__(self) -> None:
+        self._factories: list[ToolFactory] = []
+
+    def register(self, factory: ToolFactory) -> None:
+        """Register a tool factory."""
+        self._factories.append(factory)
+
+    def create_tools(self, context: ToolContext) -> list[Tool]:
+        """Create all tools whose requirements are satisfied by the context."""
+        tools: list[Tool] = []
+        for factory in self._factories:
+            if factory.requires_storage and not context.storage:
+                continue
+            if factory.requires_messaging and not context.messaging_service:
+                continue
+            tools.extend(factory.create(context))
+        return tools
+
+
+default_registry = ToolRegistry()
+
+_tool_modules_imported = False
+
+
+def ensure_tool_modules_imported() -> None:
+    """Import all tool modules so they register with the default registry.
+
+    Safe to call multiple times; only imports on the first call.
+    """
+    global _tool_modules_imported
+    if _tool_modules_imported:
+        return
+    _tool_modules_imported = True
+
+    import importlib
+
+    for module_name in (
+        "backend.app.agent.tools.memory_tools",
+        "backend.app.agent.tools.messaging_tools",
+        "backend.app.agent.tools.estimate_tools",
+        "backend.app.agent.tools.checklist_tools",
+        "backend.app.agent.tools.profile_tools",
+        "backend.app.agent.tools.file_tools",
+    ):
+        importlib.import_module(module_name)


### PR DESCRIPTION
## Summary
- Introduces `ToolRegistry`, `ToolContext`, and `ToolFactory` in `backend/app/agent/tools/registry.py` for declarative tool registration
- Each tool module (`memory_tools`, `messaging_tools`, `estimate_tools`, `checklist_tools`, `profile_tools`, `file_tools`) registers its factory with `default_registry` at import time
- Router now builds a `ToolContext` and calls `default_registry.create_tools(context)` instead of manually importing and assembling every tool module
- Conditional tool inclusion (e.g., file tools only when storage exists, messaging tools only when messaging service exists) is handled by `requires_storage` / `requires_messaging` flags on `ToolFactory`
- Adding a new tool type requires zero changes to `router.py`

Closes #294

## Test plan
- [x] All 510 existing tests pass (no test changes needed)
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] ty type check passes (pre-existing diagnostics only)
- [ ] Verify tool registration works correctly by checking all tools are available in agent loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)