### PR TITLE
feat: concurrent contractor processing in heartbeat

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -597,15 +597,28 @@ class HeartbeatScheduler:
             await asyncio.sleep(settings.heartbeat_interval_minutes * 60)
 
     async def tick(self) -> None:
-        """Single heartbeat pass: evaluate every onboarded contractor."""
-        db: Session = SessionLocal()
+        """Single heartbeat pass: evaluate every onboarded contractor concurrently."""
+        # Use a dedicated session just to fetch the contractor list, then close it.
+        listing_db: Session = SessionLocal()
         try:
             contractors = (
-                db.query(Contractor).filter(Contractor.onboarding_complete.is_(True)).all()
+                listing_db.query(Contractor).filter(Contractor.onboarding_complete.is_(True)).all()
             )
-            messaging_service = _build_messaging_service()
+            # Detach contractor objects so they can be used outside this session
+            listing_db.expunge_all()
+        finally:
+            listing_db.close()
 
-            for contractor in contractors:
+        if not contractors:
+            return
+
+        messaging_service = _build_messaging_service()
+        semaphore = asyncio.Semaphore(settings.heartbeat_concurrency)
+
+        async def _process_one(contractor: Contractor) -> None:
+            """Process a single contractor with its own DB session."""
+            async with semaphore:
+                db: Session = SessionLocal()
                 try:
                     await run_heartbeat_for_contractor(
                         db=db,
@@ -615,8 +628,23 @@ class HeartbeatScheduler:
                     )
                 except Exception:
                     logger.exception("Heartbeat failed for contractor %d", contractor.id)
-        finally:
-            db.close()
+                finally:
+                    db.close()
+
+        results = await asyncio.gather(
+            *[_process_one(c) for c in contractors],
+            return_exceptions=True,
+        )
+
+        # Log any unexpected exceptions that escaped the per-contractor handler
+        for i, result in enumerate(results):
+            if isinstance(result, BaseException):
+                logger.error(
+                    "Unhandled error in heartbeat for contractor %d: %s",
+                    contractors[i].id,
+                    result,
+                    exc_info=result if isinstance(result, Exception) else None,
+                )
 
 
 # Module-level singleton used by main.py lifespan

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -65,6 +65,7 @@ class Settings(BaseSettings):
     heartbeat_idle_days: int = 3  # flag contractors with no inbound messages for N days
     heartbeat_model: str = ""  # empty = fall back to llm_model
     heartbeat_provider: str = ""  # empty = fall back to llm_provider
+    heartbeat_concurrency: int = 5  # max concurrent contractor evaluations per tick
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1262,7 +1262,7 @@ class TestHeartbeatScheduler:
     async def test_tick_queries_onboarded(
         self, mock_messaging_cls: MagicMock, mock_session_local: MagicMock
     ) -> None:
-        """Tick should query only onboarded contractors and close the session."""
+        """Tick should query only onboarded contractors and close the listing session."""
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.all.return_value = []
         mock_session_local.return_value = mock_db
@@ -1271,4 +1271,178 @@ class TestHeartbeatScheduler:
         await scheduler.tick()
 
         mock_db.query.assert_called_once()
+        mock_db.expunge_all.assert_called_once()
         mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
