### PR TITLE
fix: skip null values in channel config update to prevent token erasure

### DIFF
--- a/backend/app/routers/contractor_profile.py
+++ b/backend/app/routers/contractor_profile.py
@@ -99,7 +99,7 @@ async def update_channel_config(
     _current_user: ContractorData = Depends(get_current_user),
 ) -> ChannelConfigResponse:
     """Update server-level channel configuration."""
-    updates = body.model_dump(exclude_unset=True)
+    updates = {k: v for k, v in body.model_dump(exclude_unset=True).items() if v is not None}
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
 
@@ -107,15 +107,14 @@ async def update_channel_config(
     env_exists = env_path.is_file()
 
     for field, value in updates.items():
-        str_value = value or ""
         # Update the in-memory settings singleton
-        setattr(settings, field, str_value)
+        setattr(settings, field, value)
 
         # Persist to .env if it exists
         if env_exists:
             from dotenv import set_key
 
-            set_key(str(env_path), _ENV_KEY_MAP[field], str_value)
+            set_key(str(env_path), _ENV_KEY_MAP[field], value)
 
     # If the bot token changed, reset the live TelegramChannel instance
     if "telegram_bot_token" in updates:

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -92,13 +92,38 @@ def test_update_channel_config_persists_to_dotenv(
     settings.telegram_bot_token = ""
 
 
-def test_update_channel_config_null_token_coerced_to_empty(
+def test_update_channel_config_null_token_is_ignored(
     client: TestClient, _set_bot_token: None
 ) -> None:
-    """PUT with null token should coerce to empty string, not set None."""
+    """PUT with null token should be ignored, preserving the existing value."""
+    resp = client.put(
+        "/api/contractor/channels/config",
+        json={"telegram_bot_token": None, "telegram_allowed_usernames": "user1"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["telegram_bot_token_set"] is True
+    assert settings.telegram_bot_token == "test-token-123"
+
+
+def test_update_channel_config_null_only_returns_400(
+    client: TestClient, _set_bot_token: None
+) -> None:
+    """PUT with only null fields should return 400 (no effective updates)."""
     resp = client.put(
         "/api/contractor/channels/config",
         json={"telegram_bot_token": None},
+    )
+    assert resp.status_code == 400
+    assert settings.telegram_bot_token == "test-token-123"
+
+
+def test_update_channel_config_empty_string_clears_token(
+    client: TestClient, _set_bot_token: None
+) -> None:
+    """PUT with empty string explicitly clears the token."""
+    resp = client.put(
+        "/api/contractor/channels/config",
+        json={"telegram_bot_token": ""},
     )
     assert resp.status_code == 200
     assert resp.json()["telegram_bot_token_set"] is False


### PR DESCRIPTION
## Description
The `PUT /api/contractor/channels/config` endpoint coerced `null` field values to empty strings and wrote them to `.env` via `dotenv.set_key()`. This silently overwrote the real `TELEGRAM_BOT_TOKEN` whenever a client included the field as `null` in its payload (e.g. when only updating `telegram_allowed_usernames`).

The fix filters out `None` values before processing, so `null` means "don't change this field." Explicit empty string (`""`) still clears the field intentionally.

Fixes mozilla-ai/clawbolt-premium#77

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- 904 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude Code identified the root cause by searching for all code that writes to `.env` files, then implemented the fix and regression tests.