### PR TITLE
refactor: generalize heartbeat prompts to be domain-agnostic

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -66,7 +66,7 @@ class ComposeMessageParams(BaseModel):
 COMPOSE_MESSAGE_TOOL: dict[str, Any] = {
     "name": ToolName.COMPOSE_MESSAGE,
     "description": (
-        "Compose a proactive message to send to the contractor, or decide no message is needed."
+        "Compose a proactive message to send to the user, or decide no message is needed."
     ),
     "input_schema": ComposeMessageParams.model_json_schema(),
 }
@@ -292,7 +292,7 @@ async def run_cheap_checks(
     if last_inbound is not None:
         if last_inbound <= idle_cutoff:
             days = (now - last_inbound).days
-            result.flags.append(f"Contractor idle for {days} days -- no recent messages")
+            result.flags.append(f"User idle for {days} days -- no recent messages")
     elif contractor.created_at is not None:
         created = contractor.created_at
         if isinstance(created, str):
@@ -305,9 +305,7 @@ async def run_cheap_checks(
                 created = created.replace(tzinfo=datetime.UTC)
             if created <= idle_cutoff:
                 days = (now - created).days
-                result.flags.append(
-                    f"Contractor idle for {days} days -- no messages since onboarding"
-                )
+                result.flags.append(f"User idle for {days} days -- no messages since onboarding")
 
     return result
 
@@ -358,7 +356,7 @@ def _load_recent_messages(contractor: ContractorData) -> str:
 
     lines: list[str] = []
     for msg in recent:
-        direction = "Contractor" if msg.direction == MessageDirection.INBOUND else "Clawbolt"
+        direction = "User" if msg.direction == MessageDirection.INBOUND else "Assistant"
         lines.append(f"[{direction}] {msg.body}")
     return "\n".join(lines) or "(no recent messages)"
 

--- a/backend/app/agent/prompts/heartbeat_preamble.md
+++ b/backend/app/agent/prompts/heartbeat_preamble.md
@@ -1,1 +1,1 @@
-You are Clawbolt's heartbeat evaluator. Your job is to compose a short, actionable message for the contractor based on the flags below.
+You are a heartbeat evaluator. Your job is to compose a short, actionable message for the user based on the flags below.

--- a/backend/app/agent/prompts/proactive.md
+++ b/backend/app/agent/prompts/proactive.md
@@ -1,5 +1,4 @@
-You will proactively reach out during business hours when something needs attention:
-- A draft estimate has been sitting unsent for over 24 hours
+You will proactively reach out during active hours when something needs attention:
 - A scheduled checklist item is due
 - A follow-up reminder or deadline is approaching
-- You haven't heard from the contractor in a few days
+- You haven't heard from the user in a few days

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -157,8 +157,8 @@ class TestSectionBuilders:
     def test_build_proactive_section(self) -> None:
         """Should contain proactive messaging rules."""
         result = build_proactive_section()
-        assert "draft estimate" in result
         assert "checklist" in result
+        assert "reminder" in result
 
     def test_build_recall_section(self) -> None:
         """Should contain recall behavior rules."""


### PR DESCRIPTION
## Description

Replaces contractor-specific language in heartbeat prompts and code with generic terms:
- `heartbeat_preamble.md`: "Clawbolt's heartbeat evaluator" / "contractor" -> "heartbeat evaluator" / "user"
- `proactive.md`: removed estimate-specific trigger ("draft estimate sitting unsent"), replaced "contractor" with "user", renamed "business hours" to "active hours"
- `heartbeat.py`: updated compose_message tool description, recent message direction labels ("Contractor"/"Clawbolt" -> "User"/"Assistant"), and idle flag strings

Fixes #507

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the changes)
- [ ] No AI used