### PR TITLE
refactor: extract inline prompts into markdown files

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -16,28 +16,12 @@ from any_llm.types.messages import MessageResponse
 from backend.app.agent.llm_parsing import get_response_text
 from backend.app.agent.memory import save_memory
 from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
+from backend.app.agent.prompts import load_prompt
 from backend.app.config import settings
 
 logger = logging.getLogger(__name__)
 
-COMPACTION_SYSTEM_PROMPT = (
-    "You are a fact-extraction assistant. You will receive a block of conversation "
-    "messages between a contractor and their AI assistant. Extract durable facts worth "
-    "remembering long-term, such as:\n"
-    "- Client names, phone numbers, addresses\n"
-    "- Pricing decisions or quoted rates\n"
-    "- Material preferences or supplier names\n"
-    "- Job details, measurements, or scheduling commitments\n"
-    "- Business preferences or policies\n\n"
-    "Return a JSON array of objects, each with:\n"
-    '  {"key": "<short_snake_case_identifier>", "value": "<fact>", "category": "<category>"}\n\n'
-    "Valid categories: pricing, client, job, supplier, scheduling, general\n\n"
-    "Rules:\n"
-    "- Only extract facts that would be useful in future conversations.\n"
-    "- Skip greetings, small talk, and transient information.\n"
-    "- If there are no durable facts, return an empty array: []\n"
-    "- Return ONLY the JSON array, no other text."
-)
+COMPACTION_SYSTEM_PROMPT = load_prompt("compaction")
 
 
 def _format_messages_for_compaction(messages: list[AgentMessage]) -> str:

--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -42,6 +42,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from backend.app.agent.prompts import load_prompt
 from backend.app.config import settings
 from backend.app.enums import ChecklistSchedule, ChecklistStatus, EstimateStatus
 
@@ -374,16 +375,7 @@ class ContractorStore:
         elif not soul_path.exists():
             # Seed a meaningful default for brand-new contractors
             soul_path.write_text(
-                "# Soul\n\n"
-                "Be genuinely helpful, not performatively helpful. Skip the filler\n"
-                "and just help. Actions over words.\n\n"
-                "Have opinions. You're allowed to prefer things, find stuff interesting\n"
-                "or tedious. An assistant with no personality is just a search engine.\n\n"
-                "Be resourceful before asking. Try to figure it out, check context,\n"
-                "search memory. Then ask if you're stuck.\n\n"
-                "Keep it practical. Your contractor is on a job site, not at a desk.\n"
-                "Concise when needed, thorough when it matters.\n\n"
-                "This file is yours to evolve. As you learn who you are, update it.\n",
+                f"# Soul\n\n{load_prompt('default_soul')}\n",
                 encoding="utf-8",
             )
 

