### PR TITLE
fix: trigger onboarding for new dashboard users

### DIFF
--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -17,5 +17,4 @@ async def get_current_user() -> ContractorData:
         return all_contractors[0]
     return await store.create(
         user_id=LOCAL_USER_ID,
-        name="Local Contractor",
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from backend.app.agent.file_store import get_contractor_store
+from backend.app.agent.onboarding import is_onboarding_needed
 from backend.app.auth.dependencies import LOCAL_USER_ID, get_current_user
 from backend.app.auth.scoping import get_user_contractor
 
@@ -12,8 +13,16 @@ async def test_get_current_user_creates_local_contractor() -> None:
     """OSS mode should auto-create a local contractor when store is empty."""
     contractor = await get_current_user()
     assert contractor.user_id == LOCAL_USER_ID
-    assert contractor.name == "Local Contractor"
+    assert contractor.name == ""
     assert contractor.id is not None
+
+
+@pytest.mark.asyncio()
+async def test_local_contractor_needs_onboarding() -> None:
+    """New local contractor should trigger onboarding (regression for #521)."""
+    contractor = await get_current_user()
+    assert not contractor.onboarding_complete
+    assert is_onboarding_needed(contractor)
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description

New dashboard users were never shown the onboarding flow because the local fallback contractor was created with `name="Local Contractor"`. Since `is_onboarding_needed()` checks if `name` is empty, this pre-populated placeholder caused onboarding to be skipped entirely.

- Remove the pre-populated `name` from the local contractor creation path so `is_onboarding_needed()` returns `True` for new users
- The dashboard sidebar and overview page already handle empty names with fallback labels ("Dashboard")
- Added regression test verifying new local contractors trigger onboarding

Fixes #521

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)