### PR TITLE
feat: add comprehensive debug logging to agent loop and pipeline

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -174,6 +174,12 @@ async def load_conversation_history(
     """
     # Count total messages in this conversation to detect overflow
     total_count = db.query(Message).filter(Message.conversation_id == conversation_id).count()
+    logger.debug(
+        "Loading conversation history: conversation=%d, total_messages=%d, limit=%d",
+        conversation_id,
+        total_count,
+        limit,
+    )
 
     messages = (
         db.query(Message)
@@ -230,6 +236,7 @@ async def load_conversation_history(
             task.add_done_callback(_background_tasks.discard)
 
     history: list[AgentMessage] = []
+    tool_interaction_count = 0
     for msg in messages:
         # Prefer processed context (includes media descriptions) over raw body
         content = msg.processed_context if msg.processed_context else msg.body
@@ -239,9 +246,16 @@ async def load_conversation_history(
             # Check for stored tool interactions
             tool_interactions = _parse_tool_interactions(msg.tool_interactions_json)
             if tool_interactions:
+                tool_interaction_count += len(tool_interactions)
                 history.extend(_expand_outbound_with_tools(tool_interactions, content))
             else:
                 history.append(AssistantMessage(content=content))
+    logger.debug(
+        "Loaded %d history messages (%d with tool interactions) for conversation %d",
+        len(history),
+        tool_interaction_count,
+        conversation_id,
+    )
     return history
 
 

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -287,6 +287,12 @@ class ClawboltAgent:
             if tool.name in self._tools_by_name:
                 logger.warning("Duplicate tool name registered: %s", tool.name)
             self._tools_by_name[tool.name] = tool
+        logger.debug(
+            "Registered %d tools for contractor %s: %s",
+            len(tools),
+            self.contractor.id if self.contractor else "N/A",
+            ", ".join(sorted(self._tools_by_name.keys())),
+        )
 
     def _activate_specialist(self, factory_name: str) -> None:
         """Activate a specialist tool factory, injecting its tools for the next round.
@@ -303,12 +309,22 @@ class ClawboltAgent:
             selected_factories={factory_name},
         )
         if not new_tools:
+            logger.debug(
+                "Specialist factory %r produced no tools (dependencies unmet?)", factory_name
+            )
             return
         self._activated_specialists.add(factory_name)
+        new_names: list[str] = []
         for tool in new_tools:
             if tool.name not in self._tools_by_name:
                 self.tools.append(tool)
                 self._tools_by_name[tool.name] = tool
