### PR TITLE
feat: add per-contractor heartbeat opt-out and frequency preferences

### DIFF
--- a/alembic/versions/004_add_contractor_heartbeat_preferences.py
+++ b/alembic/versions/004_add_contractor_heartbeat_preferences.py
@@ -1,0 +1,39 @@
+"""Add heartbeat_opt_in and heartbeat_frequency to contractors
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-03-03
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "004"
+down_revision: str | None = "003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "contractors",
+        sa.Column(
+            "heartbeat_opt_in",
+            sa.Boolean(),
+            server_default=sa.sql.expression.true(),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "contractors",
+        sa.Column("heartbeat_frequency", sa.String(20), server_default="", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("contractors", "heartbeat_frequency")
+    op.drop_column("contractors", "heartbeat_opt_in")

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -96,6 +96,33 @@ CHECKLIST_DAILY_INTERVAL_HOURS = 20
 HEARTBEAT_RECENT_MESSAGES_COUNT = 5
 WEEKDAY_FRIDAY = 4  # Monday=0 ... Friday=4
 
+_FREQ_RE = re.compile(r"^(\d+)\s*(m|h|d)(?:in(?:utes?)?|ours?|ays?)?$", re.IGNORECASE)
+
+
+def parse_frequency_to_minutes(freq: str) -> int | None:
+    """Parse a human-friendly frequency string into minutes.
+
+    Supports formats like ``"30m"``, ``"1h"``, ``"2d"``, ``"daily"``.
+    Returns *None* when the string is empty or cannot be parsed.
+    """
+    freq = freq.strip()
+    if not freq:
+        return None
+    if freq.lower() == "daily":
+        return 1440  # 24 * 60
+    m = _FREQ_RE.match(freq)
+    if not m:
+        return None
+    value = int(m.group(1))
+    unit = m.group(2).lower()
+    if unit == "m":
+        return value
+    if unit == "h":
+        return value * 60
+    if unit == "d":
+        return value * 1440
+    return None
+
 
 @dataclass
 class CheapCheckResult:
@@ -492,6 +519,10 @@ async def run_heartbeat_for_contractor(
     if not contractor.onboarding_complete:
         return None
 
+    # Gate: contractor heartbeat opt-in
+    if not contractor.heartbeat_opt_in:
+        return None
+
     # Gate: business hours
     if not is_within_business_hours(contractor):
         return None
@@ -499,6 +530,28 @@ async def run_heartbeat_for_contractor(
     # Gate: daily rate limit (persistent via heartbeat_log table)
     if get_daily_heartbeat_count(db, contractor.id) >= max_daily:
         return None
+
+    # Gate: per-contractor frequency override
+    freq_minutes = parse_frequency_to_minutes(contractor.heartbeat_frequency)
+    if freq_minutes is not None:
+        last_outbound = (
+            db.query(Message.created_at)
+            .join(Conversation, Message.conversation_id == Conversation.id)
+            .filter(
+                Conversation.contractor_id == contractor.id,
+                Message.direction == MessageDirection.OUTBOUND,
+            )
+            .order_by(Message.created_at.desc())
+            .first()
+        )
+        if last_outbound is not None:
+            last_ts = last_outbound[0]
+            if last_ts.tzinfo is None:
+                last_ts = last_ts.replace(tzinfo=datetime.UTC)
+            now = datetime.datetime.now(datetime.UTC)
+            elapsed = now - last_ts
+            if elapsed < datetime.timedelta(minutes=freq_minutes):
+                return None
 
     # Cheap checks -- skip LLM entirely if nothing is flagged
     check_result = run_cheap_checks(db, contractor)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -23,6 +23,8 @@ class Contractor(Base):
     channel_identifier: Mapped[str] = mapped_column(String(255), default="")
     onboarding_complete: Mapped[bool] = mapped_column(Boolean, default=False)
     preferences_json: Mapped[str] = mapped_column(Text, default="{}")
+    heartbeat_opt_in: Mapped[bool] = mapped_column(Boolean, default=True)
+    heartbeat_frequency: Mapped[str] = mapped_column(String(20), default="")
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -24,6 +24,7 @@ from backend.app.agent.heartbeat import (
     evaluate_heartbeat_need,
     get_daily_heartbeat_count,
     is_within_business_hours,
+    parse_frequency_to_minutes,
     run_cheap_checks,
     run_heartbeat_for_contractor,
 )
@@ -1446,3 +1447,244 @@ class TestHeartbeatScheduler:
         mock_db.close.assert_called_once()
         # SessionLocal called only once (listing session, no per-contractor sessions)
         mock_session_local.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# parse_frequency_to_minutes
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrequencyToMinutes:
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_frequency_to_minutes("") is None
+
+    def test_whitespace_returns_none(self) -> None:
+        assert parse_frequency_to_minutes("   ") is None
+
+    def test_daily_keyword(self) -> None:
+        assert parse_frequency_to_minutes("daily") == 1440
+
+    def test_daily_case_insensitive(self) -> None:
+        assert parse_frequency_to_minutes("Daily") == 1440
+        assert parse_frequency_to_minutes("DAILY") == 1440
+
+    def test_minutes_short(self) -> None:
+        assert parse_frequency_to_minutes("30m") == 30
+
+    def test_hours_short(self) -> None:
+        assert parse_frequency_to_minutes("1h") == 60
+        assert parse_frequency_to_minutes("2h") == 120
+
+    def test_days_short(self) -> None:
+        assert parse_frequency_to_minutes("1d") == 1440
+        assert parse_frequency_to_minutes("2d") == 2880
+
+    def test_long_form_minutes(self) -> None:
+        assert parse_frequency_to_minutes("45minutes") == 45
+        assert parse_frequency_to_minutes("1minute") == 1
+
+    def test_long_form_hours(self) -> None:
+        assert parse_frequency_to_minutes("3hours") == 180
+        assert parse_frequency_to_minutes("1hour") == 60
+
+    def test_long_form_days(self) -> None:
+        assert parse_frequency_to_minutes("1day") == 1440
+        assert parse_frequency_to_minutes("2days") == 2880
+
+    def test_invalid_returns_none(self) -> None:
+        assert parse_frequency_to_minutes("never") is None
+        assert parse_frequency_to_minutes("weekly") is None
+        assert parse_frequency_to_minutes("abc") is None
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat opt-in / frequency gate tests
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatOptIn:
+    @pytest.mark.asyncio
+    async def test_opted_out_contractor_is_skipped(
+        self, db: Session, contractor: Contractor
+    ) -> None:
+        """A contractor with heartbeat_opt_in=False should be skipped entirely."""
+        contractor.heartbeat_opt_in = False
+        db.commit()
+
+        mock_messaging = AsyncMock()
+        result = await run_heartbeat_for_contractor(db, contractor, mock_messaging, 5)
+
+        assert result is None
+        mock_messaging.send_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.run_cheap_checks")
+    async def test_opted_in_contractor_proceeds(
+        self,
+        mock_checks: MagicMock,
+        mock_eval: MagicMock,
+        db: Session,
+        contractor: Contractor,
+    ) -> None:
+        """A contractor with heartbeat_opt_in=True (default) should proceed normally."""
+        assert contractor.heartbeat_opt_in is True
+
+        mock_checks.return_value = CheapCheckResult(flags=[])
+        mock_messaging = AsyncMock()
+
+        with patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True):
+            result = await run_heartbeat_for_contractor(db, contractor, mock_messaging, 5)
+
+        # Should get no_action because cheap checks are clean, but NOT None (not skipped)
+        assert result is not None
+        assert result.action_type == "no_action"
+
+    @pytest.mark.asyncio
+    async def test_default_opt_in_is_true(self, db: Session) -> None:
+        """New contractors should have heartbeat_opt_in=True by default."""
+        c = Contractor(
+            user_id="hb-opt-in-default",
+            name="Default Contractor",
+            onboarding_complete=True,
+        )
+        db.add(c)
+        db.commit()
+        db.refresh(c)
+
+        assert c.heartbeat_opt_in is True
+
+    @pytest.mark.asyncio
+    async def test_default_frequency_is_empty(self, db: Session) -> None:
+        """New contractors should have empty heartbeat_frequency by default."""
+        c = Contractor(
+            user_id="hb-freq-default",
+            name="Default Freq Contractor",
+            onboarding_complete=True,
+        )
+        db.add(c)
+        db.commit()
+        db.refresh(c)
+
+        assert c.heartbeat_frequency == ""
+
+
+class TestHeartbeatFrequencyGate:
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
+    @patch("backend.app.agent.heartbeat.run_cheap_checks")
+    async def test_frequency_gate_blocks_when_too_soon(
+        self,
+        mock_checks: MagicMock,
+        mock_biz_hours: MagicMock,
+        db: Session,
+        contractor: Contractor,
+    ) -> None:
+        """If the contractor's frequency has not elapsed, skip the heartbeat."""
+        contractor.heartbeat_frequency = "2h"
+        db.commit()
+
+        # Create a recent outbound message (30 minutes ago)
+        conv = Conversation(contractor_id=contractor.id, is_active=True)
+        db.add(conv)
+        db.commit()
+        db.refresh(conv)
+
+        recent_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
+        msg = Message(
+            conversation_id=conv.id,
+            direction="outbound",
+            body="Previous heartbeat",
+            created_at=recent_time,
+        )
+        db.add(msg)
+        db.commit()
+
+        mock_messaging = AsyncMock()
+        result = await run_heartbeat_for_contractor(db, contractor, mock_messaging, 5)
+
+        assert result is None
+        mock_checks.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
+    @patch("backend.app.agent.heartbeat.run_cheap_checks")
+    async def test_frequency_gate_allows_when_elapsed(
+        self,
+        mock_checks: MagicMock,
+        mock_biz_hours: MagicMock,
+        db: Session,
+        contractor: Contractor,
+    ) -> None:
+        """If enough time has elapsed since the last message, proceed."""
+        contractor.heartbeat_frequency = "1h"
+        db.commit()
+
+        # Create an old outbound message (2 hours ago)
+        conv = Conversation(contractor_id=contractor.id, is_active=True)
+        db.add(conv)
+        db.commit()
+        db.refresh(conv)
+
+        old_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=2)
+        msg = Message(
+            conversation_id=conv.id,
+            direction="outbound",
+            body="Old heartbeat",
+            created_at=old_time,
+        )
+        db.add(msg)
+        db.commit()
+
+        mock_checks.return_value = CheapCheckResult(flags=[])
+        mock_messaging = AsyncMock()
+
+        result = await run_heartbeat_for_contractor(db, contractor, mock_messaging, 5)
+
+        assert result is not None
+        assert result.action_type == "no_action"
+        mock_checks.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
+    @patch("backend.app.agent.heartbeat.run_cheap_checks")
+    async def test_empty_frequency_skips_gate(
+        self,
+        mock_checks: MagicMock,
+        mock_biz_hours: MagicMock,
+        db: Session,
+        contractor: Contractor,
+    ) -> None:
+        """An empty heartbeat_frequency should not apply any frequency gate."""
+        contractor.heartbeat_frequency = ""
+        db.commit()
+
+        mock_checks.return_value = CheapCheckResult(flags=[])
+        mock_messaging = AsyncMock()
+
+        result = await run_heartbeat_for_contractor(db, contractor, mock_messaging, 5)
+
+        assert result is not None
+        mock_checks.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
+    @patch("backend.app.agent.heartbeat.run_cheap_checks")
+    async def test_frequency_gate_allows_when_no_prior_messages(
+        self,
+        mock_checks: MagicMock,
+        mock_biz_hours: MagicMock,
+        db: Session,
+        contractor: Contractor,
+    ) -> None:
+        """If there are no prior outbound messages, the frequency gate should not block."""
+        contractor.heartbeat_frequency = "1h"
+        db.commit()
+
+        mock_checks.return_value = CheapCheckResult(flags=[])
+        mock_messaging = AsyncMock()
+
+        result = await run_heartbeat_for_contractor(db, contractor, mock_messaging, 5)
+
+        assert result is not None
+        mock_checks.assert_called_once()


### PR DESCRIPTION
## Description
Add per-contractor heartbeat opt-out and frequency preferences to give contractors control over proactive messaging.

- Add `heartbeat_opt_in` (Boolean, default `True`) and `heartbeat_frequency` (String(20), default `""`) columns to the `Contractor` model
- Create Alembic migration `003` for the new columns
- Add `parse_frequency_to_minutes()` helper that parses human-friendly frequency strings (`"30m"`, `"1h"`, `"2d"`, `"daily"`) into minutes
- Update `run_heartbeat_for_contractor()` with two new gates:
  - **Opt-in gate**: skip contractors with `heartbeat_opt_in=False`
  - **Frequency gate**: skip if the last outbound message was sent less than `heartbeat_frequency` ago
- Add 19 new tests covering frequency parsing, opt-in/opt-out behavior, frequency gating (too soon, elapsed, empty, no prior messages), and default values

Fixes #87

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)