### PR TITLE
fix: remove user name from sidebar header

### DIFF
--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -98,11 +98,6 @@ export default function AppShell() {
             <img src="/clawbolt.png" alt="" className="w-7 h-7" />
             <h1 className="text-lg font-bold text-foreground">Clawbolt</h1>
           </div>
-          {profile && (
-            <p className="text-xs text-muted-foreground mt-0.5 truncate">
-              {profile.name || 'Dashboard'}
-            </p>
-          )}
         </div>
 
         <nav className="flex-1 p-2 space-y-0.5 overflow-y-auto">


### PR DESCRIPTION
## Description

Remove the profile name display underneath the Clawbolt logo in the sidebar. The name was shown as `profile.name || 'Dashboard'` and added unnecessary visual clutter.

Fixes #524

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)