### PR TITLE
refactor: replace string-based tool tags with StrEnum

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -434,7 +434,7 @@ class BackshopAgent:
         except ValidationError as exc:
             return tool_args, _format_validation_error(tool.name, exc, tool)
 
-    def _get_tool_tags(self, tool_name: str) -> set[str]:
+    def _get_tool_tags(self, tool_name: str) -> set[ToolTags]:
         """Look up the tags for a registered tool by name."""
         tool = self._tools_by_name.get(tool_name)
         return tool.tags if tool else set()

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -6,11 +6,12 @@ from typing import Any
 from pydantic import BaseModel
 
 
-class ToolTags:
-    """Constants for cross-cutting tool metadata tags."""
+class ToolTags(StrEnum):
+    """Cross-cutting tool metadata tags."""
 
     SENDS_REPLY = "sends_reply"
     SAVES_MEMORY = "saves_memory"
+    MODIFIES_PROFILE = "modifies_profile"
 
 
 class ToolErrorKind(StrEnum):
@@ -42,7 +43,7 @@ class Tool:
     function: Callable[..., Awaitable[ToolResult]]
     parameters: dict[str, Any] = field(default_factory=dict)
     params_model: type[BaseModel] | None = None
-    tags: set[str] = field(default_factory=set)
+    tags: set[ToolTags] = field(default_factory=set)
     usage_hint: str = ""
 
 

--- a/backend/app/agent/tools/profile_tools.py
+++ b/backend/app/agent/tools/profile_tools.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, cast
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTags
 from backend.app.agent.tools.names import ToolName
 from backend.app.models import Contractor
 
@@ -248,6 +248,7 @@ def create_profile_tools(db: Session, contractor: Contractor) -> list[Tool]:
             ),
             function=update_profile,
             params_model=UpdateProfileParams,
+            tags={ToolTags.MODIFIES_PROFILE},
             usage_hint=("Use this to update known contractor details (name, trade, rates, etc.)."),
         ),
     ]

--- a/tests/test_tool_tags.py
+++ b/tests/test_tool_tags.py
@@ -16,15 +16,32 @@ from tests.mocks.llm import make_text_response, make_tool_call_response
 # --- ToolTags constants ---
 
 
-def test_tool_tags_constants_are_strings() -> None:
-    """ToolTags constants should be plain strings for JSON serialization."""
+def test_tool_tags_is_str_enum() -> None:
+    """ToolTags should be a StrEnum for type safety with string backward compat."""
+    from enum import StrEnum
+
+    assert issubclass(ToolTags, StrEnum)
     assert isinstance(ToolTags.SENDS_REPLY, str)
     assert isinstance(ToolTags.SAVES_MEMORY, str)
+    assert isinstance(ToolTags.MODIFIES_PROFILE, str)
 
 
 def test_tool_tags_constants_are_distinct() -> None:
     """Each tag constant should be unique."""
     assert ToolTags.SENDS_REPLY != ToolTags.SAVES_MEMORY
+
+
+def test_tool_tags_values_equal_plain_strings() -> None:
+    """StrEnum values should compare equal to plain strings for backward compat."""
+    assert ToolTags.SENDS_REPLY == "sends_reply"
+    assert ToolTags.SAVES_MEMORY == "saves_memory"
+    assert ToolTags.MODIFIES_PROFILE == "modifies_profile"
+
+
+def test_tool_tags_membership_with_plain_strings() -> None:
+    """StrEnum values should be found in sets of plain strings and vice versa."""
+    assert ToolTags.SENDS_REPLY in {"sends_reply"}
+    assert "sends_reply" in {ToolTags.SENDS_REPLY}
 
 
 # --- Tool dataclass tags field ---
@@ -216,3 +233,30 @@ async def test_agent_untagged_tool_has_empty_tags(
     assert len(response.tool_calls) == 1
     assert response.tool_calls[0]["tags"] == set()
     assert len(response.memories_saved) == 0
+
+
+# --- Profile tools tags ---
+
+
+def test_update_profile_has_modifies_profile_tag() -> None:
+    """update_profile tool from create_profile_tools should have MODIFIES_PROFILE tag."""
+    from backend.app.agent.tools.profile_tools import create_profile_tools
+
+    db = MagicMock()
+    contractor = MagicMock()
+    contractor.id = 1
+    tools = create_profile_tools(db, contractor)
+    update_profile = next(t for t in tools if t.name == "update_profile")
+    assert ToolTags.MODIFIES_PROFILE in update_profile.tags
+
+
+def test_view_profile_has_no_modifies_profile_tag() -> None:
+    """view_profile should not have MODIFIES_PROFILE tag."""
+    from backend.app.agent.tools.profile_tools import create_profile_tools
+
+    db = MagicMock()
+    contractor = MagicMock()
+    contractor.id = 1
+    tools = create_profile_tools(db, contractor)
+    view_profile = next(t for t in tools if t.name == "view_profile")
+    assert ToolTags.MODIFIES_PROFILE not in view_profile.tags


### PR DESCRIPTION
## Summary
- Convert `ToolTags` from a plain class with string constants to a `StrEnum`, providing type safety while preserving backward compatibility (StrEnum values compare equal to plain strings)
- Update `Tool.tags` field type from `set[str]` to `set[ToolTags]` and `_get_tool_tags()` return type accordingly
- Add new `MODIFIES_PROFILE` tag to `ToolTags` and apply it to the `update_profile` tool in `profile_tools.py`

## Test plan
- [x] Verify `ToolTags` is a `StrEnum` subclass
- [x] Verify StrEnum values compare equal to plain strings (backward compat)
- [x] Verify `update_profile` tool has `MODIFIES_PROFILE` tag
- [x] Verify `view_profile` tool does not have `MODIFIES_PROFILE` tag
- [x] All 772 existing tests pass
- [x] Lint and format checks pass

Fixes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)