### PR TITLE
refactor: make inbound message pipeline composable via middleware

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -1,7 +1,9 @@
 """Inbound message processing pipeline.
 
 Each step is an independent function with clear inputs/outputs.
-``handle_inbound_message`` orchestrates them in sequence.
+``handle_inbound_message`` orchestrates them via a composable pipeline
+of ``PipelineStep`` callables, making it easy to add, remove, or reorder
+steps without modifying the orchestrator itself.
 """
 
 from __future__ import annotations
@@ -9,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 
 from any_llm import AuthenticationError, ContentFilterError
 from sqlalchemy.orm import Session
@@ -62,7 +65,35 @@ ensure_tool_modules_imported()
 
 
 # ---------------------------------------------------------------------------
-# Pipeline steps
+# Pipeline context and types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PipelineContext:
+    """Shared state passed through pipeline steps."""
+
+    db: Session
+    contractor: Contractor
+    message: Message
+    media_urls: list[tuple[str, str]]
+    messaging_service: MessagingService
+    to_address: str = ""
+    downloaded_media: list[DownloadedMedia] = field(default_factory=list)
+    storage: StorageBackend | None = None
+    combined_context: str = ""
+    conversation_history: list[AgentMessage] = field(default_factory=list)
+    system_prompt_override: str | None = None
+    event_subscribers: list[Callable[[AgentEvent], Awaitable[None]]] = field(default_factory=list)
+    response: AgentResponse | None = None
+    _onboarding_sub: OnboardingSubscriber | None = None
+
+
+PipelineStep = Callable[[PipelineContext], Awaitable[PipelineContext]]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline steps (original functions)
 # ---------------------------------------------------------------------------
 
 
