### PR TITLE
refactor: add agent event system for observability and extensibility

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
-from collections.abc import Callable
+import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -15,6 +16,15 @@ from any_llm.types.completion import ChatCompletion
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
+from backend.app.agent.events import (
+    AgentEndEvent,
+    AgentEvent,
+    AgentStartEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    TurnEndEvent,
+    TurnStartEvent,
+)
 from backend.app.agent.llm_parsing import parse_tool_calls
 from backend.app.agent.messages import (
     AgentMessage,
@@ -171,6 +181,23 @@ class BackshopAgent:
         self.contractor = contractor
         self.tools: list[Tool] = []
         self._tools_by_name: dict[str, Tool] = {}
+        self._subscribers: list[Callable[[AgentEvent], Awaitable[None]]] = []
+
+    def subscribe(self, callback: Callable[[AgentEvent], Awaitable[None]]) -> None:
+        """Register an event subscriber.
+
+        The callback is invoked with each ``AgentEvent`` during processing.
+        Multiple subscribers are supported and called in registration order.
+        """
+        self._subscribers.append(callback)
+
+    async def _emit(self, event: AgentEvent) -> None:
+        """Notify all subscribers of an event.  Errors are logged, not raised."""
+        for cb in self._subscribers:
+            try:
+                await cb(event)
+            except Exception:
+                logger.exception("Event subscriber error for %s", type(event).__name__)
 
     def register_tools(self, tools: list[Tool]) -> None:
         """Register available tools for this agent session."""
@@ -351,7 +378,14 @@ class BackshopAgent:
         *conversation_history* accepts both typed ``AgentMessage`` objects
         (preferred) and legacy ``dict`` messages for backward compatibility.
         """
+        agent_start_time = time.monotonic()
         system_prompt = system_prompt_override or await self._build_system_prompt(message_context)
+        await self._emit(
+            AgentStartEvent(
+                contractor_id=self.contractor.id,
+                message_context=message_context,
+            )
+        )
 
         messages: list[AgentMessage] = [SystemMessage(content=system_prompt)]
 
@@ -392,12 +426,14 @@ class BackshopAgent:
         reply_text = ""
 
         for _round in range(MAX_TOOL_ROUNDS):
+            await self._emit(TurnStartEvent(round_number=_round, message_count=len(messages)))
             response = await self._call_llm_with_retry(messages, tool_schemas, llm_kwargs)
 
             # Parse tool calls via shared parser
             parsed_raw = parse_tool_calls(response)
             if not parsed_raw:
                 reply_text = response.choices[0].message.content or ""
+                await self._emit(TurnEndEvent(round_number=_round, has_more_tool_calls=False))
                 break
 
             # Convert to typed ToolCallRequest objects
@@ -473,6 +509,10 @@ class BackshopAgent:
                         )
                         continue
 
+                    await self._emit(
+                        ToolExecutionStartEvent(tool_name=tool_name, arguments=validated_args)
+                    )
+                    tool_start = time.monotonic()
                     try:
                         result = await tool_func(**validated_args)
                         if not isinstance(result, ToolResult):
@@ -506,7 +546,17 @@ class BackshopAgent:
                         logger.exception("Tool call failed: %s", tool_name)
                         hint = _ERROR_KIND_HINTS[ToolErrorKind.INTERNAL]
                         result_str = f"Error: tool {tool_name} failed\n\n{hint}"
+                        is_error = True
                         actions_taken.append(f"Failed: {tool_name}")
+                    tool_duration = (time.monotonic() - tool_start) * 1000
+                    await self._emit(
+                        ToolExecutionEndEvent(
+                            tool_name=tool_name,
+                            result=result_str,
+                            is_error=is_error,
+                            duration_ms=tool_duration,
+                        )
+                    )
                 else:
                     available = ", ".join(sorted(self._tools_by_name.keys()))
                     result_str = (
@@ -523,9 +573,19 @@ class BackshopAgent:
                 )
 
             messages.extend(tool_results)
+            await self._emit(TurnEndEvent(round_number=_round, has_more_tool_calls=True))
         else:
             # Max rounds reached -- use last response content
             reply_text = response.choices[0].message.content or ""
+
+        total_duration = (time.monotonic() - agent_start_time) * 1000
+        await self._emit(
+            AgentEndEvent(
+                reply_text=reply_text,
+                actions_taken=actions_taken,
+                total_duration_ms=total_duration,
+            )
+        )
 
         return AgentResponse(
             reply_text=reply_text,

--- a/backend/app/agent/events.py
+++ b/backend/app/agent/events.py
@@ -1,0 +1,74 @@
+"""Typed event dataclasses for the agent lifecycle.
+
+Emitted at key points during agent processing so that subscribers can
+observe progress, collect metrics, or implement streaming without
+modifying the core loop.  When no subscribers are registered, event
+emission is effectively a no-op (just dataclass construction).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AgentStartEvent:
+    """Emitted when the agent begins processing a message."""
+
+    contractor_id: int
+    message_context: str
+
+
+@dataclass(frozen=True)
+class TurnStartEvent:
+    """Emitted at the start of each LLM call round."""
+
+    round_number: int
+    message_count: int
+
+
+@dataclass(frozen=True)
+class ToolExecutionStartEvent:
+    """Emitted before a tool function is called."""
+
+    tool_name: str
+    arguments: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolExecutionEndEvent:
+    """Emitted after a tool function completes."""
+
+    tool_name: str
+    result: str
+    is_error: bool
+    duration_ms: float
+
+
+@dataclass(frozen=True)
+class TurnEndEvent:
+    """Emitted at the end of each LLM call round."""
+
+    round_number: int
+    has_more_tool_calls: bool
+
+
+@dataclass(frozen=True)
+class AgentEndEvent:
+    """Emitted when the agent finishes processing."""
+
+    reply_text: str
+    actions_taken: list[str] = field(default_factory=list)
+    total_duration_ms: float = 0.0
+
+
+# Union type for all events
+AgentEvent = (
+    AgentStartEvent
+    | TurnStartEvent
+    | ToolExecutionStartEvent
+    | ToolExecutionEndEvent
+    | TurnEndEvent
+    | AgentEndEvent
+)

--- a/tests/test_agent_events.py
+++ b/tests/test_agent_events.py
@@ -1,0 +1,186 @@
+"""Tests for agent event system."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.core import BackshopAgent
+from backend.app.agent.events import (
+    AgentEndEvent,
+    AgentStartEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    TurnEndEvent,
+    TurnStartEvent,
+)
+from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.models import Contractor
+from tests.mocks.llm import make_text_response, make_tool_call_response
+
+
+@pytest.fixture()
+def agent(db_session: Session, test_contractor: Contractor) -> BackshopAgent:
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    return agent
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+async def test_events_emitted_for_text_response(
+    mock_prompt: AsyncMock,
+    mock_llm: AsyncMock,
+    agent: BackshopAgent,
+) -> None:
+    """Text-only response should emit start, turn_start, turn_end, and end events."""
+    mock_prompt.return_value = "system prompt"
+    mock_llm.return_value = make_text_response("Hello!")
+
+    events: list[object] = []
+    subscriber = AsyncMock(side_effect=lambda e: events.append(e))
+    agent.subscribe(subscriber)
+
+    await agent.process_message("Hi there")
+
+    assert len(events) == 4
+    assert isinstance(events[0], AgentStartEvent)
+    assert events[0].message_context == "Hi there"
+    assert isinstance(events[1], TurnStartEvent)
+    assert events[1].round_number == 0
+    assert isinstance(events[2], TurnEndEvent)
+    assert events[2].has_more_tool_calls is False
+    assert isinstance(events[3], AgentEndEvent)
+    assert events[3].reply_text == "Hello!"
+    assert events[3].total_duration_ms > 0
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+async def test_events_emitted_for_tool_call(
+    mock_prompt: AsyncMock,
+    mock_llm: AsyncMock,
+    agent: BackshopAgent,
+) -> None:
+    """Tool call should emit tool execution start/end events."""
+    mock_prompt.return_value = "system prompt"
+
+    async def mock_tool(**kwargs: object) -> ToolResult:
+        return ToolResult(content="saved")
+
+    agent.register_tools(
+        [
+            Tool(
+                name="save_fact",
+                description="Save a fact",
+                function=mock_tool,
+                parameters={"type": "object", "properties": {}},
+            )
+        ]
+    )
+
+    # First call: tool call, second call: text response
+    tool_response = make_tool_call_response(
+        [{"name": "save_fact", "arguments": json.dumps({"key": "name", "value": "Mike"})}]
+    )
+    text_response = make_text_response("Done!")
+    mock_llm.side_effect = [tool_response, text_response]
+
+    events: list[object] = []
+    subscriber = AsyncMock(side_effect=lambda e: events.append(e))
+    agent.subscribe(subscriber)
+
+    await agent.process_message("Remember my name is Mike")
+
+    event_types = [type(e).__name__ for e in events]
+    assert "AgentStartEvent" in event_types
+    assert "TurnStartEvent" in event_types
+    assert "ToolExecutionStartEvent" in event_types
+    assert "ToolExecutionEndEvent" in event_types
+    assert "TurnEndEvent" in event_types
+    assert "AgentEndEvent" in event_types
+
+    # Find tool execution events
+    tool_starts = [e for e in events if isinstance(e, ToolExecutionStartEvent)]
+    tool_ends = [e for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert len(tool_starts) == 1
+    assert tool_starts[0].tool_name == "save_fact"
+    assert len(tool_ends) == 1
+    assert tool_ends[0].tool_name == "save_fact"
+    assert tool_ends[0].is_error is False
+    assert tool_ends[0].duration_ms >= 0
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+async def test_no_events_without_subscribers(
+    mock_prompt: AsyncMock,
+    mock_llm: AsyncMock,
+    agent: BackshopAgent,
+) -> None:
+    """Without subscribers, no errors should occur."""
+    mock_prompt.return_value = "system prompt"
+    mock_llm.return_value = make_text_response("Hello!")
+
+    # No subscriber registered -- should work fine
+    response = await agent.process_message("Hi")
+    assert response.reply_text == "Hello!"
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+async def test_subscriber_error_does_not_crash_agent(
+    mock_prompt: AsyncMock,
+    mock_llm: AsyncMock,
+    agent: BackshopAgent,
+) -> None:
+    """A failing subscriber should not crash the agent pipeline."""
+    mock_prompt.return_value = "system prompt"
+    mock_llm.return_value = make_text_response("Hello!")
+
+    async def bad_subscriber(event: object) -> None:
+        raise RuntimeError("subscriber crashed")
+
+    agent.subscribe(bad_subscriber)
+
+    # Should not raise
+    response = await agent.process_message("Hi")
+    assert response.reply_text == "Hello!"
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.acompletion")
+@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+async def test_multiple_subscribers(
+    mock_prompt: AsyncMock,
+    mock_llm: AsyncMock,
+    agent: BackshopAgent,
+) -> None:
+    """Multiple subscribers should all receive events."""
+    mock_prompt.return_value = "system prompt"
+    mock_llm.return_value = make_text_response("Hello!")
+
+    events_a: list[object] = []
+    events_b: list[object] = []
+    agent.subscribe(AsyncMock(side_effect=lambda e: events_a.append(e)))
+    agent.subscribe(AsyncMock(side_effect=lambda e: events_b.append(e)))
+
+    await agent.process_message("Hi")
+
+    assert len(events_a) == 4
+    assert len(events_b) == 4
+
+
+def test_event_dataclasses_are_frozen() -> None:
+    """Event dataclasses should be immutable."""
+    event = AgentStartEvent(contractor_id=1, message_context="test")
+    try:
+        event.contractor_id = 2  # type: ignore[misc]
+        frozen = False
+    except AttributeError:
+        frozen = True
+    assert frozen


### PR DESCRIPTION
## Summary
- Add typed event dataclasses in `backend/app/agent/events.py`: `AgentStartEvent`, `TurnStartEvent`, `ToolExecutionStartEvent`, `ToolExecutionEndEvent`, `TurnEndEvent`, `AgentEndEvent`
- Add `subscribe()` method and `_emit()` helper to `BackshopAgent`
- Events emitted at key lifecycle points in the agent loop (start, turns, tool execution with timing, end)
- Subscriber errors are caught and logged, never crash the pipeline
- Zero overhead when no subscribers are registered

## Test plan
- [x] 6 new tests: text response events, tool call events, no subscribers, subscriber error handling, multiple subscribers, frozen dataclasses
- [x] All 584 tests pass
- [x] Lint, format checks pass

Fixes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)