### PR TITLE
fix: prevent generate_estimate validation error on missing line_items

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -42,6 +42,7 @@ from backend.app.agent.tools.base import (
     ToolErrorKind,
     ToolResult,
     ToolTags,
+    _inline_refs,
     tool_to_function_schema,
 )
 from backend.app.agent.tools.names import ToolName
@@ -186,23 +187,49 @@ def _format_validation_error(tool_name: str, exc: ValidationError, tool: Tool | 
     return "\n".join(error_lines)
 
 
-def _summarize_tool_params(tool: Tool) -> str:
-    """Build a concise parameter summary string from a tool's schema."""
-    schema = tool.params_model.model_json_schema()
-    props = schema.get("properties", {})
-    required = set(schema.get("required", []))
-    if not props:
-        return ""
+def _extract_type_label(info: dict[str, Any]) -> str:
+    """Extract a human-readable type label from a JSON Schema property."""
+    if "type" in info:
+        ptype = info["type"]
+        if ptype == "array" and "items" in info:
+            items = info["items"]
+            if items.get("type") == "object" and "properties" in items:
+                item_parts = _summarize_properties(
+                    items["properties"], set(items.get("required", []))
+                )
+                return "array of {" + ", ".join(item_parts) + "}"
+            return f"array of {_extract_type_label(items)}"
+        return ptype
+    if "anyOf" in info:
+        types = [alt.get("type", "any") for alt in info["anyOf"] if alt.get("type") != "null"]
+        return types[0] if types else "any"
+    return "any"
 
+
+def _summarize_properties(props: dict[str, Any], required: set[str]) -> list[str]:
+    """Summarize a set of JSON Schema properties into label strings."""
     parts: list[str] = []
     for name, info in props.items():
-        ptype = info.get("type", "any")
+        ptype = _extract_type_label(info)
         req = "required" if name in required else "optional"
         default = info.get("default")
         if default is not None:
             parts.append(f'"{name}": {ptype} ({req}, default: {default})')
         else:
             parts.append(f'"{name}": {ptype} ({req})')
+    return parts
+
+
+def _summarize_tool_params(tool: Tool) -> str:
+    """Build a concise parameter summary string from a tool's schema."""
+    schema = tool.params_model.model_json_schema()
+    schema = _inline_refs(schema)
+    props = schema.get("properties", {})
+    required = set(schema.get("required", []))
+    if not props:
+        return ""
+
+    parts = _summarize_properties(props, required)
     return "{" + ", ".join(parts) + "}"
 
 

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -178,12 +178,16 @@ def create_estimate_tools(
             name=ToolName.GENERATE_ESTIMATE,
             description=(
                 "Generate a professional estimate PDF. Use when the contractor asks for "
-                "an estimate, quote, or bid. Include line items with description, quantity, "
-                "and unit_price."
+                "an estimate, quote, or bid. Requires line_items: each item needs a "
+                "description, quantity, and unit_price. Do NOT call this tool until you "
+                "have at least one concrete line item from the contractor."
             ),
             function=generate_estimate,
             params_model=GenerateEstimateParams,
-            usage_hint=("When asked for an estimate, gather the details and generate the PDF."),
+            usage_hint=(
+                "Before calling this tool, ask the contractor for specific line items "
+                "(what work, how much, at what price). Do not guess line items."
+            ),
         ),
     ]
 

--- a/tests/test_tool_param_validation.py
+++ b/tests/test_tool_param_validation.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.core import ClawboltAgent, _summarize_tool_params
 from backend.app.agent.tools.base import Tool, ToolResult, tool_to_function_schema
 from backend.app.agent.tools.checklist_tools import (
     AddChecklistItemParams,
@@ -499,3 +499,87 @@ async def test_batch_validation_executes_valid_calls_alongside_invalid(
     success_ids = {tc.tool_call_id for tc in response.tool_calls if not tc.is_error}
     assert error_ids == {"call_bad1", "call_bad2"}
     assert success_ids == {"call_good"}
+
+
+# ---------------------------------------------------------------------------
+# Validation error summary tests: nested types in error messages (#434)
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(name: str, params_model: type[BaseModel]) -> Tool:
+    """Helper to build a Tool with a dummy function for summary tests."""
+
+    async def dummy(**kwargs: object) -> ToolResult:
+        return ToolResult(content="ok")
+
+    return Tool(name=name, description="test", function=dummy, params_model=params_model)
+
+
+def test_summarize_tool_params_includes_array_item_structure() -> None:
+    """Validation error summary should describe array item fields, not just 'array'.
+
+    Regression test for #434: when the LLM omits line_items, the error
+    message must show the expected item structure so it can self-correct.
+    """
+    tool = _make_tool("generate_estimate", GenerateEstimateParams)
+    summary = _summarize_tool_params(tool)
+
+    # Should show nested item fields, not bare 'array'
+    assert "array of {" in summary
+    assert '"description": string' in summary
+    assert '"quantity": number' in summary
+    assert '"unit_price": number' in summary
+
+
+def test_summarize_tool_params_resolves_anyof_types() -> None:
+    """Optional union fields (str | None) should show the concrete type, not 'any'."""
+    tool = _make_tool("generate_estimate", GenerateEstimateParams)
+    summary = _summarize_tool_params(tool)
+
+    assert '"client_name": string (optional)' in summary
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_validation_error_for_missing_line_items_shows_item_structure(
+    mock_amessages: AsyncMock,
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """When line_items is missing, the error sent to the LLM should describe the item schema.
+
+    Regression test for #434: the LLM needs to know what each line item
+    looks like in order to construct a valid retry.
+    """
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_est",
+                "name": "estimate_tool",
+                "arguments": json.dumps({"description": "Deck repair"}),
+            }
+        ]
+    )
+    followup_response = make_text_response("Let me add line items.")
+    mock_amessages.side_effect = [tool_response, followup_response]
+
+    mock_func = AsyncMock(return_value=ToolResult(content="ok"))
+    tool = Tool(
+        name="estimate_tool",
+        description="Generate an estimate",
+        function=mock_func,
+        params_model=GenerateEstimateParams,
+    )
+
+    agent = ClawboltAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+    response = await agent.process_message("test", system_prompt_override="system")
+
+    mock_func.assert_not_called()
+    error_result = response.tool_calls[0].result
+
+    # Error should mention the missing field
+    assert "line_items" in error_result
+    # Error should include the item structure so the LLM can self-correct
+    assert "unit_price" in error_result
+    assert "array of {" in error_result


### PR DESCRIPTION
## Description

The LLM was calling `generate_estimate` without the required `line_items` field because the tool description and usage hint were not explicit enough. "Include line items" reads like a formatting tip, and "gather the details" is vague, so the LLM would eagerly call the tool before asking the contractor for specifics.

**Root-cause fix:** Rewrite the tool `description` and `usage_hint` to explicitly instruct the LLM: "Do NOT call this tool until you have at least one concrete line item from the contractor" and "ask the contractor for specific line items. Do not guess line items."

**Defense-in-depth:** Improve `_summarize_tool_params` so that if the LLM still triggers the validation path, the error message describes the nested array item structure (`array of {"description": string, "quantity": number, "unit_price": number}`) instead of bare `array`, and resolves `anyOf` union types to show `string` instead of `any`. This gives the LLM enough context to self-correct on retry.

Fixes #434

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used