### PR TITLE
refactor: require Pydantic params_model on all tool definitions

### DIFF
--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -77,8 +77,11 @@ def _strip_titles(obj: Any) -> Any:
 def tool_to_openai_schema(tool: Tool) -> dict[str, Any]:
     """Convert a Tool to OpenAI function calling schema.
 
-    When a params_model is set, the JSON Schema is generated from the Pydantic
-    model (single source of truth). Otherwise falls back to the raw dict.
+    The JSON Schema is generated from the tool's ``params_model``
+    (Pydantic BaseModel), which is the single source of truth for
+    parameter definitions.  Falls back to the raw ``parameters`` dict
+    only for backward compatibility with tests that create tools
+    without a ``params_model``.
     """
     if tool.params_model is not None:
         schema = tool.params_model.model_json_schema()

--- a/backend/app/agent/tools/profile_tools.py
+++ b/backend/app/agent/tools/profile_tools.py
@@ -12,6 +12,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, cast
 
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
@@ -21,6 +22,36 @@ if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
 
 logger = logging.getLogger(__name__)
+
+
+class UpdateProfileParams(BaseModel):
+    """Parameters for the update_profile tool."""
+
+    name: str | None = Field(default=None, description="Contractor's full name")
+    trade: str | None = Field(
+        default=None,
+        description="Trade or profession (e.g. plumber, electrician)",
+    )
+    location: str | None = Field(
+        default=None,
+        description="City or region where they work",
+    )
+    hourly_rate: str | None = Field(
+        default=None,
+        description="Hourly rate (e.g. '$85/hr', '85')",
+    )
+    business_hours: str | None = Field(
+        default=None,
+        description="Working hours (e.g. 'Mon-Fri 7am-5pm')",
+    )
+    communication_style: str | None = Field(
+        default=None,
+        description="Preferred communication style (e.g. 'casual', 'formal')",
+    )
+    soul_text: str | None = Field(
+        default=None,
+        description="Bio or personality description for the assistant",
+    )
 
 
 def _parse_rate(value: str) -> float | None:
@@ -135,40 +166,8 @@ def create_profile_tools(db: Session, contractor: Contractor) -> list[Tool]:
                 "Only include fields you want to change."
             ),
             function=update_profile,
+            params_model=UpdateProfileParams,
             usage_hint=("Use this to update known contractor details (name, trade, rates, etc.)."),
-            parameters={
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Contractor's full name",
-                    },
-                    "trade": {
-                        "type": "string",
-                        "description": "Trade or profession (e.g. plumber, electrician)",
-                    },
-                    "location": {
-                        "type": "string",
-                        "description": "City or region where they work",
-                    },
-                    "hourly_rate": {
-                        "type": "string",
-                        "description": "Hourly rate (e.g. '$85/hr', '85')",
-                    },
-                    "business_hours": {
-                        "type": "string",
-                        "description": "Working hours (e.g. 'Mon-Fri 7am-5pm')",
-                    },
-                    "communication_style": {
-                        "type": "string",
-                        "description": ("Preferred communication style (e.g. 'casual', 'formal')"),
-                    },
-                    "soul_text": {
-                        "type": "string",
-                        "description": ("Bio or personality description for the assistant"),
-                    },
-                },
-            },
         ),
     ]
 

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -78,7 +78,11 @@ class ToolRegistry:
         )
 
     def create_tools(self, context: ToolContext) -> list[Tool]:
-        """Create all tools whose dependencies are satisfied by the context."""
+        """Create all tools whose dependencies are satisfied by the context.
+
+        Every tool must have a ``params_model`` set so that Pydantic
+        validation runs on all arguments before execution.
+        """
         tools: list[Tool] = []
         for name, factory in self._factories.items():
             if factory.requires_storage and context.storage is None:
@@ -87,7 +91,15 @@ class ToolRegistry:
             if factory.requires_messaging and context.messaging_service is None:
                 logger.debug("Skipping %s: no messaging service", name)
                 continue
