### PR TITLE
feat: add USER.md support for user profile context

### DIFF
--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -14,6 +14,7 @@ Storage layout::
         {contractor_id}/
           contractor.json
           SOUL.md
+          USER.md
           memory/
             MEMORY.md
             HISTORY.md
@@ -65,6 +66,7 @@ class ContractorData(BaseModel):
     location: str = ""
     hourly_rate: float | None = None
     soul_text: str = ""
+    user_text: str = ""
     business_hours: str = ""
     timezone: str = ""
     preferred_channel: str = "telegram"
@@ -352,10 +354,16 @@ class ContractorStore:
         soul_path = _contractor_dir(contractor_id) / "SOUL.md"
         if soul_path.exists():
             raw = soul_path.read_text(encoding="utf-8").strip()
-            # Strip the "# Soul" header if present
             if raw.startswith("# Soul"):
                 raw = raw[len("# Soul") :].strip()
             contractor.soul_text = raw
+        # Load user_text from USER.md
+        user_path = _contractor_dir(contractor_id) / "USER.md"
+        if user_path.exists():
+            raw = user_path.read_text(encoding="utf-8").strip()
+            if raw.startswith("# User"):
+                raw = raw[len("# User") :].strip()
+            contractor.user_text = raw
         return contractor
 
     def _save(self, contractor: ContractorData) -> None:
@@ -363,9 +371,10 @@ class ContractorStore:
         cdir = _contractor_dir(contractor.id)
         cdir.mkdir(parents=True, exist_ok=True)
 
-        # Save contractor.json (exclude soul_text, it goes to SOUL.md)
+        # Save contractor.json (exclude soul_text/user_text, they go to .md files)
         data = contractor.model_dump()
         soul_text = data.pop("soul_text", "")
+        user_text = data.pop("user_text", "")
         _write_json(cdir / "contractor.json", data)
 
         # Save SOUL.md
@@ -376,6 +385,16 @@ class ContractorStore:
             # Seed a meaningful default for brand-new contractors
             soul_path.write_text(
                 f"# Soul\n\n{load_prompt('default_soul')}\n",
+                encoding="utf-8",
+            )
+
+        # Save USER.md
+        user_path = cdir / "USER.md"
+        if user_text:
+            user_path.write_text(f"# User\n\n{user_text}\n", encoding="utf-8")
+        elif not user_path.exists():
+            user_path.write_text(
+                f"# User\n\n{load_prompt('default_user')}\n",
                 encoding="utf-8",
             )
 
@@ -668,6 +687,24 @@ class FileMemoryStore:
         """Write SOUL.md content."""
         self._soul_path.parent.mkdir(parents=True, exist_ok=True)
         self._soul_path.write_text(f"# Soul\n\n{content}\n", encoding="utf-8")
