### PR TITLE
refactor: require ToolResult return type from all tool functions

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -475,14 +475,18 @@ class BackshopAgent:
 
                     try:
                         result = await tool_func(**validated_args)
-                        if isinstance(result, ToolResult):
-                            result_str = result.content
-                            is_error = result.is_error
-                            if is_error:
-                                hint = _build_error_hint(result)
-                                result_str += "\n\n" + hint
-                        else:
-                            result_str = str(result)
+                        if not isinstance(result, ToolResult):
+                            logger.warning(
+                                "Tool %s returned %s instead of ToolResult",
+                                tool_name,
+                                type(result).__name__,
+                            )
+                            result = ToolResult(content=str(result))
+                        result_str = result.content
+                        is_error = result.is_error
+                        if is_error:
+                            hint = _build_error_hint(result)
+                            result_str += "\n\n" + hint
                         if is_error:
                             actions_taken.append(f"Failed: {tool_name}")
                         else:

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
@@ -39,7 +39,7 @@ class Tool:
 
     name: str
     description: str
-    function: Callable[..., Any]
+    function: Callable[..., Awaitable[ToolResult]]
     parameters: dict[str, Any] = field(default_factory=dict)
     params_model: type[BaseModel] | None = None
     tags: set[str] = field(default_factory=set)


### PR DESCRIPTION
## Summary
- Update `Tool.function` type annotation from `Callable[..., Any]` to `Callable[..., Awaitable[ToolResult]]`
- Replace `isinstance`/`str()` fallback in agent loop with defensive warning + coercion
- All 12 existing tool functions already return `ToolResult`, no tool code changes needed

## Test plan
- [x] All 569 tests pass
- [x] Lint, format checks pass

Fixes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)