### PR TITLE
enhancement: add schema validation for stored tool interaction JSON

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -6,6 +6,7 @@ import json
 import logging
 from typing import Any
 
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from backend.app.agent.compaction import compact_session
@@ -28,6 +29,16 @@ DEFAULT_HISTORY_LIMIT = settings.conversation_history_limit
 # Strong references to fire-and-forget background tasks so they are not
 # garbage-collected before completion.
 _background_tasks: set[asyncio.Task[None]] = set()
+
+
+class StoredToolInteraction(BaseModel):
+    """Schema for tool interaction records stored in Message.tool_interactions_json."""
+
+    tool_call_id: str = ""
+    name: str = ""
+    args: dict[str, Any] = Field(default_factory=dict)
+    result: str = ""
+    is_error: bool = False
 
 
 async def _run_compaction_in_background(
@@ -65,21 +76,38 @@ async def _run_compaction_in_background(
         )
 
 
-def _parse_tool_interactions(raw: str) -> list[dict[str, Any]]:
-    """Parse tool_interactions_json, returning an empty list on failure."""
+def _parse_tool_interactions(raw: str) -> list[StoredToolInteraction]:
+    """Parse tool_interactions_json, returning validated models.
+
+    Each item is validated against ``StoredToolInteraction``. Missing fields
+    receive defaults (backward compatible). Items that fail validation
+    entirely are logged and skipped so corrupt data never crashes loading.
+    """
     if not raw:
         return []
     try:
         parsed = json.loads(raw)
-        if isinstance(parsed, list):
-            return parsed
+        if not isinstance(parsed, list):
+            return []
     except (json.JSONDecodeError, TypeError):
         logger.debug("Could not parse tool_interactions_json, falling back to flat text")
-    return []
+        return []
+
+    validated: list[StoredToolInteraction] = []
+    for i, item in enumerate(parsed):
+        try:
+            validated.append(StoredToolInteraction.model_validate(item))
+        except Exception:
+            logger.warning(
+                "Skipping invalid tool interaction record at index %d: %r",
+                i,
+                item,
+            )
+    return validated
 
 
 def _expand_outbound_with_tools(
-    tool_interactions: list[dict[str, Any]],
+    tool_interactions: list[StoredToolInteraction],
     reply_text: str,
 ) -> list[AgentMessage]:
     """Expand an outbound message with tool interactions into typed messages.
@@ -96,9 +124,9 @@ def _expand_outbound_with_tools(
     for tc in tool_interactions:
         tool_call_requests.append(
             ToolCallRequest(
-                id=tc.get("tool_call_id", ""),
-                name=tc.get("name", ""),
-                arguments=tc.get("args", {}),
+                id=tc.tool_call_id,
+                name=tc.name,
+                arguments=tc.args,
             )
         )
 
@@ -109,8 +137,8 @@ def _expand_outbound_with_tools(
     for tc in tool_interactions:
         messages.append(
             ToolResultMessage(
-                tool_call_id=tc.get("tool_call_id", ""),
-                content=tc.get("result", ""),
+                tool_call_id=tc.tool_call_id,
+                content=tc.result,
             )
         )
 

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -13,7 +13,7 @@ from collections.abc import Awaitable, Callable
 from any_llm import AuthenticationError, ContentFilterError
 from sqlalchemy.orm import Session
 
-from backend.app.agent.context import load_conversation_history
+from backend.app.agent.context import StoredToolInteraction, load_conversation_history
 from backend.app.agent.core import AgentResponse, BackshopAgent
 from backend.app.agent.events import AgentEvent
 from backend.app.agent.messages import AgentMessage
@@ -261,11 +261,15 @@ def persist_outbound(
         return
 
     # Serialize tool interactions for conversation history reconstruction.
-    # Strip non-serializable 'tags' (sets) before JSON encoding.
+    # Validate each record via StoredToolInteraction, which also strips
+    # runtime-only fields like 'tags' (sets) that are not JSON-serializable.
     tool_interactions = ""
     if response.tool_calls:
-        serializable = [{k: v for k, v in tc.items() if k != "tags"} for tc in response.tool_calls]
-        tool_interactions = json.dumps(serializable)
+        validated = [
+            StoredToolInteraction.model_validate({k: v for k, v in tc.items() if k != "tags"})
+            for tc in response.tool_calls
+        ]
+        tool_interactions = json.dumps([v.model_dump() for v in validated])
 
     outbound = Message(
         conversation_id=conversation_id,

--- a/tests/test_stored_tool_interaction.py
+++ b/tests/test_stored_tool_interaction.py
@@ -1,0 +1,290 @@
+"""Tests for StoredToolInteraction schema validation."""
+
+import json
+import logging
+
+import pytest
+
+from backend.app.agent.context import (
+    StoredToolInteraction,
+    _expand_outbound_with_tools,
+    _parse_tool_interactions,
+)
+from backend.app.agent.messages import AssistantMessage, ToolResultMessage
+
+
+class TestStoredToolInteractionModel:
+    """Tests for the StoredToolInteraction Pydantic model."""
+
+    def test_full_record_parses(self) -> None:
+        """A complete record with all fields should parse correctly."""
+        data = {
+            "tool_call_id": "call_abc123",
+            "name": "save_memory",
+            "args": {"key": "trade", "value": "electrician"},
+            "result": "Saved.",
+            "is_error": False,
+        }
+        model = StoredToolInteraction.model_validate(data)
+        assert model.tool_call_id == "call_abc123"
+        assert model.name == "save_memory"
+        assert model.args == {"key": "trade", "value": "electrician"}
+        assert model.result == "Saved."
+        assert model.is_error is False
+
+    def test_missing_fields_get_defaults(self) -> None:
+        """Missing fields should receive default values."""
+        model = StoredToolInteraction.model_validate({})
+        assert model.tool_call_id == ""
+        assert model.name == ""
+        assert model.args == {}
+        assert model.result == ""
+        assert model.is_error is False
+
+    def test_partial_record_gets_defaults(self) -> None:
+        """A partial record (some fields present) gets defaults for the rest."""
+        data = {"name": "create_estimate", "is_error": True}
+        model = StoredToolInteraction.model_validate(data)
+        assert model.name == "create_estimate"
+        assert model.is_error is True
+        assert model.tool_call_id == ""
+        assert model.args == {}
+        assert model.result == ""
+
+    def test_extra_fields_ignored(self) -> None:
+        """Extra fields (like 'tags') should not cause validation failure."""
+        data = {
+            "tool_call_id": "call_xyz",
+            "name": "lookup_client",
+            "args": {},
+            "result": "Found client.",
+            "is_error": False,
+            "tags": ["SENDS_REPLY"],
+        }
+        model = StoredToolInteraction.model_validate(data)
+        assert model.name == "lookup_client"
+        assert not hasattr(model, "tags") or "tags" not in model.model_fields
+
+    def test_model_dump_excludes_extra(self) -> None:
+        """model_dump should only contain declared fields."""
+        data = {
+            "tool_call_id": "call_1",
+            "name": "tool_a",
+            "args": {"x": 1},
+            "result": "ok",
+            "is_error": False,
+        }
+        model = StoredToolInteraction.model_validate(data)
+        dumped = model.model_dump()
+        assert set(dumped.keys()) == {"tool_call_id", "name", "args", "result", "is_error"}
+
+    def test_round_trip_json(self) -> None:
+        """Serializing to JSON and parsing back should produce the same model."""
+        original = StoredToolInteraction(
+            tool_call_id="call_rt",
+            name="send_estimate",
+            args={"estimate_id": 42},
+            result="Estimate sent successfully.",
+            is_error=False,
+        )
+        json_str = json.dumps([original.model_dump()])
+        parsed = json.loads(json_str)
+        restored = StoredToolInteraction.model_validate(parsed[0])
+        assert restored == original
+
+
+class TestParseToolInteractions:
+    """Tests for _parse_tool_interactions with schema validation."""
+
+    def test_valid_json_list(self) -> None:
+        """Valid JSON list of tool interaction dicts should be parsed."""
+        records = [
+            {
+                "tool_call_id": "call_1",
+                "name": "save_memory",
+                "args": {"key": "name", "value": "Joe"},
+                "result": "Saved.",
+                "is_error": False,
+            }
+        ]
+        raw = json.dumps(records)
+        result = _parse_tool_interactions(raw)
+        assert len(result) == 1
+        assert isinstance(result[0], StoredToolInteraction)
+        assert result[0].name == "save_memory"
+
+    def test_empty_string_returns_empty(self) -> None:
+        """Empty string input should return empty list."""
+        assert _parse_tool_interactions("") == []
+
+    def test_none_returns_empty(self) -> None:
+        """None input should return empty list."""
+        assert _parse_tool_interactions(None) == []  # type: ignore[arg-type]
+
+    def test_invalid_json_returns_empty(self) -> None:
+        """Malformed JSON should return empty list."""
+        assert _parse_tool_interactions("{broken json") == []
+
+    def test_non_list_json_returns_empty(self) -> None:
+        """JSON that is not a list should return empty list."""
+        assert _parse_tool_interactions('{"not": "a list"}') == []
+
+    def test_missing_fields_get_defaults(self) -> None:
+        """Records with missing fields should parse with defaults."""
+        records = [{"name": "some_tool"}]
+        raw = json.dumps(records)
+        result = _parse_tool_interactions(raw)
+        assert len(result) == 1
+        assert result[0].tool_call_id == ""
+        assert result[0].args == {}
+        assert result[0].result == ""
+        assert result[0].is_error is False
+
+    def test_invalid_record_skipped_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Completely invalid records (non-dict) should be skipped with a warning."""
+        records = [
+            {"name": "good_tool", "tool_call_id": "call_1"},
+            "not a dict",
+            42,
+            {"name": "another_good_tool", "tool_call_id": "call_2"},
+        ]
+        raw = json.dumps(records)
+        with caplog.at_level(logging.WARNING):
+            result = _parse_tool_interactions(raw)
+
+        assert len(result) == 2
+        assert result[0].name == "good_tool"
+        assert result[1].name == "another_good_tool"
+        # Check that warnings were logged for the bad records
+        warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warning_messages) == 2
+        assert "index 1" in warning_messages[0]
+        assert "index 2" in warning_messages[1]
+
+    def test_mixed_valid_and_invalid(self) -> None:
+        """A mix of valid and invalid records preserves valid ones."""
+        records = [
+            {"tool_call_id": "call_a", "name": "tool_a"},
+            None,
+            {"tool_call_id": "call_c", "name": "tool_c"},
+        ]
+        raw = json.dumps(records)
+        result = _parse_tool_interactions(raw)
+        assert len(result) == 2
+        assert result[0].tool_call_id == "call_a"
+        assert result[1].tool_call_id == "call_c"
+
+
+class TestExpandOutboundWithTools:
+    """Tests for _expand_outbound_with_tools with StoredToolInteraction models."""
+
+    def test_expand_produces_correct_message_sequence(self) -> None:
+        """Expansion should produce assistant(tool_calls) + tool_results + assistant(reply)."""
+        interactions = [
+            StoredToolInteraction(
+                tool_call_id="call_1",
+                name="save_memory",
+                args={"key": "name", "value": "Alice"},
+                result="Saved.",
+                is_error=False,
+            ),
+        ]
+        messages = _expand_outbound_with_tools(interactions, "Got it, Alice!")
+        assert len(messages) == 3
+        # First: assistant with tool_calls
+        assert isinstance(messages[0], AssistantMessage)
+        assert len(messages[0].tool_calls) == 1
+        assert messages[0].tool_calls[0].name == "save_memory"
+        assert messages[0].tool_calls[0].id == "call_1"
+        assert messages[0].tool_calls[0].arguments == {"key": "name", "value": "Alice"}
+        # Second: tool result
+        assert isinstance(messages[1], ToolResultMessage)
+        assert messages[1].tool_call_id == "call_1"
+        assert messages[1].content == "Saved."
+        # Third: final assistant reply
+        assert isinstance(messages[2], AssistantMessage)
+        assert messages[2].content == "Got it, Alice!"
+
+    def test_expand_multiple_tools(self) -> None:
+        """Multiple tool interactions should produce multiple results."""
+        interactions = [
+            StoredToolInteraction(
+                tool_call_id="call_1",
+                name="tool_a",
+                args={},
+                result="result_a",
+            ),
+            StoredToolInteraction(
+                tool_call_id="call_2",
+                name="tool_b",
+                args={"x": 1},
+                result="result_b",
+            ),
+        ]
+        messages = _expand_outbound_with_tools(interactions, "Done.")
+        # 1 assistant(tool_calls) + 2 tool_results + 1 assistant(reply) = 4
+        assert len(messages) == 4
+        assert isinstance(messages[0], AssistantMessage)
+        assert len(messages[0].tool_calls) == 2
+        assert isinstance(messages[1], ToolResultMessage)
+        assert isinstance(messages[2], ToolResultMessage)
+        assert isinstance(messages[3], AssistantMessage)
+
+
+class TestPersistOutboundValidation:
+    """Tests for persist_outbound using StoredToolInteraction serialization."""
+
+    def test_serialization_excludes_tags(self) -> None:
+        """The 'tags' field should be stripped during serialization."""
+        from backend.app.agent.context import StoredToolInteraction
+
+        # Simulate what persist_outbound does
+        tool_calls = [
+            {
+                "tool_call_id": "call_1",
+                "name": "save_memory",
+                "args": {"key": "k"},
+                "result": "ok",
+                "is_error": False,
+                "tags": {"SAVES_MEMORY"},
+            }
+        ]
+        validated = [
+            StoredToolInteraction.model_validate({k: v for k, v in tc.items() if k != "tags"})
+            for tc in tool_calls
+        ]
+        json_str = json.dumps([v.model_dump() for v in validated])
+        parsed = json.loads(json_str)
+        assert len(parsed) == 1
+        assert "tags" not in parsed[0]
+        assert parsed[0]["name"] == "save_memory"
+
+    def test_serialization_round_trip(self) -> None:
+        """Tool interactions should survive serialize -> parse round trip."""
+        from backend.app.agent.context import StoredToolInteraction
+
+        tool_calls = [
+            {
+                "tool_call_id": "call_rt",
+                "name": "create_estimate",
+                "args": {"client_name": "Bob", "total": 500},
+                "result": "Estimate #1 created.",
+                "is_error": False,
+                "tags": {"SENDS_REPLY"},
+            }
+        ]
+        # Serialize (as persist_outbound does)
+        validated = [
+            StoredToolInteraction.model_validate({k: v for k, v in tc.items() if k != "tags"})
+            for tc in tool_calls
+        ]
+        json_str = json.dumps([v.model_dump() for v in validated])
+
+        # Parse back (as _parse_tool_interactions does)
+        restored = _parse_tool_interactions(json_str)
+        assert len(restored) == 1
+        assert restored[0].tool_call_id == "call_rt"
+        assert restored[0].name == "create_estimate"
+        assert restored[0].args == {"client_name": "Bob", "total": 500}
+        assert restored[0].result == "Estimate #1 created."
+        assert restored[0].is_error is False