-            tools.extend(factory.create(context))
+            created = factory.create(context)
+            for tool in created:
+                if tool.params_model is None:
+                    raise ValueError(
+                        f"Tool '{tool.name}' from factory '{name}' is missing "
+                        f"a params_model. All tools must define a Pydantic "
+                        f"BaseModel for parameter validation."
+                    )
+            tools.extend(created)
         return tools
 
     @property

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,6 +8,7 @@ from any_llm import (
     ContextLengthExceededError,
     RateLimitError,
 )
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from backend.app.agent.core import (
@@ -28,6 +29,10 @@ from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.models import Contractor
 from backend.app.services.messaging import MessagingService
 from tests.mocks.llm import make_text_response, make_tool_call_response
+
+
+class _EmptyParams(BaseModel):
+    """Minimal params model used by registry tests that need a valid tool."""
 
 
 @pytest.mark.asyncio()
@@ -1384,7 +1389,14 @@ class TestToolRegistry:
             async def noop() -> ToolResult:
                 return ToolResult(content="ok")
 
-            return [Tool(name="dummy", description="test tool", function=noop)]
+            return [
+                Tool(
+                    name="dummy",
+                    description="test tool",
+                    function=noop,
+                    params_model=_EmptyParams,
+                )
+            ]
 
         registry.register("dummy", dummy_factory)
         ctx = ToolContext(db=db_session, contractor=test_contractor)
@@ -1438,10 +1450,24 @@ class TestToolRegistry:
         registry = ToolRegistry()
 
         def storage_factory(ctx: ToolContext) -> list[Tool]:
-            return [Tool(name="with_storage", description="test", function=lambda: None)]
+            return [
+                Tool(
+                    name="with_storage",
+                    description="test",
+                    function=lambda: None,
+                    params_model=_EmptyParams,
+                )
+            ]
 
         def msg_factory(ctx: ToolContext) -> list[Tool]:
-            return [Tool(name="with_msg", description="test", function=lambda: None)]
+            return [
+                Tool(
+                    name="with_msg",
+                    description="test",
+                    function=lambda: None,
+                    params_model=_EmptyParams,
+                )
+            ]
 
         registry.register("s", storage_factory, requires_storage=True)
         registry.register("m", msg_factory, requires_messaging=True)
@@ -1498,10 +1524,24 @@ class TestToolRegistry:
         registry = ToolRegistry()
 
         def factory_a(ctx: ToolContext) -> list[Tool]:
-            return [Tool(name="a", description="first", function=lambda: None)]
+            return [
+                Tool(
+                    name="a",
+                    description="first",
+                    function=lambda: None,
+                    params_model=_EmptyParams,
+                )
+            ]
 
         def factory_b(ctx: ToolContext) -> list[Tool]:
-            return [Tool(name="b", description="second", function=lambda: None)]
+            return [
+                Tool(
+                    name="b",
+                    description="second",
+                    function=lambda: None,
+                    params_model=_EmptyParams,
+                )
+            ]
 
         registry.register("same_name", factory_a)
         registry.register("same_name", factory_b)

--- a/tests/test_profile_tools.py
+++ b/tests/test_profile_tools.py
@@ -351,12 +351,14 @@ def test_extract_all_fields() -> None:
 
 
 def test_update_profile_tool_schema(db_session: Session, test_contractor: Contractor) -> None:
-    """update_profile tool should have correct name and parameter schema."""
+    """update_profile tool should have correct name and params_model schema."""
     tools = create_profile_tools(db_session, test_contractor)
     assert len(tools) == 1
     tool = tools[0]
     assert tool.name == "update_profile"
-    props = tool.parameters["properties"]
+    assert tool.params_model is not None
+    schema = tool.params_model.model_json_schema()
+    props = schema["properties"]
     assert "name" in props
     assert "trade" in props
     assert "location" in props
@@ -365,4 +367,4 @@ def test_update_profile_tool_schema(db_session: Session, test_contractor: Contra
     assert "communication_style" in props
     assert "soul_text" in props
     # No required fields since all are optional
-    assert "required" not in tool.parameters
+    assert "required" not in schema

--- a/tests/test_tool_param_validation.py
+++ b/tests/test_tool_param_validation.py
@@ -25,6 +25,7 @@ from backend.app.agent.tools.memory_tools import (
     SaveFactParams,
 )
 from backend.app.agent.tools.messaging_tools import SendMediaReplyParams, SendReplyParams
+from backend.app.agent.tools.profile_tools import UpdateProfileParams
 from backend.app.models import Contractor
 from tests.mocks.llm import make_text_response, make_tool_call_response
 
@@ -110,6 +111,11 @@ def test_checklist_tool_param_models_exist() -> None:
     assert issubclass(AddChecklistItemParams, BaseModel)
     assert issubclass(ListChecklistItemsParams, BaseModel)
     assert issubclass(RemoveChecklistItemParams, BaseModel)
+
+
+def test_profile_tool_param_models_exist() -> None:
+    """Profile tool param models should be importable and valid BaseModels."""
+    assert issubclass(UpdateProfileParams, BaseModel)
 
 
 def test_file_tool_param_models_exist() -> None:
@@ -357,3 +363,58 @@ async def test_agent_validation_wrong_type_returns_field_error(
     error_result = response.tool_calls[0]["result"]
     assert "value" in error_result
     assert "Validation error for typed_tool" in error_result
+
+
+# ---------------------------------------------------------------------------
+# Registry enforcement: tools without params_model are rejected
+# ---------------------------------------------------------------------------
+
+
+def test_registry_rejects_tool_without_params_model() -> None:
+    """Registry should raise ValueError for tools without params_model."""
+    from unittest.mock import MagicMock
+
+    from backend.app.agent.tools.registry import ToolContext, ToolRegistry
+
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
+
+    def bad_factory(ctx: ToolContext) -> list[Tool]:
+        return [
+            Tool(
+                name="legacy_tool",
+                description="No params_model",
+                function=dummy,
+                parameters={"type": "object", "properties": {}},
+            )
+        ]
+
+    registry = ToolRegistry()
+    registry.register("bad", bad_factory)
+
+    ctx = ToolContext(db=MagicMock(), contractor=MagicMock())
+    with pytest.raises(ValueError, match="missing a params_model"):
+        registry.create_tools(ctx)
+
+
+def test_update_profile_params_accepts_partial_update() -> None:
+    """UpdateProfileParams should accept partial updates with all fields optional."""
+    p = UpdateProfileParams(name="Jane Doe")
+    assert p.name == "Jane Doe"
+    assert p.trade is None
+    assert p.location is None
+
+
+def test_update_profile_params_accepts_all_fields() -> None:
+    """UpdateProfileParams should accept all fields together."""
+    p = UpdateProfileParams(
+        name="Jane Doe",
+        trade="electrician",
+        location="Portland, OR",
+        hourly_rate="$85/hr",
+        business_hours="Mon-Fri 7am-5pm",
+        communication_style="casual",
+        soul_text="Friendly and efficient",
+    )
+    assert p.name == "Jane Doe"
+    assert p.hourly_rate == "$85/hr"


### PR DESCRIPTION
## Description
Add `UpdateProfileParams` Pydantic model to `profile_tools.py` (the only tool still using a raw `parameters` dict) and enforce at registry level that every tool has a `params_model` set. This ensures Pydantic validation always runs before tool execution, closing the validation gap where tools with raw dict schemas accepted unchecked LLM arguments.

Changes:
- Added `UpdateProfileParams` BaseModel in `profile_tools.py` with all 7 optional fields
- Switched `update_profile` tool from raw `parameters` dict to `params_model=UpdateProfileParams`
- Added enforcement in `ToolRegistry.create_tools()` that raises `ValueError` for tools missing `params_model`
- Updated docstring in `tool_to_openai_schema()` to reflect params_model as source of truth
- Updated tests to use `params_model` where needed

Fixes #336

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude Code implemented the changes based on the architectural analysis comparing Backshop to nanobot and Pi/OpenClaw frameworks.