### PR TITLE
fix: persist channel config to data/config.json instead of .env

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,15 @@
+import contextlib
 import hashlib
 import hmac
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
 
 from pydantic_settings import BaseSettings
+
+logger = logging.getLogger(__name__)
 
 
 def _derive_webhook_secret(bot_token: str) -> str:
@@ -111,3 +119,69 @@ class Settings(BaseSettings):
 settings = Settings()
 
 TELEGRAM_API_BASE = "https://api.telegram.org"
+
+# ---------------------------------------------------------------------------
+# Persistent config.json -- survives container restarts via volume mount
+# ---------------------------------------------------------------------------
+
+# Settings that can be persisted to config.json at runtime.
+PERSISTABLE_SETTINGS: frozenset[str] = frozenset(
+    {
+        "telegram_bot_token",
+        "telegram_allowed_chat_ids",
+        "telegram_allowed_usernames",
+        "telegram_webhook_secret",
+    }
+)
+
+
+def _config_json_path() -> Path:
+    """Return the path to config.json inside the volume-mounted data directory.
+
+    ``data_dir`` typically points at ``data/users``; the config file lives one
+    level up so it sits directly inside the mounted ``data/`` volume.
+    """
+    return Path(settings.data_dir).parent / "config.json"
+
+
+def load_persistent_config(path: Path | None = None) -> dict[str, Any]:
+    """Load config.json and apply values to the settings singleton.
+
+    Values from config.json override defaults but are themselves overridden by
+    real environment variables.  Returns the loaded dict (empty if the file
+    does not exist).
+    """
+    config_path = path or _config_json_path()
+    if not config_path.is_file():
+        return {}
+
+    try:
+        data: dict[str, Any] = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read %s: %s", config_path, exc)
+        return {}
+
+    for key, value in data.items():
+        if key not in PERSISTABLE_SETTINGS:
+            continue
+        # Environment variables always win.
+        env_name = key.upper()
+        if os.environ.get(env_name):
+            continue
+        setattr(settings, key, value)
+
+    return data
+
+
+def save_persistent_config(updates: dict[str, str], path: Path | None = None) -> None:
+    """Merge *updates* into config.json, creating the file if needed."""
+    config_path = path or _config_json_path()
+
+    existing: dict[str, Any] = {}
+    if config_path.is_file():
+        with contextlib.suppress(json.JSONDecodeError, OSError):
+            existing = json.loads(config_path.read_text(encoding="utf-8"))
+
+    existing.update(updates)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from backend.app.agent.heartbeat import heartbeat_scheduler
 from backend.app.channels import get_manager, register_channel
 from backend.app.channels.telegram import TelegramChannel
 from backend.app.channels.webchat import WebChatChannel
