### PR TITLE
refactor: extract hardcoded tool names into ToolName constants

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.llm_parsing import parse_tool_calls
 from backend.app.agent.system_prompt import build_heartbeat_system_prompt
+from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
 from backend.app.database import SessionLocal
 from backend.app.enums import (
@@ -54,7 +55,7 @@ logger = logging.getLogger(__name__)
 COMPOSE_MESSAGE_TOOL: dict[str, Any] = {
     "type": "function",
     "function": {
-        "name": "compose_message",
+        "name": ToolName.COMPOSE_MESSAGE,
         "description": (
             "Compose a proactive message to send to the contractor, or decide no message is needed."
         ),
@@ -419,7 +420,7 @@ def _parse_tool_call_response(response: ChatCompletion) -> HeartbeatAction:
 
     # Use the first tool call
     tc = parsed[0]
-    if tc.name != "compose_message":
+    if tc.name != ToolName.COMPOSE_MESSAGE:
         logger.warning("Heartbeat LLM called unexpected tool: %s", tc.name)
         return HeartbeatAction(
             action_type="no_action",

--- a/backend/app/agent/onboarding.py
+++ b/backend/app/agent/onboarding.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from backend.app.agent.events import AgentEndEvent, AgentEvent
 from backend.app.agent.profile import build_onboarding_prompt
+from backend.app.agent.tools.names import ToolName
 from backend.app.models import Contractor
 
 if TYPE_CHECKING:
@@ -110,7 +111,7 @@ class OnboardingSubscriber:
         """Process onboarding state after the agent finishes."""
         # Refresh contractor if a profile update was made (the tool already
         # committed, but the ORM object may be stale in this session).
-        if any(a == "Called update_profile" for a in event.actions_taken):
+        if any(a == f"Called {ToolName.UPDATE_PROFILE}" for a in event.actions_taken):
             self._db.refresh(self._contractor)
 
         # Transition: was onboarding and required fields are now complete

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.names import ToolName
 from backend.app.enums import ChecklistSchedule, ChecklistStatus
 from backend.app.models import HeartbeatChecklistItem
 
@@ -97,7 +98,7 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
 
     return [
         Tool(
-            name="add_checklist_item",
+            name=ToolName.ADD_CHECKLIST_ITEM,
             description=(
                 "Add an item to the contractor's heartbeat checklist. "
                 "The heartbeat will proactively check this item and remind "
@@ -108,14 +109,14 @@ def create_checklist_tools(db: Session, contractor_id: int) -> list[Tool]:
             usage_hint="When the contractor wants a recurring reminder, add it to the checklist.",
         ),
         Tool(
-            name="list_checklist_items",
+            name=ToolName.LIST_CHECKLIST_ITEMS,
             description="List all active items on the contractor's heartbeat checklist.",
             function=list_checklist_items,
             params_model=ListChecklistItemsParams,
             usage_hint="When asked about active reminders or checklist items, list them.",
         ),
         Tool(
-            name="remove_checklist_item",
+            name=ToolName.REMOVE_CHECKLIST_ITEM,
             description="Remove an item from the contractor's heartbeat checklist by its ID.",
             function=remove_checklist_item,
             params_model=RemoveChecklistItemParams,

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.file_tools import build_folder_path
+from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
 from backend.app.enums import EstimateStatus
 from backend.app.models import Contractor, Estimate, EstimateLineItem
@@ -174,7 +175,7 @@ def create_estimate_tools(
 
     return [
         Tool(
-            name="generate_estimate",
+            name=ToolName.GENERATE_ESTIMATE,
             description=(
                 "Generate a professional estimate PDF. Use when the contractor asks for "
                 "an estimate, quote, or bid. Include line items with description, quantity, "

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.names import ToolName
 from backend.app.media.download import MIME_EXTENSIONS, DownloadedMedia
 from backend.app.models import Contractor, MediaFile
 from backend.app.services.storage_service import StorageBackend
@@ -384,7 +385,7 @@ def create_file_tools(
 
     return [
         Tool(
-            name="upload_to_storage",
+            name=ToolName.UPLOAD_TO_STORAGE,
             description=(
                 "Upload a file to the contractor's cloud storage. "
                 "Files are organized by client: when you know the client name or job address, "
@@ -397,7 +398,7 @@ def create_file_tools(
             usage_hint="Upload and organize files into the contractor's cloud storage.",
         ),
         Tool(
-            name="organize_file",
+            name=ToolName.ORGANIZE_FILE,
             description=(
                 "Move an auto-saved file from the Unsorted folder into the correct "
                 "client folder. Use this when you learn which client a previously "

--- a/backend/app/agent/tools/memory_tools.py
+++ b/backend/app/agent/tools/memory_tools.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.memory import delete_memory, recall_memories, save_memory
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTags
+from backend.app.agent.tools.names import ToolName
 
 if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
@@ -66,7 +67,7 @@ def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
 
     return [
         Tool(
-            name="save_fact",
+            name=ToolName.SAVE_FACT,
             description=(
                 "Save a key-value fact to the contractor's memory. "
                 "Use for pricing, client info, preferences, etc."
@@ -77,7 +78,7 @@ def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
             usage_hint=("When you learn new information (rates, clients, preferences), save it."),
         ),
         Tool(
-            name="recall_facts",
+            name=ToolName.RECALL_FACTS,
             description="Search the contractor's memory for facts matching a query.",
             function=recall_facts,
             params_model=RecallFactsParams,
@@ -87,7 +88,7 @@ def create_memory_tools(db: Session, contractor_id: int) -> list[Tool]:
             ),
         ),
         Tool(
-            name="forget_fact",
+            name=ToolName.FORGET_FACT,
             description="Delete a fact from memory by key.",
             function=forget_fact,
             params_model=ForgetFactParams,

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTags
+from backend.app.agent.tools.names import ToolName
 from backend.app.services.messaging import MessagingService
 
 if TYPE_CHECKING:
@@ -53,7 +54,7 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
 
     return [
         Tool(
-            name="send_reply",
+            name=ToolName.SEND_REPLY,
             description="Send a text reply to the contractor.",
             function=send_reply,
             params_model=SendReplyParams,
@@ -61,7 +62,7 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
             usage_hint="Use this to send a text message to the contractor.",
         ),
         Tool(
-            name="send_media_reply",
+            name=ToolName.SEND_MEDIA_REPLY,
             description="Send a reply with a media attachment (e.g., PDF estimate).",
             function=send_media_reply,
             params_model=SendMediaReplyParams,

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -1,0 +1,36 @@
+"""Canonical tool name constants.
+
+All tool names should be defined here and imported by tool definition modules
+and any business logic that checks tool names.  This prevents silent breakage
+when a tool is renamed.
+"""
+
+
+class ToolName:
+    # Memory
+    SAVE_FACT = "save_fact"
+    RECALL_FACTS = "recall_facts"
+    FORGET_FACT = "forget_fact"
+
+    # Messaging
+    SEND_REPLY = "send_reply"
+    SEND_MEDIA_REPLY = "send_media_reply"
+
+    # Estimates
+    GENERATE_ESTIMATE = "generate_estimate"
+
+    # Checklist
+    ADD_CHECKLIST_ITEM = "add_checklist_item"
+    LIST_CHECKLIST_ITEMS = "list_checklist_items"
+    REMOVE_CHECKLIST_ITEM = "remove_checklist_item"
+
+    # File management
+    UPLOAD_TO_STORAGE = "upload_to_storage"
+    ORGANIZE_FILE = "organize_file"
+
+    # Profile
+    VIEW_PROFILE = "view_profile"
+    UPDATE_PROFILE = "update_profile"
+
+    # Heartbeat (not registered in the main tool registry)
+    COMPOSE_MESSAGE = "compose_message"

--- a/backend/app/agent/tools/profile_tools.py
+++ b/backend/app/agent/tools/profile_tools.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.names import ToolName
 from backend.app.models import Contractor
 
 if TYPE_CHECKING:
@@ -224,7 +225,7 @@ def create_profile_tools(db: Session, contractor: Contractor) -> list[Tool]:
 
     return [
         Tool(
-            name="view_profile",
+            name=ToolName.VIEW_PROFILE,
             description=(
                 "View the contractor's current profile information. "
                 "Use when the contractor asks what you know about them, "
@@ -238,7 +239,7 @@ def create_profile_tools(db: Session, contractor: Contractor) -> list[Tool]:
             ),
         ),
         Tool(
-            name="update_profile",
+            name=ToolName.UPDATE_PROFILE,
             description=(
                 "Update the contractor's profile information. "
                 "Use when you learn their name, trade, location, rate, "
@@ -279,7 +280,7 @@ def extract_profile_updates_from_tool_calls(
     updates: dict[str, object] = {}
 
     for tc in tool_calls:
-        if tc.get("name") != "update_profile":
+        if tc.get("name") != ToolName.UPDATE_PROFILE:
             continue
         if tc.get("is_error"):
             continue


### PR DESCRIPTION
## Summary
- Adds `backend/app/agent/tools/names.py` with a `ToolName` class centralizing all 14 tool name strings
- Updates all tool definition modules (memory, messaging, estimate, checklist, file, profile) to use `ToolName` constants instead of string literals
- Updates business-logic checks in `profile_tools.py`, `heartbeat.py`, and `onboarding.py` to reference `ToolName` constants
- Prevents silent breakage when a tool is renamed: changing the constant in one place updates all references

## Test plan
- [x] All 722 tests pass
- [x] Ruff lint and format pass
- [x] Verified no remaining hardcoded tool name strings in production code (only in `names.py`)
- [x] Test files intentionally keep string literals as regression checks against constant values

Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)