+    @patch("backend.app.agent.heartbeat.SessionLocal")
+    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_tick_concurrent_processing(
+        self,
+        mock_settings: MagicMock,
+        mock_messaging_cls: MagicMock,
+        mock_session_local: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """tick() should process multiple contractors concurrently with per-contractor sessions."""
+        mock_settings.heartbeat_concurrency = 2
+        mock_settings.heartbeat_max_daily_messages = 5
+
+        # Create mock contractors
+        contractors = []
+        for i in range(4):
+            c = MagicMock()
+            c.id = i + 1
+            c.onboarding_complete = True
+            contractors.append(c)
+
+        # The first SessionLocal call is the listing session;
+        # subsequent calls are per-contractor sessions.
+        listing_db = MagicMock()
+        listing_db.query.return_value.filter.return_value.all.return_value = contractors
+        per_contractor_dbs = [MagicMock() for _ in contractors]
+        mock_session_local.side_effect = [listing_db, *per_contractor_dbs]
+
+        mock_run.return_value = None
+
+        scheduler = HeartbeatScheduler()
+        await scheduler.tick()
+
+        # Listing session should be closed after fetching contractors
+        listing_db.expunge_all.assert_called_once()
+        listing_db.close.assert_called_once()
+
+        # run_heartbeat_for_contractor called once per contractor
+        assert mock_run.await_count == len(contractors)
+
+        # Each per-contractor session should be closed
+        for db_mock in per_contractor_dbs:
+            db_mock.close.assert_called_once()
+
+        # Verify each call used its own DB session (not the listing session)
+        for call_args in mock_run.call_args_list:
+            used_db = call_args.kwargs.get("db") or call_args[0][0]
+            assert used_db is not listing_db
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
+    @patch("backend.app.agent.heartbeat.SessionLocal")
+    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_tick_error_isolation(
+        self,
+        mock_settings: MagicMock,
+        mock_messaging_cls: MagicMock,
+        mock_session_local: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """One contractor failure should not prevent others from being processed."""
+        mock_settings.heartbeat_concurrency = 5
+        mock_settings.heartbeat_max_daily_messages = 5
+
+        contractors = []
+        for i in range(3):
+            c = MagicMock()
+            c.id = i + 1
+            c.onboarding_complete = True
+            contractors.append(c)
+
+        listing_db = MagicMock()
+        listing_db.query.return_value.filter.return_value.all.return_value = contractors
+        per_contractor_dbs = [MagicMock() for _ in contractors]
+        mock_session_local.side_effect = [listing_db, *per_contractor_dbs]
+
+        # Second contractor raises, others succeed
+        mock_run.side_effect = [
+            HeartbeatAction("no_action", "", "clean", 0),
+            RuntimeError("LLM timeout"),
+            HeartbeatAction("no_action", "", "clean", 0),
+        ]
+
+        scheduler = HeartbeatScheduler()
+        # Should not raise despite one contractor failing
+        await scheduler.tick()
+
+        # All three were attempted
+        assert mock_run.await_count == 3
+
+        # All per-contractor sessions closed, even the failing one
+        for db_mock in per_contractor_dbs:
+            db_mock.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
+    @patch("backend.app.agent.heartbeat.SessionLocal")
+    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_tick_semaphore_limits_concurrency(
+        self,
+        mock_settings: MagicMock,
+        mock_messaging_cls: MagicMock,
+        mock_session_local: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """Semaphore should limit the number of concurrent contractor evaluations."""
+        concurrency_limit = 2
+        mock_settings.heartbeat_concurrency = concurrency_limit
+        mock_settings.heartbeat_max_daily_messages = 5
+
+        contractors = []
+        for i in range(5):
+            c = MagicMock()
+            c.id = i + 1
+            c.onboarding_complete = True
+            contractors.append(c)
+
+        listing_db = MagicMock()
+        listing_db.query.return_value.filter.return_value.all.return_value = contractors
+        per_contractor_dbs = [MagicMock() for _ in contractors]
+        mock_session_local.side_effect = [listing_db, *per_contractor_dbs]
+
+        # Track max concurrent executions
+        import asyncio
+
+        current_count = 0
+        max_concurrent = 0
+        lock = asyncio.Lock()
+
+        async def tracked_run(*args: object, **kwargs: object) -> HeartbeatAction:
+            nonlocal current_count, max_concurrent
+            async with lock:
+                current_count += 1
+                if current_count > max_concurrent:
+                    max_concurrent = current_count
+            # Simulate some async work so concurrency can be observed
+            await asyncio.sleep(0.01)
+            async with lock:
+                current_count -= 1
+            return HeartbeatAction("no_action", "", "clean", 0)
+
+        mock_run.side_effect = tracked_run
+
+        scheduler = HeartbeatScheduler()
+        await scheduler.tick()
+
+        assert mock_run.await_count == 5
+        assert max_concurrent <= concurrency_limit
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.SessionLocal")
+    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    async def test_tick_no_contractors(
+        self, mock_messaging_cls: MagicMock, mock_session_local: MagicMock
+    ) -> None:
+        """tick() with no onboarded contractors should return early."""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+        mock_session_local.return_value = mock_db
+
+        scheduler = HeartbeatScheduler()
+        await scheduler.tick()
+
+        # Listing session should still be closed
+        mock_db.close.assert_called_once()
+        # SessionLocal called only once (listing session, no per-contractor sessions)
+        mock_session_local.assert_called_once()


### PR DESCRIPTION
## Description
Process contractors concurrently in the heartbeat tick using `asyncio.gather` with a configurable semaphore. Each contractor gets its own DB session to avoid shared session issues across coroutines. Error isolation ensures one contractor's failure does not affect others.

Fixes #88

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Changes
- Added `heartbeat_concurrency` setting (default: 5) to `Settings` in `backend/app/config.py`
- Refactored `HeartbeatScheduler.tick()` in `backend/app/agent/heartbeat.py`:
  - Listing DB session fetches contractors then closes immediately (with `expunge_all` to detach objects)
  - Each contractor is processed in its own coroutine with a dedicated DB session
  - `asyncio.Semaphore` limits the number of concurrent evaluations
  - `asyncio.gather(return_exceptions=True)` provides error isolation
- Added 4 new tests for concurrent behavior:
  - `test_tick_concurrent_processing`: verifies per-contractor sessions and parallel dispatch
  - `test_tick_error_isolation`: one failure does not block others, sessions always close
  - `test_tick_semaphore_limits_concurrency`: tracks max concurrent count stays within limit
  - `test_tick_no_contractors`: early return when no contractors found

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation generated by Claude Code (claude-opus-4-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)