### PR TITLE
fix: convert /start bot command to greeting, ignore other commands

### DIFF
--- a/backend/app/routers/telegram_webhook.py
+++ b/backend/app/routers/telegram_webhook.py
@@ -140,7 +140,20 @@ def _parse_telegram_update(update: dict) -> InboundMessage | None:
         return None
 
     chat_id = str(chat["id"])
-    text = msg.get("text") or msg.get("caption") or ""
+    raw_text = msg.get("text") or msg.get("caption") or ""
+
+    # Strip Telegram bot commands: /start is sent automatically when a user
+    # opens the bot for the first time. Treat it as a greeting so the agent
+    # sees a natural message instead of a raw command.
+    text = raw_text
+    if raw_text.strip().lower() in ("/start", "/start@"):
+        text = "Hi"
+    elif raw_text.strip().startswith("/"):
+        # Ignore other bot commands (e.g. /help, /settings) that the bot
+        # does not handle. Return None to skip processing entirely.
+        logger.debug("Ignoring unhandled bot command: %s", raw_text.strip().split()[0])
+        return None
+
     username = msg.get("from", {}).get("username", "")
 
     if not _check_allowlist(chat_id, username):

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -665,3 +665,33 @@ def test_inbound_webhook_extracts_video(
     messages = db_session.query(Message).all()
     assert len(messages) == 1
     assert "BAACAgIAAxkBAAI" in messages[0].media_urls_json
+
+
+# -- Telegram bot command handling --
+
+
+def test_start_command_converted_to_greeting(
+    client: TestClient, db_session: Session, test_contractor: Contractor
+) -> None:
+    """/start command should be converted to a greeting, not passed as raw text."""
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE):
+        payload = make_telegram_update_payload(
+            chat_id=int(test_contractor.channel_identifier),
+            text="/start",
+        )
+        response = client.post("/api/webhooks/telegram", json=payload)
+    assert response.status_code == 200
+
+    messages = db_session.query(Message).all()
+    assert len(messages) == 1
+    assert messages[0].body == "Hi"
+
+
+def test_other_bot_commands_ignored(client: TestClient, db_session: Session) -> None:
+    """Unhandled bot commands (e.g. /help) should be silently ignored."""
+    with patch(_PATCH_HANDLE, new_callable=AsyncMock, return_value=_MOCK_AGENT_RESPONSE) as mock_h:
+        payload = make_telegram_update_payload(chat_id=123456789, text="/help")
+        response = client.post("/api/webhooks/telegram", json=payload)
+    assert response.status_code == 200
+    mock_h.assert_not_called()
+    assert db_session.query(Message).count() == 0


### PR DESCRIPTION
## Summary
- `/start` (Telegram's automatic first-open command) is now converted to "Hi" so the agent sees a natural greeting
- Other unhandled bot commands (e.g. `/help`, `/settings`) are silently ignored instead of being processed as messages

## Test plan
- [x] `test_start_command_converted_to_greeting` - verifies `/start` becomes "Hi" in the stored message
- [x] `test_other_bot_commands_ignored` - verifies `/help` is dropped without processing
- [x] All 815 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)