### PR TITLE
feat: add dashboard backend endpoints for profile, sessions, memory, checklist, and stats

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,16 @@ from backend.app.agent.heartbeat import heartbeat_scheduler
 from backend.app.channels import get_manager, register_channel
 from backend.app.channels.telegram import TelegramChannel
 from backend.app.config import settings
-from backend.app.routers import auth, estimates, health
+from backend.app.routers import (
+    auth,
+    contractor_checklist,
+    contractor_memory,
+    contractor_profile,
+    contractor_sessions,
+    contractor_stats,
+    estimates,
+    health,
+)
 
 logging.basicConfig(
     level=logging.WARNING,
@@ -154,3 +163,8 @@ for _channel in get_manager().channels.values():
     app.include_router(_channel.get_router(), prefix="/api")
 
 app.include_router(estimates.router, prefix="/api")
+app.include_router(contractor_profile.router, prefix="/api")
+app.include_router(contractor_sessions.router, prefix="/api")
+app.include_router(contractor_memory.router, prefix="/api")
+app.include_router(contractor_checklist.router, prefix="/api")
+app.include_router(contractor_stats.router, prefix="/api")

--- a/backend/app/routers/contractor_checklist.py
+++ b/backend/app/routers/contractor_checklist.py
@@ -1,0 +1,60 @@
+"""Endpoints for managing checklist items."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.app.agent.file_store import ContractorData, HeartbeatStore
+from backend.app.auth.dependencies import get_current_user
+from backend.app.schemas import ChecklistCreateRequest, ChecklistItemResponse
+
+router = APIRouter()
+
+
+@router.get("/contractor/checklist", response_model=list[ChecklistItemResponse])
+async def list_checklist(
+    current_user: ContractorData = Depends(get_current_user),
+) -> list[ChecklistItemResponse]:
+    """List active checklist items."""
+    store = HeartbeatStore(current_user.id)
+    items = await store.get_checklist()
+    return [
+        ChecklistItemResponse(
+            id=item.id,
+            description=item.description,
+            schedule=item.schedule,
+            status=item.status,
+            created_at=item.created_at,
+        )
+        for item in items
+    ]
+
+
+@router.post("/contractor/checklist", response_model=ChecklistItemResponse, status_code=201)
+async def create_checklist_item(
+    body: ChecklistCreateRequest,
+    current_user: ContractorData = Depends(get_current_user),
+) -> ChecklistItemResponse:
+    """Add a new checklist item."""
+    store = HeartbeatStore(current_user.id)
+    item = await store.add_checklist_item(
+        description=body.description,
+        schedule=body.schedule,
+    )
+    return ChecklistItemResponse(
+        id=item.id,
+        description=item.description,
+        schedule=item.schedule,
+        status=item.status,
+        created_at=item.created_at,
+    )
+
+
+@router.delete("/contractor/checklist/{item_id}", status_code=204)
+async def delete_checklist_item(
+    item_id: int,
+    current_user: ContractorData = Depends(get_current_user),
+) -> None:
+    """Remove a checklist item."""
+    store = HeartbeatStore(current_user.id)
+    deleted = await store.delete_checklist_item(item_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Checklist item not found")

--- a/backend/app/routers/contractor_memory.py
+++ b/backend/app/routers/contractor_memory.py
@@ -1,0 +1,71 @@
+"""Endpoints for viewing and managing memory facts."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.app.agent.file_store import ContractorData, get_memory_store
+from backend.app.auth.dependencies import get_current_user
+from backend.app.schemas import MemoryFactResponse, MemoryFactUpdate
+
+router = APIRouter()
+
+
+@router.get("/contractor/memory", response_model=list[MemoryFactResponse])
+async def list_memory(
+    category: str | None = None,
+    current_user: ContractorData = Depends(get_current_user),
+) -> list[MemoryFactResponse]:
+    """List all memory facts, optionally filtered by category."""
+    store = get_memory_store(current_user.id)
+    facts = await store.get_all_memories(category=category)
+    return [
+        MemoryFactResponse(
+            key=f.key,
+            value=f.value,
+            category=f.category,
+            confidence=f.confidence,
+        )
+        for f in facts
+    ]
+
+
+@router.put("/contractor/memory/{key}", response_model=MemoryFactResponse)
+async def update_memory(
+    key: str,
+    body: MemoryFactUpdate,
+    current_user: ContractorData = Depends(get_current_user),
+) -> MemoryFactResponse:
+    """Update a memory fact's value, category, or confidence."""
+    store = get_memory_store(current_user.id)
+    existing = await store.get_all_memories()
+    fact = next((f for f in existing if f.key == key), None)
+    if fact is None:
+        raise HTTPException(status_code=404, detail="Memory fact not found")
+
+    value = body.value if body.value is not None else fact.value
+    category = body.category if body.category is not None else fact.category
+    confidence = body.confidence if body.confidence is not None else fact.confidence
+
+    updated = await store.save_memory(
+        key=key,
+        value=value,
+        category=category,
+        confidence=confidence,
+    )
+    return MemoryFactResponse(
+        key=updated.key,
+        value=updated.value,
+        category=updated.category,
+        confidence=updated.confidence,
+    )
+
+
+@router.delete("/contractor/memory/{key}", status_code=204)
+async def delete_memory(
+    key: str,
+    current_user: ContractorData = Depends(get_current_user),
+) -> None:
+    """Delete a memory fact."""
+    store = get_memory_store(current_user.id)
+    deleted = await store.delete_memory(key)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Memory fact not found")

--- a/backend/app/routers/contractor_profile.py
+++ b/backend/app/routers/contractor_profile.py
@@ -1,0 +1,59 @@
+"""Endpoints for contractor profile management."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.auth.dependencies import get_current_user
+from backend.app.schemas import ContractorProfileResponse, ContractorProfileUpdate
+
+router = APIRouter()
+
+
+def _profile_response(c: ContractorData) -> ContractorProfileResponse:
+    return ContractorProfileResponse(
+        id=c.id,
+        user_id=c.user_id,
+        name=c.name,
+        phone=c.phone,
+        trade=c.trade,
+        location=c.location,
+        hourly_rate=c.hourly_rate,
+        business_hours=c.business_hours,
+        timezone=c.timezone,
+        assistant_name=c.assistant_name,
+        soul_text=c.soul_text,
+        preferred_channel=c.preferred_channel,
+        channel_identifier=c.channel_identifier,
+        heartbeat_opt_in=c.heartbeat_opt_in,
+        heartbeat_frequency=c.heartbeat_frequency,
+        onboarding_complete=c.onboarding_complete,
+        is_active=c.is_active,
+        created_at=c.created_at.isoformat(),
+        updated_at=c.updated_at.isoformat(),
+    )
+
+
+@router.get("/contractor/profile", response_model=ContractorProfileResponse)
+async def get_profile(
+    current_user: ContractorData = Depends(get_current_user),
+) -> ContractorProfileResponse:
+    """Return the current contractor's profile."""
+    return _profile_response(current_user)
+
+
+@router.put("/contractor/profile", response_model=ContractorProfileResponse)
+async def update_profile(
+    body: ContractorProfileUpdate,
+    current_user: ContractorData = Depends(get_current_user),
+) -> ContractorProfileResponse:
+    """Partial update of the current contractor's profile."""
+    updates = body.model_dump(exclude_unset=True)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    store = get_contractor_store()
+    updated = await store.update(current_user.id, **updates)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Contractor not found")
+
+    return _profile_response(updated)

--- a/backend/app/routers/contractor_sessions.py
+++ b/backend/app/routers/contractor_sessions.py
@@ -1,0 +1,94 @@
+"""Endpoints for viewing conversation sessions."""
+
+import contextlib
+import json
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.app.agent.file_store import ContractorData, get_session_store
+from backend.app.auth.dependencies import get_current_user
+from backend.app.schemas import (
+    SessionDetailResponse,
+    SessionListResponse,
+    SessionMessage,
+    SessionSummary,
+)
+
+router = APIRouter()
+
+
+@router.get("/contractor/sessions", response_model=SessionListResponse)
+async def list_sessions(
+    offset: int = 0,
+    limit: int = 20,
+    current_user: ContractorData = Depends(get_current_user),
+) -> SessionListResponse:
+    """List conversation sessions for the current contractor."""
+    store = get_session_store(current_user.id)
+    files = store._list_session_files()
+    # Most recent first
+    files = list(reversed(files))
+    total = len(files)
+    page = files[offset : offset + limit]
+
+    summaries: list[SessionSummary] = []
+    for path in page:
+        session_id = path.stem
+        session = store._load_session(session_id)
+        if session is None:
+            continue
+        preview = ""
+        if session.messages:
+            preview = session.messages[-1].body[:100]
+        summaries.append(
+            SessionSummary(
+                id=session.session_id,
+                start_time=session.created_at or session.last_message_at,
+                message_count=len(session.messages),
+                last_message_preview=preview,
+            )
+        )
+
+    return SessionListResponse(
+        sessions=summaries,
+        total=total,
+        offset=offset,
+        limit=limit,
+    )
+
+
+@router.get("/contractor/sessions/{session_id}", response_model=SessionDetailResponse)
+async def get_session(
+    session_id: str,
+    current_user: ContractorData = Depends(get_current_user),
+) -> SessionDetailResponse:
+    """Get a full conversation transcript with tool interactions."""
+    store = get_session_store(current_user.id)
+    session = store._load_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    messages: list[SessionMessage] = []
+    for msg in session.messages:
+        tool_interactions: list[dict[str, object]] = []
+        if msg.tool_interactions_json and msg.tool_interactions_json not in ("", "[]"):
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                tool_interactions = json.loads(msg.tool_interactions_json)
+        messages.append(
+            SessionMessage(
+                seq=msg.seq,
+                direction=msg.direction,
+                body=msg.body,
+                timestamp=msg.timestamp,
+                tool_interactions=tool_interactions,
+            )
+        )
+
+    return SessionDetailResponse(
+        session_id=session.session_id,
+        contractor_id=session.contractor_id,
+        created_at=session.created_at,
+        last_message_at=session.last_message_at,
+        is_active=session.is_active,
+        messages=messages,
+    )

--- a/backend/app/routers/contractor_stats.py
+++ b/backend/app/routers/contractor_stats.py
@@ -1,0 +1,65 @@
+"""Endpoint for contractor overview stats."""
+
+import datetime
+
+from fastapi import APIRouter, Depends
+
+from backend.app.agent.file_store import (
+    ContractorData,
+    HeartbeatStore,
+    get_memory_store,
+    get_session_store,
+)
+from backend.app.auth.dependencies import get_current_user
+from backend.app.enums import ChecklistStatus
+from backend.app.schemas import ContractorStatsResponse
+
+router = APIRouter()
+
+
+@router.get("/contractor/stats", response_model=ContractorStatsResponse)
+async def get_stats(
+    current_user: ContractorData = Depends(get_current_user),
+) -> ContractorStatsResponse:
+    """Return aggregate stats for the dashboard overview."""
+    session_store = get_session_store(current_user.id)
+    memory_store = get_memory_store(current_user.id)
+    heartbeat_store = HeartbeatStore(current_user.id)
+
+    # Total sessions
+    session_files = session_store._list_session_files()
+    total_sessions = len(session_files)
+
+    # Messages this month
+    now = datetime.datetime.now(datetime.UTC)
+    month_prefix = now.strftime("%Y-%m")
+    messages_this_month = 0
+    last_conversation_at: str | None = None
+
+    for path in session_files:
+        session = session_store._load_session(path.stem)
+        if session is None:
+            continue
+        if session.last_message_at and (
+            last_conversation_at is None or session.last_message_at > last_conversation_at
+        ):
+            last_conversation_at = session.last_message_at
+        for msg in session.messages:
+            if msg.timestamp.startswith(month_prefix):
+                messages_this_month += 1
+
+    # Active checklist items
+    checklist = await heartbeat_store.get_checklist()
+    active_checklist_items = sum(1 for item in checklist if item.status == ChecklistStatus.ACTIVE)
+
+    # Total memory facts
+    facts = await memory_store.get_all_memories()
+    total_memory_facts = len(facts)
+
+    return ContractorStatsResponse(
+        total_sessions=total_sessions,
+        messages_this_month=messages_this_month,
+        active_checklist_items=active_checklist_items,
+        total_memory_facts=total_memory_facts,
+        last_conversation_at=last_conversation_at,
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,8 +1,9 @@
 import datetime
+from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from backend.app.enums import EstimateStatus
+from backend.app.enums import ChecklistSchedule, EstimateStatus
 
 
 class HealthResponse(BaseModel):
@@ -74,3 +75,129 @@ class EstimateResponse(EstimateBase):
     pdf_url: str = ""
     storage_path: str = ""
     created_at: str
+
+
+# ---------------------------------------------------------------------------
+# Contractor profile (dashboard)
+# ---------------------------------------------------------------------------
+
+
+class ContractorProfileResponse(BaseModel):
+    id: int
+    user_id: str
+    name: str
+    phone: str
+    trade: str
+    location: str
+    hourly_rate: float | None
+    business_hours: str
+    timezone: str
+    assistant_name: str
+    soul_text: str
+    preferred_channel: str
+    channel_identifier: str
+    heartbeat_opt_in: bool
+    heartbeat_frequency: str
+    onboarding_complete: bool
+    is_active: bool
+    created_at: str
+    updated_at: str
+
+
+class ContractorProfileUpdate(BaseModel):
+    name: str | None = None
+    phone: str | None = None
+    trade: str | None = None
+    location: str | None = None
+    hourly_rate: float | None = None
+    business_hours: str | None = None
+    timezone: str | None = None
+    assistant_name: str | None = None
+    soul_text: str | None = None
+    heartbeat_opt_in: bool | None = None
+    heartbeat_frequency: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Conversation sessions (dashboard)
+# ---------------------------------------------------------------------------
+
+
+class SessionSummary(BaseModel):
+    id: str
+    start_time: str
+    message_count: int
+    last_message_preview: str = ""
+
+
+class SessionListResponse(BaseModel):
+    sessions: list[SessionSummary]
+    total: int
+    offset: int
+    limit: int
+
+
+class SessionMessage(BaseModel):
+    seq: int
+    direction: str
+    body: str = ""
+    timestamp: str
+    tool_interactions: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class SessionDetailResponse(BaseModel):
+    session_id: str
+    contractor_id: int
+    created_at: str
+    last_message_at: str
+    is_active: bool
+    messages: list[SessionMessage]
+
+
+# ---------------------------------------------------------------------------
+# Memory / facts (dashboard)
+# ---------------------------------------------------------------------------
+
+
+class MemoryFactResponse(BaseModel):
+    key: str
+    value: str
+    category: str
+    confidence: float
+
+
+class MemoryFactUpdate(BaseModel):
+    value: str | None = None
+    category: str | None = None
+    confidence: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Checklist (dashboard)
+# ---------------------------------------------------------------------------
+
+
+class ChecklistCreateRequest(BaseModel):
+    description: str = Field(..., min_length=1)
+    schedule: str = ChecklistSchedule.DAILY
+
+
+class ChecklistItemResponse(BaseModel):
+    id: int
+    description: str
+    schedule: str
+    status: str
+    created_at: str
+
+
+# ---------------------------------------------------------------------------
+# Overview stats (dashboard)
+# ---------------------------------------------------------------------------
+
+
+class ContractorStatsResponse(BaseModel):
+    total_sessions: int
+    messages_this_month: int
+    active_checklist_items: int
+    total_memory_facts: int
+    last_conversation_at: str | None

--- a/tests/test_checklist_endpoints.py
+++ b/tests/test_checklist_endpoints.py
@@ -1,0 +1,59 @@
+"""Tests for checklist endpoints."""
+
+from fastapi.testclient import TestClient
+
+
+def test_list_checklist_empty(client: TestClient) -> None:
+    resp = client.get("/api/contractor/checklist")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_create_checklist_item(client: TestClient) -> None:
+    resp = client.post(
+        "/api/contractor/checklist",
+        json={"description": "Check job site"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["description"] == "Check job site"
+    assert data["schedule"] == "daily"
+    assert data["status"] == "active"
+    assert data["id"] > 0
+
+
+def test_create_checklist_item_custom_schedule(client: TestClient) -> None:
+    resp = client.post(
+        "/api/contractor/checklist",
+        json={"description": "Weekly review", "schedule": "weekdays"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["schedule"] == "weekdays"
+
+
+def test_list_after_create(client: TestClient) -> None:
+    client.post("/api/contractor/checklist", json={"description": "Item 1"})
+    client.post("/api/contractor/checklist", json={"description": "Item 2"})
+    resp = client.get("/api/contractor/checklist")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+def test_delete_checklist_item(client: TestClient) -> None:
+    resp = client.post("/api/contractor/checklist", json={"description": "To delete"})
+    item_id = resp.json()["id"]
+    resp = client.delete(f"/api/contractor/checklist/{item_id}")
+    assert resp.status_code == 204
+    # Verify it's gone
+    resp = client.get("/api/contractor/checklist")
+    assert len(resp.json()) == 0
+
+
+def test_delete_checklist_item_not_found(client: TestClient) -> None:
+    resp = client.delete("/api/contractor/checklist/9999")
+    assert resp.status_code == 404
+
+
+def test_create_checklist_empty_description(client: TestClient) -> None:
+    resp = client.post("/api/contractor/checklist", json={"description": ""})
+    assert resp.status_code == 422

--- a/tests/test_memory_endpoints.py
+++ b/tests/test_memory_endpoints.py
@@ -1,0 +1,85 @@
+"""Tests for memory/facts endpoints."""
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.app.agent.file_store import ContractorData
+from backend.app.config import settings
+
+
+def _seed_memory(contractor: ContractorData) -> None:
+    """Create a MEMORY.md with test data."""
+    mem_dir = Path(settings.contractor_data_dir) / str(contractor.id) / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    (mem_dir / "MEMORY.md").write_text(
+        "# Long-term Memory\n\n"
+        "## Business\n"
+        "- hourly_rate: 75 (confidence: 1.0)\n"
+        "- trade: plumbing (confidence: 0.9)\n\n"
+        "## Personal\n"
+        "- name: Mike (confidence: 1.0)\n",
+        encoding="utf-8",
+    )
+
+
+def test_list_memory_empty(client: TestClient) -> None:
+    resp = client.get("/api/contractor/memory")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_list_memory(client: TestClient, test_contractor: ContractorData) -> None:
+    _seed_memory(test_contractor)
+    resp = client.get("/api/contractor/memory")
+    assert resp.status_code == 200
+    facts = resp.json()
+    assert len(facts) == 3
+    keys = {f["key"] for f in facts}
+    assert "hourly_rate" in keys
+    assert "name" in keys
+
+
+def test_list_memory_filter_category(client: TestClient, test_contractor: ContractorData) -> None:
+    _seed_memory(test_contractor)
+    resp = client.get("/api/contractor/memory?category=business")
+    assert resp.status_code == 200
+    facts = resp.json()
+    assert len(facts) == 2
+    assert all(f["category"] == "business" for f in facts)
+
+
+def test_update_memory(client: TestClient, test_contractor: ContractorData) -> None:
+    _seed_memory(test_contractor)
+    resp = client.put(
+        "/api/contractor/memory/hourly_rate",
+        json={"value": "85"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["value"] == "85"
+    assert data["key"] == "hourly_rate"
+
+
+def test_update_memory_not_found(client: TestClient, test_contractor: ContractorData) -> None:
+    _seed_memory(test_contractor)
+    resp = client.put(
+        "/api/contractor/memory/nonexistent",
+        json={"value": "test"},
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_memory(client: TestClient, test_contractor: ContractorData) -> None:
+    _seed_memory(test_contractor)
+    resp = client.delete("/api/contractor/memory/hourly_rate")
+    assert resp.status_code == 204
+    # Verify it's gone
+    resp = client.get("/api/contractor/memory")
+    keys = {f["key"] for f in resp.json()}
+    assert "hourly_rate" not in keys
+
+
+def test_delete_memory_not_found(client: TestClient) -> None:
+    resp = client.delete("/api/contractor/memory/nonexistent")
+    assert resp.status_code == 404

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -1,0 +1,51 @@
+"""Tests for contractor profile endpoints."""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_profile(client: TestClient) -> None:
+    resp = client.get("/api/contractor/profile")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Test Contractor"
+    assert data["trade"] == "General Contractor"
+    assert data["location"] == "Portland, OR"
+    assert data["assistant_name"] == "Clawbolt"
+    assert data["onboarding_complete"] is False
+    assert data["is_active"] is True
+    assert "created_at" in data
+    assert "updated_at" in data
+
+
+def test_update_profile_partial(client: TestClient) -> None:
+    resp = client.put(
+        "/api/contractor/profile",
+        json={"name": "Updated Name", "hourly_rate": 85.0},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Updated Name"
+    assert data["hourly_rate"] == 85.0
+    assert data["trade"] == "General Contractor"
+
+
+def test_update_profile_soul_text(client: TestClient) -> None:
+    resp = client.put(
+        "/api/contractor/profile",
+        json={"soul_text": "Be friendly.", "assistant_name": "Bolt"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["soul_text"] == "Be friendly."
+    assert data["assistant_name"] == "Bolt"
+
+
+def test_update_profile_empty_body(client: TestClient) -> None:
+    resp = client.put("/api/contractor/profile", json={})
+    assert resp.status_code == 400
+
+
+def test_update_returns_updated_values(client: TestClient) -> None:
+    resp = client.put("/api/contractor/profile", json={"trade": "Electrician"})
+    assert resp.status_code == 200
+    assert resp.json()["trade"] == "Electrician"

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -1,0 +1,119 @@
+"""Tests for conversation session endpoints."""
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.app.agent.file_store import ContractorData
+from backend.app.config import settings
+
+
+def _create_session(contractor: ContractorData, session_id: str, messages: list[dict]) -> None:  # type: ignore[type-arg]
+    """Create a test session JSONL file."""
+    base = Path(settings.contractor_data_dir) / str(contractor.id) / "sessions"
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / f"{session_id}.jsonl"
+    lines = [
+        json.dumps(
+            {
+                "_type": "metadata",
+                "session_id": session_id,
+                "contractor_id": contractor.id,
+                "created_at": "2025-01-15T10:00:00+00:00",
+                "last_message_at": "2025-01-15T10:05:00+00:00",
+                "is_active": True,
+                "last_compacted_seq": 0,
+            }
+        )
+    ]
+    for msg in messages:
+        lines.append(json.dumps(msg))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_list_sessions_empty(client: TestClient) -> None:
+    resp = client.get("/api/contractor/sessions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sessions"] == []
+    assert data["total"] == 0
+
+
+def test_list_sessions(client: TestClient, test_contractor: ContractorData) -> None:
+    _create_session(
+        test_contractor,
+        "1_100",
+        [
+            {"direction": "inbound", "body": "Hello", "timestamp": "2025-01-15T10:01:00", "seq": 1},
+            {
+                "direction": "outbound",
+                "body": "Hi there!",
+                "timestamp": "2025-01-15T10:02:00",
+                "seq": 2,
+            },
+        ],
+    )
+    resp = client.get("/api/contractor/sessions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["sessions"][0]["message_count"] == 2
+    assert data["sessions"][0]["id"] == "1_100"
+
+
+def test_get_session_detail(client: TestClient, test_contractor: ContractorData) -> None:
+    tool_json = json.dumps([{"tool": "save_fact", "input": {"key": "rate"}, "result": "saved"}])
+    _create_session(
+        test_contractor,
+        "1_200",
+        [
+            {
+                "direction": "inbound",
+                "body": "Save my rate",
+                "timestamp": "2025-01-15T10:01:00",
+                "seq": 1,
+                "tool_interactions_json": "",
+            },
+            {
+                "direction": "outbound",
+                "body": "Done!",
+                "timestamp": "2025-01-15T10:02:00",
+                "seq": 2,
+                "tool_interactions_json": tool_json,
+            },
+        ],
+    )
+    resp = client.get("/api/contractor/sessions/1_200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session_id"] == "1_200"
+    assert len(data["messages"]) == 2
+    assert data["messages"][0]["tool_interactions"] == []
+    assert len(data["messages"][1]["tool_interactions"]) == 1
+    assert data["messages"][1]["tool_interactions"][0]["tool"] == "save_fact"
+
+
+def test_get_session_not_found(client: TestClient) -> None:
+    resp = client.get("/api/contractor/sessions/nonexistent")
+    assert resp.status_code == 404
+
+
+def test_list_sessions_pagination(client: TestClient, test_contractor: ContractorData) -> None:
+    for i in range(5):
+        _create_session(
+            test_contractor,
+            f"1_{i}",
+            [
+                {
+                    "direction": "inbound",
+                    "body": f"msg {i}",
+                    "timestamp": f"2025-01-15T10:0{i}:00",
+                    "seq": 1,
+                }
+            ],
+        )
+    resp = client.get("/api/contractor/sessions?offset=0&limit=2")
+    data = resp.json()
+    assert data["total"] == 5
+    assert len(data["sessions"]) == 2

--- a/tests/test_stats_endpoints.py
+++ b/tests/test_stats_endpoints.py
@@ -1,0 +1,57 @@
+"""Tests for contractor stats endpoint."""
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.app.agent.file_store import ContractorData
+from backend.app.config import settings
+
+
+def test_stats_empty(client: TestClient) -> None:
+    resp = client.get("/api/contractor/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_sessions"] == 0
+    assert data["messages_this_month"] == 0
+    assert data["active_checklist_items"] == 0
+    assert data["total_memory_facts"] == 0
+    assert data["last_conversation_at"] is None
+
+
+def test_stats_with_data(client: TestClient, test_contractor: ContractorData) -> None:
+    # Create a session with messages
+    base = Path(settings.contractor_data_dir) / str(test_contractor.id) / "sessions"
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / "1_100.jsonl"
+    meta = {
+        "_type": "metadata",
+        "session_id": "1_100",
+        "contractor_id": test_contractor.id,
+        "created_at": "2025-01-15T10:00:00+00:00",
+        "last_message_at": "2025-01-15T10:05:00+00:00",
+        "is_active": True,
+        "last_compacted_seq": 0,
+    }
+    msg = {"direction": "inbound", "body": "Hello", "timestamp": "2025-01-15T10:01:00", "seq": 1}
+    path.write_text(json.dumps(meta) + "\n" + json.dumps(msg) + "\n", encoding="utf-8")
+
+    # Create a checklist item
+    client.post("/api/contractor/checklist", json={"description": "Check site"})
+
+    # Create memory
+    mem_dir = Path(settings.contractor_data_dir) / str(test_contractor.id) / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    (mem_dir / "MEMORY.md").write_text(
+        "# Long-term Memory\n\n## General\n- rate: 85 (confidence: 1.0)\n",
+        encoding="utf-8",
+    )
+
+    resp = client.get("/api/contractor/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_sessions"] == 1
+    assert data["active_checklist_items"] == 1
+    assert data["total_memory_facts"] == 1
+    assert data["last_conversation_at"] is not None


### PR DESCRIPTION
## Description
Add REST API endpoints to support the new frontend dashboard:

- `GET/PUT /api/contractor/profile`: view and update contractor profile (#458)
- `GET /api/contractor/sessions`: list conversation sessions with pagination (#459)
- `GET /api/contractor/sessions/{id}`: session transcript with tool interactions inline (#459)
- `GET /api/contractor/memory`: list memory facts with category filter (#460)
- `PUT/DELETE /api/contractor/memory/{key}`: update or delete facts (#460)
- `GET/POST/DELETE /api/contractor/checklist`: manage checklist items (#461)
- `GET /api/contractor/stats`: overview statistics for the dashboard (#462)

All endpoints scoped to the current user via `get_current_user` dependency.
26 new tests covering all endpoints. Full test suite (871 tests) passes.

Fixes #458, Fixes #459, Fixes #460, Fixes #461, Fixes #462

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented all endpoints following existing codebase patterns)
- [ ] No AI used