### PR TITLE
fix: return existing contractor in OSS get_current_user

### DIFF
--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -4,12 +4,18 @@ LOCAL_USER_ID = "local@clawbolt.local"
 
 
 async def get_current_user() -> ContractorData:
-    """OSS mode: return the single local contractor, no auth required."""
+    """OSS mode: return the single contractor, no auth required.
+
+    In single-tenant mode there should be exactly one contractor. If Telegram
+    (or another channel) already created one, return that contractor so the
+    dashboard sees the same sessions, memory, and stats. Only create a local
+    fallback when the store is completely empty.
+    """
     store = get_contractor_store()
-    contractor = await store.get_by_user_id(LOCAL_USER_ID)
-    if contractor is None:
-        contractor = await store.create(
-            user_id=LOCAL_USER_ID,
-            name="Local Contractor",
-        )
-    return contractor
+    all_contractors = await store.list_all()
+    if all_contractors:
+        return all_contractors[0]
+    return await store.create(
+        user_id=LOCAL_USER_ID,
+        name="Local Contractor",
+    )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,7 @@ from backend.app.auth.scoping import get_user_contractor
 
 @pytest.mark.asyncio()
 async def test_get_current_user_creates_local_contractor() -> None:
-    """OSS mode should auto-create a local contractor."""
+    """OSS mode should auto-create a local contractor when store is empty."""
     contractor = await get_current_user()
     assert contractor.user_id == LOCAL_USER_ID
     assert contractor.name == "Local Contractor"
@@ -22,6 +22,23 @@ async def test_get_current_user_returns_same_contractor() -> None:
     c1 = await get_current_user()
     c2 = await get_current_user()
     assert c1.id == c2.id
+
+
+@pytest.mark.asyncio()
+async def test_get_current_user_returns_existing_telegram_contractor() -> None:
+    """When a Telegram-created contractor exists, the dashboard should use it."""
+    store = get_contractor_store()
+    telegram_contractor = await store.create(
+        user_id="telegram_123456789",
+        name="Telegram User",
+        channel_identifier="123456789",
+        preferred_channel="telegram",
+    )
+
+    # get_current_user should return the existing contractor, not create a new one
+    dashboard_user = await get_current_user()
+    assert dashboard_user.id == telegram_contractor.id
+    assert dashboard_user.user_id == "telegram_123456789"
 
 
 def test_auth_config_returns_none_mode(client: TestClient) -> None:


### PR DESCRIPTION
## Description

The dashboard created a separate `local@clawbolt.local` contractor while Telegram created `telegram_{chat_id}`, resulting in the dashboard showing no sessions, memory, or stats despite active Telegram usage.

Now `get_current_user` returns the first existing contractor in the store (e.g. the one Telegram created) and only falls back to creating a local contractor when the store is completely empty.

Fixes #473

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) - 872 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: Claude Opus 4.6 diagnosed root cause and implemented fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)