### PR TITLE
feat: add selective tool injection based on message context

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -150,7 +150,6 @@ async def build_message_context(
     return combined_context
 
 
-
 async def run_agent(
     db: Session,
     contractor: Contractor,

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -40,11 +40,11 @@ _ALWAYS_INCLUDE: frozenset[str] = frozenset({"memory", "messaging", "profile"})
 # Each entry maps a factory name to a compiled regex of trigger words.
 _KEYWORD_RULES: dict[str, re.Pattern[str]] = {
     "estimate": re.compile(
-        r"\b(estimate|quote|bid|price|cost|how\s+much|invoice)\b",
+        r"\b(estimates?|quotes?|bids?|prices?|pricing|costs?|costing|invoices?|how\s+much)\b",
         re.IGNORECASE,
     ),
     "checklist": re.compile(
-        r"\b(checklist|reminder|todo|task|to-do)\b",
+        r"\b(checklists?|reminders?|todos?|tasks?|to-dos?)\b",
         re.IGNORECASE,
     ),
 }
@@ -121,10 +121,11 @@ def select_tools(
             selected.add(name)
             specialized_matched = True
 
-    # Include file tools when media is present and storage is available
+    # Include file tools when media is present and storage is available.
+    # Media presence is orthogonal to keyword matching: it adds file tools
+    # but does not count as a "specialized match" for fallback purposes.
     if has_media and has_storage and "file" in all_names:
         selected.add("file")
-        specialized_matched = True
 
     # Fallback: when no specialized keywords matched, include everything
     # so the model has full capability for ambiguous or general messages

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -192,12 +192,66 @@ class TestWordBoundaries:
         # 'estimated' does NOT match \bestimate\b, so no specialized match, fallback
         assert result == set(ALL_FACTORIES)
 
-    def test_costing_does_not_match_cost(self) -> None:
+    def test_costing_matches_estimate(self) -> None:
         result = select_tools("The costing method is simple", factory_names=ALL_FACTORIES)
-        # 'costing' does NOT match \bcost\b, fallback to all
-        assert result == set(ALL_FACTORIES)
+        # 'costing' matches the estimate regex as a verb form
+        assert "estimate" in result
 
     def test_priceless_does_not_match_price(self) -> None:
         result = select_tools("That view is priceless", factory_names=ALL_FACTORIES)
         # 'priceless' does NOT match \bprice\b, fallback to all
         assert result == set(ALL_FACTORIES)
+
+
+class TestPluralForms:
+    """Plural and verb forms of keywords trigger tool selection."""
+
+    @pytest.mark.parametrize(
+        "keyword",
+        ["estimates", "quotes", "bids", "prices", "pricing", "costs", "costing", "invoices"],
+    )
+    def test_estimate_plural_and_verb_forms(self, keyword: str) -> None:
+        result = select_tools(
+            f"Send me the {keyword} for this job",
+            factory_names=ALL_FACTORIES,
+        )
+        assert "estimate" in result
+
+    @pytest.mark.parametrize(
+        "keyword",
+        ["checklists", "reminders", "todos", "tasks", "to-dos"],
+    )
+    def test_checklist_plural_forms(self, keyword: str) -> None:
+        result = select_tools(
+            f"Show me my {keyword}",
+            factory_names=ALL_FACTORIES,
+        )
+        assert "checklist" in result
+
+
+class TestMediaOrthogonality:
+    """Media presence adds file tools but does not suppress fallback."""
+
+    def test_media_without_keywords_still_falls_back_to_all(self) -> None:
+        """When media is present but no keywords match, all tools are included."""
+        result = select_tools(
+            "Here is the photo",
+            has_media=True,
+            has_storage=True,
+            factory_names=ALL_FACTORIES,
+        )
+        # No keyword matched, so fallback includes all tools
+        assert result == set(ALL_FACTORIES)
+
+    def test_media_with_keywords_does_not_include_unmatched(self) -> None:
+        """When media is present and keywords match, only matched + file + always tools."""
+        result = select_tools(
+            "Here is the estimate photo",
+            has_media=True,
+            has_storage=True,
+            factory_names=ALL_FACTORIES,
+        )
+        assert "estimate" in result
+        assert "file" in result
+        assert "memory" in result
+        assert "checklist" not in result


### PR DESCRIPTION
## Description
Add context-aware tool selection to reduce token waste and model confusion. Instead of registering all tools for every inbound message, a new `select_tools()` function filters tool factories based on message content, media presence, and storage configuration.

**Selection logic:**
- Always include: memory, messaging, profile tools
- Include estimate tools when: message contains "estimate", "quote", "bid", "price", "cost", "how much", "invoice"
- Include file tools when: media is present AND storage is configured
- Include checklist tools when: message contains "checklist", "reminder", "todo", "task", "to-do"
- Fallback: when no specialized keywords match, include all tools (preserves current behavior for ambiguous messages)

Fixes #178

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation authored with Claude Code (Claude Opus 4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)