### PR TITLE
feat: add configurable tool registry for agent tools

### DIFF
--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -202,6 +202,15 @@ class MemoryFact(BaseModel):
     confidence: float = 1.0
 
 
+class ToolConfigEntry(BaseModel):
+    """A single tool group entry in a user's tool_config.json."""
+
+    name: str = ""
+    description: str = ""
+    category: str = "domain"
+    enabled: bool = True
+
+
 # ---------------------------------------------------------------------------
 # Helper utilities
 # ---------------------------------------------------------------------------
@@ -1462,6 +1471,43 @@ class LLMUsageStore:
             "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
         }
         _append_jsonl(self._path, entry)
+
+
+# ---------------------------------------------------------------------------
+# ToolConfigStore
+# ---------------------------------------------------------------------------
+
+
+class ToolConfigStore:
+    """File-based storage for per-user tool configuration.
+
+    Stores a list of ``ToolConfigEntry`` objects in
+    ``data/users/{id}/tool_config.json``.
+    """
+
+    def __init__(self, contractor_id: int) -> None:
+        self.contractor_id = contractor_id
+        self._lock = asyncio.Lock()
+
+    @property
+    def _path(self) -> Path:
+        return _user_dir(self.contractor_id) / "tool_config.json"
+
+    async def load(self) -> list[ToolConfigEntry]:
+        """Load tool config entries. Returns empty list if no config exists."""
+        raw = _read_json(self._path, [])
+        return [ToolConfigEntry.model_validate(item) for item in raw]
+
+    async def save(self, entries: list[ToolConfigEntry]) -> list[ToolConfigEntry]:
+        """Save tool config entries and return them."""
+        async with self._lock:
+            _write_json(self._path, [e.model_dump() for e in entries])
+        return entries
+
+    async def get_disabled_tool_names(self) -> set[str]:
+        """Return the set of tool group names that are disabled."""
+        entries = await self.load()
+        return {e.name for e in entries if not e.enabled}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -22,6 +22,7 @@ from backend.app.agent.file_store import (
     ContractorData,
     SessionState,
     StoredMessage,
+    ToolConfigStore,
     get_session_store,
 )
 from backend.app.agent.messages import AgentMessage
@@ -234,10 +235,18 @@ async def run_agent(
         session_id=session_id,
     )
 
+    # Load user's disabled tool groups to filter out unwanted tools.
+    tool_config_store = ToolConfigStore(contractor.id)
+    disabled_groups = await tool_config_store.get_disabled_tool_names()
+
     # Start with core tools only; specialist tools are discovered on demand
-    # via the list_capabilities meta-tool.
-    tools = default_registry.create_core_tools(tool_context)
-    specialist_summaries = default_registry.get_available_specialist_summaries(tool_context)
+    # via the list_capabilities meta-tool. Exclude user-disabled groups.
+    tools = default_registry.create_core_tools(
+        tool_context, excluded_factories=disabled_groups or None
+    )
+    specialist_summaries = default_registry.get_available_specialist_summaries(
+        tool_context, excluded_factories=disabled_groups or None
+    )
     if specialist_summaries:
         tools.append(create_list_capabilities_tool(specialist_summaries))
     agent.register_tools(tools)

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -181,22 +181,41 @@ class ToolRegistry:
             tools.extend(created)
         return tools
 
-    def create_core_tools(self, context: ToolContext) -> list[Tool]:
-        """Create only core (always-available) tools."""
-        return self.create_tools(context, selected_factories=self.core_factory_names)
+    def create_core_tools(
+        self,
+        context: ToolContext,
+        *,
+        excluded_factories: set[str] | None = None,
+    ) -> list[Tool]:
+        """Create only core (always-available) tools.
+
+        When *excluded_factories* is provided, factories in that set are
+        skipped even if they are core factories.
+        """
+        selected = self.core_factory_names
+        if excluded_factories:
+            selected = selected - excluded_factories
+        return self.create_tools(context, selected_factories=selected)
 
     def get_available_specialist_summaries(
         self,
         context: ToolContext,
+        *,
+        excluded_factories: set[str] | None = None,
     ) -> dict[str, str]:
         """Return summaries of specialist factories whose dependencies are met.
 
         Used by the setup code to build the ``list_capabilities`` meta-tool
         with only the categories that are actually usable.
+
+        When *excluded_factories* is provided, factories in that set are
+        skipped.
         """
         summaries: dict[str, str] = {}
         for name, factory in self._factories.items():
             if factory.core:
