### PR TITLE
feat: editable Telegram bot token in dashboard Channels tab

### DIFF
--- a/backend/app/routers/contractor_profile.py
+++ b/backend/app/routers/contractor_profile.py
@@ -1,10 +1,18 @@
 """Endpoints for contractor profile management."""
 
+from pathlib import Path
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from backend.app.agent.file_store import ContractorData, get_contractor_store
 from backend.app.auth.dependencies import get_current_user
-from backend.app.schemas import ContractorProfileResponse, ContractorProfileUpdate
+from backend.app.config import settings
+from backend.app.schemas import (
+    ChannelConfigResponse,
+    ChannelConfigUpdate,
+    ContractorProfileResponse,
+    ContractorProfileUpdate,
+)
 
 router = APIRouter()
 
@@ -57,3 +65,68 @@ async def update_profile(
         raise HTTPException(status_code=404, detail="Contractor not found")
 
     return _profile_response(updated)
+
+
+# ---------------------------------------------------------------------------
+# Channel config
+# ---------------------------------------------------------------------------
+
+_ENV_KEY_MAP: dict[str, str] = {
+    "telegram_bot_token": "TELEGRAM_BOT_TOKEN",
+    "telegram_allowed_usernames": "TELEGRAM_ALLOWED_USERNAMES",
+}
+
+
+def _build_channel_config_response() -> ChannelConfigResponse:
+    return ChannelConfigResponse(
+        telegram_bot_token_set=bool(settings.telegram_bot_token),
+        telegram_allowed_usernames=settings.telegram_allowed_usernames,
+    )
+
+
+@router.get("/contractor/channels/config", response_model=ChannelConfigResponse)
+async def get_channel_config(
+    _current_user: ContractorData = Depends(get_current_user),
+) -> ChannelConfigResponse:
+    """Return server-level channel configuration."""
+    return _build_channel_config_response()
+
+
+@router.put("/contractor/channels/config", response_model=ChannelConfigResponse)
+async def update_channel_config(
+    body: ChannelConfigUpdate,
+    _current_user: ContractorData = Depends(get_current_user),
+) -> ChannelConfigResponse:
+    """Update server-level channel configuration."""
+    updates = body.model_dump(exclude_unset=True)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    env_path = Path(".env")
+    env_exists = env_path.is_file()
+
+    for field, value in updates.items():
+        str_value = value or ""
+        # Update the in-memory settings singleton
+        setattr(settings, field, str_value)
+
+        # Persist to .env if it exists
+        if env_exists:
+            from dotenv import set_key
+
+            set_key(str(env_path), _ENV_KEY_MAP[field], str_value)
+
+    # If the bot token changed, reset the live TelegramChannel instance
+    if "telegram_bot_token" in updates:
+        try:
+            from backend.app.channels import get_channel
+            from backend.app.channels.telegram import TelegramChannel
+
+            channel = get_channel("telegram")
+            if isinstance(channel, TelegramChannel):
+                channel._token = settings.telegram_bot_token
+                channel._bot = None
+        except KeyError:
+            pass
+
+    return _build_channel_config_response()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -207,3 +207,18 @@ class ContractorStatsResponse(BaseModel):
     active_checklist_items: int
     total_memory_facts: int
     last_conversation_at: str | None
+
+
+# ---------------------------------------------------------------------------
+# Channel config (dashboard)
+# ---------------------------------------------------------------------------
+
+
+class ChannelConfigResponse(BaseModel):
+    telegram_bot_token_set: bool
+    telegram_allowed_usernames: str
+
+
+class ChannelConfigUpdate(BaseModel):
+    telegram_bot_token: str | None = None
+    telegram_allowed_usernames: str | None = None

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,8 @@
 import type {
   AuthConfig,
   AuthUser,
+  ChannelConfig,
+  ChannelConfigUpdate,
   ChatResponse,
   ChecklistItem,
   ChecklistItemUpdate,
@@ -120,6 +122,15 @@ const api = {
     }),
   deleteChecklistItem: (id: number) =>
     _fetchVoid(`/api/contractor/checklist/${id}`, { method: 'DELETE' }),
+
+  // Channel config
+  getChannelConfig: () => _fetch<ChannelConfig>('/api/contractor/channels/config'),
+  updateChannelConfig: (body: ChannelConfigUpdate) =>
+    _fetch<ChannelConfig>('/api/contractor/channels/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
 
   // Stats
   getStats: () => _fetch<ContractorStats>('/api/contractor/stats'),

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useOutletContext, useParams, useNavigate } from 'react-router-dom';
 import Card from '@/components/ui/card';
 import Input from '@/components/ui/input';
@@ -8,7 +8,7 @@ import Select from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { toast } from 'sonner';
 import api from '@/api';
-import type { ContractorProfileUpdate } from '@/types';
+import type { ChannelConfig, ContractorProfileUpdate } from '@/types';
 import type { AppShellContext } from '@/layouts/AppShell';
 import {
   getExtraSettingsTabs,
@@ -316,11 +316,91 @@ function ChannelsTab({
   profile: { channel_identifier: string; preferred_channel: string };
 }) {
   const connected = !!profile.channel_identifier;
+  const [config, setConfig] = useState<ChannelConfig | null>(null);
+  const [botToken, setBotToken] = useState('');
+  const [allowedUsernames, setAllowedUsernames] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    api.getChannelConfig().then((cfg) => {
+      setConfig(cfg);
+      setAllowedUsernames(cfg.telegram_allowed_usernames);
+    }).catch(() => {
+      // ignore fetch errors on mount
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const body: Record<string, string> = {};
+      if (botToken) body.telegram_bot_token = botToken;
+      if (config && allowedUsernames !== config.telegram_allowed_usernames) {
+        body.telegram_allowed_usernames = allowedUsernames;
+      }
+      if (Object.keys(body).length === 0) {
+        toast.error('No changes to save');
+        setSaving(false);
+        return;
+      }
+      const updated = await api.updateChannelConfig(body);
+      setConfig(updated);
+      setBotToken('');
+      toast.success('Channel config updated');
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [botToken, allowedUsernames, config]);
 
   return (
     <Card>
       <div className="grid gap-4">
-        <Field label="Telegram">
+        <Field label="Bot Token">
+          {config === null ? (
+            <p className="text-sm text-muted-foreground">Loading...</p>
+          ) : (
+            <>
+              <div className="mb-2">
+                {config.telegram_bot_token_set ? (
+                  <span className="inline-flex items-center gap-1.5 text-sm">
+                    <span className="w-2 h-2 rounded-full bg-green-500 inline-block" />
+                    Configured
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 text-sm">
+                    <span className="w-2 h-2 rounded-full bg-red-500 inline-block" />
+                    Not configured
+                  </span>
+                )}
+              </div>
+              <Input
+                type="password"
+                value={botToken}
+                onChange={(e) => setBotToken(e.target.value)}
+                placeholder={config.telegram_bot_token_set ? 'Enter new token to replace' : 'Paste bot token from @BotFather'}
+              />
+            </>
+          )}
+        </Field>
+        <Field label="Allowed Usernames">
+          <Input
+            value={allowedUsernames}
+            onChange={(e) => setAllowedUsernames(e.target.value)}
+            placeholder='Comma-separated @usernames, or * for all'
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Controls which Telegram users can message your bot.
+          </p>
+        </Field>
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={saving || config === null}>
+            {saving ? 'Saving...' : 'Save Channel Config'}
+          </Button>
+        </div>
+        <hr className="border-border" />
+        <Field label="User Connection">
           {connected ? (
             <div className="flex items-center gap-2">
               <span className="inline-flex items-center gap-1.5 text-sm">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -123,3 +123,13 @@ export interface ChatResponse {
   reply: string;
   session_id: string;
 }
+
+export interface ChannelConfig {
+  telegram_bot_token_set: boolean;
+  telegram_allowed_usernames: string;
+}
+
+export interface ChannelConfigUpdate {
+  telegram_bot_token?: string;
+  telegram_allowed_usernames?: string;
+}

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -1,0 +1,104 @@
+"""Tests for channel config GET/PUT endpoints."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.config import settings
+
+
+@pytest.fixture()
+def _set_bot_token() -> None:
+    """Ensure settings has a known bot token for tests that need it."""
+    original = settings.telegram_bot_token
+    settings.telegram_bot_token = "test-token-123"
+    yield  # type: ignore[misc]
+    settings.telegram_bot_token = original
+
+
+@pytest.fixture()
+def _clear_bot_token() -> None:
+    """Ensure settings has no bot token."""
+    original = settings.telegram_bot_token
+    settings.telegram_bot_token = ""
+    yield  # type: ignore[misc]
+    settings.telegram_bot_token = original
+
+
+def test_get_channel_config_token_set(client: TestClient, _set_bot_token: None) -> None:
+    """GET returns telegram_bot_token_set=True when token is configured."""
+    resp = client.get("/api/contractor/channels/config")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["telegram_bot_token_set"] is True
+    # Should never leak the actual token
+    assert "test-token-123" not in str(data)
+
+
+def test_get_channel_config_token_not_set(client: TestClient, _clear_bot_token: None) -> None:
+    """GET returns telegram_bot_token_set=False when token is empty."""
+    resp = client.get("/api/contractor/channels/config")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["telegram_bot_token_set"] is False
+
+
+def test_update_channel_config_token(client: TestClient, _clear_bot_token: None) -> None:
+    """PUT with a new token updates settings in-memory and GET reflects change."""
+    resp = client.put(
+        "/api/contractor/channels/config",
+        json={"telegram_bot_token": "new-bot-token-456"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["telegram_bot_token_set"] is True
+
+    # Verify settings updated in-memory
+    assert settings.telegram_bot_token == "new-bot-token-456"
+
+    # GET should also reflect the change
+    resp2 = client.get("/api/contractor/channels/config")
+    assert resp2.json()["telegram_bot_token_set"] is True
+
+    # Clean up
+    settings.telegram_bot_token = ""
+
+
+def test_update_channel_config_persists_to_dotenv(
+    client: TestClient, tmp_path: Path, _clear_bot_token: None
+) -> None:
+    """PUT with a token writes to .env file when it exists."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("# existing config\n")
+
+    with patch(
+        "backend.app.routers.contractor_profile.Path",
+        return_value=env_file,
+    ):
+        resp = client.put(
+            "/api/contractor/channels/config",
+            json={"telegram_bot_token": "persisted-token"},
+        )
+
+    assert resp.status_code == 200
+    env_content = env_file.read_text()
+    assert "TELEGRAM_BOT_TOKEN" in env_content
+    assert "persisted-token" in env_content
+
+    # Clean up
+    settings.telegram_bot_token = ""
+
+
+def test_update_channel_config_null_token_coerced_to_empty(
+    client: TestClient, _set_bot_token: None
+) -> None:
+    """PUT with null token should coerce to empty string, not set None."""
+    resp = client.put(
+        "/api/contractor/channels/config",
+        json={"telegram_bot_token": None},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["telegram_bot_token_set"] is False
+    assert settings.telegram_bot_token == ""


### PR DESCRIPTION
## Summary
- Adds GET/PUT `/contractor/channels/config` endpoints to view/update Telegram bot token and allowed usernames from the dashboard
- Updates the Channels tab UI with bot token status badge, password input for token, and allowed usernames field
- Changes persist to `.env` and reset the live TelegramChannel instance (no restart needed)
- Null values coerced to empty strings to prevent runtime errors

## Test plan
- [x] 5 new tests in `tests/test_channel_config.py` (GET with/without token, PUT in-memory update, PUT .env persistence, null coercion)
- [x] All 892 existing tests pass
- [x] ruff lint/format clean
- [x] ty type check clean
- [x] TypeScript `tsc --noEmit` and `vite build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)