### PR TITLE
refactor: add tool registry to decouple router from tool knowledge

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -10,14 +10,12 @@ from backend.app.agent.onboarding import (
     is_onboarding_needed,
 )
 from backend.app.agent.tools.base import ToolTags
-from backend.app.agent.tools.checklist_tools import create_checklist_tools
-from backend.app.agent.tools.estimate_tools import create_estimate_tools
-from backend.app.agent.tools.file_tools import auto_save_media, create_file_tools
-from backend.app.agent.tools.memory_tools import create_memory_tools
-from backend.app.agent.tools.messaging_tools import create_messaging_tools
-from backend.app.agent.tools.profile_tools import (
-    create_profile_tools,
-    extract_profile_updates_from_tool_calls,
+from backend.app.agent.tools.file_tools import auto_save_media
+from backend.app.agent.tools.profile_tools import extract_profile_updates_from_tool_calls
+from backend.app.agent.tools.registry import (
+    ToolContext,
+    default_registry,
+    ensure_tool_modules_imported,
 )
 from backend.app.config import settings
 from backend.app.enums import MessageDirection
@@ -46,6 +44,9 @@ VISION_UNAVAILABLE_NOTE = (
     "and ask them to describe what the attachment shows."
 )
 
+# Ensure all tool modules have self-registered with the default registry.
+ensure_tool_modules_imported()
+
 
 async def handle_inbound_message(
     db: Session,
@@ -67,7 +68,7 @@ async def handle_inbound_message(
     to_address = contractor.channel_identifier or contractor.phone
     if not to_address:
         logger.error(
-            "Contractor %d has no channel_identifier or phone — cannot send replies",
+            "Contractor %d has no channel_identifier or phone -- cannot send replies",
             contractor.id,
         )
         return AgentResponse(reply_text="")
@@ -133,22 +134,21 @@ async def handle_inbound_message(
     # Step 4: Load conversation history
     conversation_history = await load_conversation_history(db, message.conversation_id)
 
-    # Step 5: Initialize agent with tools
+    # Step 5: Initialize agent with tools via registry
     was_onboarding = is_onboarding_needed(contractor)
     system_prompt_override = build_onboarding_system_prompt(contractor) if was_onboarding else None
 
     agent = BackshopAgent(db=db, contractor=contractor)
-    tools = create_memory_tools(db, contractor.id)
-    tools.extend(create_messaging_tools(messaging_service, to_address=to_address))
-    tools.extend(create_estimate_tools(db, contractor, storage))
-    tools.extend(create_checklist_tools(db, contractor.id))
-    tools.extend(create_profile_tools(db, contractor))
 
-    # Wire file tools if storage is available
-    if storage:
-        pending_media = {m.original_url: m.content for m in downloaded_media if m.content}
-        tools.extend(create_file_tools(db, contractor, storage, pending_media))
-
+    tool_context = ToolContext(
+        db=db,
+        contractor=contractor,
+        storage=storage,
+        messaging_service=messaging_service,
+        to_address=to_address,
+        downloaded_media=downloaded_media,
+    )
+    tools = default_registry.create_tools(tool_context)
     agent.register_tools(tools)
 
     # Send typing indicator while processing (non-blocking on failure)

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -1,6 +1,8 @@
 """Heartbeat checklist management tools for the agent."""
 
-from typing import Literal
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -8,6 +10,9 @@ from sqlalchemy.orm import Session
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.enums import ChecklistSchedule, ChecklistStatus
 from backend.app.models import HeartbeatChecklistItem
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
 
 
 class AddChecklistItemParams(BaseModel):
@@ -114,3 +119,17 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
             params_model=RemoveChecklistItemParams,
         ),
     ]
+
+
+def _checklist_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for checklist tools, used by the registry."""
+    return create_checklist_tools(ctx.db, ctx.contractor.id)
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import default_registry
+
+    default_registry.register("checklist", _checklist_factory)
+
+
+_register()

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -1,9 +1,11 @@
 """Estimate generation tools for the agent."""
 
+from __future__ import annotations
+
 import datetime
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -15,6 +17,9 @@ from backend.app.enums import EstimateStatus
 from backend.app.models import Contractor, Estimate, EstimateLineItem
 from backend.app.services.pdf_service import EstimatePDFData, generate_estimate_pdf
 from backend.app.services.storage_service import StorageBackend
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
 
 PDF_BASE_DIR = Path(settings.pdf_storage_dir)
 ESTIMATE_NUMBER_FORMAT = "EST-{:04d}"
@@ -179,3 +184,17 @@ def create_estimate_tools(
             params_model=GenerateEstimateParams,
         ),
     ]
+
+
+def _estimate_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for estimate tools, used by the registry."""
+    return create_estimate_tools(ctx.db, ctx.contractor, ctx.storage)
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import default_registry
+
+    default_registry.register("estimate", _estimate_factory)
+
+
+_register()

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -1,9 +1,11 @@
 """File cataloging tools for the agent."""
 
+from __future__ import annotations
+
 import datetime
 import logging
 import re
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -12,6 +14,9 @@ from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.media.download import MIME_EXTENSIONS, DownloadedMedia
 from backend.app.models import Contractor, MediaFile
 from backend.app.services.storage_service import StorageBackend
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
 
 logger = logging.getLogger(__name__)
 
@@ -403,3 +408,19 @@ def create_file_tools(
             params_model=OrganizeFileParams,
         ),
     ]
+
+
+def _file_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for file tools, used by the registry."""
+    assert ctx.storage is not None
+    pending_media = {m.original_url: m.content for m in ctx.downloaded_media if m.content}
+    return create_file_tools(ctx.db, ctx.contractor, ctx.storage, pending_media)
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import default_registry
+
+    default_registry.register("file", _file_factory, requires_storage=True)
+
+
+_register()

--- a/backend/app/agent/tools/memory_tools.py
+++ b/backend/app/agent/tools/memory_tools.py
@@ -1,10 +1,15 @@
-from typing import Literal
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.memory import delete_memory, recall_memories, save_memory
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTags
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
 
 
 class SaveFactParams(BaseModel):
@@ -83,3 +88,17 @@ def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
             params_model=ForgetFactParams,
         ),
     ]
+
+
+def _memory_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for memory tools, used by the registry."""
+    return create_memory_tools(ctx.db, ctx.contractor.id)
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import default_registry
+
+    default_registry.register("memory", _memory_factory)
+
+
+_register()

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel, Field
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTags
 from backend.app.services.messaging import MessagingService
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
 
 
 class SendReplyParams(BaseModel):
@@ -60,3 +67,18 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
             tags={ToolTags.SENDS_REPLY},
         ),
     ]
