### PR TITLE
feat: add multi-stage Docker build for frontend dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,6 @@ tests/
 .env
 .env.example
 .pre-commit-config.yaml
+node_modules/
+frontend/node_modules/
+frontend/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
+# Stage 1: Build React frontend
+FROM node:20-slim AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json* ./
+RUN npm install
+COPY frontend/ ./
+RUN npm run build
+
+# Stage 2: Python backend
 FROM python:3.11-slim
+WORKDIR /app
 
 # Install system dependencies (ffmpeg for audio processing)
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /app
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
@@ -15,6 +23,12 @@ RUN uv sync --frozen
 # Copy application code
 COPY backend/ backend/
 
+# Copy built frontend from stage 1
+COPY --from=frontend-build /app/frontend/dist ./frontend/dist
+
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"]
 
 CMD ["uv", "run", "uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Description

The Dockerfile only copied `backend/` into the image, so the frontend dashboard (added in PR #470) was never built or served. Running `docker-compose up` served the API but the dashboard at `/app` returned 404.

This adds a Node 20 build stage that compiles the React frontend, then copies `frontend/dist/` into the final Python image where `main.py` auto-detects and serves it. Also adds a healthcheck and updates `.dockerignore`.

Fixes #471

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`) - 871 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

No new tests needed - this is a Dockerfile change only, no Python code modified.

## AI Usage
- [x] AI-assisted: Claude Opus 4.6 implemented Dockerfile multi-stage build following porchsongs pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)