### PR TITLE
fix: check tool success before suppressing auto-reply

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -233,7 +233,10 @@ async def dispatch_reply(
     message_id: int,
 ) -> None:
     """Send reply to the contractor unless the agent already sent one via a tool."""
-    sent_reply = any(ToolTags.SENDS_REPLY in tc.get("tags", set()) for tc in response.tool_calls)
+    sent_reply = any(
+        ToolTags.SENDS_REPLY in tc.get("tags", set()) and not tc.get("is_error", False)
+        for tc in response.tool_calls
+    )
     if not sent_reply and response.reply_text:
         try:
             await messaging_service.send_text(to=to_address, body=response.reply_text)

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from backend.app.agent.router import (
     AUTH_ERROR_FALLBACK,
     CONTENT_FILTER_FALLBACK,
+    dispatch_reply,
     handle_inbound_message,
 )
 from backend.app.models import Contractor, Conversation, Message
@@ -1070,3 +1071,44 @@ async def test_error_fallback_sent_but_not_stored(
     # But not stored in DB
     outbound = db_session.query(Message).filter(Message.direction == "outbound").first()
     assert outbound is None
+
+
+# ---------------------------------------------------------------------------
+# dispatch_reply: reply suppression checks tool success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_dispatch_reply_suppresses_when_send_reply_succeeds() -> None:
+    """Auto-reply should be suppressed when a SENDS_REPLY tool succeeded."""
+    from backend.app.agent.core import AgentResponse
+    from backend.app.agent.tools.base import ToolTags
+
+    response = AgentResponse(
+        reply_text="Fallback text",
+        tool_calls=[{"name": "send_reply", "tags": {ToolTags.SENDS_REPLY}, "is_error": False}],
+    )
+    messaging = MagicMock(spec=MessagingService)
+    messaging.send_text = AsyncMock()
+
+    await dispatch_reply(response, messaging, to_address="123", message_id=1)
+
+    messaging.send_text.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_dispatch_reply_sends_fallback_when_send_reply_fails() -> None:
+    """Auto-reply should be sent when the SENDS_REPLY tool failed."""
+    from backend.app.agent.core import AgentResponse
+    from backend.app.agent.tools.base import ToolTags
+
+    response = AgentResponse(
+        reply_text="Fallback text",
+        tool_calls=[{"name": "send_reply", "tags": {ToolTags.SENDS_REPLY}, "is_error": True}],
+    )
+    messaging = MagicMock(spec=MessagingService)
+    messaging.send_text = AsyncMock()
+
+    await dispatch_reply(response, messaging, to_address="123", message_id=1)
+
+    messaging.send_text.assert_called_once_with(to="123", body="Fallback text")


### PR DESCRIPTION
## Summary

- `dispatch_reply` now checks `is_error` on SENDS_REPLY tool calls before suppressing the auto-reply
- Previously, a failed `send_reply` would still suppress the fallback, leaving the contractor with silence
- Added two regression tests for the success and failure cases

Fixes #351

## Test plan

- [x] `test_dispatch_reply_suppresses_when_send_reply_succeeds` - verifies auto-reply is suppressed when tool succeeds
- [x] `test_dispatch_reply_sends_fallback_when_send_reply_fails` - verifies fallback is sent when tool fails
- [x] Full suite: 722 passed
- [x] Ruff lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)