+
+
+def _messaging_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for messaging tools, used by the registry."""
+    assert ctx.messaging_service is not None
+    return create_messaging_tools(ctx.messaging_service, to_address=ctx.to_address)
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import default_registry
+
+    default_registry.register("messaging", _messaging_factory, requires_messaging=True)
+
+
+_register()

--- a/backend/app/agent/tools/profile_tools.py
+++ b/backend/app/agent/tools/profile_tools.py
@@ -5,14 +5,20 @@ replacing the fragile fuzzy-matching approach that tried to infer
 profile fields from save_fact keys.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import re
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.models import Contractor
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
 
 logger = logging.getLogger(__name__)
 
@@ -154,16 +160,30 @@ def create_profile_tools(db: Session, contractor: Contractor) -> list[Tool]:
                     },
                     "communication_style": {
                         "type": "string",
-                        "description": "Preferred communication style (e.g. 'casual', 'formal')",
+                        "description": ("Preferred communication style (e.g. 'casual', 'formal')"),
                     },
                     "soul_text": {
                         "type": "string",
-                        "description": "Bio or personality description for the assistant",
+                        "description": ("Bio or personality description for the assistant"),
                     },
                 },
             },
         ),
     ]
+
+
+def _profile_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for profile tools, used by the registry."""
+    return create_profile_tools(ctx.db, ctx.contractor)
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import default_registry
+
+    default_registry.register("profile", _profile_factory)
+
+
+_register()
 
 
 def extract_profile_updates_from_tool_calls(

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -1,0 +1,110 @@
+"""Tool registry for decoupled tool registration.
+
+Tool modules self-register with the default registry at import time.
+The router calls ``create_tools(context)`` instead of manually importing
+and assembling tools from every module.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from backend.app.agent.tools.base import Tool
+from backend.app.media.download import DownloadedMedia
+from backend.app.models import Contractor
+from backend.app.services.messaging import MessagingService
+from backend.app.services.storage_service import StorageBackend
+
+logger = logging.getLogger(__name__)
+
+# All tool modules that should be imported to trigger self-registration.
+_TOOL_MODULES: list[str] = [
+    "backend.app.agent.tools.memory_tools",
+    "backend.app.agent.tools.messaging_tools",
+    "backend.app.agent.tools.estimate_tools",
+    "backend.app.agent.tools.checklist_tools",
+    "backend.app.agent.tools.profile_tools",
+    "backend.app.agent.tools.file_tools",
+]
+
+
+@dataclass
+class ToolContext:
+    """Shared context passed to tool factories during creation."""
+
+    db: Session
+    contractor: Contractor
+    storage: StorageBackend | None = None
+    messaging_service: MessagingService | None = None
+    to_address: str = ""
+    downloaded_media: list[DownloadedMedia] = field(default_factory=list)
+
+
+@dataclass
+class ToolFactory:
+    """Metadata for a registered tool factory."""
+
+    create: Callable[[ToolContext], list[Tool]]
+    requires_storage: bool = False
+    requires_messaging: bool = False
+
+
+class ToolRegistry:
+    """Registry that collects tool factories and creates tools from context."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, ToolFactory] = {}
+
+    def register(
+        self,
+        name: str,
+        create: Callable[[ToolContext], list[Tool]],
+        *,
+        requires_storage: bool = False,
+        requires_messaging: bool = False,
+    ) -> None:
+        """Register a tool factory by name."""
+        if name in self._factories:
+            logger.warning("Overwriting existing tool factory: %s", name)
+        self._factories[name] = ToolFactory(
+            create=create,
+            requires_storage=requires_storage,
+            requires_messaging=requires_messaging,
+        )
+
+    def create_tools(self, context: ToolContext) -> list[Tool]:
+        """Create all tools whose dependencies are satisfied by the context."""
+        tools: list[Tool] = []
+        for name, factory in self._factories.items():
+            if factory.requires_storage and context.storage is None:
+                logger.debug("Skipping %s: no storage backend", name)
+                continue
+            if factory.requires_messaging and context.messaging_service is None:
+                logger.debug("Skipping %s: no messaging service", name)
+                continue
+            tools.extend(factory.create(context))
+        return tools
+
+    @property
+    def factory_names(self) -> list[str]:
+        """Return sorted list of registered factory names."""
+        return sorted(self._factories)
+
+
+# Module-level singleton used by tool modules for self-registration.
+default_registry = ToolRegistry()
+
+
+def ensure_tool_modules_imported() -> None:
+    """Import all tool modules so they self-register with ``default_registry``.
+
+    This is idempotent: Python's import system caches modules, so repeated
+    calls are essentially free.
+    """
+    for module_path in _TOOL_MODULES:
+        importlib.import_module(module_path)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -18,6 +18,7 @@ from backend.app.agent.core import (
 )
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.models import Contractor
+from backend.app.services.messaging import MessagingService
 from tests.mocks.llm import make_text_response, make_tool_call_response
 
 
@@ -1301,3 +1302,150 @@ async def test_unhandled_exception_uses_internal_hint(
     content = tool_msg["content"]
 
     assert "[An internal error occurred" in content
+
+
+# ---- Tool Registry Tests ----
+
+
+class TestToolRegistry:
+    """Tests for the ToolRegistry and related helpers."""
+
+    def test_register_and_create_tools(
+        self, db_session: Session, test_contractor: Contractor
+    ) -> None:
+        """Registry should create tools from registered factories."""
+        from backend.app.agent.tools.registry import ToolContext, ToolRegistry
+
+        registry = ToolRegistry()
+
+        def dummy_factory(ctx: ToolContext) -> list[Tool]:
+            async def noop() -> ToolResult:
+                return ToolResult(content="ok")
+
+            return [Tool(name="dummy", description="test tool", function=noop)]
+
+        registry.register("dummy", dummy_factory)
+        ctx = ToolContext(db=db_session, contractor=test_contractor)
+        tools = registry.create_tools(ctx)
+        assert len(tools) == 1
+        assert tools[0].name == "dummy"
+
+    def test_skips_factory_when_storage_missing(
+        self, db_session: Session, test_contractor: Contractor
+    ) -> None:
+        """Factories requiring storage should be skipped when storage is None."""
+        from backend.app.agent.tools.registry import ToolContext, ToolRegistry
+
+        registry = ToolRegistry()
+
+        def storage_factory(ctx: ToolContext) -> list[Tool]:
+            return [Tool(name="needs_storage", description="test", function=lambda: None)]
+
+        registry.register("storage_tool", storage_factory, requires_storage=True)
+        ctx = ToolContext(db=db_session, contractor=test_contractor, storage=None)
+        tools = registry.create_tools(ctx)
+        assert len(tools) == 0
+
+    def test_skips_factory_when_messaging_missing(
+        self, db_session: Session, test_contractor: Contractor
+    ) -> None:
+        """Factories requiring messaging should be skipped when messaging is None."""
+        from backend.app.agent.tools.registry import ToolContext, ToolRegistry
+
+        registry = ToolRegistry()
+
+        def msg_factory(ctx: ToolContext) -> list[Tool]:
+            return [Tool(name="needs_messaging", description="test", function=lambda: None)]
+
+        registry.register("msg_tool", msg_factory, requires_messaging=True)
+        ctx = ToolContext(db=db_session, contractor=test_contractor, messaging_service=None)
+        tools = registry.create_tools(ctx)
+        assert len(tools) == 0
+
+    def test_includes_factory_when_deps_satisfied(
+        self,
+        db_session: Session,
+        test_contractor: Contractor,
+        mock_messaging_service: MessagingService,
+    ) -> None:
+        """Factories should produce tools when required dependencies are present."""
+        from unittest.mock import MagicMock
+
+        from backend.app.agent.tools.registry import ToolContext, ToolRegistry
+
+        registry = ToolRegistry()
+
+        def storage_factory(ctx: ToolContext) -> list[Tool]:
+            return [Tool(name="with_storage", description="test", function=lambda: None)]
+
+        def msg_factory(ctx: ToolContext) -> list[Tool]:
+            return [Tool(name="with_msg", description="test", function=lambda: None)]
+
+        registry.register("s", storage_factory, requires_storage=True)
+        registry.register("m", msg_factory, requires_messaging=True)
+
+        mock_storage = MagicMock()
+        ctx = ToolContext(
+            db=db_session,
+            contractor=test_contractor,
+            storage=mock_storage,
+            messaging_service=mock_messaging_service,
+        )
+        tools = registry.create_tools(ctx)
+        names = {t.name for t in tools}
+        assert "with_storage" in names
+        assert "with_msg" in names
+
+    def test_factory_names_sorted(self) -> None:
+        """factory_names property should return sorted list of registered names."""
+        from backend.app.agent.tools.registry import ToolRegistry
+
+        registry = ToolRegistry()
+        registry.register("zebra", lambda ctx: [])
+        registry.register("alpha", lambda ctx: [])
+        registry.register("middle", lambda ctx: [])
+        assert registry.factory_names == ["alpha", "middle", "zebra"]
+
+    def test_default_registry_has_all_modules(self) -> None:
+        """The default_registry should have all tool modules registered."""
+        from backend.app.agent.tools.registry import default_registry, ensure_tool_modules_imported
+
+        ensure_tool_modules_imported()
+        names = default_registry.factory_names
+        assert "memory" in names
+        assert "messaging" in names
+        assert "estimate" in names
+        assert "checklist" in names
+        assert "profile" in names
+        assert "file" in names
+
+    def test_ensure_tool_modules_imported_idempotent(self) -> None:
+        """Calling ensure_tool_modules_imported() multiple times should be safe."""
+        from backend.app.agent.tools.registry import default_registry, ensure_tool_modules_imported
+
+        ensure_tool_modules_imported()
+        count1 = len(default_registry.factory_names)
+        ensure_tool_modules_imported()
+        count2 = len(default_registry.factory_names)
+        assert count1 == count2
+
+    def test_overwrite_warns(self, db_session: Session, test_contractor: Contractor) -> None:
+        """Registering the same name twice should overwrite (with a warning)."""
+        from backend.app.agent.tools.registry import ToolContext, ToolRegistry
+
+        registry = ToolRegistry()
+
+        def factory_a(ctx: ToolContext) -> list[Tool]:
+            return [Tool(name="a", description="first", function=lambda: None)]
+
+        def factory_b(ctx: ToolContext) -> list[Tool]:
+            return [Tool(name="b", description="second", function=lambda: None)]
+
+        registry.register("same_name", factory_a)
+        registry.register("same_name", factory_b)
+
+        ctx = ToolContext(db=db_session, contractor=test_contractor)
+        tools = registry.create_tools(ctx)
+        # The second factory should win
+        assert len(tools) == 1
+        assert tools[0].name == "b"


### PR DESCRIPTION
## Summary
- Introduces a `ToolRegistry` with factory pattern in `backend/app/agent/tools/registry.py` so tool modules self-register at import time and the router only needs `registry.create_tools(context)`
- Each tool module (memory, messaging, estimate, checklist, profile, file) now calls `default_registry.register()` at import time with a factory function and dependency flags
- Router no longer imports individual `create_*_tools` functions; instead uses `ensure_tool_modules_imported()` + `default_registry.create_tools(ToolContext(...))` to build all tools
- Registry automatically skips factories whose dependencies are not satisfied (e.g. file tools when no storage backend is configured)

## Test plan
- [x] 8 new tests for registry functionality (register, create, dependency skipping, idempotent import, overwrite, default registry completeness)
- [x] All 525 existing tests pass (no regressions)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `ty check` shows no new diagnostics (same 7 pre-existing issues as main)

Fixes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)