### PR TITLE
fix: add datetime awareness to agent and heartbeat prompts

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -285,7 +285,7 @@ def run_cheap_checks(
         .all()
     )
     for item in active_items:
-        if _is_checklist_item_due(item, now):
+        if _is_checklist_item_due(item, now, tz_name=contractor.timezone or ""):
             result.due_checklist_items.append(item)
             result.flags.append(f"Checklist item due: {item.description}")
 
@@ -330,10 +330,13 @@ def run_cheap_checks(
 def _is_checklist_item_due(
     item: HeartbeatChecklistItem,
     now: datetime.datetime,
+    tz_name: str = "",
 ) -> bool:
     """Determine whether a checklist item should fire on this tick."""
-    # Weekday gate applies regardless of trigger history
-    if item.schedule == ChecklistSchedule.WEEKDAYS and now.weekday() > WEEKDAY_FRIDAY:
+    # Weekday gate: convert to contractor's local timezone so that
+    # e.g. Friday 5 PM Pacific is not treated as Saturday (UTC).
+    local_now = _to_local_time(now, tz_name) if tz_name else now
+    if item.schedule == ChecklistSchedule.WEEKDAYS and local_now.weekday() > WEEKDAY_FRIDAY:
         return False
 
     # Never triggered -> due (for daily/weekdays/once)

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import zoneinfo
 
 from sqlalchemy.orm import Session
 
@@ -133,6 +134,37 @@ def build_recall_section() -> str:
     )
 
 