+                new_names.append(tool.name)
+        logger.debug(
+            "Activated specialist %r, added tools: %s",
+            factory_name,
+            ", ".join(new_names) or "(none new)",
+        )
 
     def _check_specialist_activations(
         self,
@@ -359,6 +375,15 @@ class ClawboltAgent:
         """
         await self._send_typing_indicator()
         system, msg_dicts = messages_to_messages_api(messages)
+        tool_count = len(tool_schemas) if tool_schemas else 0
+        logger.debug(
+            "Calling LLM: model=%s provider=%s messages=%d tools=%d max_tokens=%d",
+            settings.llm_model,
+            settings.llm_provider,
+            len(msg_dicts),
+            tool_count,
+            settings.llm_max_tokens_agent,
+        )
         try:
             return cast(
                 MessageResponse,
@@ -529,6 +554,12 @@ class ClawboltAgent:
     ) -> AgentResponse:
         """Process a message through the agent loop."""
         agent_start_time = time.monotonic()
+        logger.debug(
+            "Agent starting for contractor %d, message length=%d, history=%d messages",
+            self.contractor.id,
+            len(message_context),
+            len(conversation_history) if conversation_history else 0,
+        )
         system_prompt = system_prompt_override or await self._build_system_prompt(message_context)
         await self._emit(
             AgentStartEvent(
@@ -571,6 +602,12 @@ class ClawboltAgent:
         reply_text = ""
 
         for _round in range(MAX_TOOL_ROUNDS):
+            logger.debug(
+                "Round %d/%d starting, %d messages in context",
+                _round,
+                MAX_TOOL_ROUNDS,
+                len(messages),
+            )
             # Rebuild tool schemas each round so dynamically activated
             # specialist tools are visible to the LLM.
             tool_schemas = [tool_to_function_schema(t) for t in self.tools] if self.tools else None
@@ -580,11 +617,21 @@ class ClawboltAgent:
             log_llm_usage(self.db, self.contractor.id, settings.llm_model, response, purpose)
             if response.usage and response.usage.input_tokens:
                 self._last_input_tokens = response.usage.input_tokens
+                logger.debug(
+                    "LLM usage: input_tokens=%d output_tokens=%d",
+                    response.usage.input_tokens,
+                    response.usage.output_tokens or 0,
+                )
 
             # Parse tool calls via shared parser
             parsed_raw = parse_tool_calls(response)
             if not parsed_raw:
                 reply_text = get_response_text(response)
+                logger.debug(
+                    "Round %d: no tool calls, final reply length=%d",
+                    _round,
+                    len(reply_text),
+                )
                 await self._emit(TurnEndEvent(round_number=_round, has_more_tool_calls=False))
                 break
 
@@ -598,6 +645,12 @@ class ClawboltAgent:
                         arguments=ptc.arguments if ptc.arguments is not None else {},
                     )
                 )
+            logger.debug(
+                "Round %d: LLM requested %d tool call(s): %s",
+                _round,
+                len(parsed_calls),
+                ", ".join(tc.name for tc in parsed_calls),
+            )
 
             # Append the assistant message (with tool_calls) to conversation
             messages.append(
@@ -632,6 +685,7 @@ class ClawboltAgent:
 
                 tool_obj = self._tools_by_name.get(tool_name)
                 if not tool_obj:
+                    logger.debug("Unknown tool %r requested by LLM", tool_name)
                     available = ", ".join(sorted(self._tools_by_name.keys()))
                     result_str = (
                         f'Error: unknown tool "{tool_name}".'
@@ -719,6 +773,13 @@ class ClawboltAgent:
                     is_error = True
                     actions_taken.append(f"Failed: {tool_name}")
                 tool_duration = (time.monotonic() - tool_start) * 1000
+                logger.debug(
+                    "Tool %s completed in %.1fms, is_error=%s, result_length=%d",
+                    tool_name,
+                    tool_duration,
+                    is_error,
+                    len(result_str),
+                )
                 await self._emit(
                     ToolExecutionEndEvent(
                         tool_name=tool_name,
@@ -743,8 +804,16 @@ class ClawboltAgent:
         else:
             # Max rounds reached -- use last response content
             reply_text = get_response_text(response)
+            logger.debug("Max tool rounds (%d) reached, using last response", MAX_TOOL_ROUNDS)
 
         total_duration = (time.monotonic() - agent_start_time) * 1000
+        logger.debug(
+            "Agent finished for contractor %d in %.1fms, actions=%s, reply_length=%d",
+            self.contractor.id,
+            total_duration,
+            actions_taken or "(none)",
+            len(reply_text),
+        )
         await self._emit(
             AgentEndEvent(
                 reply_text=reply_text,

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -265,6 +265,17 @@ async def process_inbound_message(
     """
     contractor = _get_or_create_contractor(db, inbound.channel, inbound.sender_id)
     conversation, _is_new = await get_or_create_conversation(db, contractor.id)
+    logger.debug(
+        "Inbound message from %s/%s: contractor=%d, conversation=%d (new=%s), "
+        "text_length=%d, media=%d",
+        inbound.channel,
+        inbound.sender_id,
+        contractor.id,
+        conversation.id,
+        _is_new,
+        len(inbound.text),
+        len(inbound.media_refs),
+    )
 
     message = Message(
         conversation_id=conversation.id,

--- a/backend/app/agent/llm_parsing.py
+++ b/backend/app/agent/llm_parsing.py
@@ -53,6 +53,15 @@ def parse_tool_calls(response: MessageResponse) -> list[ParsedToolCall]:
             )
         )
 
