### PR TITLE
fix: extract captions from Telegram media messages and add missing media types

### DIFF
--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -249,7 +249,12 @@ def create_file_tools(
         if not file_bytes:
             logger.warning("upload_to_storage called but no file content available")
             return ToolResult(
-                content="No file content available to upload.",
+                content=(
+                    "No file content available to upload. This tool only works with "
+                    "media attached to the current message. To organize a previously "
+                    "received file, use the organize_file tool instead with the "
+                    "file's original_url."
+                ),
                 is_error=True,
                 error_kind=ToolErrorKind.NOT_FOUND,
             )
@@ -387,24 +392,25 @@ def create_file_tools(
         Tool(
             name=ToolName.UPLOAD_TO_STORAGE,
             description=(
-                "Upload a file to the contractor's cloud storage. "
-                "Files are organized by client: when you know the client name or job address, "
-                "provide it to file under their folder. Otherwise files go to Unsorted. "
-                "Inbound media is auto-saved, so use this to organize files into "
-                "the right client folder with a descriptive filename."
+                "Upload a file attached to the CURRENT message to the contractor's "
+                "cloud storage. Only works when the contractor sent media in this "
+                "message. Files are organized by client: provide client_name or "
+                "client_address to file under their folder, otherwise files go to "
+                "Unsorted. For files received in previous messages, use "
+                "organize_file instead."
             ),
             function=upload_to_storage,
             params_model=UploadToStorageParams,
-            usage_hint="Upload and organize files into the contractor's cloud storage.",
+            usage_hint="Upload media from the current message to cloud storage.",
         ),
         Tool(
             name=ToolName.ORGANIZE_FILE,
             description=(
-                "Move an auto-saved file from the Unsorted folder into the correct "
-                "client folder. Use this when you learn which client a previously "
-                "received file belongs to. Requires the original_url of the file "
-                "(from the inbound media list) and at least a client_name or "
-                "client_address to build the destination folder."
+                "Move a previously received file from the Unsorted folder into the "
+                "correct client folder. Use this when you learn which client a file "
+                "belongs to, even if the file was received in an earlier message. "
+                "Requires the original_url of the file and at least a client_name "
+                "or client_address to build the destination folder."
             ),
             function=organize_file,
             params_model=OrganizeFileParams,

--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -61,6 +61,27 @@ def _extract_telegram_media(
         if file_id:
             media.append((file_id, voice.get("mime_type", "audio/ogg")))
 
+    # Video
+    video = msg.get("video")
+    if video:
+        file_id = video.get("file_id")
+        if file_id:
+            media.append((file_id, video.get("mime_type", "video/mp4")))
+
+    # Video note (round video messages)
+    video_note = msg.get("video_note")
+    if video_note:
+        file_id = video_note.get("file_id")
+        if file_id:
+            media.append((file_id, "video/mp4"))
+
+    # Audio file (not voice note)
+    audio = msg.get("audio")
+    if audio:
+        file_id = audio.get("file_id")
+        if file_id:
+            media.append((file_id, audio.get("mime_type", "audio/mpeg")))
+
     # Document -- preserve Telegram-provided MIME type so images sent as
     # documents (e.g. image/png) are correctly classified downstream
     doc = msg.get("document")
@@ -119,7 +140,7 @@ def _parse_telegram_update(update: dict) -> InboundMessage | None:
         return None
 
     chat_id = str(chat["id"])
-    text = msg.get("text", "")
+    text = msg.get("text") or msg.get("caption") or ""
     username = msg.get("from", {}).get("username", "")
 
     if not _check_allowlist(chat_id, username):

--- a/tests/mocks/telegram.py
+++ b/tests/mocks/telegram.py
@@ -8,10 +8,24 @@ def make_telegram_update_payload(
     voice_mime_type: str = "audio/ogg",
     document_file_id: str | None = None,
     document_mime_type: str = "application/pdf",
+    video_file_id: str | None = None,
+    video_mime_type: str = "video/mp4",
+    video_note_file_id: str | None = None,
+    audio_file_id: str | None = None,
+    audio_mime_type: str = "audio/mpeg",
+    caption: str | None = None,
     first_name: str = "Test",
     username: str | None = None,
 ) -> dict:
-    """Build a realistic Telegram webhook Update JSON payload."""
+    """Build a realistic Telegram webhook Update JSON payload.
+
+    For media messages, Telegram puts user text in ``caption`` rather than
+    ``text``.  Pass ``caption="..."`` to simulate this.  When any media
+    field is set and the caller did not provide explicit ``text``, the
+    ``text`` key is omitted from the payload (matching real Telegram
+    behaviour).  If ``caption`` is provided it is set on the message
+    instead.
+    """
     from_obj: dict = {
         "id": chat_id,
         "is_bot": False,
@@ -19,6 +33,17 @@ def make_telegram_update_payload(
     }
     if username is not None:
         from_obj["username"] = username
+
+    has_media = any(
+        [
+            photo_file_id,
+            voice_file_id,
+            document_file_id,
+            video_file_id,
+            video_note_file_id,
+            audio_file_id,
+        ]
+    )
 
     msg: dict = {
         "message_id": message_id,
@@ -29,8 +54,23 @@ def make_telegram_update_payload(
             "type": "private",
         },
         "date": 1700000000,
-        "text": text,
     }
+
+    # Telegram uses "text" for plain messages and "caption" for media.
+    # When media is present and text was not explicitly provided, omit
+    # the text key to match real payloads.
+    if has_media and text == "Hello Backshop":
+        # Default text with media: omit text, use caption if provided
+        if caption is not None:
+            msg["caption"] = caption
+    elif has_media and text:
+        # Caller explicitly set text alongside media: treat as caption
+        msg["caption"] = text
+    else:
+        msg["text"] = text
+
+    if caption is not None and "caption" not in msg:
+        msg["caption"] = caption
 
     if photo_file_id:
         msg["photo"] = [
@@ -49,9 +89,6 @@ def make_telegram_update_payload(
                 "file_size": 5000,
             },
         ]
-        # When photo is present, text field may be empty
-        if text == "Hello Backshop":
-            msg["text"] = ""
 
     if voice_file_id:
         msg["voice"] = {
@@ -60,8 +97,32 @@ def make_telegram_update_payload(
             "duration": 5,
             "mime_type": voice_mime_type,
         }
-        if text == "Hello Backshop":
-            msg["text"] = ""
+
+    if video_file_id:
+        msg["video"] = {
+            "file_id": video_file_id,
+            "file_unique_id": "vid1",
+            "duration": 10,
+            "width": 1280,
+            "height": 720,
+            "mime_type": video_mime_type,
+        }
+
+    if video_note_file_id:
+        msg["video_note"] = {
+            "file_id": video_note_file_id,
+            "file_unique_id": "vnote1",
+            "duration": 5,
+            "length": 240,
+        }
+
+    if audio_file_id:
+        msg["audio"] = {
+            "file_id": audio_file_id,
+            "file_unique_id": "audio1",
+            "duration": 180,
+            "mime_type": audio_mime_type,
+        }
 
     if document_file_id:
         msg["document"] = {
@@ -70,8 +131,6 @@ def make_telegram_update_payload(
             "file_name": "estimate.pdf",
             "mime_type": document_mime_type,
         }
-        if text == "Hello Backshop":
-            msg["text"] = ""
 
     return {
         "update_id": update_id,

--- a/tests/test_file_cataloging.py
+++ b/tests/test_file_cataloging.py
@@ -209,13 +209,14 @@ async def test_upload_no_media_returns_error(
     db_session: Session,
     test_contractor: Contractor,
 ) -> None:
-    """Upload with no pending media should return error message."""
+    """Upload with no pending media should return error guiding to organize_file."""
     storage = MockStorageBackend()
     tools = create_file_tools(db_session, test_contractor, storage, pending_media={})
     upload = tools[0].function
 
     result = await upload(file_category="job_photo")
     assert "No file content" in result.content
+    assert "organize_file" in result.content
     assert result.is_error is True
 
 

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -502,3 +502,166 @@ def test_extract_telegram_media_document_without_mime_defaults() -> None:
     media = _extract_telegram_media(update)
     assert len(media) == 1
     assert media[0] == ("BQACAgIAAxkBAAI", "application/octet-stream")
+
+
+# -- Regression: caption extraction for media messages --
+
+
+def test_parse_photo_with_caption_extracts_text(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Photo messages with a caption should store the caption as body."""
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_telegram_update_payload(
+            chat_id=int(test_contractor.channel_identifier),
+            photo_file_id="AgACAgIAAxkBAAI",
+            caption="Kitchen remodel damage",
+        )
+        response = client.post("/api/webhooks/telegram", json=payload)
+    assert response.status_code == 200
+
+    messages = db_session.query(Message).all()
+    assert len(messages) == 1
+    assert messages[0].body == "Kitchen remodel damage"
+    assert "AgACAgIAAxkBAAI" in messages[0].media_urls_json
+
+
+def test_parse_document_with_caption_extracts_text(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Document messages with a caption should store the caption as body."""
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_telegram_update_payload(
+            chat_id=int(test_contractor.channel_identifier),
+            document_file_id="BQACAgIAAxkBAAI",
+            caption="Invoice for deck job",
+        )
+        response = client.post("/api/webhooks/telegram", json=payload)
+    assert response.status_code == 200
+
+    messages = db_session.query(Message).all()
+    assert len(messages) == 1
+    assert messages[0].body == "Invoice for deck job"
+
+
+def test_parse_media_without_caption_has_empty_body(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Media messages without a caption should have an empty body."""
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_telegram_update_payload(
+            chat_id=int(test_contractor.channel_identifier),
+            photo_file_id="AgACAgIAAxkBAAI",
+        )
+        response = client.post("/api/webhooks/telegram", json=payload)
+    assert response.status_code == 200
+
+    messages = db_session.query(Message).all()
+    assert len(messages) == 1
+    assert messages[0].body == ""
+
+
+# -- Regression: missing Telegram media types --
+
+
+def test_extract_media_video() -> None:
+    """Video file_ids should be extracted."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {
+        "message": {
+            "video": {
+                "file_id": "BAACAgIAAxkBAAI",
+                "file_unique_id": "vid1",
+                "duration": 10,
+                "width": 1280,
+                "height": 720,
+                "mime_type": "video/mp4",
+            }
+        }
+    }
+    media = _extract_telegram_media(update)
+    assert len(media) == 1
+    assert media[0] == ("BAACAgIAAxkBAAI", "video/mp4")
+
+
+def test_extract_media_video_note() -> None:
+    """Video note (round video) file_ids should be extracted."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {
+        "message": {
+            "video_note": {
+                "file_id": "DQACAgIAAxkBAAI",
+                "file_unique_id": "vnote1",
+                "duration": 5,
+                "length": 240,
+            }
+        }
+    }
+    media = _extract_telegram_media(update)
+    assert len(media) == 1
+    assert media[0] == ("DQACAgIAAxkBAAI", "video/mp4")
+
+
+def test_extract_media_audio() -> None:
+    """Audio file_ids should be extracted."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {
+        "message": {
+            "audio": {
+                "file_id": "CQACAgIAAxkBAAI",
+                "file_unique_id": "audio1",
+                "duration": 180,
+                "mime_type": "audio/mpeg",
+            }
+        }
+    }
+    media = _extract_telegram_media(update)
+    assert len(media) == 1
+    assert media[0] == ("CQACAgIAAxkBAAI", "audio/mpeg")
+
+
+def test_extract_media_video_without_file_id() -> None:
+    """Videos missing file_id should be skipped."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {"message": {"video": {"file_unique_id": "v1", "duration": 10}}}
+    media = _extract_telegram_media(update)
+    assert media == []
+
+
+def test_extract_media_video_note_without_file_id() -> None:
+    """Video notes missing file_id should be skipped."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {"message": {"video_note": {"file_unique_id": "vn1", "duration": 5}}}
+    media = _extract_telegram_media(update)
+    assert media == []
+
+
+def test_extract_media_audio_without_file_id() -> None:
+    """Audio files missing file_id should be skipped."""
+    from backend.app.routers.telegram_webhook import _extract_telegram_media
+
+    update = {"message": {"audio": {"file_unique_id": "a1", "duration": 180}}}
+    media = _extract_telegram_media(update)
+    assert media == []
+
+
+def test_inbound_webhook_extracts_video(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """Video file_ids should be extracted and stored."""
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_telegram_update_payload(
+            chat_id=int(test_contractor.channel_identifier),
+            video_file_id="BAACAgIAAxkBAAI",
+        )
+        response = client.post("/api/webhooks/telegram", json=payload)
+    assert response.status_code == 200
+
+    messages = db_session.query(Message).all()
+    assert len(messages) == 1
+    assert "BAACAgIAAxkBAAI" in messages[0].media_urls_json


### PR DESCRIPTION
## Summary

- **Caption extraction**: Telegram puts user text in the `caption` field (not `text`) for photo/document/video messages. The webhook parser only read `text`, silently dropping captions. This caused the agent to miss file-handling instructions attached to photos.
- **Missing media types**: Added extraction for `video`, `video_note`, and `audio` Telegram message types, which were previously silently ignored.
- **Tool guidance**: When `upload_to_storage` is called with no pending media (e.g., on a follow-up text message), the error now directs the LLM to use `organize_file` instead. Tool descriptions clarified to distinguish current-message vs. previously-received media.

## Test plan

- [x] 10 new regression tests covering caption extraction, all new media types, and missing-file-id edge cases
- [x] Existing 608 tests pass (0 failures)
- [x] Ruff lint and format clean
- [x] ty type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)