+
+    @property
+    def _user_path(self) -> Path:
+        return _contractor_dir(self.contractor_id) / "USER.md"
+
+    def read_user(self) -> str:
+        """Read USER.md content."""
+        if not self._user_path.exists():
+            return ""
+        raw = self._user_path.read_text(encoding="utf-8").strip()
+        if raw.startswith("# User"):
+            raw = raw[len("# User") :].strip()
+        return raw
+
+    def write_user(self, content: str) -> None:
+        """Write USER.md content."""
+        self._user_path.parent.mkdir(parents=True, exist_ok=True)
+        self._user_path.write_text(f"# User\n\n{content}\n", encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/profile.py
+++ b/backend/app/agent/profile.py
@@ -101,6 +101,7 @@ async def update_contractor_profile(
         "location",
         "hourly_rate",
         "soul_text",
+        "user_text",
         "business_hours",
         "timezone",
         "preferences_json",

--- a/backend/app/agent/prompts/default_user.md
+++ b/backend/app/agent/prompts/default_user.md
@@ -1,0 +1,9 @@
+Learn about the person you're helping. Update this as you go.
+
+- Name:
+- What to call them:
+- Timezone:
+- Notes:
+
+Context: what do they care about? What projects are they working on?
+What are their preferences? Build this over time.

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -72,6 +72,11 @@ def build_identity_section(contractor: ContractorData) -> str:
     return build_soul_prompt(contractor)
 
 
+def build_user_section(contractor: ContractorData) -> str:
+    """Build the user profile section from USER.md content."""
+    return contractor.user_text or ""
+
+
 async def build_memory_section(
     contractor_id: int,
     query: str | None = None,
@@ -175,6 +180,8 @@ async def build_agent_system_prompt(
         build_identity_section(contractor),
     )
 
+    builder.add_section("About Your User", build_user_section(contractor))
+
     memory = await build_memory_section(contractor.id, query=message_context)
     builder.add_section("Your Memory", memory)
 
@@ -209,6 +216,7 @@ async def build_heartbeat_system_prompt(
     builder.set_preamble(load_prompt("heartbeat_preamble"))
 
     builder.add_section("About the contractor", build_identity_section(contractor))
+    builder.add_section("About the user", build_user_section(contractor))
 
     memory = await build_memory_section(contractor.id)
     builder.add_section("Contractor's memory", memory)

--- a/backend/app/routers/contractor_profile.py
+++ b/backend/app/routers/contractor_profile.py
@@ -30,6 +30,7 @@ def _profile_response(c: ContractorData) -> ContractorProfileResponse:
         timezone=c.timezone,
         assistant_name=c.assistant_name,
         soul_text=c.soul_text,
+        user_text=c.user_text,
         preferred_channel=c.preferred_channel,
         channel_identifier=c.channel_identifier,
         heartbeat_opt_in=c.heartbeat_opt_in,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -94,6 +94,7 @@ class ContractorProfileResponse(BaseModel):
     timezone: str
     assistant_name: str
     soul_text: str
+    user_text: str
     preferred_channel: str
     channel_identifier: str
     heartbeat_opt_in: bool
@@ -114,6 +115,7 @@ class ContractorProfileUpdate(BaseModel):
     timezone: str | None = None
     assistant_name: str | None = None
     soul_text: str | None = None
+    user_text: str | None = None
     heartbeat_opt_in: bool | None = None
     heartbeat_frequency: str | None = None
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -230,12 +230,13 @@ function AssistantTab({
   profile,
   onSaved,
 }: {
-  profile: { assistant_name: string; soul_text: string };
+  profile: { assistant_name: string; soul_text: string; user_text: string };
   onSaved: () => void;
 }) {
   const [form, setForm] = useState({
     assistant_name: profile.assistant_name,
     soul_text: profile.soul_text,
+    user_text: profile.user_text,
   });
   const [saving, setSaving] = useState(false);
 
@@ -245,6 +246,7 @@ function AssistantTab({
       await api.updateProfile({
         assistant_name: form.assistant_name,
         soul_text: form.soul_text,
+        user_text: form.user_text,
       });
       onSaved();
       toast.success('Assistant settings updated');
@@ -274,6 +276,17 @@ function AssistantTab({
           />
           <p className="text-xs text-muted-foreground mt-1">
             This guides your assistant's personality and communication style.
+          </p>
+        </Field>
+        <Field label="About You / USER">
+          <Textarea
+            value={form.user_text}
+            onChange={(e) => setForm((prev) => ({ ...prev, user_text: e.target.value }))}
+            rows={6}
+            placeholder="Tell your assistant about yourself: your name, preferences, what projects you're working on..."
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Helps your assistant personalize responses. Updated over time as it learns about you.
           </p>
         </Field>
         <div className="flex justify-end">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,6 +12,7 @@ export interface ContractorProfile {
   timezone: string;
   assistant_name: string;
   soul_text: string;
+  user_text: string;
   preferred_channel: string;
   channel_identifier: string;
   heartbeat_opt_in: boolean;
@@ -32,6 +33,7 @@ export interface ContractorProfileUpdate {
   timezone?: string;
   assistant_name?: string;
   soul_text?: string;
+  user_text?: string;
   heartbeat_opt_in?: boolean;
   heartbeat_frequency?: string;
 }


### PR DESCRIPTION
## Description

Add USER.md support following OpenClaw's SOUL.md/USER.md pattern. Contractors can now write free-form notes about themselves that the assistant uses to personalize responses. USER.md is stored alongside SOUL.md in the contractor's data directory and injected into the system prompt.

Changes:
- **file_store.py**: Load/save USER.md, add `user_text` field to `ContractorData`, add `read_user()`/`write_user()` to `FileMemoryStore`
- **schemas.py**: Add `user_text` to profile response and update schemas
- **contractor_profile.py**: Include `user_text` in profile API response
- **profile.py**: Allow `user_text` in profile updates
- **system_prompt.py**: Add "About Your User" section to agent and heartbeat prompts
- **default_user.md**: Default template for new USER.md files
- **SettingsPage.tsx**: Add "About You / USER" textarea to Assistant settings tab
- **types.ts**: Add `user_text` to TypeScript interfaces

Fixes #496

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used