### PR TITLE
fix: remove separate assistant name field from Soul tab

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -157,22 +157,16 @@ function SoulTab({
   profile,
   onSaved,
 }: {
-  profile: { assistant_name: string; soul_text: string };
+  profile: { soul_text: string };
   onSaved: () => void;
 }) {
-  const [form, setForm] = useState({
-    assistant_name: profile.assistant_name,
-    soul_text: profile.soul_text,
-  });
+  const [soulText, setSoulText] = useState(profile.soul_text);
   const [saving, setSaving] = useState(false);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      await api.updateProfile({
-        assistant_name: form.assistant_name,
-        soul_text: form.soul_text,
-      });
+      await api.updateProfile({ soul_text: soulText });
       onSaved();
       toast.success('Soul settings updated');
     } catch (e) {
@@ -180,27 +174,20 @@ function SoulTab({
     } finally {
       setSaving(false);
     }
-  }, [form, onSaved]);
+  }, [soulText, onSaved]);
 
   return (
     <Card>
       <div className="grid gap-4">
-        <Field label="Assistant Name">
-          <Input
-            value={form.assistant_name}
-            onChange={(e) => setForm((prev) => ({ ...prev, assistant_name: e.target.value }))}
-            placeholder="e.g. Claw"
-          />
-        </Field>
         <Field label="Personality (SOUL.md)">
           <Textarea
-            value={form.soul_text}
-            onChange={(e) => setForm((prev) => ({ ...prev, soul_text: e.target.value }))}
-            rows={12}
-            placeholder="Describe how your assistant should behave, speak, and interact with clients..."
+            value={soulText}
+            onChange={(e) => setSoulText(e.target.value)}
+            rows={14}
+            placeholder="Describe how your assistant should behave, speak, and interact with clients. Include what it should call itself (e.g. 'Your name is Claw')..."
           />
           <p className="text-xs text-muted-foreground mt-1">
-            This guides your assistant's personality and communication style.
+            This guides your assistant's personality, name, and communication style.
           </p>
         </Field>
         <div className="flex justify-end">


### PR DESCRIPTION
## Description

Remove the standalone "Assistant Name" input field from the Soul settings tab. The assistant name should be part of the SOUL.md content itself (e.g. "Your name is Claw"), consistent with how openclaw handles it. The textarea placeholder now mentions including the name.

Fixes #528

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)