### PR TITLE
refactor: remove backwards compatibility code paths

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -369,15 +369,11 @@ class BackshopAgent:
     async def process_message(
         self,
         message_context: str,
-        conversation_history: list[AgentMessage] | list[dict[str, str]] | None = None,
+        conversation_history: list[AgentMessage] | None = None,
         system_prompt_override: str | None = None,
         temperature: float | None = None,
     ) -> AgentResponse:
-        """Process a message through the agent loop.
-
-        *conversation_history* accepts both typed ``AgentMessage`` objects
-        (preferred) and legacy ``dict`` messages for backward compatibility.
-        """
+        """Process a message through the agent loop."""
         agent_start_time = time.monotonic()
         system_prompt = system_prompt_override or await self._build_system_prompt(message_context)
         await self._emit(
@@ -390,11 +386,7 @@ class BackshopAgent:
         messages: list[AgentMessage] = [SystemMessage(content=system_prompt)]
 
         if conversation_history:
-            for entry in conversation_history:
-                if isinstance(entry, dict):
-                    messages.append(_dict_to_message(cast(dict[str, Any], entry)))
-                else:
-                    messages.append(entry)
+            messages.extend(conversation_history)
 
         messages.append(UserMessage(content=message_context))
 
@@ -515,13 +507,6 @@ class BackshopAgent:
                     tool_start = time.monotonic()
                     try:
                         result = await tool_func(**validated_args)
-                        if not isinstance(result, ToolResult):
-                            logger.warning(
-                                "Tool %s returned %s instead of ToolResult",
-                                tool_name,
-                                type(result).__name__,
-                            )
-                            result = ToolResult(content=str(result))
                         result_str = result.content
                         is_error = result.is_error
                         if is_error:
@@ -598,19 +583,3 @@ class BackshopAgent:
         """Find a registered tool by name."""
         tool = self._tools_by_name.get(name)
         return tool.function if tool else None
-
-
-def _dict_to_message(d: dict[str, Any]) -> AgentMessage:
-    """Convert a legacy dict message to a typed message object."""
-    role = d.get("role", "user")
-    content = d.get("content", "")
-    if role == "system":
-        return SystemMessage(content=content)
-    if role == "assistant":
-        return AssistantMessage(content=content)
-    if role == "tool":
-        return ToolResultMessage(
-            tool_call_id=d.get("tool_call_id", ""),
-            content=content,
-        )
-    return UserMessage(content=content)

--- a/backend/app/media/audio.py
+++ b/backend/app/media/audio.py
@@ -23,7 +23,7 @@ async def transcribe_audio(audio_bytes: bytes, mime_type: str = "audio/ogg") -> 
 def _transcribe_sync(audio_bytes: bytes) -> str:
     """Synchronous transcription with faster-whisper."""
     try:
-        from faster_whisper import WhisperModel
+        from faster_whisper import WhisperModel  # type: ignore[unresolved-import]
     except ImportError:
         msg = (
             "faster-whisper is required for audio transcription. "

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -13,6 +13,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from backend.app.agent.core import BackshopAgent
+from backend.app.agent.messages import AssistantMessage, UserMessage
 from backend.app.models import Contractor
 
 from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
@@ -56,8 +57,8 @@ async def test_agent_message_format_accepted(
 
         agent = BackshopAgent(db=integration_db, contractor=integration_contractor)
         history = [
-            {"role": "user", "content": "Hi there"},
-            {"role": "assistant", "content": "Hello! How can I help?"},
+            UserMessage(content="Hi there"),
+            AssistantMessage(content="Hello! How can I help?"),
         ]
         response = await agent.process_message(
             "What's a fair price for a 10x10 deck?",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -17,6 +17,7 @@ from backend.app.agent.core import (
     _estimate_tokens,
 )
 from backend.app.agent.messages import (
+    AgentMessage,
     AssistantMessage,
     SystemMessage,
     ToolCallRequest,
@@ -54,8 +55,8 @@ async def test_agent_includes_conversation_history(
 
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
     history = [
-        {"role": "user", "content": "Hi, I need help"},
-        {"role": "assistant", "content": "Hello! How can I help?"},
+        UserMessage(content="Hi, I need help"),
+        AssistantMessage(content="Hello! How can I help?"),
     ]
     await agent.process_message("What about a deck?", conversation_history=history)
 
@@ -92,8 +93,8 @@ async def test_system_prompt_includes_tool_hints(
     """System prompt should include usage hints from registered tools."""
     mock_acompletion.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
 
-    async def dummy(**kwargs: object) -> str:
-        return "ok"
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
 
     tools = [
         Tool(
@@ -148,8 +149,8 @@ async def test_system_prompt_skips_tools_without_hints(
     """Tools with empty usage_hint should not appear in the system prompt."""
     mock_acompletion.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
 
-    async def dummy(**kwargs: object) -> str:
-        return "ok"
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
 
     tools = [
         Tool(
@@ -213,7 +214,7 @@ async def test_agent_tool_loop_sends_results_back(
     mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
 
     # Register a mock save_fact tool
-    mock_save = AsyncMock(return_value="Saved hourly_rate = $75/hr")
+    mock_save = AsyncMock(return_value=ToolResult(content="Saved hourly_rate = $75/hr"))
     tool = Tool(
         name="save_fact",
         description="Save a fact",
@@ -256,7 +257,7 @@ async def test_agent_tool_loop_includes_tool_results_in_followup(
 
     mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
 
-    mock_recall = AsyncMock(return_value="hourly_rate: $75/hr")
+    mock_recall = AsyncMock(return_value=ToolResult(content="hourly_rate: $75/hr"))
     tool = Tool(
         name="recall_facts",
         description="Recall facts",
@@ -310,8 +311,8 @@ async def test_agent_multi_round_tool_calls(
 
     mock_acompletion.side_effect = [round1_response, round2_response, final_response]  # type: ignore[union-attr]
 
-    mock_recall = AsyncMock(return_value="deck: $45/sqft")
-    mock_estimate = AsyncMock(return_value="Estimate PDF generated")
+    mock_recall = AsyncMock(return_value=ToolResult(content="deck: $45/sqft"))
+    mock_estimate = AsyncMock(return_value=ToolResult(content="Estimate PDF generated"))
 
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
     agent.register_tools(
@@ -374,7 +375,7 @@ async def test_agent_tool_loop_respects_max_rounds(
 
     mock_acompletion.side_effect = tool_responses  # type: ignore[union-attr]
 
-    mock_recall = AsyncMock(return_value="some result")
+    mock_recall = AsyncMock(return_value=ToolResult(content="some result"))
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
     agent.register_tools(
         [
@@ -416,7 +417,7 @@ async def test_agent_handles_malformed_tool_arguments(
 
     mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
 
-    mock_save = AsyncMock(return_value="saved")
+    mock_save = AsyncMock(return_value=ToolResult(content="saved"))
     tool = Tool(
         name="save_fact",
         description="Save a fact",
@@ -458,7 +459,7 @@ async def test_agent_repairs_slightly_malformed_json(
 
     mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
 
-    mock_save = AsyncMock(return_value="Saved hourly_rate = $75/hr")
+    mock_save = AsyncMock(return_value=ToolResult(content="Saved hourly_rate = $75/hr"))
     tool = Tool(
         name="save_fact",
         description="Save a fact",
@@ -625,8 +626,10 @@ async def test_agent_trims_context_on_context_length_exceeded(
     ]
 
     # Supply a long conversation history to verify trimming
-    long_history = [
-        {"role": "user" if i % 2 == 0 else "assistant", "content": f"Message {i}"}
+    long_history: list[AgentMessage] = [
+        UserMessage(content=f"Message {i}")
+        if i % 2 == 0
+        else AssistantMessage(content=f"Message {i}")
         for i in range(20)
     ]
 
@@ -657,8 +660,9 @@ async def test_agent_trims_history_when_exceeding_token_limit(
     # Create a huge conversation history that exceeds MAX_INPUT_TOKENS
     # Each message ~4000 chars = ~1000 tokens; need >120K tokens = >120 messages
     big_content = "x" * 4000
-    long_history = [
-        {"role": "user" if i % 2 == 0 else "assistant", "content": big_content} for i in range(150)
+    long_history: list[AgentMessage] = [
+        UserMessage(content=big_content) if i % 2 == 0 else AssistantMessage(content=big_content)
+        for i in range(150)
     ]
 
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
@@ -702,8 +706,9 @@ async def test_agent_preserves_system_and_user_during_trimming(
 
     # Create history that will trigger trimming
     big_content = "x" * 4000
-    long_history = [
-        {"role": "user" if i % 2 == 0 else "assistant", "content": big_content} for i in range(150)
+    long_history: list[AgentMessage] = [
+        UserMessage(content=big_content) if i % 2 == 0 else AssistantMessage(content=big_content)
+        for i in range(150)
     ]
 
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
@@ -789,11 +794,11 @@ async def test_agent_does_not_trim_normal_conversations(
     """Normal-sized conversations should not be trimmed."""
     mock_acompletion.return_value = make_text_response("Got it!")
 
-    history = [
-        {"role": "user", "content": "Hi, I need help"},
-        {"role": "assistant", "content": "Hello! How can I help?"},
-        {"role": "user", "content": "Can you estimate a deck?"},
-        {"role": "assistant", "content": "Sure, what size?"},
+    history: list[AgentMessage] = [
+        UserMessage(content="Hi, I need help"),
+        AssistantMessage(content="Hello! How can I help?"),
+        UserMessage(content="Can you estimate a deck?"),
+        AssistantMessage(content="Sure, what size?"),
     ]
 
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
@@ -822,8 +827,9 @@ async def test_agent_logs_warning_when_trimming(
     mock_acompletion.return_value = make_text_response("Ok!")
 
     big_content = "x" * 4000
-    long_history = [
-        {"role": "user" if i % 2 == 0 else "assistant", "content": big_content} for i in range(150)
+    long_history: list[AgentMessage] = [
+        UserMessage(content=big_content) if i % 2 == 0 else AssistantMessage(content=big_content)
+        for i in range(150)
     ]
 
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
@@ -849,8 +855,8 @@ def test_register_tools_builds_dict_lookup(
     """register_tools should build a dict for O(1) lookup by name."""
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
 
-    async def dummy(**kwargs: object) -> str:
-        return "ok"
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
 
     tools = [
         Tool(name="tool_a", description="A", function=dummy, parameters={}),
@@ -871,8 +877,8 @@ def test_register_tools_warns_on_duplicate_name(
     """Registering tools with duplicate names should log a warning."""
     agent = BackshopAgent(db=db_session, contractor=test_contractor)
 
-    async def dummy(**kwargs: object) -> str:
-        return "ok"
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
 
     tools = [
         Tool(name="dupe", description="First", function=dummy, parameters={}),
@@ -953,35 +959,6 @@ async def test_tool_result_success_no_hint(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.acompletion")
-async def test_plain_string_return_backward_compat(
-    mock_acompletion: AsyncMock,
-    db_session: Session,
-    test_contractor: Contractor,
-) -> None:
-    """Tools returning plain strings should still work (backward compatibility)."""
-
-    async def legacy_tool(**kwargs: object) -> str:
-        return "Legacy result"
-
-    tool = Tool(name="old_tool", description="test", function=legacy_tool, parameters={})
-
-    mock_acompletion.side_effect = [
-        make_tool_call_response(
-            tool_calls=[{"id": "call_1", "name": "old_tool", "arguments": json.dumps({})}]
-        ),
-        make_text_response("Ok!"),
-    ]
-
-    agent = BackshopAgent(db=db_session, contractor=test_contractor)
-    agent.register_tools([tool])
-    response = await agent.process_message("test", system_prompt_override="system")
-
-    assert any("Called old_tool" in a for a in response.actions_taken)
-    assert response.tool_calls[0]["result"] == "Legacy result"
-
-
-@pytest.mark.asyncio()
-@patch("backend.app.agent.core.acompletion")
 async def test_tool_exception_appends_hint(
     mock_acompletion: AsyncMock,
     db_session: Session,
@@ -1022,8 +999,8 @@ async def test_unknown_tool_error_lists_available_tools(
 ) -> None:
     """Unknown tool error should list all registered tool names."""
 
-    async def dummy(**kwargs: object) -> str:
-        return "ok"
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
 
     tools = [
         Tool(name="save_fact", description="Save a fact", function=dummy, parameters={}),
@@ -1071,8 +1048,8 @@ async def test_validation_error_includes_expected_schema(
         value: str
         category: str = "general"
 
-    async def save_fact(**kwargs: object) -> str:
-        return "saved"
+    async def save_fact(**kwargs: object) -> ToolResult:
+        return ToolResult(content="saved")
 
     tool = Tool(
         name="save_fact",

--- a/tests/test_tool_param_validation.py
+++ b/tests/test_tool_param_validation.py
@@ -43,8 +43,8 @@ class SampleParams(BaseModel):
 def test_tool_to_openai_schema_uses_params_model() -> None:
     """When params_model is set, schema should be auto-generated from the model."""
 
-    async def dummy(**kwargs: object) -> str:
-        return "ok"
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
 
     tool = Tool(
         name="sample",
@@ -68,8 +68,8 @@ def test_tool_to_openai_schema_uses_params_model() -> None:
 def test_tool_to_openai_schema_falls_back_to_raw_dict() -> None:
     """When no params_model is set, raw parameters dict should be used."""
 
-    async def dummy(**kwargs: object) -> str:
-        return "ok"
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
 
     raw_params = {"type": "object", "properties": {"x": {"type": "string"}}}
     tool = Tool(
@@ -315,42 +315,6 @@ async def test_agent_validation_coerces_types(
 
     # Should be called with coerced int, not string
     mock_func.assert_called_once_with(name="test", value=42)
-
-
-@pytest.mark.asyncio()
-@patch("backend.app.agent.core.acompletion")
-async def test_agent_no_params_model_skips_validation(
-    mock_acompletion: AsyncMock,
-    db_session: Session,
-    test_contractor: Contractor,
-) -> None:
-    """Tools without params_model should skip validation (backward compat)."""
-    tool_response = make_tool_call_response(
-        tool_calls=[
-            {
-                "id": "call_1",
-                "name": "legacy_tool",
-                "arguments": json.dumps({"anything": "goes"}),
-            }
-        ]
-    )
-    followup_response = make_text_response("Done!")
-    mock_acompletion.side_effect = [tool_response, followup_response]
-
-    mock_func = AsyncMock(return_value=ToolResult(content="ok"))
-    tool = Tool(
-        name="legacy_tool",
-        description="No params_model",
-        function=mock_func,
-        parameters={"type": "object", "properties": {}},
-    )
-
-    agent = BackshopAgent(db=db_session, contractor=test_contractor)
-    agent.register_tools([tool])
-    await agent.process_message("test", system_prompt_override="system")
-
-    # Should be called with raw args, no validation
-    mock_func.assert_called_once_with(anything="goes")
 
 
 @pytest.mark.asyncio()

--- a/tests/test_tool_schema.py
+++ b/tests/test_tool_schema.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from backend.app.agent.tools.base import (
     Tool,
+    ToolResult,
     _inline_refs,
     _strip_titles,
     tool_to_openai_schema,
@@ -126,8 +127,8 @@ def test_strip_titles_preserves_non_title_keys() -> None:
 # --- tool_to_openai_schema with nested Pydantic model ---
 
 
-def _dummy_func() -> None:
-    pass
+async def _dummy_func() -> ToolResult:
+    return ToolResult(content="ok")
 
 
 def test_tool_to_openai_schema_flat_for_estimate_params() -> None:

--- a/tests/test_tool_tags.py
+++ b/tests/test_tool_tags.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from backend.app.agent.core import BackshopAgent
-from backend.app.agent.tools.base import Tool, ToolTags
+from backend.app.agent.tools.base import Tool, ToolResult, ToolTags
 from backend.app.agent.tools.memory_tools import create_memory_tools
 from backend.app.agent.tools.messaging_tools import create_messaging_tools
 from backend.app.models import Contractor
@@ -132,7 +132,7 @@ async def test_agent_tool_call_records_include_tags(
     followup_response = make_text_response("Got it!")
     mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
 
-    mock_save = AsyncMock(return_value="Saved rate = $50/hr")
+    mock_save = AsyncMock(return_value=ToolResult(content="Saved rate = $50/hr"))
     tool = Tool(
         name="save_fact",
         description="Save a fact",
@@ -167,7 +167,7 @@ async def test_agent_memories_saved_uses_tags_not_name(
     followup_response = make_text_response("Noted!")
     mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
 
-    mock_fn = AsyncMock(return_value="Saved")
+    mock_fn = AsyncMock(return_value=ToolResult(content="Saved"))
     tool = Tool(
         name="custom_memory_saver",
         description="Custom memory saver",
@@ -201,7 +201,7 @@ async def test_agent_untagged_tool_has_empty_tags(
     followup_response = make_text_response("Done!")
     mock_acompletion.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
 
-    mock_fn = AsyncMock(return_value="ok")
+    mock_fn = AsyncMock(return_value=ToolResult(content="ok"))
     tool = Tool(
         name="some_tool",
         description="A tool",


### PR DESCRIPTION
## Description

Remove unnecessary backwards compatibility code paths since the project is not in production yet (fixes #319).

- Remove `_dict_to_message()` and dict-based conversation history support in `process_message()` (all callers already use typed `AgentMessage` objects)
- Remove plain string tool return fallback in the agent loop (all tools already return `ToolResult`)
- Remove two backwards compat tests (`test_plain_string_return_backward_compat`, `test_agent_no_params_model_skips_validation`)
- Update all test tool functions/mocks to return `ToolResult` instead of plain strings
- Convert all dict-based test conversation histories to typed `UserMessage`/`AssistantMessage`
- Fix all pre-existing ty type errors (19 -> 0)

Net result: -146 lines added, +58 lines removed = **88 fewer lines of code**.

Fixes #319

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code: identified backwards compat patterns, implemented removal, fixed pre-existing type errors)
- [ ] No AI used