### PR TITLE
fix: remove manual token estimation drift logging

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -62,12 +62,6 @@ CONTEXT_TRIM_TARGET_TOKENS = settings.context_trim_target_tokens
 # Conservative default; most models support 128K+ but we leave room for output
 MAX_INPUT_TOKENS = settings.max_input_tokens
 
-# Per-message overhead tokens for role/delimiters/structural framing
-_MESSAGE_OVERHEAD_TOKENS = 4
-# Characters per token ratio for English text (slightly more accurate than 4.0)
-_CHARS_PER_TOKEN = 3.5
-
-
 _SUMMARY_MAX_CHARS = 500
 
 
@@ -114,62 +108,23 @@ def _summarize_dropped_messages(dropped: list[AgentMessage]) -> str:
     return summary[:_SUMMARY_MAX_CHARS]
 
 
-def _estimate_tokens(messages: list[AgentMessage]) -> int:
-    """Estimate token count from typed messages, including tool call content.
+def _total_content_length(messages: list[AgentMessage]) -> int:
+    """Return total character count of all message content.
 
-    Counts content and any tool-call function names + serialized arguments.
-    Adds a small per-message overhead for role and delimiter tokens.
+    Used for rough content-size comparisons in context trimming.
+    For accurate token counts, use response.usage.input_tokens from the API.
     """
     total = 0
     for m in messages:
-        total += _MESSAGE_OVERHEAD_TOKENS
-
         if isinstance(m, (SystemMessage, UserMessage)):
-            if m.content:
-                total += int(len(m.content) / _CHARS_PER_TOKEN)
+            total += len(m.content or "")
         elif isinstance(m, AssistantMessage):
-            if m.content:
-                total += int(len(m.content) / _CHARS_PER_TOKEN)
+            total += len(m.content or "")
             for tc in m.tool_calls:
-                total += int(len(tc.name) / _CHARS_PER_TOKEN)
-                # Estimate from the dict representation of arguments
-                args_str = str(tc.arguments)
-                total += int(len(args_str) / _CHARS_PER_TOKEN)
-        elif isinstance(m, ToolResultMessage) and m.content:
-            total += int(len(m.content) / _CHARS_PER_TOKEN)
-
+                total += len(tc.name) + len(str(tc.arguments))
+        elif isinstance(m, ToolResultMessage):
+            total += len(m.content or "")
     return total
-
-
-def _log_token_estimation_drift(
-    messages: list[AgentMessage],
-    response: MessageResponse,
-) -> None:
-    """Log a warning when estimated token count drifts >30% from actual usage.
-
-    Uses ``response.usage.input_tokens`` (reported by the LLM provider) to
-    compare against our character-ratio estimate.
-    """
-    actual = response.usage.input_tokens
-    if not actual:
-        return
-
-    estimated = _estimate_tokens(messages)
-    if abs(estimated - actual) > actual * 0.3:
-        total_chars = sum(
-            len(m.content or "")
-            for m in messages
-            if isinstance(m, (SystemMessage, UserMessage, AssistantMessage, ToolResultMessage))
-            and m.content
-        )
-        observed_ratio = total_chars / actual if actual else 0.0
-        logger.warning(
-            "Token estimate drift: estimated=%d actual=%d ratio=%.2f (configured=%.1f)",
-            estimated,
-            actual,
-            observed_ratio,
-            _CHARS_PER_TOKEN,
-        )
 
 
 def _format_validation_error(tool_name: str, exc: ValidationError, tool: Tool | None = None) -> str:
@@ -298,6 +253,7 @@ class ClawboltAgent:
         self._tool_context = tool_context
         self._registry = registry
         self._activated_specialists: set[str] = set()
+        self._last_input_tokens: int = 0
 
     def subscribe(self, callback: Callable[[AgentEvent], Awaitable[None]]) -> None:
         """Register an event subscriber.
