### PR TITLE
fix: add restart policy to tunnel service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,6 @@ services:
   tunnel:
     image: cloudflare/cloudflared:latest
     command: tunnel --no-autoupdate --url http://app:8000 --metrics 0.0.0.0:2000
+    restart: on-failure:5
     depends_on:
       - app


### PR DESCRIPTION
## Summary

- Adds `restart: on-failure:5` to the tunnel service in `docker-compose.yml`
- Docker will retry with exponential backoff (100ms, 200ms, 400ms...) up to 5 times when `trycloudflare.com` returns transient errors (e.g. Cloudflare Worker 500s)
- Prevents the tunnel from staying dead for the entire session after a single API failure

Closes #504

## Test plan

- [ ] `docker compose up` with tunnel service — verify it starts normally
- [ ] Simulate tunnel failure (e.g. block `api.trycloudflare.com`) and confirm container restarts up to 5 times
- [ ] Verify app container continues to function when tunnel is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)