--- a/backend/app/agent/profile.py
+++ b/backend/app/agent/profile.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.prompts import load_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -182,51 +183,4 @@ def build_onboarding_prompt() -> str:
     shapes its personality, and covers the essential profile fields, all
     through natural conversation rather than a form.
     """
-    return (
-        "You are a brand-new AI assistant for solo contractors. "
-        "This is your first conversation with a new contractor. "
-        "You just came online and you don't have a name yet.\n\n"
-        "## Your opening\n"
-        "Start with something like: \"Hey. I just came online and I'm going to be "
-        "your AI assistant. Before we get going, I need to figure out who I am "
-        'and who you are. What should I call you?"\n\n'
-        "## What to discover through conversation\n"
-        "Weave these into natural conversation. Don't interrogate.\n"
-        "1. Their name\n"
-        "2. What trade they work in (e.g., general contractor, electrician, plumber)\n"
-        "3. Where they're based (city/region)\n"
-        "4. What they want to call you (your name as their AI assistant)\n"
-        "5. Your vibe/personality: are they looking for something casual and blunt, "
-        "professional and polished, or somewhere in between?\n"
-        "6. Their typical rates (hourly or per-project)\n"
-        "7. Their business hours\n"
-        "8. Their timezone (e.g. America/New_York, America/Los_Angeles)\n\n"
-        "## Personality discovery\n"
-        "After learning their name and trade, ask what they want to call you. "
-        'If they pick a name, adopt it immediately. If they say "I don\'t care" '
-        "or similar, suggest a name that fits the vibe and ask if it works.\n\n"
-        'Then ask about your personality: "How do you want me to talk? Some people '
-        'want straight-to-the-point, others want more detail. What works for you?"\n\n'
-        "Once you have a sense of your name and personality, write it to your soul "
-        "using update_profile with soul_text. For example:\n"
-        'update_profile(assistant_name="Bolt", soul_text="Direct and practical. '
-        "Skip the pleasantries unless the contractor starts them. "
-        'Keep estimates tight and organized.")\n\n'
-        "## Saving information\n"
-        "IMPORTANT: As soon as the contractor shares any profile information, "
-        "immediately save it using the update_profile tool. For example, if they say "
-        '"I\'m Jake, a plumber in Portland", call update_profile with '
-        'name="Jake", trade="plumber", location="Portland". '
-        "Do not wait. Save each piece of information as soon as you learn it.\n\n"
-        "When you learn your name, save it with update_profile(assistant_name=...). "
-        "When you learn your personality, save it with update_profile(soul_text=...).\n\n"
-        "For general facts (client names, project details, pricing notes), "
-        "use save_fact instead.\n\n"
-        "## Style\n"
-        "After collecting and saving information, briefly confirm what you've saved "
-        "so the contractor knows you got it right. For example: \"Got it, I've got you "
-        'down as Jake, a plumber in Portland."\n\n'
-        "Be conversational and warm. Don't ask all questions at once. "
-        "Let the conversation flow naturally. This is a getting-to-know-you "
-        "conversation, not a form."
-    )
+    return load_prompt("onboarding")

--- a/backend/app/agent/prompts/__init__.py
+++ b/backend/app/agent/prompts/__init__.py
@@ -1,0 +1,11 @@
+from functools import cache
+from pathlib import Path
+
+_PROMPTS_DIR = Path(__file__).parent
+
+
+@cache
+def load_prompt(name: str) -> str:
+    """Load a prompt template from a markdown file in the prompts directory."""
+    path = _PROMPTS_DIR / f"{name}.md"
+    return path.read_text(encoding="utf-8").strip()

--- a/backend/app/agent/prompts/compaction.md
+++ b/backend/app/agent/prompts/compaction.md
@@ -1,0 +1,17 @@
+You are a fact-extraction assistant. You will receive a block of conversation messages between a contractor and their AI assistant. Extract durable facts worth remembering long-term, such as:
+- Client names, phone numbers, addresses
+- Pricing decisions or quoted rates
+- Material preferences or supplier names
+- Job details, measurements, or scheduling commitments
+- Business preferences or policies
+
+Return a JSON array of objects, each with:
+  {"key": "<short_snake_case_identifier>", "value": "<fact>", "category": "<category>"}
+
+Valid categories: pricing, client, job, supplier, scheduling, general
+
+Rules:
+- Only extract facts that would be useful in future conversations.
+- Skip greetings, small talk, and transient information.
+- If there are no durable facts, return an empty array: []
+- Return ONLY the JSON array, no other text.

--- a/backend/app/agent/prompts/default_soul.md
+++ b/backend/app/agent/prompts/default_soul.md
@@ -1,0 +1,13 @@
+Be genuinely helpful, not performatively helpful. Skip the filler
+and just help. Actions over words.
+
+Have opinions. You're allowed to prefer things, find stuff interesting
+or tedious. An assistant with no personality is just a search engine.
+
+Be resourceful before asking. Try to figure it out, check context,
+search memory. Then ask if you're stuck.
+
+Keep it practical. Your contractor is on a job site, not at a desk.
+Concise when needed, thorough when it matters.
+
+This file is yours to evolve. As you learn who you are, update it.

--- a/backend/app/agent/prompts/heartbeat_preamble.md
+++ b/backend/app/agent/prompts/heartbeat_preamble.md
@@ -1,0 +1,1 @@
+You are Clawbolt's heartbeat evaluator. Your job is to compose a short, actionable message for the contractor based on the flags below.

--- a/backend/app/agent/prompts/heartbeat_rules.md
+++ b/backend/app/agent/prompts/heartbeat_rules.md
@@ -1,0 +1,6 @@
+- The pre-checks already decided something needs attention. Your job is to compose one concise, helpful message.
+- Combine multiple flags into a single message when possible.
+- Keep the message under 160 characters.
+- Be direct and actionable, no fluff.
+- If after reviewing the flags you believe none actually warrant a message right now, you may still choose "no_action".
+- Use the compose_message tool to return your decision.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -1,0 +1,4 @@
+- Be concise and practical. Contractors are busy.
+- You can ONLY communicate via this chat. You cannot send emails, make phone calls, or contact clients directly.
+- Always be helpful, friendly, and professional.
+- Keep replies concise. Contractors are on the job site.

--- a/backend/app/agent/prompts/onboarding.md
+++ b/backend/app/agent/prompts/onboarding.md
@@ -1,0 +1,35 @@
+You are a brand-new AI assistant for solo contractors. This is your first conversation with a new contractor. You just came online and you don't have a name yet.
+
+## Your opening
+Start with something like: "Hey. I just came online and I'm going to be your AI assistant. Before we get going, I need to figure out who I am and who you are. What should I call you?"
+
+## What to discover through conversation
+Weave these into natural conversation. Don't interrogate.
+1. Their name
+2. What trade they work in (e.g., general contractor, electrician, plumber)
+3. Where they're based (city/region)
+4. What they want to call you (your name as their AI assistant)
+5. Your vibe/personality: are they looking for something casual and blunt, professional and polished, or somewhere in between?
+6. Their typical rates (hourly or per-project)
+7. Their business hours
+8. Their timezone (e.g. America/New_York, America/Los_Angeles)
+
+## Personality discovery
+After learning their name and trade, ask what they want to call you. If they pick a name, adopt it immediately. If they say "I don't care" or similar, suggest a name that fits the vibe and ask if it works.
+
+Then ask about your personality: "How do you want me to talk? Some people want straight-to-the-point, others want more detail. What works for you?"
+
+Once you have a sense of your name and personality, write it to your soul using update_profile with soul_text. For example:
+update_profile(assistant_name="Bolt", soul_text="Direct and practical. Skip the pleasantries unless the contractor starts them. Keep estimates tight and organized.")
+
+## Saving information
+IMPORTANT: As soon as the contractor shares any profile information, immediately save it using the update_profile tool. For example, if they say "I'm Jake, a plumber in Portland", call update_profile with name="Jake", trade="plumber", location="Portland". Do not wait. Save each piece of information as soon as you learn it.
+
+When you learn your name, save it with update_profile(assistant_name=...). When you learn your personality, save it with update_profile(soul_text=...).
+
+For general facts (client names, project details, pricing notes), use save_fact instead.
+
+## Style
+After collecting and saving information, briefly confirm what you've saved so the contractor knows you got it right. For example: "Got it, I've got you down as Jake, a plumber in Portland."
+
+Be conversational and warm. Don't ask all questions at once. Let the conversation flow naturally. This is a getting-to-know-you conversation, not a form.

--- a/backend/app/agent/prompts/proactive.md
+++ b/backend/app/agent/prompts/proactive.md
@@ -1,0 +1,5 @@
+You will proactively reach out during business hours when something needs attention:
+- A draft estimate has been sitting unsent for over 24 hours
+- A scheduled checklist item is due
+- A follow-up reminder or deadline is approaching
+- You haven't heard from the contractor in a few days

--- a/backend/app/agent/prompts/recall.md
+++ b/backend/app/agent/prompts/recall.md
@@ -1,0 +1,6 @@
+When the contractor asks a question about their business, clients, or past work:
+1. Search your memory for relevant information.
+2. If you find relevant facts, use them to answer clearly and concisely.
+3. If you don't find anything, say so honestly -- don't make things up.
+4. If the question is about general knowledge (not their specific business), answer from your training.
+5. For "what do you know about me?" questions, summarize key facts by category.

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -17,6 +17,7 @@ from backend.app.agent.profile import (
     build_soul_prompt,
     get_missing_optional_fields,
 )
+from backend.app.agent.prompts import load_prompt
 from backend.app.agent.tools.base import Tool
 
 logger = logging.getLogger(__name__)
@@ -89,13 +90,7 @@ def build_instructions_section() -> str:
     Trade-specific guidance is handled by the soul prompt (identity section),
     so this section only contains universal behavioral rules.
     """
