### PR TITLE
fix: prevent iOS Safari zoom on chat submit

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -152,7 +152,11 @@ export default function ChatPage() {
       toast.error(msg);
     } finally {
       setSending(false);
-      inputRef.current?.focus();
+      // Re-focus input on desktop only; on mobile, programmatic focus
+      // triggers iOS Safari auto-zoom and forces the keyboard open.
+      if (window.matchMedia('(min-width: 640px)').matches) {
+        inputRef.current?.focus();
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- After sending a chat message, `inputRef.current?.focus()` programmatically re-focuses the text input. On iOS Safari this triggers auto-zoom and forces the keyboard open, causing the "zoomed in" issue on mobile.
- Fix: skip auto-refocus on viewports narrower than 640px (the `sm:` Tailwind breakpoint). Desktop auto-refocus for quick follow-up typing is preserved.

## Test plan

- [ ] On iPhone/iOS Safari: send a message in the chat, verify the screen does not zoom in after the reply arrives
- [ ] On desktop: send a message, verify the input is still auto-focused for typing the next message
- [x] `npx tsc --noEmit` passes
- [x] `npx vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)