### PR TITLE
feat: add complete frontend dashboard UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,14 @@
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from any_llm import amessages
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from backend.app.agent.heartbeat import heartbeat_scheduler
 from backend.app.channels import get_manager, register_channel
@@ -168,3 +171,20 @@ app.include_router(contractor_sessions.router, prefix="/api")
 app.include_router(contractor_memory.router, prefix="/api")
 app.include_router(contractor_checklist.router, prefix="/api")
 app.include_router(contractor_stats.router, prefix="/api")
+
+# ---------------------------------------------------------------------------
+# Static file serving (built frontend)
+# ---------------------------------------------------------------------------
+_FRONTEND_DIST = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
+
+if _FRONTEND_DIST.is_dir():
+    # Serve static assets (JS, CSS, images)
+    app.mount("/assets", StaticFiles(directory=_FRONTEND_DIST / "assets"), name="assets")
+
+    @app.get("/{full_path:path}")
+    async def _spa_fallback(request: Request, full_path: str) -> FileResponse:
+        """Serve the SPA index.html for all non-API routes."""
+        file_path = _FRONTEND_DIST / full_path
+        if file_path.is_file() and ".." not in full_path:
+            return FileResponse(file_path)
+        return FileResponse(_FRONTEND_DIST / "index.html")

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,14 +1,31 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '@/contexts/AuthContext';
 import App from '@/App';
 
