### PR TITLE
feat: elevate channels to its own sidebar tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import MemoryPage from '@/pages/MemoryPage';
 import SettingsPage from '@/pages/SettingsPage';
 import ChatPage from '@/pages/ChatPage';
 import ChecklistPage from '@/pages/ChecklistPage';
+import ChannelsPage from '@/pages/ChannelsPage';
 import { useAuth } from '@/contexts/AuthContext';
 import {
   getLoginPageElement,
@@ -43,6 +44,7 @@ export default function App() {
         <Route path="conversations/:sessionId" element={<ConversationsPage />} />
         <Route path="memory" element={<MemoryPage />} />
         <Route path="checklist" element={<ChecklistPage />} />
+        <Route path="channels" element={<ChannelsPage />} />
         <Route path="settings/:tab" element={<SettingsPage />} />
         <Route path="settings" element={<Navigate to={`/app/settings/${getDefaultSettingsTab(isPremium)}`} replace />} />
       </Route>

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -22,6 +22,7 @@ const NAV_ITEMS = [
   { to: '/app/conversations', label: 'Conversations', icon: ConversationsIcon, end: false },
   { to: '/app/memory', label: 'Memory', icon: MemoryIcon, end: false },
   { to: '/app/checklist', label: 'Checklist', icon: ChecklistIcon, end: false },
+  { to: '/app/channels', label: 'Channels', icon: ChannelsIcon, end: false },
   { to: '/app/settings', label: 'Settings', icon: SettingsIcon, end: false },
 ] as const;
 
@@ -220,6 +221,14 @@ function ChecklistIcon() {
   return (
     <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+    </svg>
+  );
+}
+
+function ChannelsIcon() {
+  return (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
     </svg>
   );
 }

--- a/frontend/src/pages/ChannelsPage.tsx
+++ b/frontend/src/pages/ChannelsPage.tsx
@@ -1,0 +1,146 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useOutletContext } from 'react-router-dom';
+import Card from '@/components/ui/card';
+import Input from '@/components/ui/input';
+import Button from '@/components/ui/button';
+import { toast } from 'sonner';
+import api from '@/api';
+import type { ChannelConfig } from '@/types';
+import type { AppShellContext } from '@/layouts/AppShell';
+
+export default function ChannelsPage() {
+  const { profile } = useOutletContext<AppShellContext>();
+
+  if (!profile) return null;
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-6">Channels</h2>
+      <ChannelsContent profile={profile} />
+    </div>
+  );
+}
+
+function ChannelsContent({
+  profile,
+}: {
+  profile: { channel_identifier: string; preferred_channel: string };
+}) {
+  const connected = !!profile.channel_identifier;
+  const [config, setConfig] = useState<ChannelConfig | null>(null);
+  const [botToken, setBotToken] = useState('');
+  const [allowedUsernames, setAllowedUsernames] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    api.getChannelConfig().then((cfg) => {
+      setConfig(cfg);
+      setAllowedUsernames(cfg.telegram_allowed_usernames);
+    }).catch(() => {
+      // ignore fetch errors on mount
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const body: Record<string, string> = {};
+      if (botToken) body.telegram_bot_token = botToken;
+      if (config && allowedUsernames !== config.telegram_allowed_usernames) {
+        body.telegram_allowed_usernames = allowedUsernames;
+      }
+      if (Object.keys(body).length === 0) {
+        toast.error('No changes to save');
+        setSaving(false);
+        return;
+      }
+      const updated = await api.updateChannelConfig(body);
+      setConfig(updated);
+      setBotToken('');
+      toast.success('Channel config updated');
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [botToken, allowedUsernames, config]);
+
+  return (
+    <Card>
+      <div className="grid gap-4">
+        <Field label="Bot Token">
+          {config === null ? (
+            <p className="text-sm text-muted-foreground">Loading...</p>
+          ) : (
+            <>
+              <div className="mb-2">
+                {config.telegram_bot_token_set ? (
+                  <span className="inline-flex items-center gap-1.5 text-sm">
+                    <span className="w-2 h-2 rounded-full bg-green-500 inline-block" />
+                    Configured
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 text-sm">
+                    <span className="w-2 h-2 rounded-full bg-red-500 inline-block" />
+                    Not configured
+                  </span>
+                )}
+              </div>
+              <Input
+                type="password"
+                value={botToken}
+                onChange={(e) => setBotToken(e.target.value)}
+                placeholder={config.telegram_bot_token_set ? 'Enter new token to replace' : 'Paste bot token from @BotFather'}
+              />
+            </>
+          )}
+        </Field>
+        <Field label="Allowed Usernames">
+          <Input
+            value={allowedUsernames}
+            onChange={(e) => setAllowedUsernames(e.target.value)}
+            placeholder='Comma-separated @usernames, or * for all'
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Controls which Telegram users can message your bot.
+          </p>
+        </Field>
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={saving || config === null}>
+            {saving ? 'Saving...' : 'Save Channel Config'}
+          </Button>
+        </div>
+        <hr className="border-border" />
+        <Field label="User Connection">
+          {connected ? (
+            <div className="flex items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 text-sm">
+                <span className="w-2 h-2 rounded-full bg-green-500 inline-block" />
+                Connected
+              </span>
+              <span className="text-xs text-muted-foreground">
+                Chat ID: {profile.channel_identifier}
+              </span>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Send a message to your bot on Telegram to connect.
+            </p>
+          )}
+        </Field>
+        <Field label="Active Channel">
+          <p className="text-sm">{profile.preferred_channel || 'webchat'}</p>
+        </Field>
+      </div>
+    </Card>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="text-xs font-medium text-muted-foreground block mb-1">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { useOutletContext, useParams, useNavigate } from 'react-router-dom';
+import { Navigate, useOutletContext, useParams, useNavigate } from 'react-router-dom';
 import Card from '@/components/ui/card';
 import Input from '@/components/ui/input';
 import Textarea from '@/components/ui/textarea';
@@ -8,7 +8,7 @@ import Select from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { toast } from 'sonner';
 import api from '@/api';
-import type { ChannelConfig, ContractorProfileUpdate, ToolConfigEntry } from '@/types';
+import type { ContractorProfileUpdate, ToolConfigEntry } from '@/types';
 import type { AppShellContext } from '@/layouts/AppShell';
 import {
   getExtraSettingsTabs,
@@ -20,6 +20,11 @@ export default function SettingsPage() {
   const { tab } = useParams<{ tab: string }>();
   const navigate = useNavigate();
   const { profile, reloadProfile, isPremium, isAdmin } = useOutletContext<AppShellContext>();
+
+  // Redirect old /app/settings/channels to /app/channels
+  if (tab === 'channels') {
+    return <Navigate to="/app/channels" replace />;
+  }
 
   const extraTabs = getExtraSettingsTabs(isPremium, isAdmin);
   const activeTab = tab || 'profile';
@@ -41,7 +46,6 @@ export default function SettingsPage() {
                 <TabsTrigger value="profile">Profile</TabsTrigger>
                 <TabsTrigger value="assistant">Assistant</TabsTrigger>
                 <TabsTrigger value="heartbeat">Heartbeat</TabsTrigger>
-                <TabsTrigger value="channels">Channels</TabsTrigger>
                 <TabsTrigger value="tools">Tools</TabsTrigger>
               </>
             )}
@@ -65,7 +69,6 @@ export default function SettingsPage() {
           <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="assistant">Assistant</TabsTrigger>
           <TabsTrigger value="heartbeat">Heartbeat</TabsTrigger>
-          <TabsTrigger value="channels">Channels</TabsTrigger>
           <TabsTrigger value="tools">Tools</TabsTrigger>
           {extraTabs.map((t) => (
             <TabsTrigger key={t.key} value={t.key}>{t.label}</TabsTrigger>
@@ -82,10 +85,6 @@ export default function SettingsPage() {
 
         <TabsContent value="heartbeat">
           {profile && <HeartbeatTab profile={profile} onSaved={reloadProfile} />}
-        </TabsContent>
-
-        <TabsContent value="channels">
-          {profile && <ChannelsTab profile={profile} />}
         </TabsContent>
 
         <TabsContent value="tools">
@@ -382,123 +381,6 @@ function HeartbeatTab({
             {saving ? 'Saving...' : 'Save Heartbeat Settings'}
           </Button>
         </div>
-      </div>
-    </Card>
-  );
-}
-
-// --- Channels Tab ---
-
-function ChannelsTab({
-  profile,
-}: {
-  profile: { channel_identifier: string; preferred_channel: string };
-}) {
-  const connected = !!profile.channel_identifier;
-  const [config, setConfig] = useState<ChannelConfig | null>(null);
-  const [botToken, setBotToken] = useState('');
-  const [allowedUsernames, setAllowedUsernames] = useState('');
-  const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    api.getChannelConfig().then((cfg) => {
-      setConfig(cfg);
-      setAllowedUsernames(cfg.telegram_allowed_usernames);
-    }).catch(() => {
-      // ignore fetch errors on mount
-    });
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    setSaving(true);
-    try {
-      const body: Record<string, string> = {};
-      if (botToken) body.telegram_bot_token = botToken;
-      if (config && allowedUsernames !== config.telegram_allowed_usernames) {
-        body.telegram_allowed_usernames = allowedUsernames;
-      }
-      if (Object.keys(body).length === 0) {
-        toast.error('No changes to save');
-        setSaving(false);
-        return;
-      }
-      const updated = await api.updateChannelConfig(body);
-      setConfig(updated);
-      setBotToken('');
-      toast.success('Channel config updated');
-    } catch (e) {
-      toast.error((e as Error).message);
-    } finally {
-      setSaving(false);
-    }
-  }, [botToken, allowedUsernames, config]);
-
-  return (
-    <Card>
-      <div className="grid gap-4">
-        <Field label="Bot Token">
-          {config === null ? (
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          ) : (
-            <>
-              <div className="mb-2">
-                {config.telegram_bot_token_set ? (
-                  <span className="inline-flex items-center gap-1.5 text-sm">
-                    <span className="w-2 h-2 rounded-full bg-green-500 inline-block" />
-                    Configured
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center gap-1.5 text-sm">
-                    <span className="w-2 h-2 rounded-full bg-red-500 inline-block" />
-                    Not configured
-                  </span>
-                )}
-              </div>
-              <Input
-                type="password"
-                value={botToken}
-                onChange={(e) => setBotToken(e.target.value)}
-                placeholder={config.telegram_bot_token_set ? 'Enter new token to replace' : 'Paste bot token from @BotFather'}
-              />
-            </>
-          )}
-        </Field>
-        <Field label="Allowed Usernames">
-          <Input
-            value={allowedUsernames}
-            onChange={(e) => setAllowedUsernames(e.target.value)}
-            placeholder='Comma-separated @usernames, or * for all'
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            Controls which Telegram users can message your bot.
-          </p>
-        </Field>
-        <div className="flex justify-end">
-          <Button onClick={handleSave} disabled={saving || config === null}>
-            {saving ? 'Saving...' : 'Save Channel Config'}
-          </Button>
-        </div>
-        <hr className="border-border" />
-        <Field label="User Connection">
-          {connected ? (
-            <div className="flex items-center gap-2">
-              <span className="inline-flex items-center gap-1.5 text-sm">
-                <span className="w-2 h-2 rounded-full bg-green-500 inline-block" />
-                Connected
-              </span>
-              <span className="text-xs text-muted-foreground">
-                Chat ID: {profile.channel_identifier}
-              </span>
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              Send a message to your bot on Telegram to connect.
-            </p>
-          )}
-        </Field>
-        <Field label="Active Channel">
-          <p className="text-sm">{profile.preferred_channel || 'webchat'}</p>
-        </Field>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Description

Elevates the Channels configuration from a nested tab inside Settings to its own top-level sidebar navigation item, matching the pattern used in openclaw.

- Added "Channels" entry to the sidebar navigation in `AppShell.tsx` with a lightning bolt icon
- Created `ChannelsPage.tsx` as a standalone page (extracted from `SettingsPage.tsx`)
- Added `/app/channels` route in `App.tsx`
- Removed the Channels tab from Settings (both OSS and premium views)
- Added redirect from `/app/settings/channels` to `/app/channels` for backward compatibility

Fixes #514

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)