### PR TITLE
refactor: auto-discover tool modules instead of manual list

### DIFF
--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import pkgutil
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -22,16 +23,6 @@ from backend.app.services.messaging import MessagingService
 from backend.app.services.storage_service import StorageBackend
 
 logger = logging.getLogger(__name__)
-
-# All tool modules that should be imported to trigger self-registration.
-_TOOL_MODULES: list[str] = [
-    "backend.app.agent.tools.memory_tools",
-    "backend.app.agent.tools.messaging_tools",
-    "backend.app.agent.tools.estimate_tools",
-    "backend.app.agent.tools.checklist_tools",
-    "backend.app.agent.tools.profile_tools",
-    "backend.app.agent.tools.file_tools",
-]
 
 # Factory names that are always included regardless of message content.
 _ALWAYS_INCLUDE: frozenset[str] = frozenset({"memory", "messaging", "profile"})
@@ -205,10 +196,12 @@ default_registry = ToolRegistry()
 
 
 def ensure_tool_modules_imported() -> None:
-    """Import all tool modules so they self-register with ``default_registry``.
+    """Auto-discover and import all tool modules that end with ``_tools``.
 
     This is idempotent: Python's import system caches modules, so repeated
     calls are essentially free.
     """
-    for module_path in _TOOL_MODULES:
-        importlib.import_module(module_path)
+    package = importlib.import_module("backend.app.agent.tools")
+    for _, name, _ in pkgutil.iter_modules(package.__path__, package.__name__ + "."):
+        if name.endswith("_tools"):
+            importlib.import_module(name)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,51 @@
+"""Tests for tool registry auto-discovery."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+from backend.app.agent.tools.registry import ensure_tool_modules_imported
+
+EXPECTED_TOOL_MODULES: set[str] = {
+    "backend.app.agent.tools.memory_tools",
+    "backend.app.agent.tools.messaging_tools",
+    "backend.app.agent.tools.estimate_tools",
+    "backend.app.agent.tools.checklist_tools",
+    "backend.app.agent.tools.profile_tools",
+    "backend.app.agent.tools.file_tools",
+}
+
+
+def test_auto_discovery_finds_all_tool_modules() -> None:
+    """ensure_tool_modules_imported discovers every *_tools module."""
+    imported: list[str] = []
+    original_import = importlib.import_module
+
+    def tracking_import(name: str) -> object:
+        imported.append(name)
+        return original_import(name)
+
+    with patch.object(importlib, "import_module", side_effect=tracking_import):
+        ensure_tool_modules_imported()
+
+    discovered = {m for m in imported if m.endswith("_tools")}
+    assert discovered == EXPECTED_TOOL_MODULES
+
+
+def test_auto_discovery_ignores_non_tool_modules() -> None:
+    """Modules not ending with '_tools' (e.g. base, registry, names) are skipped."""
+    imported: list[str] = []
+    original_import = importlib.import_module
+
+    def tracking_import(name: str) -> object:
+        imported.append(name)
+        return original_import(name)
+
+    with patch.object(importlib, "import_module", side_effect=tracking_import):
+        ensure_tool_modules_imported()
+
+    non_tool = {
+        m for m in imported if m.startswith("backend.app.agent.tools.") and not m.endswith("_tools")
+    }
+    assert non_tool == set(), f"Non-tool modules were imported: {non_tool}"


### PR DESCRIPTION
## Summary
- Replace the hardcoded `_TOOL_MODULES` list in `registry.py` with `pkgutil`-based auto-discovery that finds all modules ending with `_tools`
- Remove the need to manually update the list when adding new tool modules
- Add tests verifying auto-discovery finds all expected tool modules and ignores non-tool modules

Fixes #352

## Test plan
- [x] New tests in `tests/test_tool_registry.py` verify all 6 expected tool modules are discovered
- [x] New tests verify non-tool modules (base, registry, names) are not imported
- [x] Full test suite passes (724 tests)
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)