### PR TITLE
fix: resolve ty type-check failures in CI

### DIFF
--- a/backend/app/media/audio.py
+++ b/backend/app/media/audio.py
@@ -23,7 +23,7 @@ async def transcribe_audio(audio_bytes: bytes, mime_type: str = "audio/ogg") -> 
 def _transcribe_sync(audio_bytes: bytes) -> str:
     """Synchronous transcription with faster-whisper."""
     try:
-        from faster_whisper import WhisperModel  # type: ignore[unresolved-import]
+        from faster_whisper import WhisperModel
     except ImportError:
         msg = (
             "faster-whisper is required for audio transcription. "

--- a/tests/test_tool_tags.py
+++ b/tests/test_tool_tags.py
@@ -88,8 +88,8 @@ def test_tool_tags_do_not_leak_between_instances() -> None:
     """Each Tool instance should have its own tags set (no shared default)."""
     tool_a = Tool(name="a", description="A", function=lambda: None, parameters={})
     tool_b = Tool(name="b", description="B", function=lambda: None, parameters={})
-    tool_a.tags.add("custom")
-    assert "custom" not in tool_b.tags
+    tool_a.tags.add(ToolTags.SAVES_MEMORY)
+    assert ToolTags.SAVES_MEMORY not in tool_b.tags
 
 
 # --- Tool factory tags ---


### PR DESCRIPTION
## Summary
- Remove unused `type: ignore[unresolved-import]` on `faster_whisper` import in `audio.py` (the package is installed in CI, so the suppression was flagged as unused by ty)
- Fix `test_tool_tags_do_not_leak_between_instances` to use `ToolTags.SAVES_MEMORY` instead of a plain string `"custom"` after `Tool.tags` was typed as `set[ToolTags]` in PR #368

## Test plan
- [x] All 813 tests pass
- [x] Ruff lint and format pass
- [x] Fixes the two ty diagnostics shown in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)