### PR TITLE
refactor: rename /api/contractor/* routes to /api/user/*

### DIFF
--- a/backend/app/channels/webchat.py
+++ b/backend/app/channels/webchat.py
@@ -74,7 +74,7 @@ class WebChatChannel(BaseChannel):
         router = APIRouter(tags=["webchat"])
         channel = self
 
-        @router.post("/contractor/chat", response_model=_ChatResponse)
+        @router.post("/user/chat", response_model=_ChatResponse)
         async def send_chat_message(
             message: str = Form(default=""),
             session_id: str | None = Form(default=None),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,13 +17,13 @@ from backend.app.channels.webchat import WebChatChannel
 from backend.app.config import settings
 from backend.app.routers import (
     auth,
-    contractor_checklist,
-    contractor_memory,
-    contractor_profile,
-    contractor_sessions,
-    contractor_stats,
     estimates,
     health,
+    user_checklist,
+    user_memory,
+    user_profile,
+    user_sessions,
+    user_stats,
 )
 
 logging.basicConfig(
@@ -168,11 +168,11 @@ for _channel in get_manager().channels.values():
     app.include_router(_channel.get_router(), prefix="/api")
 
 app.include_router(estimates.router, prefix="/api")
-app.include_router(contractor_profile.router, prefix="/api")
-app.include_router(contractor_sessions.router, prefix="/api")
-app.include_router(contractor_memory.router, prefix="/api")
-app.include_router(contractor_checklist.router, prefix="/api")
-app.include_router(contractor_stats.router, prefix="/api")
+app.include_router(user_profile.router, prefix="/api")
+app.include_router(user_sessions.router, prefix="/api")
+app.include_router(user_memory.router, prefix="/api")
+app.include_router(user_checklist.router, prefix="/api")
+app.include_router(user_stats.router, prefix="/api")
 
 # ---------------------------------------------------------------------------
 # Static file serving (built frontend)

--- a/backend/app/routers/user_checklist.py
+++ b/backend/app/routers/user_checklist.py
@@ -13,7 +13,7 @@ from backend.app.schemas import (
 router = APIRouter()
 
 
-@router.get("/contractor/checklist", response_model=list[ChecklistItemResponse])
+@router.get("/user/checklist", response_model=list[ChecklistItemResponse])
 async def list_checklist(
     current_user: ContractorData = Depends(get_current_user),
 ) -> list[ChecklistItemResponse]:
@@ -32,7 +32,7 @@ async def list_checklist(
     ]
 
 
-@router.post("/contractor/checklist", response_model=ChecklistItemResponse, status_code=201)
+@router.post("/user/checklist", response_model=ChecklistItemResponse, status_code=201)
 async def create_checklist_item(
     body: ChecklistCreateRequest,
     current_user: ContractorData = Depends(get_current_user),
@@ -52,7 +52,7 @@ async def create_checklist_item(
     )
 
 
-@router.put("/contractor/checklist/{item_id}", response_model=ChecklistItemResponse)
+@router.put("/user/checklist/{item_id}", response_model=ChecklistItemResponse)
 async def update_checklist_item(
     item_id: int,
     body: ChecklistUpdateRequest,
@@ -77,7 +77,7 @@ async def update_checklist_item(
     )
 
 
-@router.delete("/contractor/checklist/{item_id}", status_code=204)
+@router.delete("/user/checklist/{item_id}", status_code=204)
 async def delete_checklist_item(
     item_id: int,
     current_user: ContractorData = Depends(get_current_user),

--- a/backend/app/routers/user_memory.py
+++ b/backend/app/routers/user_memory.py
@@ -9,7 +9,7 @@ from backend.app.schemas import MemoryFactResponse, MemoryFactUpdate
 router = APIRouter()
 
 
-@router.get("/contractor/memory", response_model=list[MemoryFactResponse])
+@router.get("/user/memory", response_model=list[MemoryFactResponse])
 async def list_memory(
     category: str | None = None,
     current_user: ContractorData = Depends(get_current_user),
@@ -28,7 +28,7 @@ async def list_memory(
     ]
 
 
-@router.put("/contractor/memory/{key}", response_model=MemoryFactResponse)
+@router.put("/user/memory/{key}", response_model=MemoryFactResponse)
 async def update_memory(
     key: str,
     body: MemoryFactUpdate,
@@ -59,7 +59,7 @@ async def update_memory(
     )
 
 
-@router.delete("/contractor/memory/{key}", status_code=204)
+@router.delete("/user/memory/{key}", status_code=204)
 async def delete_memory(
     key: str,
     current_user: ContractorData = Depends(get_current_user),

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -42,7 +42,7 @@ def _profile_response(c: ContractorData) -> ContractorProfileResponse:
     )
 
 
-@router.get("/contractor/profile", response_model=ContractorProfileResponse)
+@router.get("/user/profile", response_model=ContractorProfileResponse)
 async def get_profile(
     current_user: ContractorData = Depends(get_current_user),
 ) -> ContractorProfileResponse:
@@ -50,7 +50,7 @@ async def get_profile(
     return _profile_response(current_user)
 
 
-@router.put("/contractor/profile", response_model=ContractorProfileResponse)
+@router.put("/user/profile", response_model=ContractorProfileResponse)
 async def update_profile(
     body: ContractorProfileUpdate,
     current_user: ContractorData = Depends(get_current_user),
@@ -85,7 +85,7 @@ def _build_channel_config_response() -> ChannelConfigResponse:
     )
 
 
-@router.get("/contractor/channels/config", response_model=ChannelConfigResponse)
+@router.get("/user/channels/config", response_model=ChannelConfigResponse)
 async def get_channel_config(
     _current_user: ContractorData = Depends(get_current_user),
 ) -> ChannelConfigResponse:
@@ -93,7 +93,7 @@ async def get_channel_config(
     return _build_channel_config_response()
 
 
-@router.put("/contractor/channels/config", response_model=ChannelConfigResponse)
+@router.put("/user/channels/config", response_model=ChannelConfigResponse)
 async def update_channel_config(
     body: ChannelConfigUpdate,
     _current_user: ContractorData = Depends(get_current_user),

--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -17,7 +17,7 @@ from backend.app.schemas import (
 router = APIRouter()
 
 
-@router.get("/contractor/sessions", response_model=SessionListResponse)
+@router.get("/user/sessions", response_model=SessionListResponse)
 async def list_sessions(
     offset: int = 0,
     limit: int = 20,
@@ -57,7 +57,7 @@ async def list_sessions(
     )
 
 
-@router.get("/contractor/sessions/{session_id}", response_model=SessionDetailResponse)
+@router.get("/user/sessions/{session_id}", response_model=SessionDetailResponse)
 async def get_session(
     session_id: str,
     current_user: ContractorData = Depends(get_current_user),

--- a/backend/app/routers/user_stats.py
+++ b/backend/app/routers/user_stats.py
@@ -17,7 +17,7 @@ from backend.app.schemas import ContractorStatsResponse
 router = APIRouter()
 
 
-@router.get("/contractor/stats", response_model=ContractorStatsResponse)
+@router.get("/user/stats", response_model=ContractorStatsResponse)
 async def get_stats(
     current_user: ContractorData = Depends(get_current_user),
 ) -> ContractorStatsResponse:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -78,9 +78,9 @@ const api = {
   tryRestoreSession: _tryRestoreSession as () => Promise<AuthUser | null>,
 
   // Profile
-  getProfile: () => _fetch<ContractorProfile>('/api/contractor/profile'),
+  getProfile: () => _fetch<ContractorProfile>('/api/user/profile'),
   updateProfile: (body: ContractorProfileUpdate) =>
-    _fetch<ContractorProfile>('/api/contractor/profile', {
+    _fetch<ContractorProfile>('/api/user/profile', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -88,52 +88,52 @@ const api = {
 
   // Sessions
   listSessions: (offset = 0, limit = 20) =>
-    _fetch<SessionListResponse>(`/api/contractor/sessions?offset=${offset}&limit=${limit}`),
+    _fetch<SessionListResponse>(`/api/user/sessions?offset=${offset}&limit=${limit}`),
   getSession: (sessionId: string) =>
-    _fetch<SessionDetail>(`/api/contractor/sessions/${encodeURIComponent(sessionId)}`),
+    _fetch<SessionDetail>(`/api/user/sessions/${encodeURIComponent(sessionId)}`),
 
   // Memory
   listMemoryFacts: (category?: string) => {
     const params = category ? `?category=${encodeURIComponent(category)}` : '';
-    return _fetch<MemoryFact[]>(`/api/contractor/memory${params}`);
+    return _fetch<MemoryFact[]>(`/api/user/memory${params}`);
   },
   updateMemoryFact: (key: string, body: MemoryFactUpdate) =>
-    _fetch<MemoryFact>(`/api/contractor/memory/${encodeURIComponent(key)}`, {
+    _fetch<MemoryFact>(`/api/user/memory/${encodeURIComponent(key)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
   deleteMemoryFact: (key: string) =>
-    _fetchVoid(`/api/contractor/memory/${encodeURIComponent(key)}`, { method: 'DELETE' }),
+    _fetchVoid(`/api/user/memory/${encodeURIComponent(key)}`, { method: 'DELETE' }),
 
   // Checklist
-  listChecklist: () => _fetch<ChecklistItem[]>('/api/contractor/checklist'),
+  listChecklist: () => _fetch<ChecklistItem[]>('/api/user/checklist'),
   createChecklistItem: (body: { description: string; schedule?: string }) =>
-    _fetch<ChecklistItem>('/api/contractor/checklist', {
+    _fetch<ChecklistItem>('/api/user/checklist', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
   updateChecklistItem: (id: number, body: ChecklistItemUpdate) =>
-    _fetch<ChecklistItem>(`/api/contractor/checklist/${id}`, {
+    _fetch<ChecklistItem>(`/api/user/checklist/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
   deleteChecklistItem: (id: number) =>
-    _fetchVoid(`/api/contractor/checklist/${id}`, { method: 'DELETE' }),
+    _fetchVoid(`/api/user/checklist/${id}`, { method: 'DELETE' }),
 
   // Channel config
-  getChannelConfig: () => _fetch<ChannelConfig>('/api/contractor/channels/config'),
+  getChannelConfig: () => _fetch<ChannelConfig>('/api/user/channels/config'),
   updateChannelConfig: (body: ChannelConfigUpdate) =>
-    _fetch<ChannelConfig>('/api/contractor/channels/config', {
+    _fetch<ChannelConfig>('/api/user/channels/config', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
 
   // Stats
-  getStats: () => _fetch<ContractorStats>('/api/contractor/stats'),
+  getStats: () => _fetch<ContractorStats>('/api/user/stats'),
 
   // Chat
   sendChatMessage: (message: string, sessionId?: string, files?: File[]) => {
@@ -147,7 +147,7 @@ const api = {
         formData.append('files', file);
       }
     }
-    return _fetch<ChatResponse>('/api/contractor/chat', {
+    return _fetch<ChatResponse>('/api/user/chat', {
       method: 'POST',
       body: formData,
     });

--- a/tests/integration/test_dashboard_telegram.py
+++ b/tests/integration/test_dashboard_telegram.py
@@ -113,7 +113,7 @@ class TestDashboardSeesTelegramData:
         real_auth_client: TestClient,
         telegram_contractor: ContractorData,
     ) -> None:
-        resp = real_auth_client.get("/api/contractor/profile")
+        resp = real_auth_client.get("/api/user/profile")
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "Telegram User"
@@ -143,7 +143,7 @@ class TestDashboardSeesTelegramData:
                 },
             ],
         )
-        resp = real_auth_client.get("/api/contractor/sessions")
+        resp = real_auth_client.get("/api/user/sessions")
         assert resp.status_code == 200
         data = resp.json()
         assert data["total"] == 1
@@ -156,7 +156,7 @@ class TestDashboardSeesTelegramData:
         telegram_contractor: ContractorData,
     ) -> None:
         _seed_memory(telegram_contractor)
-        resp = real_auth_client.get("/api/contractor/memory")
+        resp = real_auth_client.get("/api/user/memory")
         assert resp.status_code == 200
         facts = resp.json()
         assert len(facts) == 2
@@ -182,7 +182,7 @@ class TestDashboardSeesTelegramData:
             ],
         )
         _seed_memory(telegram_contractor)
-        resp = real_auth_client.get("/api/contractor/stats")
+        resp = real_auth_client.get("/api/user/stats")
         assert resp.status_code == 200
         data = resp.json()
         assert data["total_sessions"] == 1
@@ -258,7 +258,7 @@ class TestMultiChannelSingleTenant:
             patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
             TestClient(app) as c,
         ):
-            resp = c.get("/api/contractor/sessions")
+            resp = c.get("/api/user/sessions")
             assert resp.status_code == 200
             data = resp.json()
             assert data["total"] == 1

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -30,7 +30,7 @@ def _clear_bot_token() -> Iterator[None]:
 
 def test_get_channel_config_token_set(client: TestClient, _set_bot_token: None) -> None:
     """GET returns telegram_bot_token_set=True when token is configured."""
-    resp = client.get("/api/contractor/channels/config")
+    resp = client.get("/api/user/channels/config")
     assert resp.status_code == 200
     data = resp.json()
     assert data["telegram_bot_token_set"] is True
@@ -40,7 +40,7 @@ def test_get_channel_config_token_set(client: TestClient, _set_bot_token: None) 
 
 def test_get_channel_config_token_not_set(client: TestClient, _clear_bot_token: None) -> None:
     """GET returns telegram_bot_token_set=False when token is empty."""
-    resp = client.get("/api/contractor/channels/config")
+    resp = client.get("/api/user/channels/config")
     assert resp.status_code == 200
     data = resp.json()
     assert data["telegram_bot_token_set"] is False
@@ -49,7 +49,7 @@ def test_get_channel_config_token_not_set(client: TestClient, _clear_bot_token: 
 def test_update_channel_config_token(client: TestClient, _clear_bot_token: None) -> None:
     """PUT with a new token updates settings in-memory and GET reflects change."""
     resp = client.put(
-        "/api/contractor/channels/config",
+        "/api/user/channels/config",
         json={"telegram_bot_token": "new-bot-token-456"},
     )
     assert resp.status_code == 200
@@ -60,7 +60,7 @@ def test_update_channel_config_token(client: TestClient, _clear_bot_token: None)
     assert settings.telegram_bot_token == "new-bot-token-456"
 
     # GET should also reflect the change
-    resp2 = client.get("/api/contractor/channels/config")
+    resp2 = client.get("/api/user/channels/config")
     assert resp2.json()["telegram_bot_token_set"] is True
 
     # Clean up
@@ -75,11 +75,11 @@ def test_update_channel_config_persists_to_dotenv(
     env_file.write_text("# existing config\n")
 
     with patch(
-        "backend.app.routers.contractor_profile.Path",
+        "backend.app.routers.user_profile.Path",
         return_value=env_file,
     ):
         resp = client.put(
-            "/api/contractor/channels/config",
+            "/api/user/channels/config",
             json={"telegram_bot_token": "persisted-token"},
         )
 
@@ -97,7 +97,7 @@ def test_update_channel_config_null_token_is_ignored(
 ) -> None:
     """PUT with null token should be ignored, preserving the existing value."""
     resp = client.put(
-        "/api/contractor/channels/config",
+        "/api/user/channels/config",
         json={"telegram_bot_token": None, "telegram_allowed_usernames": "user1"},
     )
     assert resp.status_code == 200
@@ -110,7 +110,7 @@ def test_update_channel_config_null_only_returns_400(
 ) -> None:
     """PUT with only null fields should return 400 (no effective updates)."""
     resp = client.put(
-        "/api/contractor/channels/config",
+        "/api/user/channels/config",
         json={"telegram_bot_token": None},
     )
     assert resp.status_code == 400
@@ -122,7 +122,7 @@ def test_update_channel_config_empty_string_clears_token(
 ) -> None:
     """PUT with empty string explicitly clears the token."""
     resp = client.put(
-        "/api/contractor/channels/config",
+        "/api/user/channels/config",
         json={"telegram_bot_token": ""},
     )
     assert resp.status_code == 200

--- a/tests/test_checklist_endpoints.py
+++ b/tests/test_checklist_endpoints.py
@@ -4,14 +4,14 @@ from fastapi.testclient import TestClient
 
 
 def test_list_checklist_empty(client: TestClient) -> None:
-    resp = client.get("/api/contractor/checklist")
+    resp = client.get("/api/user/checklist")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
 def test_create_checklist_item(client: TestClient) -> None:
     resp = client.post(
-        "/api/contractor/checklist",
+        "/api/user/checklist",
         json={"description": "Check job site"},
     )
     assert resp.status_code == 201
@@ -24,7 +24,7 @@ def test_create_checklist_item(client: TestClient) -> None:
 
 def test_create_checklist_item_custom_schedule(client: TestClient) -> None:
     resp = client.post(
-        "/api/contractor/checklist",
+        "/api/user/checklist",
         json={"description": "Weekly review", "schedule": "weekdays"},
     )
     assert resp.status_code == 201
@@ -32,39 +32,39 @@ def test_create_checklist_item_custom_schedule(client: TestClient) -> None:
 
 
 def test_list_after_create(client: TestClient) -> None:
-    client.post("/api/contractor/checklist", json={"description": "Item 1"})
-    client.post("/api/contractor/checklist", json={"description": "Item 2"})
-    resp = client.get("/api/contractor/checklist")
+    client.post("/api/user/checklist", json={"description": "Item 1"})
+    client.post("/api/user/checklist", json={"description": "Item 2"})
+    resp = client.get("/api/user/checklist")
     assert resp.status_code == 200
     assert len(resp.json()) == 2
 
 
 def test_delete_checklist_item(client: TestClient) -> None:
-    resp = client.post("/api/contractor/checklist", json={"description": "To delete"})
+    resp = client.post("/api/user/checklist", json={"description": "To delete"})
     item_id = resp.json()["id"]
-    resp = client.delete(f"/api/contractor/checklist/{item_id}")
+    resp = client.delete(f"/api/user/checklist/{item_id}")
     assert resp.status_code == 204
     # Verify it's gone
-    resp = client.get("/api/contractor/checklist")
+    resp = client.get("/api/user/checklist")
     assert len(resp.json()) == 0
 
 
 def test_delete_checklist_item_not_found(client: TestClient) -> None:
-    resp = client.delete("/api/contractor/checklist/9999")
+    resp = client.delete("/api/user/checklist/9999")
     assert resp.status_code == 404
 
 
 def test_create_checklist_empty_description(client: TestClient) -> None:
-    resp = client.post("/api/contractor/checklist", json={"description": ""})
+    resp = client.post("/api/user/checklist", json={"description": ""})
     assert resp.status_code == 422
 
 
 def test_update_checklist_item(client: TestClient) -> None:
-    resp = client.post("/api/contractor/checklist", json={"description": "Original"})
+    resp = client.post("/api/user/checklist", json={"description": "Original"})
     item_id = resp.json()["id"]
 
     resp = client.put(
-        f"/api/contractor/checklist/{item_id}",
+        f"/api/user/checklist/{item_id}",
         json={"description": "Updated", "schedule": "weekdays", "status": "paused"},
     )
     assert resp.status_code == 200
@@ -77,13 +77,13 @@ def test_update_checklist_item(client: TestClient) -> None:
 def test_update_checklist_partial(client: TestClient) -> None:
     """Only provided fields should change."""
     resp = client.post(
-        "/api/contractor/checklist",
+        "/api/user/checklist",
         json={"description": "My task", "schedule": "daily"},
     )
     item_id = resp.json()["id"]
 
     resp = client.put(
-        f"/api/contractor/checklist/{item_id}",
+        f"/api/user/checklist/{item_id}",
         json={"status": "completed"},
     )
     assert resp.status_code == 200
@@ -95,7 +95,7 @@ def test_update_checklist_partial(client: TestClient) -> None:
 
 def test_update_checklist_not_found(client: TestClient) -> None:
     resp = client.put(
-        "/api/contractor/checklist/9999",
+        "/api/user/checklist/9999",
         json={"description": "nope"},
     )
     assert resp.status_code == 404

--- a/tests/test_memory_endpoints.py
+++ b/tests/test_memory_endpoints.py
@@ -24,14 +24,14 @@ def _seed_memory(contractor: ContractorData) -> None:
 
 
 def test_list_memory_empty(client: TestClient) -> None:
-    resp = client.get("/api/contractor/memory")
+    resp = client.get("/api/user/memory")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
 def test_list_memory(client: TestClient, test_contractor: ContractorData) -> None:
     _seed_memory(test_contractor)
-    resp = client.get("/api/contractor/memory")
+    resp = client.get("/api/user/memory")
     assert resp.status_code == 200
     facts = resp.json()
     assert len(facts) == 3
@@ -42,7 +42,7 @@ def test_list_memory(client: TestClient, test_contractor: ContractorData) -> Non
 
 def test_list_memory_filter_category(client: TestClient, test_contractor: ContractorData) -> None:
     _seed_memory(test_contractor)
-    resp = client.get("/api/contractor/memory?category=business")
+    resp = client.get("/api/user/memory?category=business")
     assert resp.status_code == 200
     facts = resp.json()
     assert len(facts) == 2
@@ -52,7 +52,7 @@ def test_list_memory_filter_category(client: TestClient, test_contractor: Contra
 def test_update_memory(client: TestClient, test_contractor: ContractorData) -> None:
     _seed_memory(test_contractor)
     resp = client.put(
-        "/api/contractor/memory/hourly_rate",
+        "/api/user/memory/hourly_rate",
         json={"value": "85"},
     )
     assert resp.status_code == 200
@@ -64,7 +64,7 @@ def test_update_memory(client: TestClient, test_contractor: ContractorData) -> N
 def test_update_memory_not_found(client: TestClient, test_contractor: ContractorData) -> None:
     _seed_memory(test_contractor)
     resp = client.put(
-        "/api/contractor/memory/nonexistent",
+        "/api/user/memory/nonexistent",
         json={"value": "test"},
     )
     assert resp.status_code == 404
@@ -72,14 +72,14 @@ def test_update_memory_not_found(client: TestClient, test_contractor: Contractor
 
 def test_delete_memory(client: TestClient, test_contractor: ContractorData) -> None:
     _seed_memory(test_contractor)
-    resp = client.delete("/api/contractor/memory/hourly_rate")
+    resp = client.delete("/api/user/memory/hourly_rate")
     assert resp.status_code == 204
     # Verify it's gone
-    resp = client.get("/api/contractor/memory")
+    resp = client.get("/api/user/memory")
     keys = {f["key"] for f in resp.json()}
     assert "hourly_rate" not in keys
 
 
 def test_delete_memory_not_found(client: TestClient) -> None:
-    resp = client.delete("/api/contractor/memory/nonexistent")
+    resp = client.delete("/api/user/memory/nonexistent")
     assert resp.status_code == 404

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 
 
 def test_get_profile(client: TestClient) -> None:
-    resp = client.get("/api/contractor/profile")
+    resp = client.get("/api/user/profile")
     assert resp.status_code == 200
     data = resp.json()
     assert data["name"] == "Test Contractor"
@@ -19,7 +19,7 @@ def test_get_profile(client: TestClient) -> None:
 
 def test_update_profile_partial(client: TestClient) -> None:
     resp = client.put(
-        "/api/contractor/profile",
+        "/api/user/profile",
         json={"name": "Updated Name", "hourly_rate": 85.0},
     )
     assert resp.status_code == 200
@@ -31,7 +31,7 @@ def test_update_profile_partial(client: TestClient) -> None:
 
 def test_update_profile_soul_text(client: TestClient) -> None:
     resp = client.put(
-        "/api/contractor/profile",
+        "/api/user/profile",
         json={"soul_text": "Be friendly.", "assistant_name": "Bolt"},
     )
     assert resp.status_code == 200
@@ -41,11 +41,11 @@ def test_update_profile_soul_text(client: TestClient) -> None:
 
 
 def test_update_profile_empty_body(client: TestClient) -> None:
-    resp = client.put("/api/contractor/profile", json={})
+    resp = client.put("/api/user/profile", json={})
     assert resp.status_code == 400
 
 
 def test_update_returns_updated_values(client: TestClient) -> None:
-    resp = client.put("/api/contractor/profile", json={"trade": "Electrician"})
+    resp = client.put("/api/user/profile", json={"trade": "Electrician"})
     assert resp.status_code == 200
     assert resp.json()["trade"] == "Electrician"

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -35,7 +35,7 @@ def _create_session(
 
 
 def test_list_sessions_empty(client: TestClient) -> None:
-    resp = client.get("/api/contractor/sessions")
+    resp = client.get("/api/user/sessions")
     assert resp.status_code == 200
     data = resp.json()
     assert data["sessions"] == []
@@ -56,7 +56,7 @@ def test_list_sessions(client: TestClient, test_contractor: ContractorData) -> N
             },
         ],
     )
-    resp = client.get("/api/contractor/sessions")
+    resp = client.get("/api/user/sessions")
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 1
@@ -86,7 +86,7 @@ def test_get_session_detail(client: TestClient, test_contractor: ContractorData)
             },
         ],
     )
-    resp = client.get("/api/contractor/sessions/1_200")
+    resp = client.get("/api/user/sessions/1_200")
     assert resp.status_code == 200
     data = resp.json()
     assert data["session_id"] == "1_200"
@@ -111,7 +111,7 @@ def test_session_direction_values(client: TestClient, test_contractor: Contracto
             },
         ],
     )
-    resp = client.get("/api/contractor/sessions/1_300")
+    resp = client.get("/api/user/sessions/1_300")
     assert resp.status_code == 200
     data = resp.json()
     assert data["messages"][0]["direction"] == "inbound"
@@ -119,7 +119,7 @@ def test_session_direction_values(client: TestClient, test_contractor: Contracto
 
 
 def test_get_session_not_found(client: TestClient) -> None:
-    resp = client.get("/api/contractor/sessions/nonexistent")
+    resp = client.get("/api/user/sessions/nonexistent")
     assert resp.status_code == 404
 
 
@@ -137,7 +137,7 @@ def test_list_sessions_pagination(client: TestClient, test_contractor: Contracto
                 }
             ],
         )
-    resp = client.get("/api/contractor/sessions?offset=0&limit=2")
+    resp = client.get("/api/user/sessions?offset=0&limit=2")
     data = resp.json()
     assert data["total"] == 5
     assert len(data["sessions"]) == 2

--- a/tests/test_stats_endpoints.py
+++ b/tests/test_stats_endpoints.py
@@ -10,7 +10,7 @@ from backend.app.config import settings
 
 
 def test_stats_empty(client: TestClient) -> None:
-    resp = client.get("/api/contractor/stats")
+    resp = client.get("/api/user/stats")
     assert resp.status_code == 200
     data = resp.json()
     assert data["total_sessions"] == 0
@@ -38,7 +38,7 @@ def test_stats_with_data(client: TestClient, test_contractor: ContractorData) ->
     path.write_text(json.dumps(meta) + "\n" + json.dumps(msg) + "\n", encoding="utf-8")
 
     # Create a checklist item
-    client.post("/api/contractor/checklist", json={"description": "Check site"})
+    client.post("/api/user/checklist", json={"description": "Check site"})
 
     # Create memory
     mem_dir = Path(settings.contractor_data_dir) / str(test_contractor.id) / "memory"
@@ -48,7 +48,7 @@ def test_stats_with_data(client: TestClient, test_contractor: ContractorData) ->
         encoding="utf-8",
     )
 
-    resp = client.get("/api/contractor/stats")
+    resp = client.get("/api/user/stats")
     assert resp.status_code == 200
     data = resp.json()
     assert data["total_sessions"] == 1

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -47,7 +47,7 @@ def test_chat_endpoint_returns_reply(
     webchat_client: TestClient,
     webchat_contractor: ContractorData,
 ) -> None:
-    """POST /api/contractor/chat should return an agent reply."""
+    """POST /api/user/chat should return an agent reply."""
     with patch(
         "backend.app.agent.router.run_agent",
         new_callable=AsyncMock,
@@ -57,7 +57,7 @@ def test_chat_endpoint_returns_reply(
         mock_agent.return_value = AgentResponse(reply_text="Hello from the agent!")
 
         resp = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "Hi there"},
         )
 
@@ -81,7 +81,7 @@ def test_chat_endpoint_persists_messages(
         mock_agent.return_value = AgentResponse(reply_text="Got it!")
 
         resp = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "Remember my rate is 85"},
         )
         assert resp.status_code == 200
@@ -105,7 +105,7 @@ def test_chat_endpoint_persists_messages(
 
 def test_chat_endpoint_missing_body(webchat_client: TestClient) -> None:
     """Empty request (no message, no files) should return 422."""
-    resp = webchat_client.post("/api/contractor/chat", data={"message": ""})
+    resp = webchat_client.post("/api/user/chat", data={"message": ""})
     assert resp.status_code == 422
 
 
@@ -122,13 +122,13 @@ def test_chat_returns_same_session(
 
         mock_agent.return_value = AgentResponse(reply_text="Reply 1")
         resp1 = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "First message"},
         )
 
         mock_agent.return_value = AgentResponse(reply_text="Reply 2")
         resp2 = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "Second message"},
         )
 
@@ -148,14 +148,14 @@ def test_chat_with_explicit_session_id(
 
         mock_agent.return_value = AgentResponse(reply_text="Reply 1")
         resp1 = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "First message"},
         )
         session_id = resp1.json()["session_id"]
 
         mock_agent.return_value = AgentResponse(reply_text="Reply 2")
         resp2 = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "Second message", "session_id": session_id},
         )
 
@@ -166,7 +166,7 @@ def test_chat_with_explicit_session_id(
 def test_chat_with_invalid_session_id(webchat_client: TestClient) -> None:
     """Invalid session_id format should return 422."""
     resp = webchat_client.post(
-        "/api/contractor/chat",
+        "/api/user/chat",
         data={"message": "Hello", "session_id": "../../bad"},
     )
     assert resp.status_code == 422
@@ -185,7 +185,7 @@ def test_chat_with_nonexistent_session_id(
 
         mock_agent.return_value = AgentResponse(reply_text="Hello!")
         resp = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "Hello", "session_id": "9999_9999"},
         )
 
@@ -220,7 +220,7 @@ def test_chat_with_image_upload(
             b"\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
         )
         resp = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "Check this out"},
             files=[("files", ("photo.png", io.BytesIO(png_bytes), "image/png"))],
         )
@@ -251,7 +251,7 @@ def test_chat_with_files_only(
         mock_agent.return_value = AgentResponse(reply_text="Got your file!")
 
         resp = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             files=[("files", ("doc.pdf", io.BytesIO(b"%PDF-1.4 test"), "application/pdf"))],
         )
 
@@ -261,7 +261,7 @@ def test_chat_with_files_only(
 
 def test_chat_no_message_no_files(webchat_client: TestClient) -> None:
     """Empty request with no text and no files should return 422."""
-    resp = webchat_client.post("/api/contractor/chat", data={"message": "  "})
+    resp = webchat_client.post("/api/user/chat", data={"message": "  "})
     assert resp.status_code == 422
 
 
@@ -272,7 +272,7 @@ def test_chat_file_too_large(
     """Oversized file should return 422."""
     with patch.object(settings, "max_media_size_bytes", 10):
         resp = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "here is a big file"},
             files=[("files", ("big.bin", io.BytesIO(b"x" * 100), "application/octet-stream"))],
         )
@@ -295,7 +295,7 @@ def test_chat_multiple_files(
         mock_agent.return_value = AgentResponse(reply_text="Got them all!")
 
         resp = webchat_client.post(
-            "/api/contractor/chat",
+            "/api/user/chat",
             data={"message": "Multiple attachments"},
             files=[
                 ("files", ("a.png", io.BytesIO(b"img1"), "image/png")),


### PR DESCRIPTION
## Description

Renames all API routes from `/api/contractor/*` to `/api/user/*` to make the API domain-agnostic.

- Renamed 5 router files: `contractor_*.py` -> `user_*.py`
- Updated all route prefixes in router decorators
- Updated webchat endpoint: `/api/contractor/chat` -> `/api/user/chat`
- Updated all 15 frontend API paths in `api.ts`
- Updated all test URL references across 8 test files
- Updated imports in `main.py`

Fixes #509

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the changes)
- [ ] No AI used