### PR TITLE
feat: send typing indicator before each LLM call

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -46,6 +46,7 @@ from backend.app.agent.tools.base import (
 from backend.app.config import settings
 from backend.app.models import Contractor
 from backend.app.services.llm_usage import log_llm_usage
+from backend.app.services.messaging import MessagingService
 
 logger = logging.getLogger(__name__)
 
@@ -223,9 +224,17 @@ class AgentResponse:
 class BackshopAgent:
     """Main agent that processes contractor messages and produces actions."""
 
-    def __init__(self, db: Session, contractor: Contractor) -> None:
+    def __init__(
+        self,
+        db: Session,
+        contractor: Contractor,
+        messaging_service: MessagingService | None = None,
+        chat_id: str | None = None,
+    ) -> None:
         self.db = db
         self.contractor = contractor
+        self._messaging_service = messaging_service
+        self._chat_id = chat_id
         self.tools: list[Tool] = []
         self._tools_by_name: dict[str, Tool] = {}
         self._subscribers: list[Callable[[AgentEvent], Awaitable[None]]] = []
@@ -245,6 +254,14 @@ class BackshopAgent:
                 await cb(event)
             except Exception:
                 logger.exception("Event subscriber error for %s", type(event).__name__)
+
+    async def _send_typing_indicator(self) -> None:
+        """Send a typing indicator if a messaging service and chat_id are available."""
+        if self._messaging_service and self._chat_id:
+            try:
+                await self._messaging_service.send_typing_indicator(to=self._chat_id)
+            except Exception:
+                logger.debug("Failed to send typing indicator to %s", self._chat_id)
 
     def register_tools(self, tools: list[Tool]) -> None:
         """Register available tools for this agent session."""
@@ -275,6 +292,7 @@ class BackshopAgent:
         ContentFilterError and AuthenticationError are re-raised with
         appropriate logging so the caller can produce a user-facing message.
         """
+        await self._send_typing_indicator()
         msg_dicts = messages_to_dicts(messages)
         try:
             return cast(

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -461,13 +461,24 @@ async def evaluate_heartbeat_need(
     db: Session,
     contractor: Contractor,
     flags: list[str],
+    messaging_service: MessagingService | None = None,
 ) -> HeartbeatAction:
     """Ask the LLM to compose a message based on flagged items.
 
     Uses the compose_message tool calling protocol instead of raw JSON parsing.
     If the LLM does not call the tool, defaults to no_action.
+    Sends a typing indicator before the LLM call when a messaging_service is provided.
     """
     prompt = await build_heartbeat_context(db, contractor, flags)
+
+    # Send typing indicator before LLM call
+    if messaging_service:
+        to_address = contractor.channel_identifier or contractor.phone
+        if to_address:
+            try:
+                await messaging_service.send_typing_indicator(to=to_address)
+            except Exception:
+                logger.debug("Failed to send heartbeat typing indicator to %s", to_address)
 
     model = settings.heartbeat_model or settings.llm_model
     provider = settings.heartbeat_provider or settings.llm_provider
@@ -584,7 +595,9 @@ async def run_heartbeat_for_contractor(
         )
 
     # Something was flagged -- escalate to LLM for message composition
-    action = await evaluate_heartbeat_need(db, contractor, check_result.flags)
+    action = await evaluate_heartbeat_need(
+        db, contractor, check_result.flags, messaging_service=messaging_service
+    )
 
     if action.action_type != "send_message" or not action.message:
         return action

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -168,7 +168,12 @@ async def run_agent(
     Handles LLM-level errors (content filter, auth, unexpected) by returning
     an error fallback AgentResponse.
     """
-    agent = BackshopAgent(db=db, contractor=contractor)
+    agent = BackshopAgent(
+        db=db,
+        contractor=contractor,
+        messaging_service=messaging_service,
+        chat_id=to_address,
+    )
 
     tool_context = ToolContext(
         db=db,
@@ -191,12 +196,7 @@ async def run_agent(
     for subscriber in event_subscribers or []:
         agent.subscribe(subscriber)
 
-    # Send typing indicator while processing (non-blocking on failure)
-    try:
-        await messaging_service.send_typing_indicator(to=to_address)
-    except Exception:
-        logger.debug("Failed to send typing indicator to %s", to_address)
-
+    # Note: typing indicators are sent automatically by the agent before each LLM call
     try:
         return await agent.process_message(
             message_context=combined_context,

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1153,7 +1153,9 @@ class TestRunHeartbeatForContractor:
         logs = db.query(HeartbeatLog).filter(HeartbeatLog.contractor_id == contractor.id).all()
         assert len(logs) == 1
         # LLM was called with the flags
-        mock_eval.assert_awaited_once_with(db, contractor, ["Stale draft estimate"])
+        mock_eval.assert_awaited_once_with(
+            db, contractor, ["Stale draft estimate"], messaging_service=mock_messaging
+        )
 
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -1,0 +1,278 @@
+"""Tests for typing indicator integration with the agent loop and heartbeat."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.core import BackshopAgent
+from backend.app.agent.heartbeat import evaluate_heartbeat_need
+from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.models import Contractor
+from backend.app.services.messaging import MessagingService
+from tests.mocks.llm import make_text_response, make_tool_call_response
+
+# ---------------------------------------------------------------------------
+# BackshopAgent typing indicator tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_sends_typing_indicator_before_llm_call(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Agent should send a typing indicator before each acompletion call."""
+    mock_acompletion.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
+
+    mock_messaging = MagicMock(spec=MessagingService)
+    mock_messaging.send_typing_indicator = AsyncMock()
+
+    agent = BackshopAgent(
+        db=db_session,
+        contractor=test_contractor,
+        messaging_service=mock_messaging,
+        chat_id="123456789",
+    )
+    await agent.process_message("Hi there")
+
+    mock_messaging.send_typing_indicator.assert_called_once_with(to="123456789")
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_sends_typing_indicator_before_each_tool_round(
+    mock_acompletion: object,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Agent should send typing indicator before each LLM call in multi-round tool loops."""
+
+    async def mock_tool_fn(**kwargs: object) -> ToolResult:
+        return ToolResult(content="tool result")
+
+    tool = Tool(
+        name="test_tool",
+        description="A test tool",
+        function=mock_tool_fn,
+        parameters={
+            "type": "object",
+            "properties": {"input": {"type": "string"}},
+            "required": ["input"],
+        },
+    )
+
+    # First call returns a tool call, second call returns a text response
+    mock_acompletion.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(
+            [{"name": "test_tool", "arguments": json.dumps({"input": "test"})}],
+            content=None,
+        ),
+        make_text_response("Done!"),
+    ]
+
+    mock_messaging = MagicMock(spec=MessagingService)
+    mock_messaging.send_typing_indicator = AsyncMock()
+
+    agent = BackshopAgent(
+        db=db_session,
+        contractor=test_contractor,
+        messaging_service=mock_messaging,
+        chat_id="123456789",
+    )
+    agent.register_tools([tool])
+    response = await agent.process_message("Do something")
+
+    assert response.reply_text == "Done!"
+    # Called twice: once before initial LLM call, once before second LLM call after tool execution
+    assert mock_messaging.send_typing_indicator.call_count == 2
+    mock_messaging.send_typing_indicator.assert_called_with(to="123456789")
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_works_without_messaging_service(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Agent should work correctly when no messaging_service is provided."""
+    mock_acompletion.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
+
+    agent = BackshopAgent(db=db_session, contractor=test_contractor)
+    response = await agent.process_message("Hi there")
+
+    assert response.reply_text == "Hello!"
+    mock_acompletion.assert_called_once()  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_typing_indicator_failure_does_not_break_agent(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Agent should continue processing even if typing indicator fails."""
+    mock_acompletion.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
+
+    mock_messaging = MagicMock(spec=MessagingService)
+    mock_messaging.send_typing_indicator = AsyncMock(side_effect=RuntimeError("API down"))
+
+    agent = BackshopAgent(
+        db=db_session,
+        contractor=test_contractor,
+        messaging_service=mock_messaging,
+        chat_id="123456789",
+    )
+    response = await agent.process_message("Hi there")
+
+    assert response.reply_text == "Hello!"
+    mock_messaging.send_typing_indicator.assert_called_once_with(to="123456789")
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.acompletion")
+async def test_agent_no_typing_indicator_without_chat_id(
+    mock_acompletion: object, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Agent should not send typing indicator when chat_id is not provided."""
+    mock_acompletion.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
+
+    mock_messaging = MagicMock(spec=MessagingService)
+    mock_messaging.send_typing_indicator = AsyncMock()
+
+    agent = BackshopAgent(
+        db=db_session,
+        contractor=test_contractor,
+        messaging_service=mock_messaging,
+        chat_id=None,
+    )
+    await agent.process_message("Hi there")
+
+    mock_messaging.send_typing_indicator.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat typing indicator tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.heartbeat.settings")
+@patch("backend.app.agent.heartbeat.acompletion")
+async def test_heartbeat_sends_typing_indicator_before_llm_call(
+    mock_llm: AsyncMock,
+    mock_settings: MagicMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Heartbeat should send typing indicator before calling the LLM."""
+    mock_settings.llm_model = "gpt-4o"
+    mock_settings.llm_provider = "openai"
+    mock_settings.llm_api_base = None
+    mock_settings.heartbeat_model = ""
+    mock_settings.heartbeat_provider = ""
+    mock_settings.llm_max_tokens_heartbeat = 256
+
+    # Build a mock tool call response
+    mock_tc = MagicMock()
+    mock_tc.id = "call_0"
+    mock_tc.function.name = "compose_message"
+    mock_tc.function.arguments = json.dumps(
+        {
+            "action": "no_action",
+            "message": "",
+            "reasoning": "Nothing actionable",
+            "priority": 1,
+        }
+    )
+    msg = MagicMock()
+    msg.content = None
+    msg.tool_calls = [mock_tc]
+    msg.model_dump.return_value = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_0",
+                "type": "function",
+                "function": {
+                    "name": "compose_message",
+                    "arguments": mock_tc.function.arguments,
+                },
+            }
+        ],
+    }
+    choice = MagicMock()
+    choice.message = msg
+    mock_llm.return_value = MagicMock(choices=[choice])
+
+    mock_messaging = MagicMock(spec=MessagingService)
+    mock_messaging.send_typing_indicator = AsyncMock()
+
+    await evaluate_heartbeat_need(
+        db_session,
+        test_contractor,
+        ["Stale draft estimate"],
+        messaging_service=mock_messaging,
+    )
+
+    mock_messaging.send_typing_indicator.assert_called_once_with(
+        to=test_contractor.channel_identifier
+    )
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.heartbeat.settings")
+@patch("backend.app.agent.heartbeat.acompletion")
+async def test_heartbeat_works_without_messaging_service(
+    mock_llm: AsyncMock,
+    mock_settings: MagicMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Heartbeat should work when no messaging_service is provided."""
+    mock_settings.llm_model = "gpt-4o"
+    mock_settings.llm_provider = "openai"
+    mock_settings.llm_api_base = None
+    mock_settings.heartbeat_model = ""
+    mock_settings.heartbeat_provider = ""
+    mock_settings.llm_max_tokens_heartbeat = 256
+
+    mock_tc = MagicMock()
+    mock_tc.id = "call_0"
+    mock_tc.function.name = "compose_message"
+    mock_tc.function.arguments = json.dumps(
+        {
+            "action": "no_action",
+            "message": "",
+            "reasoning": "Nothing actionable",
+            "priority": 1,
+        }
+    )
+    msg = MagicMock()
+    msg.content = None
+    msg.tool_calls = [mock_tc]
+    msg.model_dump.return_value = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_0",
+                "type": "function",
+                "function": {
+                    "name": "compose_message",
+                    "arguments": mock_tc.function.arguments,
+                },
+            }
+        ],
+    }
+    choice = MagicMock()
+    choice.message = msg
+    mock_llm.return_value = MagicMock(choices=[choice])
+
+    # Should not raise when no messaging_service is provided
+    action = await evaluate_heartbeat_need(
+        db_session,
+        test_contractor,
+        ["Stale draft estimate"],
+    )
+    assert action.action_type == "no_action"


### PR DESCRIPTION
## Description
Send a "typing..." chat action indicator before every `acompletion()` call in the agent loop and heartbeat engine. Previously, a single typing indicator was sent in the router before the agent started processing. Now the indicator fires before each LLM round (including tool-loop iterations), giving the user visible feedback that the bot is still working.

Changes:
- Added optional `messaging_service` and `chat_id` params to `BackshopAgent.__init__`
- Added `_send_typing_indicator()` helper called at the start of `_call_llm_with_retry()`
- Updated `evaluate_heartbeat_need()` to accept an optional `messaging_service` and send a typing indicator before its LLM call
- Removed the redundant single typing indicator call from `router.py` (now handled internally by the agent)
- Added 7 new tests covering agent and heartbeat typing indicator behavior

Fixes #176

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)