### PR TITLE
fix: address PR #425 review feedback

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy.orm import Session
 
 from backend.app.agent.context import get_or_create_conversation
-from backend.app.agent.llm_parsing import parse_tool_calls
+from backend.app.agent.llm_parsing import get_response_text, parse_tool_calls
 from backend.app.agent.system_prompt import build_heartbeat_system_prompt
 from backend.app.agent.tools.names import ToolName
 from backend.app.channels import get_channel, get_default_channel
@@ -399,8 +399,6 @@ def _parse_tool_call_response(response: MessageResponse) -> HeartbeatAction:
 
     if not parsed:
         # LLM returned text instead of calling the tool: default to no_action
-        from backend.app.agent.llm_parsing import get_response_text
-
         content = get_response_text(response)
         logger.warning("Heartbeat LLM returned text instead of tool call: %s", content[:200])
         return HeartbeatAction(

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -295,8 +295,9 @@ class TelegramChannel(BaseChannel):
 
             try:
                 update = TelegramUpdate.model_validate(raw)
-            except ValidationError:
+            except ValidationError as exc:
                 logger.warning("Telegram webhook payload failed validation")
+                logger.debug("Validation details: %s", exc.errors())
                 return JSONResponse(content={"ok": True})
 
             inbound = TelegramChannel.parse_update(update)


### PR DESCRIPTION
## Summary
- Move inline `get_response_text` import to module level in `heartbeat.py`
- Add `exc.errors()` debug logging to `ValidationError` handler in `telegram.py`

Follow-up to #425 (merged before these fixes were pushed).

## Test plan
- [x] All tests pass locally (828 passed)
- [x] Ruff lint/format clean
- [x] ty type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)