### PR TITLE
refactor: centralize magic constants into Settings configuration

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -50,12 +50,12 @@ from backend.app.services.llm_usage import log_llm_usage
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_ROUNDS = settings.max_tool_rounds
-RATE_LIMIT_RETRY_DELAY = 2.0
+RATE_LIMIT_RETRY_DELAY = settings.rate_limit_retry_delay
 # Target token budget when trimming for context length (leave room for output tokens)
-CONTEXT_TRIM_TARGET_TOKENS = 80_000
+CONTEXT_TRIM_TARGET_TOKENS = settings.context_trim_target_tokens
 
 # Conservative default; most models support 128K+ but we leave room for output
-MAX_INPUT_TOKENS = 120_000
+MAX_INPUT_TOKENS = settings.max_input_tokens
 
 # Per-message overhead tokens for role/delimiters/structural framing
 _MESSAGE_OVERHEAD_TOKENS = 4

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -95,8 +95,8 @@ _TIME_KEYWORDS = re.compile(
 
 STALE_ESTIMATE_HOURS = settings.heartbeat_stale_estimate_hours
 IDLE_DAYS = settings.heartbeat_idle_days
-CHECKLIST_DAILY_INTERVAL_HOURS = 20
-HEARTBEAT_RECENT_MESSAGES_COUNT = 5
+CHECKLIST_DAILY_INTERVAL_HOURS = settings.checklist_daily_interval_hours
+HEARTBEAT_RECENT_MESSAGES_COUNT = settings.heartbeat_recent_messages_count
 WEEKDAY_FRIDAY = 4  # Monday=0 ... Friday=4
 
 _FREQ_RE = re.compile(r"^(\d+)\s*(m|h|d)(?:in(?:utes?)?|ours?|ays?)?$", re.IGNORECASE)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,6 +40,9 @@ class Settings(BaseSettings):
 
     # Agent loop
     max_tool_rounds: int = 10
+    max_input_tokens: int = 120_000
+    context_trim_target_tokens: int = 80_000
+    rate_limit_retry_delay: float = 2.0
 
     # Conversation & memory
     conversation_timeout_hours: int = 4
@@ -69,6 +72,8 @@ class Settings(BaseSettings):
     heartbeat_model: str = ""  # empty = fall back to llm_model
     heartbeat_provider: str = ""  # empty = fall back to llm_provider
     heartbeat_concurrency: int = 5  # max concurrent contractor evaluations per tick
+    checklist_daily_interval_hours: int = 20
+    heartbeat_recent_messages_count: int = 5
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 


### PR DESCRIPTION
## Summary
- Move five operator-tunable constants (`max_input_tokens`, `context_trim_target_tokens`, `rate_limit_retry_delay`, `checklist_daily_interval_hours`, `heartbeat_recent_messages_count`) from hardcoded module-level values in `core.py` and `heartbeat.py` into the Pydantic `Settings` class in `config.py`
- These can now be overridden via environment variables (e.g. `MAX_INPUT_TOKENS=200000`)
- Internal estimation constants (`_CHARS_PER_TOKEN`, `_MESSAGE_OVERHEAD_TOKENS`, `_SUMMARY_MAX_CHARS`, `CONTEXT_QUERY_MAX_LENGTH`) remain as module constants since they are not intended for operator tuning

Fixes #359

## Test plan
- [x] All 730 existing tests pass
- [x] Ruff lint and format checks pass
- [x] Default values are identical to the previous hardcoded values, so behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)