### PR TITLE
feat: organize storage by client with slug-based IDs

### DIFF
--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -21,7 +21,8 @@ Storage layout::
             {session_id}.jsonl
           clients.json
           estimates/
-            {estimate_id}.json
+            {client_slug}/
+              EST-0001.json
           media.json
           heartbeat/
             checklist.json
@@ -74,6 +75,7 @@ class ContractorData(BaseModel):
     preferences_json: str = "{}"
     heartbeat_opt_in: bool = True
     heartbeat_frequency: str = ""
+    folder_scheme: str = "by_client"
     created_at: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.UTC)
     )
@@ -124,7 +126,7 @@ class SessionState(BaseModel):
 class ClientData(BaseModel):
     """Replaces the Client ORM model."""
 
-    id: int = 0
+    id: str = ""
     name: str = ""
     phone: str = ""
     email: str = ""
@@ -146,13 +148,14 @@ class EstimateLineItemData(BaseModel):
 class EstimateData(BaseModel):
     """Replaces the Estimate + EstimateLineItem ORM models."""
 
-    id: int = 0
+    id: str = ""
     contractor_id: int = 0
-    client_id: int | None = None
+    client_id: str | None = None
     description: str = ""
     total_amount: float = 0.0
     status: str = EstimateStatus.DRAFT
     pdf_url: str = ""
+    storage_path: str = ""
     created_at: str = Field(default_factory=lambda: datetime.datetime.now(datetime.UTC).isoformat())
     line_items: list[EstimateLineItemData] = Field(default_factory=list)
 
@@ -160,7 +163,7 @@ class EstimateData(BaseModel):
 class MediaData(BaseModel):
     """Replaces the MediaFile ORM model."""
 
-    id: int = 0
+    id: str = ""
     message_id: int | None = None
     contractor_id: int = 0
     original_url: str = ""
@@ -266,6 +269,57 @@ def _next_id(items: list[dict[str, Any]]) -> int:
     if not items:
         return 1
     return max(item.get("id", 0) for item in items) + 1
+
+
+def slugify(text: str, max_length: int = 60) -> str:
+    """Convert text to a filesystem-safe slug.
+
+    Example: "John Smith - 116 Virginia Ave" -> "john_smith_116_virginia_ave"
+    """
+    slug = text.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_-]+", "_", slug)
+    return slug[:max_length].rstrip("_")
+
+
+def _unique_slug(base_slug: str, existing_ids: set[str]) -> str:
+    """Return a unique slug by appending a counter suffix if needed."""
+    if base_slug not in existing_ids:
+        return base_slug
+    counter = 2
+    while f"{base_slug}_{counter}" in existing_ids:
+        counter += 1
+    return f"{base_slug}_{counter}"
+
+
+def make_client_slug(
+    name: str = "",
+    address: str = "",
+    folder_scheme: str = "by_client",
+) -> str:
+    """Build a client slug based on the folder scheme preference.
+
+    folder_scheme options:
+        "by_client" (default): slug from client name
+        "by_address": slug from address
+        "by_client_and_address": slug from "name address"
+    """
+    if folder_scheme == "by_address" and address.strip():
+        return slugify(address)
+    if folder_scheme == "by_client_and_address":
+        parts = []
+        if name.strip():
+            parts.append(name.strip())
+        if address.strip():
+            parts.append(address.strip())
+        if parts:
+            return slugify(" ".join(parts))
+    # Default: by_client, or fallback when preferred field is empty
+    if name.strip():
+        return slugify(name)
+    if address.strip():
+        return slugify(address)
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -891,20 +945,30 @@ class ClientStore:
         items = self._load_all()
         return [ClientData.model_validate(item) for item in items]
 
-    async def get(self, client_id: int) -> ClientData | None:
-        """Get a client by ID."""
+    async def get(self, client_id: str) -> ClientData | None:
+        """Get a client by ID (slug)."""
         for item in self._load_all():
             if item.get("id") == client_id:
                 return ClientData.model_validate(item)
         return None
 
     async def create(
-        self, name: str = "", phone: str = "", email: str = "", address: str = "", notes: str = ""
+        self,
+        name: str = "",
+        phone: str = "",
+        email: str = "",
+        address: str = "",
+        notes: str = "",
+        folder_scheme: str = "by_client",
     ) -> ClientData:
-        """Create a new client."""
+        """Create a new client with a slug-based ID."""
         async with self._lock:
             items = self._load_all()