+                continue
+            if excluded_factories and name in excluded_factories:
                 continue
             if factory.requires_storage and context.storage is None:
                 continue

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from backend.app.routers import (
     user_profile,
     user_sessions,
     user_stats,
+    user_tools,
 )
 
 logging.basicConfig(
@@ -173,6 +174,7 @@ app.include_router(user_sessions.router, prefix="/api")
 app.include_router(user_memory.router, prefix="/api")
 app.include_router(user_checklist.router, prefix="/api")
 app.include_router(user_stats.router, prefix="/api")
+app.include_router(user_tools.router, prefix="/api")
 
 # ---------------------------------------------------------------------------
 # Static file serving (built frontend)

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -1,0 +1,138 @@
+"""Endpoints for user tool configuration.
+
+Users can view and toggle domain-specific agent tools. Core tools
+(workspace, profile, memory, messaging) are always enabled.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.app.agent.file_store import (
+    ContractorData,
+    ToolConfigEntry,
+    ToolConfigStore,
+)
+from backend.app.agent.tools.registry import (
+    default_registry,
+    ensure_tool_modules_imported,
+)
+from backend.app.auth.dependencies import get_current_user
+from backend.app.schemas import (
+    ToolConfigEntryResponse,
+    ToolConfigResponse,
+    ToolConfigUpdate,
+)
+
+router = APIRouter()
+
+# Ensure tool modules are loaded so the registry has all factories.
+ensure_tool_modules_imported()
+
+# Factories whose tools are always available and cannot be disabled.
+_CORE_FACTORIES: frozenset[str] = frozenset({"workspace", "profile", "memory", "messaging"})
+
+# Human-readable descriptions for each factory group.
+_FACTORY_DESCRIPTIONS: dict[str, str] = {
+    "workspace": "Read, write, and edit markdown files in the workspace",
+    "profile": "View and update contractor profile information",
+    "memory": "Save, recall, and forget long-term facts",
+    "messaging": "Send text and media replies to the contractor",
+    "estimate": "Generate professional estimates and quotes with PDF output",
+    "file": "Upload and organize files in cloud storage",
+    "checklist": "Manage recurring reminders and task checklists",
+}
+
+
+def _build_tool_list(
+    disabled_names: set[str],
+) -> list[ToolConfigEntry]:
+    """Build the full tool config list from the registry.
+
+    Each registered factory becomes one entry. Factories in
+    ``_CORE_FACTORIES`` are always enabled; others respect the
+    user's disabled set.
+    """
+    entries: list[ToolConfigEntry] = []
+    for name in sorted(default_registry.factory_names):
+        is_core = name in _CORE_FACTORIES
+        entries.append(
+            ToolConfigEntry(
+                name=name,
+                description=_FACTORY_DESCRIPTIONS.get(name, ""),
+                category="core" if is_core else "domain",
+                enabled=True if is_core else name not in disabled_names,
+            )
+        )
+    return entries
+
+
+@router.get("/user/tools", response_model=ToolConfigResponse)
+async def get_tool_config(
+    current_user: ContractorData = Depends(get_current_user),
+) -> ToolConfigResponse:
+    """Return the current tool configuration for the user."""
+    store = ToolConfigStore(current_user.id)
+    saved = await store.load()
+    disabled_names = {e.name for e in saved if not e.enabled}
+    entries = _build_tool_list(disabled_names)
+    return ToolConfigResponse(
+        tools=[
+            ToolConfigEntryResponse(
+                name=e.name,
+                description=e.description,
+                category=e.category,
+                enabled=e.enabled,
+            )
+            for e in entries
+        ]
+    )
+
+
+@router.put("/user/tools", response_model=ToolConfigResponse)
+async def update_tool_config(
+    body: ToolConfigUpdate,
+    current_user: ContractorData = Depends(get_current_user),
+) -> ToolConfigResponse:
+    """Update tool configuration for the user.
+
+    Only domain-specific tools can be toggled. Attempts to disable
+    core tools are silently ignored.
+    """
+    if not body.tools:
+        raise HTTPException(status_code=400, detail="No tools to update")
+
+    # Build a map of requested changes
+    requested: dict[str, bool] = {t.name: t.enabled for t in body.tools}
+
+    # Load current config to merge with
+    store = ToolConfigStore(current_user.id)
+    saved = await store.load()
+    disabled_names = {e.name for e in saved if not e.enabled}
+
+    # Apply changes, ignoring core tools
+    valid_factories = set(default_registry.factory_names)
+    for name, enabled in requested.items():
+        if name not in valid_factories:
+            continue
+        if name in _CORE_FACTORIES:
+            # Core tools cannot be disabled
+            continue
+        if enabled:
+            disabled_names.discard(name)
+        else:
+            disabled_names.add(name)
+
+    # Build and save the full config
+    entries = _build_tool_list(disabled_names)
+    await store.save(entries)
+
+    return ToolConfigResponse(
+        tools=[
+            ToolConfigEntryResponse(
+                name=e.name,
+                description=e.description,
+                category=e.category,
+                enabled=e.enabled,
+            )
+            for e in entries
+        ]
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -212,3 +212,28 @@ class ChannelConfigResponse(BaseModel):
 class ChannelConfigUpdate(BaseModel):
     telegram_bot_token: str | None = None
     telegram_allowed_usernames: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Tool config (dashboard)
+# ---------------------------------------------------------------------------
+
+
+class ToolConfigEntryResponse(BaseModel):
+    name: str
+    description: str
+    category: str
+    enabled: bool
+
+
+class ToolConfigResponse(BaseModel):
+    tools: list[ToolConfigEntryResponse]
+
+
+class ToolConfigUpdateEntry(BaseModel):
+    name: str
+    enabled: bool
+
+
+class ToolConfigUpdate(BaseModel):
+    tools: list[ToolConfigUpdateEntry]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,6 +13,8 @@ import type {
   MemoryFactUpdate,
   SessionDetail,
   SessionListResponse,
+  ToolConfigResponse,
+  ToolConfigUpdateEntry,
 } from '@/types';
 import { getAccessToken, setAccessToken, setRefreshToken } from '@/lib/api-client';
 import { tryRestoreSession as _tryRestoreSession } from '@/extensions';
@@ -130,6 +132,15 @@ const api = {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
+    }),
+
+  // Tool config
+  getToolConfig: () => _fetch<ToolConfigResponse>('/api/user/tools'),
+  updateToolConfig: (tools: ToolConfigUpdateEntry[]) =>
+    _fetch<ToolConfigResponse>('/api/user/tools', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tools }),
     }),
 
   // Stats

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,7 +8,7 @@ import Select from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { toast } from 'sonner';
 import api from '@/api';
-import type { ChannelConfig, ContractorProfileUpdate } from '@/types';
+import type { ChannelConfig, ContractorProfileUpdate, ToolConfigEntry } from '@/types';
 import type { AppShellContext } from '@/layouts/AppShell';
 import {
   getExtraSettingsTabs,
@@ -42,6 +42,7 @@ export default function SettingsPage() {
                 <TabsTrigger value="assistant">Assistant</TabsTrigger>
                 <TabsTrigger value="heartbeat">Heartbeat</TabsTrigger>
                 <TabsTrigger value="channels">Channels</TabsTrigger>
+                <TabsTrigger value="tools">Tools</TabsTrigger>
               </>
             )}
             {extraTabs.map((t) => (
@@ -65,6 +66,7 @@ export default function SettingsPage() {
           <TabsTrigger value="assistant">Assistant</TabsTrigger>
           <TabsTrigger value="heartbeat">Heartbeat</TabsTrigger>
           <TabsTrigger value="channels">Channels</TabsTrigger>
+          <TabsTrigger value="tools">Tools</TabsTrigger>
           {extraTabs.map((t) => (
             <TabsTrigger key={t.key} value={t.key}>{t.label}</TabsTrigger>
           ))}
@@ -84,6 +86,10 @@ export default function SettingsPage() {
 
         <TabsContent value="channels">
           {profile && <ChannelsTab profile={profile} />}
+        </TabsContent>
+
+        <TabsContent value="tools">
+          <ToolsTab />
         </TabsContent>
       </Tabs>
     </div>
@@ -493,6 +499,109 @@ function ChannelsTab({
         <Field label="Active Channel">
           <p className="text-sm">{profile.preferred_channel || 'webchat'}</p>
         </Field>
+      </div>
+    </Card>
+  );
+}
+
+// --- Tools Tab ---
+
+function ToolsTab() {
+  const [tools, setTools] = useState<ToolConfigEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.getToolConfig().then((res) => {
+      setTools(res.tools);
+      setLoading(false);
+    }).catch(() => {
+      setLoading(false);
+    });
+  }, []);
+
+  const handleToggle = useCallback(async (name: string, enabled: boolean) => {
+    setSaving(name);
+    try {
+      const res = await api.updateToolConfig([{ name, enabled }]);
+      setTools(res.tools);
+      toast.success(`${name} tool group ${enabled ? 'enabled' : 'disabled'}`);
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setSaving(null);
+    }
+  }, []);
+
+  if (loading) {
+    return (
+      <Card>
+        <p className="text-sm text-muted-foreground">Loading tool configuration...</p>
+      </Card>
+    );
+  }
+
+  const coreTools = tools.filter((t) => t.category === 'core');
+  const domainTools = tools.filter((t) => t.category === 'domain');
+
+  return (
+    <Card>
+      <div className="grid gap-6">
+        <div>
+          <p className="text-sm text-muted-foreground mb-4">
+            Configure which tool groups are available to your AI assistant.
+            Core tools are always enabled. Domain-specific tools can be toggled on or off.
+          </p>
+        </div>
+
+        {coreTools.length > 0 && (
+          <div>
+            <h3 className="text-sm font-medium mb-3">Core Tools (always enabled)</h3>
+            <div className="grid gap-2">
+              {coreTools.map((tool) => (
+                <div key={tool.name} className="flex items-center justify-between py-2 px-3 rounded bg-muted/50">
+                  <div>
+                    <span className="text-sm font-medium">{tool.name}</span>
+                    {tool.description && (
+                      <p className="text-xs text-muted-foreground">{tool.description}</p>
+                    )}
+                  </div>
+                  <input
+                    type="checkbox"
+                    checked={true}
+                    disabled={true}
+                    className="w-4 h-4 rounded border-border text-primary opacity-50 cursor-not-allowed"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {domainTools.length > 0 && (
+          <div>
+            <h3 className="text-sm font-medium mb-3">Domain Tools</h3>
+            <div className="grid gap-2">
+              {domainTools.map((tool) => (
+                <div key={tool.name} className="flex items-center justify-between py-2 px-3 rounded border border-border">
+                  <div>
+                    <span className="text-sm font-medium">{tool.name}</span>
+                    {tool.description && (
+                      <p className="text-xs text-muted-foreground">{tool.description}</p>
+                    )}
+                  </div>
+                  <input
+                    type="checkbox"
+                    checked={tool.enabled}
+                    disabled={saving === tool.name}
+                    onChange={(e) => handleToggle(tool.name, e.target.checked)}
+                    className="w-4 h-4 rounded border-border text-primary focus:ring-primary"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </Card>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -127,3 +127,19 @@ export interface ChannelConfigUpdate {
   telegram_bot_token?: string;
   telegram_allowed_usernames?: string;
 }
+
+export interface ToolConfigEntry {
+  name: string;
+  description: string;
+  category: string;
+  enabled: boolean;
+}
+
+export interface ToolConfigResponse {
+  tools: ToolConfigEntry[];
+}
+
+export interface ToolConfigUpdateEntry {
+  name: string;
+  enabled: boolean;
+}

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -1,0 +1,200 @@
+"""Tests for the configurable tool registry (tool config API and store)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.agent.file_store import (
+    ContractorData,
+    ToolConfigEntry,
+    ToolConfigStore,
+)
+from backend.app.agent.tools.registry import (
+    ToolContext,
+    default_registry,
+    ensure_tool_modules_imported,
+)
+
+ensure_tool_modules_imported()
+
+
+# ---------------------------------------------------------------------------
+# ToolConfigStore unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_tool_config_store_empty_on_first_load(
+    test_contractor: ContractorData,
+) -> None:
+    """First load returns an empty list when no config file exists."""
+    store = ToolConfigStore(test_contractor.id)
+    entries = await store.load()
+    assert entries == []
+
+
+@pytest.mark.asyncio()
+async def test_tool_config_store_save_and_load(
+    test_contractor: ContractorData,
+) -> None:
+    """Saved entries can be loaded back."""
+    store = ToolConfigStore(test_contractor.id)
+    entries = [
+        ToolConfigEntry(name="estimate", description="Estimates", category="domain", enabled=False),
+        ToolConfigEntry(name="workspace", description="Files", category="core", enabled=True),
+    ]
+    saved = await store.save(entries)
+    assert len(saved) == 2
+
+    loaded = await store.load()
+    assert len(loaded) == 2
+    assert loaded[0].name == "estimate"
+    assert loaded[0].enabled is False
+    assert loaded[1].name == "workspace"
+    assert loaded[1].enabled is True
+
+
+@pytest.mark.asyncio()
+async def test_tool_config_store_get_disabled_tool_names(
+    test_contractor: ContractorData,
+) -> None:
+    """get_disabled_tool_names returns only disabled entries."""
+    store = ToolConfigStore(test_contractor.id)
+    entries = [
+        ToolConfigEntry(name="estimate", category="domain", enabled=False),
+        ToolConfigEntry(name="file", category="domain", enabled=True),
+        ToolConfigEntry(name="checklist", category="domain", enabled=False),
+    ]
+    await store.save(entries)
+
+    disabled = await store.get_disabled_tool_names()
+    assert disabled == {"estimate", "checklist"}
+
+
+# ---------------------------------------------------------------------------
+# Registry exclusion tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_core_tools_excludes_disabled_factories() -> None:
+    """create_core_tools should skip excluded factories."""
+    contractor = ContractorData(id=999, user_id="test")
+    ctx = ToolContext(contractor=contractor)
+
+    all_core = default_registry.create_core_tools(ctx)
+    excluded = default_registry.create_core_tools(ctx, excluded_factories={"memory"})
+    # Excluding memory should remove save_fact, recall_facts, forget_fact
+    all_names = {t.name for t in all_core}
+    excluded_names = {t.name for t in excluded}
+    assert "save_fact" in all_names
+    assert "save_fact" not in excluded_names
+
+
+def test_specialist_summaries_excludes_disabled_factories() -> None:
+    """get_available_specialist_summaries should skip excluded factories."""
+    contractor = ContractorData(id=999, user_id="test")
+    ctx = ToolContext(contractor=contractor)
+
+    all_summaries = default_registry.get_available_specialist_summaries(ctx)
+    excluded_summaries = default_registry.get_available_specialist_summaries(
+        ctx, excluded_factories={"estimate"}
+    )
+    assert "estimate" in all_summaries
+    assert "estimate" not in excluded_summaries
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_tool_config(client: TestClient) -> None:
+    """GET /api/user/tools returns all tools grouped by category."""
+    response = client.get("/api/user/tools")
+    assert response.status_code == 200
+    data = response.json()
+    assert "tools" in data
+    tools = data["tools"]
+    assert len(tools) > 0
+
+    # All tools should have required fields
+    for tool in tools:
+        assert "name" in tool
+        assert "description" in tool
+        assert "category" in tool
+        assert "enabled" in tool
+        assert tool["category"] in ("core", "domain")
+
+    # Core tools should all be enabled
+    core_tools = [t for t in tools if t["category"] == "core"]
+    assert len(core_tools) > 0
+    for t in core_tools:
+        assert t["enabled"] is True
+
+    # Verify known factories are present
+    names = {t["name"] for t in tools}
+    assert "workspace" in names
+    assert "profile" in names
+    assert "memory" in names
+
+
+def test_put_tool_config_disable_domain_tool(client: TestClient) -> None:
+    """PUT /api/user/tools can disable a domain tool."""
+    response = client.put(
+        "/api/user/tools",
+        json={"tools": [{"name": "estimate", "enabled": False}]},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    tools_by_name = {t["name"]: t for t in data["tools"]}
+    assert tools_by_name["estimate"]["enabled"] is False
+
+    # Verify it persists
+    get_response = client.get("/api/user/tools")
+    tools_by_name = {t["name"]: t for t in get_response.json()["tools"]}
+    assert tools_by_name["estimate"]["enabled"] is False
+
+
+def test_put_tool_config_cannot_disable_core_tool(client: TestClient) -> None:
+    """PUT /api/user/tools silently ignores attempts to disable core tools."""
+    response = client.put(
+        "/api/user/tools",
+        json={"tools": [{"name": "workspace", "enabled": False}]},
+    )
+    assert response.status_code == 200
+    tools_by_name = {t["name"]: t for t in response.json()["tools"]}
+    assert tools_by_name["workspace"]["enabled"] is True
+
+
+def test_put_tool_config_reenable(client: TestClient) -> None:
+    """PUT /api/user/tools can re-enable a previously disabled tool."""
+    # Disable
+    client.put(
+        "/api/user/tools",
+        json={"tools": [{"name": "estimate", "enabled": False}]},
+    )
+    # Re-enable
+    response = client.put(
+        "/api/user/tools",
+        json={"tools": [{"name": "estimate", "enabled": True}]},
+    )
+    assert response.status_code == 200
+    tools_by_name = {t["name"]: t for t in response.json()["tools"]}
+    assert tools_by_name["estimate"]["enabled"] is True
+
+
+def test_put_tool_config_empty_body(client: TestClient) -> None:
+    """PUT /api/user/tools rejects empty tool list."""
+    response = client.put("/api/user/tools", json={"tools": []})
+    assert response.status_code == 400
+
+
+def test_put_tool_config_unknown_tool_ignored(client: TestClient) -> None:
+    """PUT /api/user/tools ignores unknown tool names without error."""
+    response = client.put(
+        "/api/user/tools",
+        json={"tools": [{"name": "nonexistent_tool", "enabled": False}]},
+    )
+    assert response.status_code == 200
+    # All tools should still be present and unchanged
+    tools = response.json()["tools"]
+    assert len(tools) > 0


### PR DESCRIPTION
## Description
Add a per-user tool configuration system that allows users to view and enable/disable tool groups from the web UI. Users can toggle domain-specific tool groups (estimate, file, checklist) while core groups (workspace, profile, memory, messaging) remain always-on.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## Changes

**Backend:**
- `backend/app/agent/file_store.py`: Added `ToolConfigEntry` data class and `ToolConfigStore` for persisting per-user tool config as `tool_config.json`
- `backend/app/schemas.py`: Added `ToolConfigEntryResponse`, `ToolConfigResponse`, `ToolConfigUpdate`, `ToolConfigUpdateEntry` schemas
- `backend/app/routers/user_tools.py`: New router with `GET /api/user/tools` and `PUT /api/user/tools` endpoints
- `backend/app/agent/tools/registry.py`: Added `excluded_factories` parameter to `create_core_tools()` and `get_available_specialist_summaries()`
- `backend/app/agent/router.py`: Loads user's disabled tool groups and filters them out when assembling agent tools
- `backend/app/main.py`: Registered the `user_tools` router

**Frontend:**
- `frontend/src/types.ts`: Added `ToolConfigEntry`, `ToolConfigResponse`, `ToolConfigUpdateEntry` interfaces
- `frontend/src/api.ts`: Added `getToolConfig` and `updateToolConfig` API methods
- `frontend/src/pages/SettingsPage.tsx`: Added "Tools" tab to Settings page with toggles for domain-specific groups and greyed-out display for core groups

**Tests:**
- `tests/test_tool_config.py`: 11 tests covering store operations, registry exclusion, and API endpoints

Fixes #508

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with Claude Code (claude-opus-4-6).