@@ -282,6 +313,103 @@ def persist_outbound(
 
 
 # ---------------------------------------------------------------------------
+# Composable pipeline step wrappers
+# ---------------------------------------------------------------------------
+
+
+async def prepare_media_step(ctx: PipelineContext) -> PipelineContext:
+    """Download media and initialize storage backend."""
+    ctx.downloaded_media, ctx.storage = await prepare_media(
+        ctx.db, ctx.contractor, ctx.message.id, ctx.media_urls, ctx.messaging_service
+    )
+    return ctx
+
+
+async def build_context_step(ctx: PipelineContext) -> PipelineContext:
+    """Run media pipeline and build combined context."""
+    ctx.combined_context = await build_message_context(
+        ctx.db, ctx.message, ctx.contractor, ctx.media_urls, ctx.downloaded_media
+    )
+    return ctx
+
+
+async def load_history_step(ctx: PipelineContext) -> PipelineContext:
+    """Load conversation history and set up onboarding."""
+    ctx.conversation_history = await load_conversation_history(
+        ctx.db, ctx.message.conversation_id, contractor_id=ctx.contractor.id
+    )
+    was_onboarding = is_onboarding_needed(ctx.contractor)
+    if was_onboarding:
+        ctx.system_prompt_override = build_onboarding_system_prompt(ctx.contractor)
+    onboarding_sub = OnboardingSubscriber(ctx.db, ctx.contractor, was_onboarding)
+    ctx.event_subscribers.append(onboarding_sub)
+    ctx._onboarding_sub = onboarding_sub
+    return ctx
+
+
+async def run_agent_step(ctx: PipelineContext) -> PipelineContext:
+    """Initialize agent with tools and process the message."""
+    ctx.response = await run_agent(
+        db=ctx.db,
+        contractor=ctx.contractor,
+        message=ctx.message,
+        combined_context=ctx.combined_context,
+        conversation_history=ctx.conversation_history,
+        storage=ctx.storage,
+        messaging_service=ctx.messaging_service,
+        to_address=ctx.to_address,
+        downloaded_media=ctx.downloaded_media,
+        system_prompt_override=ctx.system_prompt_override,
+        event_subscribers=ctx.event_subscribers,
+    )
+    return ctx
+
+
+async def finalize_onboarding_step(ctx: PipelineContext) -> PipelineContext:
+    """Append onboarding completion note if applicable."""
+    if ctx._onboarding_sub and ctx.response:
+        ctx._onboarding_sub.finalize(ctx.response)
+    return ctx
+
+
+async def dispatch_reply_step(ctx: PipelineContext) -> PipelineContext:
+    """Send reply to the contractor."""
+    if ctx.response:
+        await dispatch_reply(ctx.response, ctx.messaging_service, ctx.to_address, ctx.message.id)
+    return ctx
+
+
+async def persist_outbound_step(ctx: PipelineContext) -> PipelineContext:
+    """Store outbound message record."""
+    if ctx.response:
+        persist_outbound(ctx.db, ctx.message.conversation_id, ctx.response)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Pipeline runner and default pipeline
+# ---------------------------------------------------------------------------
+
+
+async def run_pipeline(ctx: PipelineContext, steps: list[PipelineStep]) -> PipelineContext:
+    """Execute pipeline steps in sequence."""
+    for step in steps:
+        ctx = await step(ctx)
+    return ctx
+
+
+DEFAULT_PIPELINE: list[PipelineStep] = [
+    prepare_media_step,
+    build_context_step,
+    load_history_step,
+    run_agent_step,
+    finalize_onboarding_step,
+    dispatch_reply_step,
+    persist_outbound_step,
+]
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
 
@@ -292,16 +420,13 @@ async def handle_inbound_message(
     message: Message,
     media_urls: list[tuple[str, str]],
     messaging_service: MessagingService,
+    pipeline: list[PipelineStep] | None = None,
 ) -> AgentResponse:
     """Full message processing pipeline.
 
-    Orchestrates discrete pipeline steps:
-    1. prepare_media        - download and auto-save media
-    2. build_message_context - run media pipeline, build combined context
-    3. run_agent            - initialize agent with tools and event subscribers
-    4. finalize_onboarding  - append completion note if onboarding just finished
-    5. dispatch_reply       - send reply to contractor
-    6. persist_outbound     - store outbound message record
+    Orchestrates discrete pipeline steps via a composable list of
+    ``PipelineStep`` callables. Pass a custom ``pipeline`` to add,
+    remove, or reorder steps; defaults to ``DEFAULT_PIPELINE``.
     """
     to_address = contractor.channel_identifier or contractor.phone
     if not to_address:
@@ -311,44 +436,13 @@ async def handle_inbound_message(
         )
         return AgentResponse(reply_text="")
 
-    # 1. Download and auto-save media
-    downloaded_media, storage = await prepare_media(
-        db, contractor, message.id, media_urls, messaging_service
-    )
-
-    # 2. Build combined context from text + media
-    combined_context = await build_message_context(
-        db, message, contractor, media_urls, downloaded_media
-    )
-
-    # 3. Load history and run agent (with onboarding subscriber)
-    conversation_history = await load_conversation_history(
-        db, message.conversation_id, contractor_id=contractor.id
-    )
-    was_onboarding = is_onboarding_needed(contractor)
-    system_prompt_override = build_onboarding_system_prompt(contractor) if was_onboarding else None
-    onboarding_sub = OnboardingSubscriber(db, contractor, was_onboarding)
-    response = await run_agent(
+    ctx = PipelineContext(
         db=db,
         contractor=contractor,
         message=message,
-        combined_context=combined_context,
-        conversation_history=conversation_history,
-        storage=storage,
+        media_urls=media_urls,
         messaging_service=messaging_service,
         to_address=to_address,
-        downloaded_media=downloaded_media,
-        system_prompt_override=system_prompt_override,
-        event_subscribers=[onboarding_sub],
     )
-
-    # 4. Finalize onboarding (append completion note if applicable)
-    onboarding_sub.finalize(response)
-
-    # 5. Send reply
-    await dispatch_reply(response, messaging_service, to_address, message.id)
-
-    # 6. Persist outbound message
-    persist_outbound(db, message.conversation_id, response)
-
-    return response
+    ctx = await run_pipeline(ctx, pipeline or DEFAULT_PIPELINE)
+    return ctx.response or AgentResponse(reply_text="")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,207 @@
+"""Tests for the composable inbound message pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.app.agent.router import (
+    DEFAULT_PIPELINE,
+    PipelineContext,
+    PipelineStep,
+    build_context_step,
+    dispatch_reply_step,
+    finalize_onboarding_step,
+    load_history_step,
+    persist_outbound_step,
+    prepare_media_step,
+    run_agent_step,
+    run_pipeline,
+)
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_executes_steps_in_order() -> None:
+    """Steps should execute sequentially, each receiving the context from the prior step."""
+    call_order: list[str] = []
+
+    async def step_a(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("a")
+        return ctx
+
+    async def step_b(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("b")
+        return ctx
+
+    async def step_c(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("c")
+        return ctx
+
+    # Use a minimal context; fields are unused by these test steps
+    ctx = PipelineContext(
+        db=None,  # type: ignore[arg-type]
+        contractor=None,  # type: ignore[arg-type]
+        message=None,  # type: ignore[arg-type]
+        media_urls=[],
+        messaging_service=None,  # type: ignore[arg-type]
+    )
+
+    await run_pipeline(ctx, [step_a, step_b, step_c])
+    assert call_order == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_passes_context_through() -> None:
+    """Each step should receive and return the same context object."""
+    seen_contexts: list[PipelineContext] = []
+
+    async def tracking_step(ctx: PipelineContext) -> PipelineContext:
+        seen_contexts.append(ctx)
+        return ctx
+
+    ctx = PipelineContext(
+        db=None,  # type: ignore[arg-type]
+        contractor=None,  # type: ignore[arg-type]
+        message=None,  # type: ignore[arg-type]
+        media_urls=[],
+        messaging_service=None,  # type: ignore[arg-type]
+    )
+
+    result = await run_pipeline(ctx, [tracking_step, tracking_step])
+    assert result is ctx
+    assert all(c is ctx for c in seen_contexts)
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_empty_steps() -> None:
+    """An empty pipeline should return the context unchanged."""
+    ctx = PipelineContext(
+        db=None,  # type: ignore[arg-type]
+        contractor=None,  # type: ignore[arg-type]
+        message=None,  # type: ignore[arg-type]
+        media_urls=[],
+        messaging_service=None,  # type: ignore[arg-type]
+    )
+    result = await run_pipeline(ctx, [])
+    assert result is ctx
+
+
+def test_default_pipeline_contains_all_steps() -> None:
+    """DEFAULT_PIPELINE should include all seven standard steps in the correct order."""
+    expected: list[PipelineStep] = [
+        prepare_media_step,
+        build_context_step,
+        load_history_step,
+        run_agent_step,
+        finalize_onboarding_step,
+        dispatch_reply_step,
+        persist_outbound_step,
+    ]
+    assert expected == DEFAULT_PIPELINE
+
+
+def test_default_pipeline_length() -> None:
+    """DEFAULT_PIPELINE should have exactly 7 steps."""
+    assert len(DEFAULT_PIPELINE) == 7
+
+
+@pytest.mark.asyncio
+async def test_custom_pipeline_can_skip_steps() -> None:
+    """A custom pipeline can omit steps from the default."""
+    call_order: list[str] = []
+
+    async def mock_prepare(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("prepare")
+        return ctx
+
+    async def mock_agent(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("agent")
+        return ctx
+
+    ctx = PipelineContext(
+        db=None,  # type: ignore[arg-type]
+        contractor=None,  # type: ignore[arg-type]
+        message=None,  # type: ignore[arg-type]
+        media_urls=[],
+        messaging_service=None,  # type: ignore[arg-type]
+    )
+
+    await run_pipeline(ctx, [mock_prepare, mock_agent])
+    assert call_order == ["prepare", "agent"]
+
+
+@pytest.mark.asyncio
+async def test_custom_pipeline_can_add_steps() -> None:
+    """A custom pipeline can inject extra steps between default ones."""
+    call_order: list[str] = []
+
+    async def step_default(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("default")
+        return ctx
+
+    async def step_custom(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("custom")
+        return ctx
+
+    ctx = PipelineContext(
+        db=None,  # type: ignore[arg-type]
+        contractor=None,  # type: ignore[arg-type]
+        message=None,  # type: ignore[arg-type]
+        media_urls=[],
+        messaging_service=None,  # type: ignore[arg-type]
+    )
+
+    await run_pipeline(ctx, [step_default, step_custom, step_default])
+    assert call_order == ["default", "custom", "default"]
+
+
+@pytest.mark.asyncio
+async def test_custom_pipeline_can_reorder_steps() -> None:
+    """A custom pipeline can reorder steps."""
+    call_order: list[str] = []
+
+    async def step_x(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("x")
+        return ctx
+
+    async def step_y(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("y")
+        return ctx
+
+    async def step_z(ctx: PipelineContext) -> PipelineContext:
+        call_order.append("z")
+        return ctx
+
+    ctx = PipelineContext(
+        db=None,  # type: ignore[arg-type]
+        contractor=None,  # type: ignore[arg-type]
+        message=None,  # type: ignore[arg-type]
+        media_urls=[],
+        messaging_service=None,  # type: ignore[arg-type]
+    )
+
+    # Reverse order
+    await run_pipeline(ctx, [step_z, step_y, step_x])
+    assert call_order == ["z", "y", "x"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_step_can_mutate_context() -> None:
+    """A step should be able to set fields on the context for later steps."""
+
+    async def set_context(ctx: PipelineContext) -> PipelineContext:
+        ctx.combined_context = "hello from step"
+        return ctx
+
+    async def check_context(ctx: PipelineContext) -> PipelineContext:
+        assert ctx.combined_context == "hello from step"
+        return ctx
+
+    ctx = PipelineContext(
+        db=None,  # type: ignore[arg-type]
+        contractor=None,  # type: ignore[arg-type]
+        message=None,  # type: ignore[arg-type]
+        media_urls=[],
+        messaging_service=None,  # type: ignore[arg-type]
+    )
+
+    await run_pipeline(ctx, [set_context, check_context])


### PR DESCRIPTION
## Summary
- Introduce `PipelineContext` dataclass and `PipelineStep` type alias to make `handle_inbound_message` orchestrate a composable list of step functions instead of hardcoded calls
- Wrap the seven existing pipeline steps (prepare_media, build_context, load_history, run_agent, finalize_onboarding, dispatch_reply, persist_outbound) as thin step wrappers in `DEFAULT_PIPELINE`
- `handle_inbound_message` now accepts an optional `pipeline` parameter for extensibility while defaulting to `DEFAULT_PIPELINE`, maintaining full backward compatibility

## Test plan
- [x] All 813 existing tests pass unchanged (purely structural refactor)
- [x] 9 new tests in `tests/test_pipeline.py` covering:
  - `run_pipeline` executes steps in order
  - Context is passed through and mutated correctly
  - Empty pipeline returns context unchanged
  - `DEFAULT_PIPELINE` contains all 7 expected steps in correct order
  - Custom pipelines can skip, add, and reorder steps
- [x] Ruff lint and format checks pass

Fixes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)