@@ -465,15 +421,21 @@ class ClawboltAgent:
     def _trim_messages(
         messages: list[AgentMessage],
         target_tokens: int = CONTEXT_TRIM_TARGET_TOKENS,
+        input_tokens: int | None = None,
     ) -> list[AgentMessage]:
         """Trim conversation messages to fit within a token budget.
 
+        When *input_tokens* (from ``response.usage.input_tokens``) is provided
+        the budget check uses the actual API-reported token count.  Otherwise
+        falls back to a conservative content-length approximation (4 chars per
+        token).
+
         Keeps the system prompt (first message) and removes the oldest
-        conversation messages until the estimated token count is at or below
-        *target_tokens*. Tool-call / tool-result pairs are treated as atomic
-        units: an ``AssistantMessage`` with ``tool_calls`` is never removed
-        without also removing the ``ToolResultMessage`` entries that follow it
-        (and vice-versa).
+        conversation messages until the content fits within *target_tokens*.
+        Tool-call / tool-result pairs are treated as atomic units: an
+        ``AssistantMessage`` with ``tool_calls`` is never removed without also
+        removing the ``ToolResultMessage`` entries that follow it (and
+        vice-versa).
 
         Dropped messages are summarized and injected as a context note so
         the LLM retains awareness of what was discussed.
@@ -481,7 +443,17 @@ class ClawboltAgent:
         if len(messages) <= 2:
             return messages
 
-        if _estimate_tokens(messages) <= target_tokens:
+        def _tokens_for(msgs: list[AgentMessage]) -> int:
+            """Return actual or approximate token count for *msgs*."""
+            if input_tokens is not None:
+                # Scale the known input_tokens by the content-length ratio
+                # between *msgs* and the original *messages*.
+                orig_len = _total_content_length(messages) or 1
+                return int(input_tokens * _total_content_length(msgs) / orig_len)
+            # Fallback: conservative 4 chars/token approximation.
+            return _total_content_length(msgs) // 4
+
+        if _tokens_for(messages) <= target_tokens:
             return messages
 
         system = messages[0]
@@ -514,7 +486,7 @@ class ClawboltAgent:
             remaining: list[AgentMessage] = [system]
             for blk in blocks:
                 remaining.extend(blk)
-            if _estimate_tokens(remaining) <= target_tokens:
+            if _tokens_for(remaining) <= target_tokens:
                 break
             removed_block = blocks.pop(0)
             dropped.extend(removed_block)
@@ -572,18 +544,20 @@ class ClawboltAgent:
 
         messages.append(UserMessage(content=message_context))
 
-        # Trim oldest conversation history if estimated tokens exceed the limit.
+        # Trim oldest conversation history if content exceeds the limit.
         # Uses the block-based trimmer which preserves tool-call/result pairing
         # and injects a summary of dropped messages.
         original_count = len(messages)
-        messages = self._trim_messages(messages, target_tokens=MAX_INPUT_TOKENS)
+        messages = self._trim_messages(
+            messages,
+            target_tokens=MAX_INPUT_TOKENS,
+            input_tokens=self._last_input_tokens or None,
+        )
         trimmed_count = original_count - len(messages)
         if trimmed_count > 0:
             logger.warning(
-                "Trimmed %d message(s) from conversation history, injected summary "
-                "(estimated %d tokens, limit %d)",
+                "Trimmed %d message(s) from conversation history (limit %d tokens)",
                 trimmed_count,
-                _estimate_tokens(messages),
                 MAX_INPUT_TOKENS,
             )
 
@@ -604,7 +578,8 @@ class ClawboltAgent:
             response = await self._call_llm_with_retry(messages, tool_schemas, llm_kwargs)
             purpose = "agent_main" if _round == 0 else "agent_followup"
             log_llm_usage(self.db, self.contractor.id, settings.llm_model, response, purpose)
-            _log_token_estimation_drift(messages, response)
+            if response.usage and response.usage.input_tokens:
+                self._last_input_tokens = response.usage.input_tokens
 
             # Parse tool calls via shared parser
             parsed_raw = parse_tool_calls(response)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from any_llm import (
@@ -14,8 +14,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.core import (
     ClawboltAgent,
-    _estimate_tokens,
-    _log_token_estimation_drift,
+    _total_content_length,
 )
 from backend.app.agent.messages import (
     AgentMessage,
@@ -564,36 +563,33 @@ async def test_agent_rate_limit_retry_failure_propagates(
 # ---------------------------------------------------------------------------
 
 
-def test_estimate_tokens_returns_reasonable_estimate() -> None:
-    """_estimate_tokens should return a char-based token count with per-message overhead."""
-    messages = [
-        SystemMessage(content="Hello world"),  # 11 chars / 3.5 = 3 + 4 overhead = 7
-        UserMessage(content="How are you?"),  # 12 chars / 3.5 = 3 + 4 overhead = 7
+def test_total_content_length_counts_all_message_types() -> None:
+    """_total_content_length should sum character counts across message types."""
+    messages: list[AgentMessage] = [
+        SystemMessage(content="Hello world"),  # 11 chars
+        UserMessage(content="How are you?"),  # 12 chars
     ]
-    result = _estimate_tokens(messages)
-    # int(11/3.5) + 4 + int(12/3.5) + 4 = 3 + 4 + 3 + 4 = 14
-    assert result == 14
+    result = _total_content_length(messages)
+    assert result == 23
 
 
-def test_estimate_tokens_handles_empty_messages() -> None:
-    """_estimate_tokens should handle empty content, counting only overhead."""
-    messages = [
+def test_total_content_length_handles_empty_messages() -> None:
+    """_total_content_length should return 0 for empty content."""
+    messages: list[AgentMessage] = [
         SystemMessage(content=""),
         UserMessage(content=""),
     ]
-    result = _estimate_tokens(messages)
-    # 2 messages x 4 overhead tokens each = 8
-    assert result == 8
+    assert _total_content_length(messages) == 0
 
 
-def test_estimate_tokens_handles_empty_list() -> None:
-    """_estimate_tokens should return 0 for an empty message list."""
-    assert _estimate_tokens([]) == 0
+def test_total_content_length_handles_empty_list() -> None:
+    """_total_content_length should return 0 for an empty message list."""
+    assert _total_content_length([]) == 0
 
 
-def test_estimate_tokens_counts_tool_call_content() -> None:
-    """_estimate_tokens should include tool_calls function names and arguments."""
-    messages = [
+def test_total_content_length_includes_tool_call_content() -> None:
+    """_total_content_length should include tool call names and arguments."""
+    messages: list[AgentMessage] = [
         AssistantMessage(
             content=None,
             tool_calls=[
@@ -605,78 +601,27 @@ def test_estimate_tokens_counts_tool_call_content() -> None:
             ],
         ),
     ]
-    result = _estimate_tokens(messages)
+    result = _total_content_length(messages)
 
-    # Overhead: 4 tokens
-    # content is None -> 0
-    # tool_calls: "save_fact" = 9 chars -> int(9/3.5) = 2
-    #   arguments dict str repr has variable length, but should be > 0
-    # Total > 4 (overhead only)
-    assert result > 4
+    # Should include "save_fact" (9 chars) + str(arguments)
+    assert result > 9
 
-    # Compare with a message that has no tool_calls -- should be less
-    plain = [AssistantMessage(content=None)]
-    assert _estimate_tokens(plain) < result
+    # Compare with a message that has no tool_calls
+    plain: list[AgentMessage] = [AssistantMessage(content=None)]
+    assert _total_content_length(plain) < result
 
 
-# ---------------------------------------------------------------------------
-# Token estimation drift logging
-# ---------------------------------------------------------------------------
+def test_no_token_estimation_drift_logging(caplog: pytest.LogCaptureFixture) -> None:
+    """Token estimation drift logging should not occur (removed in #431)."""
+    # The old _log_token_estimation_drift would log warnings about token
+    # estimate drift. Verify the function no longer exists on the module.
+    from backend.app.agent import core as agent_core
 
-
-def test_log_token_estimation_drift_warns_when_off(caplog: pytest.LogCaptureFixture) -> None:
-    """_log_token_estimation_drift should warn when estimate drifts more than 30 percent."""
-    messages: list[AgentMessage] = [
-        SystemMessage(content="You are a helpful assistant."),
-        UserMessage(content="Hello, how are you today?"),
-    ]
-    # Build a mock response whose actual input_tokens differs greatly from our estimate.
-    # Our estimate: ~(35 + 26) / 3.5 + 2*4 = ~25 tokens
-    # Set actual to 100 so the estimate (~25) is far below actual.
-    response = MagicMock()
-    usage = MagicMock()
-    usage.input_tokens = 100
-    response.usage = usage
+    assert not hasattr(agent_core, "_log_token_estimation_drift")
+    assert not hasattr(agent_core, "_estimate_tokens")
 
     with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
-        _log_token_estimation_drift(messages, response)
-
-    assert any("Token estimate drift" in rec.message for rec in caplog.records)
-    # Verify logged values contain the key details
-    drift_record = next(r for r in caplog.records if "Token estimate drift" in r.message)
-    assert "estimated=" in drift_record.message
-    assert "actual=100" in drift_record.message
-
-
-def test_log_token_estimation_drift_silent_when_close(caplog: pytest.LogCaptureFixture) -> None:
-    """_log_token_estimation_drift should not warn when estimate is within 30 percent."""
-    messages: list[AgentMessage] = [
-        SystemMessage(content="x" * 350),  # ~100 tokens
-    ]
-    # Our estimate: 350/3.5 + 4 = 104 tokens. Set actual to 100 (4% off).
-    response = MagicMock()
-    usage = MagicMock()
-    usage.input_tokens = 100
-    response.usage = usage
-
-    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
-        _log_token_estimation_drift(messages, response)
-
-    assert not any("Token estimate drift" in rec.message for rec in caplog.records)
-
-
-def test_log_token_estimation_drift_zero_prompt_tokens(caplog: pytest.LogCaptureFixture) -> None:
-    """_log_token_estimation_drift should be silent when input_tokens is 0."""
-    messages: list[AgentMessage] = [
-        SystemMessage(content="Hello"),
-    ]
-    response = MagicMock()
-    usage = MagicMock()
-    usage.input_tokens = 0
-    response.usage = usage
-
-    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
-        _log_token_estimation_drift(messages, response)
+        pass  # No drift logging to trigger
 
     assert not any("Token estimate drift" in rec.message for rec in caplog.records)
 
@@ -694,8 +639,9 @@ def test_trim_messages_preserves_tool_call_result_pairs() -> None:
 
     messages = [system, user1, assistant_tc, tool_result, user2]
 
-    # Use a small budget that forces trimming of some messages
-    trimmed = ClawboltAgent._trim_messages(messages, target_tokens=5000)
+    # Use a small budget that forces trimming of some messages.
+    # Total content length is ~10500 chars, so ~2625 tokens at 4 chars/token.
+    trimmed = ClawboltAgent._trim_messages(messages, target_tokens=1000)
 
     # The trimmed result should never contain tool_result without assistant_tc
     has_tool_msg = any(isinstance(m, ToolResultMessage) for m in trimmed)
@@ -875,8 +821,8 @@ def test_trim_messages_keeps_system_and_recent() -> None:
     assert len(trimmed) < len(messages)
     # Last message should be the most recent one
     assert trimmed[-1] == messages[-1]
-    # Should fit within the target budget
-    assert _estimate_tokens(trimmed) <= 5000
+    # Should fit within the target budget (4 chars/token approximation)
+    assert _total_content_length(trimmed) // 4 <= 5000
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description

Remove the character-ratio-based token estimation system (`_estimate_tokens`, `_log_token_estimation_drift`, `_CHARS_PER_TOKEN`, `_MESSAGE_OVERHEAD_TOKENS`) that produced confusing "Token estimate drift" warnings in the logs.

Replace with:
- `_total_content_length()`: simple character-count helper for content-size comparisons in context trimming
- `_last_input_tokens` on `ClawboltAgent`: tracks actual API-reported `input_tokens` from `response.usage`
- Updated `_trim_messages()`: accepts optional `input_tokens` parameter to use actual API-reported token counts, with a conservative content-length fallback (4 chars/token) when actual counts are not available

Fixes #431

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the fix, wrote tests, and verified all checks pass)
- [ ] No AI used