### PR TITLE
docs: add demo video embed to README and docs landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Clawbolt is a messaging-first AI assistant that helps contractors manage their b
 
 ## Demo
 
-<!-- TODO: Replace YOUTUBE_VIDEO_ID with the actual video ID -->
-[![Clawbolt Demo](https://img.youtube.com/vi/YOUTUBE_VIDEO_ID/maxresdefault.jpg)](https://www.youtube.com/watch?v=YOUTUBE_VIDEO_ID)
+[![Clawbolt Demo](https://img.youtube.com/vi/Tp4nS8CapD4/maxresdefault.jpg)](https://www.youtube.com/watch?v=Tp4nS8CapD4)
 
 ## Features
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -21,11 +21,10 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 
 ## See it in action
 
-{/* TODO: Replace YOUTUBE_VIDEO_ID with the actual video ID */}
 <iframe
   width="100%"
   style="aspect-ratio:16/9;border-radius:8px"
-  src="https://www.youtube-nocookie.com/embed/YOUTUBE_VIDEO_ID"
+  src="https://www.youtube-nocookie.com/embed/Tp4nS8CapD4"
   title="Clawbolt Demo"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## Summary

- Adds a YouTube thumbnail link to the README (Demo section between intro and Features)
- Adds an iframe embed to the docs landing page (new "See it in action" section below the hero)
- Both use `YOUTUBE_VIDEO_ID` placeholder to swap in once the video is uploaded

Stacked on #381 (docs site PR).

## Before merging

Find-and-replace `YOUTUBE_VIDEO_ID` with the actual video ID in both files:
- `README.md`
- `docs/src/content/docs/index.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)