-            cid = _next_id(items)
+            base_slug = make_client_slug(name, address, folder_scheme)
+            if not base_slug:
+                base_slug = "client"
+            existing_ids = {item.get("id", "") for item in items}
+            cid = _unique_slug(base_slug, existing_ids)
             client = ClientData(
                 id=cid,
                 name=name,
@@ -917,7 +981,7 @@ class ClientStore:
             _write_json(self._path, items)
             return client
 
-    async def update(self, client_id: int, **fields: Any) -> ClientData | None:
+    async def update(self, client_id: str, **fields: Any) -> ClientData | None:
         """Update a client's fields."""
         async with self._lock:
             items = self._load_all()
@@ -931,7 +995,7 @@ class ClientStore:
                     return ClientData.model_validate(item)
             return None
 
-    async def delete(self, client_id: int) -> bool:
+    async def delete(self, client_id: str) -> bool:
         """Delete a client. Returns True if found and deleted."""
         async with self._lock:
             items = self._load_all()
@@ -949,7 +1013,16 @@ class ClientStore:
 
 
 class EstimateStore:
-    """File-based estimate storage. Replaces Estimate + EstimateLineItem models."""
+    """File-based estimate storage. Replaces Estimate + EstimateLineItem models.
+
+    Estimates are organized under client subdirectories::
+
+        estimates/
+          {client_slug}/
+            EST-0001.json
+          unsorted/
+            EST-0003.json
+    """
 
     def __init__(self, contractor_id: int) -> None:
         self.contractor_id = contractor_id
@@ -959,41 +1032,72 @@ class EstimateStore:
     def _estimates_dir(self) -> Path:
         return _contractor_dir(self.contractor_id) / "estimates"
 
-    def _estimate_path(self, estimate_id: int) -> Path:
-        return self._estimates_dir / f"{estimate_id}.json"
+    def _estimate_path(self, estimate_id: str, client_id: str | None = None) -> Path:
+        folder = client_id if client_id else "unsorted"
+        return self._estimates_dir / folder / f"{estimate_id}.json"
+
+    def _find_estimate_path(self, estimate_id: str) -> Path | None:
+        """Search all subdirectories for an estimate by ID."""
+        edir = self._estimates_dir
+        if not edir.exists():
+            return None
+        for path in edir.rglob(f"{estimate_id}.json"):
+            return path
+        return None
 
     async def list_all(self) -> list[EstimateData]:
-        """List all estimates."""
+        """List all estimates across all client subdirectories."""
         edir = self._estimates_dir
         if not edir.exists():
             return []
         result: list[EstimateData] = []
-        for path in sorted(edir.glob("*.json")):
+        for path in sorted(edir.rglob("*.json")):
             data = _read_json(path)
             if data:
                 result.append(EstimateData.model_validate(data))
         return result
 
-    async def get(self, estimate_id: int) -> EstimateData | None:
+    async def get(self, estimate_id: str) -> EstimateData | None:
         """Get an estimate by ID."""
-        data = _read_json(self._estimate_path(estimate_id))
+        path = self._find_estimate_path(estimate_id)
+        if path is None:
+            return None
+        data = _read_json(path)
         if data is None:
             return None
         return EstimateData.model_validate(data)
+
+    def _next_estimate_number(self, existing: list[EstimateData]) -> int:
+        """Get the next sequential estimate number across all estimates."""
+        max_num = 0
+        for e in existing:
+            # Parse number from "EST-0001" format
+            if e.id.startswith("EST-"):
+                try:
+                    num = int(e.id[4:])
+                    max_num = max(max_num, num)
+                except ValueError:
+                    pass
+        return max_num + 1
 
     async def create(
         self,
         description: str = "",
         total_amount: float = 0.0,
         status: str = EstimateStatus.DRAFT,
-        client_id: int | None = None,
+        client_id: str | None = None,
         line_items: list[dict[str, Any]] | None = None,
     ) -> EstimateData:
-        """Create a new estimate."""
+        """Create a new estimate.
+
+        Args:
+            client_id: Client slug used as the subdirectory name.
+                       Falls back to "unsorted" when not provided.
+        """
         async with self._lock:
-            # Find next ID across existing estimates
             existing = await self.list_all()
-            eid = max((e.id for e in existing), default=0) + 1
+            num = self._next_estimate_number(existing)
+            eid = f"EST-{num:04d}"
 
             items: list[EstimateLineItemData] = []
             if line_items:
@@ -1017,11 +1121,12 @@ class EstimateStore:
                 status=status,
                 line_items=items,
             )
