### PR TITLE
ci: add ty type checking job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
       - run: uv run ruff check backend/ tests/ alembic/
       - run: uv run ruff format --check backend/ tests/ alembic/
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync --all-extras
+      - run: uv run ty check --python .venv backend/ tests/
+
   test:
     runs-on: ubuntu-latest
     env:

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -19,7 +19,7 @@ class AddChecklistItemParams(BaseModel):
     """Parameters for the add_checklist_item tool."""
 
     description: str = Field(description="What to check or remind about")
-    schedule: Literal["daily", "weekdays", "once"] = Field(
+    schedule: ChecklistSchedule = Field(
         default=ChecklistSchedule.DAILY,
         description="How often to check (default: daily)",
     )

--- a/backend/app/agent/tools/profile_tools.py
+++ b/backend/app/agent/tools/profile_tools.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from sqlalchemy.orm import Session
 
@@ -204,9 +204,10 @@ def extract_profile_updates_from_tool_calls(
             continue
         if tc.get("is_error"):
             continue
-        args = tc.get("args", {})
-        if not isinstance(args, dict):
+        args_raw = tc.get("args", {})
+        if not isinstance(args_raw, dict):
             continue
+        args = cast(dict[str, object], args_raw)
 
         for field in ("name", "trade", "location", "business_hours", "soul_text"):
             val = args.get(field)

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -101,7 +101,9 @@ async def test_load_history_prefers_processed_context(
     db_session.commit()
 
     history = await load_conversation_history(db_session, conversation.id)
-    assert "damaged deck railing" in history[0].content
+    content = history[0].content
+    assert content is not None
+    assert "damaged deck railing" in content
 
 
 @pytest.mark.asyncio()

--- a/tests/test_tool_param_validation.py
+++ b/tests/test_tool_param_validation.py
@@ -14,7 +14,10 @@ from backend.app.agent.tools.checklist_tools import (
     ListChecklistItemsParams,
     RemoveChecklistItemParams,
 )
-from backend.app.agent.tools.estimate_tools import GenerateEstimateParams
+from backend.app.agent.tools.estimate_tools import (
+    EstimateLineItemParams,
+    GenerateEstimateParams,
+)
 from backend.app.agent.tools.file_tools import OrganizeFileParams, UploadToStorageParams
 from backend.app.agent.tools.memory_tools import (
     ForgetFactParams,
@@ -137,7 +140,7 @@ def test_save_fact_params_default_category() -> None:
 def test_save_fact_params_rejects_invalid_category() -> None:
     """SaveFactParams should reject invalid category values."""
     with pytest.raises(Exception):  # noqa: B017
-        SaveFactParams(key="note", value="test", category="invalid")
+        SaveFactParams(key="note", value="test", category="invalid")  # type: ignore[invalid-argument-type]
 
 
 def test_remove_checklist_item_coerces_string_to_int() -> None:
@@ -156,7 +159,7 @@ def test_generate_estimate_params_accepts_valid_input() -> None:
     """GenerateEstimateParams should accept valid arguments with line items."""
     p = GenerateEstimateParams(
         description="Deck work",
-        line_items=[{"description": "Materials", "unit_price": 100.0, "quantity": 2}],
+        line_items=[EstimateLineItemParams(description="Materials", unit_price=100.0, quantity=2)],
     )
     assert p.description == "Deck work"
     assert len(p.line_items) == 1


### PR DESCRIPTION
## Summary
- Adds a `typecheck` job to the CI workflow that runs `uv run ty check --python .venv backend/ tests/`
- The Definition of Done in CLAUDE.md requires ty to pass, but it was not enforced in CI until now
- Runs in parallel with existing lint and test jobs

## Test plan
- [ ] Verify the new `typecheck` job appears in the CI run
- [ ] Confirm it runs in parallel with other jobs (no `needs:` dependency)
- [ ] Confirm it passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)