### PR TITLE
refactor: composable system prompt builder to replace str.format() templates

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -16,7 +16,6 @@ from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from backend.app.agent.llm_parsing import parse_tool_calls
-from backend.app.agent.memory import build_memory_context
 from backend.app.agent.messages import (
     AgentMessage,
     AssistantMessage,
@@ -26,7 +25,7 @@ from backend.app.agent.messages import (
     UserMessage,
     messages_to_dicts,
 )
-from backend.app.agent.profile import build_soul_prompt, get_missing_optional_fields
+from backend.app.agent.system_prompt import build_agent_system_prompt
 from backend.app.agent.tools.base import (
     Tool,
     ToolErrorKind,
@@ -40,7 +39,6 @@ from backend.app.models import Contractor
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_ROUNDS = 5
-CONTEXT_QUERY_MAX_LENGTH = 100
 RATE_LIMIT_RETRY_DELAY = 2.0
 # Target token budget when trimming for context length (leave room for output tokens)
 CONTEXT_TRIM_TARGET_TOKENS = 80_000
@@ -156,38 +154,6 @@ def _build_error_hint(result: ToolResult) -> str:
     return _DEFAULT_ERROR_HINT
 
 
-SYSTEM_PROMPT_TEMPLATE = """You are Backshop, an AI assistant for solo contractors.
-
-## About {contractor_name}
-{soul_prompt}
-
-## Your Memory
-{memory_context}
-
-## Instructions
-- Be concise and practical. Contractors are busy.
-- You can ONLY communicate via this chat. You cannot send emails, make phone calls, or contact clients directly.
-- Always be helpful, friendly, and professional.
-- Keep replies concise. Contractors are on the job site.
-{tool_instructions}
-
-## Proactive Messaging
-You will proactively reach out during business hours when something needs attention:
-- A draft estimate has been sitting unsent for over 24 hours
-- A scheduled checklist item is due
-- A follow-up reminder or deadline is approaching
-- You haven't heard from the contractor in a few days
-
-## Recall Behavior
-When the contractor asks a question about their business, clients, or past work:
-1. Search your memory for relevant information.
-2. If you find relevant facts, use them to answer clearly and concisely.
-3. If you don't find anything, say so honestly -- don't make things up.
-4. If the question is about general knowledge (not their specific business), answer from your training.
-5. For "what do you know about me?" questions, summarize key facts by category.
-"""
-
-
 @dataclass
 class AgentResponse:
     reply_text: str
@@ -215,40 +181,11 @@ class BackshopAgent:
                 logger.warning("Duplicate tool name registered: %s", tool.name)
             self._tools_by_name[tool.name] = tool
 
-    def _build_tool_instructions(self) -> str:
-        """Generate tool usage instructions from registered tools."""
-        hints = [tool.usage_hint for tool in self.tools if tool.usage_hint]
-        if not hints:
-            return ""
-        lines = "\n".join(f"- {hint}" for hint in hints)
-        return f"\n## Tool Guidelines\n{lines}"
-
     async def _build_system_prompt(self, message_context: str) -> str:
-        """Build the full system prompt with soul + memory + tool instructions."""
-        soul_prompt = build_soul_prompt(self.contractor)
-        memory_context = await build_memory_context(
-            self.db,
-            self.contractor.id,
-            query=message_context[:CONTEXT_QUERY_MAX_LENGTH] if message_context else None,
+        """Build the full system prompt via the composable builder."""
+        return await build_agent_system_prompt(
+            self.db, self.contractor, self.tools, message_context
         )
-        tool_instructions = self._build_tool_instructions()
-        prompt = SYSTEM_PROMPT_TEMPLATE.format(
-            contractor_name=self.contractor.name or "Contractor",
-            soul_prompt=soul_prompt,
-            memory_context=memory_context or "(No memories saved yet)",
-            tool_instructions=tool_instructions,
-        )
-
-        missing = get_missing_optional_fields(self.contractor)
-        if missing:
-            missing_str = " and ".join(missing)
-            prompt += (
-                f"\nNote: You haven't learned this contractor's {missing_str} yet. "
-                "If the opportunity comes up naturally in conversation, "
-                "try to learn and save these details.\n"
-            )
-
-        return prompt
 
     async def _call_llm_with_retry(
         self,

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -22,8 +22,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.llm_parsing import parse_tool_calls
-from backend.app.agent.memory import build_memory_context
-from backend.app.agent.profile import build_soul_prompt
+from backend.app.agent.system_prompt import build_heartbeat_system_prompt
 from backend.app.config import settings
 from backend.app.database import SessionLocal
 from backend.app.enums import (
@@ -47,36 +46,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
-
-HEARTBEAT_SYSTEM_PROMPT = """\
-You are Backshop's heartbeat evaluator. Your job is to compose a short, \
-actionable message for the contractor based on the flags below.
-
-## About the contractor
-{soul_prompt}
-
-## Contractor's memory
-{memory_context}
-
-## Recent conversation (last 5 messages)
-{recent_messages}
-
-## Flags raised by pre-checks
-{flags}
-
-## Current time
-{current_time}
-
-## Rules
-- The pre-checks already decided something needs attention. Your job is to \
-compose one concise, helpful message.
-- Combine multiple flags into a single message when possible.
-- Keep the message under 160 characters.
-- Be direct and actionable, no fluff.
-- If after reviewing the flags you believe none actually warrant a message \
-right now, you may still choose "no_action".
-- Use the compose_message tool to return your decision.
-"""
 
 # Tool schema for the heartbeat compose_message tool
 COMPOSE_MESSAGE_TOOL: dict[str, Any] = {
@@ -340,17 +309,20 @@ def _is_checklist_item_due(
 # ---------------------------------------------------------------------------
 
 
-async def build_heartbeat_context(
-    db: Session,
-    contractor: Contractor,
-    flags: list[str],
-) -> dict[str, str]:
-    """Gather all context needed for the heartbeat LLM evaluation."""
-    soul_prompt = build_soul_prompt(contractor)
-    memory_context = await build_memory_context(db, contractor.id)
+def _load_recent_messages(db: Session, contractor: Contractor) -> str:
+    """Load recent messages as formatted text for heartbeat context."""
+    conv = (
+        db.query(Conversation)
+        .filter(
+            Conversation.contractor_id == contractor.id,
+            Conversation.is_active.is_(True),
+        )
+        .order_by(Conversation.last_message_at.desc())
+        .first()
+    )
+    if conv is None:
+        return "(no recent messages)"
 
-    # Recent messages (last 5)
-    conv, _ = await get_or_create_conversation(db, contractor.id)
     recent = (
         db.query(Message)
         .filter(Message.conversation_id == conv.id)
@@ -358,18 +330,21 @@ async def build_heartbeat_context(
         .limit(HEARTBEAT_RECENT_MESSAGES_COUNT)
         .all()
     )
-    recent_lines: list[str] = []
+    lines: list[str] = []
     for msg in reversed(recent):
         direction = "Contractor" if msg.direction == MessageDirection.INBOUND else "Backshop"
-        recent_lines.append(f"[{direction}] {msg.body}")
+        lines.append(f"[{direction}] {msg.body}")
+    return "\n".join(lines) or "(no recent messages)"
 
-    return {
-        "soul_prompt": soul_prompt,
-        "memory_context": memory_context or "(none)",
-        "recent_messages": "\n".join(recent_lines) or "(no recent messages)",
-        "flags": "\n".join(f"- {f}" for f in flags),
-        "current_time": datetime.datetime.now(datetime.UTC).isoformat(),
-    }
+
+async def build_heartbeat_context(
+    db: Session,
+    contractor: Contractor,
+    flags: list[str],
+) -> str:
+    """Build the full heartbeat system prompt via the composable builder."""
+    recent_messages = _load_recent_messages(db, contractor)
+    return await build_heartbeat_system_prompt(db, contractor, flags, recent_messages)
 
 
 # ---------------------------------------------------------------------------
@@ -445,8 +420,7 @@ async def evaluate_heartbeat_need(
     Uses the compose_message tool calling protocol instead of raw JSON parsing.
     If the LLM does not call the tool, defaults to no_action.
     """
-    ctx = await build_heartbeat_context(db, contractor, flags)
-    prompt = HEARTBEAT_SYSTEM_PROMPT.format(**ctx)
+    prompt = await build_heartbeat_context(db, contractor, flags)
 
     model = settings.heartbeat_model or settings.llm_model
     provider = settings.heartbeat_provider or settings.llm_provider

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -1,0 +1,229 @@
+"""Composable system prompt builder.
+
+Replaces monolithic ``str.format()`` templates with a section-based builder
+that safely concatenates user-supplied content without ``{``/``}`` injection
+risks.  Both the main agent loop and the heartbeat engine use this builder.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+
+from sqlalchemy.orm import Session
+
+from backend.app.agent.memory import build_memory_context
+from backend.app.agent.profile import build_soul_prompt, get_missing_optional_fields
+from backend.app.agent.tools.base import Tool
+from backend.app.models import Contractor
+
+logger = logging.getLogger(__name__)
+
+CONTEXT_QUERY_MAX_LENGTH = 100
+
+
+class SystemPromptBuilder:
+    """Build a system prompt from composable sections.
+
+    Each section has a heading and body.  ``build()`` assembles them
+    into a single string with Markdown-style ``## Heading`` separators.
+    No ``str.format()`` is used, so user-supplied content with curly
+    braces is safe.
+    """
+
+    def __init__(self) -> None:
+        self._preamble: str = ""
+        self._sections: list[tuple[str, str]] = []
+
+    def set_preamble(self, text: str) -> SystemPromptBuilder:
+        """Set the opening line(s) before any sections."""
+        self._preamble = text
+        return self
+
+    def add_section(self, heading: str, content: str) -> SystemPromptBuilder:
+        """Append a named section.  Empty content sections are skipped in output."""
+        self._sections.append((heading, content))
+        return self
+
+    def build(self) -> str:
+        """Assemble all sections into the final prompt string."""
+        parts: list[str] = []
+        if self._preamble:
+            parts.append(self._preamble)
+
+        for heading, content in self._sections:
+            if not content:
+                continue
+            parts.append(f"## {heading}\n{content}")
+
+        return "\n\n".join(parts)
+
+
+# -----------------------------------------------------------------------
+# Reusable section builders
+# -----------------------------------------------------------------------
+
+
+def build_identity_section(contractor: Contractor) -> str:
+    """Build the 'About <name>' section content."""
+    return build_soul_prompt(contractor)
+
+
+async def build_memory_section(
+    db: Session,
+    contractor_id: int,
+    query: str | None = None,
+) -> str:
+    """Build the memory context section content."""
+    ctx = await build_memory_context(
+        db,
+        contractor_id,
+        query=query[:CONTEXT_QUERY_MAX_LENGTH] if query else None,
+    )
+    return ctx or "(No memories saved yet)"
+
+
+def build_instructions_section() -> str:
+    """Build the behavioral instructions section content."""
+    return (
+        "- Be concise and practical. Contractors are busy.\n"
+        "- You can ONLY communicate via this chat. You cannot send emails, "
+        "make phone calls, or contact clients directly.\n"
+        "- Always be helpful, friendly, and professional.\n"
+        "- Keep replies concise. Contractors are on the job site."
+    )
+
+
+def build_tool_guidelines_section(tools: list[Tool]) -> str:
+    """Build tool usage guidelines from registered tools."""
+    hints = [tool.usage_hint for tool in tools if tool.usage_hint]
+    if not hints:
+        return ""
+    return "\n".join(f"- {hint}" for hint in hints)
+
+
+def build_proactive_section() -> str:
+    """Build the proactive messaging rules section content."""
+    return (
+        "You will proactively reach out during business hours when something needs attention:\n"
+        "- A draft estimate has been sitting unsent for over 24 hours\n"
+        "- A scheduled checklist item is due\n"
+        "- A follow-up reminder or deadline is approaching\n"
+        "- You haven't heard from the contractor in a few days"
+    )
+
+
+def build_recall_section() -> str:
+    """Build the recall behavior section content."""
+    return (
+        "When the contractor asks a question about their business, clients, or past work:\n"
+        "1. Search your memory for relevant information.\n"
+        "2. If you find relevant facts, use them to answer clearly and concisely.\n"
+        "3. If you don't find anything, say so honestly -- don't make things up.\n"
+        "4. If the question is about general knowledge (not their specific business), "
+        "answer from your training.\n"
+        '5. For "what do you know about me?" questions, summarize key facts by category.'
+    )
+
+
+def build_missing_fields_section(contractor: Contractor) -> str:
+    """Build a note about missing optional profile fields, if any."""
+    missing = get_missing_optional_fields(contractor)
+    if not missing:
+        return ""
+    missing_str = " and ".join(missing)
+    return (
+        f"Note: You haven't learned this contractor's {missing_str} yet. "
+        "If the opportunity comes up naturally in conversation, "
+        "try to learn and save these details."
+    )
+
+
+# -----------------------------------------------------------------------
+# Pre-built prompt assemblers
+# -----------------------------------------------------------------------
+
+
+async def build_agent_system_prompt(
+    db: Session,
+    contractor: Contractor,
+    tools: list[Tool],
+    message_context: str,
+) -> str:
+    """Assemble the full system prompt for the main agent loop."""
+    builder = SystemPromptBuilder()
+    builder.set_preamble("You are Backshop, an AI assistant for solo contractors.")
+
+    builder.add_section(
+        f"About {contractor.name or 'Contractor'}",
+        build_identity_section(contractor),
+    )
+
+    memory = await build_memory_section(db, contractor.id, query=message_context)
+    builder.add_section("Your Memory", memory)
+
+    tool_guidelines = build_tool_guidelines_section(tools)
+    if tool_guidelines:
+        instructions = (
+            build_instructions_section() + "\n" + "\n## Tool Guidelines\n" + tool_guidelines
+        )
+    else:
+        instructions = build_instructions_section()
+    builder.add_section("Instructions", instructions)
+
+    builder.add_section("Proactive Messaging", build_proactive_section())
+    builder.add_section("Recall Behavior", build_recall_section())
+
+    missing = build_missing_fields_section(contractor)
+    if missing:
+        builder.add_section("Profile Gaps", missing)
+
+    return builder.build()
+
+
+async def build_heartbeat_system_prompt(
+    db: Session,
+    contractor: Contractor,
+    flags: list[str],
+    recent_messages: str,
+) -> str:
+    """Assemble the system prompt for the heartbeat evaluator."""
+    builder = SystemPromptBuilder()
+    builder.set_preamble(
+        "You are Backshop's heartbeat evaluator. Your job is to compose a short, "
+        "actionable message for the contractor based on the flags below."
+    )
+
+    builder.add_section("About the contractor", build_identity_section(contractor))
+
+    memory = await build_memory_section(db, contractor.id)
+    builder.add_section("Contractor's memory", memory)
+
+    builder.add_section(
+        "Recent conversation (last 5 messages)",
+        recent_messages or "(no recent messages)",
+    )
+
+    builder.add_section(
+        "Flags raised by pre-checks",
+        "\n".join(f"- {f}" for f in flags),
+    )
+
+    builder.add_section(
+        "Current time",
+        datetime.datetime.now(datetime.UTC).isoformat(),
+    )
+
+    rules = (
+        "- The pre-checks already decided something needs attention. Your job is to "
+        "compose one concise, helpful message.\n"
+        "- Combine multiple flags into a single message when possible.\n"
+        "- Keep the message under 160 characters.\n"
+        "- Be direct and actionable, no fluff.\n"
+        "- If after reviewing the flags you believe none actually warrant a message "
+        'right now, you may still choose "no_action".\n'
+        "- Use the compose_message tool to return your decision."
+    )
+    builder.add_section("Rules", rules)
+
+    return builder.build()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1180,11 +1180,12 @@ class TestBuildHeartbeatContext:
         db.commit()
 
         flags = ["Stale draft estimate: Kitchen remodel"]
-        ctx = await build_heartbeat_context(db, contractor, flags)
+        prompt = await build_heartbeat_context(db, contractor, flags)
 
-        assert "Plumber" in ctx["soul_prompt"]
-        assert "Kitchen remodel" in ctx["flags"]
-        assert "I need a quote" in ctx["recent_messages"]
+        # build_heartbeat_context now returns a full prompt string
+        assert "Plumber" in prompt
+        assert "Kitchen remodel" in prompt
+        assert "I need a quote" in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1,0 +1,239 @@
+"""Tests for the composable system prompt builder."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.app.agent.system_prompt import (
+    SystemPromptBuilder,
+    build_agent_system_prompt,
+    build_identity_section,
+    build_instructions_section,
+    build_memory_section,
+    build_missing_fields_section,
+    build_proactive_section,
+    build_recall_section,
+    build_tool_guidelines_section,
+)
+
+
+class TestSystemPromptBuilder:
+    def test_empty_builder(self) -> None:
+        """Empty builder should produce empty string."""
+        builder = SystemPromptBuilder()
+        assert builder.build() == ""
+
+    def test_preamble_only(self) -> None:
+        """Builder with just preamble should produce it."""
+        builder = SystemPromptBuilder()
+        builder.set_preamble("Hello world")
+        assert builder.build() == "Hello world"
+
+    def test_single_section(self) -> None:
+        """Builder with one section should produce heading + content."""
+        builder = SystemPromptBuilder()
+        builder.add_section("Test", "Content here")
+        result = builder.build()
+        assert "## Test" in result
+        assert "Content here" in result
+
+    def test_preamble_and_sections(self) -> None:
+        """Builder should combine preamble and sections with double newlines."""
+        builder = SystemPromptBuilder()
+        builder.set_preamble("You are a bot.")
+        builder.add_section("About", "Details here")
+        builder.add_section("Rules", "Be nice")
+        result = builder.build()
+        assert result.startswith("You are a bot.")
+        assert "## About\nDetails here" in result
+        assert "## Rules\nBe nice" in result
+
+    def test_empty_content_skipped(self) -> None:
+        """Sections with empty content should be omitted."""
+        builder = SystemPromptBuilder()
+        builder.add_section("Present", "Has content")
+        builder.add_section("Empty", "")
+        builder.add_section("Also Present", "Also has content")
+        result = builder.build()
+        assert "## Present" in result
+        assert "## Empty" not in result
+        assert "## Also Present" in result
+
+    def test_curly_braces_safe(self) -> None:
+        """User-supplied content with curly braces should not cause errors."""
+        builder = SystemPromptBuilder()
+        builder.set_preamble("You are a bot.")
+        builder.add_section("About", "User name is {Mike}")
+        builder.add_section("Memory", "key={value}")
+        result = builder.build()
+        assert "{Mike}" in result
+        assert "key={value}" in result
+
+    def test_chaining(self) -> None:
+        """Builder methods should support method chaining."""
+        result = (
+            SystemPromptBuilder()
+            .set_preamble("Hello")
+            .add_section("A", "Content A")
+            .add_section("B", "Content B")
+            .build()
+        )
+        assert "Hello" in result
+        assert "## A" in result
+        assert "## B" in result
+
+
+class TestSectionBuilders:
+    def test_build_identity_section(self) -> None:
+        """Should include contractor name and trade."""
+        contractor = MagicMock()
+        contractor.name = "Mike"
+        contractor.trade = "plumbing"
+        contractor.location = "Portland"
+        contractor.hourly_rate = 85
+        contractor.business_hours = "7am-5pm"
+        contractor.soul_text = None
+        contractor.preferences_json = None
+        result = build_identity_section(contractor)
+        assert "Mike" in result
+        assert "plumbing" in result
+        assert "Portland" in result
+
+    @pytest.mark.asyncio
+    async def test_build_memory_section_with_content(self) -> None:
+        """Should return memory context when available."""
+        with patch(
+            "backend.app.agent.system_prompt.build_memory_context",
+            new_callable=AsyncMock,
+            return_value="client: John Doe, deck work",
+        ):
+            result = await build_memory_section(MagicMock(), contractor_id=1)
+        assert "John Doe" in result
+
+    @pytest.mark.asyncio
+    async def test_build_memory_section_empty(self) -> None:
+        """Should return placeholder when no memories exist."""
+        with patch(
+            "backend.app.agent.system_prompt.build_memory_context",
+            new_callable=AsyncMock,
+            return_value="",
+        ):
+            result = await build_memory_section(MagicMock(), contractor_id=1)
+        assert result == "(No memories saved yet)"
+
+    def test_build_instructions_section(self) -> None:
+        """Should contain core behavioral rules."""
+        result = build_instructions_section()
+        assert "concise" in result
+        assert "ONLY communicate via this chat" in result
+
+    def test_build_tool_guidelines_empty(self) -> None:
+        """Should return empty string when no tools have usage hints."""
+        tool = MagicMock()
+        tool.usage_hint = None
+        assert build_tool_guidelines_section([tool]) == ""
+
+    def test_build_tool_guidelines_with_hints(self) -> None:
+        """Should format tool hints as bullet points."""
+        tool1 = MagicMock()
+        tool1.usage_hint = "Use save_fact for important info"
+        tool2 = MagicMock()
+        tool2.usage_hint = "Use create_estimate for quotes"
+        result = build_tool_guidelines_section([tool1, tool2])
+        assert "- Use save_fact" in result
+        assert "- Use create_estimate" in result
+
+    def test_build_proactive_section(self) -> None:
+        """Should contain proactive messaging rules."""
+        result = build_proactive_section()
+        assert "draft estimate" in result
+        assert "checklist" in result
+
+    def test_build_recall_section(self) -> None:
+        """Should contain recall behavior rules."""
+        result = build_recall_section()
+        assert "Search your memory" in result
+        assert "don't make things up" in result
+
+    def test_build_missing_fields_with_gaps(self) -> None:
+        """Should mention missing fields."""
+        contractor = MagicMock()
+        contractor.hourly_rate = None
+        contractor.business_hours = None
+        result = build_missing_fields_section(contractor)
+        assert "rates" in result
+        assert "business hours" in result
+
+    def test_build_missing_fields_none(self) -> None:
+        """Should return empty string when all fields present."""
+        contractor = MagicMock()
+        contractor.hourly_rate = 85
+        contractor.business_hours = "7am-5pm"
+        result = build_missing_fields_section(contractor)
+        assert result == ""
+
+
+class TestBuildAgentSystemPrompt:
+    @pytest.mark.asyncio
+    async def test_assembles_all_sections(self) -> None:
+        """Full agent prompt should contain all key sections."""
+        contractor = MagicMock()
+        contractor.name = "Jake"
+        contractor.trade = "electrician"
+        contractor.location = "Seattle"
+        contractor.hourly_rate = 90
+        contractor.business_hours = "8am-6pm"
+        contractor.soul_text = None
+        contractor.preferences_json = None
+        contractor.id = 1
+
+        tool = MagicMock()
+        tool.usage_hint = "Use save_fact for memories"
+
+        with patch(
+            "backend.app.agent.system_prompt.build_memory_context",
+            new_callable=AsyncMock,
+            return_value="client: Jane, roof repair",
+        ):
+            result = await build_agent_system_prompt(
+                db=MagicMock(),
+                contractor=contractor,
+                tools=[tool],
+                message_context="how much for a roof repair?",
+            )
+
+        assert "Backshop" in result
+        assert "Jake" in result
+        assert "electrician" in result
+        assert "Jane" in result
+        assert "Tool Guidelines" in result
+        assert "save_fact" in result
+        assert "Proactive Messaging" in result
+        assert "Recall Behavior" in result
+
+    @pytest.mark.asyncio
+    async def test_curly_braces_in_contractor_name(self) -> None:
+        """Contractor name with curly braces should not break the prompt."""
+        contractor = MagicMock()
+        contractor.name = "Mike {The Plumber}"
+        contractor.trade = "plumbing"
+        contractor.location = None
+        contractor.hourly_rate = None
+        contractor.business_hours = None
+        contractor.soul_text = None
+        contractor.preferences_json = None
+        contractor.id = 1
+
+        with patch(
+            "backend.app.agent.system_prompt.build_memory_context",
+            new_callable=AsyncMock,
+            return_value="",
+        ):
+            result = await build_agent_system_prompt(
+                db=MagicMock(),
+                contractor=contractor,
+                tools=[],
+                message_context="hello",
+            )
+
+        assert "Mike {The Plumber}" in result


### PR DESCRIPTION
## Summary
- Create `SystemPromptBuilder` class with `add_section()`/`build()` API in `backend/app/agent/system_prompt.py`
- Extract reusable section builders: identity, memory, instructions, tool guidelines, proactive, recall, missing fields
- Both agent loop and heartbeat use the builder instead of `str.format()` on monolithic templates
- Eliminates `{`/`}` injection risk from user-supplied content (contractor names, memory values)
- `build_heartbeat_context` now returns a full prompt string instead of a dict

## Test plan
- [x] 19 new unit tests for builder and section builders (empty, preamble, sections, curly braces, chaining, all section builders, full assembly)
- [x] All 569 tests pass
- [x] Lint, format, and type checks pass

Fixes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)