### PR TITLE
fix: verify LLM provider and model settings on startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
+from any_llm import acompletion
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -59,9 +60,73 @@ async def _auto_register_webhook() -> None:
         logger.warning("Failed to auto-register Telegram webhook")
 
 
+async def _verify_llm_settings() -> None:
+    """Verify LLM provider/model settings by making a minimal completion call.
+
+    Surfaces misconfigurations (bad provider, invalid model, missing API key)
+    at startup rather than at first user request.  The primary model is
+    required; failures for optional model overrides are logged as warnings.
+    """
+    configs: list[tuple[str, str, str]] = [
+        ("primary", settings.llm_provider, settings.llm_model),
+    ]
+    if settings.vision_model:
+        configs.append(("vision", settings.llm_provider, settings.vision_model))
+    if settings.compaction_model or settings.compaction_provider:
+        configs.append(
+            (
+                "compaction",
+                settings.compaction_provider or settings.llm_provider,
+                settings.compaction_model or settings.llm_model,
+            )
+        )
+    if settings.heartbeat_model or settings.heartbeat_provider:
+        configs.append(
+            (
+                "heartbeat",
+                settings.heartbeat_provider or settings.llm_provider,
+                settings.heartbeat_model or settings.llm_model,
+            )
+        )
+
+    # Deduplicate by (provider, model) to avoid redundant API calls.
+    seen: set[tuple[str, str]] = set()
+    unique: list[tuple[str, str, str]] = []
+    for label, provider, model in configs:
+        key = (provider, model)
+        if key not in seen:
+            seen.add(key)
+            unique.append((label, provider, model))
+
+    for label, provider, model in unique:
+        try:
+            await acompletion(
+                model=model,
+                provider=provider,
+                api_base=settings.llm_api_base,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+            )
+            logger.info("LLM verified (%s): provider=%s, model=%s", label, provider, model)
+        except Exception as exc:
+            if label == "primary":
+                raise RuntimeError(
+                    f"LLM startup check failed for {label} model "
+                    f"(LLM_PROVIDER={provider!r}, LLM_MODEL={model!r}): {exc}"
+                ) from exc
+            logger.warning(
+                "LLM startup check failed for %s model (provider=%r, model=%r): %s",
+                label,
+                provider,
+                model,
+                exc,
+            )
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     """Start/stop background services."""
+    await _verify_llm_settings()
     heartbeat_scheduler.start()
 
     if settings.telegram_bot_token:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ def client(
     app.dependency_overrides[get_current_user] = _override_get_current_user
     app.dependency_overrides[get_messaging_service] = _override_get_messaging_service
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.agent.ingestion.SessionLocal", test_session_factory),
         # Default allowlist to "*" (allow all) so tests are not blocked.

--- a/tests/e2e/test_telegram_e2e.py
+++ b/tests/e2e/test_telegram_e2e.py
@@ -66,6 +66,7 @@ def e2e_client(
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_messaging_service] = _override_get_messaging_service
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.agent.ingestion.SessionLocal", test_session_factory),
         # Disable webhook secret validation so e2e tests don't need to derive

--- a/tests/test_allowlist_empty_warning.py
+++ b/tests/test_allowlist_empty_warning.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Generator
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -30,6 +30,7 @@ def test_warns_when_both_allowlists_empty(caplog: "pytest.LogCaptureFixture") ->
     app.dependency_overrides[get_db] = _override_get_db
 
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.main.settings") as mock_settings,
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
@@ -65,6 +66,7 @@ def test_no_warning_when_chat_ids_set(caplog: "pytest.LogCaptureFixture") -> Non
     app.dependency_overrides[get_db] = _override_get_db
 
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.main.settings") as mock_settings,
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
@@ -100,6 +102,7 @@ def test_no_warning_when_usernames_set(caplog: "pytest.LogCaptureFixture") -> No
     app.dependency_overrides[get_db] = _override_get_db
 
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.main.settings") as mock_settings,
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
@@ -137,6 +140,7 @@ def test_no_allowlist_warning_when_bot_token_not_set(
     app.dependency_overrides[get_db] = _override_get_db
 
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.main.settings") as mock_settings,
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),

--- a/tests/test_llm_verification.py
+++ b/tests/test_llm_verification.py
@@ -1,0 +1,270 @@
+"""Tests for LLM settings verification at startup."""
+
+import logging
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.app.database import Base, get_db
+from backend.app.main import app
+
+
+def _setup_db() -> tuple[Session, "sessionmaker[Session]"]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    return session, sessionmaker(bind=engine)
+
+
+def test_startup_succeeds_when_primary_model_is_valid(
+    caplog: "pytest.LogCaptureFixture",
+) -> None:
+    """Startup should succeed and log verification when the primary model works."""
+    session, _ = _setup_db()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.acompletion", new_callable=AsyncMock) as mock_acompletion,
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_api_base = None
+        mock_settings.vision_model = ""
+        mock_settings.compaction_model = ""
+        mock_settings.compaction_provider = ""
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.telegram_bot_token = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.INFO, logger="backend.app.main"), TestClient(app):
+            pass
+
+        mock_acompletion.assert_called_once()
+        call_kwargs = mock_acompletion.call_args
+        assert call_kwargs.kwargs["provider"] == "openai"
+        assert call_kwargs.kwargs["model"] == "gpt-4o"
+        assert call_kwargs.kwargs["max_tokens"] == 1
+
+    assert any("LLM verified (primary)" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_startup_fails_when_primary_model_is_invalid() -> None:
+    """Startup should raise RuntimeError when the primary model check fails."""
+    session, _ = _setup_db()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch(
+            "backend.app.main.acompletion",
+            new_callable=AsyncMock,
+            side_effect=Exception("model not found: bad-model"),
+        ),
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_model = "bad-model"
+        mock_settings.llm_api_base = None
+        mock_settings.vision_model = ""
+        mock_settings.compaction_model = ""
+        mock_settings.compaction_provider = ""
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.telegram_bot_token = ""
+        mock_settings.cors_origins = "*"
+
+        with (
+            pytest.raises(RuntimeError, match="LLM startup check failed for primary model"),
+            TestClient(app),
+        ):
+            pass
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_startup_warns_when_optional_model_is_invalid(
+    caplog: "pytest.LogCaptureFixture",
+) -> None:
+    """Optional model failures should warn but not block startup."""
+    session, _ = _setup_db()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    call_count = 0
+
+    async def _selective_fail(**kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Primary model succeeds
+            return
+        # Vision model fails
+        raise Exception("model not found: bad-vision")
+
+    with (
+        patch("backend.app.main.acompletion", side_effect=_selective_fail),
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_api_base = None
+        mock_settings.vision_model = "bad-vision"
+        mock_settings.compaction_model = ""
+        mock_settings.compaction_provider = ""
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.telegram_bot_token = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
+            pass
+
+    assert any("LLM startup check failed for vision model" in msg for msg in caplog.messages)
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_deduplicates_identical_provider_model_pairs(
+    caplog: "pytest.LogCaptureFixture",
+) -> None:
+    """Identical (provider, model) pairs should only be checked once."""
+    session, _ = _setup_db()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.acompletion", new_callable=AsyncMock) as mock_acompletion,
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_api_base = None
+        mock_settings.vision_model = ""
+        # Compaction uses same provider/model as primary (explicit override to same values)
+        mock_settings.compaction_model = "gpt-4o"
+        mock_settings.compaction_provider = "openai"
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.telegram_bot_token = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.INFO, logger="backend.app.main"), TestClient(app):
+            pass
+
+        # Only one call since (openai, gpt-4o) is deduplicated
+        assert mock_acompletion.call_count == 1
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_checks_all_distinct_model_configs(
+    caplog: "pytest.LogCaptureFixture",
+) -> None:
+    """Each distinct (provider, model) pair should get its own verification call."""
+    session, _ = _setup_db()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch("backend.app.main.acompletion", new_callable=AsyncMock) as mock_acompletion,
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_api_base = None
+        mock_settings.vision_model = "gpt-4o-vision"
+        mock_settings.compaction_model = "gpt-4o-mini"
+        mock_settings.compaction_provider = "openai"
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = "anthropic"
+        mock_settings.telegram_bot_token = ""
+        mock_settings.cors_origins = "*"
+
+        with caplog.at_level(logging.INFO, logger="backend.app.main"), TestClient(app):
+            pass
+
+        # 4 distinct configs: primary, vision, compaction, heartbeat
+        assert mock_acompletion.call_count == 4
+
+    session.close()
+    app.dependency_overrides.clear()
+
+
+def test_error_message_includes_env_var_names() -> None:
+    """RuntimeError message should reference LLM_PROVIDER and LLM_MODEL env var names."""
+    session, _ = _setup_db()
+
+    def _override_get_db() -> Generator[Session]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with (
+        patch(
+            "backend.app.main.acompletion",
+            new_callable=AsyncMock,
+            side_effect=Exception("auth failed"),
+        ),
+        patch("backend.app.main.settings") as mock_settings,
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+    ):
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_api_base = None
+        mock_settings.vision_model = ""
+        mock_settings.compaction_model = ""
+        mock_settings.compaction_provider = ""
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.telegram_bot_token = ""
+        mock_settings.cors_origins = "*"
+
+        with pytest.raises(RuntimeError, match=r"LLM_PROVIDER.*LLM_MODEL"), TestClient(app):
+            pass
+
+    session.close()
+    app.dependency_overrides.clear()

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -91,7 +91,11 @@ def _rate_limited_client() -> Generator[TestClient]:
     # Explicitly remove rate limiter override so the real one is used
     app.dependency_overrides.pop(check_webhook_rate_limit, None)
 
-    with patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"), TestClient(app) as c:
+    with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        TestClient(app) as c,
+    ):
         yield c
 
     app.dependency_overrides.clear()

--- a/tests/test_webhook_secret_validation.py
+++ b/tests/test_webhook_secret_validation.py
@@ -79,6 +79,7 @@ def _make_client(
     app.dependency_overrides[check_webhook_rate_limit] = lambda: None
 
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch(
             "backend.app.routers.telegram_webhook.settings.telegram_webhook_secret",

--- a/tests/test_webhook_secret_warning.py
+++ b/tests/test_webhook_secret_warning.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Generator
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -32,6 +32,7 @@ def test_logs_auto_derived_secret_when_no_explicit_secret(
     app.dependency_overrides[get_db] = _override_get_db
 
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.main.settings") as mock_settings,
         patch("backend.app.main.get_effective_webhook_secret"),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
@@ -70,6 +71,7 @@ def test_logs_configured_secret_when_explicit_secret_set(
     app.dependency_overrides[get_db] = _override_get_db
 
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.main.settings") as mock_settings,
         patch("backend.app.main.get_effective_webhook_secret"),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
@@ -105,6 +107,7 @@ def test_no_warning_when_bot_token_not_set(caplog: "pytest.LogCaptureFixture") -
     app.dependency_overrides[get_db] = _override_get_db
 
     with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.main.settings") as mock_settings,
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),


### PR DESCRIPTION
## Description
Adds startup verification of LLM settings by making a minimal `acompletion` call (`max_tokens=1`) for each configured model during the `lifespan` startup phase. This surfaces misconfigurations (bad provider, invalid model, missing API key) immediately rather than at first user request.

- **Primary model** (`LLM_PROVIDER`/`LLM_MODEL`): blocks startup with a clear `RuntimeError` on failure
- **Optional overrides** (`VISION_MODEL`, `COMPACTION_MODEL`/`COMPACTION_PROVIDER`, `HEARTBEAT_MODEL`/`HEARTBEAT_PROVIDER`): logs warnings but allows startup
- Deduplicates identical (provider, model) pairs to avoid redundant API calls

Fixes #385

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)