### PR TITLE
fix: remove user kwarg from acompletion calls

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -445,7 +445,7 @@ class BackshopAgent:
 
         tool_schemas = [tool_to_openai_schema(t) for t in self.tools] if self.tools else None
 
-        llm_kwargs: dict[str, Any] = {"user": str(self.contractor.id)}
+        llm_kwargs: dict[str, Any] = {}
         if temperature is not None:
             llm_kwargs["temperature"] = temperature
 

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -461,8 +461,6 @@ async def evaluate_heartbeat_need(
     model = settings.heartbeat_model or settings.llm_model
     provider = settings.heartbeat_provider or settings.llm_provider
 
-    llm_kwargs: dict[str, Any] = {"user": str(contractor.id)}
-
     response = cast(
         ChatCompletion,
         await acompletion(
@@ -478,7 +476,6 @@ async def evaluate_heartbeat_need(
             ],
             tools=[COMPOSE_MESSAGE_TOOL],
             max_tokens=settings.llm_max_tokens_heartbeat,
-            **llm_kwargs,
         ),
     )
 

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -110,9 +110,7 @@ async def handle_inbound_message(
         media_notes.append(MEDIA_DOWNLOAD_ERROR)
 
     try:
-        pipeline_result = await process_message_media(
-            message.body, downloaded_media, user=str(contractor.id)
-        )
+        pipeline_result = await process_message_media(message.body, downloaded_media)
     except Exception:
         logger.exception(
             "Media pipeline failed for message %d, contractor %d",

--- a/backend/app/media/pipeline.py
+++ b/backend/app/media/pipeline.py
@@ -39,7 +39,7 @@ class PipelineResult:
 
 
 async def _process_single_media(
-    media: DownloadedMedia, index: int, context: str = "", user: str | None = None
+    media: DownloadedMedia, index: int, context: str = ""
 ) -> ProcessedMedia:
     """Process a single media item based on its type."""
     category = classify_media(media.mime_type)
@@ -48,9 +48,7 @@ async def _process_single_media(
 
     if category == "image":
         try:
-            extracted_text = await analyze_image(
-                media.content, media.mime_type, context=context, user=user
-            )
+            extracted_text = await analyze_image(media.content, media.mime_type, context=context)
         except Exception:
             logger.exception(
                 "Vision analysis failed for %s (mime_type=%s)", media.original_url, media.mime_type
@@ -87,13 +85,10 @@ async def _process_single_media(
 async def process_message_media(
     text_body: str,
     media_items: list[DownloadedMedia],
-    user: str | None = None,
 ) -> PipelineResult:
     """Process all media in a message and combine into unified context."""
     logger.info("Processing %d media item(s)", len(media_items))
-    tasks = [
-        _process_single_media(m, i, context=text_body, user=user) for i, m in enumerate(media_items)
-    ]
+    tasks = [_process_single_media(m, i, context=text_body) for i, m in enumerate(media_items)]
     media_results = await asyncio.gather(*tasks)
     media_results = list(media_results)
     logger.info(

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -17,9 +17,7 @@ VISION_SYSTEM_PROMPT = (
 )
 
 
-async def analyze_image(
-    image_bytes: bytes, mime_type: str, context: str = "", user: str | None = None
-) -> str:
+async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -> str:
     """Send an image to a vision LLM and get a text description."""
     logger.info(
         "Sending image to vision LLM: mime_type=%s, size=%d bytes", mime_type, len(image_bytes)
@@ -36,10 +34,6 @@ async def analyze_image(
     model = settings.vision_model or settings.llm_model
     logger.info("Using vision model: %s (provider=%s)", model, settings.llm_provider)
 
-    llm_kwargs: dict[str, Any] = {}
-    if user is not None:
-        llm_kwargs["user"] = user
-
     response = cast(
         ChatCompletion,
         await acompletion(
@@ -51,7 +45,6 @@ async def analyze_image(
                 {"role": "user", "content": user_content},
             ],
             max_tokens=settings.llm_max_tokens_vision,
-            **llm_kwargs,
         ),
     )
     logger.debug("Vision LLM response received for mime_type=%s", mime_type)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -93,23 +93,6 @@ async def test_agent_does_not_pass_api_key(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.acompletion")
-async def test_agent_always_passes_user_parameter(
-    mock_acompletion: object,
-    db_session: Session,
-    test_contractor: Contractor,
-) -> None:
-    """acompletion should always be called with user=contractor.id regardless of provider."""
-    mock_acompletion.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
-
-    agent = BackshopAgent(db=db_session, contractor=test_contractor)
-    await agent.process_message("Hello")
-
-    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
-    assert call_args.kwargs["user"] == str(test_contractor.id)
-
-
-@pytest.mark.asyncio()
-@patch("backend.app.agent.core.acompletion")
 async def test_agent_tool_loop_sends_results_back(
     mock_acompletion: object, db_session: Session, test_contractor: Contractor
 ) -> None:

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -107,9 +107,6 @@ async def test_message_with_photo(
     assert response.reply_text == "Looks like a great deck project!"
     mock_messaging.download_media.assert_called_once()  # type: ignore[union-attr]
     mock_vision.assert_called_once()
-    # Verify user (contractor ID) is passed for OpenAI tracking
-    call_kwargs = mock_vision.call_args
-    assert call_kwargs.kwargs.get("user") == str(test_contractor.id)
 
 
 @pytest.mark.asyncio()

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -73,34 +73,6 @@ async def test_analyze_image_does_not_pass_api_key(mock_acompletion: object) -> 
 
 @pytest.mark.asyncio()
 @patch("backend.app.media.vision.acompletion")
-async def test_analyze_image_always_passes_user_when_provided(
-    mock_acompletion: object,
-) -> None:
-    """When user is provided, it should always be passed to acompletion regardless of provider."""
-    mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]
-
-    await analyze_image(b"fake-jpeg-bytes", "image/jpeg", user="42")
-
-    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
-    assert call_args.kwargs["user"] == "42"
-
-
-@pytest.mark.asyncio()
-@patch("backend.app.media.vision.acompletion")
-async def test_analyze_image_omits_user_when_not_provided(
-    mock_acompletion: object,
-) -> None:
-    """When user is not provided, user should NOT be passed to acompletion."""
-    mock_acompletion.return_value = make_vision_response("Test.")  # type: ignore[union-attr]
-
-    await analyze_image(b"fake-jpeg-bytes", "image/jpeg")
-
-    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
-    assert "user" not in call_args.kwargs
-
-
-@pytest.mark.asyncio()
-@patch("backend.app.media.vision.acompletion")
 @patch("backend.app.media.vision.settings")
 async def test_analyze_image_falls_back_to_llm_model(
     mock_settings: object, mock_acompletion: object

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
     { name = "httpx" },
+    { name = "json-repair" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -188,6 +189,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "json-repair", specifier = ">=0.30" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -960,6 +962,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "json-repair"
+version = "0.58.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/50/6addf33a1827ee9ad9ce156cc1d48d5a69b975a9d49bd857a52cc9c121c2/json_repair-0.58.2.tar.gz", hash = "sha256:b88a4426436543d3d0952f4aad53de0402726ee928af88ce1f7106eab50484df", size = 59171, upload-time = "2026-03-02T14:55:14.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d2/7be3ff7f3cd167028fa03bb29e8bbb9fda67f90b6afb4dd65976e000aa57/json_repair-0.58.2-py3-none-any.whl", hash = "sha256:720a1df3f5e33865e72b6b37667d34fbc55f548158973d36a5e5fc614bea1a10", size = 40843, upload-time = "2026-03-02T14:55:12.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Removes the `user` kwarg from all `acompletion()` calls (agent, heartbeat, vision)
- Removes `build_llm_kwargs()` helper and `_PROVIDERS_SUPPORTING_USER` from config.py
- Removes `user` parameter from `analyze_image()` and `process_message_media()` signatures
- Drops 5 tests that only tested user-kwarg passing behavior

The `user` parameter was being passed for OpenAI usage tracking, but Anthropic's SDK rejects it with `TypeError: AsyncMessages.create() got an unexpected keyword argument 'user'`, breaking CI on main when `llm_provider=anthropic`.

## Test plan
- [x] All 517 tests pass
- [x] Lint clean
- [x] Format clean
- [x] No remaining references to `build_llm_kwargs` or `user` kwarg in LLM calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)