### PR TITLE
refactor: split router into composable pipeline steps

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -155,15 +155,13 @@ async def run_agent(
     messaging_service: MessagingService,
     to_address: str,
     downloaded_media: list[DownloadedMedia],
+    system_prompt_override: str | None = None,
 ) -> AgentResponse:
     """Initialize agent with tools and process the message.
 
     Handles LLM-level errors (content filter, auth, unexpected) by returning
     an error fallback AgentResponse.
     """
-    was_onboarding = is_onboarding_needed(contractor)
-    system_prompt_override = build_onboarding_system_prompt(contractor) if was_onboarding else None
-
     agent = BackshopAgent(db=db, contractor=contractor)
 
     tool_context = ToolContext(
@@ -345,6 +343,7 @@ async def handle_inbound_message(
     # 3. Load history and run agent
     conversation_history = await load_conversation_history(db, message.conversation_id)
     was_onboarding = is_onboarding_needed(contractor)
+    system_prompt_override = build_onboarding_system_prompt(contractor) if was_onboarding else None
     response = await run_agent(
         db=db,
         contractor=contractor,
@@ -355,6 +354,7 @@ async def handle_inbound_message(
         messaging_service=messaging_service,
         to_address=to_address,
         downloaded_media=downloaded_media,
+        system_prompt_override=system_prompt_override,
     )
 
     # 4. Post-process (onboarding, profile updates)


### PR DESCRIPTION
## Summary
- Breaks the monolithic `handle_inbound_message` (~200 lines) into six focused pipeline functions:
  - `prepare_media()` - download media, init storage backend, auto-save
  - `build_message_context()` - run media pipeline, build combined context string
  - `run_agent()` - init agent with tools, process message, handle LLM errors
  - `post_process()` - onboarding completion, profile update detection
  - `dispatch_reply()` - send reply unless agent already sent one via tool
  - `persist_outbound()` - store outbound message record
- `handle_inbound_message` becomes a thin orchestrator calling these steps in sequence
- Pure refactor: no behavior changes

## Test plan
- [x] All 592 existing tests pass (zero test changes needed)
- [x] Lint, format, and type checks pass
- [x] Each pipeline step is independently testable

Fixes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)