### PR TITLE
feat: raise MAX_TOOL_ROUNDS from 5 to 10 via Settings

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -49,7 +49,7 @@ from backend.app.services.llm_usage import log_llm_usage
 
 logger = logging.getLogger(__name__)
 
-MAX_TOOL_ROUNDS = 5
+MAX_TOOL_ROUNDS = settings.max_tool_rounds
 RATE_LIMIT_RETRY_DELAY = 2.0
 # Target token budget when trimming for context length (leave room for output tokens)
 CONTEXT_TRIM_TARGET_TOKENS = 80_000

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,6 +38,9 @@ class Settings(BaseSettings):
     whisper_device: str = "cpu"
     whisper_compute_type: str = "int8"
 
+    # Agent loop
+    max_tool_rounds: int = 10
+
     # Conversation & memory
     conversation_timeout_hours: int = 4
     conversation_history_limit: int = 20


### PR DESCRIPTION
## Summary

- Make `MAX_TOOL_ROUNDS` configurable via `settings.max_tool_rounds` (default: 10)
- Previous hardcoded value of 5 was too low for complex multi-step tasks like estimates with multiple line items

Fixes #354

## Test plan

- [x] Existing `test_agent_tool_loop_respects_max_rounds` passes (dynamically imports the constant)
- [x] Full test suite: 708 passed
- [x] Ruff lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)