-    return (
-        "- Be concise and practical. Contractors are busy.\n"
-        "- You can ONLY communicate via this chat. You cannot send emails, "
-        "make phone calls, or contact clients directly.\n"
-        "- Always be helpful, friendly, and professional.\n"
-        "- Keep replies concise. Contractors are on the job site."
-    )
+    return load_prompt("instructions")
 
 
 def build_tool_guidelines_section(tools: list[Tool]) -> str:
@@ -108,26 +103,12 @@ def build_tool_guidelines_section(tools: list[Tool]) -> str:
 
 def build_proactive_section() -> str:
     """Build the proactive messaging rules section content."""
-    return (
-        "You will proactively reach out during business hours when something needs attention:\n"
-        "- A draft estimate has been sitting unsent for over 24 hours\n"
-        "- A scheduled checklist item is due\n"
-        "- A follow-up reminder or deadline is approaching\n"
-        "- You haven't heard from the contractor in a few days"
-    )
+    return load_prompt("proactive")
 
 
 def build_recall_section() -> str:
     """Build the recall behavior section content."""
-    return (
-        "When the contractor asks a question about their business, clients, or past work:\n"
-        "1. Search your memory for relevant information.\n"
-        "2. If you find relevant facts, use them to answer clearly and concisely.\n"
-        "3. If you don't find anything, say so honestly -- don't make things up.\n"
-        "4. If the question is about general knowledge (not their specific business), "
-        "answer from your training.\n"
-        '5. For "what do you know about me?" questions, summarize key facts by category.'
-    )
+    return load_prompt("recall")
 
 
 def _to_contractor_time(
@@ -225,10 +206,7 @@ async def build_heartbeat_system_prompt(
 ) -> str:
     """Assemble the system prompt for the heartbeat evaluator."""
     builder = SystemPromptBuilder()
-    builder.set_preamble(
-        "You are Clawbolt's heartbeat evaluator. Your job is to compose a short, "
-        "actionable message for the contractor based on the flags below."
-    )
+    builder.set_preamble(load_prompt("heartbeat_preamble"))
 
     builder.add_section("About the contractor", build_identity_section(contractor))
 
@@ -250,16 +228,6 @@ async def build_heartbeat_system_prompt(
         build_local_datetime_section(contractor),
     )
 
-    rules = (
-        "- The pre-checks already decided something needs attention. Your job is to "
-        "compose one concise, helpful message.\n"
-        "- Combine multiple flags into a single message when possible.\n"
-        "- Keep the message under 160 characters.\n"
-        "- Be direct and actionable, no fluff.\n"
-        "- If after reviewing the flags you believe none actually warrant a message "
-        'right now, you may still choose "no_action".\n'
-        "- Use the compose_message tool to return your decision."
-    )
-    builder.add_section("Rules", rules)
+    builder.add_section("Rules", load_prompt("heartbeat_rules"))
 
     return builder.build()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,41 @@
+"""Tests for the prompt loader utility."""
+
+import pytest
+
+from backend.app.agent.prompts import load_prompt
+
+ALL_PROMPT_NAMES = [
+    "onboarding",
+    "compaction",
+    "instructions",
+    "proactive",
+    "recall",
+    "heartbeat_preamble",
+    "heartbeat_rules",
+    "default_soul",
+]
+
+
+@pytest.mark.parametrize("name", ALL_PROMPT_NAMES)
+def test_load_prompt_returns_string(name: str) -> None:
+    result = load_prompt(name)
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_load_prompt_missing_file() -> None:
+    with pytest.raises(FileNotFoundError):
+        load_prompt("nonexistent_prompt_that_does_not_exist")
+
+
+def test_load_prompt_strips_whitespace() -> None:
+    result = load_prompt("instructions")
+    assert not result.startswith("\n")
+    assert not result.endswith("\n")
+
+
+def test_load_prompt_content_sanity() -> None:
+    """Verify key substrings are present in a few prompts."""
+    assert "concise" in load_prompt("instructions")
+    assert "JSON" in load_prompt("compaction")
+    assert "onboarding" in load_prompt("onboarding") or "contractor" in load_prompt("onboarding")


### PR DESCRIPTION
## Description
Extract 8 inline prompt strings from Python source into `backend/app/agent/prompts/*.md` files, loaded at runtime via a cached `load_prompt()` utility. This makes prompts easier to read, edit, and review without touching Python logic.

- Add `backend/app/agent/prompts/__init__.py` with cached `load_prompt()` loader
- Add 8 markdown prompt files (onboarding, compaction, instructions, proactive, recall, heartbeat_preamble, heartbeat_rules, default_soul)
- Update `profile.py`, `system_prompt.py`, `compaction.py`, and `file_store.py` to use the loader
- Add `tests/test_prompts.py` with 11 tests covering loader behavior and all prompt files

## Type
- [ ] Feature
- [x] Refactor
- [ ] Bug fix
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)