### PR TITLE
feat: add PUT endpoint for checklist items

### DIFF
--- a/backend/app/routers/contractor_checklist.py
+++ b/backend/app/routers/contractor_checklist.py
@@ -4,7 +4,11 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from backend.app.agent.file_store import ContractorData, HeartbeatStore
 from backend.app.auth.dependencies import get_current_user
-from backend.app.schemas import ChecklistCreateRequest, ChecklistItemResponse
+from backend.app.schemas import (
+    ChecklistCreateRequest,
+    ChecklistItemResponse,
+    ChecklistUpdateRequest,
+)
 
 router = APIRouter()
 
@@ -45,6 +49,31 @@ async def create_checklist_item(
         schedule=item.schedule,
         status=item.status,
         created_at=item.created_at,
+    )
+
+
+@router.put("/contractor/checklist/{item_id}", response_model=ChecklistItemResponse)
+async def update_checklist_item(
+    item_id: int,
+    body: ChecklistUpdateRequest,
+    current_user: ContractorData = Depends(get_current_user),
+) -> ChecklistItemResponse:
+    """Update a checklist item."""
+    store = HeartbeatStore(current_user.id)
+    updated = await store.update_checklist_item(
+        item_id,
+        description=body.description,
+        schedule=body.schedule,
+        status=body.status,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Checklist item not found")
+    return ChecklistItemResponse(
+        id=updated.id,
+        description=updated.description,
+        schedule=updated.schedule,
+        status=updated.status,
+        created_at=updated.created_at,
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -182,6 +182,12 @@ class ChecklistCreateRequest(BaseModel):
     schedule: str = ChecklistSchedule.DAILY
 
 
+class ChecklistUpdateRequest(BaseModel):
+    description: str | None = None
+    schedule: str | None = None
+    status: str | None = None
+
+
 class ChecklistItemResponse(BaseModel):
     id: int
     description: str

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,7 @@ import type {
   AuthUser,
   ChatResponse,
   ChecklistItem,
+  ChecklistItemUpdate,
   ContractorProfile,
   ContractorProfileUpdate,
   ContractorStats,
@@ -108,6 +109,12 @@ const api = {
   createChecklistItem: (body: { description: string; schedule?: string }) =>
     _fetch<ChecklistItem>('/api/contractor/checklist', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  updateChecklistItem: (id: number, body: ChecklistItemUpdate) =>
+    _fetch<ChecklistItem>(`/api/contractor/checklist/${id}`, {
+      method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),

--- a/frontend/src/pages/ChecklistPage.tsx
+++ b/frontend/src/pages/ChecklistPage.tsx
@@ -13,6 +13,11 @@ export default function ChecklistPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editDescription, setEditDescription] = useState('');
+  const [editSchedule, setEditSchedule] = useState('');
+  const [editStatus, setEditStatus] = useState('');
+  const [saving, setSaving] = useState(false);
 
   // New item form
   const [newDescription, setNewDescription] = useState('');
@@ -46,6 +51,31 @@ export default function ChecklistPage() {
       alert((err as Error).message);
     } finally {
       setCreating(false);
+    }
+  };
+
+  const startEditing = (item: ChecklistItem) => {
+    setEditingId(item.id);
+    setEditDescription(item.description);
+    setEditSchedule(item.schedule);
+    setEditStatus(item.status);
+  };
+
+  const handleUpdate = async () => {
+    if (editingId === null || !editDescription.trim()) return;
+    setSaving(true);
+    try {
+      const updated = await api.updateChecklistItem(editingId, {
+        description: editDescription.trim(),
+        schedule: editSchedule,
+        status: editStatus,
+      });
+      setItems((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      setEditingId(null);
+    } catch (err) {
+      alert((err as Error).message);
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -118,52 +148,112 @@ export default function ChecklistPage() {
       ) : (
         <div className="space-y-2">
           {items.map((item) => (
-            <Card key={item.id} className="flex items-center justify-between gap-3">
-              <div className="min-w-0 flex-1">
-                <p className="text-sm">{item.description}</p>
-                <div className="flex items-center gap-2 mt-1">
-                  <Badge>{item.schedule}</Badge>
-                  <Badge className={
-                    item.status === 'active'
-                      ? 'bg-success-bg text-success-text'
-                      : ''
-                  }>
-                    {item.status}
-                  </Badge>
-                  <span className="text-[10px] text-muted-foreground">
-                    Added {new Date(item.created_at).toLocaleDateString()}
-                  </span>
+            <Card key={item.id}>
+              {editingId === item.id ? (
+                <div className="space-y-2">
+                  <Input
+                    value={editDescription}
+                    onChange={(e) => setEditDescription(e.target.value)}
+                  />
+                  <div className="flex gap-2 items-end flex-wrap">
+                    <div className="w-36">
+                      <label className="text-xs font-medium text-muted-foreground block mb-1">
+                        Schedule
+                      </label>
+                      <Select
+                        value={editSchedule}
+                        onChange={(e) => setEditSchedule(e.target.value)}
+                      >
+                        <option value="daily">Daily</option>
+                        <option value="weekdays">Weekdays</option>
+                        <option value="weekly">Weekly</option>
+                        <option value="monthly">Monthly</option>
+                      </Select>
+                    </div>
+                    <div className="w-36">
+                      <label className="text-xs font-medium text-muted-foreground block mb-1">
+                        Status
+                      </label>
+                      <Select
+                        value={editStatus}
+                        onChange={(e) => setEditStatus(e.target.value)}
+                      >
+                        <option value="active">Active</option>
+                        <option value="paused">Paused</option>
+                        <option value="completed">Completed</option>
+                      </Select>
+                    </div>
+                    <div className="flex gap-1">
+                      <Button size="sm" onClick={handleUpdate} disabled={saving}>
+                        {saving ? 'Saving...' : 'Save'}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setEditingId(null)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
                 </div>
-              </div>
-              <div className="shrink-0">
-                {deleteConfirm === item.id ? (
-                  <div className="flex gap-1">
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      onClick={() => handleDelete(item.id)}
-                    >
-                      Confirm
-                    </Button>
+              ) : (
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm">{item.description}</p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <Badge>{item.schedule}</Badge>
+                      <Badge className={
+                        item.status === 'active'
+                          ? 'bg-success-bg text-success-text'
+                          : ''
+                      }>
+                        {item.status}
+                      </Badge>
+                      <span className="text-[10px] text-muted-foreground">
+                        Added {new Date(item.created_at).toLocaleDateString()}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="shrink-0 flex gap-1">
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => setDeleteConfirm(null)}
+                      onClick={() => startEditing(item)}
+                      aria-label={`Edit ${item.description}`}
                     >
-                      Cancel
+                      Edit
                     </Button>
+                    {deleteConfirm === item.id ? (
+                      <div className="flex gap-1">
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={() => handleDelete(item.id)}
+                        >
+                          Confirm
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setDeleteConfirm(null)}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDeleteConfirm(item.id)}
+                        aria-label={`Delete ${item.description}`}
+                      >
+                        Delete
+                      </Button>
+                    )}
                   </div>
-                ) : (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setDeleteConfirm(item.id)}
-                    aria-label={`Delete ${item.description}`}
-                  >
-                    Delete
-                  </Button>
-                )}
-              </div>
+                </div>
+              )}
             </Card>
           ))}
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -92,6 +92,12 @@ export interface ChecklistItem {
   created_at: string;
 }
 
+export interface ChecklistItemUpdate {
+  description?: string;
+  schedule?: string;
+  status?: string;
+}
+
 export interface ContractorStats {
   total_sessions: number;
   messages_this_month: number;

--- a/tests/test_checklist_endpoints.py
+++ b/tests/test_checklist_endpoints.py
@@ -57,3 +57,45 @@ def test_delete_checklist_item_not_found(client: TestClient) -> None:
 def test_create_checklist_empty_description(client: TestClient) -> None:
     resp = client.post("/api/contractor/checklist", json={"description": ""})
     assert resp.status_code == 422
+
+
+def test_update_checklist_item(client: TestClient) -> None:
+    resp = client.post("/api/contractor/checklist", json={"description": "Original"})
+    item_id = resp.json()["id"]
+
+    resp = client.put(
+        f"/api/contractor/checklist/{item_id}",
+        json={"description": "Updated", "schedule": "weekdays", "status": "paused"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["description"] == "Updated"
+    assert data["schedule"] == "weekdays"
+    assert data["status"] == "paused"
+
+
+def test_update_checklist_partial(client: TestClient) -> None:
+    """Only provided fields should change."""
+    resp = client.post(
+        "/api/contractor/checklist",
+        json={"description": "My task", "schedule": "daily"},
+    )
+    item_id = resp.json()["id"]
+
+    resp = client.put(
+        f"/api/contractor/checklist/{item_id}",
+        json={"status": "completed"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["description"] == "My task"
+    assert data["schedule"] == "daily"
+    assert data["status"] == "completed"
+
+
+def test_update_checklist_not_found(client: TestClient) -> None:
+    resp = client.put(
+        "/api/contractor/checklist/9999",
+        json={"description": "nope"},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Description
Add PUT `/api/contractor/checklist/{item_id}` endpoint so dashboard users can update checklist item description, schedule, and status. Includes:
- `ChecklistUpdateRequest` Pydantic schema with optional `description`, `schedule`, `status` fields
- PUT endpoint in `contractor_checklist.py` using existing `HeartbeatStore.update_checklist_item()`
- Frontend `updateChecklistItem()` API method and `ChecklistItemUpdate` type
- Inline edit UI on ChecklistPage with description, schedule, and status controls
- 3 new backend tests: full update, partial update, not-found

Fixes #480

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the full feature end-to-end)
- [ ] No AI used