+// Mock fetch for auth config (OSS mode: not required)
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ required: false }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('App', () => {
-  it('renders without crashing', () => {
+  it('renders loading spinner initially', () => {
     render(
       <MemoryRouter>
-        <App />
-      </MemoryRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </MemoryRouter>,
     );
-    expect(screen.getByText('Clawbolt')).toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,61 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Spinner from '@/components/ui/spinner';
+import AppShell from '@/layouts/AppShell';
+import OverviewPage from '@/pages/OverviewPage';
+import ConversationsPage from '@/pages/ConversationsPage';
+import MemoryPage from '@/pages/MemoryPage';
+import SettingsPage from '@/pages/SettingsPage';
+import ChecklistPage from '@/pages/ChecklistPage';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  getLoginPageElement,
+  getPremiumRouteElements,
+  getDefaultSettingsTab,
+  shouldRedirectRootToApp,
+} from '@/extensions';
 
 export default function App() {
+  const { authState, isPremium } = useAuth();
+
+  if (authState === 'loading') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-dvh gap-3 text-muted-foreground">
+        <Spinner />
+        <span className="text-sm">Loading...</span>
+      </div>
+    );
+  }
+
   return (
     <Routes>
-      <Route path="/" element={<div className="flex items-center justify-center min-h-screen"><h1 className="text-2xl font-bold text-foreground">Clawbolt</h1></div>} />
+      {/* Premium route elements (marketing pages, etc.) */}
+      {getPremiumRouteElements()}
+
+      {/* Login: OSS redirects to /app, premium renders its LoginPage */}
+      <Route path="/app/login" element={getLoginPageElement()} />
+
+      {/* Authenticated app */}
+      <Route path="/app" element={<AppShell />}>
+        <Route index element={<OverviewPage />} />
+        <Route path="conversations" element={<ConversationsPage />} />
+        <Route path="conversations/:sessionId" element={<ConversationsPage />} />
+        <Route path="memory" element={<MemoryPage />} />
+        <Route path="checklist" element={<ChecklistPage />} />
+        <Route path="settings/:tab" element={<SettingsPage />} />
+        <Route path="settings" element={<Navigate to={`/app/settings/${getDefaultSettingsTab(isPremium)}`} replace />} />
+      </Route>
+
+      {/* OSS root redirects to app; premium root handled by extension routes */}
+      {shouldRedirectRootToApp(isPremium) && <Route path="/" element={<Navigate to="/app" replace />} />}
+
+      {/* 404 */}
+      <Route path="*" element={
+        <div className="flex flex-col items-center justify-center min-h-dvh gap-3 text-muted-foreground">
+          <p className="text-lg font-semibold">404</p>
+          <p className="text-sm">Page not found</p>
+          <a href="/app" className="text-sm text-primary hover:underline">Go to dashboard</a>
+        </div>
+      } />
     </Routes>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,120 @@
+import type {
+  AuthConfig,
+  AuthUser,
+  ChecklistItem,
+  ContractorProfile,
+  ContractorProfileUpdate,
+  ContractorStats,
+  MemoryFact,
+  MemoryFactUpdate,
+  SessionDetail,
+  SessionListResponse,
+} from '@/types';
+import { getAccessToken, setAccessToken, setRefreshToken } from '@/lib/api-client';
+import { tryRestoreSession as _tryRestoreSession } from '@/extensions';
+
+// --- Storage keys ---
+const STORAGE_KEYS = {
+  REFRESH_TOKEN: 'clawbolt_refresh_token',
+  THEME: 'clawbolt_theme',
+} as const;
+
+export { STORAGE_KEYS };
+
+// --- Shared helpers ---
+
+function _getAuthHeaders(): Record<string, string> {
+  const token = getAccessToken();
+  if (token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return {};
+}
+
+async function _fetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...init?.headers, ..._getAuthHeaders() },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const b = body as { detail?: string };
+    throw new Error(b.detail || `Request failed: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+async function _fetchVoid(url: string, init?: RequestInit): Promise<void> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...init?.headers, ..._getAuthHeaders() },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const b = body as { detail?: string };
+    throw new Error(b.detail || `Request failed: ${res.status}`);
+  }
+}
+
+// --- Auth API ---
+
+async function getAuthConfig(): Promise<AuthConfig> {
+  const res = await fetch('/api/auth/config');
+  return res.json() as Promise<AuthConfig>;
+}
+
+function logout(): void {
+  setAccessToken(null);
+  setRefreshToken(null);
+}
+
+const api = {
+  getAuthConfig,
+  logout,
+  tryRestoreSession: _tryRestoreSession as () => Promise<AuthUser | null>,
+
+  // Profile
+  getProfile: () => _fetch<ContractorProfile>('/api/contractor/profile'),
+  updateProfile: (body: ContractorProfileUpdate) =>
+    _fetch<ContractorProfile>('/api/contractor/profile', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+
+  // Sessions
+  listSessions: (offset = 0, limit = 20) =>
+    _fetch<SessionListResponse>(`/api/contractor/sessions?offset=${offset}&limit=${limit}`),
+  getSession: (sessionId: string) =>
+    _fetch<SessionDetail>(`/api/contractor/sessions/${encodeURIComponent(sessionId)}`),
+
+  // Memory
+  listMemoryFacts: (category?: string) => {
+    const params = category ? `?category=${encodeURIComponent(category)}` : '';
+    return _fetch<MemoryFact[]>(`/api/contractor/memory${params}`);
+  },
+  updateMemoryFact: (key: string, body: MemoryFactUpdate) =>
+    _fetch<MemoryFact>(`/api/contractor/memory/${encodeURIComponent(key)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  deleteMemoryFact: (key: string) =>
+    _fetchVoid(`/api/contractor/memory/${encodeURIComponent(key)}`, { method: 'DELETE' }),
+
+  // Checklist
+  listChecklist: () => _fetch<ChecklistItem[]>('/api/contractor/checklist'),
+  createChecklistItem: (body: { description: string; schedule?: string }) =>
+    _fetch<ChecklistItem>('/api/contractor/checklist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  deleteChecklistItem: (id: number) =>
+    _fetchVoid(`/api/contractor/checklist/${id}`, { method: 'DELETE' }),
+
+  // Stats
+  getStats: () => _fetch<ContractorStats>('/api/contractor/stats'),
+};
+
+export default api;

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,17 @@
+import { type HTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const Badge = forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(
+        'inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-[--radius-full] bg-primary-light text-primary',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Badge.displayName = 'Badge';
+export default Badge;

--- a/frontend/src/components/ui/button.test.tsx
+++ b/frontend/src/components/ui/button.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import Button from './button';
+
+describe('Button', () => {
+  it('renders with default variant', () => {
+    render(<Button>Click me</Button>);
+    const btn = screen.getByRole('button', { name: 'Click me' });
+    expect(btn).toBeInTheDocument();
+    expect(btn.className).toContain('bg-primary');
+  });
+
+  it('renders secondary variant', () => {
+    render(<Button variant="secondary">Secondary</Button>);
+    const btn = screen.getByRole('button', { name: 'Secondary' });
+    expect(btn.className).toContain('bg-card');
+  });
+
+  it('renders danger variant', () => {
+    render(<Button variant="danger">Danger</Button>);
+    const btn = screen.getByRole('button', { name: 'Danger' });
+    expect(btn.className).toContain('bg-danger');
+  });
+
+  it('applies disabled state', () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByRole('button', { name: 'Disabled' })).toBeDisabled();
+  });
+
+  it('accepts custom className', () => {
+    render(<Button className="mt-4">Custom</Button>);
+    expect(screen.getByRole('button', { name: 'Custom' }).className).toContain('mt-4');
+  });
+});

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,37 @@
+import { type ButtonHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const variants = {
+  primary: 'bg-primary text-white hover:bg-primary-hover',
+  secondary: 'bg-card text-foreground border border-border hover:bg-secondary-hover',
+  danger: 'bg-danger text-white hover:opacity-90',
+  ghost: 'text-foreground hover:bg-secondary-hover',
+} as const;
+
+const sizes = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-6 py-2.5 text-base',
+} as const;
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: keyof typeof variants;
+  size?: keyof typeof sizes;
+};
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', size = 'md', ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center font-medium rounded-[--radius-md] transition-colors disabled:opacity-50 disabled:pointer-events-none',
+        variants[variant],
+        sizes[size],
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Button.displayName = 'Button';
+export default Button;

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,17 @@
+import { type HTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'bg-card border border-border rounded-[--radius-md] shadow-sm p-4',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Card.displayName = 'Card';
+export default Card;

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,75 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = forwardRef<
+  ElementRef<typeof DialogPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/40 animate-overlay-in',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = 'DialogOverlay';
+
+const DialogContent = forwardRef<
+  ElementRef<typeof DialogPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-[--radius-lg] bg-card border border-border p-6 shadow-lg animate-dialog-in',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+));
+DialogContent.displayName = 'DialogContent';
+
+const DialogTitle = forwardRef<
+  ElementRef<typeof DialogPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-foreground', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = 'DialogTitle';
+
+const DialogDescription = forwardRef<
+  ElementRef<typeof DialogPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground mt-1', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = 'DialogDescription';
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+};

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,59 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuContent = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[8rem] rounded-[--radius-md] border border-border bg-card p-1 shadow-md animate-overlay-in',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = 'DropdownMenuContent';
+
+const DropdownMenuItem = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'flex items-center gap-2 rounded-[--radius-sm] px-2 py-1.5 text-sm cursor-pointer outline-none transition-colors hover:bg-secondary-hover focus:bg-secondary-hover data-[disabled]:opacity-50 data-[disabled]:pointer-events-none',
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = 'DropdownMenuItem';
+
+const DropdownMenuSeparator = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-border', className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = 'DropdownMenuSeparator';
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+};

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,17 @@
+import { type InputHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn(
+        'w-full px-3 py-2.5 sm:py-2 text-sm bg-card border border-border rounded-[--radius-md] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-colors',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Input.displayName = 'Input';
+export default Input;

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,17 @@
+import { type SelectHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const Select = forwardRef<HTMLSelectElement, SelectHTMLAttributes<HTMLSelectElement>>(
+  ({ className, ...props }, ref) => (
+    <select
+      ref={ref}
+      className={cn(
+        'w-full px-3 py-2.5 sm:py-2 text-sm bg-card border border-border rounded-[--radius-md] text-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-colors',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Select.displayName = 'Select';
+export default Select;

--- a/frontend/src/components/ui/spinner.tsx
+++ b/frontend/src/components/ui/spinner.tsx
@@ -1,0 +1,11 @@
+import { cn } from '@/lib/utils';
+
+export default function Spinner({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn('w-5 h-5 border-2 border-muted-foreground/30 border-t-primary rounded-full animate-spin', className)}
+      role="status"
+      aria-label="Loading"
+    />
+  );
+}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,49 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = forwardRef<
+  ElementRef<typeof TabsPrimitive.List>,
+  ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex items-center gap-1 border-b border-border',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = 'TabsList';
+
+const TabsTrigger = forwardRef<
+  ElementRef<typeof TabsPrimitive.Trigger>,
+  ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:text-foreground transition-colors',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = 'TabsTrigger';
+
+const TabsContent = forwardRef<
+  ElementRef<typeof TabsPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn('mt-4 focus:outline-none', className)}
+    {...props}
+  />
+));
+TabsContent.displayName = 'TabsContent';
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,17 @@
+import { type TextareaHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        'w-full px-3 py-2.5 sm:py-2 text-sm bg-card border border-border rounded-[--radius-md] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-colors resize-y min-h-[80px]',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Textarea.displayName = 'Textarea';
+export default Textarea;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,100 @@
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import api from '@/api';
+import type { AuthConfig, AuthUser } from '@/types';
+import { isPremiumAuth } from '@/extensions';
+
+type AuthState = 'loading' | 'login' | 'ready';
+
+interface AuthContextValue {
+  authState: AuthState;
+  authConfig: AuthConfig | null;
+  currentAuthUser: AuthUser | null;
+  isPremium: boolean;
+  handleLogin: (user: AuthUser) => void;
+  handleLogout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [authState, setAuthState] = useState<AuthState>('loading');
+  const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
+  const [currentAuthUser, setCurrentAuthUser] = useState<AuthUser | null>(null);
+
+  const isPremium = isPremiumAuth(authConfig);
+
+  // Check auth requirement on mount
+  useEffect(() => {
+    api.getAuthConfig()
+      .then((config) => {
+        setAuthConfig(config);
+        if (!config.required) {
+          // OSS mode: no auth needed, immediately ready
+          setAuthState('ready');
+        } else {
+          // Premium mode: try to restore existing session with timeout
+          const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 10_000));
+          Promise.race([api.tryRestoreSession(), timeout]).then((user) => {
+            if (user) {
+              setCurrentAuthUser(user);
+              setAuthState('ready');
+            } else {
+              setAuthState('login');
+            }
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        console.error('[AuthContext] Failed to fetch auth config:', err);
+        // Fallback to ready in OSS mode (server may not have auth config endpoint)
+        setAuthState('ready');
+      });
+  }, []);
+
+  // Listen for logout events (e.g. 401 from expired/changed token)
+  useEffect(() => {
+    const handler = () => {
+      if (authConfig?.required) {
+        api.logout();
+        setCurrentAuthUser(null);
+        setAuthState('login');
+      }
+    };
+    window.addEventListener('clawbolt-logout', handler);
+    return () => window.removeEventListener('clawbolt-logout', handler);
+  }, [authConfig]);
+
+  const handleLogout = useCallback(() => {
+    api.logout();
+    setCurrentAuthUser(null);
+    if (isPremium) {
+      window.location.href = '/';
+    } else {
+      setAuthState('login');
+    }
+  }, [isPremium]);
+
+  const handleLogin = useCallback((user: AuthUser) => {
+    setCurrentAuthUser(user);
+    setAuthState('ready');
+  }, []);
+
+  return (
+    <AuthContext value={{
+      authState,
+      authConfig,
+      currentAuthUser,
+      isPremium,
+      handleLogin,
+      handleLogout,
+    }}>
+      {children}
+    </AuthContext>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/frontend/src/extensions/admin/admin-api.ts
+++ b/frontend/src/extensions/admin/admin-api.ts
@@ -1,0 +1,13 @@
+/** OSS stub: premium overlay replaces with real admin API calls. */
+
+export interface AdminContractor {
+  id: number;
+  name: string;
+  user_id: string;
+  is_active: boolean;
+  created_at: string;
+}
+
+export async function getAdminContractors(): Promise<AdminContractor[]> {
+  throw new Error('Not available in OSS');
+}

--- a/frontend/src/extensions/admin/index.tsx
+++ b/frontend/src/extensions/admin/index.tsx
@@ -1,0 +1,5 @@
+/** OSS stub: premium overlay replaces with real admin panel. */
+
+export default function AdminPanel(): null {
+  return null;
+}

--- a/frontend/src/extensions/api.ts
+++ b/frontend/src/extensions/api.ts
@@ -1,0 +1,12 @@
+export async function tryRestoreSession(): Promise<null> {
+  // OSS mode: no session to restore. Premium overrides this.
+  return null;
+}
+
+export function getSubscription(): Promise<never> {
+  throw new Error('Not available in OSS');
+}
+
+export function listPlans(): Promise<never> {
+  throw new Error('Not available in OSS');
+}

--- a/frontend/src/extensions/auth.ts
+++ b/frontend/src/extensions/auth.ts
@@ -1,0 +1,5 @@
+import type { AuthConfig } from '@/types';
+
+export function isPremiumAuth(_config: AuthConfig | null): boolean {
+  return false;
+}

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -1,0 +1,25 @@
+export { isPremiumAuth } from './auth';
+export {
+  getPremiumRouteElements,
+  getLoginPageElement,
+  getDefaultSettingsTab,
+  shouldRedirectRootToApp,
+  getFeatureRequestUrl,
+  getReportIssueUrl,
+} from './routes';
+export {
+  getExtraSettingsTabs,
+  renderPremiumSettingsTab,
+  showOssSettingsTabs,
+} from './settings';
+export type { ExtensionTab } from './settings';
+export {
+  tryRestoreSession,
+  getSubscription,
+  listPlans,
+} from './api';
+export type {
+  SubscriptionInfo,
+  PlanInfo,
+} from './types';
+export { QuotaBanner, OnboardingBanner, isQuotaError } from './quota';

--- a/frontend/src/extensions/quota.tsx
+++ b/frontend/src/extensions/quota.tsx
@@ -1,0 +1,14 @@
+/** OSS stub: premium overlay replaces this with real quota UI. */
+import type { ReactNode } from 'react';
+
+export function QuotaBanner(): null {
+  return null;
+}
+
+export function OnboardingBanner({ children }: { children?: ReactNode }): ReactNode {
+  return children ?? null;
+}
+
+export function isQuotaError(_message: string): boolean {
+  return false;
+}

--- a/frontend/src/extensions/routes.tsx
+++ b/frontend/src/extensions/routes.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+
+export function getPremiumRouteElements(): ReactNode {
+  return null;
+}
+
+export function getLoginPageElement(): ReactNode {
+  // OSS has no login, redirect to app
+  return <Navigate to="/app" replace />;
+}
+
+export function getDefaultSettingsTab(_isPremium: boolean): string {
+  return 'profile';
+}
+
+export function shouldRedirectRootToApp(_isPremium: boolean): boolean {
+  return true;
+}
+
+export function getFeatureRequestUrl(): string {
+  return 'https://github.com/mozilla-ai/clawbolt/issues/new?title=Feature+request:+&labels=enhancement';
+}
+
+export function getReportIssueUrl(): string {
+  return 'https://github.com/mozilla-ai/clawbolt/issues/new?title=Bug:+&labels=bug';
+}

--- a/frontend/src/extensions/settings.tsx
+++ b/frontend/src/extensions/settings.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+export interface ExtensionTab {
+  key: string;
+  label: string;
+}
+
+export function getExtraSettingsTabs(_isPremium: boolean, _isAdmin: boolean): ExtensionTab[] {
+  return [];
+}
+
+export function renderPremiumSettingsTab(_key: string): ReactNode {
+  return null;
+}
+
+export function showOssSettingsTabs(_isPremium: boolean): boolean {
+  return true;
+}

--- a/frontend/src/extensions/types.ts
+++ b/frontend/src/extensions/types.ts
@@ -1,0 +1,7 @@
+export interface SubscriptionInfo {
+  [key: string]: unknown;
+}
+
+export interface PlanInfo {
+  [key: string]: unknown;
+}

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -1,0 +1,81 @@
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '@/test/test-utils';
+import AppShell from '@/layouts/AppShell';
+
+// Mock auth context
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    authState: 'ready',
+    currentAuthUser: { id: 1, name: 'Test User' },
+    authConfig: { required: false },
+    isPremium: false,
+    handleLogin: vi.fn(),
+    handleLogout: vi.fn(),
+  }),
+}));
+
+// Mock fetch for profile
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({
+      id: 1,
+      user_id: 'local@clawbolt.local',
+      name: 'Test Contractor',
+      phone: '555-0100',
+      trade: 'Electrician',
+      location: 'Portland, OR',
+      hourly_rate: 75,
+      business_hours: 'Mon-Fri 8-5',
+      timezone: 'America/Los_Angeles',
+      assistant_name: 'Claw',
+      soul_text: '',
+      preferred_channel: 'telegram',
+      channel_identifier: '',
+      heartbeat_opt_in: true,
+      heartbeat_frequency: 'daily',
+      onboarding_complete: true,
+      is_active: true,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AppShell', () => {
+  it('renders navigation links', async () => {
+    renderWithRouter(<AppShell />, { route: '/app' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Overview')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Conversations')).toBeInTheDocument();
+    expect(screen.getByText('Memory')).toBeInTheDocument();
+    expect(screen.getByText('Checklist')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('displays contractor name when loaded', async () => {
+    renderWithRouter(<AppShell />, { route: '/app' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Contractor')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when profile fails to load', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+
+    renderWithRouter(<AppShell />, { route: '/app' });
+
+    await waitFor(() => {
+      expect(screen.getByText(/unable to load your profile/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -1,0 +1,227 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Outlet, NavLink, Navigate } from 'react-router-dom';
+import { Toaster } from 'sonner';
+import api from '@/api';
+import Button from '@/components/ui/button';
+import Spinner from '@/components/ui/spinner';
+import { useAuth } from '@/contexts/AuthContext';
+import { getFeatureRequestUrl, getReportIssueUrl } from '@/extensions';
+import type { ContractorProfile } from '@/types';
+
+/** Context value provided to child routes via useOutletContext(). */
+export interface AppShellContext {
+  profile: ContractorProfile | null;
+  reloadProfile: () => void;
+  isPremium: boolean;
+  isAdmin: boolean;
+}
+
+const NAV_ITEMS = [
+  { to: '/app', label: 'Overview', icon: OverviewIcon, end: true },
+  { to: '/app/conversations', label: 'Conversations', icon: ConversationsIcon, end: false },
+  { to: '/app/memory', label: 'Memory', icon: MemoryIcon, end: false },
+  { to: '/app/checklist', label: 'Checklist', icon: ChecklistIcon, end: false },
+  { to: '/app/settings', label: 'Settings', icon: SettingsIcon, end: false },
+] as const;
+
+export default function AppShell() {
+  const { authState, currentAuthUser, isPremium, handleLogout } = useAuth();
+  const [profile, setProfile] = useState<ContractorProfile | null>(null);
+  const [profileError, setProfileError] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const loadProfile = useCallback(() => {
+    setProfileError(false);
+    api.getProfile()
+      .then(setProfile)
+      .catch((err: unknown) => {
+        console.error('[AppShell] Failed to load profile:', err);
+        setProfileError(true);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (authState !== 'ready') return;
+    loadProfile();
+  }, [authState, loadProfile]);
+
+  // Redirect to login if not authenticated
+  if (authState === 'login') {
+    return <Navigate to="/app/login" replace />;
+  }
+
+  if (authState === 'loading') {
+    return (
+      <div className="flex items-center justify-center min-h-dvh">
+        <Spinner />
+      </div>
+    );
+  }
+
+  // Show error banner if profile loading failed
+  if (profileError) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-dvh gap-3 text-muted-foreground">
+        <p className="text-sm">Unable to load your profile. The server may be unavailable.</p>
+        <Button onClick={loadProfile}>Retry</Button>
+      </div>
+    );
+  }
+
+  const ctx: AppShellContext = {
+    profile,
+    reloadProfile: loadProfile,
+    isPremium,
+    isAdmin: currentAuthUser?.role === 'admin',
+  };
+
+  return (
+    <div className="flex h-dvh">
+      {/* Mobile overlay */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={`fixed md:static z-50 top-0 left-0 h-full w-64 bg-card border-r border-border flex flex-col transition-transform md:translate-x-0 ${
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="p-4 border-b border-border">
+          <h1 className="text-lg font-bold text-foreground">Clawbolt</h1>
+          {profile && (
+            <p className="text-xs text-muted-foreground mt-0.5 truncate">
+              {profile.name || profile.trade || 'Dashboard'}
+            </p>
+          )}
+        </div>
+
+        <nav className="flex-1 p-2 space-y-0.5 overflow-y-auto">
+          {NAV_ITEMS.map(({ to, label, icon: Icon, end }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={end}
+              onClick={() => setSidebarOpen(false)}
+              className={({ isActive }) =>
+                `flex items-center gap-3 px-3 py-2 rounded-[--radius-md] text-sm transition-colors ${
+                  isActive
+                    ? 'bg-selected-bg text-primary font-medium'
+                    : 'text-muted-foreground hover:bg-secondary-hover hover:text-foreground'
+                }`
+              }
+            >
+              <Icon />
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+
+        {!profile?.onboarding_complete && (
+          <div className="mx-2 mb-2 p-3 rounded-[--radius-md] bg-info-bg border border-info-border text-info-text text-xs">
+            Connect with your assistant on Telegram to get started.
+          </div>
+        )}
+
+        <div className="p-2 border-t border-border text-xs text-muted-foreground space-y-1">
+          <div className="flex gap-2 px-3 py-1">
+            <a
+              href={getReportIssueUrl()}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors"
+            >
+              Report issue
+            </a>
+            <a
+              href={getFeatureRequestUrl()}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors"
+            >
+              Feature request
+            </a>
+          </div>
+          {isPremium && (
+            <button
+              onClick={handleLogout}
+              className="w-full text-left px-3 py-1 hover:text-foreground transition-colors"
+            >
+              Log out
+            </button>
+          )}
+        </div>
+      </aside>
+
+      {/* Main content */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Mobile header */}
+        <header className="md:hidden flex items-center gap-3 px-4 py-3 border-b border-border bg-card">
+          <button
+            onClick={() => setSidebarOpen(true)}
+            className="text-foreground"
+            aria-label="Open menu"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+          <h1 className="text-lg font-bold text-foreground">Clawbolt</h1>
+        </header>
+
+        <main className="flex-1 overflow-y-auto p-4 sm:p-6 max-w-5xl w-full mx-auto">
+          <Outlet context={ctx} />
+        </main>
+      </div>
+
+      <Toaster position="bottom-right" richColors />
+    </div>
+  );
+}
+
+// --- Nav icons (inline SVG) ---
+
+function OverviewIcon() {
+  return (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z" />
+    </svg>
+  );
+}
+
+function ConversationsIcon() {
+  return (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+    </svg>
+  );
+}
+
+function MemoryIcon() {
+  return (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+    </svg>
+  );
+}
+
+function ChecklistIcon() {
+  return (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+    </svg>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,0 +1,102 @@
+import createClient, { type Middleware } from 'openapi-fetch';
+
+// --- Token state (shared with api.ts via getters/setters) ---
+let _accessToken: string | null = null;
+
+const REFRESH_TOKEN_KEY = 'clawbolt_refresh_token';
+
+function _getRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+function _setRefreshToken(token: string | null): void {
+  if (token) {
+    localStorage.setItem(REFRESH_TOKEN_KEY, token);
+  } else {
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+  }
+}
+
+export function getAccessToken(): string | null {
+  return _accessToken;
+}
+
+export function setAccessToken(token: string | null): void {
+  _accessToken = token;
+}
+
+export function getRefreshToken(): string | null {
+  return _getRefreshToken();
+}
+
+export function setRefreshToken(token: string | null): void {
+  _setRefreshToken(token);
+}
+
+// --- Refresh token deduplication ---
+let _refreshPromise: Promise<boolean> | null = null;
+
+async function _doRefresh(): Promise<boolean> {
+  const refreshToken = _getRefreshToken();
+  if (!refreshToken) return false;
+
+  try {
+    const res = await fetch('/api/auth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+    if (!res.ok) {
+      _accessToken = null;
+      _setRefreshToken(null);
+      return false;
+    }
+    const data = (await res.json()) as { access_token: string; refresh_token: string };
+    _accessToken = data.access_token;
+    _setRefreshToken(data.refresh_token);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function tryRefresh(): Promise<boolean> {
+  if (!_refreshPromise) {
+    _refreshPromise = _doRefresh().finally(() => {
+      _refreshPromise = null;
+    });
+  }
+  return _refreshPromise;
+}
+
+// --- Auth middleware for openapi-fetch ---
+const authMiddleware: Middleware = {
+  async onRequest({ request }) {
+    if (_accessToken) {
+      request.headers.set('Authorization', `Bearer ${_accessToken}`);
+    }
+    return request;
+  },
+  async onResponse({ request, response }) {
+    if (response.status === 401) {
+      const refreshed = await tryRefresh();
+      if (refreshed) {
+        const retryRequest = new Request(request, {
+          headers: new Headers(request.headers),
+        });
+        retryRequest.headers.set('Authorization', `Bearer ${_accessToken}`);
+        return fetch(retryRequest);
+      }
+      window.dispatchEvent(new CustomEvent('clawbolt-logout'));
+    }
+    return response;
+  },
+};
+
+// --- Create typed client ---
+// Using `never` for paths since we don't have generated types yet.
+// Once `npm run generate:api` is run against the live server, replace with `paths`.
+const client = createClient<Record<string, never>>({ baseUrl: '' });
+client.use(authMiddleware);
+
+export default client;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider } from '@/contexts/AuthContext';
 import App from '@/App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/ChecklistPage.tsx
+++ b/frontend/src/pages/ChecklistPage.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect, useCallback } from 'react';
+import Card from '@/components/ui/card';
+import Badge from '@/components/ui/badge';
+import Button from '@/components/ui/button';
+import Input from '@/components/ui/input';
+import Select from '@/components/ui/select';
+import Spinner from '@/components/ui/spinner';
+import api from '@/api';
+import type { ChecklistItem } from '@/types';
+
+export default function ChecklistPage() {
+  const [items, setItems] = useState<ChecklistItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+
+  // New item form
+  const [newDescription, setNewDescription] = useState('');
+  const [newSchedule, setNewSchedule] = useState('daily');
+  const [creating, setCreating] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    api.listChecklist()
+      .then(setItems)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newDescription.trim()) return;
+    setCreating(true);
+    try {
+      const item = await api.createChecklistItem({
+        description: newDescription.trim(),
+        schedule: newSchedule,
+      });
+      setItems((prev) => [...prev, item]);
+      setNewDescription('');
+      setNewSchedule('daily');
+    } catch (err) {
+      alert((err as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await api.deleteChecklistItem(id);
+      setItems((prev) => prev.filter((item) => item.id !== id));
+      setDeleteConfirm(null);
+    } catch (e) {
+      alert((e as Error).message);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold">Checklist</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Manage items your assistant will remind you about during heartbeat check-ins.
+        </p>
+      </div>
+
+      {/* Add new item */}
+      <Card className="mb-6">
+        <form onSubmit={handleCreate} className="flex gap-2 items-end flex-wrap sm:flex-nowrap">
+          <div className="flex-1 min-w-[200px]">
+            <label className="text-xs font-medium text-muted-foreground block mb-1">
+              New checklist item
+            </label>
+            <Input
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+              placeholder="e.g. Follow up with new leads"
+            />
+          </div>
+          <div className="w-36">
+            <label className="text-xs font-medium text-muted-foreground block mb-1">
+              Schedule
+            </label>
+            <Select
+              value={newSchedule}
+              onChange={(e) => setNewSchedule(e.target.value)}
+            >
+              <option value="daily">Daily</option>
+              <option value="weekdays">Weekdays</option>
+              <option value="weekly">Weekly</option>
+              <option value="monthly">Monthly</option>
+            </Select>
+          </div>
+          <Button type="submit" disabled={creating || !newDescription.trim()}>
+            {creating ? 'Adding...' : 'Add'}
+          </Button>
+        </form>
+      </Card>
+
+      {/* List */}
+      {loading ? (
+        <div className="flex justify-center py-12"><Spinner /></div>
+      ) : error ? (
+        <Card className="text-center py-8">
+          <p className="text-sm text-danger">{error}</p>
+          <Button variant="secondary" size="sm" className="mt-2" onClick={load}>Retry</Button>
+        </Card>
+      ) : items.length === 0 ? (
+        <Card className="text-center py-8">
+          <p className="text-sm text-muted-foreground">
+            No checklist items yet. Add one above to get started.
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {items.map((item) => (
+            <Card key={item.id} className="flex items-center justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm">{item.description}</p>
+                <div className="flex items-center gap-2 mt-1">
+                  <Badge>{item.schedule}</Badge>
+                  <Badge className={
+                    item.status === 'active'
+                      ? 'bg-success-bg text-success-text'
+                      : ''
+                  }>
+                    {item.status}
+                  </Badge>
+                  <span className="text-[10px] text-muted-foreground">
+                    Added {new Date(item.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+              </div>
+              <div className="shrink-0">
+                {deleteConfirm === item.id ? (
+                  <div className="flex gap-1">
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      onClick={() => handleDelete(item.id)}
+                    >
+                      Confirm
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteConfirm(null)}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                ) : (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setDeleteConfirm(item.id)}
+                    aria-label={`Delete ${item.description}`}
+                  >
+                    Delete
+                  </Button>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ConversationsPage.tsx
+++ b/frontend/src/pages/ConversationsPage.tsx
@@ -1,0 +1,220 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import Card from '@/components/ui/card';
+import Badge from '@/components/ui/badge';
+import Button from '@/components/ui/button';
+import Spinner from '@/components/ui/spinner';
+import api from '@/api';
+import type { SessionSummary, SessionDetail, SessionMessage } from '@/types';
+
+export default function ConversationsPage() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+
+  if (sessionId) {
+    return <SessionDetailView sessionId={sessionId} />;
+  }
+  return <SessionListView />;
+}
+
+// --- Session List ---
+
+function SessionListView() {
+  const navigate = useNavigate();
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const limit = 20;
+
+  const load = useCallback((off: number) => {
+    setLoading(true);
+    setError(null);
+    api.listSessions(off, limit)
+      .then((res) => {
+        setSessions(res.sessions);
+        setTotal(res.total);
+        setOffset(res.offset);
+      })
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { load(0); }, [load]);
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const currentPage = Math.floor(offset / limit) + 1;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold">Conversations</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Review past conversations with your AI assistant.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12"><Spinner /></div>
+      ) : error ? (
+        <Card className="text-center py-8">
+          <p className="text-sm text-danger">{error}</p>
+          <Button variant="secondary" size="sm" className="mt-2" onClick={() => load(offset)}>Retry</Button>
+        </Card>
+      ) : sessions.length === 0 ? (
+        <Card className="text-center py-8">
+          <p className="text-sm text-muted-foreground">No conversations yet. Start chatting on Telegram!</p>
+        </Card>
+      ) : (
+        <>
+          <div className="space-y-2">
+            {sessions.map((s) => (
+              <Card
+                key={s.id}
+                className="cursor-pointer hover:border-primary/50 transition-colors"
+                onClick={() => navigate(`/app/conversations/${s.id}`)}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium truncate">
+                      {s.last_message_preview || 'No messages'}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {new Date(s.start_time).toLocaleString()}
+                    </p>
+                  </div>
+                  <Badge className="ml-3 shrink-0">{s.message_count} msgs</Badge>
+                </div>
+              </Card>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between mt-4 text-sm text-muted-foreground">
+              <span>{total} conversation{total !== 1 ? 's' : ''}</span>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={offset === 0}
+                  onClick={() => load(offset - limit)}
+                >
+                  Previous
+                </Button>
+                <span>Page {currentPage} of {totalPages}</span>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={currentPage >= totalPages}
+                  onClick={() => load(offset + limit)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// --- Session Detail ---
+
+function SessionDetailView({ sessionId }: { sessionId: string }) {
+  const navigate = useNavigate();
+  const [session, setSession] = useState<SessionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    api.getSession(sessionId)
+      .then(setSession)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [sessionId]);
+
+  return (
+    <div>
+      <button
+        onClick={() => navigate('/app/conversations')}
+        className="text-sm text-primary hover:underline mb-4 inline-flex items-center gap-1"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to conversations
+      </button>
+
+      {loading ? (
+        <div className="flex justify-center py-12"><Spinner /></div>
+      ) : error ? (
+        <Card className="text-center py-8">
+          <p className="text-sm text-danger">{error}</p>
+        </Card>
+      ) : session ? (
+        <>
+          <div className="mb-4 flex items-center gap-3">
+            <h2 className="text-xl font-semibold">Conversation</h2>
+            {session.is_active && <Badge>Active</Badge>}
+          </div>
+          <p className="text-xs text-muted-foreground mb-4">
+            Started: {new Date(session.created_at).toLocaleString()}
+            {' | '}
+            Last message: {new Date(session.last_message_at).toLocaleString()}
+          </p>
+
+          <div className="space-y-3">
+            {session.messages.map((msg) => (
+              <MessageBubble key={msg.seq} message={msg} />
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: SessionMessage }) {
+  const isUser = message.direction === 'incoming';
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={`max-w-[80%] rounded-[--radius-lg] px-4 py-2.5 ${
+          isUser
+            ? 'bg-primary text-white'
+            : 'bg-card border border-border'
+        }`}
+      >
+        <p className="text-sm whitespace-pre-wrap">{message.body}</p>
+
+        {message.tool_interactions.length > 0 && (
+          <div className="mt-2 space-y-1">
+            {message.tool_interactions.map((tool, i) => (
+              <div
+                key={i}
+                className={`text-xs px-2 py-1 rounded-[--radius-sm] ${
+                  isUser
+                    ? 'bg-white/10'
+                    : 'bg-panel'
+                }`}
+              >
+                <span className="font-medium">Tool: </span>
+                {String(tool['name'] ?? tool['tool'] ?? 'unknown')}
+                {'result' in tool && (
+                  <span className="opacity-70"> - {String(tool['result']).slice(0, 100)}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <p className={`text-[10px] mt-1 ${isUser ? 'text-white/60' : 'text-muted-foreground'}`}>
+          {new Date(message.timestamp).toLocaleTimeString()}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -1,0 +1,218 @@
+import { useState, useEffect, useCallback } from 'react';
+import Card from '@/components/ui/card';
+import Badge from '@/components/ui/badge';
+import Button from '@/components/ui/button';
+import Input from '@/components/ui/input';
+import Spinner from '@/components/ui/spinner';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import api from '@/api';
+import type { MemoryFact } from '@/types';
+
+export default function MemoryPage() {
+  const [facts, setFacts] = useState<MemoryFact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+  const [editingFact, setEditingFact] = useState<MemoryFact | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    api.listMemoryFacts()
+      .then(setFacts)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const categories = [...new Set(facts.map((f) => f.category))].sort();
+  const filtered = filter
+    ? facts.filter((f) => f.category === filter)
+    : facts;
+
+  const handleDelete = async (key: string) => {
+    try {
+      await api.deleteMemoryFact(key);
+      setFacts((prev) => prev.filter((f) => f.key !== key));
+      setDeleteConfirm(null);
+    } catch (e) {
+      alert((e as Error).message);
+    }
+  };
+
+  const handleSaveEdit = async (key: string, value: string) => {
+    try {
+      const updated = await api.updateMemoryFact(key, { value });
+      setFacts((prev) => prev.map((f) => (f.key === key ? updated : f)));
+      setEditingFact(null);
+    } catch (e) {
+      alert((e as Error).message);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold">Memory / Facts</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Review and correct what your AI assistant knows about you and your business.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12"><Spinner /></div>
+      ) : error ? (
+        <Card className="text-center py-8">
+          <p className="text-sm text-danger">{error}</p>
+          <Button variant="secondary" size="sm" className="mt-2" onClick={load}>Retry</Button>
+        </Card>
+      ) : facts.length === 0 ? (
+        <Card className="text-center py-8">
+          <p className="text-sm text-muted-foreground">
+            No memory facts yet. Chat with your assistant on Telegram to build up knowledge.
+          </p>
+        </Card>
+      ) : (
+        <>
+          {/* Category filter */}
+          {categories.length > 1 && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              <button
+                className={`px-3 py-1 text-xs rounded-[--radius-full] border transition-colors ${
+                  !filter ? 'bg-primary text-white border-primary' : 'border-border text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setFilter('')}
+              >
+                All ({facts.length})
+              </button>
+              {categories.map((cat) => {
+                const count = facts.filter((f) => f.category === cat).length;
+                return (
+                  <button
+                    key={cat}
+                    className={`px-3 py-1 text-xs rounded-[--radius-full] border transition-colors ${
+                      filter === cat ? 'bg-primary text-white border-primary' : 'border-border text-muted-foreground hover:text-foreground'
+                    }`}
+                    onClick={() => setFilter(cat)}
+                  >
+                    {cat} ({count})
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            {filtered.map((fact) => (
+              <Card key={fact.key} className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-sm font-medium">{fact.key}</span>
+                    <Badge>{fact.category}</Badge>
+                    {fact.confidence < 1 && (
+                      <span className="text-[10px] text-muted-foreground">
+                        {Math.round(fact.confidence * 100)}% confidence
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-muted-foreground">{fact.value}</p>
+                </div>
+                <div className="flex gap-1 shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEditingFact(fact)}
+                    aria-label={`Edit ${fact.key}`}
+                  >
+                    Edit
+                  </Button>
+                  {deleteConfirm === fact.key ? (
+                    <div className="flex gap-1">
+                      <Button
+                        variant="danger"
+                        size="sm"
+                        onClick={() => handleDelete(fact.key)}
+                      >
+                        Confirm
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDeleteConfirm(null)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteConfirm(fact.key)}
+                      aria-label={`Delete ${fact.key}`}
+                    >
+                      Delete
+                    </Button>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Edit dialog */}
+      <Dialog open={!!editingFact} onOpenChange={() => setEditingFact(null)}>
+        <DialogContent>
+          <DialogTitle>Edit Fact: {editingFact?.key}</DialogTitle>
+          {editingFact && (
+            <EditFactForm
+              fact={editingFact}
+              onSave={handleSaveEdit}
+              onCancel={() => setEditingFact(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function EditFactForm({
+  fact,
+  onSave,
+  onCancel,
+}: {
+  fact: MemoryFact;
+  onSave: (key: string, value: string) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(fact.value);
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await onSave(fact.key, value);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+      <div>
+        <label className="text-xs text-muted-foreground block mb-1">Value</label>
+        <Input value={value} onChange={(e) => setValue(e.target.value)} />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={onCancel}>Cancel</Button>
+        <Button type="submit" disabled={saving || value === fact.value}>
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/pages/OverviewPage.tsx
+++ b/frontend/src/pages/OverviewPage.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect } from 'react';
+import { useOutletContext, Link } from 'react-router-dom';
+import Card from '@/components/ui/card';
+import Spinner from '@/components/ui/spinner';
+import api from '@/api';
+import type { ContractorStats } from '@/types';
+import type { AppShellContext } from '@/layouts/AppShell';
+
+export default function OverviewPage() {
+  const { profile } = useOutletContext<AppShellContext>();
+  const [stats, setStats] = useState<ContractorStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    api.getStats()
+      .then(setStats)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold">
+          {profile?.name ? `Welcome back, ${profile.name}` : 'Dashboard'}
+        </h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Overview of your AI assistant activity.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Spinner />
+        </div>
+      ) : error ? (
+        <Card className="text-center py-8">
+          <p className="text-sm text-danger">{error}</p>
+          <button
+            className="text-sm text-primary hover:underline mt-2"
+            onClick={() => window.location.reload()}
+          >
+            Retry
+          </button>
+        </Card>
+      ) : stats ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatCard
+            label="Conversations"
+            value={stats.total_sessions}
+            linkTo="/app/conversations"
+          />
+          <StatCard
+            label="Messages this month"
+            value={stats.messages_this_month}
+          />
+          <StatCard
+            label="Memory facts"
+            value={stats.total_memory_facts}
+            linkTo="/app/memory"
+          />
+          <StatCard
+            label="Checklist items"
+            value={stats.active_checklist_items}
+            linkTo="/app/checklist"
+          />
+        </div>
+      ) : null}
+
+      {stats?.last_conversation_at && (
+        <p className="text-xs text-muted-foreground mt-4">
+          Last conversation: {new Date(stats.last_conversation_at).toLocaleString()}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function StatCard({ label, value, linkTo }: { label: string; value: number; linkTo?: string }) {
+  const content = (
+    <Card className={linkTo ? 'hover:border-primary/50 transition-colors cursor-pointer' : ''}>
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
+    </Card>
+  );
+
+  if (linkTo) {
+    return <Link to={linkTo}>{content}</Link>;
+  }
+  return content;
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,314 @@
+import { useState, useCallback } from 'react';
+import { useOutletContext, useParams, useNavigate } from 'react-router-dom';
+import Card from '@/components/ui/card';
+import Input from '@/components/ui/input';
+import Textarea from '@/components/ui/textarea';
+import Button from '@/components/ui/button';
+import Select from '@/components/ui/select';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { toast } from 'sonner';
+import api from '@/api';
+import type { ContractorProfileUpdate } from '@/types';
+import type { AppShellContext } from '@/layouts/AppShell';
+import {
+  getExtraSettingsTabs,
+  renderPremiumSettingsTab,
+  showOssSettingsTabs,
+} from '@/extensions';
+
+export default function SettingsPage() {
+  const { tab } = useParams<{ tab: string }>();
+  const navigate = useNavigate();
+  const { profile, reloadProfile, isPremium, isAdmin } = useOutletContext<AppShellContext>();
+
+  const extraTabs = getExtraSettingsTabs(isPremium, isAdmin);
+  const activeTab = tab || 'profile';
+
+  const handleTabChange = (value: string) => {
+    navigate(`/app/settings/${value}`, { replace: true });
+  };
+
+  // Premium-only tab
+  const premiumContent = renderPremiumSettingsTab(activeTab);
+  if (premiumContent) {
+    return (
+      <div>
+        <h2 className="text-xl font-semibold mb-6">Settings</h2>
+        <Tabs value={activeTab} onValueChange={handleTabChange}>
+          <TabsList>
+            {showOssSettingsTabs(isPremium) && (
+              <>
+                <TabsTrigger value="profile">Profile</TabsTrigger>
+                <TabsTrigger value="assistant">Assistant</TabsTrigger>
+                <TabsTrigger value="heartbeat">Heartbeat</TabsTrigger>
+              </>
+            )}
+            {extraTabs.map((t) => (
+              <TabsTrigger key={t.key} value={t.key}>{t.label}</TabsTrigger>
+            ))}
+          </TabsList>
+          <TabsContent value={activeTab}>
+            {premiumContent}
+          </TabsContent>
+        </Tabs>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-6">Settings</h2>
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <TabsList>
+          <TabsTrigger value="profile">Profile</TabsTrigger>
+          <TabsTrigger value="assistant">Assistant</TabsTrigger>
+          <TabsTrigger value="heartbeat">Heartbeat</TabsTrigger>
+          {extraTabs.map((t) => (
+            <TabsTrigger key={t.key} value={t.key}>{t.label}</TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="profile">
+          {profile && <ProfileTab profile={profile} onSaved={reloadProfile} />}
+        </TabsContent>
+
+        <TabsContent value="assistant">
+          {profile && <AssistantTab profile={profile} onSaved={reloadProfile} />}
+        </TabsContent>
+
+        <TabsContent value="heartbeat">
+          {profile && <HeartbeatTab profile={profile} onSaved={reloadProfile} />}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+// --- Profile Tab ---
+
+function ProfileTab({
+  profile,
+  onSaved,
+}: {
+  profile: { name: string; phone: string; trade: string; location: string; hourly_rate: number | null; business_hours: string; timezone: string };
+  onSaved: () => void;
+}) {
+  const [form, setForm] = useState({
+    name: profile.name,
+    phone: profile.phone,
+    trade: profile.trade,
+    location: profile.location,
+    hourly_rate: profile.hourly_rate?.toString() ?? '',
+    business_hours: profile.business_hours,
+    timezone: profile.timezone,
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const body: ContractorProfileUpdate = {
+        name: form.name,
+        phone: form.phone,
+        trade: form.trade,
+        location: form.location,
+        hourly_rate: form.hourly_rate ? parseFloat(form.hourly_rate) : null,
+        business_hours: form.business_hours,
+        timezone: form.timezone,
+      };
+      await api.updateProfile(body);
+      onSaved();
+      toast.success('Profile updated');
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [form, onSaved]);
+
+  const set = (field: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  return (
+    <Card>
+      <div className="grid gap-4">
+        <Field label="Name">
+          <Input value={form.name} onChange={set('name')} />
+        </Field>
+        <Field label="Phone">
+          <Input value={form.phone} onChange={set('phone')} type="tel" />
+        </Field>
+        <Field label="Trade">
+          <Input value={form.trade} onChange={set('trade')} placeholder="e.g. Electrician, Plumber" />
+        </Field>
+        <Field label="Location">
+          <Input value={form.location} onChange={set('location')} placeholder="City, State" />
+        </Field>
+        <Field label="Hourly Rate ($)">
+          <Input value={form.hourly_rate} onChange={set('hourly_rate')} type="number" step="0.01" />
+        </Field>
+        <Field label="Business Hours">
+          <Input value={form.business_hours} onChange={set('business_hours')} placeholder="Mon-Fri 8am-5pm" />
+        </Field>
+        <Field label="Timezone">
+          <Select value={form.timezone} onChange={set('timezone')}>
+            <option value="America/New_York">Eastern (ET)</option>
+            <option value="America/Chicago">Central (CT)</option>
+            <option value="America/Denver">Mountain (MT)</option>
+            <option value="America/Los_Angeles">Pacific (PT)</option>
+            <option value="America/Anchorage">Alaska (AKT)</option>
+            <option value="Pacific/Honolulu">Hawaii (HT)</option>
+          </Select>
+        </Field>
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving...' : 'Save Profile'}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// --- Assistant Tab ---
+
+function AssistantTab({
+  profile,
+  onSaved,
+}: {
+  profile: { assistant_name: string; soul_text: string };
+  onSaved: () => void;
+}) {
+  const [form, setForm] = useState({
+    assistant_name: profile.assistant_name,
+    soul_text: profile.soul_text,
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      await api.updateProfile({
+        assistant_name: form.assistant_name,
+        soul_text: form.soul_text,
+      });
+      onSaved();
+      toast.success('Assistant settings updated');
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [form, onSaved]);
+
+  return (
+    <Card>
+      <div className="grid gap-4">
+        <Field label="Assistant Name">
+          <Input
+            value={form.assistant_name}
+            onChange={(e) => setForm((prev) => ({ ...prev, assistant_name: e.target.value }))}
+            placeholder="e.g. Claw"
+          />
+        </Field>
+        <Field label="Personality / SOUL">
+          <Textarea
+            value={form.soul_text}
+            onChange={(e) => setForm((prev) => ({ ...prev, soul_text: e.target.value }))}
+            rows={8}
+            placeholder="Describe how your assistant should behave, speak, and interact with clients..."
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            This guides your assistant's personality and communication style.
+          </p>
+        </Field>
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving...' : 'Save Assistant Settings'}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// --- Heartbeat Tab ---
+
+function HeartbeatTab({
+  profile,
+  onSaved,
+}: {
+  profile: { heartbeat_opt_in: boolean; heartbeat_frequency: string };
+  onSaved: () => void;
+}) {
+  const [form, setForm] = useState({
+    heartbeat_opt_in: profile.heartbeat_opt_in,
+    heartbeat_frequency: profile.heartbeat_frequency,
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      await api.updateProfile({
+        heartbeat_opt_in: form.heartbeat_opt_in,
+        heartbeat_frequency: form.heartbeat_frequency,
+      });
+      onSaved();
+      toast.success('Heartbeat settings updated');
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [form, onSaved]);
+
+  return (
+    <Card>
+      <div className="grid gap-4">
+        <div className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            id="heartbeat-opt-in"
+            checked={form.heartbeat_opt_in}
+            onChange={(e) => setForm((prev) => ({ ...prev, heartbeat_opt_in: e.target.checked }))}
+            className="w-4 h-4 rounded border-border text-primary focus:ring-primary"
+          />
+          <label htmlFor="heartbeat-opt-in" className="text-sm">
+            Enable daily heartbeat check-ins
+          </label>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          When enabled, your assistant will proactively send you reminders and updates based on your checklist.
+        </p>
+        <Field label="Frequency">
+          <Select
+            value={form.heartbeat_frequency}
+            onChange={(e) => setForm((prev) => ({ ...prev, heartbeat_frequency: e.target.value }))}
+            disabled={!form.heartbeat_opt_in}
+          >
+            <option value="daily">Daily</option>
+            <option value="weekdays">Weekdays only</option>
+            <option value="weekly">Weekly</option>
+          </Select>
+        </Field>
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving...' : 'Save Heartbeat Settings'}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// --- Shared field wrapper ---
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="text-xs font-medium text-muted-foreground block mb-1">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -1,0 +1,22 @@
+import { render, type RenderOptions } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactElement, ReactNode } from 'react';
+
+interface RouterRenderOptions extends Omit<RenderOptions, 'wrapper'> {
+  route?: string;
+}
+
+/**
+ * Render helper that wraps components in MemoryRouter.
+ * Use this for any component that uses React Router hooks.
+ */
+export function renderWithRouter(ui: ReactElement, { route = '/', ...options }: RouterRenderOptions = {}) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[route]}>
+        {children}
+      </MemoryRouter>
+    );
+  }
+  return render(ui, { wrapper: Wrapper, ...options });
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,114 @@
+// API response types matching backend schemas
+
+export interface ContractorProfile {
+  id: number;
+  user_id: string;
+  name: string;
+  phone: string;
+  trade: string;
+  location: string;
+  hourly_rate: number | null;
+  business_hours: string;
+  timezone: string;
+  assistant_name: string;
+  soul_text: string;
+  preferred_channel: string;
+  channel_identifier: string;
+  heartbeat_opt_in: boolean;
+  heartbeat_frequency: string;
+  onboarding_complete: boolean;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ContractorProfileUpdate {
+  name?: string;
+  phone?: string;
+  trade?: string;
+  location?: string;
+  hourly_rate?: number | null;
+  business_hours?: string;
+  timezone?: string;
+  assistant_name?: string;
+  soul_text?: string;
+  heartbeat_opt_in?: boolean;
+  heartbeat_frequency?: string;
+}
+
+export interface SessionSummary {
+  id: string;
+  start_time: string;
+  message_count: number;
+  last_message_preview: string;
+}
+
+export interface SessionListResponse {
+  sessions: SessionSummary[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+export interface ToolInteraction {
+  [key: string]: unknown;
+}
+
+export interface SessionMessage {
+  seq: number;
+  direction: string;
+  body: string;
+  timestamp: string;
+  tool_interactions: ToolInteraction[];
+}
+
+export interface SessionDetail {
+  session_id: string;
+  contractor_id: number;
+  created_at: string;
+  last_message_at: string;
+  is_active: boolean;
+  messages: SessionMessage[];
+}
+
+export interface MemoryFact {
+  key: string;
+  value: string;
+  category: string;
+  confidence: number;
+}
+
+export interface MemoryFactUpdate {
+  value?: string;
+  category?: string;
+  confidence?: number;
+}
+
+export interface ChecklistItem {
+  id: number;
+  description: string;
+  schedule: string;
+  status: string;
+  created_at: string;
+}
+
+export interface ContractorStats {
+  total_sessions: number;
+  messages_this_month: number;
+  active_checklist_items: number;
+  total_memory_facts: number;
+  last_conversation_at: string | null;
+}
+
+export interface AuthConfig {
+  required: boolean;
+  method?: string;
+  provider?: string;
+  client_id?: string;
+}
+
+export interface AuthUser {
+  id: number;
+  name: string;
+  role?: string;
+}


### PR DESCRIPTION
## Description
Implements the complete frontend dashboard UI for managing the AI assistant. This is a control panel where contractors review what the assistant did, correct its knowledge, and manage settings.

**Components implemented:**
- UI component library: Button, Input, Textarea, Card, Spinner, Badge, Dialog, Tabs, DropdownMenu, Select
- Extension system with OSS stubs matching the porchsongs pattern (auth, routes, settings, API, quota, admin)
- API client with openapi-fetch, token management, and auth middleware
- Auth context with auto-local-user for OSS mode
- App shell layout with sidebar navigation and responsive mobile menu
- FastAPI static file serving for the built frontend
- Test utilities with renderWithRouter helper

**Dashboard pages:**
- **Overview**: Stats dashboard (conversations, messages, memory facts, checklist items)
- **Conversations**: Paginated list + detail view with tool interaction display
- **Memory/Facts**: Category filtering, inline edit, delete with confirmation
- **Profile & Settings**: Tabbed interface (profile, assistant personality, heartbeat)
- **Checklist**: Add/delete checklist items with schedule selection

Fixes #451, fixes #452, fixes #453, fixes #454, fixes #455, fixes #456, fixes #457, fixes #463, fixes #464, fixes #465, fixes #466, fixes #467

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.6 via Claude Code: implemented all frontend components, pages, extension system, API client, and backend static serving)
- [ ] No AI used