### PR TITLE
feat: add role column to Contractor model

### DIFF
--- a/alembic/versions/002_add_contractor_role.py
+++ b/alembic/versions/002_add_contractor_role.py
@@ -1,0 +1,29 @@
+"""Add role column to contractors
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-03-04
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "contractors",
+        sa.Column("role", sa.String(20), server_default="user", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("contractors", "role")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -24,6 +24,7 @@ class Contractor(Base):
     channel_identifier: Mapped[str] = mapped_column(String(255), default="")
     onboarding_complete: Mapped[bool] = mapped_column(Boolean, default=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    role: Mapped[str] = mapped_column(String(20), default="user")
     preferences_json: Mapped[str] = mapped_column(Text, default="{}")
     heartbeat_opt_in: Mapped[bool] = mapped_column(Boolean, default=True)
     heartbeat_frequency: Mapped[str] = mapped_column(String(20), default="")


### PR DESCRIPTION
## Summary
- Add `role` column (String(20), default `"user"`) to the Contractor model
- Add migration `002_add_contractor_role.py` for the new column
- Used by clawbolt-premium for DB-based admin role assignment and auto-promotion on first login

## Test plan
- [x] Column added to model with correct type and default
- [x] Migration creates column with `server_default="user"`
- [x] Premium tests pass with this change (83/83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)