### PR TITLE
enhancement: log token estimation drift from actual LLM usage

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -137,6 +137,41 @@ def _estimate_tokens(messages: list[AgentMessage]) -> int:
     return total
 
 
+def _log_token_estimation_drift(
+    messages: list[AgentMessage],
+    response: ChatCompletion,
+) -> None:
+    """Log a warning when estimated token count drifts >30% from actual usage.
+
+    Uses ``response.usage.prompt_tokens`` (reported by the LLM provider) to
+    compare against our character-ratio estimate.  Not all providers return
+    usage data, so missing values are silently ignored.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return
+    actual = getattr(usage, "prompt_tokens", None)
+    if not actual:
+        return
+
+    estimated = _estimate_tokens(messages)
+    if abs(estimated - actual) > actual * 0.3:
+        total_chars = sum(
+            len(m.content or "")
+            for m in messages
+            if isinstance(m, (SystemMessage, UserMessage, AssistantMessage, ToolResultMessage))
+            and m.content
+        )
+        observed_ratio = total_chars / actual if actual else 0.0
+        logger.warning(
+            "Token estimate drift: estimated=%d actual=%d ratio=%.2f (configured=%.1f)",
+            estimated,
+            actual,
+            observed_ratio,
+            _CHARS_PER_TOKEN,
+        )
+
+
 def _format_validation_error(tool_name: str, exc: ValidationError, tool: Tool | None = None) -> str:
     """Format a Pydantic ValidationError into a structured message for the LLM."""
     error_lines: list[str] = [f"Validation error for {tool_name}:"]
@@ -494,6 +529,7 @@ class BackshopAgent:
             response = await self._call_llm_with_retry(messages, tool_schemas, llm_kwargs)
             purpose = "agent_main" if _round == 0 else "agent_followup"
             log_llm_usage(self.db, self.contractor.id, settings.llm_model, response, purpose)
+            _log_token_estimation_drift(messages, response)
 
             # Parse tool calls via shared parser
             parsed_raw = parse_tool_calls(response)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,5 +1,6 @@
 import json
-from unittest.mock import AsyncMock, patch
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from any_llm import (
@@ -16,6 +17,7 @@ from backend.app.agent.core import (
     MAX_INPUT_TOKENS,
     BackshopAgent,
     _estimate_tokens,
+    _log_token_estimation_drift,
 )
 from backend.app.agent.messages import (
     AgentMessage,
@@ -589,6 +591,82 @@ def test_estimate_tokens_counts_tool_call_content() -> None:
     # Compare with a message that has no tool_calls -- should be less
     plain = [AssistantMessage(content=None)]
     assert _estimate_tokens(plain) < result
+
+
+# ---------------------------------------------------------------------------
+# Token estimation drift logging
+# ---------------------------------------------------------------------------
+
+
+def test_log_token_estimation_drift_warns_when_off(caplog: pytest.LogCaptureFixture) -> None:
+    """_log_token_estimation_drift should warn when estimate drifts more than 30 percent."""
+    messages: list[AgentMessage] = [
+        SystemMessage(content="You are a helpful assistant."),
+        UserMessage(content="Hello, how are you today?"),
+    ]
+    # Build a mock response whose actual prompt_tokens differs greatly from our estimate.
+    # Our estimate: ~(35 + 26) / 3.5 + 2*4 = ~25 tokens
+    # Set actual to 100 so the estimate (~25) is far below actual.
+    response = MagicMock()
+    usage = MagicMock()
+    usage.prompt_tokens = 100
+    response.usage = usage
+
+    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
+        _log_token_estimation_drift(messages, response)
+
+    assert any("Token estimate drift" in rec.message for rec in caplog.records)
+    # Verify logged values contain the key details
+    drift_record = next(r for r in caplog.records if "Token estimate drift" in r.message)
+    assert "estimated=" in drift_record.message
+    assert "actual=100" in drift_record.message
+
+
+def test_log_token_estimation_drift_silent_when_close(caplog: pytest.LogCaptureFixture) -> None:
+    """_log_token_estimation_drift should not warn when estimate is within 30 percent."""
+    messages: list[AgentMessage] = [
+        SystemMessage(content="x" * 350),  # ~100 tokens
+    ]
+    # Our estimate: 350/3.5 + 4 = 104 tokens. Set actual to 100 (4% off).
+    response = MagicMock()
+    usage = MagicMock()
+    usage.prompt_tokens = 100
+    response.usage = usage
+
+    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
+        _log_token_estimation_drift(messages, response)
+
+    assert not any("Token estimate drift" in rec.message for rec in caplog.records)
+
+
+def test_log_token_estimation_drift_no_usage(caplog: pytest.LogCaptureFixture) -> None:
+    """_log_token_estimation_drift should be silent when response has no usage."""
+    messages: list[AgentMessage] = [
+        SystemMessage(content="Hello"),
+    ]
+    response = MagicMock()
+    response.usage = None
+
+    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
+        _log_token_estimation_drift(messages, response)
+
+    assert not any("Token estimate drift" in rec.message for rec in caplog.records)
+
+
+def test_log_token_estimation_drift_zero_prompt_tokens(caplog: pytest.LogCaptureFixture) -> None:
+    """_log_token_estimation_drift should be silent when prompt_tokens is 0."""
+    messages: list[AgentMessage] = [
+        SystemMessage(content="Hello"),
+    ]
+    response = MagicMock()
+    usage = MagicMock()
+    usage.prompt_tokens = 0
+    response.usage = usage
+
+    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
+        _log_token_estimation_drift(messages, response)
+
+    assert not any("Token estimate drift" in rec.message for rec in caplog.records)
 
 
 def test_trim_messages_preserves_tool_call_result_pairs() -> None:


### PR DESCRIPTION
## Summary
- Adds `_log_token_estimation_drift()` to `backend/app/agent/core.py` that compares the character-ratio token estimate against `response.usage.prompt_tokens` from the LLM provider
- Logs a WARNING when the estimate drifts more than 30% from actual, including the observed chars-per-token ratio so operators can tune `_CHARS_PER_TOKEN`
- Gracefully handles providers that don't return usage data (skips silently)
- Called after each `_call_llm_with_retry` in the agent loop, right after existing `log_llm_usage`

## Test plan
- [x] `test_log_token_estimation_drift_warns_when_off` - verifies warning is logged when estimate is significantly off
- [x] `test_log_token_estimation_drift_silent_when_close` - verifies no warning when estimate is within 30%
- [x] `test_log_token_estimation_drift_no_usage` - verifies silent when response has no usage data
- [x] `test_log_token_estimation_drift_zero_prompt_tokens` - verifies silent when prompt_tokens is 0
- [x] All 776 existing tests pass
- [x] Ruff lint and format checks pass

Fixes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)