### PR TITLE
fix: resolve duplicate migration revision causing CI failure

### DIFF
--- a/alembic/versions/008_add_tool_interactions_json_to_messages.py
+++ b/alembic/versions/008_add_tool_interactions_json_to_messages.py
@@ -1,7 +1,7 @@
 """Add tool_interactions_json column to messages
 
-Revision ID: 003
-Revises: 002
+Revision ID: 008
+Revises: 007
 Create Date: 2026-03-03
 
 """
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "003"
-down_revision: str | None = "002"
+revision: str = "008"
+down_revision: str | None = "007"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary
- Two migrations both used revision ID `003` with `down_revision = "002"`, creating a fork in the Alembic chain
- `003_add_heartbeat_log.py` and `003_add_tool_interactions_json_to_messages.py` were both `003`
- Renumbered `tool_interactions_json` to revision `008` (after current head `007`)
- Restores a single linear migration chain: 001 -> 002 -> 003 -> ... -> 007 -> 008

## Test plan
- [x] `alembic upgrade head` succeeds on a fresh SQLite database
- [x] All 772 tests pass
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)