### PR TITLE
feat: add web chat channel as alternative to Telegram

### DIFF
--- a/backend/app/channels/webchat.py
+++ b/backend/app/channels/webchat.py
@@ -1,0 +1,129 @@
+"""Web chat channel: browser-based chat via the dashboard.
+
+Provides a POST endpoint for sending messages and receiving agent responses
+synchronously. The dashboard chat UI calls this endpoint and displays the
+response. Responses are also persisted in the session store so they appear
+in the Conversations page.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from backend.app.agent.concurrency import contractor_locks
+from backend.app.agent.context import get_or_create_conversation
+from backend.app.agent.file_store import ContractorData, get_contractor_store, get_session_store
+from backend.app.agent.router import (
+    PipelineContext,
+    build_context_step,
+    finalize_onboarding_step,
+    load_history_step,
+    persist_outbound_step,
+    run_agent_step,
+    run_pipeline,
+)
+from backend.app.auth.dependencies import get_current_user
+from backend.app.channels.base import BaseChannel
+from backend.app.enums import MessageDirection
+from backend.app.media.download import DownloadedMedia
+
+logger = logging.getLogger(__name__)
+
+
+class _ChatRequest(BaseModel):
+    message: str
+
+
+class _ChatResponse(BaseModel):
+    reply: str
+    session_id: str
+
+
+# Pipeline for web chat: same as default but without dispatch_reply_step
+# (the reply is returned directly in the HTTP response) and without
+# prepare_media_step (web chat text-only for now).
+_WEBCHAT_PIPELINE = [
+    build_context_step,
+    load_history_step,
+    run_agent_step,
+    finalize_onboarding_step,
+    persist_outbound_step,
+]
+
+
+class WebChatChannel(BaseChannel):
+    """Browser-based chat channel for the dashboard.
+
+    Messages are sent via POST and responses are returned synchronously.
+    The channel's outbound methods (send_text, etc.) are no-ops because
+    responses are returned directly in the HTTP response body.
+    """
+
+    @property
+    def name(self) -> str:
+        return "webchat"
+
+    def get_router(self) -> APIRouter:
+        router = APIRouter(tags=["webchat"])
+        channel = self
+
+        @router.post("/contractor/chat", response_model=_ChatResponse)
+        async def send_chat_message(
+            body: _ChatRequest,
+            contractor: ContractorData = Depends(get_current_user),
+        ) -> _ChatResponse:
+            """Send a message and receive the agent's response."""
+            session, _ = await get_or_create_conversation(contractor.id)
+
+            session_store = get_session_store(contractor.id)
+            message = await session_store.add_message(
+                session=session,
+                direction=MessageDirection.INBOUND,
+                body=body.message,
+            )
+
+            ctx = PipelineContext(
+                contractor=contractor,
+                session=session,
+                message=message,
+                media_urls=[],
+                messaging_service=channel,
+                to_address=str(contractor.id),
+            )
+
+            async with contractor_locks.acquire(contractor.id):
+                # Reload contractor in case it was updated concurrently
+                store = get_contractor_store()
+                fresh = await store.get_by_id(contractor.id)
+                if fresh is not None:
+                    ctx.contractor = fresh
+                ctx = await run_pipeline(ctx, _WEBCHAT_PIPELINE)
+
+            reply = ctx.response.reply_text if ctx.response else ""
+            return _ChatResponse(reply=reply, session_id=session.session_id)
+
+        return router
+
+    def is_allowed(self, sender_id: str, username: str) -> bool:
+        return True
+
+    async def send_text(self, to: str, body: str) -> str:
+        """No-op: web chat returns responses via the HTTP response body."""
+        return ""
+
+    async def send_media(self, to: str, body: str, media_url: str) -> str:
+        """No-op: web chat returns responses via the HTTP response body."""
+        return ""
+
+    async def send_message(self, to: str, body: str, media_urls: list[str] | None = None) -> str:
+        """No-op: web chat returns responses via the HTTP response body."""
+        return ""
+
+    async def send_typing_indicator(self, to: str) -> None:
+        """No-op: typing state handled client-side."""
+
+    async def download_media(self, file_id: str) -> DownloadedMedia:
+        """Web chat does not support media uploads yet."""
+        msg = "Web chat does not support media uploads"
+        raise NotImplementedError(msg)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from backend.app.agent.heartbeat import heartbeat_scheduler
 from backend.app.channels import get_manager, register_channel
 from backend.app.channels.telegram import TelegramChannel