### PR DESCRIPTION
## Summary
- Add `StoredToolInteraction` Pydantic model in `backend/app/agent/context.py` to validate tool interaction records stored in `Message.tool_interactions_json`
- Update `_parse_tool_interactions` to return validated `StoredToolInteraction` models, with defaults for missing fields (backward compatible) and warnings for invalid records that are skipped
- Update `_expand_outbound_with_tools` to use typed model attributes instead of dict `.get()` calls
- Update `persist_outbound` in `router.py` to validate via `StoredToolInteraction` before JSON serialization, which also strips runtime-only fields like `tags`
- Add 18 tests covering schema validation, round-trip serialization, backward compatibility with partial data, and corrupt data handling

Fixes #360

## Test plan
- [x] `StoredToolInteraction` model validates complete records correctly
- [x] Missing fields receive sensible defaults (empty string, empty dict, False)
- [x] Extra fields (like `tags`) are silently ignored
- [x] `model_dump()` produces only the declared schema fields
- [x] JSON round-trip (serialize then parse) produces identical models
- [x] `_parse_tool_interactions` returns empty list for empty/None/invalid JSON
- [x] Valid records parse into `StoredToolInteraction` instances
- [x] Invalid records (non-dict items) are skipped with logged warnings
- [x] Mixed valid/invalid records preserve only the valid ones
- [x] `_expand_outbound_with_tools` produces correct message sequences from models
- [x] Serialization in `persist_outbound` excludes `tags` field
- [x] Full test suite (790 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)