### PR TITLE
fix: correct message direction check from 'incoming' to 'inbound'

### DIFF
--- a/frontend/src/pages/ConversationsPage.tsx
+++ b/frontend/src/pages/ConversationsPage.tsx
@@ -177,7 +177,7 @@ function SessionDetailView({ sessionId }: { sessionId: string }) {
 }
 
 function MessageBubble({ message }: { message: SessionMessage }) {
-  const isUser = message.direction === 'incoming';
+  const isUser = message.direction === 'inbound';
 
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -94,6 +94,28 @@ def test_get_session_detail(client: TestClient, test_contractor: ContractorData)
     assert data["messages"][1]["tool_interactions"][0]["tool"] == "save_fact"
 
 
+def test_session_direction_values(client: TestClient, test_contractor: ContractorData) -> None:
+    """API response direction values must be 'inbound'/'outbound' (not 'incoming'/'outgoing')."""
+    _create_session(
+        test_contractor,
+        "1_300",
+        [
+            {"direction": "inbound", "body": "Hi", "timestamp": "2025-01-15T10:01:00", "seq": 1},
+            {
+                "direction": "outbound",
+                "body": "Hello!",
+                "timestamp": "2025-01-15T10:02:00",
+                "seq": 2,
+            },
+        ],
+    )
+    resp = client.get("/api/contractor/sessions/1_300")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["messages"][0]["direction"] == "inbound"
+    assert data["messages"][1]["direction"] == "outbound"
+
+
 def test_get_session_not_found(client: TestClient) -> None:
     resp = client.get("/api/contractor/sessions/nonexistent")
     assert resp.status_code == 404


### PR DESCRIPTION
## Description

The backend stores message directions as `'inbound'`/`'outbound'` (via `MessageDirection` enum in `backend/app/enums.py`), but the frontend `ConversationsPage` checked for `'incoming'`, causing all messages to display on the wrong side (user messages appeared as assistant messages).

Changed `message.direction === 'incoming'` to `message.direction === 'inbound'` to match backend values.

Added a regression test that asserts the API returns `'inbound'`/`'outbound'` direction values.

Fixes #479

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implementation by Claude Code)
- [ ] No AI used