-            self._estimates_dir.mkdir(parents=True, exist_ok=True)
-            _write_json(self._estimate_path(eid), estimate.model_dump())
+            path = self._estimate_path(eid, client_id)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            _write_json(path, estimate.model_dump())
             return estimate
 
-    async def update(self, estimate_id: int, **fields: Any) -> EstimateData | None:
+    async def update(self, estimate_id: str, **fields: Any) -> EstimateData | None:
         """Update an estimate's fields."""
         async with self._lock:
             estimate = await self.get(estimate_id)
@@ -1029,7 +1134,10 @@ class EstimateStore:
                 return None
             data = estimate.model_dump()
             data.update({k: v for k, v in fields.items() if v is not None})
-            _write_json(self._estimate_path(estimate_id), data)
+            path = self._find_estimate_path(estimate_id)
+            if path is None:
+                return None
+            _write_json(path, data)
             return EstimateData.model_validate(data)
 
 
@@ -1056,6 +1164,19 @@ class MediaStore:
         """List all media files."""
         return [MediaData.model_validate(item) for item in self._load_all()]
 
+    def _next_media_id(self, items: list[dict[str, Any]]) -> str:
+        """Generate the next sequential media ID string."""
+        max_num = 0
+        for item in items:
+            mid = str(item.get("id", ""))
+            if mid.startswith("media-"):
+                try:
+                    num = int(mid[6:])
+                    max_num = max(max_num, num)
+                except ValueError:
+                    pass
+        return f"media-{max_num + 1:03d}"
+
     async def create(
         self,
         original_url: str = "",
@@ -1068,7 +1189,7 @@ class MediaStore:
         """Create a media file record."""
         async with self._lock:
             items = self._load_all()
-            mid = _next_id(items)
+            mid = self._next_media_id(items)
             media = MediaData(
                 id=mid,
                 contractor_id=self.contractor_id,
@@ -1090,12 +1211,12 @@ class MediaStore:
                 return MediaData.model_validate(item)
         return None
 
-    async def update(self, media_id: int, **fields: Any) -> MediaData | None:
+    async def update(self, media_id: str, **fields: Any) -> MediaData | None:
         """Update a media file record."""
         async with self._lock:
             items = self._load_all()
             for i, item in enumerate(items):
-                if item.get("id") == media_id:
+                if str(item.get("id", "")) == media_id:
                     for k, v in fields.items():
                         if v is not None:
                             item[k] = v

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
-from backend.app.agent.file_store import ContractorData, EstimateStore
+from backend.app.agent.file_store import ContractorData, EstimateStore, make_client_slug
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.file_tools import build_folder_path
 from backend.app.agent.tools.names import ToolName
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
 
 PDF_BASE_DIR = Path(settings.pdf_storage_dir)
-ESTIMATE_NUMBER_FORMAT = "EST-{:04d}"
 
 logger = logging.getLogger(__name__)
 
@@ -97,16 +96,27 @@ def create_estimate_tools(
 
         total_amount = subtotal
 
+        # Build client slug for folder organization
+        client_slug = (
+            make_client_slug(
+                name=client_name or "",
+                address=client_address or "",
+                folder_scheme=contractor.folder_scheme,
+            )
+            or None
+        )
+
         # Create estimate via file store
         estimate_store = EstimateStore(contractor.id)
         estimate = await estimate_store.create(
             description=description,
             total_amount=total_amount,
             status=EstimateStatus.DRAFT,
+            client_id=client_slug,
             line_items=processed_items,
         )
 
-        estimate_number = ESTIMATE_NUMBER_FORMAT.format(estimate.id)
+        estimate_number = estimate.id  # Already in EST-NNNN format
 
         # Generate PDF
         pdf_data = EstimatePDFData(
@@ -126,26 +136,31 @@ def create_estimate_tools(
 
         pdf_bytes = await generate_estimate_pdf(pdf_data)
 
-        # Save PDF to local storage (per-contractor subdirectory)
-        pdf_dir = PDF_BASE_DIR / str(contractor.id)
+        # Save PDF to local storage, organized by client
+        pdf_dir = PDF_BASE_DIR / str(contractor.id) / (client_slug or "unsorted")
         pdf_dir.mkdir(parents=True, exist_ok=True)
         pdf_path = pdf_dir / f"{estimate.id}.pdf"
         pdf_path.write_bytes(pdf_bytes)
 
         # Also upload to cloud storage if available
+        cloud_path = ""
         if storage:
             try:
                 folder_path = build_folder_path("estimate", client_name, client_address)
                 await storage.create_folder(folder_path)
                 await storage.upload_file(pdf_bytes, folder_path, f"{estimate_number}.pdf")
+                cloud_path = f"{folder_path}/{estimate_number}.pdf"
             except Exception:
                 logger.warning(
                     "Cloud upload failed for estimate %s, local PDF saved successfully",
                     estimate_number,
                 )
 
-        # Update estimate with PDF path
-        await estimate_store.update(estimate.id, pdf_url=str(pdf_path))
+        # Update estimate with PDF path and cloud storage path
+        update_fields: dict[str, str] = {"pdf_url": str(pdf_path)}
+        if cloud_path:
+            update_fields["storage_path"] = cloud_path
+        await estimate_store.update(estimate.id, **update_fields)
 
         return ToolResult(
             content=(

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import datetime
 import logging
-import re
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
 from backend.app.agent.file_store import ContractorData, MediaStore
+from backend.app.agent.file_store import slugify as _store_slugify
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.media.download import MIME_EXTENSIONS, DownloadedMedia
@@ -87,10 +87,7 @@ class OrganizeFileParams(BaseModel):
 
 def _slugify(text: str, max_length: int = DESCRIPTION_SLUG_MAX_LENGTH) -> str:
     """Convert text to a filesystem-safe slug."""
-    slug = text.lower().strip()
-    slug = re.sub(r"[^\w\s-]", "", slug)
-    slug = re.sub(r"[\s_]+", "_", slug)
-    return slug[:max_length].rstrip("_")
+    return _store_slugify(text, max_length)
 
 
 def _build_client_folder(

--- a/backend/app/auth/scoping.py
+++ b/backend/app/auth/scoping.py
@@ -23,7 +23,7 @@ async def get_user_contractor(
 
 async def get_user_client(
     user: ContractorData,
-    client_id: int,
+    client_id: str,
 ) -> None:
     """Verify a client exists and belongs to the current user's contractor. 404 on mismatch."""
     client_store = ClientStore(user.id)
@@ -34,7 +34,7 @@ async def get_user_client(
 
 async def get_user_estimate(
     user: ContractorData,
-    estimate_id: int,
+    estimate_id: str,
 ) -> None:
     """Verify an estimate exists and belongs to the current user's contractor. 404 on mismatch."""
     estimate_store = EstimateStore(user.id)

--- a/backend/app/routers/estimates.py
+++ b/backend/app/routers/estimates.py
@@ -19,7 +19,7 @@ PDF_BASE_DIR = Path(settings.pdf_storage_dir)
 
 @router.get("/estimates/{estimate_id}/pdf")
 async def serve_estimate_pdf(
-    estimate_id: int,
+    estimate_id: str,
     current_user: ContractorData = Depends(get_current_user),
 ) -> Response:
     """Serve a generated estimate PDF by estimate ID."""
@@ -29,7 +29,12 @@ async def serve_estimate_pdf(
     if not estimate:
         raise HTTPException(status_code=404, detail="Estimate not found")
 
-    pdf_path = PDF_BASE_DIR / str(current_user.id) / f"{estimate_id}.pdf"
+    # Look for PDF under client subfolder, then fallback to flat path
+    client_folder = estimate.client_id or "unsorted"
+    pdf_path = PDF_BASE_DIR / str(current_user.id) / client_folder / f"{estimate_id}.pdf"
+    if not pdf_path.exists():
+        # Fallback: old-style flat path for pre-existing PDFs
+        pdf_path = PDF_BASE_DIR / str(current_user.id) / f"{estimate_id}.pdf"
     if not pdf_path.exists():
         raise HTTPException(status_code=404, detail="Estimate PDF not found")
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -68,8 +68,9 @@ class EstimateBase(BaseModel):
 
 
 class EstimateResponse(EstimateBase):
-    id: int
+    id: str
     contractor_id: int
-    client_id: int | None = None
+    client_id: str | None = None
     pdf_url: str = ""
+    storage_path: str = ""
     created_at: str

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -69,6 +69,11 @@ async def test_generate_estimate_with_client_info(
     assert "EST-0001" in result.content
     assert "$8,500.00" in result.content
 
+    # Verify estimate is filed under the client slug
+    store = EstimateStore(test_contractor.id)
+    estimates = await store.list_all()
+    assert estimates[0].client_id == "john_johnson"
+
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_pdf_generated(
@@ -90,7 +95,10 @@ async def test_generate_estimate_pdf_generated(
     store = EstimateStore(test_contractor.id)
     estimates = await store.list_all()
     assert len(estimates) == 1
-    pdf_path = tmp_path / "estimates" / str(test_contractor.id) / f"{estimates[0].id}.pdf"
+    # Without client info, PDFs go under the "unsorted" subfolder
+    pdf_path = (
+        tmp_path / "estimates" / str(test_contractor.id) / "unsorted" / f"{estimates[0].id}.pdf"
+    )
     assert pdf_path.exists()
     assert pdf_path.stat().st_size > 0
 
@@ -250,7 +258,8 @@ def test_serve_estimate_pdf_endpoint(
     )
 
     # Create a test PDF file in the temp directory (patched via _use_tmp_pdf_dir)
-    contractor_dir = tmp_path / "estimates" / str(test_contractor.id)
+    # Estimates without client_id go under "unsorted"
+    contractor_dir = tmp_path / "estimates" / str(test_contractor.id) / "unsorted"
     contractor_dir.mkdir(parents=True, exist_ok=True)
     test_pdf = contractor_dir / f"{estimate.id}.pdf"
     test_pdf.write_bytes(b"%PDF-1.4 test content")
@@ -292,7 +301,7 @@ def test_serve_estimate_pdf_other_user_rejected(client: TestClient, tmp_path: Pa
     )
 
     # Create the PDF file so we can verify auth blocks access, not file absence
-    contractor_dir = tmp_path / "estimates" / str(other_contractor.id)
+    contractor_dir = tmp_path / "estimates" / str(other_contractor.id) / "unsorted"
     contractor_dir.mkdir(parents=True, exist_ok=True)
     test_pdf = contractor_dir / f"{estimate.id}.pdf"
     test_pdf.write_bytes(b"%PDF-1.4 secret content")
@@ -362,7 +371,9 @@ async def test_generate_estimate_no_storage_still_saves_locally(
     store = EstimateStore(test_contractor.id)
     estimates = await store.list_all()
     assert len(estimates) == 1
-    pdf_path = tmp_path / "estimates" / str(test_contractor.id) / f"{estimates[0].id}.pdf"
+    pdf_path = (
+        tmp_path / "estimates" / str(test_contractor.id) / "unsorted" / f"{estimates[0].id}.pdf"
+    )
     assert pdf_path.exists()
 
 
@@ -407,9 +418,11 @@ async def test_generate_estimate_cloud_upload_failure_does_not_kill_call(
     assert "EST-0001" in result.content
     assert "$2,000.00" in result.content
 
-    # Verify local PDF was saved
+    # Verify local PDF was saved (client_name="John Smith" -> john_smith subfolder)
     store = EstimateStore(test_contractor.id)
     estimates = await store.list_all()
     assert len(estimates) == 1
-    pdf_path = tmp_path / "estimates" / str(test_contractor.id) / f"{estimates[0].id}.pdf"
+    pdf_path = (
+        tmp_path / "estimates" / str(test_contractor.id) / "john_smith" / f"{estimates[0].id}.pdf"
+    )
     assert pdf_path.exists()


### PR DESCRIPTION
## Description
Reorganize file-based storage so data is grouped by client/address rather than bare numeric IDs. Estimates are now stored under client subdirectories (`estimates/{client_slug}/EST-0001.json`) instead of flat numeric files (`estimates/1.json`). All entity IDs (clients, estimates, media) are now meaningful slug-based strings instead of sequential integers.

Adds a per-contractor `folder_scheme` preference so users can tell the agent how they want things organized (by client name, by address, or by both).

Key changes:
- `ClientData.id`: `int` -> `str` (slug from name/address based on `folder_scheme`)
- `EstimateData.id`: `int` -> `str` (`EST-NNNN` format)
- `MediaData.id`: `int` -> `str` (`media-NNN` format)
- `EstimateStore` organizes files under client subdirectories
- Estimate creation now populates `client_id` (was never set before) and `storage_path`
- Local PDFs organized under client subfolders (`pdfs/{contractor_id}/{client_slug}/`)
- PDF serving endpoint falls back to flat path for backward compatibility with pre-existing data
- Shared `slugify()` helper in `file_store.py`, reused by `file_tools.py`

Fixes #435

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)
