### PR TITLE
refactor: generate system prompt tool instructions from registered tools

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -166,11 +166,10 @@ SYSTEM_PROMPT_TEMPLATE = """You are Backshop, an AI assistant for solo contracto
 
 ## Instructions
 - Be concise and practical. Contractors are busy.
-- When you learn new information (rates, clients, preferences), save it using the save_fact tool.
-- When asked for an estimate, gather the details, generate the PDF, and send it back using send_media_reply.
 - You can ONLY communicate via this chat. You cannot send emails, make phone calls, or contact clients directly.
 - Always be helpful, friendly, and professional.
 - Keep replies concise. Contractors are on the job site.
+{tool_instructions}
 
 ## Proactive Messaging
 You will proactively reach out during business hours when something needs attention:
@@ -181,7 +180,7 @@ You will proactively reach out during business hours when something needs attent
 
 ## Recall Behavior
 When the contractor asks a question about their business, clients, or past work:
-1. Use recall_facts to search your memory for relevant information.
+1. Search your memory for relevant information.
 2. If you find relevant facts, use them to answer clearly and concisely.
 3. If you don't find anything, say so honestly -- don't make things up.
 4. If the question is about general knowledge (not their specific business), answer from your training.
@@ -216,18 +215,28 @@ class BackshopAgent:
                 logger.warning("Duplicate tool name registered: %s", tool.name)
             self._tools_by_name[tool.name] = tool
 
+    def _build_tool_instructions(self) -> str:
+        """Generate tool usage instructions from registered tools."""
+        hints = [tool.usage_hint for tool in self.tools if tool.usage_hint]
+        if not hints:
+            return ""
+        lines = "\n".join(f"- {hint}" for hint in hints)
+        return f"\n## Tool Guidelines\n{lines}"
+
     async def _build_system_prompt(self, message_context: str) -> str:
-        """Build the full system prompt with soul + memory."""
+        """Build the full system prompt with soul + memory + tool instructions."""
         soul_prompt = build_soul_prompt(self.contractor)
         memory_context = await build_memory_context(
             self.db,
             self.contractor.id,
             query=message_context[:CONTEXT_QUERY_MAX_LENGTH] if message_context else None,
         )
+        tool_instructions = self._build_tool_instructions()
         prompt = SYSTEM_PROMPT_TEMPLATE.format(
             contractor_name=self.contractor.name or "Contractor",
             soul_prompt=soul_prompt,
             memory_context=memory_context or "(No memories saved yet)",
+            tool_instructions=tool_instructions,
         )
 
         missing = get_missing_optional_fields(self.contractor)

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -43,6 +43,7 @@ class Tool:
     parameters: dict[str, Any] = field(default_factory=dict)
     params_model: type[BaseModel] | None = None
     tags: set[str] = field(default_factory=set)
+    usage_hint: str = ""
 
 
 def _inline_refs(schema: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -105,18 +105,21 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
             ),
             function=add_checklist_item,
             params_model=AddChecklistItemParams,
+            usage_hint="When the contractor wants a recurring reminder, add it to the checklist.",
         ),
         Tool(
             name="list_checklist_items",
             description="List all active items on the contractor's heartbeat checklist.",
             function=list_checklist_items,
             params_model=ListChecklistItemsParams,
+            usage_hint="When asked about active reminders or checklist items, list them.",
         ),
         Tool(
             name="remove_checklist_item",
             description="Remove an item from the contractor's heartbeat checklist by its ID.",
             function=remove_checklist_item,
             params_model=RemoveChecklistItemParams,
+            usage_hint="When the contractor wants to stop a reminder, remove it by ID.",
         ),
     ]
 

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -182,6 +182,7 @@ def create_estimate_tools(
             ),
             function=generate_estimate,
             params_model=GenerateEstimateParams,
+            usage_hint=("When asked for an estimate, gather the details and generate the PDF."),
         ),
     ]
 

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -394,6 +394,7 @@ def create_file_tools(
             ),
             function=upload_to_storage,
             params_model=UploadToStorageParams,
+            usage_hint="Upload and organize files into the contractor's cloud storage.",
         ),
         Tool(
             name="organize_file",
@@ -406,6 +407,7 @@ def create_file_tools(
             ),
             function=organize_file,
             params_model=OrganizeFileParams,
+            usage_hint="Move an unsorted file into the correct client folder.",
         ),
     ]
 

--- a/backend/app/agent/tools/memory_tools.py
+++ b/backend/app/agent/tools/memory_tools.py
@@ -74,18 +74,24 @@ def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
             function=save_fact,
             params_model=SaveFactParams,
             tags={ToolTags.SAVES_MEMORY},
+            usage_hint=("When you learn new information (rates, clients, preferences), save it."),
         ),
         Tool(
             name="recall_facts",
             description="Search the contractor's memory for facts matching a query.",
             function=recall_facts,
             params_model=RecallFactsParams,
+            usage_hint=(
+                "When asked about the contractor's business, clients, or past work,"
+                " search your memory first."
+            ),
         ),
         Tool(
             name="forget_fact",
             description="Delete a fact from memory by key.",
             function=forget_fact,
             params_model=ForgetFactParams,
+            usage_hint="When asked to forget or delete a specific fact, remove it.",
         ),
     ]
 

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -58,6 +58,7 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
             function=send_reply,
             params_model=SendReplyParams,
             tags={ToolTags.SENDS_REPLY},
+            usage_hint="Use this to send a text message to the contractor.",
         ),
         Tool(
             name="send_media_reply",
@@ -65,6 +66,9 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
             function=send_media_reply,
             params_model=SendMediaReplyParams,
             tags={ToolTags.SENDS_REPLY},
+            usage_hint=(
+                "When sending estimates or files, use this to send media to the contractor."
+            ),
         ),
     ]
 

--- a/backend/app/agent/tools/profile_tools.py
+++ b/backend/app/agent/tools/profile_tools.py
@@ -135,6 +135,7 @@ def create_profile_tools(db: Session, contractor: Contractor) -> list[Tool]:
                 "Only include fields you want to change."
             ),
             function=update_profile,
+            usage_hint=("Use this to update known contractor details (name, trade, rates, etc.)."),
             parameters={
                 "type": "object",
                 "properties": {

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -79,6 +79,99 @@ async def test_agent_system_prompt_includes_soul(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.acompletion")
+async def test_system_prompt_includes_tool_hints(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """System prompt should include usage hints from registered tools."""
+    mock_acompletion.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
+
+    async def dummy(**kwargs: object) -> str:
+        return "ok"
+
+    tools = [
+        Tool(
+            name="save_fact",
+            description="Save a fact",
+            function=dummy,
+            parameters={},
+            usage_hint="When you learn new info, save it.",
+        ),
+        Tool(
+            name="recall_facts",
+            description="Recall facts",
+            function=dummy,
+            parameters={},
+            usage_hint="Search memory for relevant information.",
+        ),
+    ]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools(tools)
+    await agent.process_message("Hello")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    system_prompt = call_args.kwargs["messages"][0]["content"]
+    assert "Tool Guidelines" in system_prompt
+    assert "When you learn new info, save it." in system_prompt
+    assert "Search memory for relevant information." in system_prompt
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_system_prompt_omits_tool_section_when_no_hints(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """System prompt should not include tool guidelines when no tools have hints."""
+    mock_acompletion.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    # No tools registered
+    await agent.process_message("Hello")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    system_prompt = call_args.kwargs["messages"][0]["content"]
+    assert "Tool Guidelines" not in system_prompt
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_system_prompt_skips_tools_without_hints(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Tools with empty usage_hint should not appear in the system prompt."""
+    mock_acompletion.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
+
+    async def dummy(**kwargs: object) -> str:
+        return "ok"
+
+    tools = [
+        Tool(
+            name="tool_with_hint",
+            description="Has a hint",
+            function=dummy,
+            parameters={},
+            usage_hint="This tool does something useful.",
+        ),
+        Tool(
+            name="tool_without_hint",
+            description="No hint",
+            function=dummy,
+            parameters={},
+        ),
+    ]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools(tools)
+    await agent.process_message("Hello")
+
+    call_args = mock_acompletion.call_args  # type: ignore[union-attr]
+    system_prompt = call_args.kwargs["messages"][0]["content"]
+    assert "This tool does something useful." in system_prompt
+    assert "tool_without_hint" not in system_prompt
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
 async def test_agent_does_not_pass_api_key(
     mock_acompletion: object, db_session: Session, test_contractor: Contractor
 ) -> None:

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -198,7 +198,7 @@ async def test_system_prompt_includes_recall_guidance(
     call_args = mock_acompletion.call_args  # type: ignore[union-attr]
     system_msg = call_args.kwargs["messages"][0]["content"]
     assert "Recall Behavior" in system_msg
-    assert "recall_facts" in system_msg
+    assert "search your memory" in system_msg.lower()
     assert "don't make things up" in system_msg
 
 


### PR DESCRIPTION
## Summary
- Added `usage_hint` field to `Tool` dataclass in `base.py`
- Each tool module populates `usage_hint` with concise behavioral instructions
- System prompt tool instructions generated dynamically from registered tools via `_build_tool_instructions()`
- No hardcoded tool names remain in the system prompt template
- Updated `test_recall.py` to match the new dynamic prompt structure

Fixes #295

## Test plan
- [x] All 528 tests pass
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] New tests verify tool hints appear in system prompt when registered
- [x] New test verifies Tool Guidelines section is omitted when no tools have hints
- [x] New test verifies tools without `usage_hint` are excluded from the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)