+def _to_contractor_time(
+    now: datetime.datetime,
+    tz_name: str,
+) -> datetime.datetime:
+    """Convert *now* to the contractor's IANA timezone, falling back to UTC."""
+    if not tz_name:
+        return now
+    try:
+        return now.astimezone(zoneinfo.ZoneInfo(tz_name))
+    except (zoneinfo.ZoneInfoNotFoundError, KeyError, ValueError):
+        logger.warning("Invalid timezone %r, falling back to UTC", tz_name)
+        return now
+
+
+def build_date_section(contractor: Contractor) -> str:
+    """Build a cache-friendly date string in the contractor's local timezone.
+
+    Uses date-only granularity (no minutes) to avoid prompt-cache busting.
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    local = _to_contractor_time(now, contractor.timezone)
+    return local.strftime("%A, %Y-%m-%d")
+
+
+def build_local_datetime_section(contractor: Contractor) -> str:
+    """Build a human-readable local datetime for the heartbeat evaluator."""
+    now = datetime.datetime.now(datetime.UTC)
+    local = _to_contractor_time(now, contractor.timezone)
+    return local.strftime("%A, %Y-%m-%d %I:%M %p %Z").strip()
+
+
 def build_missing_fields_section(contractor: Contractor) -> str:
     """Build a note about missing optional profile fields, if any."""
     missing = get_missing_optional_fields(contractor)
@@ -178,6 +210,8 @@ async def build_agent_system_prompt(
         instructions = build_instructions_section()
     builder.add_section("Instructions", instructions)
 
+    builder.add_section("Current date", build_date_section(contractor))
+
     builder.add_section("Proactive Messaging", build_proactive_section())
     builder.add_section("Recall Behavior", build_recall_section())
 
@@ -218,7 +252,7 @@ async def build_heartbeat_system_prompt(
 
     builder.add_section(
         "Current time",
-        datetime.datetime.now(datetime.UTC).isoformat(),
+        build_local_datetime_section(contractor),
     )
 
     rules = (

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -663,6 +663,39 @@ class TestIsChecklistItemDue:
         # Should not raise TypeError and should be due (>20h elapsed)
         assert _is_checklist_item_due(item, now) is True
 
+    def test_weekdays_saturday_utc_but_friday_local(self) -> None:
+        """Weekday item should fire when UTC is Saturday but local time is still Friday.
+
+        Regression test: before this fix, _is_checklist_item_due checked
+        now.weekday() in UTC. A contractor in America/Los_Angeles at 5 PM
+        Friday Pacific (00:00 Saturday UTC) would have the weekday gate
+        incorrectly skip the item.
+        """
+        # Saturday 00:00 UTC = Friday 5:00 PM Pacific (PDT, UTC-7)
+        saturday_utc = datetime.datetime(2025, 6, 14, 0, 0, tzinfo=datetime.UTC)
+        item = HeartbeatChecklistItem(
+            contractor_id=1,
+            description="Weekly check-in",
+            schedule="weekdays",
+            last_triggered_at=None,
+        )
+        # Without timezone: UTC says Saturday -> should skip (old buggy behavior)
+        assert _is_checklist_item_due(item, saturday_utc) is False
+        # With timezone: local is Friday -> should fire (fixed behavior)
+        assert _is_checklist_item_due(item, saturday_utc, tz_name="America/Los_Angeles") is True
+
+    def test_weekdays_sunday_local_still_skipped(self) -> None:
+        """Weekday item should still be skipped on a genuine local Sunday."""
+        # Sunday 10 AM Pacific = Sunday 5 PM UTC
+        sunday_utc = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
+        item = HeartbeatChecklistItem(
+            contractor_id=1,
+            description="Test",
+            schedule="weekdays",
+            last_triggered_at=None,
+        )
+        assert _is_checklist_item_due(item, sunday_utc, tz_name="America/Los_Angeles") is False
+
 
 # ---------------------------------------------------------------------------
 # COMPOSE_MESSAGE_TOOL schema validation

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1,14 +1,18 @@
 """Tests for the composable system prompt builder."""
 
+import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from backend.app.agent.system_prompt import (
     SystemPromptBuilder,
+    _to_contractor_time,
     build_agent_system_prompt,
+    build_date_section,
     build_identity_section,
     build_instructions_section,
+    build_local_datetime_section,
     build_memory_section,
     build_missing_fields_section,
     build_proactive_section,
@@ -299,3 +303,113 @@ class TestBuildAgentSystemPrompt:
             )
 
         assert "Mike {The Plumber}" in result
+
+
+class TestToContractorTime:
+    def test_converts_to_pacific(self) -> None:
+        utc = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
+        result = _to_contractor_time(utc, "America/Los_Angeles")
+        # UTC 17:00 in June (PDT, UTC-7) -> 10:00 local
+        assert result.hour == 10
+
+    def test_empty_timezone_returns_utc(self) -> None:
+        utc = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
+        result = _to_contractor_time(utc, "")
+        assert result.hour == 17
+
+    def test_invalid_timezone_returns_utc(self) -> None:
+        utc = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
+        result = _to_contractor_time(utc, "Not/A_Real_Zone")
+        assert result.hour == 17
+
+
+class TestBuildDateSection:
+    @patch("backend.app.agent.system_prompt.datetime")
+    def test_includes_day_of_week_and_date(self, mock_dt: MagicMock) -> None:
+        mock_dt.UTC = datetime.UTC
+        mock_dt.datetime.now.return_value = datetime.datetime(
+            2025, 6, 16, 15, 30, tzinfo=datetime.UTC
+        )
+        contractor = MagicMock()
+        contractor.timezone = ""
+        result = build_date_section(contractor)
+        # 2025-06-16 is a Monday
+        assert result == "Monday, 2025-06-16"
+
+    @patch("backend.app.agent.system_prompt.datetime")
+    def test_converts_to_contractor_timezone(self, mock_dt: MagicMock) -> None:
+        mock_dt.UTC = datetime.UTC
+        # Saturday 3 AM UTC -> Friday 8 PM Pacific (PDT)
+        mock_dt.datetime.now.return_value = datetime.datetime(
+            2025, 6, 14, 3, 0, tzinfo=datetime.UTC
+        )
+        contractor = MagicMock()
+        contractor.timezone = "America/Los_Angeles"
+        result = build_date_section(contractor)
+        # Should show Friday (local), not Saturday (UTC)
+        assert result == "Friday, 2025-06-13"
+
+
+class TestBuildLocalDatetimeSection:
+    @patch("backend.app.agent.system_prompt.datetime")
+    def test_includes_time_and_timezone(self, mock_dt: MagicMock) -> None:
+        mock_dt.UTC = datetime.UTC
+        mock_dt.datetime.now.return_value = datetime.datetime(
+            2025, 6, 15, 17, 30, tzinfo=datetime.UTC
+        )
+        contractor = MagicMock()
+        contractor.timezone = "America/New_York"
+        result = build_local_datetime_section(contractor)
+        # UTC 17:30 -> 1:30 PM EDT
+        assert "01:30 PM" in result
+        assert "Sunday" in result
+        assert "2025-06-15" in result
+
+    @patch("backend.app.agent.system_prompt.datetime")
+    def test_utc_fallback_when_no_timezone(self, mock_dt: MagicMock) -> None:
+        mock_dt.UTC = datetime.UTC
+        mock_dt.datetime.now.return_value = datetime.datetime(
+            2025, 6, 15, 17, 30, tzinfo=datetime.UTC
+        )
+        contractor = MagicMock()
+        contractor.timezone = ""
+        result = build_local_datetime_section(contractor)
+        assert "05:30 PM" in result
+        assert "Sunday" in result
+
+
+class TestAgentSystemPromptIncludesDate:
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.system_prompt.datetime")
+    async def test_agent_prompt_has_current_date(self, mock_dt: MagicMock) -> None:
+        """Main agent prompt should include a Current date section."""
+        mock_dt.UTC = datetime.UTC
+        mock_dt.datetime.now.return_value = datetime.datetime(
+            2025, 6, 16, 15, 0, tzinfo=datetime.UTC
+        )
+        contractor = MagicMock()
+        contractor.name = "Jake"
+        contractor.trade = "electrician"
+        contractor.location = "Seattle"
+        contractor.hourly_rate = 90
+        contractor.business_hours = "8am-6pm"
+        contractor.soul_text = None
+        contractor.preferences_json = None
+        contractor.timezone = "America/Los_Angeles"
+        contractor.id = 1
+
+        with patch(
+            "backend.app.agent.system_prompt.build_memory_context",
+            new_callable=AsyncMock,
+            return_value="",
+        ):
+            result = await build_agent_system_prompt(
+                db=MagicMock(),
+                contractor=contractor,
+                tools=[],
+                message_context="hello",
+            )
+
+        assert "## Current date" in result
+        assert "Monday" in result
+        assert "2025-06-16" in result


### PR DESCRIPTION
## Description
Add time/date awareness to the main agent and heartbeat evaluator, and fix a timezone bug in the weekday gate for checklist items.

**Problem:** The main agent loop had no concept of current date/time, causing incorrect responses to time-sensitive questions like "remind me tomorrow" or "is it too late to send that invoice?". The heartbeat evaluator used raw UTC instead of the contractor's local timezone, and `_is_checklist_item_due()` checked `weekday()` in UTC -- meaning a Friday 5 PM Pacific contractor would be incorrectly treated as Saturday.

**Changes:**
- Add a "Current date" section to `build_agent_system_prompt()` using the contractor's timezone (date-only format like `Monday, 2025-06-16` for prompt cache stability)
- Convert heartbeat evaluator's "Current time" from raw UTC ISO to contractor-local datetime with day-of-week (e.g. `Monday, 2025-06-16 08:00 AM PDT`)
- Fix weekday gate in `_is_checklist_item_due()` to convert to local timezone before checking `weekday()`

**Research:** Investigated how OpenClaw and nanobot handle this (see issue #413 comment). OpenClaw uses date-only in system prompt + timestamp prefix in user messages. Nanobot injects full datetime but hit cache-busting and timezone issues. Our approach takes the best of both.

Fixes #413

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude Code researched OpenClaw/nanobot datetime approaches, identified four gaps in Clawbolt's implementation, implemented the fixes, and wrote regression tests.