### PR TITLE
docs: configure Astro site for clawbolt.ai custom domain

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,9 +3,9 @@ import starlight from "@astrojs/starlight";
 
 export default defineConfig({
   site: process.env.CI
-    ? "https://mozilla-ai.github.io"
+    ? "https://clawbolt.ai"
     : "http://localhost:4321",
-  base: process.env.CI ? "/clawbolt" : "/",
+  base: "/",
   integrations: [
     starlight({
       title: "Clawbolt",

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+clawbolt.ai


### PR DESCRIPTION
## Summary
- Update `site` from `mozilla-ai.github.io` to `clawbolt.ai` and remove the `/clawbolt` base path prefix so assets resolve at the domain root
- Add `CNAME` file to `docs/public/` so GitHub Pages preserves the custom domain across deploys

## Test plan
- [ ] Verify deploy-docs workflow builds successfully
- [ ] Confirm `clawbolt.ai` serves the site without 404s on `_astro/` assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)