+from backend.app.channels.webchat import WebChatChannel
 from backend.app.config import settings
 from backend.app.routers import (
     auth,
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 # -- Build and register channels at module scope ----------------------------
 
 register_channel(TelegramChannel(bot_token=settings.telegram_bot_token))
+register_channel(WebChatChannel())
 
 
 async def _verify_llm_settings() -> None:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import OverviewPage from '@/pages/OverviewPage';
 import ConversationsPage from '@/pages/ConversationsPage';
 import MemoryPage from '@/pages/MemoryPage';
 import SettingsPage from '@/pages/SettingsPage';
+import ChatPage from '@/pages/ChatPage';
 import ChecklistPage from '@/pages/ChecklistPage';
 import { useAuth } from '@/contexts/AuthContext';
 import {
@@ -37,6 +38,7 @@ export default function App() {
       {/* Authenticated app */}
       <Route path="/app" element={<AppShell />}>
         <Route index element={<OverviewPage />} />
+        <Route path="chat" element={<ChatPage />} />
         <Route path="conversations" element={<ConversationsPage />} />
         <Route path="conversations/:sessionId" element={<ConversationsPage />} />
         <Route path="memory" element={<MemoryPage />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   AuthConfig,
   AuthUser,
+  ChatResponse,
   ChecklistItem,
   ContractorProfile,
   ContractorProfileUpdate,
@@ -115,6 +116,14 @@ const api = {
 
   // Stats
   getStats: () => _fetch<ContractorStats>('/api/contractor/stats'),
+
+  // Chat
+  sendChatMessage: (message: string) =>
+    _fetch<ChatResponse>('/api/contractor/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    }),
 };
 
 export default api;

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -18,6 +18,7 @@ export interface AppShellContext {
 
 const NAV_ITEMS = [
   { to: '/app', label: 'Overview', icon: OverviewIcon, end: true },
+  { to: '/app/chat', label: 'Chat', icon: ChatIcon, end: false },
   { to: '/app/conversations', label: 'Conversations', icon: ConversationsIcon, end: false },
   { to: '/app/memory', label: 'Memory', icon: MemoryIcon, end: false },
   { to: '/app/checklist', label: 'Checklist', icon: ChecklistIcon, end: false },
@@ -123,7 +124,7 @@ export default function AppShell() {
 
         {!profile?.onboarding_complete && (
           <div className="mx-2 mb-2 p-3 rounded-[--radius-md] bg-info-bg border border-info-border text-info-text text-xs">
-            Connect with your assistant on Telegram to get started.
+            Start chatting with your assistant using the Chat page or connect via Telegram.
           </div>
         )}
 
@@ -184,6 +185,14 @@ export default function AppShell() {
 }
 
 // --- Nav icons (inline SVG) ---
+
+function ChatIcon() {
+  return (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+    </svg>
+  );
+}
 
 function OverviewIcon() {
   return (

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,0 +1,163 @@
+import { useState, useRef, useEffect, useCallback, type FormEvent } from 'react';
+import Button from '@/components/ui/button';
+import Card from '@/components/ui/card';
+import Spinner from '@/components/ui/spinner';
+import api from '@/api';
+import { toast } from 'sonner';
+
+interface ChatMessage {
+  id: number;
+  role: 'user' | 'assistant';
+  body: string;
+  timestamp: Date;
+}
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const nextId = useRef(1);
+
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || sending) return;
+
+    const userMsg: ChatMessage = {
+      id: nextId.current++,
+      role: 'user',
+      body: text,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setSending(true);
+
+    try {
+      const res = await api.sendChatMessage(text);
+      const assistantMsg: ChatMessage = {
+        id: nextId.current++,
+        role: 'assistant',
+        body: res.reply,
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, assistantMsg]);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to send message';
+      toast.error(msg);
+    } finally {
+      setSending(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full -my-4 sm:-my-6">
+      {/* Header */}
+      <div className="py-4 sm:py-6">
+        <h2 className="text-xl font-semibold">Chat</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Talk with your AI assistant directly from the dashboard.
+        </p>
+      </div>
+
+      {/* Messages area */}
+      <div className="flex-1 overflow-y-auto min-h-0 pb-4">
+        {messages.length === 0 ? (
+          <Card className="text-center py-12">
+            <div className="text-muted-foreground">
+              <ChatBubbleIcon />
+              <p className="text-sm mt-3">Send a message to start chatting.</p>
+            </div>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {messages.map((msg) => (
+              <div
+                key={msg.id}
+                className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[80%] rounded-[--radius-lg] px-4 py-2.5 ${
+                    msg.role === 'user'
+                      ? 'bg-primary text-white'
+                      : 'bg-card border border-border'
+                  }`}
+                >
+                  <p className="text-sm whitespace-pre-wrap">{msg.body}</p>
+                  <p
+                    className={`text-[10px] mt-1 ${
+                      msg.role === 'user' ? 'text-white/60' : 'text-muted-foreground'
+                    }`}
+                  >
+                    {msg.timestamp.toLocaleTimeString()}
+                  </p>
+                </div>
+              </div>
+            ))}
+
+            {sending && (
+              <div className="flex justify-start">
+                <div className="bg-card border border-border rounded-[--radius-lg] px-4 py-2.5">
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Spinner className="w-4 h-4" />
+                    Thinking...
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div ref={messagesEndRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Input area */}
+      <div className="border-t border-border pt-4 pb-4 sm:pb-6">
+        <form onSubmit={handleSubmit} className="flex gap-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type a message..."
+            disabled={sending}
+            className="flex-1 px-3 py-2.5 sm:py-2 text-sm bg-card border border-border rounded-[--radius-md] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-colors disabled:opacity-50"
+            autoComplete="off"
+          />
+          <Button type="submit" disabled={sending || !input.trim()}>
+            Send
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function ChatBubbleIcon() {
+  return (
+    <svg
+      className="w-10 h-10 mx-auto text-muted-foreground/50"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/pages/ConversationsPage.tsx
+++ b/frontend/src/pages/ConversationsPage.tsx
@@ -63,7 +63,7 @@ function SessionListView() {
         </Card>
       ) : sessions.length === 0 ? (
         <Card className="text-center py-8">
-          <p className="text-sm text-muted-foreground">No conversations yet. Start chatting on Telegram!</p>
+          <p className="text-sm text-muted-foreground">No conversations yet. Start chatting via the Chat page or Telegram!</p>
         </Card>
       ) : (
         <>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -112,3 +112,8 @@ export interface AuthUser {
   name: string;
   role?: string;
 }
+
+export interface ChatResponse {
+  reply: string;
+  session_id: string;
+}

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -1,0 +1,134 @@
+"""Tests for the web chat channel endpoint."""
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.config import settings
+from backend.app.main import app
+
+
+@pytest.fixture()
+async def webchat_contractor() -> ContractorData:
+    """Create a contractor for web chat tests."""
+    store = get_contractor_store()
+    return await store.create(
+        user_id="webchat-test-user",
+        name="Test Contractor",
+        trade="Electrician",
+    )
+
+
+@pytest.fixture()
+def webchat_client(webchat_contractor: ContractorData) -> Generator[TestClient]:
+    """TestClient that uses real get_current_user (no auth override).
+
+    Mocks the LLM to avoid external API calls during tests.
+    """
+    with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+        patch("backend.app.channels.telegram.settings.telegram_bot_token", ""),
+        patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
+        TestClient(app) as c,
+    ):
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_chat_endpoint_returns_reply(
+    webchat_client: TestClient,
+    webchat_contractor: ContractorData,
+) -> None:
+    """POST /api/contractor/chat should return an agent reply."""
+    with patch(
+        "backend.app.agent.router.run_agent",
+        new_callable=AsyncMock,
+    ) as mock_agent:
+        from backend.app.agent.core import AgentResponse
+
+        mock_agent.return_value = AgentResponse(reply_text="Hello from the agent!")
+
+        resp = webchat_client.post(
+            "/api/contractor/chat",
+            json={"message": "Hi there"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["reply"] == "Hello from the agent!"
+    assert "session_id" in data
+
+
+def test_chat_endpoint_persists_messages(
+    webchat_client: TestClient,
+    webchat_contractor: ContractorData,
+) -> None:
+    """Chat messages should be persisted in the session store."""
+    with patch(
+        "backend.app.agent.router.run_agent",
+        new_callable=AsyncMock,
+    ) as mock_agent:
+        from backend.app.agent.core import AgentResponse
+
+        mock_agent.return_value = AgentResponse(reply_text="Got it!")
+
+        resp = webchat_client.post(
+            "/api/contractor/chat",
+            json={"message": "Remember my rate is 85"},
+        )
+        assert resp.status_code == 200
+        session_id = resp.json()["session_id"]
+
+    # Read the session JSONL file directly to verify persistence
+    session_path = (
+        Path(settings.contractor_data_dir)
+        / str(webchat_contractor.id)
+        / "sessions"
+        / f"{session_id}.jsonl"
+    )
+    assert session_path.exists()
+    lines = [json.loads(line) for line in session_path.read_text().strip().split("\n")]
+    # First line is metadata, subsequent lines are messages
+    message_lines = [line for line in lines if line.get("_type") != "metadata"]
+    bodies = [m["body"] for m in message_lines]
+    assert "Remember my rate is 85" in bodies
+    assert "Got it!" in bodies
+
+
+def test_chat_endpoint_missing_body(webchat_client: TestClient) -> None:
+    """Missing body should return 422."""
+    resp = webchat_client.post("/api/contractor/chat", json={})
+    assert resp.status_code == 422
+
+
+def test_chat_returns_same_session(
+    webchat_client: TestClient,
+    webchat_contractor: ContractorData,
+) -> None:
+    """Multiple messages within the session timeout should use the same session."""
+    with patch(
+        "backend.app.agent.router.run_agent",
+        new_callable=AsyncMock,
+    ) as mock_agent:
+        from backend.app.agent.core import AgentResponse
+
+        mock_agent.return_value = AgentResponse(reply_text="Reply 1")
+        resp1 = webchat_client.post(
+            "/api/contractor/chat",
+            json={"message": "First message"},
+        )
+
+        mock_agent.return_value = AgentResponse(reply_text="Reply 2")
+        resp2 = webchat_client.post(
+            "/api/contractor/chat",
+            json={"message": "Second message"},
+        )
+
+    assert resp1.json()["session_id"] == resp2.json()["session_id"]


### PR DESCRIPTION
## Description

Adds a browser-based chat interface to the dashboard so users can talk to their AI assistant without requiring Telegram. The web chat channel:

- Implements `BaseChannel` with a `POST /api/contractor/chat` endpoint
- Runs the same agent pipeline as Telegram (shared session, memory, tools)
- Returns responses synchronously in the HTTP response body
- Persists messages in the session store (visible in Conversations page)
- Shares sessions with Telegram (same contractor, same conversations)

Frontend adds a Chat page with message bubbles, input field, and thinking indicator. Navigation updated to include Chat in the sidebar.

Fixes #476

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implementation by Claude Code)
- [ ] No AI used