### PR TITLE
fix: persist channel_identifier when linking Telegram to existing contractor

### DIFF
--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -68,7 +68,12 @@ async def _get_or_create_contractor(channel: str, sender_id: str) -> ContractorD
     if len(all_contractors) == 1:
         contractor = all_contractors[0]
         store.link_channel(channel, sender_id, contractor.id)
-        return contractor
+        contractor = await store.update(
+            contractor.id,
+            channel_identifier=sender_id,
+            preferred_channel=channel,
+        )
+        return contractor  # type: ignore[return-value]
 
     contractor = await store.create(
         user_id=f"{channel}_{sender_id}",

--- a/tests/integration/test_dashboard_telegram.py
+++ b/tests/integration/test_dashboard_telegram.py
@@ -208,6 +208,20 @@ class TestMultiChannelSingleTenant:
 
         assert tg_contractor.id == web_contractor.id
 
+    def test_telegram_link_sets_channel_identifier(self) -> None:
+        """Linking a Telegram chat to an existing contractor persists channel_identifier."""
+        store = get_contractor_store()
+        asyncio.get_event_loop().run_until_complete(
+            store.create(user_id="local@clawbolt.local", name="Web User")
+        )
+
+        tg_contractor = asyncio.get_event_loop().run_until_complete(
+            _get_or_create_contractor("telegram", "11223344")
+        )
+
+        assert tg_contractor.channel_identifier == "11223344"
+        assert tg_contractor.preferred_channel == "telegram"
+
     def test_telegram_sessions_visible_in_dashboard_after_web_signup(self) -> None:
         """Sessions created via Telegram appear in dashboard when web created first."""
         store = get_contractor_store()


### PR DESCRIPTION
## Summary

- When a Telegram message arrives and a single contractor already exists (typical OSS single-tenant setup), `_get_or_create_contractor()` called `link_channel()` which updated the index file but did **not** persist `channel_identifier` on the contractor record
- The router then failed with: `Contractor X has no channel_identifier or phone -- cannot send replies`
- Now also calls `store.update()` to set `channel_identifier` and `preferred_channel` on the contractor record

## Test plan

- [x] Added regression test `test_telegram_link_sets_channel_identifier` verifying the field is persisted
- [x] Full test suite passes (879 passed)
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)