### PR TITLE
fix: link Telegram channel to existing contractor in single-tenant mode

### DIFF
--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -418,6 +418,14 @@ class ContractorStore:
             index[key] = contractor.id
         _write_json(idx_path, index)
 
+    def link_channel(self, channel: str, channel_identifier: str, contractor_id: int) -> None:
+        """Add a channel mapping to the index for an existing contractor."""
+        idx_path = _index_path()
+        index: dict[str, int] = _read_json(idx_path, {})
+        key = f"{channel}:{channel_identifier}"
+        index[key] = contractor_id
+        _write_json(idx_path, index)
+
     def _next_contractor_id(self) -> int:
         """Get the next contractor ID by scanning existing directories."""
         dirs = self._all_dirs()

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -51,15 +51,30 @@ class InboundMessage:
 
 
 async def _get_or_create_contractor(channel: str, sender_id: str) -> ContractorData:
-    """Look up or create a contractor by channel-specific sender ID."""
+    """Look up or create a contractor by channel-specific sender ID.
+
+    In single-tenant (OSS) mode there should be exactly one contractor shared
+    across all channels.  When a new channel arrives and a contractor already
+    exists, link the channel to that contractor instead of creating a duplicate.
+    """
     store = get_contractor_store()
     contractor = await store.get_by_channel(sender_id)
-    if contractor is None:
-        contractor = await store.create(
-            user_id=f"{channel}_{sender_id}",
-            channel_identifier=sender_id,
-            preferred_channel=channel,
-        )
+    if contractor is not None:
+        return contractor
+
+    # Reuse the sole existing contractor (single-tenant OSS) so sessions from
+    # every channel are visible in the dashboard.
+    all_contractors = await store.list_all()
+    if len(all_contractors) == 1:
+        contractor = all_contractors[0]
+        store.link_channel(channel, sender_id, contractor.id)
+        return contractor
+
+    contractor = await store.create(
+        user_id=f"{channel}_{sender_id}",
+        channel_identifier=sender_id,
+        preferred_channel=channel,
+    )
     return contractor
 
 

--- a/tests/integration/test_dashboard_telegram.py
+++ b/tests/integration/test_dashboard_telegram.py
@@ -4,10 +4,16 @@ Regression test for https://github.com/mozilla-ai/clawbolt/issues/475.
 Previously, `get_current_user` always created a new `local@clawbolt.local`
 contractor, so the dashboard never showed data from Telegram sessions.
 
+Regression test for https://github.com/mozilla-ai/clawbolt/issues/499.
+When a web-created contractor exists and Telegram messages arrive, the
+Telegram channel must be linked to the same contractor so sessions appear
+in the dashboard.
+
 These tests use a TestClient that does NOT override `get_current_user`,
 exercising the real auth dependency against a pre-populated store.
 """
 
+import asyncio
 import json
 from collections.abc import Generator
 from pathlib import Path
@@ -17,6 +23,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.ingestion import _get_or_create_contractor
 from backend.app.config import settings
 from backend.app.main import app
 
@@ -180,3 +187,86 @@ class TestDashboardSeesTelegramData:
         data = resp.json()
         assert data["total_sessions"] == 1
         assert data["total_memory_facts"] == 2
+
+
+class TestMultiChannelSingleTenant:
+    """Telegram messages reuse an existing web-created contractor.
+
+    Regression test for https://github.com/mozilla-ai/clawbolt/issues/499.
+    """
+
+    def test_telegram_links_to_existing_web_contractor(self) -> None:
+        """When a web-created contractor exists, Telegram reuses it."""
+        store = get_contractor_store()
+        web_contractor = asyncio.get_event_loop().run_until_complete(
+            store.create(user_id="local@clawbolt.local", name="Web User")
+        )
+
+        tg_contractor = asyncio.get_event_loop().run_until_complete(
+            _get_or_create_contractor("telegram", "99887766")
+        )
+
+        assert tg_contractor.id == web_contractor.id
+
+    def test_telegram_sessions_visible_in_dashboard_after_web_signup(self) -> None:
+        """Sessions created via Telegram appear in dashboard when web created first."""
+        store = get_contractor_store()
+        web_contractor = asyncio.get_event_loop().run_until_complete(
+            store.create(user_id="local@clawbolt.local", name="Web User")
+        )
+
+        # Simulate Telegram ingestion linking to the same contractor
+        tg_contractor = asyncio.get_event_loop().run_until_complete(
+            _get_or_create_contractor("telegram", "55544433")
+        )
+        assert tg_contractor.id == web_contractor.id
+
+        # Create a session under the (shared) contractor
+        _create_session(
+            tg_contractor,
+            f"{tg_contractor.id}_500",
+            [
+                {
+                    "direction": "inbound",
+                    "body": "Hey from Telegram",
+                    "timestamp": "2025-06-01T12:00:00",
+                    "seq": 1,
+                },
+            ],
+        )
+
+        # Dashboard (real auth, no override) should see the session
+        with (
+            patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
+            patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+            patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+            patch("backend.app.channels.telegram.settings.telegram_bot_token", ""),
+            patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
+            TestClient(app) as c,
+        ):
+            resp = c.get("/api/contractor/sessions")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["total"] == 1
+            assert data["sessions"][0]["id"] == f"{tg_contractor.id}_500"
+
+    def test_subsequent_telegram_lookup_uses_index(self) -> None:
+        """After linking, future messages find the contractor via the index."""
+        store = get_contractor_store()
+        asyncio.get_event_loop().run_until_complete(
+            store.create(user_id="local@clawbolt.local", name="Web User")
+        )
+
+        # First call links the channel
+        first = asyncio.get_event_loop().run_until_complete(
+            _get_or_create_contractor("telegram", "11122233")
+        )
+        # Second call should find via index
+        second = asyncio.get_event_loop().run_until_complete(
+            _get_or_create_contractor("telegram", "11122233")
+        )
+        assert first.id == second.id
+
+        # Verify only one contractor exists
+        all_contractors = asyncio.get_event_loop().run_until_complete(store.list_all())
+        assert len(all_contractors) == 1


### PR DESCRIPTION
## Description

When the web UI creates a contractor first and Telegram messages arrive later, `_get_or_create_contractor` would create a second contractor because the channel lookup found no match. The dashboard only shows sessions for the first contractor, so Telegram sessions were invisible.

Now, when the channel lookup fails and exactly one contractor exists (single-tenant OSS), the new channel is linked to that existing contractor via the index instead of creating a duplicate.

Fixes #499

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the fix and regression tests)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)