### PR TITLE
feat: add ChannelManager for concurrent channel lifecycle management

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -25,6 +25,7 @@ from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.llm_parsing import parse_tool_calls
 from backend.app.agent.system_prompt import build_heartbeat_system_prompt
 from backend.app.agent.tools.names import ToolName
+from backend.app.channels import get_channel, get_default_channel
 from backend.app.config import settings
 from backend.app.database import SessionLocal
 from backend.app.enums import (
@@ -43,7 +44,7 @@ from backend.app.models import (
     Message,
 )
 from backend.app.services.llm_usage import log_llm_usage
-from backend.app.services.messaging import MessagingService, _build_messaging_service
+from backend.app.services.messaging import MessagingService
 
 logger = logging.getLogger(__name__)
 
@@ -698,7 +699,6 @@ class HeartbeatScheduler:
         if not contractors:
             return
 
-        messaging_service = _build_messaging_service()
         semaphore = asyncio.Semaphore(settings.heartbeat_concurrency)
 
         async def _process_one(contractor: Contractor) -> None:
@@ -706,6 +706,15 @@ class HeartbeatScheduler:
             async with semaphore:
                 db: Session = SessionLocal()
                 try:
+                    # Route to the contractor's preferred channel, falling
+                    # back to the first registered channel.
+                    try:
+                        messaging_service: MessagingService = get_channel(
+                            contractor.preferred_channel
+                        )
+                    except KeyError:
+                        messaging_service = get_default_channel()
+
                     await run_heartbeat_for_contractor(
                         db=db,
                         contractor=contractor,

--- a/backend/app/channels/__init__.py
+++ b/backend/app/channels/__init__.py
@@ -1,31 +1,36 @@
 """Channel registry and BaseChannel export."""
 
 from backend.app.channels.base import BaseChannel
+from backend.app.channels.manager import ChannelManager
 
-_active_channels: dict[str, BaseChannel] = {}
+_manager = ChannelManager()
+
+
+def get_manager() -> ChannelManager:
+    """Return the module-level ChannelManager singleton."""
+    return _manager
 
 
 def register_channel(channel: BaseChannel) -> None:
     """Register a channel instance by its ``name``."""
-    _active_channels[channel.name] = channel
+    _manager.register(channel)
 
 
 def get_channel(name: str) -> BaseChannel:
     """Return a registered channel by name, or raise ``KeyError``."""
-    return _active_channels[name]
+    return _manager.get(name)
 
 
 def get_default_channel() -> BaseChannel:
     """Return the first registered channel (convenience for single-channel setups)."""
-    if not _active_channels:
-        msg = "No channels registered"
-        raise RuntimeError(msg)
-    return next(iter(_active_channels.values()))
+    return _manager.get_default()
 
 
 __all__ = [
     "BaseChannel",
+    "ChannelManager",
     "get_channel",
     "get_default_channel",
+    "get_manager",
     "register_channel",
 ]

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -1,0 +1,72 @@
+"""ChannelManager: lifecycle and routing for all enabled channels."""
+
+import asyncio
+import logging
+
+from backend.app.channels.base import BaseChannel
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelManager:
+    """Start, stop, and route messages across all registered channels.
+
+    Replaces the pattern of manually wiring each channel in ``main.py``.
+    Each channel is registered via :meth:`register` and its lifecycle
+    (start/stop) is coordinated through :meth:`start_all` / :meth:`stop_all`.
+    """
+
+    def __init__(self) -> None:
+        self._channels: dict[str, BaseChannel] = {}
+
+    # -- Registration ----------------------------------------------------------
+
+    def register(self, channel: BaseChannel) -> None:
+        """Register a channel instance by its ``name``."""
+        if channel.name in self._channels:
+            msg = f"Channel {channel.name!r} is already registered"
+            raise ValueError(msg)
+        self._channels[channel.name] = channel
+        logger.info("Registered channel: %s", channel.name)
+
+    # -- Lookup ----------------------------------------------------------------
+
+    @property
+    def channels(self) -> dict[str, BaseChannel]:
+        """Return a read-only view of registered channels."""
+        return dict(self._channels)
+
+    def get(self, name: str) -> BaseChannel:
+        """Return a channel by name, or raise ``KeyError``."""
+        return self._channels[name]
+
+    def get_default(self) -> BaseChannel:
+        """Return the first registered channel (single-channel convenience)."""
+        if not self._channels:
+            msg = "No channels registered"
+            raise RuntimeError(msg)
+        return next(iter(self._channels.values()))
+
+    # -- Lifecycle -------------------------------------------------------------
+
+    async def start_all(self) -> list[asyncio.Task[None]]:
+        """Start all registered channels concurrently.
+
+        Returns a list of fire-and-forget tasks so callers can cancel them
+        during shutdown if needed.
+        """
+        tasks: list[asyncio.Task[None]] = []
+        for channel in self._channels.values():
+            task = asyncio.create_task(channel.start())
+            tasks.append(task)
+            logger.info("Starting channel: %s", channel.name)
+        return tasks
+
+    async def stop_all(self) -> None:
+        """Gracefully stop all registered channels."""
+        for channel in self._channels.values():
+            try:
+                await channel.stop()
+                logger.info("Stopped channel: %s", channel.name)
+            except Exception:
+                logger.exception("Error stopping channel %s", channel.name)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -9,7 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.app.agent.heartbeat import heartbeat_scheduler
-from backend.app.channels import register_channel
+from backend.app.channels import get_manager, register_channel
 from backend.app.channels.telegram import TelegramChannel
 from backend.app.config import settings
 from backend.app.routers import auth, estimates, health
@@ -26,8 +25,7 @@ logger = logging.getLogger(__name__)
 
 # -- Build and register channels at module scope ----------------------------
 
-_telegram_channel = TelegramChannel(bot_token=settings.telegram_bot_token)
-register_channel(_telegram_channel)
+register_channel(TelegramChannel(bot_token=settings.telegram_bot_token))
 
 
 async def _verify_llm_settings() -> None:
@@ -124,16 +122,17 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             'Set to "*" to allow all users, or provide a comma-separated list of IDs/usernames.'
         )
 
-    # Fire-and-forget: start channel lifecycle (e.g. webhook registration).
-    channel_task: asyncio.Task[None] | None = None
-    if settings.telegram_bot_token:
-        channel_task = asyncio.create_task(_telegram_channel.start())
+    # Start all registered channels concurrently.
+    manager = get_manager()
+    channel_tasks = await manager.start_all()
 
     yield
 
-    if channel_task and not channel_task.done():
-        channel_task.cancel()
-    await _telegram_channel.stop()
+    # Cancel any channel start tasks still running.
+    for task in channel_tasks:
+        if not task.done():
+            task.cancel()
+    await manager.stop_all()
     heartbeat_scheduler.stop()
 
 
@@ -149,5 +148,9 @@ app.add_middleware(
 
 app.include_router(health.router, prefix="/api")
 app.include_router(auth.router, prefix="/api")
-app.include_router(_telegram_channel.get_router(), prefix="/api")
+
+# Include routers from all registered channels.
+for _channel in get_manager().channels.values():
+    app.include_router(_channel.get_router(), prefix="/api")
+
 app.include_router(estimates.router, prefix="/api")

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,10 +1,62 @@
-"""Tests for channel base class and protocol conformance."""
+"""Tests for channel base class, ChannelManager, and protocol conformance."""
+
+import asyncio
 
 import pytest
+from fastapi import APIRouter
 
 from backend.app.channels.base import BaseChannel
+from backend.app.channels.manager import ChannelManager
 from backend.app.channels.telegram import TelegramChannel
+from backend.app.media.download import DownloadedMedia
 from backend.app.services.messaging import MessagingService
+
+# -- Stub channel for manager tests ----------------------------------------
+
+
+class _StubChannel(BaseChannel):
+    """Minimal concrete channel for testing ChannelManager."""
+
+    def __init__(self, channel_name: str) -> None:
+        self._name = channel_name
+        self.started = False
+        self.stopped = False
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def get_router(self) -> APIRouter:
+        return APIRouter()
+
+    def is_allowed(self, sender_id: str, username: str) -> bool:
+        return True
+
+    async def send_text(self, to: str, body: str) -> str:
+        return "stub-id"
+
+    async def send_media(self, to: str, body: str, media_url: str) -> str:
+        return "stub-id"
+
+    async def send_message(self, to: str, body: str, media_urls: list[str] | None = None) -> str:
+        return "stub-id"
+
+    async def send_typing_indicator(self, to: str) -> None:
+        pass
+
+    async def download_media(self, file_id: str) -> DownloadedMedia:
+        return DownloadedMedia(
+            content=b"", mime_type="application/octet-stream", original_url="", filename="stub"
+        )
+
+
+# -- BaseChannel tests -----------------------------------------------------
 
 
 def test_base_channel_cannot_be_instantiated() -> None:
@@ -17,3 +69,83 @@ def test_telegram_channel_satisfies_messaging_protocol() -> None:
     """TelegramChannel should satisfy the MessagingService protocol."""
     channel = TelegramChannel(bot_token="test-token")
     assert isinstance(channel, MessagingService)
+
+
+# -- ChannelManager tests --------------------------------------------------
+
+
+def test_manager_register_and_get() -> None:
+    """ChannelManager.register stores and get retrieves channels by name."""
+    mgr = ChannelManager()
+    ch = _StubChannel("sms")
+    mgr.register(ch)
+    assert mgr.get("sms") is ch
+
+
+def test_manager_register_duplicate_raises() -> None:
+    """Registering two channels with the same name raises ValueError."""
+    mgr = ChannelManager()
+    mgr.register(_StubChannel("telegram"))
+    with pytest.raises(ValueError, match="already registered"):
+        mgr.register(_StubChannel("telegram"))
+
+
+def test_manager_get_unknown_raises() -> None:
+    """Getting an unregistered channel name raises KeyError."""
+    mgr = ChannelManager()
+    with pytest.raises(KeyError):
+        mgr.get("nonexistent")
+
+
+def test_manager_get_default() -> None:
+    """get_default returns the first registered channel."""
+    mgr = ChannelManager()
+    first = _StubChannel("telegram")
+    mgr.register(first)
+    mgr.register(_StubChannel("sms"))
+    assert mgr.get_default() is first
+
+
+def test_manager_get_default_empty_raises() -> None:
+    """get_default raises RuntimeError when no channels are registered."""
+    mgr = ChannelManager()
+    with pytest.raises(RuntimeError, match="No channels registered"):
+        mgr.get_default()
+
+
+def test_manager_channels_returns_copy() -> None:
+    """channels property returns a copy, not the internal dict."""
+    mgr = ChannelManager()
+    ch = _StubChannel("web")
+    mgr.register(ch)
+    channels = mgr.channels
+    channels["injected"] = ch
+    assert "injected" not in mgr.channels
+
+
+@pytest.mark.asyncio
+async def test_manager_start_all() -> None:
+    """start_all calls start() on every registered channel."""
+    mgr = ChannelManager()
+    ch1 = _StubChannel("a")
+    ch2 = _StubChannel("b")
+    mgr.register(ch1)
+    mgr.register(ch2)
+    tasks = await mgr.start_all()
+    # Wait for fire-and-forget tasks to finish
+    await asyncio.gather(*tasks)
+    assert ch1.started
+    assert ch2.started
+
+
+@pytest.mark.asyncio
+async def test_manager_stop_all() -> None:
+    """stop_all calls stop() on every registered channel."""
+    mgr = ChannelManager()
+    ch1 = _StubChannel("a")
+    ch2 = _StubChannel("b")
+    mgr.register(ch1)
+    mgr.register(ch2)
+    await mgr.stop_all()
+    assert ch1.stopped
+    assert ch2.stopped

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1358,7 +1358,7 @@ class TestHeartbeatScheduler:
 
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.SessionLocal")
-    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    @patch("backend.app.agent.heartbeat.get_default_channel")
     async def test_tick_queries_onboarded(
         self, mock_messaging_cls: MagicMock, mock_session_local: MagicMock
     ) -> None:
@@ -1377,7 +1377,7 @@ class TestHeartbeatScheduler:
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
     @patch("backend.app.agent.heartbeat.SessionLocal")
-    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    @patch("backend.app.agent.heartbeat.get_default_channel")
     @patch("backend.app.agent.heartbeat.settings")
     async def test_tick_concurrent_processing(
         self,
@@ -1429,7 +1429,7 @@ class TestHeartbeatScheduler:
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
     @patch("backend.app.agent.heartbeat.SessionLocal")
-    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    @patch("backend.app.agent.heartbeat.get_default_channel")
     @patch("backend.app.agent.heartbeat.settings")
     async def test_tick_error_isolation(
         self,
@@ -1475,7 +1475,7 @@ class TestHeartbeatScheduler:
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
     @patch("backend.app.agent.heartbeat.SessionLocal")
-    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    @patch("backend.app.agent.heartbeat.get_default_channel")
     @patch("backend.app.agent.heartbeat.settings")
     async def test_tick_semaphore_limits_concurrency(
         self,
@@ -1530,7 +1530,7 @@ class TestHeartbeatScheduler:
 
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.SessionLocal")
-    @patch("backend.app.agent.heartbeat._build_messaging_service")
+    @patch("backend.app.agent.heartbeat.get_default_channel")
     async def test_tick_no_contractors(
         self, mock_messaging_cls: MagicMock, mock_session_local: MagicMock
     ) -> None:


### PR DESCRIPTION
## Description
Add a `ChannelManager` that registers, starts, and stops all enabled channels through a single interface, replacing the manual per-channel wiring in `main.py`. The heartbeat engine now routes outbound messages to each contractor's preferred channel instead of always using the default.

Fixes #266

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code: implementation, tests, and PR)
- [ ] No AI used