+    if result:
+        logger.debug(
+            "Parsed %d tool call(s) from LLM response: %s",
+            len(result),
+            ", ".join(
+                f"{tc.name}({', '.join(tc.arguments.keys()) if tc.arguments else ''})"
+                for tc in result
+            ),
+        )
     return result
 
 

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -110,10 +110,17 @@ async def prepare_media(
     Also auto-saves downloaded media to storage when available.
     """
     downloaded_media: list[DownloadedMedia] = []
+    logger.debug(
+        "Preparing media for contractor %d, message %d: %d attachment(s)",
+        contractor.id,
+        message_id,
+        len(media_urls),
+    )
     for file_id, _mime_type in media_urls:
         try:
             media = await messaging_service.download_media(file_id)
             downloaded_media.append(media)
+            logger.debug("Downloaded media %s (%s)", file_id, _mime_type)
         except Exception:
             logger.exception("Failed to download media: %s", file_id)
 
@@ -224,6 +231,14 @@ async def run_agent(
     if specialist_summaries:
         tools.append(create_list_capabilities_tool(specialist_summaries))
     agent.register_tools(tools)
+    logger.debug(
+        "Agent initialized for contractor %d, message %d with %d core tools, "
+        "%d specialist categories available",
+        contractor.id,
+        message.id,
+        len(tools),
+        len(specialist_summaries),
+    )
 
     for subscriber in event_subscribers or []:
         agent.subscribe(subscriber)
@@ -268,7 +283,17 @@ async def dispatch_reply(
     sent_reply = any(
         ToolTags.SENDS_REPLY in tc.tags and not tc.is_error for tc in response.tool_calls
     )
+    if sent_reply:
+        logger.debug("Reply already sent via tool, skipping dispatch for message %d", message_id)
+    elif not response.reply_text:
+        logger.debug("No reply text to dispatch for message %d", message_id)
     if not sent_reply and response.reply_text:
+        logger.debug(
+            "Dispatching reply to %s for message %d (length=%d)",
+            to_address,
+            message_id,
+            len(response.reply_text),
+        )
         try:
             await messaging_service.send_text(to=to_address, body=response.reply_text)
         except Exception:
@@ -389,7 +414,10 @@ async def persist_outbound_step(ctx: PipelineContext) -> PipelineContext:
 async def run_pipeline(ctx: PipelineContext, steps: list[PipelineStep]) -> PipelineContext:
     """Execute pipeline steps in sequence."""
     for step in steps:
+        step_name = getattr(step, "__name__", type(step).__name__)
+        logger.debug("Pipeline step starting: %s", step_name)
         ctx = await step(ctx)
+        logger.debug("Pipeline step completed: %s", step_name)
     return ctx
 
 
@@ -423,6 +451,12 @@ async def handle_inbound_message(
     ``PipelineStep`` callables. Pass a custom ``pipeline`` to add,
     remove, or reorder steps; defaults to ``DEFAULT_PIPELINE``.
     """
+    logger.debug(
+        "Handling inbound message %d for contractor %d, %d media attachment(s)",
+        message.id,
+        contractor.id,
+        len(media_urls),
+    )
     to_address = contractor.channel_identifier or contractor.phone
     if not to_address:
         logger.error(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1767,3 +1767,55 @@ class TestToolRegistry:
         # The second factory should win
         assert len(tools) == 1
         assert tools[0].name == "b"
+
+
+# ---------------------------------------------------------------------------
+# Debug logging tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_emits_debug_logs_for_full_loop(
+    mock_amessages: AsyncMock,
+    db_session: Session,
+    test_contractor: Contractor,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Debug logging should trace the full agent loop lifecycle."""
+    tool_func = AsyncMock(return_value=ToolResult(content="saved"))
+    tool = Tool(
+        name="save_fact",
+        description="save",
+        function=tool_func,
+        params_model=_KeyValueParams,
+    )
+    mock_amessages.side_effect = [
+        make_tool_call_response(
+            [{"name": "save_fact", "arguments": {"key": "color", "value": "blue"}}]
+        ),
+        make_text_response("Done!"),
+    ]
+
+    agent = ClawboltAgent(db=db_session, contractor=test_contractor)
+    agent.register_tools([tool])
+
+    with caplog.at_level("DEBUG", logger="backend.app.agent.core"):
+        await agent.process_message(
+            "Remember my favorite color is blue",
+            system_prompt_override="You are a helpful assistant.",
+        )
+
+    debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+    # Agent start
+    assert any("Agent starting" in m for m in debug_messages)
+    # Round logging
+    assert any("Round 0" in m and "starting" in m for m in debug_messages)
+    # Tool calls parsed
+    assert any("save_fact" in m and "tool call" in m for m in debug_messages)
+    # Tool execution result
+    assert any("save_fact" in m and "completed" in m for m in debug_messages)
+    # Agent finished
+    assert any("Agent finished" in m for m in debug_messages)
+    # LLM call
+    assert any("Calling LLM" in m for m in debug_messages)


### PR DESCRIPTION
## Description
Adds `logger.debug()` calls throughout the agent processing pipeline so that running with `LOG_LEVEL=DEBUG` produces a clear trace of what the agent is doing and why at each step.

**Files changed:**
- `backend/app/agent/core.py` - Agent loop: start/finish timing, round tracking, LLM calls (model, tokens), tool call parsing, tool execution (duration, success/error), specialist activation, max rounds
- `backend/app/agent/router.py` - Pipeline orchestration: step-by-step tracing, media download, agent init, reply dispatch decisions
- `backend/app/agent/context.py` - History loading: message counts, tool interaction counts
- `backend/app/agent/llm_parsing.py` - Tool call parsing: parsed tool names and parameter keys
- `backend/app/agent/ingestion.py` - Message ingestion: channel, sender, contractor, conversation, text/media counts

All logging uses `logger.debug()` so it is invisible at the default INFO level and only appears when `LOG_LEVEL=DEBUG`.

Fixes #432

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the debug logging and test)
- [ ] No AI used