### PR TITLE
fix: remove hardcoded DEFAULT_ESTIMATE_TERMS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,6 @@ STORAGE_PROVIDER=local
 # GOOGLE_DRIVE_CREDENTIALS_JSON=
 # PDF_STORAGE_DIR=data/estimates
 # FILE_STORAGE_BASE_DIR=data/storage
-# DEFAULT_ESTIMATE_TERMS=Payment due within 30 days of project completion.
 
 # Whisper
 WHISPER_MODEL_SIZE=base

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -137,7 +137,7 @@ def create_estimate_tools(
             estimate_number=estimate_number,
             client_name=client_name,
             client_address=client_address,
-            terms=terms or settings.default_estimate_terms,
+            terms=terms,
         )
 
         pdf_bytes = await generate_estimate_pdf(pdf_data)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -56,7 +56,6 @@ class Settings(BaseSettings):
     google_drive_credentials_json: str = ""
     pdf_storage_dir: str = "data/estimates"
     file_storage_base_dir: str = "data/storage"
-    default_estimate_terms: str = "Payment due within 30 days of project completion."
 
     # Whisper
     whisper_model_size: str = "base"

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -59,7 +59,6 @@ Set the API key env var for your chosen provider, or set `ANY_LLM_KEY` to use th
 | `CLAWBOLT_DATA_DIR` | `./data` | Host path bind-mounted to `/app/data` (Docker Compose only) |
 | `PDF_STORAGE_DIR` | `data/estimates` | Directory for generated PDF estimates |
 | `FILE_STORAGE_BASE_DIR` | `data/storage` | Base directory for local file storage |
-| `DEFAULT_ESTIMATE_TERMS` | `Payment due within 30 days of project completion.` | Default terms printed on estimates |
 
 See [Storage Providers](../deployment/storage/) for setup instructions.
 

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -159,6 +159,29 @@ async def test_generate_estimate_custom_terms(
     )
 
     assert "EST-0001" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_generate_estimate_no_terms_omits_default(
+    db_session: Session,
+    test_contractor: Contractor,
+) -> None:
+    """Omitting terms should pass None to the PDF, not a hardcoded default."""
+    tools = create_estimate_tools(db_session, test_contractor)
+    generate = tools[0].function
+
+    with patch(
+        "backend.app.agent.tools.estimate_tools.generate_estimate_pdf",
+        new_callable=AsyncMock,
+        return_value=b"%PDF-fake",
+    ) as mock_pdf:
+        await generate(
+            description="No terms job",
+            line_items=[{"description": "Work", "quantity": 1, "unit_price": 100.00}],
+        )
+
+        pdf_data = mock_pdf.call_args[0][0]
+        assert pdf_data.terms is None
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description
Remove the hardcoded `DEFAULT_ESTIMATE_TERMS` setting ("Payment due within 30 days of project completion.") from the config, env example, and docs. Estimate terms should be provided by the user per-estimate via the `terms` parameter, not pre-determined by the system. When no terms are provided, the PDF simply omits the terms section.

Fixes #430

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code -- implemented fix and regression test)
- [ ] No AI used