-from backend.app.config import settings
+from backend.app.config import load_persistent_config, settings
 from backend.app.routers import (
     auth,
     estimates,
@@ -108,6 +108,13 @@ async def _verify_llm_settings() -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     """Start/stop background services."""
+    # Load runtime-configurable settings (Telegram token, allowlists, etc.)
+    # from the volume-mounted data/config.json so they survive container
+    # restarts. This runs *before* load_dotenv() so that os.environ only
+    # contains real env vars at this point; .env values have not yet been
+    # injected. Real env vars still take precedence over config.json.
+    load_persistent_config()
+
     # Pydantic Settings reads .env for its own declared fields only and
     # does not mutate os.environ. Provider API keys like GROQ_API_KEY are
     # consumed by the any-llm SDK, which reads them directly from

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -1,12 +1,10 @@
 """Endpoints for contractor profile management."""
 
-from pathlib import Path
-
 from fastapi import APIRouter, Depends, HTTPException
 
 from backend.app.agent.file_store import ContractorData, get_contractor_store
 from backend.app.auth.dependencies import get_current_user
-from backend.app.config import settings
+from backend.app.config import save_persistent_config, settings
 from backend.app.schemas import (
     ChannelConfigResponse,
     ChannelConfigUpdate,
@@ -68,11 +66,6 @@ async def update_profile(
 # Channel config
 # ---------------------------------------------------------------------------
 
-_ENV_KEY_MAP: dict[str, str] = {
-    "telegram_bot_token": "TELEGRAM_BOT_TOKEN",
-    "telegram_allowed_usernames": "TELEGRAM_ALLOWED_USERNAMES",
-}
-
 
 def _build_channel_config_response() -> ChannelConfigResponse:
     return ChannelConfigResponse(
@@ -99,20 +92,13 @@ async def update_channel_config(
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
 
-    env_path = Path(".env")
-    env_exists = env_path.is_file()
-
     for field, value in updates.items():
-        # Update the in-memory settings singleton
         setattr(settings, field, value)
 
-        # Persist to .env if it exists
-        if env_exists:
-            from dotenv import set_key
+    # Persist to config.json inside the volume-mounted data directory.
+    save_persistent_config(updates)
 
-            set_key(str(env_path), _ENV_KEY_MAP[field], value)
-
-    # If the bot token changed, reset the live TelegramChannel instance
+    # If the bot token changed, reset the live TelegramChannel instance.
     if "telegram_bot_token" in updates:
         try:
             from backend.app.channels import get_channel

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -1,5 +1,6 @@
 """Tests for channel config GET/PUT endpoints."""
 
+import json
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
@@ -67,16 +68,15 @@ def test_update_channel_config_token(client: TestClient, _clear_bot_token: None)
     settings.telegram_bot_token = ""
 
 
-def test_update_channel_config_persists_to_dotenv(
+def test_update_channel_config_persists_to_config_json(
     client: TestClient, tmp_path: Path, _clear_bot_token: None
 ) -> None:
-    """PUT with a token writes to .env file when it exists."""
-    env_file = tmp_path / ".env"
-    env_file.write_text("# existing config\n")
+    """PUT with a token writes to config.json in the data directory."""
+    config_path = tmp_path / "config.json"
 
     with patch(
-        "backend.app.routers.user_profile.Path",
-        return_value=env_file,
+        "backend.app.routers.user_profile.save_persistent_config",
+        wraps=lambda updates, path=None: _write_config(config_path, updates),
     ):
         resp = client.put(
             "/api/user/channels/config",
@@ -84,12 +84,20 @@ def test_update_channel_config_persists_to_dotenv(
         )
 
     assert resp.status_code == 200
-    env_content = env_file.read_text()
-    assert "TELEGRAM_BOT_TOKEN" in env_content
-    assert "persisted-token" in env_content
+    config_data = json.loads(config_path.read_text())
+    assert config_data["telegram_bot_token"] == "persisted-token"
 
     # Clean up
     settings.telegram_bot_token = ""
+
+
+def _write_config(path: Path, updates: dict[str, str]) -> None:
+    """Helper to write config.json for testing."""
+    existing: dict[str, str] = {}
+    if path.is_file():
+        existing = json.loads(path.read_text())
+    existing.update(updates)
+    path.write_text(json.dumps(existing, indent=2) + "\n")
 
 
 def test_update_channel_config_null_token_is_ignored(

--- a/tests/test_persistent_config.py
+++ b/tests/test_persistent_config.py
@@ -1,0 +1,188 @@
+"""Tests for persistent config.json loading and saving."""
+
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from backend.app.config import (
+    PERSISTABLE_SETTINGS,
+    load_persistent_config,
+    save_persistent_config,
+    settings,
+)
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> Path:
+    """Return a temporary directory for config.json."""
+    return tmp_path
+
+
+@pytest.fixture()
+def config_path(config_dir: Path) -> Path:
+    """Return the path to a temporary config.json."""
+    return config_dir / "config.json"
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings() -> Iterator[None]:
+    """Save and restore telegram-related settings around each test.
+
+    Also temporarily remove the corresponding env vars so that earlier tests
+    (which may have called ``load_dotenv()``) do not pollute ``os.environ``
+    and cause ``load_persistent_config`` to skip config.json values.
+    """
+    originals = {key: getattr(settings, key) for key in PERSISTABLE_SETTINGS}
+    env_keys = [key.upper() for key in PERSISTABLE_SETTINGS]
+    saved_env = {k: os.environ.pop(k) for k in env_keys if k in os.environ}
+    yield
+    for key, value in originals.items():
+        setattr(settings, key, value)
+    # Restore any env vars we removed.
+    for k, v in saved_env.items():
+        os.environ[k] = v
+
+
+def test_load_nonexistent_config_returns_empty(config_path: Path) -> None:
+    """Loading a missing config.json returns an empty dict and is a no-op."""
+    result = load_persistent_config(path=config_path)
+    assert result == {}
+
+
+def test_load_config_applies_values(config_path: Path) -> None:
+    """Values from config.json are applied to the settings singleton."""
+    config_path.write_text(
+        json.dumps(
+            {
+                "telegram_bot_token": "saved-token",
+                "telegram_allowed_usernames": "alice,bob",
+            }
+        )
+    )
+
+    result = load_persistent_config(path=config_path)
+
+    assert result["telegram_bot_token"] == "saved-token"
+    assert settings.telegram_bot_token == "saved-token"
+    assert settings.telegram_allowed_usernames == "alice,bob"
+
+
+def test_load_config_env_var_takes_precedence(config_path: Path) -> None:
+    """Environment variables override config.json values."""
+    config_path.write_text(json.dumps({"telegram_bot_token": "from-config-json"}))
+
+    with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "from-env-var"}):
+        load_persistent_config(path=config_path)
+
+    # The env var should win, so settings should NOT be overwritten.
+    assert settings.telegram_bot_token != "from-config-json"
+
+
+def test_load_config_ignores_non_persistable_keys(config_path: Path) -> None:
+    """Keys not in PERSISTABLE_SETTINGS are ignored."""
+    original_log_level = settings.log_level
+    config_path.write_text(json.dumps({"log_level": "DEBUG", "telegram_bot_token": "tok"}))
+
+    load_persistent_config(path=config_path)
+
+    assert settings.log_level == original_log_level
+    assert settings.telegram_bot_token == "tok"
+
+
+def test_load_config_handles_corrupt_json(config_path: Path) -> None:
+    """Corrupt JSON is handled gracefully, returning an empty dict."""
+    config_path.write_text("{invalid json!!!")
+
+    result = load_persistent_config(path=config_path)
+
+    assert result == {}
+
+
+def test_save_creates_file(config_path: Path) -> None:
+    """save_persistent_config creates config.json if it does not exist."""
+    assert not config_path.exists()
+
+    save_persistent_config({"telegram_bot_token": "new-tok"}, path=config_path)
+
+    assert config_path.is_file()
+    data = json.loads(config_path.read_text())
+    assert data["telegram_bot_token"] == "new-tok"
+
+
+def test_save_merges_with_existing(config_path: Path) -> None:
+    """save_persistent_config merges new keys into existing config."""
+    config_path.write_text(json.dumps({"telegram_bot_token": "existing-tok"}))
+
+    save_persistent_config({"telegram_allowed_usernames": "alice"}, path=config_path)
+
+    data = json.loads(config_path.read_text())
+    assert data["telegram_bot_token"] == "existing-tok"
+    assert data["telegram_allowed_usernames"] == "alice"
+
+
+def test_save_overwrites_existing_key(config_path: Path) -> None:
+    """save_persistent_config overwrites a key that already exists."""
+    config_path.write_text(json.dumps({"telegram_bot_token": "old-tok"}))
+
+    save_persistent_config({"telegram_bot_token": "new-tok"}, path=config_path)
+
+    data = json.loads(config_path.read_text())
+    assert data["telegram_bot_token"] == "new-tok"
+
+
+def test_save_creates_parent_directories(tmp_path: Path) -> None:
+    """save_persistent_config creates parent directories if needed."""
+    deep_path = tmp_path / "nested" / "dir" / "config.json"
+
+    save_persistent_config({"telegram_bot_token": "tok"}, path=deep_path)
+
+    assert deep_path.is_file()
+    data = json.loads(deep_path.read_text())
+    assert data["telegram_bot_token"] == "tok"
+
+
+def test_save_handles_corrupt_existing_file(config_path: Path) -> None:
+    """save_persistent_config handles a corrupt existing file by overwriting it."""
+    config_path.write_text("{corrupt!!!")
+
+    save_persistent_config({"telegram_bot_token": "fresh"}, path=config_path)
+
+    data = json.loads(config_path.read_text())
+    assert data["telegram_bot_token"] == "fresh"
+
+
+def test_load_all_persistable_settings(config_path: Path) -> None:
+    """All four persistable settings can be loaded from config.json."""
+    all_values = {
+        "telegram_bot_token": "bot-token-value",
+        "telegram_allowed_chat_ids": "111,222",
+        "telegram_allowed_usernames": "user1,user2",
+        "telegram_webhook_secret": "secret-value",
+    }
+    config_path.write_text(json.dumps(all_values))
+
+    load_persistent_config(path=config_path)
+
+    for key, expected in all_values.items():
+        assert getattr(settings, key) == expected, f"{key} was not applied"
+
+
+def test_round_trip_save_then_load(config_path: Path) -> None:
+    """Values saved with save_persistent_config can be loaded back."""
+    save_persistent_config(
+        {"telegram_bot_token": "rt-token", "telegram_allowed_usernames": "rt-user"},
+        path=config_path,
+    )
+
+    # Reset settings to defaults
+    settings.telegram_bot_token = ""
+    settings.telegram_allowed_usernames = ""
+
+    load_persistent_config(path=config_path)
+
+    assert settings.telegram_bot_token == "rt-token"
+    assert settings.telegram_allowed_usernames == "rt-user"


### PR DESCRIPTION
## Description
The channel config update endpoint (`PUT /api/user/channels/config`) used
`dotenv.set_key()` to persist Telegram settings (bot token, allowed usernames)
to `.env`. Since `.env` is not volume-mounted in Docker (only `data/` is), all
runtime config changes were lost on container restart.

This PR replaces `.env` persistence with a `data/config.json` file inside the
volume-mounted `data/` directory. A `load_persistent_config()` function is called
at app startup to restore saved values, and `save_persistent_config()` is called
by the channel config endpoint on updates. Environment variables always take
precedence over `config.json` values.

### Changes
- **`backend/app/config.py`**: Added `load_persistent_config()`, `save_persistent_config()`,
  `PERSISTABLE_SETTINGS`, and `_config_json_path()`.
- **`backend/app/routers/user_profile.py`**: Replaced `dotenv.set_key()` with
  `save_persistent_config()`. Removed `_ENV_KEY_MAP` and `Path` import.
- **`backend/app/main.py`**: Call `load_persistent_config()` at startup (before
  `load_dotenv()` so env vars take precedence).
- **`tests/test_channel_config.py`**: Updated persistence test to verify
  `config.json` instead of `.env`.
- **`tests/test_persistent_config.py`**: New test file with 12 tests covering
  load, save, env var precedence, corrupt file handling, round-trip, and all
  persistable settings.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.6 via Claude Code)
- [ ] No AI used