### PR TITLE
fix: prevent iOS Safari zoom on chat message send

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -119,4 +119,13 @@
       font-size: 16px;
     }
   }
+
+  /* Prevent double-tap-to-zoom on interactive elements (iOS Safari) */
+  button,
+  input,
+  select,
+  textarea,
+  a {
+    touch-action: manipulation;
+  }
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -35,18 +35,34 @@ export default function ChatPage() {
   const [loadingSessions, setLoadingSessions] = useState(true);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const nextId = useRef(1);
 
+  // Use scrollTop instead of scrollIntoView to avoid iOS Safari viewport zoom
+  // bug that occurs when scrollIntoView fires during keyboard dismissal.
   const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const el = scrollContainerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
   }, []);
 
   useEffect(() => {
     scrollToBottom();
   }, [messages, scrollToBottom]);
+
+  // Prevent iOS Safari auto-zoom on input focus. Since iOS 10, maximum-scale=1
+  // only blocks automatic zoom (not user pinch-zoom), so accessibility is preserved.
+  // Applied only on iOS to avoid disabling pinch-zoom on Android.
+  useEffect(() => {
+    if (!/iPhone|iPad|iPod/.test(navigator.userAgent)) return;
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    if (meta && !meta.content.includes('maximum-scale')) {
+      meta.setAttribute('content', meta.content + ', maximum-scale=1');
+    }
+  }, []);
 
   // Load recent sessions for the selector
   useEffect(() => {
@@ -179,7 +195,7 @@ export default function ChatPage() {
             <select
               value={activeSessionId ?? '__new__'}
               onChange={(e) => handleSessionChange(e.target.value)}
-              className="px-2 py-1.5 text-xs bg-card border border-border rounded-[--radius-md] text-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-colors max-w-[200px]"
+              className="px-2 py-1.5 text-base sm:text-xs bg-card border border-border rounded-[--radius-md] text-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-colors max-w-[200px]"
             >
               <option value="__new__">New conversation</option>
               {sessions.map((s) => (
@@ -195,7 +211,7 @@ export default function ChatPage() {
       </div>
 
       {/* Messages area */}
-      <div className="flex-1 overflow-y-auto min-h-0 pb-4">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto min-h-0 pb-4">
         {loadingHistory ? (
           <div className="flex justify-center py-12"><Spinner /></div>
         ) : messages.length === 0 ? (
@@ -270,8 +286,6 @@ export default function ChatPage() {
                 </div>
               </div>
             )}
-
-            <div ref={messagesEndRef} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Replace `scrollIntoView` with direct `scrollTop` manipulation to avoid iOS Safari viewport zoom bug triggered when `scrollIntoView` fires during keyboard dismissal
- Add iOS-only `maximum-scale=1` viewport meta tag (since iOS 10, this only blocks automatic zoom, not user pinch-zoom, so accessibility is preserved)
- Fix session `<select>` font-size from `text-xs` (12px) to `text-base sm:text-xs` (16px on mobile) to stay above the 16px auto-zoom threshold
- Add `touch-action: manipulation` globally on interactive elements to prevent double-tap-to-zoom
- Remove dead `messagesEndRef` ref and sentinel div that were only used by the old `scrollIntoView` approach

## Checklist
- [x] Tests pass
- [x] Lint passes
- [x] Build passes

## Test plan
- [ ] On iPhone Safari, open the chat page and send a message: screen should NOT zoom in
- [ ] Verify the keyboard dismisses cleanly after tapping Send without viewport jumping
- [ ] Tap the session selector dropdown on mobile: should NOT trigger zoom
- [ ] Double-tap the Send button quickly: should NOT zoom the page
- [ ] On desktop, verify auto-refocus into the input still works after sending
- [ ] Verify pinch-to-zoom still works on iOS (accessibility preserved)
- [ ] Verify Android browsers are not affected (no zoom restrictions applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)