### PR TITLE
fix: rephrase "blue-collar" to "in the trades"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Clawbolt
 
-Clawbolt is an AI assistant for solo blue-collar contractors. FastAPI backend with a Telegram messaging interface and a custom tool-calling agent loop built on any-llm. Built by Mozilla.ai using the open-core model.
+Clawbolt is an AI assistant for the trades. FastAPI backend with a Telegram messaging interface and a custom tool-calling agent loop built on any-llm. Built by Mozilla.ai using the open-core model.
 
 ## Build & Run Commands
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Clawbolt
-description: AI assistant for solo blue-collar contractors. Built by Mozilla.ai.
+description: AI assistant for the trades. Built by Mozilla.ai.
 template: splash
 hero:
-  tagline: AI assistant for solo blue-collar contractors. Estimates, memory, photos, voice memos, and more, all through Telegram.
+  tagline: AI assistant for the trades. Estimates, memory, photos, voice memos, and more, all through Telegram.
   image:
     file: ../../assets/clawbolt_text.png
   actions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "clawbolt"
 version = "0.1.0"
-description = "AI assistant for solo blue-collar contractors"
+description = "AI assistant for the trades"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",


### PR DESCRIPTION
## Description
Replace remaining occurrences of "solo blue-collar contractors" with "the trades" across pyproject.toml, AGENTS.md, and the docs site, matching the phrasing already used in README.md.

Fixes #392

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)