### PR TITLE
fix: persist local storage across Docker container rebuilds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,7 @@ LLM_MODEL=
 # Local storage saves files to data/storage/ on disk.
 # See README.md "File Storage Setup" for Dropbox/Google Drive configuration.
 STORAGE_PROVIDER=local
+# CLAWBOLT_DATA_DIR=./data   # Host path for local file storage (Docker Compose only)
 # DROPBOX_ACCESS_TOKEN=
 # GOOGLE_DRIVE_CREDENTIALS_JSON=
 # PDF_STORAGE_DIR=data/estimates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - ${CLAWBOLT_DATA_DIR:-./data}:/app/data
     command: >
       sh -c "uv run alembic upgrade head &&
              uv run uvicorn backend.app.main:app --host 0.0.0.0 --port 8000

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -56,6 +56,7 @@ Set the API key env var for your chosen provider, or set `ANY_LLM_KEY` to use th
 | `STORAGE_PROVIDER` | `local` | Storage backend: `local`, `dropbox`, or `google_drive` |
 | `DROPBOX_ACCESS_TOKEN` | | Dropbox access token (when using Dropbox) |
 | `GOOGLE_DRIVE_CREDENTIALS_JSON` | | Google Drive OAuth credentials JSON (when using Google Drive) |
+| `CLAWBOLT_DATA_DIR` | `./data` | Host path bind-mounted to `/app/data` (Docker Compose only) |
 | `PDF_STORAGE_DIR` | `data/estimates` | Directory for generated PDF estimates |
 | `FILE_STORAGE_BASE_DIR` | `data/storage` | Base directory for local file storage |
 | `DEFAULT_ESTIMATE_TERMS` | `Payment due within 30 days of project completion.` | Default terms printed on estimates |

--- a/docs/src/content/docs/deployment/storage.mdx
+++ b/docs/src/content/docs/deployment/storage.mdx
@@ -21,6 +21,12 @@ data/storage/
 
 This is ideal for development and demos. Set `STORAGE_PROVIDER=local` or leave it unset (it's the default).
 
+When running with Docker Compose, the `data/` directory is bind-mounted to the host (default: `./data` in the project root) so files persist across container rebuilds. Set `CLAWBOLT_DATA_DIR` to change the host path:
+
+```bash
+CLAWBOLT_DATA_DIR=/mnt/storage/clawbolt
+```
+
 ## Dropbox
 
 1. Go to the [Dropbox App Console](https://www.dropbox.com/developers/apps) and create a new app


### PR DESCRIPTION
## Description

Bind-mount the app's `data/` directory to the host so locally stored estimates and uploaded files survive `docker compose up --build`. The host path defaults to `./data` in the project root and can be overridden via the `CLAWBOLT_DATA_DIR` environment variable.

Fixes #426

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

> No regression test: this is a Docker Compose configuration fix, not application logic. The app code already writes to the correct paths. There is no Python unit test that can verify Docker volume mounts.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation by Claude Code.