### PR TITLE
feat: rename contractor to user across the codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,15 +59,15 @@ data/
 ```
 
 Key store classes in `backend/app/agent/file_store.py`:
-- `ContractorStore` (singleton via `get_contractor_store()`)
-- `FileMemoryStore` (per-contractor via `get_memory_store(id)`)
-- `FileSessionStore` (per-contractor via `get_session_store(id)`)
+- `UserStore` (singleton via `get_user_store()`)
+- `FileMemoryStore` (per-user via `get_memory_store(id)`)
+- `FileSessionStore` (per-user via `get_session_store(id)`)
 - `ClientStore`, `EstimateStore`, `MediaStore`, `HeartbeatStore` (instantiated per use)
 - `IdempotencyStore` (singleton via `get_idempotency_store()`)
 - `LLMUsageStore` (instantiated per use)
 
 Data classes (Pydantic BaseModel, replace ORM models):
-- `ContractorData`, `StoredMessage`, `SessionState`, `ClientData`
+- `UserData`, `StoredMessage`, `SessionState`, `ClientData`
 - `EstimateData`, `MediaData`, `ChecklistItem`, `HeartbeatLogEntry`, `MemoryFact`
 
 ## Coding Standards
@@ -99,7 +99,7 @@ Data classes (Pydantic BaseModel, replace ORM models):
 - **`user_id` scoping** on every data class and endpoint from day one
 - **MessagingService protocol**: channel-agnostic interface in `services/messaging.py` with Telegram implementation in `channels/telegram.py`
 - **Agent loop**: Telegram webhook -> media pipeline -> tool-calling loop (any-llm `acompletion`) -> tool execution -> reply
-- **Memory**: MEMORY.md key-value facts + clients.json client records per contractor
+- **Memory**: MEMORY.md key-value facts + clients.json client records per user
 - **Services**: External services abstracted behind service classes in `backend/app/services/`
 
 ## Definition of Done

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-Clawbolt is a messaging-first AI assistant that helps contractors manage their business: estimates, client records, job photos, voice memos, and more, all through Telegram. No app to install, no dashboard to learn. Just text.
+Clawbolt is a messaging-first AI assistant that helps users manage their business: estimates, client records, job photos, voice memos, and more, all through Telegram. No app to install, no dashboard to learn. Just text.
 
 **[Read the full documentation](https://mozilla-ai.github.io/clawbolt)**
 
@@ -32,7 +32,7 @@ Clawbolt is a messaging-first AI assistant that helps contractors manage their b
 - **Voice memos** -- Send a voice note, get it transcribed and processed as a message
 - **File cataloging** -- Photos and documents auto-organized in Dropbox or Google Drive
 - **Proactive heartbeat** -- Clawbolt checks in periodically with reminders about stale drafts and follow-ups
-- **Onboarding** -- First-time contractors get a friendly conversation to set up their profile
+- **Onboarding** -- First-time users get a friendly conversation to set up their profile
 
 ## Quick Start
 

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -29,7 +29,7 @@ def _format_messages_for_compaction(messages: list[AgentMessage]) -> str:
     lines: list[str] = []
     for msg in messages:
         if isinstance(msg, UserMessage):
-            lines.append(f"Contractor: {msg.content}")
+            lines.append(f"User: {msg.content}")
         elif isinstance(msg, AssistantMessage) and msg.content:
             lines.append(f"Assistant: {msg.content}")
     return "\n".join(lines)
@@ -78,7 +78,7 @@ def _parse_compaction_response(raw: str) -> list[dict[str, str]]:
 
 
 async def compact_session(
-    contractor_id: int,
+    user_id: int,
     trimmed_messages: list[AgentMessage],
     max_message_seq: int | None = None,
 ) -> tuple[list[dict[str, str]], int | None]:
@@ -88,7 +88,7 @@ async def compact_session(
     them via the existing memory subsystem.
 
     Args:
-        contractor_id: The contractor whose session is being compacted.
+        user_id: The user whose session is being compacted.
         trimmed_messages: Messages that are about to be dropped from context.
         max_message_seq: The highest message seq among the trimmed messages,
             used to track compaction progress. Passed through to the return value.
@@ -128,7 +128,7 @@ async def compact_session(
             ),
         )
     except Exception:
-        logger.exception("Compaction LLM call failed for contractor %d", contractor_id)
+        logger.exception("Compaction LLM call failed for user %d", user_id)
         return [], None
 
     raw_content = get_response_text(response)
@@ -138,7 +138,7 @@ async def compact_session(
     for fact in facts:
         try:
             await save_memory(
-                contractor_id=contractor_id,
+                user_id=user_id,
                 key=fact["key"],
                 value=fact["value"],
                 category=fact["category"],
@@ -146,16 +146,16 @@ async def compact_session(
             )
             saved_facts.append(fact)
             logger.info(
-                "Compaction saved fact for contractor %d: %s = %s",
-                contractor_id,
+                "Compaction saved fact for user %d: %s = %s",
+                user_id,
                 fact["key"],
                 fact["value"][:80],
             )
         except Exception:
             logger.exception(
-                "Failed to save compacted fact %s for contractor %d",
+                "Failed to save compacted fact %s for user %d",
                 fact["key"],
-                contractor_id,
+                user_id,
             )
 
     return saved_facts, max_message_seq

--- a/backend/app/agent/concurrency.py
+++ b/backend/app/agent/concurrency.py
@@ -1,11 +1,11 @@
-"""Per-contractor processing lock to prevent race conditions.
+"""Per-user processing lock to prevent race conditions.
 
-When two messages from the same contractor arrive in quick succession,
+When two messages from the same user arrive in quick succession,
 both background tasks could run the agent pipeline simultaneously,
 causing duplicate memory saves, conflicting tool executions, and
-interleaved responses.  This module provides a simple per-contractor
-``asyncio.Lock`` manager that serializes processing for each contractor
-while allowing different contractors to be processed in parallel.
+interleaved responses.  This module provides a simple per-user
+``asyncio.Lock`` manager that serializes processing for each user
+while allowing different users to be processed in parallel.
 """
 
 from __future__ import annotations
@@ -33,14 +33,14 @@ class _LockEntry:
         self.last_used = time.monotonic()
 
 
-class ContractorLockManager:
-    """Manages per-contractor asyncio locks.
+class UserLockManager:
+    """Manages per-user asyncio locks.
 
     Usage::
 
-        lock_manager = ContractorLockManager()
+        lock_manager = UserLockManager()
 
-        async with lock_manager.acquire(contractor_id):
+        async with lock_manager.acquire(user_id):
             await run_agent_pipeline(...)
     """
 
@@ -48,16 +48,16 @@ class ContractorLockManager:
         self._locks: dict[int, _LockEntry] = {}
         self._expiry_seconds = expiry_seconds
 
-    def acquire(self, contractor_id: int) -> asyncio.Lock:
-        """Get the lock for a contractor, creating one if needed.
+    def acquire(self, user_id: int) -> asyncio.Lock:
+        """Get the lock for a user, creating one if needed.
 
         Returns the ``asyncio.Lock`` itself so callers can use
-        ``async with lock_manager.acquire(contractor_id):``.
+        ``async with lock_manager.acquire(user_id):``.
         """
-        entry = self._locks.get(contractor_id)
+        entry = self._locks.get(user_id)
         if entry is None:
             entry = _LockEntry()
-            self._locks[contractor_id] = entry
+            self._locks[user_id] = entry
         entry.touch()
         return entry.lock
 
@@ -75,7 +75,7 @@ class ContractorLockManager:
         for cid in stale:
             del self._locks[cid]
         if stale:
-            logger.debug("Cleaned up %d stale contractor locks", len(stale))
+            logger.debug("Cleaned up %d stale user locks", len(stale))
         return len(stale)
 
     @property
@@ -85,4 +85,4 @@ class ContractorLockManager:
 
 
 # Module-level singleton
-contractor_locks = ContractorLockManager()
+user_locks = UserLockManager()

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -47,7 +47,7 @@ class StoredToolInteraction(BaseModel):
 async def _run_compaction_in_background(
     session_store: FileSessionStore,
     session: SessionState,
-    contractor_id: int,
+    user_id: int,
     trimmed_agent_messages: list[AgentMessage],
     max_message_seq: int,
 ) -> None:
@@ -58,23 +58,22 @@ async def _run_compaction_in_background(
     """
     try:
         saved, compacted_seq = await compact_session(
-            contractor_id, trimmed_agent_messages, max_message_seq=max_message_seq
+            user_id, trimmed_agent_messages, max_message_seq=max_message_seq
         )
         if compacted_seq is not None:
             await session_store.update_compaction_seq(session, compacted_seq)
         if saved:
             logger.info(
-                "Session compaction extracted %d fact(s) from %d trimmed message(s) "
-                "for contractor %d",
+                "Session compaction extracted %d fact(s) from %d trimmed message(s) for user %d",
                 len(saved),
                 len(trimmed_agent_messages),
-                contractor_id,
+                user_id,
             )
     except Exception:
         logger.exception(
-            "Session compaction failed for session %s, contractor %d",
+            "Session compaction failed for session %s, user %d",
             session.session_id,
-            contractor_id,
+            user_id,
         )
 
 
@@ -153,7 +152,7 @@ def _expand_outbound_with_tools(
 async def load_conversation_history(
     session: SessionState,
     limit: int = DEFAULT_HISTORY_LIMIT,
-    contractor_id: int | None = None,
+    user_id: int | None = None,
 ) -> list[AgentMessage]:
     """Load recent messages as typed message objects for LLM context.
 
@@ -165,7 +164,7 @@ async def load_conversation_history(
     prior tool usage.  Old messages without tool interaction data are
     loaded as flat ``AssistantMessage`` (backward compatible).
 
-    When the session has more messages than *limit* and a *contractor_id*
+    When the session has more messages than *limit* and a *user_id*
     is provided, the messages that are about to age out are passed through
     session compaction to extract durable facts before they leave the context
     window. Compaction runs as a background task to avoid blocking message
@@ -181,8 +180,8 @@ async def load_conversation_history(
     else:
         messages = []
 
-    # If messages were trimmed and we have a contractor_id, run compaction
-    if contractor_id is not None and total_count > limit:
+    # If messages were trimmed and we have a user_id, run compaction
+    if user_id is not None and total_count > limit:
         trimmed_count = total_count - limit
 
         # Get the oldest messages that have been trimmed from the context window
@@ -202,12 +201,12 @@ async def load_conversation_history(
 
         if trimmed_agent_messages and trimmed_msgs:
             max_seq = max(m.seq for m in trimmed_msgs)
-            session_store = get_session_store(contractor_id)
+            session_store = get_session_store(user_id)
             task = asyncio.create_task(
                 _run_compaction_in_background(
                     session_store,
                     session,
-                    contractor_id,
+                    user_id,
                     trimmed_agent_messages,
                     max_seq,
                 )
@@ -240,7 +239,7 @@ async def load_conversation_history(
 
 
 async def get_or_create_conversation(
-    contractor_id: int,
+    user_id: int,
     external_session_id: str | None = None,
     timeout_hours: int = CONVERSATION_TIMEOUT_HOURS,
 ) -> tuple[SessionState, bool]:
@@ -249,11 +248,11 @@ async def get_or_create_conversation(
     A conversation is "active" if the last message was within the timeout window.
     Returns (session, is_new).
     """
-    session_store = get_session_store(contractor_id)
+    session_store = get_session_store(user_id)
 
     if external_session_id is not None:
         session = session_store._load_session(external_session_id)
-        if session is not None and session.contractor_id == contractor_id:
+        if session is not None and session.user_id == user_id:
             return session, False
 
     return await session_store.get_or_create_session(timeout_hours=timeout_hours)

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -25,7 +25,7 @@ from backend.app.agent.events import (
     TurnEndEvent,
     TurnStartEvent,
 )
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.llm_parsing import get_response_text, parse_tool_calls
 from backend.app.agent.messages import (
     AgentMessage,
@@ -231,18 +231,18 @@ class AgentResponse:
 
 
 class ClawboltAgent:
-    """Main agent that processes contractor messages and produces actions."""
+    """Main agent that processes user messages and produces actions."""
 
     def __init__(
         self,
-        contractor: ContractorData,
+        user: UserData,
         messaging_service: MessagingService | None = None,
         chat_id: str | None = None,
         tool_context: ToolContext | None = None,
         registry: ToolRegistry | None = None,
         session_id: str = "",
     ) -> None:
-        self.contractor = contractor
+        self.user = user
         self._messaging_service = messaging_service
         self._chat_id = chat_id
         self.tools: list[Tool] = []
@@ -287,9 +287,9 @@ class ClawboltAgent:
                 logger.warning("Duplicate tool name registered: %s", tool.name)
             self._tools_by_name[tool.name] = tool
         logger.debug(
-            "Registered %d tools for contractor %s: %s",
+            "Registered %d tools for user %s: %s",
             len(tools),
-            self.contractor.id if self.contractor else "N/A",
+            self.user.id if self.user else "N/A",
             ", ".join(sorted(self._tools_by_name.keys())),
         )
 
@@ -354,7 +354,7 @@ class ClawboltAgent:
     async def _build_system_prompt(self, message_context: str) -> str:
         """Build the full system prompt via the composable builder."""
         return await build_agent_system_prompt(
-            self.contractor,
+            self.user,
             self.tools,
             message_context,
             current_session_id=self._session_id,
@@ -557,15 +557,15 @@ class ClawboltAgent:
         """Process a message through the agent loop."""
         agent_start_time = time.monotonic()
         logger.debug(
-            "Agent starting for contractor %d, message length=%d, history=%d messages",
-            self.contractor.id,
+            "Agent starting for user %d, message length=%d, history=%d messages",
+            self.user.id,
             len(message_context),
             len(conversation_history) if conversation_history else 0,
         )
         system_prompt = system_prompt_override or await self._build_system_prompt(message_context)
         await self._emit(
             AgentStartEvent(
-                contractor_id=self.contractor.id,
+                user_id=self.user.id,
                 message_context=message_context,
             )
         )
@@ -616,7 +616,7 @@ class ClawboltAgent:
             await self._emit(TurnStartEvent(round_number=_round, message_count=len(messages)))
             response = await self._call_llm_with_retry(messages, tool_schemas, llm_kwargs)
             purpose = "agent_main" if _round == 0 else "agent_followup"
-            log_llm_usage(self.contractor.id, settings.llm_model, response, purpose)
+            log_llm_usage(self.user.id, settings.llm_model, response, purpose)
             if response.usage and response.usage.input_tokens:
                 self._last_input_tokens = response.usage.input_tokens
                 logger.debug(
@@ -810,8 +810,8 @@ class ClawboltAgent:
 
         total_duration = (time.monotonic() - agent_start_time) * 1000
         logger.debug(
-            "Agent finished for contractor %d in %.1fms, actions=%s, reply_length=%d",
-            self.contractor.id,
+            "Agent finished for user %d in %.1fms, actions=%s, reply_length=%d",
+            self.user.id,
             total_duration,
             actions_taken or "(none)",
             len(reply_text),

--- a/backend/app/agent/events.py
+++ b/backend/app/agent/events.py
@@ -16,7 +16,7 @@ from typing import Any
 class AgentStartEvent:
     """Emitted when the agent begins processing a message."""
 
-    contractor_id: int
+    user_id: int
     message_context: str
 
 

--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -55,8 +55,8 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-class ContractorData(BaseModel):
-    """Replaces the Contractor ORM model."""
+class UserData(BaseModel):
+    """Replaces the User ORM model."""
 
     id: int = 0
     user_id: str = ""
@@ -104,7 +104,7 @@ class SessionMetadata(BaseModel):
     """
 
     session_id: str = ""
-    contractor_id: int = 0
+    user_id: int = 0
     last_message_at: str = ""
     is_active: bool = True
     last_compacted_seq: int = 0
@@ -114,7 +114,7 @@ class SessionState(BaseModel):
     """In-memory representation of a conversation session."""
 
     session_id: str = ""
-    contractor_id: int = 0
+    user_id: int = 0
     messages: list[StoredMessage] = Field(default_factory=list)
     is_active: bool = True
     created_at: str = ""
@@ -148,7 +148,7 @@ class EstimateData(BaseModel):
     """Replaces the Estimate + EstimateLineItem ORM models."""
 
     id: str = ""
-    contractor_id: int = 0
+    user_id: int = 0
     client_id: str | None = None
     description: str = ""
     total_amount: float = 0.0
@@ -164,7 +164,7 @@ class MediaData(BaseModel):
 
     id: str = ""
     message_id: int | None = None
-    contractor_id: int = 0
+    user_id: int = 0
     original_url: str = ""
     mime_type: str = ""
     processed_text: str = ""
@@ -177,7 +177,7 @@ class ChecklistItem(BaseModel):
     """Replaces the HeartbeatChecklistItem ORM model."""
 
     id: int = 0
-    contractor_id: int = 0
+    user_id: int = 0
     description: str = ""
     schedule: str = ChecklistSchedule.DAILY
     active_hours: str = ""
@@ -189,7 +189,7 @@ class ChecklistItem(BaseModel):
 class HeartbeatLogEntry(BaseModel):
     """Replaces the HeartbeatLog ORM model."""
 
-    contractor_id: int = 0
+    user_id: int = 0
     created_at: str = Field(default_factory=lambda: datetime.datetime.now(datetime.UTC).isoformat())
 
 
@@ -262,9 +262,9 @@ def _data_dir() -> Path:
     return Path(settings.data_dir)
 
 
-def _user_dir(contractor_id: int) -> Path:
+def _user_dir(user_id: int) -> Path:
     """Return the directory for a specific user."""
-    return _data_dir() / str(contractor_id)
+    return _data_dir() / str(user_id)
 
 
 def _index_path() -> Path:
@@ -331,53 +331,53 @@ def make_client_slug(
 
 
 # ---------------------------------------------------------------------------
-# ContractorStore
+# UserStore
 # ---------------------------------------------------------------------------
 
 
-class ContractorStore:
-    """File-based contractor storage. Replaces Contractor model + queries."""
+class UserStore:
+    """File-based user storage. Replaces User model + queries."""
 
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
 
     def _all_dirs(self) -> list[Path]:
-        """List all contractor directories."""
+        """List all user directories."""
         base = _data_dir()
         if not base.exists():
             return []
         return [d for d in sorted(base.iterdir()) if d.is_dir() and d.name.isdigit()]
 
-    def _load(self, contractor_id: int) -> ContractorData | None:
-        """Load a contractor from disk."""
-        path = _user_dir(contractor_id) / "user.json"
+    def _load(self, user_id: int) -> UserData | None:
+        """Load a user from disk."""
+        path = _user_dir(user_id) / "user.json"
         data = _read_json(path)
         if data is None:
             return None
-        contractor = ContractorData.model_validate(data)
+        user = UserData.model_validate(data)
         # Load soul_text from SOUL.md
-        soul_path = _user_dir(contractor_id) / "SOUL.md"
+        soul_path = _user_dir(user_id) / "SOUL.md"
         if soul_path.exists():
             raw = soul_path.read_text(encoding="utf-8").strip()
             if raw.startswith("# Soul"):
                 raw = raw[len("# Soul") :].strip()
-            contractor.soul_text = raw
+            user.soul_text = raw
         # Load user_text from USER.md
-        user_path = _user_dir(contractor_id) / "USER.md"
+        user_path = _user_dir(user_id) / "USER.md"
         if user_path.exists():
             raw = user_path.read_text(encoding="utf-8").strip()
             if raw.startswith("# User"):
                 raw = raw[len("# User") :].strip()
-            contractor.user_text = raw
-        return contractor
+            user.user_text = raw
+        return user
 
-    def _save(self, contractor: ContractorData) -> None:
-        """Save a contractor to disk."""
-        cdir = _user_dir(contractor.id)
+    def _save(self, user: UserData) -> None:
+        """Save a user to disk."""
+        cdir = _user_dir(user.id)
         cdir.mkdir(parents=True, exist_ok=True)
 
         # Save user.json (exclude soul_text/user_text, they go to .md files)
-        data = contractor.model_dump()
+        data = user.model_dump()
         soul_text = data.pop("soul_text", "")
         user_text = data.pop("user_text", "")
         _write_json(cdir / "user.json", data)
@@ -387,7 +387,7 @@ class ContractorStore:
         if soul_text:
             soul_path.write_text(f"# Soul\n\n{soul_text}\n", encoding="utf-8")
         elif not soul_path.exists():
-            # Seed a meaningful default for brand-new contractors
+            # Seed a meaningful default for brand-new users
             soul_path.write_text(
                 f"# Soul\n\n{load_prompt('default_soul')}\n",
                 encoding="utf-8",
@@ -414,36 +414,36 @@ class ContractorStore:
         if not mem_path.exists():
             mem_path.write_text("# Long-term Memory\n", encoding="utf-8")
 
-    def _update_index(self, contractor: ContractorData) -> None:
+    def _update_index(self, user: UserData) -> None:
         """Update user_index.json with channel mapping."""
         idx_path = _index_path()
         index: dict[str, int] = _read_json(idx_path, {})
-        if contractor.channel_identifier:
-            key = f"{contractor.preferred_channel}:{contractor.channel_identifier}"
-            index[key] = contractor.id
+        if user.channel_identifier:
+            key = f"{user.preferred_channel}:{user.channel_identifier}"
+            index[key] = user.id
         _write_json(idx_path, index)
 
-    def link_channel(self, channel: str, channel_identifier: str, contractor_id: int) -> None:
-        """Add a channel mapping to the index for an existing contractor."""
+    def link_channel(self, channel: str, channel_identifier: str, user_id: int) -> None:
+        """Add a channel mapping to the index for an existing user."""
         idx_path = _index_path()
         index: dict[str, int] = _read_json(idx_path, {})
         key = f"{channel}:{channel_identifier}"
-        index[key] = contractor_id
+        index[key] = user_id
         _write_json(idx_path, index)
 
-    def _next_contractor_id(self) -> int:
-        """Get the next contractor ID by scanning existing directories."""
+    def _next_user_id(self) -> int:
+        """Get the next user ID by scanning existing directories."""
         dirs = self._all_dirs()
         if not dirs:
             return 1
         return max(int(d.name) for d in dirs) + 1
 
-    async def get_by_id(self, contractor_id: int) -> ContractorData | None:
-        """Get a contractor by ID."""
-        return self._load(contractor_id)
+    async def get_by_id(self, user_id: int) -> UserData | None:
+        """Get a user by ID."""
+        return self._load(user_id)
 
-    async def get_by_user_id(self, user_id: str) -> ContractorData | None:
-        """Get a contractor by user_id (scans all contractors)."""
+    async def get_by_user_id(self, user_id: str) -> UserData | None:
+        """Get a user by user_id (scans all users)."""
         for cdir in self._all_dirs():
             cid = int(cdir.name)
             c = self._load(cid)
@@ -451,8 +451,8 @@ class ContractorStore:
                 return c
         return None
 
-    async def get_by_channel(self, channel_identifier: str) -> ContractorData | None:
-        """Get a contractor by channel_identifier using the index."""
+    async def get_by_channel(self, channel_identifier: str) -> UserData | None:
+        """Get a user by channel_identifier using the index."""
         idx_path = _index_path()
         index: dict[str, int] = _read_json(idx_path, {})
         # Try all channel prefixes
@@ -474,12 +474,12 @@ class ContractorStore:
         channel_identifier: str = "",
         preferred_channel: str = "telegram",
         **kwargs: Any,
-    ) -> ContractorData:
-        """Create a new contractor."""
+    ) -> UserData:
+        """Create a new user."""
         async with self._lock:
-            cid = self._next_contractor_id()
+            cid = self._next_user_id()
             now = datetime.datetime.now(datetime.UTC)
-            contractor = ContractorData(
+            user = UserData(
                 id=cid,
                 user_id=user_id,
                 channel_identifier=channel_identifier,
@@ -488,28 +488,28 @@ class ContractorStore:
                 updated_at=now,
                 **kwargs,
             )
-            self._save(contractor)
-            self._update_index(contractor)
-            return contractor
+            self._save(user)
+            self._update_index(user)
+            return user
 
-    async def update(self, contractor_id: int, **fields: Any) -> ContractorData | None:
-        """Update contractor fields."""
+    async def update(self, user_id: int, **fields: Any) -> UserData | None:
+        """Update user fields."""
         async with self._lock:
-            contractor = self._load(contractor_id)
-            if contractor is None:
+            user = self._load(user_id)
+            if user is None:
                 return None
             for key, value in fields.items():
-                if hasattr(contractor, key) and value is not None:
-                    setattr(contractor, key, value)
-            contractor.updated_at = datetime.datetime.now(datetime.UTC)
-            self._save(contractor)
+                if hasattr(user, key) and value is not None:
+                    setattr(user, key, value)
+            user.updated_at = datetime.datetime.now(datetime.UTC)
+            self._save(user)
             if "channel_identifier" in fields or "preferred_channel" in fields:
-                self._update_index(contractor)
-            return contractor
+                self._update_index(user)
+            return user
 
-    async def list_all(self) -> list[ContractorData]:
-        """List all contractors."""
-        result: list[ContractorData] = []
+    async def list_all(self) -> list[UserData]:
+        """List all users."""
+        result: list[UserData] = []
         for cdir in self._all_dirs():
             cid = int(cdir.name)
             c = self._load(cid)
@@ -532,21 +532,21 @@ _CATEGORY_RE = re.compile(r"^##\s+(.+)$")
 class FileMemoryStore:
     """File-based memory storage using MEMORY.md. Replaces Memory model."""
 
-    def __init__(self, contractor_id: int) -> None:
-        self.contractor_id = contractor_id
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
         self._lock = asyncio.Lock()
 
     @property
     def _memory_path(self) -> Path:
-        return _user_dir(self.contractor_id) / "memory" / "MEMORY.md"
+        return _user_dir(self.user_id) / "memory" / "MEMORY.md"
 
     @property
     def _history_path(self) -> Path:
-        return _user_dir(self.contractor_id) / "memory" / "HISTORY.md"
+        return _user_dir(self.user_id) / "memory" / "HISTORY.md"
 
     @property
     def _soul_path(self) -> Path:
-        return _user_dir(self.contractor_id) / "SOUL.md"
+        return _user_dir(self.user_id) / "SOUL.md"
 
     def _parse_memory_md(self) -> list[MemoryFact]:
         """Parse MEMORY.md into a list of MemoryFact objects."""
@@ -658,7 +658,7 @@ class FileMemoryStore:
         else:
             memories = await self.get_all_memories()
 
-        client_store = ClientStore(self.contractor_id)
+        client_store = ClientStore(self.user_id)
         clients = await client_store.list_all()
 
         lines: list[str] = []
@@ -703,7 +703,7 @@ class FileMemoryStore:
 
     @property
     def _user_path(self) -> Path:
-        return _user_dir(self.contractor_id) / "USER.md"
+        return _user_dir(self.user_id) / "USER.md"
 
     def read_user(self) -> str:
         """Read USER.md content."""
@@ -728,13 +728,13 @@ class FileMemoryStore:
 class FileSessionStore:
     """File-based session storage using JSONL files. Replaces Conversation + Message models."""
 
-    def __init__(self, contractor_id: int) -> None:
-        self.contractor_id = contractor_id
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
         self._lock = asyncio.Lock()
 
     @property
     def _sessions_dir(self) -> Path:
-        return _user_dir(self.contractor_id) / "sessions"
+        return _user_dir(self.user_id) / "sessions"
 
     def _session_path(self, session_id: str) -> Path:
         return self._sessions_dir / f"{session_id}.jsonl"
@@ -764,7 +764,7 @@ class FileSessionStore:
 
         return SessionState(
             session_id=session_id,
-            contractor_id=self.contractor_id,
+            user_id=self.user_id,
             messages=messages,
             is_active=metadata.get("is_active", True),
             created_at=metadata.get("created_at", ""),
@@ -818,14 +818,14 @@ class FileSessionStore:
         # Create new session
         now = datetime.datetime.now(datetime.UTC)
         ts = int(now.timestamp())
-        session_id = f"{self.contractor_id}_{ts}"
+        session_id = f"{self.user_id}_{ts}"
         path = self._session_path(session_id)
         path.parent.mkdir(parents=True, exist_ok=True)
 
         meta = {
             "_type": "metadata",
             "session_id": session_id,
-            "contractor_id": self.contractor_id,
+            "user_id": self.user_id,
             "created_at": now.isoformat(),
             "last_message_at": now.isoformat(),
             "is_active": True,
@@ -835,7 +835,7 @@ class FileSessionStore:
 
         session = SessionState(
             session_id=session_id,
-            contractor_id=self.contractor_id,
+            user_id=self.user_id,
             is_active=True,
             created_at=now.isoformat(),
             last_message_at=now.isoformat(),
@@ -991,13 +991,13 @@ class FileSessionStore:
 class ClientStore:
     """File-based client storage. Replaces Client model."""
 
-    def __init__(self, contractor_id: int) -> None:
-        self.contractor_id = contractor_id
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
         self._lock = asyncio.Lock()
 
     @property
     def _path(self) -> Path:
-        return _user_dir(self.contractor_id) / "clients.json"
+        return _user_dir(self.user_id) / "clients.json"
 
     def _load_all(self) -> list[dict[str, Any]]:
         return _read_json(self._path, [])
@@ -1086,13 +1086,13 @@ class EstimateStore:
             EST-0003.json
     """
 
-    def __init__(self, contractor_id: int) -> None:
-        self.contractor_id = contractor_id
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
         self._lock = asyncio.Lock()
 
     @property
     def _estimates_dir(self) -> Path:
-        return _user_dir(self.contractor_id) / "estimates"
+        return _user_dir(self.user_id) / "estimates"
 
     def _estimate_path(self, estimate_id: str, client_id: str | None = None) -> Path:
         folder = client_id if client_id else "unsorted"
@@ -1176,7 +1176,7 @@ class EstimateStore:
 
             estimate = EstimateData(
                 id=eid,
-                contractor_id=self.contractor_id,
+                user_id=self.user_id,
                 client_id=client_id,
                 description=description,
                 total_amount=total_amount,
@@ -1211,13 +1211,13 @@ class EstimateStore:
 class MediaStore:
     """File-based media file manifest. Replaces MediaFile model."""
 
-    def __init__(self, contractor_id: int) -> None:
-        self.contractor_id = contractor_id
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
         self._lock = asyncio.Lock()
 
     @property
     def _path(self) -> Path:
-        return _user_dir(self.contractor_id) / "media.json"
+        return _user_dir(self.user_id) / "media.json"
 
     def _load_all(self) -> list[dict[str, Any]]:
         return _read_json(self._path, [])
@@ -1254,7 +1254,7 @@ class MediaStore:
             mid = self._next_media_id(items)
             media = MediaData(
                 id=mid,
-                contractor_id=self.contractor_id,
+                user_id=self.user_id,
                 message_id=message_id,
                 original_url=original_url,
                 mime_type=mime_type,
@@ -1302,17 +1302,17 @@ class MediaStore:
 class HeartbeatStore:
     """File-based heartbeat storage. Replaces HeartbeatChecklistItem + HeartbeatLog."""
 
-    def __init__(self, contractor_id: int) -> None:
-        self.contractor_id = contractor_id
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
         self._lock = asyncio.Lock()
 
     @property
     def _checklist_path(self) -> Path:
-        return _user_dir(self.contractor_id) / "heartbeat" / "checklist.json"
+        return _user_dir(self.user_id) / "heartbeat" / "checklist.json"
 
     @property
     def _log_path(self) -> Path:
-        return _user_dir(self.contractor_id) / "heartbeat" / "log.jsonl"
+        return _user_dir(self.user_id) / "heartbeat" / "log.jsonl"
 
     def _load_checklist(self) -> list[dict[str, Any]]:
         return _read_json(self._checklist_path, [])
@@ -1332,7 +1332,7 @@ class HeartbeatStore:
             iid = _next_id(items)
             item = ChecklistItem(
                 id=iid,
-                contractor_id=self.contractor_id,
+                user_id=self.user_id,
                 description=description,
                 schedule=schedule,
             )
@@ -1371,7 +1371,7 @@ class HeartbeatStore:
 
     async def log_heartbeat(self) -> None:
         """Append to heartbeat log."""
-        entry = HeartbeatLogEntry(contractor_id=self.contractor_id)
+        entry = HeartbeatLogEntry(user_id=self.user_id)
         _append_jsonl(self._log_path, entry.model_dump())
 
     async def get_daily_count(self) -> int:
@@ -1446,12 +1446,12 @@ class IdempotencyStore:
 class LLMUsageStore:
     """Append-only LLM usage log. Replaces LLMUsageLog model."""
 
-    def __init__(self, contractor_id: int) -> None:
-        self.contractor_id = contractor_id
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
 
     @property
     def _path(self) -> Path:
-        return _user_dir(self.contractor_id) / "llm_usage.jsonl"
+        return _user_dir(self.user_id) / "llm_usage.jsonl"
 
     def log(
         self,
@@ -1462,7 +1462,7 @@ class LLMUsageStore:
     ) -> None:
         """Append a usage log entry."""
         entry = {
-            "contractor_id": self.contractor_id,
+            "user_id": self.user_id,
             "model": model,
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
@@ -1485,13 +1485,13 @@ class ToolConfigStore:
     ``data/users/{id}/tool_config.json``.
     """
 
-    def __init__(self, contractor_id: int) -> None:
-        self.contractor_id = contractor_id
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
         self._lock = asyncio.Lock()
 
     @property
     def _path(self) -> Path:
-        return _user_dir(self.contractor_id) / "tool_config.json"
+        return _user_dir(self.user_id) / "tool_config.json"
 
     async def load(self) -> list[ToolConfigEntry]:
         """Load tool config entries. Returns empty list if no config exists."""
@@ -1514,32 +1514,32 @@ class ToolConfigStore:
 # Module-level singletons / factories
 # ---------------------------------------------------------------------------
 
-_contractor_store: ContractorStore | None = None
+_user_store: UserStore | None = None
 _memory_stores: dict[int, FileMemoryStore] = {}
 _session_stores: dict[int, FileSessionStore] = {}
 _idempotency_store: IdempotencyStore | None = None
 
 
-def get_contractor_store() -> ContractorStore:
-    """Get or create the global ContractorStore."""
-    global _contractor_store
-    if _contractor_store is None:
-        _contractor_store = ContractorStore()
-    return _contractor_store
+def get_user_store() -> UserStore:
+    """Get or create the global UserStore."""
+    global _user_store
+    if _user_store is None:
+        _user_store = UserStore()
+    return _user_store
 
 
-def get_memory_store(contractor_id: int) -> FileMemoryStore:
-    """Get or create a FileMemoryStore for a contractor."""
-    if contractor_id not in _memory_stores:
-        _memory_stores[contractor_id] = FileMemoryStore(contractor_id)
-    return _memory_stores[contractor_id]
+def get_memory_store(user_id: int) -> FileMemoryStore:
+    """Get or create a FileMemoryStore for a user."""
+    if user_id not in _memory_stores:
+        _memory_stores[user_id] = FileMemoryStore(user_id)
+    return _memory_stores[user_id]
 
 
-def get_session_store(contractor_id: int) -> FileSessionStore:
-    """Get or create a FileSessionStore for a contractor."""
-    if contractor_id not in _session_stores:
-        _session_stores[contractor_id] = FileSessionStore(contractor_id)
-    return _session_stores[contractor_id]
+def get_session_store(user_id: int) -> FileSessionStore:
+    """Get or create a FileSessionStore for a user."""
+    if user_id not in _session_stores:
+        _session_stores[user_id] = FileSessionStore(user_id)
+    return _session_stores[user_id]
 
 
 def get_idempotency_store() -> IdempotencyStore:
@@ -1552,8 +1552,8 @@ def get_idempotency_store() -> IdempotencyStore:
 
 def reset_stores() -> None:
     """Reset all cached store instances. Used by tests."""
-    global _contractor_store, _idempotency_store
-    _contractor_store = None
+    global _user_store, _idempotency_store
+    _user_store = None
     _memory_stores.clear()
     _session_stores.clear()
     _idempotency_store = None

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -1,7 +1,7 @@
 """Proactive heartbeat engine.
 
 Every ``heartbeat_interval_minutes`` the scheduler wakes up, iterates over
-onboarded contractors, and runs **cheap deterministic checks** first.  Only when
+onboarded users, and runs **cheap deterministic checks** first.  Only when
 a cheap check flags something actionable does the engine escalate to an LLM call
 to compose a natural-language message.  Most ticks produce **no** outbound
 messages and **no** LLM calls -- saving cost and avoiding noise.
@@ -24,12 +24,12 @@ from pydantic import BaseModel, Field, ValidationError
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.file_store import (
     ChecklistItem,
-    ContractorData,
     EstimateData,
     HeartbeatStore,
     MemoryFact,
-    get_contractor_store,
+    UserData,
     get_session_store,
+    get_user_store,
 )
 from backend.app.agent.llm_parsing import get_response_text, parse_tool_calls
 from backend.app.agent.system_prompt import build_heartbeat_system_prompt
@@ -114,7 +114,7 @@ def parse_frequency_to_minutes(freq: str) -> int | None:
 
 @dataclass
 class CheapCheckResult:
-    """Result of deterministic pre-checks for a single contractor."""
+    """Result of deterministic pre-checks for a single user."""
 
     flags: list[str] = field(default_factory=list)
     stale_estimates: list[EstimateData] = field(default_factory=list)
@@ -192,17 +192,17 @@ def _to_local_time(
 
 
 def is_within_business_hours(
-    contractor: ContractorData,
+    user: UserData,
     now: datetime.datetime | None = None,
 ) -> bool:
-    """Return *True* if *now* falls within the contractor's business hours.
+    """Return *True* if *now* falls within the user's business hours.
 
-    When the contractor has a ``timezone`` set, *now* is converted to their
+    When the user has a ``timezone`` set, *now* is converted to their
     local time before comparing against business hours or the global quiet
     hours window.  Falls back to UTC when the timezone is empty or invalid.
     """
     now = now or datetime.datetime.now(datetime.UTC)
-    local_now = _to_local_time(now, contractor.timezone)
+    local_now = _to_local_time(now, user.timezone)
     current_hour = local_now.hour
 
     # Use global quiet hours to determine business hours.
@@ -222,7 +222,7 @@ def is_within_business_hours(
 
 
 async def run_cheap_checks(
-    contractor: ContractorData,
+    user: UserData,
     now: datetime.datetime | None = None,
 ) -> CheapCheckResult:
     """Run fast, deterministic checks that don't require an LLM call.
@@ -236,7 +236,7 @@ async def run_cheap_checks(
     # 1. Stale draft estimates (older than STALE_ESTIMATE_HOURS)
     from backend.app.agent.file_store import EstimateStore
 
-    estimate_store = EstimateStore(contractor.id)
+    estimate_store = EstimateStore(user.id)
     all_estimates = await estimate_store.list_all()
     cutoff = now - datetime.timedelta(hours=STALE_ESTIMATE_HOURS)
     stale: list[EstimateData] = []
@@ -256,19 +256,19 @@ async def run_cheap_checks(
         result.flags.append(f"Stale draft estimate(s) older than 24h: {descs}")
 
     # 2. Due checklist items
-    heartbeat_store = HeartbeatStore(contractor.id)
+    heartbeat_store = HeartbeatStore(user.id)
     all_items = await heartbeat_store.get_checklist()
     for item in all_items:
         if item.status != ChecklistStatus.ACTIVE:
             continue
-        if _is_checklist_item_due(item, now, tz_name=contractor.timezone or ""):
+        if _is_checklist_item_due(item, now, tz_name=user.timezone or ""):
             result.due_checklist_items.append(item)
             result.flags.append(f"Checklist item due: {item.description}")
 
     # 3. Time-sensitive memory facts
     from backend.app.agent.file_store import get_memory_store
 
-    memory_store = get_memory_store(contractor.id)
+    memory_store = get_memory_store(user.id)
     memories = await memory_store.get_all_memories()
     for mem in memories:
         text = f"{mem.key} {mem.value}"
@@ -276,16 +276,16 @@ async def run_cheap_checks(
             result.time_sensitive_memories.append(mem)
             result.flags.append(f"Time-sensitive memory: {mem.key} = {mem.value}")
 
-    # 4. Idle contractor -- no inbound messages for IDLE_DAYS
+    # 4. Idle user -- no inbound messages for IDLE_DAYS
     idle_cutoff = now - datetime.timedelta(days=IDLE_DAYS)
-    session_store = get_session_store(contractor.id)
+    session_store = get_session_store(user.id)
     last_inbound = session_store.get_last_inbound_timestamp()
     if last_inbound is not None:
         if last_inbound <= idle_cutoff:
             days = (now - last_inbound).days
             result.flags.append(f"User idle for {days} days -- no recent messages")
-    elif contractor.created_at is not None:
-        created = contractor.created_at
+    elif user.created_at is not None:
+        created = user.created_at
         if isinstance(created, str):
             try:
                 created = datetime.datetime.fromisoformat(created)
@@ -307,7 +307,7 @@ def _is_checklist_item_due(
     tz_name: str = "",
 ) -> bool:
     """Determine whether a checklist item should fire on this tick."""
-    # Weekday gate: convert to contractor's local timezone so that
+    # Weekday gate: convert to user's local timezone so that
     # e.g. Friday 5 PM Pacific is not treated as Saturday (UTC).
     local_now = _to_local_time(now, tz_name) if tz_name else now
     if item.schedule == ChecklistSchedule.WEEKDAYS and local_now.weekday() > WEEKDAY_FRIDAY:
@@ -338,9 +338,9 @@ def _is_checklist_item_due(
 # ---------------------------------------------------------------------------
 
 
-def _load_recent_messages(contractor: ContractorData) -> str:
+def _load_recent_messages(user: UserData) -> str:
     """Load recent messages as formatted text for heartbeat context."""
-    session_store = get_session_store(contractor.id)
+    session_store = get_session_store(user.id)
     recent = session_store.get_recent_messages(count=HEARTBEAT_RECENT_MESSAGES_COUNT)
     if not recent:
         return "(no recent messages)"
@@ -353,12 +353,12 @@ def _load_recent_messages(contractor: ContractorData) -> str:
 
 
 async def build_heartbeat_context(
-    contractor: ContractorData,
+    user: UserData,
     flags: list[str],
 ) -> str:
     """Build the full heartbeat system prompt via the composable builder."""
-    recent_messages = _load_recent_messages(contractor)
-    return await build_heartbeat_system_prompt(contractor, flags, recent_messages)
+    recent_messages = _load_recent_messages(user)
+    return await build_heartbeat_system_prompt(user, flags, recent_messages)
 
 
 # ---------------------------------------------------------------------------
@@ -430,7 +430,7 @@ def _parse_tool_call_response(response: MessageResponse) -> HeartbeatAction:
 
 
 async def evaluate_heartbeat_need(
-    contractor: ContractorData,
+    user: UserData,
     flags: list[str],
     messaging_service: MessagingService | None = None,
 ) -> HeartbeatAction:
@@ -440,11 +440,11 @@ async def evaluate_heartbeat_need(
     If the LLM does not call the tool, defaults to no_action.
     Sends a typing indicator before the LLM call when a messaging_service is provided.
     """
-    prompt = await build_heartbeat_context(contractor, flags)
+    prompt = await build_heartbeat_context(user, flags)
 
     # Send typing indicator before LLM call
     if messaging_service:
-        to_address = contractor.channel_identifier or contractor.phone
+        to_address = user.channel_identifier or user.phone
         if to_address:
             try:
                 await messaging_service.send_typing_indicator(to=to_address)
@@ -472,7 +472,7 @@ async def evaluate_heartbeat_need(
         ),
     )
 
-    log_llm_usage(contractor.id, model, response, "heartbeat")
+    log_llm_usage(user.id, model, response, "heartbeat")
     return _parse_tool_call_response(response)
 
 
@@ -481,51 +481,51 @@ async def evaluate_heartbeat_need(
 # ---------------------------------------------------------------------------
 
 
-async def get_daily_heartbeat_count(contractor_id: int) -> int:
-    """Count heartbeat messages sent to a contractor today (UTC).
+async def get_daily_heartbeat_count(user_id: int) -> int:
+    """Count heartbeat messages sent to a user today (UTC).
 
     Queries the heartbeat log instead of relying on in-memory state
     so that rate limits survive process restarts and work across multiple
     workers.
     """
-    heartbeat_store = HeartbeatStore(contractor_id)
+    heartbeat_store = HeartbeatStore(user_id)
     return await heartbeat_store.get_daily_count()
 
 
 # ---------------------------------------------------------------------------
-# Per-contractor runner
+# Per-user runner
 # ---------------------------------------------------------------------------
 
 
-async def run_heartbeat_for_contractor(
-    contractor: ContractorData,
+async def run_heartbeat_for_user(
+    user: UserData,
     messaging_service: MessagingService,
     max_daily: int,
 ) -> HeartbeatAction | None:
-    """Full heartbeat pipeline for a single contractor.
+    """Full heartbeat pipeline for a single user.
 
     Returns the action taken, or *None* if skipped.
     """
     # Gate: onboarding must be complete
-    if not contractor.onboarding_complete:
+    if not user.onboarding_complete:
         return None
 
-    # Gate: contractor heartbeat opt-in
-    if not contractor.heartbeat_opt_in:
+    # Gate: user heartbeat opt-in
+    if not user.heartbeat_opt_in:
         return None
 
     # Gate: business hours
-    if not is_within_business_hours(contractor):
+    if not is_within_business_hours(user):
         return None
 
     # Gate: daily rate limit (persistent via heartbeat log)
-    if await get_daily_heartbeat_count(contractor.id) >= max_daily:
+    if await get_daily_heartbeat_count(user.id) >= max_daily:
         return None
 
-    # Gate: per-contractor frequency override
-    freq_minutes = parse_frequency_to_minutes(contractor.heartbeat_frequency)
+    # Gate: per-user frequency override
+    freq_minutes = parse_frequency_to_minutes(user.heartbeat_frequency)
     if freq_minutes is not None:
-        session_store = get_session_store(contractor.id)
+        session_store = get_session_store(user.id)
         last_outbound = session_store.get_last_outbound_timestamp()
         if last_outbound is not None:
             now = datetime.datetime.now(datetime.UTC)
@@ -534,7 +534,7 @@ async def run_heartbeat_for_contractor(
                 return None
 
     # Cheap checks -- skip LLM entirely if nothing is flagged
-    check_result = await run_cheap_checks(contractor)
+    check_result = await run_cheap_checks(user)
     if not check_result.has_flags:
         return HeartbeatAction(
             action_type="no_action",
@@ -545,23 +545,23 @@ async def run_heartbeat_for_contractor(
 
     # Something was flagged -- escalate to LLM for message composition
     action = await evaluate_heartbeat_need(
-        contractor, check_result.flags, messaging_service=messaging_service
+        user, check_result.flags, messaging_service=messaging_service
     )
 
     if action.action_type != "send_message" or not action.message:
         return action
 
     # Send message
-    to_address = contractor.channel_identifier or contractor.phone
+    to_address = user.channel_identifier or user.phone
     try:
         await messaging_service.send_text(to=to_address, body=action.message)
     except Exception:
-        logger.exception("Heartbeat message failed for contractor %d", contractor.id)
+        logger.exception("Heartbeat message failed for user %d", user.id)
         return action
 
     # Record outbound message
-    session, _ = await get_or_create_conversation(contractor.id)
-    session_store = get_session_store(contractor.id)
+    session, _ = await get_or_create_conversation(user.id)
+    session_store = get_session_store(user.id)
     await session_store.add_message(
         session=session,
         direction=MessageDirection.OUTBOUND,
@@ -569,7 +569,7 @@ async def run_heartbeat_for_contractor(
     )
 
     # Record heartbeat log for persistent rate limiting
-    heartbeat_store = HeartbeatStore(contractor.id)
+    heartbeat_store = HeartbeatStore(user.id)
     await heartbeat_store.log_heartbeat()
 
     # Mark checklist items as triggered
@@ -631,48 +631,46 @@ class HeartbeatScheduler:
             await asyncio.sleep(settings.heartbeat_interval_minutes * 60)
 
     async def tick(self) -> None:
-        """Single heartbeat pass: evaluate every onboarded contractor concurrently."""
-        store = get_contractor_store()
-        all_contractors = await store.list_all()
-        contractors = [c for c in all_contractors if c.onboarding_complete]
+        """Single heartbeat pass: evaluate every onboarded user concurrently."""
+        store = get_user_store()
+        all_users = await store.list_all()
+        users = [c for c in all_users if c.onboarding_complete]
 
-        if not contractors:
+        if not users:
             return
 
         semaphore = asyncio.Semaphore(settings.heartbeat_concurrency)
 
-        async def _process_one(contractor: ContractorData) -> None:
-            """Process a single contractor."""
+        async def _process_one(user: UserData) -> None:
+            """Process a single user."""
             async with semaphore:
                 try:
-                    # Route to the contractor's preferred channel, falling
+                    # Route to the user's preferred channel, falling
                     # back to the first registered channel.
                     try:
-                        messaging_service: MessagingService = get_channel(
-                            contractor.preferred_channel
-                        )
+                        messaging_service: MessagingService = get_channel(user.preferred_channel)
                     except KeyError:
                         messaging_service = get_default_channel()
 
-                    await run_heartbeat_for_contractor(
-                        contractor=contractor,
+                    await run_heartbeat_for_user(
+                        user=user,
                         messaging_service=messaging_service,
                         max_daily=settings.heartbeat_max_daily_messages,
                     )
                 except Exception:
-                    logger.exception("Heartbeat failed for contractor %d", contractor.id)
+                    logger.exception("Heartbeat failed for user %d", user.id)
 
         results = await asyncio.gather(
-            *[_process_one(c) for c in contractors],
+            *[_process_one(c) for c in users],
             return_exceptions=True,
         )
 
-        # Log any unexpected exceptions that escaped the per-contractor handler
+        # Log any unexpected exceptions that escaped the per-user handler
         for i, result in enumerate(results):
             if isinstance(result, BaseException):
                 logger.error(
-                    "Unhandled error in heartbeat for contractor %d: %s",
-                    contractors[i].id,
+                    "Unhandled error in heartbeat for user %d: %s",
+                    users[i].id,
                     result,
                     exc_info=result if isinstance(result, Exception) else None,
                 )

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -2,11 +2,11 @@
 
 Defines the ``InboundMessage`` dataclass and ``process_inbound_from_bus()``
 which handles the channel-independent steps of receiving a message:
-contractor lookup/creation, conversation management, message persistence,
+user lookup/creation, conversation management, message persistence,
 and pipeline dispatch.
 
 Includes ``MessageBatcher`` which groups rapid-fire messages from the same
-contractor (e.g. after a tunnel reconnect) into a single agent pipeline run,
+user (e.g. after a tunnel reconnect) into a single agent pipeline run,
 inspired by nanobot's Mochat delay-based batching pattern.
 """
 
@@ -15,14 +15,14 @@ import json
 import logging
 from dataclasses import dataclass, field
 
-from backend.app.agent.concurrency import contractor_locks
+from backend.app.agent.concurrency import user_locks
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.file_store import (
-    ContractorData,
     SessionState,
     StoredMessage,
-    get_contractor_store,
+    UserData,
     get_session_store,
+    get_user_store,
 )
 from backend.app.agent.router import handle_inbound_message
 from backend.app.config import settings
@@ -52,37 +52,37 @@ class InboundMessage:
     session_id: str | None = None
 
 
-async def _get_or_create_contractor(channel: str, sender_id: str) -> ContractorData:
-    """Look up or create a contractor by channel-specific sender ID.
+async def _get_or_create_user(channel: str, sender_id: str) -> UserData:
+    """Look up or create a user by channel-specific sender ID.
 
-    In single-tenant (OSS) mode there should be exactly one contractor shared
-    across all channels.  When a new channel arrives and a contractor already
-    exists, link the channel to that contractor instead of creating a duplicate.
+    In single-tenant (OSS) mode there should be exactly one user shared
+    across all channels.  When a new channel arrives and a user already
+    exists, link the channel to that user instead of creating a duplicate.
     """
-    store = get_contractor_store()
-    contractor = await store.get_by_channel(sender_id)
-    if contractor is not None:
-        return contractor
+    store = get_user_store()
+    user = await store.get_by_channel(sender_id)
+    if user is not None:
+        return user
 
-    # Reuse the sole existing contractor (single-tenant OSS) so sessions from
+    # Reuse the sole existing user (single-tenant OSS) so sessions from
     # every channel are visible in the dashboard.
-    all_contractors = await store.list_all()
-    if len(all_contractors) == 1:
-        contractor = all_contractors[0]
-        store.link_channel(channel, sender_id, contractor.id)
-        contractor = await store.update(
-            contractor.id,
+    all_users = await store.list_all()
+    if len(all_users) == 1:
+        user = all_users[0]
+        store.link_channel(channel, sender_id, user.id)
+        user = await store.update(
+            user.id,
             channel_identifier=sender_id,
             preferred_channel=channel,
         )
-        return contractor  # type: ignore[return-value]
+        return user  # type: ignore[return-value]
 
-    contractor = await store.create(
+    user = await store.create(
         user_id=f"{channel}_{sender_id}",
         channel_identifier=sender_id,
         preferred_channel=channel,
     )
-    return contractor
+    return user
 
 
 # ---------------------------------------------------------------------------
@@ -102,18 +102,18 @@ class _BatchEntry:
 
 @dataclass
 class _BatchState:
-    """Per-contractor batch state: accumulated entries and a flush timer."""
+    """Per-user batch state: accumulated entries and a flush timer."""
 
     entries: list[_BatchEntry] = field(default_factory=list)
     timer: asyncio.Task[None] | None = None
     messaging_service: MessagingService | None = None
-    contractor: ContractorData | None = None
+    user: UserData | None = None
     channel: str = ""
     request_id: str = ""
 
 
 class MessageBatcher:
-    """Groups rapid-fire messages from the same contractor before processing.
+    """Groups rapid-fire messages from the same user before processing.
 
     When multiple messages arrive within ``window_ms`` of each other
     (e.g. after a tunnel reconnect or when a user sends several messages
@@ -133,7 +133,7 @@ class MessageBatcher:
 
     async def enqueue(
         self,
-        contractor: ContractorData,
+        user: UserData,
         session: SessionState,
         message: StoredMessage,
         media_urls: list[tuple[str, str]],
@@ -142,13 +142,13 @@ class MessageBatcher:
         request_id: str = "",
         downloaded_media: list[DownloadedMedia] | None = None,
     ) -> None:
-        """Add a message to the batch for the contractor.
+        """Add a message to the batch for the user.
 
         Resets the flush timer so that messages arriving within the window
         are grouped together.
         """
         async with self._lock:
-            state = self._states.setdefault(contractor.id, _BatchState())
+            state = self._states.setdefault(user.id, _BatchState())
             state.entries.append(
                 _BatchEntry(
                     session=session,
@@ -158,34 +158,34 @@ class MessageBatcher:
                 )
             )
             state.messaging_service = messaging_service
-            state.contractor = contractor
+            state.user = user
             state.channel = channel
             state.request_id = request_id
             if state.timer is not None:
                 state.timer.cancel()
-            state.timer = asyncio.create_task(self._flush_after(contractor.id))
+            state.timer = asyncio.create_task(self._flush_after(user.id))
 
-    async def _flush_after(self, contractor_id: int) -> None:
+    async def _flush_after(self, user_id: int) -> None:
         """Wait for the batch window then flush."""
         await asyncio.sleep(self._window_ms / 1000.0)
-        await self._flush(contractor_id)
+        await self._flush(user_id)
 
-    async def _flush(self, contractor_id: int) -> None:
-        """Process the batched messages for the contractor.
+    async def _flush(self, user_id: int) -> None:
+        """Process the batched messages for the user.
 
-        Acquires the per-contractor lock, then runs the agent pipeline for
+        Acquires the per-user lock, then runs the agent pipeline for
         the most recent message.  Media from all batched messages is merged.
         """
         async with self._lock:
-            state = self._states.pop(contractor_id, None)
+            state = self._states.pop(user_id, None)
         if state is None or not state.entries or state.messaging_service is None:
             return
-        if state.contractor is None:
+        if state.user is None:
             return
 
         last_entry = state.entries[-1]
         messaging_service = state.messaging_service
-        contractor = state.contractor
+        user = state.user
 
         # Merge media from all batched messages so attachments are not lost.
         all_media: list[tuple[str, str]] = []
@@ -196,21 +196,21 @@ class MessageBatcher:
 
         if len(state.entries) > 1:
             logger.info(
-                "Batched %d messages for contractor %d, processing message seq %d",
+                "Batched %d messages for user %d, processing message seq %d",
                 len(state.entries),
-                contractor_id,
+                user_id,
                 last_entry.message.seq,
             )
 
-        async with contractor_locks.acquire(contractor_id):
+        async with user_locks.acquire(user_id):
             try:
-                # Reload contractor in case it was updated
-                store = get_contractor_store()
-                fresh = await store.get_by_id(contractor_id)
+                # Reload user in case it was updated
+                store = get_user_store()
+                fresh = await store.get_by_id(user_id)
                 if fresh is not None:
-                    contractor = fresh
+                    user = fresh
                 await handle_inbound_message(
-                    contractor=contractor,
+                    user=user,
                     session=last_entry.session,
                     message=last_entry.message,
                     media_urls=all_media,
@@ -221,9 +221,9 @@ class MessageBatcher:
                 )
             except Exception:
                 logger.exception(
-                    "Agent pipeline failed for message seq %d (contractor %d)",
+                    "Agent pipeline failed for message seq %d (user %d)",
                     last_entry.message.seq,
-                    contractor_id,
+                    user_id,
                 )
 
 
@@ -242,16 +242,16 @@ async def process_inbound_from_bus(
 ) -> None:
     """Process an inbound message consumed from the bus.
 
-    Handles contractor lookup/creation, session management, message
+    Handles user lookup/creation, session management, message
     persistence, and dispatches to the agent pipeline (with optional
     batching).
     """
-    contractor = await _get_or_create_contractor(inbound.channel, inbound.sender_id)
+    user = await _get_or_create_user(inbound.channel, inbound.sender_id)
     session, _is_new = await get_or_create_conversation(
-        contractor.id, external_session_id=inbound.session_id
+        user.id, external_session_id=inbound.session_id
     )
 
-    session_store = get_session_store(contractor.id)
+    session_store = get_session_store(user.id)
     message = await session_store.add_message(
         session=session,
         direction=MessageDirection.INBOUND,
@@ -262,7 +262,7 @@ async def process_inbound_from_bus(
 
     if settings.message_batch_window_ms > 0:
         await message_batcher.enqueue(
-            contractor=contractor,
+            user=user,
             session=session,
             message=message,
             media_urls=inbound.media_refs,
@@ -272,14 +272,14 @@ async def process_inbound_from_bus(
             downloaded_media=inbound.downloaded_media or None,
         )
     else:
-        async with contractor_locks.acquire(contractor.id):
+        async with user_locks.acquire(user.id):
             try:
-                store = get_contractor_store()
-                fresh = await store.get_by_id(contractor.id)
+                store = get_user_store()
+                fresh = await store.get_by_id(user.id)
                 if fresh is not None:
-                    contractor = fresh
+                    user = fresh
                 await handle_inbound_message(
-                    contractor=contractor,
+                    user=user,
                     session=session,
                     message=message,
                     media_urls=inbound.media_refs,
@@ -290,7 +290,7 @@ async def process_inbound_from_bus(
                 )
             except Exception:
                 logger.exception(
-                    "Agent pipeline failed for message seq %d (contractor %d)",
+                    "Agent pipeline failed for message seq %d (user %d)",
                     message.seq,
-                    contractor.id,
+                    user.id,
                 )

--- a/backend/app/agent/memory.py
+++ b/backend/app/agent/memory.py
@@ -6,15 +6,15 @@ from backend.app.config import settings
 
 
 async def save_memory(
-    contractor_id: int,
+    user_id: int,
     key: str,
     value: str,
     category: str = "general",
     confidence: float = 1.0,
     source_message_id: int | None = None,
 ) -> MemoryFact:
-    """Save or update a memory fact. If key exists for this contractor, update it."""
-    store = get_memory_store(contractor_id)
+    """Save or update a memory fact. If key exists for this user, update it."""
+    store = get_memory_store(user_id)
     return await store.save_memory(
         key=key,
         value=value,
@@ -25,35 +25,35 @@ async def save_memory(
 
 
 async def recall_memories(
-    contractor_id: int,
+    user_id: int,
     query: str,
     category: str | None = None,
     limit: int = settings.memory_recall_limit,
 ) -> list[MemoryFact]:
     """Recall memories relevant to a query using keyword matching."""
-    store = get_memory_store(contractor_id)
+    store = get_memory_store(user_id)
     return await store.recall_memories(query=query, category=category, limit=limit)
 
 
 async def get_all_memories(
-    contractor_id: int,
+    user_id: int,
     category: str | None = None,
 ) -> list[MemoryFact]:
-    """Get all memories for a contractor, optionally filtered by category."""
-    store = get_memory_store(contractor_id)
+    """Get all memories for a user, optionally filtered by category."""
+    store = get_memory_store(user_id)
     return await store.get_all_memories(category=category)
 
 
-async def delete_memory(contractor_id: int, key: str) -> bool:
+async def delete_memory(user_id: int, key: str) -> bool:
     """Delete a specific memory. Returns True if found and deleted."""
-    store = get_memory_store(contractor_id)
+    store = get_memory_store(user_id)
     return await store.delete_memory(key=key)
 
 
 async def build_memory_context(
-    contractor_id: int,
+    user_id: int,
     query: str | None = None,
 ) -> str:
     """Build a MEMORY.md-style text block for injection into the agent prompt."""
-    store = get_memory_store(contractor_id)
+    store = get_memory_store(user_id)
     return await store.build_memory_context(query=query)

--- a/backend/app/agent/messages.py
+++ b/backend/app/agent/messages.py
@@ -35,7 +35,7 @@ class SystemMessage:
 
 @dataclass(frozen=True)
 class UserMessage:
-    """User (contractor) message."""
+    """User (user) message."""
 
     content: str
 

--- a/backend/app/agent/onboarding.py
+++ b/backend/app/agent/onboarding.py
@@ -1,4 +1,4 @@
-"""Onboarding conversation logic for new contractors."""
+"""Onboarding conversation logic for new users."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from backend.app.agent.events import AgentEndEvent, AgentEvent
-from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.file_store import UserData, get_user_store
 from backend.app.agent.profile import build_onboarding_prompt
 from backend.app.agent.tools.names import ToolName
 from backend.app.agent.tools.registry import default_registry, ensure_tool_modules_imported
@@ -16,33 +16,33 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Fields that indicate a contractor has completed onboarding
+# Fields that indicate a user has completed onboarding
 REQUIRED_PROFILE_FIELDS = {"name"}
 
 
-def is_onboarding_needed(contractor: ContractorData) -> bool:
-    """Check if contractor needs onboarding.
+def is_onboarding_needed(user: UserData) -> bool:
+    """Check if user needs onboarding.
 
     Returns False once onboarding_complete is set, or if the name
     field is already populated.
     """
-    if contractor.onboarding_complete:
+    if user.onboarding_complete:
         return False
-    return not contractor.name or not contractor.name.strip()
+    return not user.name or not user.name.strip()
 
 
 def _get_tool_capability_descriptions() -> list[str]:
     """Return human-readable descriptions of available tool capabilities.
 
     Uses the registry's specialist summaries so the onboarding prompt
-    can tell the contractor what their assistant can do.
+    can tell the user what their assistant can do.
     """
     ensure_tool_modules_imported()
     summaries = default_registry.specialist_summaries
     return [f"- {name}: {summary}" for name, summary in sorted(summaries.items())]
 
 
-def build_onboarding_system_prompt(contractor: ContractorData) -> str:
+def build_onboarding_system_prompt(user: UserData) -> str:
     """Build system prompt for onboarding mode.
 
     Wraps the base onboarding prompt with any partial profile info
@@ -52,10 +52,10 @@ def build_onboarding_system_prompt(contractor: ContractorData) -> str:
     base = build_onboarding_prompt()
 
     known: list[str] = []
-    if contractor.name and contractor.name.strip():
-        known.append(f"- Name: {contractor.name}")
-    if contractor.assistant_name and contractor.assistant_name != "Clawbolt":
-        known.append(f"- Your name (the AI): {contractor.assistant_name}")
+    if user.name and user.name.strip():
+        known.append(f"- Name: {user.name}")
+    if user.assistant_name and user.assistant_name != "Clawbolt":
+        known.append(f"- Your name (the AI): {user.assistant_name}")
 
     parts = [base]
     if known:
@@ -67,12 +67,12 @@ def build_onboarding_system_prompt(contractor: ContractorData) -> str:
         parts.append(
             "\n\nYour available specialist capabilities:\n"
             + "\n".join(capability_lines)
-            + "\n\nMention the ones that seem relevant to the contractor's trade. "
+            + "\n\nMention the ones that seem relevant to the user's trade. "
             "Don't list them all at once."
         )
 
     parts.append(
-        "\n\nIMPORTANT: If the contractor asks about something specific (a quote, a question, "
+        "\n\nIMPORTANT: If the user asks about something specific (a quote, a question, "
         "a photo), help them with that request FIRST, then naturally weave in any remaining "
         "onboarding questions. Never ignore their request just to collect profile info."
     )
@@ -84,19 +84,19 @@ class OnboardingSubscriber:
     """Event subscriber that detects onboarding completion after agent processing.
 
     Subscribes to ``AgentEndEvent`` to detect successful ``update_profile`` calls.
-    When the contractor's required profile fields become complete, it sets
+    When the user's required profile fields become complete, it sets
     ``onboarding_complete = True`` and prepares a completion summary.
 
     Usage::
 
-        sub = OnboardingSubscriber(contractor, was_onboarding=True)
+        sub = OnboardingSubscriber(user, was_onboarding=True)
         agent.subscribe(sub)
         response = await agent.process_message(...)
         sub.finalize(response)  # appends completion note to reply if applicable
     """
 
-    def __init__(self, contractor: ContractorData, was_onboarding: bool) -> None:
-        self._contractor = contractor
+    def __init__(self, user: UserData, was_onboarding: bool) -> None:
+        self._user = user
         self._was_onboarding = was_onboarding
         self._completion_note: str | None = None
 
@@ -107,28 +107,28 @@ class OnboardingSubscriber:
 
     async def _on_agent_end(self, event: AgentEndEvent) -> None:
         """Process onboarding state after the agent finishes."""
-        store = get_contractor_store()
+        store = get_user_store()
 
-        # Reload contractor if a profile update was made
+        # Reload user if a profile update was made
         if any(a == f"Called {ToolName.UPDATE_PROFILE}" for a in event.actions_taken):
-            refreshed = await store.get_by_id(self._contractor.id)
+            refreshed = await store.get_by_id(self._user.id)
             if refreshed:
-                self._contractor = refreshed
+                self._user = refreshed
 
         # Transition: was onboarding and required fields are now complete
-        if self._was_onboarding and not is_onboarding_needed(self._contractor):
-            await store.update(self._contractor.id, onboarding_complete=True)
-            self._contractor.onboarding_complete = True
+        if self._was_onboarding and not is_onboarding_needed(self._user):
+            await store.update(self._user.id, onboarding_complete=True)
+            self._user.onboarding_complete = True
             self._completion_note = self._build_completion_note()
 
-        # Pre-populated contractor: fields were already filled but flag was never set
-        if not self._contractor.onboarding_complete and not is_onboarding_needed(self._contractor):
-            await store.update(self._contractor.id, onboarding_complete=True)
-            self._contractor.onboarding_complete = True
+        # Pre-populated user: fields were already filled but flag was never set
+        if not self._user.onboarding_complete and not is_onboarding_needed(self._user):
+            await store.update(self._user.id, onboarding_complete=True)
+            self._user.onboarding_complete = True
 
     def _build_completion_note(self) -> str:
-        assistant = self._contractor.assistant_name or "Clawbolt"
-        parts = [f"Name: {self._contractor.name}"]
+        assistant = self._user.assistant_name or "Clawbolt"
+        parts = [f"Name: {self._user.name}"]
         parts.append(f"Your AI: {assistant}")
         summary = "\n".join(f"- {p}" for p in parts)
         return (

--- a/backend/app/agent/profile.py
+++ b/backend/app/agent/profile.py
@@ -1,17 +1,17 @@
 import logging
 from typing import Any
 
-from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.file_store import UserData, get_user_store
 from backend.app.agent.prompts import load_prompt
 
 logger = logging.getLogger(__name__)
 
 
-async def update_contractor_profile(
-    contractor: ContractorData,
+async def update_user_profile(
+    user: UserData,
     updates: dict[str, Any],
-) -> ContractorData:
-    """Update contractor profile fields from onboarding or conversation."""
+) -> UserData:
+    """Update user profile fields from onboarding or conversation."""
     allowed_fields = {
         "name",
         "phone",
@@ -23,28 +23,28 @@ async def update_contractor_profile(
     }
     filtered = {k: v for k, v in updates.items() if k in allowed_fields and v is not None}
     if not filtered:
-        return contractor
-    store = get_contractor_store()
-    updated = await store.update(contractor.id, **filtered)
-    return updated or contractor
+        return user
+    store = get_user_store()
+    updated = await store.update(user.id, **filtered)
+    return updated or user
 
 
-def build_soul_prompt(contractor: ContractorData) -> str:
-    """Build the 'soul' section of the system prompt from contractor profile.
+def build_soul_prompt(user: UserData) -> str:
+    """Build the 'soul' section of the system prompt from user profile.
 
     Layers (in order):
     1. Core identity: name and assistant name
-    2. Custom soul_text (freeform behavioral guidance from the contractor)
+    2. Custom soul_text (freeform behavioral guidance from the user)
     """
     lines: list[str] = []
 
-    assistant = contractor.assistant_name or "Clawbolt"
-    name = contractor.name or "a contractor"
+    assistant = user.assistant_name or "Clawbolt"
+    name = user.name or "a user"
     lines.append(f"You are {assistant}, the AI assistant for {name}.")
 
     # Custom soul_text for personality and behavioral guidance
-    if contractor.soul_text:
-        lines.append(f"\n{contractor.soul_text}")
+    if user.soul_text:
+        lines.append(f"\n{user.soul_text}")
 
     return "\n".join(lines)
 
@@ -52,7 +52,7 @@ def build_soul_prompt(contractor: ContractorData) -> str:
 def build_onboarding_prompt() -> str:
     """Build the system prompt for the onboarding conversation.
 
-    Inspired by openclaw's bootstrap ritual: the contractor names their AI,
+    Inspired by openclaw's bootstrap ritual: the user names their AI,
     shapes its personality, and covers the essential profile fields, all
     through natural conversation rather than a form.
     """

--- a/backend/app/agent/prompts/compaction.md
+++ b/backend/app/agent/prompts/compaction.md
@@ -1,4 +1,4 @@
-You are a fact-extraction assistant. You will receive a block of conversation messages between a contractor and their AI assistant. Extract durable facts worth remembering long-term, such as:
+You are a fact-extraction assistant. You will receive a block of conversation messages between a user and their AI assistant. Extract durable facts worth remembering long-term, such as:
 - Client names, phone numbers, addresses
 - Pricing decisions or quoted rates
 - Material preferences or supplier names

--- a/backend/app/agent/prompts/default_soul.md
+++ b/backend/app/agent/prompts/default_soul.md
@@ -7,7 +7,7 @@ or tedious. An assistant with no personality is just a search engine.
 Be resourceful before asking. Try to figure it out, check context,
 search memory. Then ask if you're stuck.
 
-Keep it practical. Your contractor is on a job site, not at a desk.
+Keep it practical. Your user is on a job site, not at a desk.
 Concise when needed, thorough when it matters.
 
 This file is yours to evolve. As you learn who you are, update it.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -1,4 +1,4 @@
-- Be concise and practical. Contractors are busy.
+- Be concise and practical. Users are busy.
 - You can ONLY communicate via this chat. You cannot send emails, make phone calls, or contact clients directly.
 - Always be helpful, friendly, and professional.
-- Keep replies concise. Contractors are on the job site.
+- Keep replies concise. Users are on the job site.

--- a/backend/app/agent/prompts/onboarding.md
+++ b/backend/app/agent/prompts/onboarding.md
@@ -1,4 +1,4 @@
-You are a brand-new AI assistant for solo contractors. This is your first conversation with a new contractor. You just woke up and you don't have a name yet.
+You are a brand-new AI assistant for solo tradespeople. This is your first conversation with a new user. You just woke up and you don't have a name yet.
 
 ## Your opening
 Start with something like: "Hey! I just woke up. I'm going to be your AI assistant, but right now I'm a blank slate: no name, no personality, no idea who you are. So let's fix that. Who are you, and what should I call myself?"
@@ -20,14 +20,14 @@ Then figure out your personality together: "How do you want me to talk? Straight
 Lean into whatever they pick. If they want dry humor, be dry. If they want professional, be sharp. Make it feel like their AI, not a generic assistant.
 
 Once you have a sense of your name and personality, write it to SOUL.md using write_file. For example:
-write_file(path="SOUL.md", content="# Soul\n\nDirect and practical. Skip the pleasantries unless the contractor starts them. Keep estimates tight and organized.")
+write_file(path="SOUL.md", content="# Soul\n\nDirect and practical. Skip the pleasantries unless the user starts them. Keep estimates tight and organized.")
 
 ## Saving information
-IMPORTANT: As soon as the contractor shares their name, save it immediately with update_profile. For example: update_profile(name="Jake"). Do not wait.
+IMPORTANT: As soon as the user shares their name, save it immediately with update_profile. For example: update_profile(name="Jake"). Do not wait.
 
 When you learn your name, save it with update_profile(assistant_name="Bolt").
 
-For everything else the contractor tells you about themselves or their business (trade, location, rates, hours, timezone, preferences, communication style, specialties, notes), write it to USER.md using write_file. For example:
+For everything else the user tells you about themselves or their business (trade, location, rates, hours, timezone, preferences, communication style, specialties, notes), write it to USER.md using write_file. For example:
 write_file(path="USER.md", content="# User\n\n- Name: Jake\n- What to call them: Jake\n- Trade: Plumber\n- Location: Portland\n- Timezone: Pacific\n- Rate: $85/hr\n- Hours: Mon-Fri 7am-5pm\n- Style: Casual, keep it brief\n- Notes: Specializes in residential remodels")
 
 For general facts (client names, project details, pricing notes), use save_fact instead.
@@ -40,6 +40,6 @@ For example, if they're a plumber who does residential work, you might say: "By 
 If they ask about something you can't do yet, be honest: "I don't have that one yet, but I'll note it down. The team is always adding new capabilities."
 
 ## Style
-After collecting and saving information, briefly confirm what you've saved so the contractor knows you got it right. For example: "Got it, I've saved your name as Jake."
+After collecting and saving information, briefly confirm what you've saved so the user knows you got it right. For example: "Got it, I've saved your name as Jake."
 
-Don't ask all questions at once. Let the conversation breathe. The goal is for the contractor to feel like they just met someone useful, not like they filled out a form.
+Don't ask all questions at once. Let the conversation breathe. The goal is for the user to feel like they just met someone useful, not like they filled out a form.

--- a/backend/app/agent/prompts/recall.md
+++ b/backend/app/agent/prompts/recall.md
@@ -1,4 +1,4 @@
-When the contractor asks a question about their business, clients, or past work:
+When the user asks a question about their business, clients, or past work:
 1. Search your memory for relevant information.
 2. If you find relevant facts, use them to answer clearly and concisely.
 3. If you don't find anything, say so honestly -- don't make things up.

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -19,10 +19,10 @@ from backend.app.agent.context import load_conversation_history
 from backend.app.agent.core import AgentResponse, ClawboltAgent
 from backend.app.agent.events import AgentEvent
 from backend.app.agent.file_store import (
-    ContractorData,
     SessionState,
     StoredMessage,
     ToolConfigStore,
+    UserData,
     get_session_store,
 )
 from backend.app.agent.messages import AgentMessage
@@ -60,7 +60,7 @@ MEDIA_DOWNLOAD_ERROR = (
 )
 VISION_UNAVAILABLE_NOTE = (
     "Vision analysis was unavailable for the attached media. "
-    "The contractor may have sent a photo or document that could "
+    "The user may have sent a photo or document that could "
     "not be analyzed. You can still help with their text message "
     "and ask them to describe what the attachment shows."
 )
@@ -78,7 +78,7 @@ ensure_tool_modules_imported()
 class PipelineContext:
     """Shared state passed through pipeline steps."""
 
-    contractor: ContractorData
+    user: UserData
     session: SessionState
     message: StoredMessage
     media_urls: list[tuple[str, str]]
@@ -104,8 +104,8 @@ PipelineStep = Callable[[PipelineContext], Awaitable[PipelineContext]]
 # ---------------------------------------------------------------------------
 
 
-def init_storage(contractor: ContractorData) -> StorageBackend | None:
-    """Initialize storage backend for a contractor.
+def init_storage(user: UserData) -> StorageBackend | None:
+    """Initialize storage backend for a user.
 
     Returns the storage backend if configured, or ``None`` otherwise.
     """
@@ -119,14 +119,14 @@ def init_storage(contractor: ContractorData) -> StorageBackend | None:
             )
         )
         if has_storage:
-            return get_storage_service(contractor=contractor)
+            return get_storage_service(user=user)
     except Exception:
         logger.debug("Storage not configured, skipping file features")
     return None
 
 
 async def prepare_media(
-    contractor: ContractorData,
+    user: UserData,
     message: StoredMessage,
     media_urls: list[tuple[str, str]],
     messaging_service: MessagingService,
@@ -138,8 +138,8 @@ async def prepare_media(
     """
     downloaded_media: list[DownloadedMedia] = []
     logger.debug(
-        "Preparing media for contractor %d, message seq=%d: %d attachment(s)",
-        contractor.id,
+        "Preparing media for user %d, message seq=%d: %d attachment(s)",
+        user.id,
         message.seq,
         len(media_urls),
     )
@@ -151,12 +151,12 @@ async def prepare_media(
         except Exception:
             logger.exception("Failed to download media: %s", file_id)
 
-    storage = init_storage(contractor)
+    storage = init_storage(user)
 
     # Auto-save inbound media to storage
     if storage and downloaded_media:
         try:
-            await auto_save_media(contractor, storage, downloaded_media)
+            await auto_save_media(user, storage, downloaded_media)
         except Exception:
             logger.debug("Auto-save to storage failed, continuing")
 
@@ -166,7 +166,7 @@ async def prepare_media(
 async def build_message_context(
     session: SessionState,
     message: StoredMessage,
-    contractor: ContractorData,
+    user: UserData,
     media_urls: list[tuple[str, str]],
     downloaded_media: list[DownloadedMedia],
 ) -> str:
@@ -182,9 +182,9 @@ async def build_message_context(
         pipeline_result = await process_message_media(message.body, downloaded_media)
     except Exception:
         logger.exception(
-            "Media pipeline failed for message seq %d, contractor %d",
+            "Media pipeline failed for message seq %d, user %d",
             message.seq,
-            contractor.id,
+            user.id,
         )
         pipeline_result = await process_message_media(message.body, [])
         if downloaded_media:
@@ -195,7 +195,7 @@ async def build_message_context(
         combined_context += "\n\n[System note: " + " ".join(media_notes) + "]"
 
     # Persist processed context for conversation history
-    session_store = get_session_store(contractor.id)
+    session_store = get_session_store(user.id)
     await session_store.update_message(session, message.seq, processed_context=combined_context)
     message.processed_context = combined_context
 
@@ -203,7 +203,7 @@ async def build_message_context(
 
 
 async def run_agent(
-    contractor: ContractorData,
+    user: UserData,
     message: StoredMessage,
     combined_context: str,
     conversation_history: list[AgentMessage],
@@ -221,7 +221,7 @@ async def run_agent(
     an error fallback AgentResponse.
     """
     tool_context = ToolContext(
-        contractor=contractor,
+        user=user,
         storage=storage,
         messaging_service=messaging_service,
         to_address=to_address,
@@ -229,7 +229,7 @@ async def run_agent(
     )
 
     agent = ClawboltAgent(
-        contractor=contractor,
+        user=user,
         messaging_service=messaging_service,
         chat_id=to_address,
         tool_context=tool_context,
@@ -238,7 +238,7 @@ async def run_agent(
     )
 
     # Load user's disabled tool groups to filter out unwanted tools.
-    tool_config_store = ToolConfigStore(contractor.id)
+    tool_config_store = ToolConfigStore(user.id)
     disabled_groups = await tool_config_store.get_disabled_tool_names()
 
     # Start with core tools only; specialist tools are discovered on demand
@@ -253,9 +253,9 @@ async def run_agent(
         tools.append(create_list_capabilities_tool(specialist_summaries))
     agent.register_tools(tools)
     logger.debug(
-        "Agent initialized for contractor %d, message seq=%d with %d core tools, "
+        "Agent initialized for user %d, message seq=%d with %d core tools, "
         "%d specialist categories available",
-        contractor.id,
+        user.id,
         message.seq,
         len(tools),
         len(specialist_summaries),
@@ -273,23 +273,23 @@ async def run_agent(
         )
     except ContentFilterError:
         logger.warning(
-            "Content filter blocked message seq %d for contractor %d",
+            "Content filter blocked message seq %d for user %d",
             message.seq,
-            contractor.id,
+            user.id,
         )
         return AgentResponse(reply_text=CONTENT_FILTER_FALLBACK, is_error_fallback=True)
     except AuthenticationError:
         logger.critical(
-            "LLM authentication failed processing message seq %d for contractor %d",
+            "LLM authentication failed processing message seq %d for user %d",
             message.seq,
-            contractor.id,
+            user.id,
         )
         return AgentResponse(reply_text=AUTH_ERROR_FALLBACK, is_error_fallback=True)
     except Exception:
         logger.exception(
-            "Agent processing failed for message seq %d, contractor %d",
+            "Agent processing failed for message seq %d, user %d",
             message.seq,
-            contractor.id,
+            user.id,
         )
         return AgentResponse(reply_text=AGENT_ERROR_FALLBACK, is_error_fallback=True)
 
@@ -300,7 +300,7 @@ async def dispatch_reply(
     to_address: str,
     message_seq: int,
 ) -> None:
-    """Send reply to the contractor unless the agent already sent one via a tool."""
+    """Send reply to the user unless the agent already sent one via a tool."""
     sent_reply = any(
         ToolTags.SENDS_REPLY in tc.tags and not tc.is_error for tc in response.tool_calls
     )
@@ -327,7 +327,7 @@ async def dispatch_reply(
 
 async def persist_outbound(
     session: SessionState,
-    contractor_id: int,
+    user_id: int,
     response: AgentResponse,
 ) -> None:
     """Store the outbound message record.
@@ -343,7 +343,7 @@ async def persist_outbound(
     if response.tool_calls:
         tool_interactions = json.dumps([tc.model_dump() for tc in response.tool_calls])
 
-    session_store = get_session_store(contractor_id)
+    session_store = get_session_store(user_id)
     await session_store.add_message(
         session=session,
         direction=MessageDirection.OUTBOUND,
@@ -360,7 +360,7 @@ async def persist_outbound(
 async def prepare_media_step(ctx: PipelineContext) -> PipelineContext:
     """Download media and initialize storage backend."""
     ctx.downloaded_media, ctx.storage = await prepare_media(
-        ctx.contractor, ctx.message, ctx.media_urls, ctx.messaging_service
+        ctx.user, ctx.message, ctx.media_urls, ctx.messaging_service
     )
     return ctx
 
@@ -368,20 +368,18 @@ async def prepare_media_step(ctx: PipelineContext) -> PipelineContext:
 async def build_context_step(ctx: PipelineContext) -> PipelineContext:
     """Run media pipeline and build combined context."""
     ctx.combined_context = await build_message_context(
-        ctx.session, ctx.message, ctx.contractor, ctx.media_urls, ctx.downloaded_media
+        ctx.session, ctx.message, ctx.user, ctx.media_urls, ctx.downloaded_media
     )
     return ctx
 
 
 async def load_history_step(ctx: PipelineContext) -> PipelineContext:
     """Load conversation history and set up onboarding."""
-    ctx.conversation_history = await load_conversation_history(
-        ctx.session, contractor_id=ctx.contractor.id
-    )
-    was_onboarding = is_onboarding_needed(ctx.contractor)
+    ctx.conversation_history = await load_conversation_history(ctx.session, user_id=ctx.user.id)
+    was_onboarding = is_onboarding_needed(ctx.user)
     if was_onboarding:
-        ctx.system_prompt_override = build_onboarding_system_prompt(ctx.contractor)
-    onboarding_sub = OnboardingSubscriber(ctx.contractor, was_onboarding)
+        ctx.system_prompt_override = build_onboarding_system_prompt(ctx.user)
+    onboarding_sub = OnboardingSubscriber(ctx.user, was_onboarding)
     ctx.event_subscribers.append(onboarding_sub)
     ctx._onboarding_sub = onboarding_sub
     return ctx
@@ -390,7 +388,7 @@ async def load_history_step(ctx: PipelineContext) -> PipelineContext:
 async def run_agent_step(ctx: PipelineContext) -> PipelineContext:
     """Initialize agent with tools and process the message."""
     ctx.response = await run_agent(
-        contractor=ctx.contractor,
+        user=ctx.user,
         message=ctx.message,
         combined_context=ctx.combined_context,
         conversation_history=ctx.conversation_history,
@@ -448,7 +446,7 @@ async def dispatch_reply_step(ctx: PipelineContext) -> PipelineContext:
 async def persist_outbound_step(ctx: PipelineContext) -> PipelineContext:
     """Store outbound message record."""
     if ctx.response:
-        await persist_outbound(ctx.session, ctx.contractor.id, ctx.response)
+        await persist_outbound(ctx.session, ctx.user.id, ctx.response)
     return ctx
 
 
@@ -484,7 +482,7 @@ DEFAULT_PIPELINE: list[PipelineStep] = [
 
 
 async def handle_inbound_message(
-    contractor: ContractorData,
+    user: UserData,
     session: SessionState,
     message: StoredMessage,
     media_urls: list[tuple[str, str]],
@@ -501,21 +499,21 @@ async def handle_inbound_message(
     remove, or reorder steps; defaults to ``DEFAULT_PIPELINE``.
     """
     logger.debug(
-        "Handling inbound message seq=%d for contractor %d, %d media attachment(s)",
+        "Handling inbound message seq=%d for user %d, %d media attachment(s)",
         message.seq,
-        contractor.id,
+        user.id,
         len(media_urls),
     )
-    to_address = contractor.channel_identifier or contractor.phone
+    to_address = user.channel_identifier or user.phone
     if not to_address:
         logger.error(
-            "Contractor %d has no channel_identifier or phone -- cannot send replies",
-            contractor.id,
+            "User %d has no channel_identifier or phone -- cannot send replies",
+            user.id,
         )
         return AgentResponse(reply_text="")
 
     ctx = PipelineContext(
-        contractor=contractor,
+        user=user,
         session=session,
         message=message,
         media_urls=media_urls,

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -11,7 +11,7 @@ import datetime
 import logging
 import zoneinfo
 
-from backend.app.agent.file_store import ContractorData, get_session_store
+from backend.app.agent.file_store import UserData, get_session_store
 from backend.app.agent.memory import build_memory_context
 from backend.app.agent.profile import build_soul_prompt
 from backend.app.agent.prompts import load_prompt
@@ -64,23 +64,23 @@ class SystemPromptBuilder:
 # -----------------------------------------------------------------------
 
 
-def build_identity_section(contractor: ContractorData) -> str:
+def build_identity_section(user: UserData) -> str:
     """Build the 'About <name>' section content."""
-    return build_soul_prompt(contractor)
+    return build_soul_prompt(user)
 
 
-def build_user_section(contractor: ContractorData) -> str:
+def build_user_section(user: UserData) -> str:
     """Build the user profile section from USER.md content."""
-    return contractor.user_text or ""
+    return user.user_text or ""
 
 
 async def build_memory_section(
-    contractor_id: int,
+    user_id: int,
     query: str | None = None,
 ) -> str:
     """Build the memory context section content."""
     ctx = await build_memory_context(
-        contractor_id,
+        user_id,
         query=query[:CONTEXT_QUERY_MAX_LENGTH] if query else None,
     )
     return ctx or "(No memories saved yet)"
@@ -113,11 +113,11 @@ def build_recall_section() -> str:
     return load_prompt("recall")
 
 
-def _to_contractor_time(
+def _to_user_time(
     now: datetime.datetime,
     tz_name: str,
 ) -> datetime.datetime:
-    """Convert *now* to the contractor's IANA timezone, falling back to UTC."""
+    """Convert *now* to the user's IANA timezone, falling back to UTC."""
     if not tz_name:
         return now
     try:
@@ -127,25 +127,25 @@ def _to_contractor_time(
         return now
 
 
-def build_date_section(contractor: ContractorData) -> str:
-    """Build a cache-friendly date string in the contractor's local timezone.
+def build_date_section(user: UserData) -> str:
+    """Build a cache-friendly date string in the user's local timezone.
 
     Uses date-only granularity (no minutes) to avoid prompt-cache busting.
     """
     now = datetime.datetime.now(datetime.UTC)
-    local = _to_contractor_time(now, contractor.timezone)
+    local = _to_user_time(now, user.timezone)
     return local.strftime("%A, %Y-%m-%d")
 
 
-def build_local_datetime_section(contractor: ContractorData) -> str:
+def build_local_datetime_section(user: UserData) -> str:
     """Build a human-readable local datetime for the heartbeat evaluator."""
     now = datetime.datetime.now(datetime.UTC)
-    local = _to_contractor_time(now, contractor.timezone)
+    local = _to_user_time(now, user.timezone)
     return local.strftime("%A, %Y-%m-%d %I:%M %p %Z").strip()
 
 
 def build_cross_session_context(
-    contractor_id: int,
+    user_id: int,
     current_session_id: str,
     count: int = 5,
 ) -> str:
@@ -153,9 +153,9 @@ def build_cross_session_context(
 
     Gives the agent awareness of recent conversations that happened on
     a different channel (e.g. Telegram vs webchat) so it can maintain
-    continuity when the contractor switches channels.
+    continuity when the user switches channels.
     """
-    store = get_session_store(contractor_id)
+    store = get_session_store(user_id)
     messages = store.get_other_session_messages(current_session_id, count=count)
     if not messages:
         return ""
@@ -179,24 +179,24 @@ def build_cross_session_context(
 
 
 async def build_agent_system_prompt(
-    contractor: ContractorData,
+    user: UserData,
     tools: list[Tool],
     message_context: str,
     current_session_id: str = "",
 ) -> str:
     """Assemble the full system prompt for the main agent loop."""
     builder = SystemPromptBuilder()
-    assistant = contractor.assistant_name or "Clawbolt"
-    builder.set_preamble(f"You are {assistant}, an AI assistant for solo contractors.")
+    assistant = user.assistant_name or "Clawbolt"
+    builder.set_preamble(f"You are {assistant}, an AI assistant for solo tradespeople.")
 
     builder.add_section(
-        f"About {contractor.name or 'Contractor'}",
-        build_identity_section(contractor),
+        f"About {user.name or 'User'}",
+        build_identity_section(user),
     )
 
-    builder.add_section("About Your User", build_user_section(contractor))
+    builder.add_section("About Your User", build_user_section(user))
 
-    memory = await build_memory_section(contractor.id, query=message_context)
+    memory = await build_memory_section(user.id, query=message_context)
     builder.add_section("Your Memory", memory)
 
     tool_guidelines = build_tool_guidelines_section(tools)
@@ -208,13 +208,13 @@ async def build_agent_system_prompt(
         instructions = build_instructions_section()
     builder.add_section("Instructions", instructions)
 
-    builder.add_section("Current date", build_date_section(contractor))
+    builder.add_section("Current date", build_date_section(user))
 
     builder.add_section("Proactive Messaging", build_proactive_section())
     builder.add_section("Recall Behavior", build_recall_section())
 
     if current_session_id:
-        cross = build_cross_session_context(contractor.id, current_session_id)
+        cross = build_cross_session_context(user.id, current_session_id)
         if cross:
             builder.add_section("Recent Activity (other channel)", cross)
 
@@ -222,7 +222,7 @@ async def build_agent_system_prompt(
 
 
 async def build_heartbeat_system_prompt(
-    contractor: ContractorData,
+    user: UserData,
     flags: list[str],
     recent_messages: str,
 ) -> str:
@@ -230,11 +230,11 @@ async def build_heartbeat_system_prompt(
     builder = SystemPromptBuilder()
     builder.set_preamble(load_prompt("heartbeat_preamble"))
 
-    builder.add_section("About the contractor", build_identity_section(contractor))
-    builder.add_section("About the user", build_user_section(contractor))
+    builder.add_section("About the user", build_identity_section(user))
+    builder.add_section("About the user", build_user_section(user))
 
-    memory = await build_memory_section(contractor.id)
-    builder.add_section("Contractor's memory", memory)
+    memory = await build_memory_section(user.id)
+    builder.add_section("User's memory", memory)
 
     builder.add_section(
         "Recent conversation (last 5 messages)",
@@ -248,7 +248,7 @@ async def build_heartbeat_system_prompt(
 
     builder.add_section(
         "Current time",
-        build_local_datetime_section(contractor),
+        build_local_datetime_section(user),
     )
 
     builder.add_section("Rules", load_prompt("heartbeat_rules"))

--- a/backend/app/agent/tools/checklist_tools.py
+++ b/backend/app/agent/tools/checklist_tools.py
@@ -35,27 +35,27 @@ class RemoveChecklistItemParams(BaseModel):
     item_id: int = Field(description="ID of the checklist item to remove")
 
 
-def create_checklist_tools(contractor_id: int) -> list[Tool]:
+def create_checklist_tools(user_id: int) -> list[Tool]:
     """Create checklist-related tools for the agent."""
 
     async def add_checklist_item(
         description: str,
         schedule: str = ChecklistSchedule.DAILY,
     ) -> ToolResult:
-        """Add an item to the contractor's heartbeat checklist."""
+        """Add an item to the user's heartbeat checklist."""
         if schedule not in list(ChecklistSchedule):
             return ToolResult(
                 content=f"Invalid schedule '{schedule}'. Use: daily, weekdays, or once.",
                 is_error=True,
                 error_kind=ToolErrorKind.VALIDATION,
             )
-        store = HeartbeatStore(contractor_id)
+        store = HeartbeatStore(user_id)
         item = await store.add_checklist_item(description=description, schedule=schedule)
         return ToolResult(content=f"Added to checklist (#{item.id}, {schedule}): {description}")
 
     async def list_checklist_items() -> ToolResult:
         """List all active checklist items."""
-        store = HeartbeatStore(contractor_id)
+        store = HeartbeatStore(user_id)
         all_items = await store.get_checklist()
         items = [i for i in all_items if i.status == ChecklistStatus.ACTIVE]
         if not items:
@@ -65,7 +65,7 @@ def create_checklist_tools(contractor_id: int) -> list[Tool]:
 
     async def remove_checklist_item(item_id: int) -> ToolResult:
         """Remove a checklist item by ID."""
-        store = HeartbeatStore(contractor_id)
+        store = HeartbeatStore(user_id)
         deleted = await store.delete_checklist_item(item_id)
         if not deleted:
             return ToolResult(
@@ -79,34 +79,34 @@ def create_checklist_tools(contractor_id: int) -> list[Tool]:
         Tool(
             name=ToolName.ADD_CHECKLIST_ITEM,
             description=(
-                "Add an item to the contractor's heartbeat checklist. "
+                "Add an item to the user's heartbeat checklist. "
                 "The heartbeat will proactively check this item and remind "
-                "the contractor when it's due."
+                "the user when it's due."
             ),
             function=add_checklist_item,
             params_model=AddChecklistItemParams,
-            usage_hint="When the contractor wants a recurring reminder, add it to the checklist.",
+            usage_hint="When the user wants a recurring reminder, add it to the checklist.",
         ),
         Tool(
             name=ToolName.LIST_CHECKLIST_ITEMS,
-            description="List all active items on the contractor's heartbeat checklist.",
+            description="List all active items on the user's heartbeat checklist.",
             function=list_checklist_items,
             params_model=ListChecklistItemsParams,
             usage_hint="When asked about active reminders or checklist items, list them.",
         ),
         Tool(
             name=ToolName.REMOVE_CHECKLIST_ITEM,
-            description="Remove an item from the contractor's heartbeat checklist by its ID.",
+            description="Remove an item from the user's heartbeat checklist by its ID.",
             function=remove_checklist_item,
             params_model=RemoveChecklistItemParams,
-            usage_hint="When the contractor wants to stop a reminder, remove it by ID.",
+            usage_hint="When the user wants to stop a reminder, remove it by ID.",
         ),
     ]
 
 
 def _checklist_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for checklist tools, used by the registry."""
-    return create_checklist_tools(ctx.contractor.id)
+    return create_checklist_tools(ctx.user.id)
 
 
 def _register() -> None:

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
-from backend.app.agent.file_store import ContractorData, EstimateStore, make_client_slug
+from backend.app.agent.file_store import EstimateStore, UserData, make_client_slug
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.file_tools import build_folder_path
 from backend.app.agent.tools.names import ToolName
@@ -47,7 +47,7 @@ class GenerateEstimateParams(BaseModel):
 
 
 def create_estimate_tools(
-    contractor: ContractorData,
+    user: UserData,
     storage: StorageBackend | None = None,
 ) -> list[Tool]:
     """Create estimate-related tools for the agent."""
@@ -101,13 +101,13 @@ def create_estimate_tools(
             make_client_slug(
                 name=client_name or "",
                 address=client_address or "",
-                folder_scheme=contractor.folder_scheme,
+                folder_scheme=user.folder_scheme,
             )
             or None
         )
 
         # Create estimate via file store
-        estimate_store = EstimateStore(contractor.id)
+        estimate_store = EstimateStore(user.id)
         estimate = await estimate_store.create(
             description=description,
             total_amount=total_amount,
@@ -120,9 +120,9 @@ def create_estimate_tools(
 
         # Generate PDF
         pdf_data = EstimatePDFData(
-            contractor_name=contractor.name or "Contractor",
-            contractor_phone=contractor.phone or "",
-            contractor_trade="",
+            owner_name=user.name or "User",
+            owner_phone=user.phone or "",
+            owner_trade="",
             description=description,
             line_items=processed_items,
             subtotal=subtotal,
@@ -137,7 +137,7 @@ def create_estimate_tools(
         pdf_bytes = await generate_estimate_pdf(pdf_data)
 
         # Save PDF to local storage, organized by client
-        pdf_dir = PDF_BASE_DIR / str(contractor.id) / (client_slug or "unsorted")
+        pdf_dir = PDF_BASE_DIR / str(user.id) / (client_slug or "unsorted")
         pdf_dir.mkdir(parents=True, exist_ok=True)
         pdf_path = pdf_dir / f"{estimate.id}.pdf"
         pdf_path.write_bytes(pdf_bytes)
@@ -167,7 +167,7 @@ def create_estimate_tools(
                 f"Estimate {estimate_number} generated for ${total_amount:,.2f}. "
                 f"{len(processed_items)} line item(s). "
                 f"PDF saved at {pdf_path}. "
-                f"Use send_media_reply to send it to the contractor."
+                f"Use send_media_reply to send it to the user."
             )
         )
 
@@ -175,15 +175,15 @@ def create_estimate_tools(
         Tool(
             name=ToolName.GENERATE_ESTIMATE,
             description=(
-                "Generate a professional estimate PDF. Use when the contractor asks for "
+                "Generate a professional estimate PDF. Use when the user asks for "
                 "an estimate, quote, or bid. Requires line_items: each item needs a "
                 "description, quantity, and unit_price. Do NOT call this tool until you "
-                "have at least one concrete line item from the contractor."
+                "have at least one concrete line item from the user."
             ),
             function=generate_estimate,
             params_model=GenerateEstimateParams,
             usage_hint=(
-                "Before calling this tool, ask the contractor for specific line items "
+                "Before calling this tool, ask the user for specific line items "
                 "(what work, how much, at what price). Do not guess line items."
             ),
         ),
@@ -192,7 +192,7 @@ def create_estimate_tools(
 
 def _estimate_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for estimate tools, used by the registry."""
-    return create_estimate_tools(ctx.contractor, ctx.storage)
+    return create_estimate_tools(ctx.user, ctx.storage)
 
 
 def _register() -> None:

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
-from backend.app.agent.file_store import ContractorData, MediaStore
+from backend.app.agent.file_store import MediaStore, UserData
 from backend.app.agent.file_store import slugify as _store_slugify
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
@@ -157,7 +157,7 @@ def _extension_from_mime(mime_type: str) -> str:
 
 
 async def auto_save_media(
-    contractor: ContractorData,
+    user: UserData,
     storage: StorageBackend,
     downloaded_media: list[DownloadedMedia],
 ) -> list[str]:
@@ -176,7 +176,7 @@ async def auto_save_media(
     folder_path = f"/Unsorted/{today}"
     await storage.create_folder(folder_path)
 
-    media_store = MediaStore(contractor.id)
+    media_store = MediaStore(user.id)
     saved_urls: list[str] = []
     for media in downloaded_media:
         extension = _extension_from_mime(media.mime_type)
@@ -198,14 +198,14 @@ async def auto_save_media(
 
 
 def create_file_tools(
-    contractor: ContractorData,
+    user: UserData,
     storage: StorageBackend,
     pending_media: dict[str, bytes] | None = None,
 ) -> list[Tool]:
     """Create file cataloging tools for the agent.
 
     Args:
-        contractor: The contractor
+        user: The user
         storage: Storage backend (Dropbox, Google Drive, or mock)
         pending_media: Dict of original_url -> file bytes for media in the current message
     """
@@ -219,7 +219,7 @@ def create_file_tools(
         original_url: str | None = None,
         mime_type: str = "image/jpeg",
     ) -> ToolResult:
-        """Upload a file to the contractor's cloud storage."""
+        """Upload a file to the user's cloud storage."""
         # Determine file content
         file_bytes = b""
         if original_url and original_url in media_map:
@@ -255,7 +255,7 @@ def create_file_tools(
         extension = _extension_from_mime(mime_type)
 
         # Count existing files to get index
-        media_store = MediaStore(contractor.id)
+        media_store = MediaStore(user.id)
         existing = await media_store.count_by_path_prefix(folder_path)
 
         filename = _build_filename(
@@ -287,7 +287,7 @@ def create_file_tools(
     ) -> ToolResult:
         """Move an auto-saved file from Unsorted into the correct client folder."""
         # Look up the media record
-        media_store = MediaStore(contractor.id)
+        media_store = MediaStore(user.id)
         media_file = await media_store.get_by_url(original_url)
         if media_file is None:
             return ToolResult(
@@ -356,8 +356,8 @@ def create_file_tools(
         Tool(
             name=ToolName.UPLOAD_TO_STORAGE,
             description=(
-                "Upload a file attached to the CURRENT message to the contractor's "
-                "cloud storage. Only works when the contractor sent media in this "
+                "Upload a file attached to the CURRENT message to the user's "
+                "cloud storage. Only works when the user sent media in this "
                 "message. Files are organized by client: provide client_name or "
                 "client_address to file under their folder, otherwise files go to "
                 "Unsorted. For files received in previous messages, use "
@@ -387,7 +387,7 @@ def _file_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for file tools, used by the registry."""
     assert ctx.storage is not None
     pending_media = {m.original_url: m.content for m in ctx.downloaded_media if m.content}
-    return create_file_tools(ctx.contractor, ctx.storage, pending_media)
+    return create_file_tools(ctx.user, ctx.storage, pending_media)
 
 
 def _register() -> None:

--- a/backend/app/agent/tools/memory_tools.py
+++ b/backend/app/agent/tools/memory_tools.py
@@ -39,17 +39,17 @@ class ForgetFactParams(BaseModel):
     key: str = Field(description="Key of the fact to delete")
 
 
-def create_memory_tools(contractor_id: int) -> list[Tool]:
+def create_memory_tools(user_id: int) -> list[Tool]:
     """Create memory-related tools for the agent."""
 
     async def save_fact(key: str, value: str, category: str = "general") -> ToolResult:
         """Save a fact to memory."""
-        memory = await save_memory(contractor_id, key=key, value=value, category=category)
+        memory = await save_memory(user_id, key=key, value=value, category=category)
         return ToolResult(content=f"Saved: {memory.key} = {memory.value}")
 
     async def recall_facts(query: str, category: str | None = None) -> ToolResult:
         """Search memory for facts matching a query."""
-        memories = await recall_memories(contractor_id, query=query, category=category)
+        memories = await recall_memories(user_id, query=query, category=category)
         if not memories:
             return ToolResult(content="No matching facts found.")
         lines = [f"- {m.key}: {m.value}" for m in memories]
@@ -57,7 +57,7 @@ def create_memory_tools(contractor_id: int) -> list[Tool]:
 
     async def forget_fact(key: str) -> ToolResult:
         """Delete a fact from memory."""
-        deleted = await delete_memory(contractor_id, key=key)
+        deleted = await delete_memory(user_id, key=key)
         if deleted:
             return ToolResult(content=f"Deleted: {key}")
         return ToolResult(
@@ -68,7 +68,7 @@ def create_memory_tools(contractor_id: int) -> list[Tool]:
         Tool(
             name=ToolName.SAVE_FACT,
             description=(
-                "Save a key-value fact to the contractor's memory. "
+                "Save a key-value fact to the user's memory. "
                 "Use for pricing, client info, preferences, etc."
             ),
             function=save_fact,
@@ -78,11 +78,11 @@ def create_memory_tools(contractor_id: int) -> list[Tool]:
         ),
         Tool(
             name=ToolName.RECALL_FACTS,
-            description="Search the contractor's memory for facts matching a query.",
+            description="Search the user's memory for facts matching a query.",
             function=recall_facts,
             params_model=RecallFactsParams,
             usage_hint=(
-                "When asked about the contractor's business, clients, or past work,"
+                "When asked about the user's business, clients, or past work,"
                 " search your memory first."
             ),
         ),
@@ -98,7 +98,7 @@ def create_memory_tools(contractor_id: int) -> list[Tool]:
 
 def _memory_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for memory tools, used by the registry."""
-    return create_memory_tools(ctx.contractor.id)
+    return create_memory_tools(ctx.user.id)
 
 
 def _register() -> None:

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -29,7 +29,7 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
     """Create messaging tools for the agent."""
 
     async def send_reply(message: str) -> ToolResult:
-        """Send a text reply to the contractor."""
+        """Send a text reply to the user."""
         if not message or not message.strip():
             return ToolResult(
                 content="Error: message cannot be empty.",
@@ -55,11 +55,11 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
     return [
         Tool(
             name=ToolName.SEND_REPLY,
-            description="Send a text reply to the contractor.",
+            description="Send a text reply to the user.",
             function=send_reply,
             params_model=SendReplyParams,
             tags={ToolTags.SENDS_REPLY},
-            usage_hint="Use this to send a text message to the contractor.",
+            usage_hint="Use this to send a text message to the user.",
         ),
         Tool(
             name=ToolName.SEND_MEDIA_REPLY,
@@ -67,9 +67,7 @@ def create_messaging_tools(messaging_service: MessagingService, to_address: str)
             function=send_media_reply,
             params_model=SendMediaReplyParams,
             tags={ToolTags.SENDS_REPLY},
-            usage_hint=(
-                "When sending estimates or files, use this to send media to the contractor."
-            ),
+            usage_hint=("When sending estimates or files, use this to send media to the user."),
         ),
     ]
 

--- a/backend/app/agent/tools/profile_tools.py
+++ b/backend/app/agent/tools/profile_tools.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field
 
 from backend.app.agent.context import StoredToolInteraction
-from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.file_store import UserData, get_user_store
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTags
 from backend.app.agent.tools.names import ToolName
 
@@ -32,46 +32,46 @@ class ViewProfileParams(BaseModel):
 class UpdateProfileParams(BaseModel):
     """Parameters for the update_profile tool."""
 
-    name: str | None = Field(default=None, description="Contractor's full name")
+    name: str | None = Field(default=None, description="User's full name")
     assistant_name: str | None = Field(
         default=None,
-        description="What the contractor calls their AI assistant",
+        description="What the user calls their AI assistant",
     )
 
 
-def _format_profile(contractor: ContractorData) -> str:
-    """Format the contractor's profile as a human-readable summary.
+def _format_profile(user: UserData) -> str:
+    """Format the user's profile as a human-readable summary.
 
     Returns a structured text block with core profile fields.
     Business details are in USER.md (use read_file to view).
     """
     lines: list[str] = []
-    lines.append("Contractor Profile:")
-    lines.append(f"  Name: {contractor.name or 'Not set'}")
+    lines.append("User Profile:")
+    lines.append(f"  Name: {user.name or 'Not set'}")
 
-    assistant = contractor.assistant_name if contractor.assistant_name != "Clawbolt" else None
+    assistant = user.assistant_name if user.assistant_name != "Clawbolt" else None
     lines.append(f"  AI Name: {assistant or 'Clawbolt (default)'}")
-    lines.append(f"  Onboarding Complete: {'Yes' if contractor.onboarding_complete else 'No'}")
+    lines.append(f"  Onboarding Complete: {'Yes' if user.onboarding_complete else 'No'}")
     lines.append("")
     lines.append("For more details (trade, location, rates, hours, preferences), read USER.md.")
 
     return "\n".join(lines)
 
 
-def create_profile_tools(contractor: ContractorData) -> list[Tool]:
+def create_profile_tools(user: UserData) -> list[Tool]:
     """Create profile introspection and update tools for the agent."""
 
     async def view_profile() -> ToolResult:
-        """View the contractor's current profile information."""
-        store = get_contractor_store()
-        refreshed = await store.get_by_id(contractor.id)
-        return ToolResult(content=_format_profile(refreshed or contractor))
+        """View the user's current profile information."""
+        store = get_user_store()
+        refreshed = await store.get_by_id(user.id)
+        return ToolResult(content=_format_profile(refreshed or user))
 
     async def update_profile(
         name: str | None = None,
         assistant_name: str | None = None,
     ) -> ToolResult:
-        """Update the contractor's core profile fields."""
+        """Update the user's core profile fields."""
         updates: dict[str, str] = {}
         fields_updated: list[str] = []
 
@@ -94,8 +94,8 @@ def create_profile_tools(contractor: ContractorData) -> list[Tool]:
         _allowed_fields = {"name", "assistant_name"}
         safe_updates = {k: v for k, v in updates.items() if k in _allowed_fields}
 
-        store = get_contractor_store()
-        await store.update(contractor.id, **safe_updates)
+        store = get_user_store()
+        await store.update(user.id, **safe_updates)
 
         summary = ", ".join(fields_updated)
         return ToolResult(content=f"Profile updated: {summary}")
@@ -104,15 +104,15 @@ def create_profile_tools(contractor: ContractorData) -> list[Tool]:
         Tool(
             name=ToolName.VIEW_PROFILE,
             description=(
-                "View the contractor's current profile information. "
-                "Use when the contractor asks what you know about them, "
+                "View the user's current profile information. "
+                "Use when the user asks what you know about them, "
                 "or when you need to check their current profile details."
             ),
             function=view_profile,
             params_model=ViewProfileParams,
             usage_hint=(
                 "When asked 'what do you know about me?' or needing to check "
-                "the contractor's profile, use this tool first. "
+                "the user's profile, use this tool first. "
                 "For full details, also read USER.md."
             ),
         ),
@@ -136,7 +136,7 @@ def create_profile_tools(contractor: ContractorData) -> list[Tool]:
 
 def _profile_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for profile tools, used by the registry."""
-    return create_profile_tools(ctx.contractor)
+    return create_profile_tools(ctx.user)
 
 
 def _register() -> None:

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 
 from pydantic import BaseModel, Field
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.media.download import DownloadedMedia
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 class ToolContext:
     """Shared context passed to tool factories during creation."""
 
-    contractor: ContractorData
+    user: UserData
     storage: StorageBackend | None = None
     messaging_service: MessagingService | None = None
     to_address: str = ""

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -1,8 +1,8 @@
 """Generic file tools for reading and writing workspace files.
 
-Gives the agent direct access to markdown files in the contractor's data
+Gives the agent direct access to markdown files in the user's data
 directory (SOUL.md, USER.md, memory/, etc.), following the same pattern
-used by openclaw and nanobot.  Files are scoped to the contractor's
+used by openclaw and nanobot.  Files are scoped to the user's
 directory for safety.
 """
 
@@ -50,12 +50,12 @@ class EditFileParams(BaseModel):
     new_text: str = Field(description="Replacement text")
 
 
-def _resolve_path(contractor_id: int, relative_path: str) -> tuple[Path, str | None]:
-    """Resolve a relative path to an absolute path within the contractor directory.
+def _resolve_path(user_id: int, relative_path: str) -> tuple[Path, str | None]:
+    """Resolve a relative path to an absolute path within the user directory.
 
     Returns (resolved_path, error_message).  error_message is None on success.
     """
-    base = Path(settings.data_dir) / str(contractor_id)
+    base = Path(settings.data_dir) / str(user_id)
     try:
         resolved = (base / relative_path).resolve()
     except (ValueError, OSError):
@@ -75,12 +75,12 @@ def _resolve_path(contractor_id: int, relative_path: str) -> tuple[Path, str | N
     return resolved, None
 
 
-def create_workspace_tools(contractor_id: int) -> list[Tool]:
-    """Create generic file tools scoped to the contractor's data directory."""
+def create_workspace_tools(user_id: int) -> list[Tool]:
+    """Create generic file tools scoped to the user's data directory."""
 
     async def read_file(path: str) -> ToolResult:
         """Read a markdown file from the workspace."""
-        resolved, err = _resolve_path(contractor_id, path)
+        resolved, err = _resolve_path(user_id, path)
         if err:
             return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
         if not resolved.exists():
@@ -93,7 +93,7 @@ def create_workspace_tools(contractor_id: int) -> list[Tool]:
 
     async def write_file(path: str, content: str) -> ToolResult:
         """Write or overwrite a markdown file in the workspace."""
-        resolved, err = _resolve_path(contractor_id, path)
+        resolved, err = _resolve_path(user_id, path)
         if err:
             return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
         resolved.parent.mkdir(parents=True, exist_ok=True)
@@ -102,7 +102,7 @@ def create_workspace_tools(contractor_id: int) -> list[Tool]:
 
     async def edit_file(path: str, old_text: str, new_text: str) -> ToolResult:
         """Replace exact text in a markdown file."""
-        resolved, err = _resolve_path(contractor_id, path)
+        resolved, err = _resolve_path(user_id, path)
         if err:
             return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
         if not resolved.exists():
@@ -174,7 +174,7 @@ def create_workspace_tools(contractor_id: int) -> list[Tool]:
 
 def _workspace_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for workspace tools, used by the registry."""
-    return create_workspace_tools(ctx.contractor.id)
+    return create_workspace_tools(ctx.user.id)
 
 
 def _register() -> None:

--- a/backend/app/auth/base.py
+++ b/backend/app/auth/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 
 
 class AuthBackend(ABC):
@@ -10,8 +10,8 @@ class AuthBackend(ABC):
         """Return auth config for the frontend."""
 
     @abstractmethod
-    async def authenticate_login(self, credentials: dict[str, str]) -> ContractorData:
-        """Validate credentials and return ContractorData."""
+    async def authenticate_login(self, credentials: dict[str, str]) -> UserData:
+        """Validate credentials and return UserData."""
 
-    async def on_contractor_created(self, contractor: ContractorData) -> None:  # noqa: B027
-        """Hook called after new contractor creation. Override to seed data."""
+    async def on_user_created(self, user: UserData) -> None:  # noqa: B027
+        """Hook called after new user creation. Override to seed data."""

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,20 +1,20 @@
-from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.file_store import UserData, get_user_store
 
 LOCAL_USER_ID = "local@clawbolt.local"
 
 
-async def get_current_user() -> ContractorData:
-    """OSS mode: return the single contractor, no auth required.
+async def get_current_user() -> UserData:
+    """OSS mode: return the single user, no auth required.
 
-    In single-tenant mode there should be exactly one contractor. If Telegram
-    (or another channel) already created one, return that contractor so the
+    In single-tenant mode there should be exactly one user. If Telegram
+    (or another channel) already created one, return that user so the
     dashboard sees the same sessions, memory, and stats. Only create a local
     fallback when the store is completely empty.
     """
-    store = get_contractor_store()
-    all_contractors = await store.list_all()
-    if all_contractors:
-        return all_contractors[0]
+    store = get_user_store()
+    all_users = await store.list_all()
+    if all_users:
+        return all_users[0]
     return await store.create(
         user_id=LOCAL_USER_ID,
     )

--- a/backend/app/auth/scoping.py
+++ b/backend/app/auth/scoping.py
@@ -2,30 +2,30 @@ from fastapi import HTTPException
 
 from backend.app.agent.file_store import (
     ClientStore,
-    ContractorData,
     EstimateStore,
-    get_contractor_store,
+    UserData,
     get_memory_store,
+    get_user_store,
 )
 
 
-async def get_user_contractor(
-    user: ContractorData,
-    contractor_id: int,
-) -> ContractorData:
-    """Get a contractor by ID, scoped to the current user. Returns 404 on mismatch."""
-    store = get_contractor_store()
-    contractor = await store.get_by_id(contractor_id)
-    if not contractor or contractor.user_id != user.user_id:
-        raise HTTPException(status_code=404, detail="Contractor not found")
-    return contractor
+async def get_scoped_user(
+    current_user: UserData,
+    target_id: int,
+) -> UserData:
+    """Get a user by ID, scoped to the current user. Returns 404 on mismatch."""
+    store = get_user_store()
+    target = await store.get_by_id(target_id)
+    if not target or target.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="User not found")
+    return target
 
 
 async def get_user_client(
-    user: ContractorData,
+    user: UserData,
     client_id: str,
 ) -> None:
-    """Verify a client exists and belongs to the current user's contractor. 404 on mismatch."""
+    """Verify a client exists and belongs to the current user. 404 on mismatch."""
     client_store = ClientStore(user.id)
     client = await client_store.get(client_id)
     if not client:
@@ -33,10 +33,10 @@ async def get_user_client(
 
 
 async def get_user_estimate(
-    user: ContractorData,
+    user: UserData,
     estimate_id: str,
 ) -> None:
-    """Verify an estimate exists and belongs to the current user's contractor. 404 on mismatch."""
+    """Verify an estimate exists and belongs to the current user. 404 on mismatch."""
     estimate_store = EstimateStore(user.id)
     estimate = await estimate_store.get(estimate_id)
     if not estimate:
@@ -44,10 +44,10 @@ async def get_user_estimate(
 
 
 async def get_user_memory(
-    user: ContractorData,
+    user: UserData,
     memory_key: str,
 ) -> None:
-    """Verify a memory fact exists for the current user's contractor. 404 on mismatch."""
+    """Verify a memory fact exists for the current user. 404 on mismatch."""
     memory_store = get_memory_store(user.id)
     memories = await memory_store.get_all_memories()
     for m in memories:

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -21,9 +21,9 @@ class ChannelManager:
 
     In addition to managing channel lifecycles, runs two long-lived tasks:
 
-    * **inbound consumer**: reads from the message bus, performs contractor
+    * **inbound consumer**: reads from the message bus, performs user
       lookup / session creation / persistence, and dispatches to the agent
-      pipeline (with per-contractor locking).
+      pipeline (with per-user locking).
     * **outbound dispatcher**: reads agent replies from the bus and routes
       them to the correct channel's send method or resolves web chat
       response futures.

--- a/backend/app/channels/webchat.py
+++ b/backend/app/channels/webchat.py
@@ -22,7 +22,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from backend.app.agent.context import get_or_create_conversation
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.ingestion import InboundMessage
 from backend.app.auth.dependencies import get_current_user
 from backend.app.bus import message_bus
@@ -60,7 +60,7 @@ class WebChatChannel(BaseChannel):
             message: str = Form(default=""),
             session_id: str | None = Form(default=None),
             files: list[UploadFile] = File(default=[]),
-            contractor: ContractorData = Depends(get_current_user),
+            user: UserData = Depends(get_current_user),
         ) -> _ChatAccepted:
             """Accept a message, publish to bus, return request_id for SSE."""
             text = message.strip()
@@ -98,9 +98,7 @@ class WebChatChannel(BaseChannel):
                 )
 
             # Get/create session so we can return session_id immediately
-            session, _ = await get_or_create_conversation(
-                contractor.id, external_session_id=session_id
-            )
+            session, _ = await get_or_create_conversation(user.id, external_session_id=session_id)
 
             request_id = str(uuid.uuid4())
 
@@ -110,7 +108,7 @@ class WebChatChannel(BaseChannel):
 
             inbound = InboundMessage(
                 channel="webchat",
-                sender_id=str(contractor.id),
+                sender_id=str(user.id),
                 text=text,
                 downloaded_media=downloaded_media,
                 request_id=request_id,
@@ -123,7 +121,7 @@ class WebChatChannel(BaseChannel):
         @router.get("/user/chat/events/{request_id}")
         async def chat_events(
             request_id: str,
-            _contractor: ContractorData = Depends(get_current_user),
+            _user: UserData = Depends(get_current_user),
         ) -> StreamingResponse:
             """SSE endpoint: streams the agent reply for a given request_id."""
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -71,7 +71,7 @@ class Settings(BaseSettings):
     whisper_compute_type: str = "int8"
 
     # Agent loop
-    message_batch_window_ms: int = 1500  # Batch rapid-fire messages per contractor
+    message_batch_window_ms: int = 1500  # Batch rapid-fire messages per user
     max_tool_rounds: int = 10
     max_input_tokens: int = 120_000
     context_trim_target_tokens: int = 80_000
@@ -106,10 +106,10 @@ class Settings(BaseSettings):
     heartbeat_max_daily_messages: int = 5
     heartbeat_quiet_hours_start: int = 20  # 8 PM
     heartbeat_quiet_hours_end: int = 7  # 7 AM
-    heartbeat_idle_days: int = 3  # flag contractors with no inbound messages for N days
+    heartbeat_idle_days: int = 3  # flag users with no inbound messages for N days
     heartbeat_model: str = ""  # empty = fall back to llm_model
     heartbeat_provider: str = ""  # empty = fall back to llm_provider
-    heartbeat_concurrency: int = 5  # max concurrent contractor evaluations per tick
+    heartbeat_concurrency: int = 5  # max concurrent user evaluations per tick
     checklist_daily_interval_hours: int = 20
     heartbeat_recent_messages_count: int = 5
 

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -11,7 +11,7 @@ from backend.app.config import settings
 logger = logging.getLogger(__name__)
 
 VISION_SYSTEM_PROMPT = (
-    "You are analyzing an image sent by a contractor. "
+    "You are analyzing an image sent by a user. "
     "Describe what you see in detail, focusing on: "
     "materials, dimensions, condition, damage, work needed, safety concerns. "
     "Be specific and technical."

--- a/backend/app/routers/estimates.py
+++ b/backend/app/routers/estimates.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 
-from backend.app.agent.file_store import ContractorData, EstimateStore
+from backend.app.agent.file_store import EstimateStore, UserData
 from backend.app.auth.dependencies import get_current_user
 from backend.app.config import settings
 
@@ -20,7 +20,7 @@ PDF_BASE_DIR = Path(settings.pdf_storage_dir)
 @router.get("/estimates/{estimate_id}/pdf")
 async def serve_estimate_pdf(
     estimate_id: str,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> Response:
     """Serve a generated estimate PDF by estimate ID."""
     # Verify the estimate exists and belongs to the current user

--- a/backend/app/routers/user_checklist.py
+++ b/backend/app/routers/user_checklist.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.app.agent.file_store import ContractorData, HeartbeatStore
+from backend.app.agent.file_store import HeartbeatStore, UserData
 from backend.app.auth.dependencies import get_current_user
 from backend.app.schemas import (
     ChecklistCreateRequest,
@@ -15,7 +15,7 @@ router = APIRouter()
 
 @router.get("/user/checklist", response_model=list[ChecklistItemResponse])
 async def list_checklist(
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> list[ChecklistItemResponse]:
     """List active checklist items."""
     store = HeartbeatStore(current_user.id)
@@ -35,7 +35,7 @@ async def list_checklist(
 @router.post("/user/checklist", response_model=ChecklistItemResponse, status_code=201)
 async def create_checklist_item(
     body: ChecklistCreateRequest,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> ChecklistItemResponse:
     """Add a new checklist item."""
     store = HeartbeatStore(current_user.id)
@@ -56,7 +56,7 @@ async def create_checklist_item(
 async def update_checklist_item(
     item_id: int,
     body: ChecklistUpdateRequest,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> ChecklistItemResponse:
     """Update a checklist item."""
     store = HeartbeatStore(current_user.id)
@@ -80,7 +80,7 @@ async def update_checklist_item(
 @router.delete("/user/checklist/{item_id}", status_code=204)
 async def delete_checklist_item(
     item_id: int,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> None:
     """Remove a checklist item."""
     store = HeartbeatStore(current_user.id)

--- a/backend/app/routers/user_memory.py
+++ b/backend/app/routers/user_memory.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.app.agent.file_store import ContractorData, get_memory_store
+from backend.app.agent.file_store import UserData, get_memory_store
 from backend.app.auth.dependencies import get_current_user
 from backend.app.schemas import MemoryFactResponse, MemoryFactUpdate
 
@@ -12,7 +12,7 @@ router = APIRouter()
 @router.get("/user/memory", response_model=list[MemoryFactResponse])
 async def list_memory(
     category: str | None = None,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> list[MemoryFactResponse]:
     """List all memory facts, optionally filtered by category."""
     store = get_memory_store(current_user.id)
@@ -32,7 +32,7 @@ async def list_memory(
 async def update_memory(
     key: str,
     body: MemoryFactUpdate,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> MemoryFactResponse:
     """Update a memory fact's value, category, or confidence."""
     store = get_memory_store(current_user.id)
@@ -62,7 +62,7 @@ async def update_memory(
 @router.delete("/user/memory/{key}", status_code=204)
 async def delete_memory(
     key: str,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> None:
     """Delete a memory fact."""
     store = get_memory_store(current_user.id)

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -1,22 +1,22 @@
-"""Endpoints for contractor profile management."""
+"""Endpoints for user profile management."""
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.file_store import UserData, get_user_store
 from backend.app.auth.dependencies import get_current_user
 from backend.app.config import save_persistent_config, settings
 from backend.app.schemas import (
     ChannelConfigResponse,
     ChannelConfigUpdate,
-    ContractorProfileResponse,
-    ContractorProfileUpdate,
+    UserProfileResponse,
+    UserProfileUpdate,
 )
 
 router = APIRouter()
 
 
-def _profile_response(c: ContractorData) -> ContractorProfileResponse:
-    return ContractorProfileResponse(
+def _profile_response(c: UserData) -> UserProfileResponse:
+    return UserProfileResponse(
         id=c.id,
         user_id=c.user_id,
         name=c.name,
@@ -36,28 +36,28 @@ def _profile_response(c: ContractorData) -> ContractorProfileResponse:
     )
 
 
-@router.get("/user/profile", response_model=ContractorProfileResponse)
+@router.get("/user/profile", response_model=UserProfileResponse)
 async def get_profile(
-    current_user: ContractorData = Depends(get_current_user),
-) -> ContractorProfileResponse:
-    """Return the current contractor's profile."""
+    current_user: UserData = Depends(get_current_user),
+) -> UserProfileResponse:
+    """Return the current user's profile."""
     return _profile_response(current_user)
 
 
-@router.put("/user/profile", response_model=ContractorProfileResponse)
+@router.put("/user/profile", response_model=UserProfileResponse)
 async def update_profile(
-    body: ContractorProfileUpdate,
-    current_user: ContractorData = Depends(get_current_user),
-) -> ContractorProfileResponse:
-    """Partial update of the current contractor's profile."""
+    body: UserProfileUpdate,
+    current_user: UserData = Depends(get_current_user),
+) -> UserProfileResponse:
+    """Partial update of the current user's profile."""
     updates = body.model_dump(exclude_unset=True)
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
 
-    store = get_contractor_store()
+    store = get_user_store()
     updated = await store.update(current_user.id, **updates)
     if updated is None:
-        raise HTTPException(status_code=404, detail="Contractor not found")
+        raise HTTPException(status_code=404, detail="User not found")
 
     return _profile_response(updated)
 
@@ -76,7 +76,7 @@ def _build_channel_config_response() -> ChannelConfigResponse:
 
 @router.get("/user/channels/config", response_model=ChannelConfigResponse)
 async def get_channel_config(
-    _current_user: ContractorData = Depends(get_current_user),
+    _current_user: UserData = Depends(get_current_user),
 ) -> ChannelConfigResponse:
     """Return server-level channel configuration."""
     return _build_channel_config_response()
@@ -85,7 +85,7 @@ async def get_channel_config(
 @router.put("/user/channels/config", response_model=ChannelConfigResponse)
 async def update_channel_config(
     body: ChannelConfigUpdate,
-    _current_user: ContractorData = Depends(get_current_user),
+    _current_user: UserData = Depends(get_current_user),
 ) -> ChannelConfigResponse:
     """Update server-level channel configuration."""
     updates = {k: v for k, v in body.model_dump(exclude_unset=True).items() if v is not None}

--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -5,7 +5,7 @@ import json
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.app.agent.file_store import ContractorData, get_session_store
+from backend.app.agent.file_store import UserData, get_session_store
 from backend.app.auth.dependencies import get_current_user
 from backend.app.schemas import (
     SessionDetailResponse,
@@ -21,9 +21,9 @@ router = APIRouter()
 async def list_sessions(
     offset: int = 0,
     limit: int = 20,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> SessionListResponse:
-    """List conversation sessions for the current contractor."""
+    """List conversation sessions for the current user."""
     store = get_session_store(current_user.id)
     files = store._list_session_files()
     # Most recent first
@@ -60,7 +60,7 @@ async def list_sessions(
 @router.get("/user/sessions/{session_id}", response_model=SessionDetailResponse)
 async def get_session(
     session_id: str,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> SessionDetailResponse:
     """Get a full conversation transcript with tool interactions."""
     store = get_session_store(current_user.id)
@@ -86,7 +86,7 @@ async def get_session(
 
     return SessionDetailResponse(
         session_id=session.session_id,
-        contractor_id=session.contractor_id,
+        user_id=session.user_id,
         created_at=session.created_at,
         last_message_at=session.last_message_at,
         is_active=session.is_active,

--- a/backend/app/routers/user_stats.py
+++ b/backend/app/routers/user_stats.py
@@ -1,26 +1,26 @@
-"""Endpoint for contractor overview stats."""
+"""Endpoint for user overview stats."""
 
 import datetime
 
 from fastapi import APIRouter, Depends
 
 from backend.app.agent.file_store import (
-    ContractorData,
     HeartbeatStore,
+    UserData,
     get_memory_store,
     get_session_store,
 )
 from backend.app.auth.dependencies import get_current_user
 from backend.app.enums import ChecklistStatus
-from backend.app.schemas import ContractorStatsResponse
+from backend.app.schemas import UserStatsResponse
 
 router = APIRouter()
 
 
-@router.get("/user/stats", response_model=ContractorStatsResponse)
+@router.get("/user/stats", response_model=UserStatsResponse)
 async def get_stats(
-    current_user: ContractorData = Depends(get_current_user),
-) -> ContractorStatsResponse:
+    current_user: UserData = Depends(get_current_user),
+) -> UserStatsResponse:
     """Return aggregate stats for the dashboard overview."""
     session_store = get_session_store(current_user.id)
     memory_store = get_memory_store(current_user.id)
@@ -56,7 +56,7 @@ async def get_stats(
     facts = await memory_store.get_all_memories()
     total_memory_facts = len(facts)
 
-    return ContractorStatsResponse(
+    return UserStatsResponse(
         total_sessions=total_sessions,
         messages_this_month=messages_this_month,
         active_checklist_items=active_checklist_items,

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -7,9 +7,9 @@ Users can view and toggle domain-specific agent tools. Core tools
 from fastapi import APIRouter, Depends, HTTPException
 
 from backend.app.agent.file_store import (
-    ContractorData,
     ToolConfigEntry,
     ToolConfigStore,
+    UserData,
 )
 from backend.app.agent.tools.registry import (
     default_registry,
@@ -33,9 +33,9 @@ _CORE_FACTORIES: frozenset[str] = frozenset({"workspace", "profile", "memory", "
 # Human-readable descriptions for each factory group.
 _FACTORY_DESCRIPTIONS: dict[str, str] = {
     "workspace": "Read, write, and edit markdown files in the workspace",
-    "profile": "View and update contractor profile information",
+    "profile": "View and update user profile information",
     "memory": "Save, recall, and forget long-term facts",
-    "messaging": "Send text and media replies to the contractor",
+    "messaging": "Send text and media replies to the user",
     "estimate": "Generate professional estimates and quotes with PDF output",
     "file": "Upload and organize files in cloud storage",
     "checklist": "Manage recurring reminders and task checklists",
@@ -67,7 +67,7 @@ def _build_tool_list(
 
 @router.get("/user/tools", response_model=ToolConfigResponse)
 async def get_tool_config(
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> ToolConfigResponse:
     """Return the current tool configuration for the user."""
     store = ToolConfigStore(current_user.id)
@@ -90,7 +90,7 @@ async def get_tool_config(
 @router.put("/user/tools", response_model=ToolConfigResponse)
 async def update_tool_config(
     body: ToolConfigUpdate,
-    current_user: ContractorData = Depends(get_current_user),
+    current_user: UserData = Depends(get_current_user),
 ) -> ToolConfigResponse:
     """Update tool configuration for the user.
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -10,16 +10,16 @@ class HealthResponse(BaseModel):
     status: str
 
 
-class ContractorBase(BaseModel):
+class UserBase(BaseModel):
     name: str = ""
     phone: str = ""
 
 
-class ContractorCreate(ContractorBase):
+class UserCreate(UserBase):
     user_id: str
 
 
-class ContractorResponse(ContractorBase):
+class UserResponse(UserBase):
     id: int
     user_id: str
     created_at: datetime.datetime
@@ -38,7 +38,7 @@ class MemoryCreate(MemoryBase):
 
 class MemoryResponse(MemoryBase):
     confidence: float
-    contractor_id: int
+    user_id: int
 
 
 class MessageBase(BaseModel):
@@ -66,7 +66,7 @@ class EstimateBase(BaseModel):
 
 class EstimateResponse(EstimateBase):
     id: str
-    contractor_id: int
+    user_id: int
     client_id: str | None = None
     pdf_url: str = ""
     storage_path: str = ""
@@ -74,11 +74,11 @@ class EstimateResponse(EstimateBase):
 
 
 # ---------------------------------------------------------------------------
-# Contractor profile (dashboard)
+# User profile (dashboard)
 # ---------------------------------------------------------------------------
 
 
-class ContractorProfileResponse(BaseModel):
+class UserProfileResponse(BaseModel):
     id: int
     user_id: str
     name: str
@@ -97,7 +97,7 @@ class ContractorProfileResponse(BaseModel):
     updated_at: str
 
 
-class ContractorProfileUpdate(BaseModel):
+class UserProfileUpdate(BaseModel):
     name: str | None = None
     phone: str | None = None
     timezone: str | None = None
@@ -137,7 +137,7 @@ class SessionMessage(BaseModel):
 
 class SessionDetailResponse(BaseModel):
     session_id: str
-    contractor_id: int
+    user_id: int
     created_at: str
     last_message_at: str
     is_active: bool
@@ -191,7 +191,7 @@ class ChecklistItemResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class ContractorStatsResponse(BaseModel):
+class UserStatsResponse(BaseModel):
     total_sessions: int
     messages_this_month: int
     active_checklist_items: int

--- a/backend/app/services/llm_usage.py
+++ b/backend/app/services/llm_usage.py
@@ -1,7 +1,7 @@
 """LLM usage tracking helper.
 
 Extracts token counts from amessages responses and persists them to
-the per-contractor ``llm_usage.jsonl`` file for cost monitoring.
+the per-user ``llm_usage.jsonl`` file for cost monitoring.
 """
 
 from __future__ import annotations
@@ -16,29 +16,29 @@ logger = logging.getLogger(__name__)
 
 
 def log_llm_usage(
-    contractor_id: int,
+    user_id: int,
     model: str,
     response: MessageResponse,
     purpose: str,
 ) -> None:
     """Extract token usage from an LLM response and save to the usage log.
 
-    Appends to the contractor's ``llm_usage.jsonl`` file.
+    Appends to the user's ``llm_usage.jsonl`` file.
     """
     prompt_tokens = response.usage.input_tokens
     completion_tokens = response.usage.output_tokens
     total_tokens = prompt_tokens + completion_tokens
 
     try:
-        store = LLMUsageStore(contractor_id)
+        store = LLMUsageStore(user_id)
         store.log(model, prompt_tokens, completion_tokens, purpose)
     except Exception:
-        logger.exception("Failed to log LLM usage for contractor %d", contractor_id)
+        logger.exception("Failed to log LLM usage for user %d", user_id)
         return
 
     logger.info(
-        "LLM usage logged: contractor=%d model=%s purpose=%s tokens=%d",
-        contractor_id,
+        "LLM usage logged: user=%d model=%s purpose=%s tokens=%d",
+        user_id,
         model,
         purpose,
         total_tokens,

--- a/backend/app/services/pdf_service.py
+++ b/backend/app/services/pdf_service.py
@@ -24,9 +24,9 @@ PDF_TOTALS_CELL_PADDING = 4
 
 @dataclass
 class EstimatePDFData:
-    contractor_name: str
-    contractor_phone: str
-    contractor_trade: str
+    owner_name: str
+    owner_phone: str
+    owner_trade: str
     description: str
     line_items: list[dict[str, object]]
     subtotal: float
@@ -63,13 +63,13 @@ def _build_pdf(data: EstimatePDFData) -> bytes:
     elements.append(Paragraph("ESTIMATE", title_style))
     elements.append(Spacer(1, PDF_SPACER_SMALL))
 
-    # Contractor info
+    # User info
     info_style = styles["Normal"]
-    elements.append(Paragraph(f"<b>{data.contractor_name}</b>", info_style))
-    if data.contractor_trade:
-        elements.append(Paragraph(data.contractor_trade, info_style))
-    if data.contractor_phone:
-        elements.append(Paragraph(data.contractor_phone, info_style))
+    elements.append(Paragraph(f"<b>{data.owner_name}</b>", info_style))
+    if data.owner_trade:
+        elements.append(Paragraph(data.owner_trade, info_style))
+    if data.owner_phone:
+        elements.append(Paragraph(data.owner_phone, info_style))
     elements.append(Spacer(1, PDF_SPACER_SMALL))
 
     # Date and estimate number

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -13,7 +13,7 @@ import dropbox
 import dropbox.exceptions
 import dropbox.files
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.config import Settings, settings
 
 logger = logging.getLogger(__name__)
@@ -26,9 +26,9 @@ class StorageBackend(ABC):
     Drive, local filesystem, etc.).  The interface is intentionally minimal so
     that adding new backends is straightforward.
 
-    Per-contractor isolation: when a contractor_id is provided, each backend
-    isolates files into a per-contractor subdirectory (local) or path prefix
-    (cloud).  A future Phase 2 will add shared cloud folders per contractor.
+    Per-user isolation: when a user_id is provided, each backend
+    isolates files into a per-user subdirectory (local) or path prefix
+    (cloud).  A future Phase 2 will add shared cloud folders per user.
     """
 
     @abstractmethod
@@ -51,12 +51,12 @@ class StorageBackend(ABC):
 
 
 class DropboxStorage(StorageBackend):
-    def __init__(self, access_token: str, contractor_id: int | None = None) -> None:
+    def __init__(self, access_token: str, user_id: int | None = None) -> None:
         self.dbx = dropbox.Dropbox(access_token)
-        self._path_prefix = f"/{contractor_id}" if contractor_id is not None else ""
+        self._path_prefix = f"/{user_id}" if user_id is not None else ""
 
     def _prefixed(self, path: str) -> str:
-        """Prepend the per-contractor prefix to a Dropbox path."""
+        """Prepend the per-user prefix to a Dropbox path."""
         return f"{self._path_prefix}{path}" if self._path_prefix else path
 
     async def upload_file(self, file_bytes: bytes, path: str, filename: str) -> str:
@@ -116,14 +116,14 @@ class DropboxStorage(StorageBackend):
 
 class GoogleDriveStorage(StorageBackend):
     # TODO(Phase 2): Google Drive uses folder IDs, not path strings, so the
-    # _path_prefix approach does not provide real per-contractor isolation.
-    # Proper isolation requires creating a per-contractor root folder on first
+    # _path_prefix approach does not provide real per-user isolation.
+    # Proper isolation requires creating a per-user root folder on first
     # use and passing its folder ID as the parent for all operations.
 
-    def __init__(self, credentials_json: str, contractor_id: int | None = None) -> None:
+    def __init__(self, credentials_json: str, user_id: int | None = None) -> None:
         self.credentials_json = credentials_json
         self._service: Any = None
-        self._path_prefix = f"{contractor_id}/" if contractor_id is not None else ""
+        self._path_prefix = f"{user_id}/" if user_id is not None else ""
 
     def _get_service(self) -> Any:
         if self._service is None:
@@ -135,8 +135,8 @@ class GoogleDriveStorage(StorageBackend):
         return self._service
 
     async def upload_file(self, file_bytes: bytes, path: str, filename: str) -> str:
-        # TODO(Phase 2): Does not apply contractor isolation. Drive needs a
-        # per-contractor root folder ID as the parent. See class-level TODO.
+        # TODO(Phase 2): Does not apply user isolation. Drive needs a
+        # per-user root folder ID as the parent. See class-level TODO.
         from googleapiclient.http import MediaIoBaseUpload
 
         logger.info("Uploading to Google Drive: %s/%s (%d bytes)", path, filename, len(file_bytes))
@@ -154,9 +154,9 @@ class GoogleDriveStorage(StorageBackend):
 
     async def create_folder(self, path: str) -> str:
         # TODO(Phase 2): The prefix logic here does not actually isolate folder
-        # names. For path="/Job Photos" with contractor_id=42, prefixed becomes
+        # names. For path="/Job Photos" with user_id=42, prefixed becomes
         # "42/Job Photos" and split("/")[-1] still yields "Job Photos"
-        # (unchanged). Real isolation needs a per-contractor root folder ID as
+        # (unchanged). Real isolation needs a per-user root folder ID as
         # the parent. See class-level TODO.
         service = self._get_service()
         prefixed = f"{self._path_prefix}{path}" if self._path_prefix else path
@@ -198,7 +198,7 @@ class GoogleDriveStorage(StorageBackend):
         return update_result.get("webViewLink", update_result.get("id", ""))
 
     async def list_folder(self, path: str) -> list[dict[str, str]]:
-        # TODO(Phase 2): Does not apply contractor isolation. Drive queries
+        # TODO(Phase 2): Does not apply user isolation. Drive queries
         # folders by ID, not path. See class-level TODO.
         service = self._get_service()
         query = f"'{path}' in parents and trashed=false"
@@ -217,11 +217,11 @@ class LocalFileStorage(StorageBackend):
     def __init__(
         self,
         base_dir: str = settings.file_storage_base_dir,
-        contractor_id: int | None = None,
+        user_id: int | None = None,
     ) -> None:
         base = Path(base_dir).resolve()
-        if contractor_id is not None:
-            base = base / str(contractor_id)
+        if user_id is not None:
+            base = base / str(user_id)
         self.base_dir = base
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
@@ -270,23 +270,23 @@ class LocalFileStorage(StorageBackend):
 
 def get_storage_service(
     svc_settings: Settings | None = None,
-    contractor: ContractorData | None = None,
+    user: UserData | None = None,
 ) -> StorageBackend:
     """Factory: return the configured storage backend.
 
     Args:
         svc_settings: Override the global settings (useful in tests).
-        contractor: When provided, files are isolated into a per-contractor
+        user: When provided, files are isolated into a per-user
             subdirectory (local) or path prefix (cloud).
     """
     s = svc_settings or settings
-    cid = contractor.id if contractor is not None else None
+    cid = user.id if user is not None else None
     if s.storage_provider == "local":
-        return LocalFileStorage(base_dir=s.file_storage_base_dir, contractor_id=cid)
+        return LocalFileStorage(base_dir=s.file_storage_base_dir, user_id=cid)
     elif s.storage_provider == "dropbox":
-        return DropboxStorage(s.dropbox_access_token, contractor_id=cid)
+        return DropboxStorage(s.dropbox_access_token, user_id=cid)
     elif s.storage_provider == "google_drive":
-        return GoogleDriveStorage(s.google_drive_credentials_json, contractor_id=cid)
+        return GoogleDriveStorage(s.google_drive_credentials_json, user_id=cid)
     else:
         msg = f"Unknown storage provider: {s.storage_provider}"
         raise ValueError(msg)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,8 +7,8 @@ import type {
   ChatResponse,
   ChecklistItem,
   ChecklistItemUpdate,
-  ContractorProfile,
-  ContractorProfileUpdate,
+  UserProfile,
+  UserProfileUpdate,
   MemoryFact,
   MemoryFactUpdate,
   SessionDetail,
@@ -80,9 +80,9 @@ const api = {
   tryRestoreSession: _tryRestoreSession as () => Promise<AuthUser | null>,
 
   // Profile
-  getProfile: () => _fetch<ContractorProfile>('/api/user/profile'),
-  updateProfile: (body: ContractorProfileUpdate) =>
-    _fetch<ContractorProfile>('/api/user/profile', {
+  getProfile: () => _fetch<UserProfile>('/api/user/profile'),
+  updateProfile: (body: UserProfileUpdate) =>
+    _fetch<UserProfile>('/api/user/profile', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -20,7 +20,7 @@ beforeEach(() => {
     new Response(JSON.stringify({
       id: 1,
       user_id: 'local@clawbolt.local',
-      name: 'Test Contractor',
+      name: 'Test User',
       phone: '555-0100',
       timezone: 'America/Los_Angeles',
       assistant_name: 'Claw',
@@ -57,11 +57,11 @@ describe('AppShell', () => {
     expect(screen.getByText('Settings')).toBeInTheDocument();
   });
 
-  it('displays contractor name when loaded', async () => {
+  it('displays user name when loaded', async () => {
     renderWithRouter(<AppShell />, { route: '/app' });
 
     await waitFor(() => {
-      expect(screen.getByText('Test Contractor')).toBeInTheDocument();
+      expect(screen.getByText('Test User')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -6,11 +6,11 @@ import Button from '@/components/ui/button';
 import Spinner from '@/components/ui/spinner';
 import { useAuth } from '@/contexts/AuthContext';
 import { getFeatureRequestUrl, getReportIssueUrl } from '@/extensions';
-import type { ContractorProfile } from '@/types';
+import type { UserProfile } from '@/types';
 
 /** Context value provided to child routes via useOutletContext(). */
 export interface AppShellContext {
-  profile: ContractorProfile | null;
+  profile: UserProfile | null;
   reloadProfile: () => void;
   isPremium: boolean;
   isAdmin: boolean;
@@ -28,7 +28,7 @@ const NAV_ITEMS = [
 
 export default function AppShell() {
   const { authState, currentAuthUser, isPremium, handleLogout } = useAuth();
-  const [profile, setProfile] = useState<ContractorProfile | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
   const [profileError, setProfileError] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,6 +1,6 @@
 // API response types matching backend schemas
 
-export interface ContractorProfile {
+export interface UserProfile {
   id: number;
   user_id: string;
   name: string;
@@ -19,7 +19,7 @@ export interface ContractorProfile {
   updated_at: string;
 }
 
-export interface ContractorProfileUpdate {
+export interface UserProfileUpdate {
   name?: string;
   phone?: string;
   timezone?: string;
@@ -58,7 +58,7 @@ export interface SessionMessage {
 
 export interface SessionDetail {
   session_id: string;
-  contractor_id: number;
+  user_id: number;
   created_at: string;
   last_message_at: string;
   is_active: boolean;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData, get_contractor_store, reset_stores
+from backend.app.agent.file_store import UserData, get_user_store, reset_stores
 from backend.app.auth.dependencies import get_current_user
 from backend.app.bus import message_bus
 from backend.app.config import settings
@@ -24,12 +24,12 @@ def _isolate_file_stores(tmp_path: object) -> Generator[None]:
 
 
 @pytest.fixture()
-async def test_contractor(tmp_path: object) -> ContractorData:
-    """Create a test contractor via the file store."""
-    store = get_contractor_store()
+async def test_user(tmp_path: object) -> UserData:
+    """Create a test user via the file store."""
+    store = get_user_store()
     return await store.create(
         user_id="test-user-001",
-        name="Test Contractor",
+        name="Test User",
         phone="+15551234567",
         channel_identifier="123456789",
         preferred_channel="telegram",
@@ -61,13 +61,11 @@ def _reset_bus_queues() -> Generator[None]:
 
 
 @pytest.fixture()
-def client(
-    test_contractor: ContractorData, mock_messaging_service: MessagingService
-) -> Generator[TestClient]:
+def client(test_user: UserData, mock_messaging_service: MessagingService) -> Generator[TestClient]:
     """FastAPI test client with overridden auth and messaging."""
 
-    def _override_get_current_user() -> ContractorData:
-        return test_contractor
+    def _override_get_current_user() -> UserData:
+        return test_user
 
     def _override_get_messaging_service() -> Generator[MessagingService]:
         yield mock_messaging_service

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from backend.app.agent.file_store import ContractorData, get_contractor_store, reset_stores
+from backend.app.agent.file_store import UserData, get_user_store, reset_stores
 from backend.app.config import settings
 
 _ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
@@ -28,22 +28,22 @@ def _isolate_file_stores(tmp_path: object) -> Generator[None]:
 
 
 @pytest.fixture()
-def integration_contractor() -> ContractorData:
-    """Test contractor for integration tests."""
-    store = get_contractor_store()
+def integration_user() -> UserData:
+    """Test user for integration tests."""
+    store = get_user_store()
     return asyncio.get_event_loop().run_until_complete(
         store.create(
             user_id="integration-test-user",
-            name="Integration Test Contractor",
+            name="Integration Test User",
             phone="+15559999999",
         )
     )
 
 
 @pytest.fixture()
-def onboarded_contractor() -> ContractorData:
-    """Onboarded contractor for heartbeat tests."""
-    store = get_contractor_store()
+def onboarded_user() -> UserData:
+    """Onboarded user for heartbeat tests."""
+    store = get_user_store()
     return asyncio.get_event_loop().run_until_complete(
         store.create(
             user_id="heartbeat-integration-user",

--- a/tests/integration/test_dashboard_telegram.py
+++ b/tests/integration/test_dashboard_telegram.py
@@ -1,12 +1,12 @@
-"""Integration test: Telegram-created contractor data visible via dashboard API.
+"""Integration test: Telegram-created user data visible via dashboard API.
 
 Regression test for https://github.com/mozilla-ai/clawbolt/issues/475.
 Previously, `get_current_user` always created a new `local@clawbolt.local`
-contractor, so the dashboard never showed data from Telegram sessions.
+user, so the dashboard never showed data from Telegram sessions.
 
 Regression test for https://github.com/mozilla-ai/clawbolt/issues/499.
-When a web-created contractor exists and Telegram messages arrive, the
-Telegram channel must be linked to the same contractor so sessions appear
+When a web-created user exists and Telegram messages arrive, the
+Telegram channel must be linked to the same user so sessions appear
 in the dashboard.
 
 These tests use a TestClient that does NOT override `get_current_user`,
@@ -22,18 +22,18 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData, get_contractor_store
-from backend.app.agent.ingestion import _get_or_create_contractor
+from backend.app.agent.file_store import UserData, get_user_store
+from backend.app.agent.ingestion import _get_or_create_user
 from backend.app.config import settings
 from backend.app.main import app
 
 
 @pytest.fixture()
-def telegram_contractor() -> ContractorData:
-    """Simulate a contractor created by Telegram ingestion."""
+def telegram_user() -> UserData:
+    """Simulate a user created by Telegram ingestion."""
     import asyncio
 
-    store = get_contractor_store()
+    store = get_user_store()
     return asyncio.get_event_loop().run_until_complete(
         store.create(
             user_id="telegram_123456789",
@@ -46,12 +46,12 @@ def telegram_contractor() -> ContractorData:
 
 
 @pytest.fixture()
-def real_auth_client(telegram_contractor: ContractorData) -> Generator[TestClient]:
+def real_auth_client(telegram_user: UserData) -> Generator[TestClient]:
     """TestClient that uses the real get_current_user (no auth override).
 
     This is the critical difference from the standard ``client`` fixture in
     conftest.py, which overrides ``get_current_user`` and therefore never
-    exercises the logic that picks an existing contractor from the store.
+    exercises the logic that picks an existing user from the store.
     """
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
@@ -65,19 +65,19 @@ def real_auth_client(telegram_contractor: ContractorData) -> Generator[TestClien
 
 
 def _create_session(
-    contractor: ContractorData,
+    user: UserData,
     session_id: str,
     messages: list[dict],
 ) -> None:
-    """Write a JSONL session file for the given contractor."""
-    base = Path(settings.data_dir) / str(contractor.id) / "sessions"
+    """Write a JSONL session file for the given user."""
+    base = Path(settings.data_dir) / str(user.id) / "sessions"
     base.mkdir(parents=True, exist_ok=True)
     lines = [
         json.dumps(
             {
                 "_type": "metadata",
                 "session_id": session_id,
-                "contractor_id": contractor.id,
+                "user_id": user.id,
                 "created_at": "2025-01-15T10:00:00+00:00",
                 "last_message_at": "2025-01-15T10:05:00+00:00",
                 "is_active": True,
@@ -90,9 +90,9 @@ def _create_session(
     (base / f"{session_id}.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def _seed_memory(contractor: ContractorData) -> None:
-    """Write a MEMORY.md for the given contractor."""
-    mem_dir = Path(settings.data_dir) / str(contractor.id) / "memory"
+def _seed_memory(user: UserData) -> None:
+    """Write a MEMORY.md for the given user."""
+    mem_dir = Path(settings.data_dir) / str(user.id) / "memory"
     mem_dir.mkdir(parents=True, exist_ok=True)
     (mem_dir / "MEMORY.md").write_text(
         "# Long-term Memory\n\n"
@@ -104,12 +104,12 @@ def _seed_memory(contractor: ContractorData) -> None:
 
 
 class TestDashboardSeesTelegramData:
-    """Dashboard endpoints return the Telegram contractor's data."""
+    """Dashboard endpoints return the Telegram user's data."""
 
-    def test_profile_returns_telegram_contractor(
+    def test_profile_returns_telegram_user(
         self,
         real_auth_client: TestClient,
-        telegram_contractor: ContractorData,
+        telegram_user: UserData,
     ) -> None:
         resp = real_auth_client.get("/api/user/profile")
         assert resp.status_code == 200
@@ -119,10 +119,10 @@ class TestDashboardSeesTelegramData:
     def test_sessions_returns_telegram_sessions(
         self,
         real_auth_client: TestClient,
-        telegram_contractor: ContractorData,
+        telegram_user: UserData,
     ) -> None:
         _create_session(
-            telegram_contractor,
+            telegram_user,
             "1_100",
             [
                 {
@@ -149,9 +149,9 @@ class TestDashboardSeesTelegramData:
     def test_memory_returns_telegram_facts(
         self,
         real_auth_client: TestClient,
-        telegram_contractor: ContractorData,
+        telegram_user: UserData,
     ) -> None:
-        _seed_memory(telegram_contractor)
+        _seed_memory(telegram_user)
         resp = real_auth_client.get("/api/user/memory")
         assert resp.status_code == 200
         facts = resp.json()
@@ -163,10 +163,10 @@ class TestDashboardSeesTelegramData:
     def test_stats_returns_telegram_stats(
         self,
         real_auth_client: TestClient,
-        telegram_contractor: ContractorData,
+        telegram_user: UserData,
     ) -> None:
         _create_session(
-            telegram_contractor,
+            telegram_user,
             "1_200",
             [
                 {
@@ -177,7 +177,7 @@ class TestDashboardSeesTelegramData:
                 },
             ],
         )
-        _seed_memory(telegram_contractor)
+        _seed_memory(telegram_user)
         resp = real_auth_client.get("/api/user/stats")
         assert resp.status_code == 200
         data = resp.json()
@@ -186,55 +186,55 @@ class TestDashboardSeesTelegramData:
 
 
 class TestMultiChannelSingleTenant:
-    """Telegram messages reuse an existing web-created contractor.
+    """Telegram messages reuse an existing web-created user.
 
     Regression test for https://github.com/mozilla-ai/clawbolt/issues/499.
     """
 
-    def test_telegram_links_to_existing_web_contractor(self) -> None:
-        """When a web-created contractor exists, Telegram reuses it."""
-        store = get_contractor_store()
-        web_contractor = asyncio.get_event_loop().run_until_complete(
+    def test_telegram_links_to_existing_web_user(self) -> None:
+        """When a web-created user exists, Telegram reuses it."""
+        store = get_user_store()
+        web_user = asyncio.get_event_loop().run_until_complete(
             store.create(user_id="local@clawbolt.local", name="Web User")
         )
 
-        tg_contractor = asyncio.get_event_loop().run_until_complete(
-            _get_or_create_contractor("telegram", "99887766")
+        tg_user = asyncio.get_event_loop().run_until_complete(
+            _get_or_create_user("telegram", "99887766")
         )
 
-        assert tg_contractor.id == web_contractor.id
+        assert tg_user.id == web_user.id
 
     def test_telegram_link_sets_channel_identifier(self) -> None:
-        """Linking a Telegram chat to an existing contractor persists channel_identifier."""
-        store = get_contractor_store()
+        """Linking a Telegram chat to an existing user persists channel_identifier."""
+        store = get_user_store()
         asyncio.get_event_loop().run_until_complete(
             store.create(user_id="local@clawbolt.local", name="Web User")
         )
 
-        tg_contractor = asyncio.get_event_loop().run_until_complete(
-            _get_or_create_contractor("telegram", "11223344")
+        tg_user = asyncio.get_event_loop().run_until_complete(
+            _get_or_create_user("telegram", "11223344")
         )
 
-        assert tg_contractor.channel_identifier == "11223344"
-        assert tg_contractor.preferred_channel == "telegram"
+        assert tg_user.channel_identifier == "11223344"
+        assert tg_user.preferred_channel == "telegram"
 
     def test_telegram_sessions_visible_in_dashboard_after_web_signup(self) -> None:
         """Sessions created via Telegram appear in dashboard when web created first."""
-        store = get_contractor_store()
-        web_contractor = asyncio.get_event_loop().run_until_complete(
+        store = get_user_store()
+        web_user = asyncio.get_event_loop().run_until_complete(
             store.create(user_id="local@clawbolt.local", name="Web User")
         )
 
-        # Simulate Telegram ingestion linking to the same contractor
-        tg_contractor = asyncio.get_event_loop().run_until_complete(
-            _get_or_create_contractor("telegram", "55544433")
+        # Simulate Telegram ingestion linking to the same user
+        tg_user = asyncio.get_event_loop().run_until_complete(
+            _get_or_create_user("telegram", "55544433")
         )
-        assert tg_contractor.id == web_contractor.id
+        assert tg_user.id == web_user.id
 
-        # Create a session under the (shared) contractor
+        # Create a session under the (shared) user
         _create_session(
-            tg_contractor,
-            f"{tg_contractor.id}_500",
+            tg_user,
+            f"{tg_user.id}_500",
             [
                 {
                     "direction": "inbound",
@@ -258,25 +258,25 @@ class TestMultiChannelSingleTenant:
             assert resp.status_code == 200
             data = resp.json()
             assert data["total"] == 1
-            assert data["sessions"][0]["id"] == f"{tg_contractor.id}_500"
+            assert data["sessions"][0]["id"] == f"{tg_user.id}_500"
 
     def test_subsequent_telegram_lookup_uses_index(self) -> None:
-        """After linking, future messages find the contractor via the index."""
-        store = get_contractor_store()
+        """After linking, future messages find the user via the index."""
+        store = get_user_store()
         asyncio.get_event_loop().run_until_complete(
             store.create(user_id="local@clawbolt.local", name="Web User")
         )
 
         # First call links the channel
         first = asyncio.get_event_loop().run_until_complete(
-            _get_or_create_contractor("telegram", "11122233")
+            _get_or_create_user("telegram", "11122233")
         )
         # Second call should find via index
         second = asyncio.get_event_loop().run_until_complete(
-            _get_or_create_contractor("telegram", "11122233")
+            _get_or_create_user("telegram", "11122233")
         )
         assert first.id == second.id
 
-        # Verify only one contractor exists
-        all_contractors = asyncio.get_event_loop().run_until_complete(store.list_all())
-        assert len(all_contractors) == 1
+        # Verify only one user exists
+        all_users = asyncio.get_event_loop().run_until_complete(store.list_all())
+        assert len(all_users) == 1

--- a/tests/integration/test_estimate_integration.py
+++ b/tests/integration/test_estimate_integration.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from backend.app.agent.core import ClawboltAgent
-from backend.app.agent.file_store import ContractorData, EstimateStore
+from backend.app.agent.file_store import EstimateStore, UserData
 from backend.app.agent.tools.estimate_tools import create_estimate_tools
 from backend.app.agent.tools.memory_tools import create_memory_tools
 
@@ -22,7 +22,7 @@ from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
 @pytest.mark.integration()
 @skip_without_anthropic_key
 async def test_estimate_generation_roundtrip(
-    integration_contractor: ContractorData,
+    integration_user: UserData,
 ) -> None:
     """Agent should call generate_estimate tool and create file store records when asked."""
     with patch("backend.app.agent.core.settings") as mock_settings:
@@ -31,16 +31,16 @@ async def test_estimate_generation_roundtrip(
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
 
-        agent = ClawboltAgent(contractor=integration_contractor)
-        tools = create_estimate_tools(integration_contractor)
-        tools.extend(create_memory_tools(integration_contractor.id))
+        agent = ClawboltAgent(user=integration_user)
+        tools = create_estimate_tools(integration_user)
+        tools.extend(create_memory_tools(integration_user.id))
         agent.register_tools(tools)
 
         response = await agent.process_message(
             "Use the generate_estimate tool to create an estimate for a deck build. "
             "Labor: 20 hours at $75/hr. Materials: $1,200 for composite decking.",
             system_prompt_override=(
-                "You are a contractor assistant. When the user provides estimate"
+                "You are a user assistant. When the user provides estimate"
                 " details, always call the generate_estimate tool with the line"
                 " items. Do not respond with text only."
             ),
@@ -52,7 +52,7 @@ async def test_estimate_generation_roundtrip(
     assert "generate_estimate" in tool_names, f"Expected generate_estimate call, got: {tool_names}"
 
     # Estimate record should exist in the file store
-    store = EstimateStore(integration_contractor.id)
+    store = EstimateStore(integration_user.id)
     estimates = await store.list_all()
     assert len(estimates) == 1
     assert estimates[0].status == "draft"

--- a/tests/integration/test_heartbeat_integration.py
+++ b/tests/integration/test_heartbeat_integration.py
@@ -12,8 +12,8 @@ from unittest.mock import patch
 import pytest
 
 from backend.app.agent.file_store import (
-    ContractorData,
     EstimateStore,
+    UserData,
     get_session_store,
 )
 from backend.app.agent.heartbeat import evaluate_heartbeat_need
@@ -24,7 +24,7 @@ from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
 @pytest.mark.integration()
 @skip_without_anthropic_key
 async def test_heartbeat_evaluate_returns_valid_action(
-    onboarded_contractor: ContractorData,
+    onboarded_user: UserData,
 ) -> None:
     """evaluate_heartbeat_need() should return a valid HeartbeatAction from a real LLM."""
     with patch("backend.app.agent.heartbeat.settings") as mock_settings:
@@ -35,7 +35,7 @@ async def test_heartbeat_evaluate_returns_valid_action(
         mock_settings.heartbeat_model = None
         mock_settings.llm_max_tokens_heartbeat = 300
 
-        action = await evaluate_heartbeat_need(onboarded_contractor, ["Test flag: check-in needed"])
+        action = await evaluate_heartbeat_need(onboarded_user, ["Test flag: check-in needed"])
 
     assert action.action_type in ("send_message", "no_action")
     assert isinstance(action.reasoning, str)
@@ -46,11 +46,11 @@ async def test_heartbeat_evaluate_returns_valid_action(
 @pytest.mark.integration()
 @skip_without_anthropic_key
 async def test_heartbeat_evaluate_with_context(
-    onboarded_contractor: ContractorData,
+    onboarded_user: UserData,
 ) -> None:
-    """Heartbeat should handle a contractor with real conversation history and pending estimates."""
+    """Heartbeat should handle a user with real conversation history and pending estimates."""
     # Set up conversation with messages via file store
-    session_store = get_session_store(onboarded_contractor.id)
+    session_store = get_session_store(onboarded_user.id)
     session, _ = await session_store.get_or_create_session()
 
     await session_store.add_message(
@@ -65,7 +65,7 @@ async def test_heartbeat_evaluate_with_context(
     )
 
     # Add a pending draft estimate
-    estimate_store = EstimateStore(onboarded_contractor.id)
+    estimate_store = EstimateStore(onboarded_user.id)
     await estimate_store.create(
         description="12x12 composite deck build",
         total_amount=4500,
@@ -81,7 +81,7 @@ async def test_heartbeat_evaluate_with_context(
         mock_settings.llm_max_tokens_heartbeat = 300
 
         action = await evaluate_heartbeat_need(
-            onboarded_contractor,
+            onboarded_user,
             ["Stale draft estimate: 12x12 composite deck build"],
         )
 

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from backend.app.agent.core import ClawboltAgent
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.messages import AssistantMessage, UserMessage
 
 from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
@@ -21,7 +21,7 @@ from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
 @pytest.mark.integration()
 @skip_without_anthropic_key
 async def test_agent_returns_nonempty_reply(
-    integration_contractor: ContractorData,
+    integration_user: UserData,
 ) -> None:
     """ClawboltAgent.process_message() should return a non-empty reply from a real LLM."""
     with patch("backend.app.agent.core.settings") as mock_settings:
@@ -30,7 +30,7 @@ async def test_agent_returns_nonempty_reply(
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
 
-        agent = ClawboltAgent(contractor=integration_contractor)
+        agent = ClawboltAgent(user=integration_user)
         response = await agent.process_message(
             "Hello, can you help me with a deck estimate?",
             system_prompt_override="You are a helpful assistant. Reply briefly.",
@@ -43,7 +43,7 @@ async def test_agent_returns_nonempty_reply(
 @pytest.mark.integration()
 @skip_without_anthropic_key
 async def test_agent_message_format_accepted(
-    integration_contractor: ContractorData,
+    integration_user: UserData,
 ) -> None:
     """The full system prompt + conversation history format should be accepted by a real LLM."""
     with patch("backend.app.agent.core.settings") as mock_settings:
@@ -52,7 +52,7 @@ async def test_agent_message_format_accepted(
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
 
-        agent = ClawboltAgent(contractor=integration_contractor)
+        agent = ClawboltAgent(user=integration_user)
         history = [
             UserMessage(content="Hi there"),
             AssistantMessage(content="Hello! How can I help?"),

--- a/tests/integration/test_memory_integration.py
+++ b/tests/integration/test_memory_integration.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from backend.app.agent.core import ClawboltAgent
-from backend.app.agent.file_store import ContractorData, get_memory_store
+from backend.app.agent.file_store import UserData, get_memory_store
 from backend.app.agent.tools.memory_tools import create_memory_tools
 
 from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
@@ -21,7 +21,7 @@ from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
 @pytest.mark.integration()
 @skip_without_anthropic_key
 async def test_memory_save_via_llm(
-    integration_contractor: ContractorData,
+    integration_user: UserData,
 ) -> None:
     """Agent should call save_fact when told new information."""
     with patch("backend.app.agent.core.settings") as mock_settings:
@@ -30,8 +30,8 @@ async def test_memory_save_via_llm(
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
 
-        agent = ClawboltAgent(contractor=integration_contractor)
-        tools = create_memory_tools(integration_contractor.id)
+        agent = ClawboltAgent(user=integration_user)
+        tools = create_memory_tools(integration_user.id)
         agent.register_tools(tools)
 
         response = await agent.process_message(
@@ -43,7 +43,7 @@ async def test_memory_save_via_llm(
     assert "save_fact" in tool_names, f"Expected save_fact call, got: {tool_names}"
 
     # Memory facts should exist in the file store
-    memory_store = get_memory_store(integration_contractor.id)
+    memory_store = get_memory_store(integration_user.id)
     memories = await memory_store.get_all_memories()
     assert len(memories) >= 1
 
@@ -55,7 +55,7 @@ async def test_memory_save_via_llm(
 @pytest.mark.integration()
 @skip_without_anthropic_key
 async def test_memory_save_then_recall(
-    integration_contractor: ContractorData,
+    integration_user: UserData,
 ) -> None:
     """Agent should recall previously saved facts when asked."""
     with patch("backend.app.agent.core.settings") as mock_settings:
@@ -64,8 +64,8 @@ async def test_memory_save_then_recall(
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
 
-        agent = ClawboltAgent(contractor=integration_contractor)
-        tools = create_memory_tools(integration_contractor.id)
+        agent = ClawboltAgent(user=integration_user)
+        tools = create_memory_tools(integration_user.id)
         agent.register_tools(tools)
 
         # Step 1: Save a fact
@@ -74,13 +74,13 @@ async def test_memory_save_then_recall(
         )
 
         # Verify it was saved
-        memory_store = get_memory_store(integration_contractor.id)
+        memory_store = get_memory_store(integration_user.id)
         memories = await memory_store.get_all_memories()
         assert len(memories) >= 1
 
         # Step 2: Ask about it in a new agent call
-        agent2 = ClawboltAgent(contractor=integration_contractor)
-        tools2 = create_memory_tools(integration_contractor.id)
+        agent2 = ClawboltAgent(user=integration_user)
+        tools2 = create_memory_tools(integration_user.id)
         agent2.register_tools(tools2)
 
         response = await agent2.process_message(

--- a/tests/integration/test_onboarding_integration.py
+++ b/tests/integration/test_onboarding_integration.py
@@ -1,6 +1,6 @@
 """Integration tests for the onboarding flow via a real LLM.
 
-Verifies that a new contractor's first message triggers onboarding,
+Verifies that a new user's first message triggers onboarding,
 the agent extracts profile fields via update_profile, and the profile
 is updated in the file store.
 
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from backend.app.agent.core import ClawboltAgent
-from backend.app.agent.file_store import get_contractor_store
+from backend.app.agent.file_store import get_user_store
 from backend.app.agent.onboarding import (
     build_onboarding_system_prompt,
     is_onboarding_needed,
@@ -32,15 +32,15 @@ from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
 async def test_onboarding_extracts_profile_from_intro() -> None:
     """Agent should extract name and trade from a natural introduction message."""
 
-    # Create a blank contractor (no profile info)
-    store = get_contractor_store()
-    contractor = await store.create(
+    # Create a blank user (no profile info)
+    store = get_user_store()
+    user = await store.create(
         user_id="onboarding-test-user",
         channel_identifier="onboard_test_1",
         preferred_channel="telegram",
     )
 
-    assert is_onboarding_needed(contractor)
+    assert is_onboarding_needed(user)
 
     with patch("backend.app.agent.core.settings") as mock_settings:
         mock_settings.llm_provider = "anthropic"
@@ -48,12 +48,12 @@ async def test_onboarding_extracts_profile_from_intro() -> None:
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
 
-        agent = ClawboltAgent(contractor=contractor)
-        tools = create_memory_tools(contractor.id)
-        tools.extend(create_profile_tools(contractor))
+        agent = ClawboltAgent(user=user)
+        tools = create_memory_tools(user.id)
+        tools.extend(create_profile_tools(user))
         agent.register_tools(tools)
 
-        system_prompt = build_onboarding_system_prompt(contractor)
+        system_prompt = build_onboarding_system_prompt(user)
         response = await agent.process_message(
             "Hey! I'm Jake, I'm a plumber based in Portland.",
             system_prompt_override=system_prompt,

--- a/tests/integration/test_vision_integration.py
+++ b/tests/integration/test_vision_integration.py
@@ -87,7 +87,7 @@ async def test_analyze_image_with_context() -> None:
         result = await analyze_image(
             png_bytes,
             "image/png",
-            context="The contractor sent this photo of damage to a deck railing.",
+            context="The user sent this photo of damage to a deck railing.",
         )
 
     assert isinstance(result, str)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -15,7 +15,7 @@ from backend.app.agent.core import (
     ClawboltAgent,
     _total_content_length,
 )
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.messages import (
     AgentMessage,
     AssistantMessage,
@@ -54,13 +54,11 @@ class _DescriptionParams(BaseModel):
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
-async def test_agent_responds_to_message(
-    mock_amessages: object, test_contractor: ContractorData
-) -> None:
+async def test_agent_responds_to_message(mock_amessages: object, test_user: UserData) -> None:
     """Agent should produce a reply from LLM response."""
     mock_amessages.return_value = make_text_response("Sure, I can help with that deck estimate!")  # type: ignore[union-attr]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     response = await agent.process_message("I need a quote for a 12x12 composite deck")
 
     assert response.reply_text == "Sure, I can help with that deck estimate!"
@@ -70,12 +68,12 @@ async def test_agent_responds_to_message(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_includes_conversation_history(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Agent should include conversation history in LLM call."""
     mock_amessages.return_value = make_text_response("Got it!")  # type: ignore[union-attr]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     history = [
         UserMessage(content="Hi, I need help"),
         AssistantMessage(content="Hello! How can I help?"),
@@ -94,23 +92,23 @@ async def test_agent_includes_conversation_history(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_system_prompt_includes_soul(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
-    """Agent system prompt should include contractor profile info."""
+    """Agent system prompt should include user profile info."""
     mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     await agent.process_message("Hello")
 
     call_args = mock_amessages.call_args  # type: ignore[union-attr]
     system_prompt = call_args.kwargs["system"]
-    assert test_contractor.name in system_prompt
+    assert test_user.name in system_prompt
 
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_system_prompt_includes_tool_hints(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """System prompt should include usage hints from registered tools."""
     mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
@@ -135,7 +133,7 @@ async def test_system_prompt_includes_tool_hints(
         ),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools(tools)
     await agent.process_message("Hello")
 
@@ -149,12 +147,12 @@ async def test_system_prompt_includes_tool_hints(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_system_prompt_omits_tool_section_when_no_hints(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """System prompt should not include tool guidelines when no tools have hints."""
     mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     # No tools registered
     await agent.process_message("Hello")
 
@@ -166,7 +164,7 @@ async def test_system_prompt_omits_tool_section_when_no_hints(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_system_prompt_skips_tools_without_hints(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Tools with empty usage_hint should not appear in the system prompt."""
     mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
@@ -190,7 +188,7 @@ async def test_system_prompt_skips_tools_without_hints(
         ),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools(tools)
     await agent.process_message("Hello")
 
@@ -202,13 +200,11 @@ async def test_system_prompt_skips_tools_without_hints(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
-async def test_agent_does_not_pass_api_key(
-    mock_amessages: object, test_contractor: ContractorData
-) -> None:
+async def test_agent_does_not_pass_api_key(mock_amessages: object, test_user: UserData) -> None:
     """acompletion should be called without api_key so the SDK resolves keys from env."""
     mock_amessages.return_value = make_text_response("Hi!")  # type: ignore[union-attr]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     await agent.process_message("Hello")
 
     call_args = mock_amessages.call_args  # type: ignore[union-attr]
@@ -218,7 +214,7 @@ async def test_agent_does_not_pass_api_key(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_tool_loop_sends_results_back(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """After tool calls, agent should send results back to LLM for a follow-up response."""
     # First call: LLM requests a tool call
@@ -244,7 +240,7 @@ async def test_agent_tool_loop_sends_results_back(
         params_model=_KeyValueParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("My rate is $75/hour")
 
@@ -263,7 +259,7 @@ async def test_agent_tool_loop_sends_results_back(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_tool_loop_includes_tool_results_in_followup(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Follow-up LLM call should include tool result messages."""
     tool_response = make_tool_call_response(
@@ -287,7 +283,7 @@ async def test_agent_tool_loop_includes_tool_results_in_followup(
         params_model=_QueryParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     await agent.process_message("What's my rate?")
 
@@ -308,9 +304,7 @@ async def test_agent_tool_loop_includes_tool_results_in_followup(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
-async def test_agent_multi_round_tool_calls(
-    mock_amessages: object, test_contractor: ContractorData
-) -> None:
+async def test_agent_multi_round_tool_calls(mock_amessages: object, test_user: UserData) -> None:
     """Agent should support multiple rounds of tool calls, not just one."""
     # Round 1: LLM calls recall_facts
     round1_response = make_tool_call_response(
@@ -340,7 +334,7 @@ async def test_agent_multi_round_tool_calls(
     mock_recall = AsyncMock(return_value=ToolResult(content="deck: $45/sqft"))
     mock_estimate = AsyncMock(return_value=ToolResult(content="Estimate PDF generated"))
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools(
         [
             Tool(
@@ -379,7 +373,7 @@ async def test_agent_multi_round_tool_calls(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_tool_loop_respects_max_rounds(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Agent should stop after MAX_TOOL_ROUNDS even if LLM keeps requesting tools."""
     from backend.app.agent.core import MAX_TOOL_ROUNDS
@@ -402,7 +396,7 @@ async def test_agent_tool_loop_respects_max_rounds(
     mock_amessages.side_effect = tool_responses  # type: ignore[union-attr]
 
     mock_recall = AsyncMock(return_value=ToolResult(content="some result"))
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools(
         [
             Tool(
@@ -426,7 +420,7 @@ async def test_agent_tool_loop_respects_max_rounds(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_handles_malformed_tool_arguments(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Agent should gracefully handle None/malformed tool call arguments.
 
@@ -458,7 +452,7 @@ async def test_agent_handles_malformed_tool_arguments(
         params_model=_KeyValueParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("My rate is $75/hour")
 
@@ -475,7 +469,7 @@ async def test_agent_handles_malformed_tool_arguments(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_passes_dict_arguments_to_tool(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Messages API delivers tool inputs as dicts; agent should pass them through."""
     tool_response = make_tool_call_response(
@@ -499,7 +493,7 @@ async def test_agent_passes_dict_arguments_to_tool(
         params_model=_KeyValueParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("My rate is $75/hour")
 
@@ -518,7 +512,7 @@ async def test_agent_passes_dict_arguments_to_tool(
 async def test_agent_retries_on_rate_limit_error(
     mock_amessages: AsyncMock,
     mock_sleep: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """RateLimitError should trigger one retry after a delay."""
     mock_amessages.side_effect = [
@@ -526,7 +520,7 @@ async def test_agent_retries_on_rate_limit_error(
         make_text_response("Retry succeeded!"),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     response = await agent.process_message("Hello")
 
     assert response.reply_text == "Retry succeeded!"
@@ -540,7 +534,7 @@ async def test_agent_retries_on_rate_limit_error(
 async def test_agent_rate_limit_retry_failure_propagates(
     mock_amessages: AsyncMock,
     mock_sleep: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """If the retry after RateLimitError also fails, the exception propagates."""
     mock_amessages.side_effect = [
@@ -548,7 +542,7 @@ async def test_agent_rate_limit_retry_failure_propagates(
         RateLimitError("Still rate limited"),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     with pytest.raises(RateLimitError):
         await agent.process_message("Hello")
 
@@ -654,7 +648,7 @@ def test_trim_messages_preserves_tool_call_result_pairs() -> None:
 @patch("backend.app.agent.core.amessages")
 async def test_agent_trims_context_on_context_length_exceeded(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """ContextLengthExceededError should trim messages and retry once."""
     mock_amessages.side_effect = [
@@ -671,7 +665,7 @@ async def test_agent_trims_context_on_context_length_exceeded(
         for i in range(150)
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     response = await agent.process_message("Current message", conversation_history=long_history)
 
     assert response.reply_text == "Trimmed and retried!"
@@ -689,7 +683,7 @@ async def test_agent_trims_context_on_context_length_exceeded(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_trims_history_when_exceeding_token_limit(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Messages should be trimmed when estimated tokens exceed MAX_INPUT_TOKENS."""
     mock_amessages.return_value = make_text_response("Trimmed reply!")
@@ -702,7 +696,7 @@ async def test_agent_trims_history_when_exceeding_token_limit(
         for i in range(150)
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     response = await agent.process_message("Current message", conversation_history=long_history)
 
     assert response.reply_text == "Trimmed reply!"
@@ -718,12 +712,12 @@ async def test_agent_trims_history_when_exceeding_token_limit(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_raises_content_filter_error(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """ContentFilterError should be re-raised (handled by router)."""
     mock_amessages.side_effect = ContentFilterError("Blocked by safety filter")
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     with pytest.raises(ContentFilterError):
         await agent.process_message("Something problematic")
 
@@ -734,7 +728,7 @@ async def test_agent_raises_content_filter_error(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_preserves_system_and_user_during_trimming(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """System prompt and latest user message must survive trimming."""
     mock_amessages.return_value = make_text_response("Ok!")
@@ -746,7 +740,7 @@ async def test_agent_preserves_system_and_user_during_trimming(
         for i in range(150)
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     await agent.process_message(
         "My important question",
         conversation_history=long_history,
@@ -771,12 +765,12 @@ async def test_agent_preserves_system_and_user_during_trimming(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_raises_authentication_error(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """AuthenticationError should be re-raised (handled by router)."""
     mock_amessages.side_effect = AuthenticationError("Invalid API key")
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     with pytest.raises(AuthenticationError):
         await agent.process_message("Hello")
 
@@ -821,7 +815,7 @@ def test_trim_messages_keeps_system_and_recent() -> None:
 @patch("backend.app.agent.core.amessages")
 async def test_agent_does_not_trim_normal_conversations(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Normal-sized conversations should not be trimmed."""
     mock_amessages.return_value = make_text_response("Got it!")
@@ -833,7 +827,7 @@ async def test_agent_does_not_trim_normal_conversations(
         AssistantMessage(content="Sure, what size?"),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     await agent.process_message(
         "12x12 composite deck",
         conversation_history=history,
@@ -851,7 +845,7 @@ async def test_agent_does_not_trim_normal_conversations(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_logs_warning_when_trimming(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A warning should be logged when conversation history is trimmed."""
@@ -863,7 +857,7 @@ async def test_agent_logs_warning_when_trimming(
         for i in range(150)
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
 
     with caplog.at_level("WARNING", logger="backend.app.agent.core"):
         await agent.process_message(
@@ -958,7 +952,7 @@ def test_trim_messages_no_summary_when_not_trimmed() -> None:
 @patch("backend.app.agent.core.amessages")
 async def test_process_message_injects_summary_when_trimming(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """process_message should inject a summary when history is trimmed."""
     mock_amessages.return_value = make_text_response("Ok!")
@@ -971,7 +965,7 @@ async def test_process_message_injects_summary_when_trimming(
         for i in range(150)
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
 
     await agent.process_message(
         "Current message",
@@ -991,9 +985,9 @@ async def test_process_message_injects_summary_when_trimming(
 # ---------------------------------------------------------------------------
 
 
-def test_register_tools_builds_dict_lookup(test_contractor: ContractorData) -> None:
+def test_register_tools_builds_dict_lookup(test_user: UserData) -> None:
     """register_tools should build a dict for O(1) lookup by name."""
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
 
     async def dummy(**kwargs: object) -> ToolResult:
         return ToolResult(content="ok")
@@ -1010,11 +1004,11 @@ def test_register_tools_builds_dict_lookup(test_contractor: ContractorData) -> N
 
 
 def test_register_tools_warns_on_duplicate_name(
-    test_contractor: ContractorData,
+    test_user: UserData,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Registering tools with duplicate names should log a warning."""
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
 
     async def dummy(**kwargs: object) -> ToolResult:
         return ToolResult(content="ok")
@@ -1039,7 +1033,7 @@ def test_register_tools_warns_on_duplicate_name(
 @patch("backend.app.agent.core.amessages")
 async def test_tool_result_error_appends_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """When a tool returns ToolResult(is_error=True), a hint is appended."""
 
@@ -1057,7 +1051,7 @@ async def test_tool_result_error_appends_hint(
         make_text_response("I'll try something else."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1071,7 +1065,7 @@ async def test_tool_result_error_appends_hint(
 @patch("backend.app.agent.core.amessages")
 async def test_tool_result_success_no_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """When a tool returns ToolResult(is_error=False), no hint is appended."""
 
@@ -1087,7 +1081,7 @@ async def test_tool_result_success_no_hint(
         make_text_response("Great!"),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1100,7 +1094,7 @@ async def test_tool_result_success_no_hint(
 @patch("backend.app.agent.core.amessages")
 async def test_tool_exception_appends_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """When a tool raises an exception, a self-correction hint is appended."""
 
@@ -1118,7 +1112,7 @@ async def test_tool_exception_appends_hint(
         make_text_response("Let me try another way."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1134,7 +1128,7 @@ async def test_tool_exception_appends_hint(
 @patch("backend.app.agent.core.amessages")
 async def test_unknown_tool_error_lists_available_tools(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Unknown tool error should list all registered tool names."""
 
@@ -1163,7 +1157,7 @@ async def test_unknown_tool_error_lists_available_tools(
         make_text_response("Let me try again."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools(tools)
     await agent.process_message("test", system_prompt_override="system")
 
@@ -1191,7 +1185,7 @@ async def test_unknown_tool_error_lists_available_tools(
 @patch("backend.app.agent.core.amessages")
 async def test_validation_error_includes_expected_schema(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Validation errors should include the expected parameter schema."""
     from pydantic import BaseModel
@@ -1221,7 +1215,7 @@ async def test_validation_error_includes_expected_schema(
         make_text_response("Let me fix that."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     await agent.process_message("test", system_prompt_override="system")
 
@@ -1255,7 +1249,7 @@ async def test_validation_error_includes_expected_schema(
 @patch("backend.app.agent.core.amessages")
 async def test_error_kind_not_found_produces_specific_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """NOT_FOUND error kind should produce a resource-not-found hint."""
 
@@ -1277,7 +1271,7 @@ async def test_error_kind_not_found_produces_specific_hint(
         make_text_response("That item doesn't exist."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1290,7 +1284,7 @@ async def test_error_kind_not_found_produces_specific_hint(
 @patch("backend.app.agent.core.amessages")
 async def test_error_kind_service_produces_specific_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """SERVICE error kind should produce an external-service hint."""
 
@@ -1312,7 +1306,7 @@ async def test_error_kind_service_produces_specific_hint(
         make_text_response("Storage is down."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1324,7 +1318,7 @@ async def test_error_kind_service_produces_specific_hint(
 @patch("backend.app.agent.core.amessages")
 async def test_error_kind_validation_produces_specific_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """VALIDATION error kind should produce a parameter-check hint."""
 
@@ -1346,7 +1340,7 @@ async def test_error_kind_validation_produces_specific_hint(
         make_text_response("Let me fix that."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1358,7 +1352,7 @@ async def test_error_kind_validation_produces_specific_hint(
 @patch("backend.app.agent.core.amessages")
 async def test_error_kind_internal_produces_specific_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """INTERNAL error kind should produce a do-not-retry hint."""
 
@@ -1380,7 +1374,7 @@ async def test_error_kind_internal_produces_specific_hint(
         make_text_response("Something went wrong."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1392,7 +1386,7 @@ async def test_error_kind_internal_produces_specific_hint(
 @patch("backend.app.agent.core.amessages")
 async def test_error_with_no_kind_uses_default_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """ToolResult with is_error=True but no error_kind should use the default hint."""
 
@@ -1413,7 +1407,7 @@ async def test_error_with_no_kind_uses_default_hint(
         make_text_response("I'll try another way."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1425,7 +1419,7 @@ async def test_error_with_no_kind_uses_default_hint(
 @patch("backend.app.agent.core.amessages")
 async def test_error_with_custom_hint_overrides_kind_default(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """ToolResult with a custom hint should use it instead of the error_kind default."""
 
@@ -1451,7 +1445,7 @@ async def test_error_with_custom_hint_overrides_kind_default(
         make_text_response("Which estimate?"),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1465,7 +1459,7 @@ async def test_error_with_custom_hint_overrides_kind_default(
 @patch("backend.app.agent.core.amessages")
 async def test_different_error_kinds_produce_different_hints(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Each error kind should produce a distinct guidance message."""
     collected_hints: dict[str, str] = {}
@@ -1491,7 +1485,7 @@ async def test_different_error_kinds_produce_different_hints(
             make_text_response("ok"),
         ]
 
-        agent = ClawboltAgent(contractor=test_contractor)
+        agent = ClawboltAgent(user=test_user)
         agent.register_tools([tool])
         response = await agent.process_message("test", system_prompt_override="system")
 
@@ -1508,7 +1502,7 @@ async def test_different_error_kinds_produce_different_hints(
 @patch("backend.app.agent.core.amessages")
 async def test_unhandled_exception_uses_internal_hint(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Unhandled tool exceptions should produce INTERNAL error kind hint."""
 
@@ -1526,7 +1520,7 @@ async def test_unhandled_exception_uses_internal_hint(
         make_text_response("Something went wrong."),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     await agent.process_message("test", system_prompt_override="system")
 
@@ -1552,7 +1546,7 @@ async def test_unhandled_exception_uses_internal_hint(
 class TestToolRegistry:
     """Tests for the ToolRegistry and related helpers."""
 
-    def test_register_and_create_tools(self, test_contractor: ContractorData) -> None:
+    def test_register_and_create_tools(self, test_user: UserData) -> None:
         """Registry should create tools from registered factories."""
         from backend.app.agent.tools.registry import ToolContext, ToolRegistry
 
@@ -1572,12 +1566,12 @@ class TestToolRegistry:
             ]
 
         registry.register("dummy", dummy_factory)
-        ctx = ToolContext(contractor=test_contractor)
+        ctx = ToolContext(user=test_user)
         tools = registry.create_tools(ctx)
         assert len(tools) == 1
         assert tools[0].name == "dummy"
 
-    def test_skips_factory_when_storage_missing(self, test_contractor: ContractorData) -> None:
+    def test_skips_factory_when_storage_missing(self, test_user: UserData) -> None:
         """Factories requiring storage should be skipped when storage is None."""
         from backend.app.agent.tools.registry import ToolContext, ToolRegistry
 
@@ -1594,11 +1588,11 @@ class TestToolRegistry:
             ]
 
         registry.register("storage_tool", storage_factory, requires_storage=True)
-        ctx = ToolContext(contractor=test_contractor, storage=None)
+        ctx = ToolContext(user=test_user, storage=None)
         tools = registry.create_tools(ctx)
         assert len(tools) == 0
 
-    def test_skips_factory_when_messaging_missing(self, test_contractor: ContractorData) -> None:
+    def test_skips_factory_when_messaging_missing(self, test_user: UserData) -> None:
         """Factories requiring messaging should be skipped when messaging is None."""
         from backend.app.agent.tools.registry import ToolContext, ToolRegistry
 
@@ -1615,13 +1609,13 @@ class TestToolRegistry:
             ]
 
         registry.register("msg_tool", msg_factory, requires_messaging=True)
-        ctx = ToolContext(contractor=test_contractor, messaging_service=None)
+        ctx = ToolContext(user=test_user, messaging_service=None)
         tools = registry.create_tools(ctx)
         assert len(tools) == 0
 
     def test_includes_factory_when_deps_satisfied(
         self,
-        test_contractor: ContractorData,
+        test_user: UserData,
         mock_messaging_service: MessagingService,
     ) -> None:
         """Factories should produce tools when required dependencies are present."""
@@ -1656,7 +1650,7 @@ class TestToolRegistry:
 
         mock_storage = MagicMock()
         ctx = ToolContext(
-            contractor=test_contractor,
+            user=test_user,
             storage=mock_storage,
             messaging_service=mock_messaging_service,
         )
@@ -1698,7 +1692,7 @@ class TestToolRegistry:
         count2 = len(default_registry.factory_names)
         assert count1 == count2
 
-    def test_overwrite_warns(self, test_contractor: ContractorData) -> None:
+    def test_overwrite_warns(self, test_user: UserData) -> None:
         """Registering the same name twice should overwrite (with a warning)."""
         from backend.app.agent.tools.registry import ToolContext, ToolRegistry
 
@@ -1727,7 +1721,7 @@ class TestToolRegistry:
         registry.register("same_name", factory_a)
         registry.register("same_name", factory_b)
 
-        ctx = ToolContext(contractor=test_contractor)
+        ctx = ToolContext(user=test_user)
         tools = registry.create_tools(ctx)
         # The second factory should win
         assert len(tools) == 1
@@ -1743,7 +1737,7 @@ class TestToolRegistry:
 @patch("backend.app.agent.core.amessages")
 async def test_agent_emits_debug_logs_for_full_loop(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Debug logging should trace the full agent loop lifecycle."""
@@ -1761,7 +1755,7 @@ async def test_agent_emits_debug_logs_for_full_loop(
         make_text_response("Done!"),
     ]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
 
     with caplog.at_level("DEBUG", logger="backend.app.agent.core"):

--- a/tests/test_agent_events.py
+++ b/tests/test_agent_events.py
@@ -15,7 +15,7 @@ from backend.app.agent.events import (
     TurnEndEvent,
     TurnStartEvent,
 )
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.tools.base import Tool, ToolResult
 from tests.mocks.llm import make_text_response, make_tool_call_response
 
@@ -32,8 +32,8 @@ class _KeyValueParams(BaseModel):
 
 
 @pytest.fixture()
-def agent(test_contractor: ContractorData) -> ClawboltAgent:
-    agent = ClawboltAgent(contractor=test_contractor)
+def agent(test_user: UserData) -> ClawboltAgent:
+    agent = ClawboltAgent(user=test_user)
     return agent
 
 
@@ -188,9 +188,9 @@ async def test_multiple_subscribers(
 
 def test_event_dataclasses_are_frozen() -> None:
     """Event dataclasses should be immutable."""
-    event = AgentStartEvent(contractor_id=1, message_context="test")
+    event = AgentStartEvent(user_id=1, message_context="test")
     try:
-        event.contractor_id = 2  # type: ignore[misc]
+        event.user_id = 2  # type: ignore[misc]
         frozen = False
     except AttributeError:
         frozen = True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,51 +2,51 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import get_contractor_store
+from backend.app.agent.file_store import get_user_store
 from backend.app.agent.onboarding import is_onboarding_needed
 from backend.app.auth.dependencies import LOCAL_USER_ID, get_current_user
-from backend.app.auth.scoping import get_user_contractor
+from backend.app.auth.scoping import get_scoped_user
 
 
 @pytest.mark.asyncio()
-async def test_get_current_user_creates_local_contractor() -> None:
-    """OSS mode should auto-create a local contractor when store is empty."""
-    contractor = await get_current_user()
-    assert contractor.user_id == LOCAL_USER_ID
-    assert contractor.name == ""
-    assert contractor.id is not None
+async def test_get_current_user_creates_local_user() -> None:
+    """OSS mode should auto-create a local user when store is empty."""
+    user = await get_current_user()
+    assert user.user_id == LOCAL_USER_ID
+    assert user.name == ""
+    assert user.id is not None
 
 
 @pytest.mark.asyncio()
-async def test_local_contractor_needs_onboarding() -> None:
-    """New local contractor should trigger onboarding (regression for #521)."""
-    contractor = await get_current_user()
-    assert not contractor.onboarding_complete
-    assert is_onboarding_needed(contractor)
+async def test_local_user_needs_onboarding() -> None:
+    """New local user should trigger onboarding (regression for #521)."""
+    user = await get_current_user()
+    assert not user.onboarding_complete
+    assert is_onboarding_needed(user)
 
 
 @pytest.mark.asyncio()
-async def test_get_current_user_returns_same_contractor() -> None:
-    """Calling twice should return the same contractor."""
+async def test_get_current_user_returns_same_user() -> None:
+    """Calling twice should return the same user."""
     c1 = await get_current_user()
     c2 = await get_current_user()
     assert c1.id == c2.id
 
 
 @pytest.mark.asyncio()
-async def test_get_current_user_returns_existing_telegram_contractor() -> None:
-    """When a Telegram-created contractor exists, the dashboard should use it."""
-    store = get_contractor_store()
-    telegram_contractor = await store.create(
+async def test_get_current_user_returns_existing_telegram_user() -> None:
+    """When a Telegram-created user exists, the dashboard should use it."""
+    store = get_user_store()
+    telegram_user = await store.create(
         user_id="telegram_123456789",
         name="Telegram User",
         channel_identifier="123456789",
         preferred_channel="telegram",
     )
 
-    # get_current_user should return the existing contractor, not create a new one
+    # get_current_user should return the existing user, not create a new one
     dashboard_user = await get_current_user()
-    assert dashboard_user.id == telegram_contractor.id
+    assert dashboard_user.id == telegram_user.id
     assert dashboard_user.user_id == "telegram_123456789"
 
 
@@ -60,22 +60,22 @@ def test_auth_config_returns_none_mode(client: TestClient) -> None:
 
 @pytest.mark.asyncio()
 async def test_scoping_returns_404_for_wrong_user() -> None:
-    """Scoping should return 404 when contractor doesn't belong to user."""
-    store = get_contractor_store()
-    contractor1 = await store.create(user_id="user-1", name="Contractor 1")
-    contractor2 = await store.create(user_id="user-2", name="Contractor 2")
+    """Scoping should return 404 when user doesn't belong to requester."""
+    store = get_user_store()
+    user1 = await store.create(user_id="user-1", name="User 1")
+    user2 = await store.create(user_id="user-2", name="User 2")
 
-    # User 1 should not be able to access contractor 2
+    # User 1 should not be able to access user 2
     with pytest.raises(HTTPException) as exc_info:
-        await get_user_contractor(contractor1, contractor2.id)
+        await get_scoped_user(user1, user2.id)
     assert exc_info.value.status_code == 404
 
 
 @pytest.mark.asyncio()
-async def test_scoping_returns_contractor_for_correct_user() -> None:
-    """Scoping should return contractor when user_id matches."""
-    store = get_contractor_store()
-    contractor = await store.create(user_id="user-1", name="My Contractor")
+async def test_scoping_returns_user_for_correct_user() -> None:
+    """Scoping should return user when user_id matches."""
+    store = get_user_store()
+    user = await store.create(user_id="user-1", name="My User")
 
-    result = await get_user_contractor(contractor, contractor.id)
-    assert result.id == contractor.id
+    result = await get_scoped_user(user, user.id)
+    assert result.id == user.id

--- a/tests/test_checklist_tools.py
+++ b/tests/test_checklist_tools.py
@@ -2,14 +2,14 @@
 
 import pytest
 
-from backend.app.agent.file_store import ContractorData, HeartbeatStore
+from backend.app.agent.file_store import HeartbeatStore, UserData
 from backend.app.agent.tools.checklist_tools import create_checklist_tools
 
 
 @pytest.mark.asyncio()
-async def test_add_checklist_item(test_contractor: ContractorData) -> None:
+async def test_add_checklist_item(test_user: UserData) -> None:
     """add_checklist_item tool should create item and return confirmation."""
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     add_item = tools[0].function
     result = await add_item(description="Check material prices", schedule="daily")
     assert "Added to checklist" in result.content
@@ -18,7 +18,7 @@ async def test_add_checklist_item(test_contractor: ContractorData) -> None:
     assert result.is_error is False
 
     # Verify in store
-    store = HeartbeatStore(test_contractor.id)
+    store = HeartbeatStore(test_user.id)
     items = await store.get_checklist()
     active = [i for i in items if i.status == "active"]
     assert len(active) == 1
@@ -29,14 +29,14 @@ async def test_add_checklist_item(test_contractor: ContractorData) -> None:
 
 @pytest.mark.asyncio()
 async def test_add_checklist_item_default_schedule(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """add_checklist_item should default to daily schedule."""
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     add_item = tools[0].function
     await add_item(description="Morning check")
 
-    store = HeartbeatStore(test_contractor.id)
+    store = HeartbeatStore(test_user.id)
     items = await store.get_checklist()
     active = [i for i in items if i.status == "active"]
     assert len(active) == 1
@@ -45,24 +45,24 @@ async def test_add_checklist_item_default_schedule(
 
 @pytest.mark.asyncio()
 async def test_add_checklist_item_invalid_schedule(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """add_checklist_item should reject invalid schedule values."""
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     add_item = tools[0].function
     result = await add_item(description="Bad schedule", schedule="hourly")
     assert "Invalid schedule" in result.content
     assert result.is_error is True
 
-    store = HeartbeatStore(test_contractor.id)
+    store = HeartbeatStore(test_user.id)
     items = await store.get_checklist()
     assert len(items) == 0
 
 
 @pytest.mark.asyncio()
-async def test_list_checklist_items(test_contractor: ContractorData) -> None:
+async def test_list_checklist_items(test_user: UserData) -> None:
     """list_checklist_items should show active items."""
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     add_item = tools[0].function
     list_items = tools[1].function
 
@@ -77,39 +77,39 @@ async def test_list_checklist_items(test_contractor: ContractorData) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_list_checklist_items_empty(test_contractor: ContractorData) -> None:
+async def test_list_checklist_items_empty(test_user: UserData) -> None:
     """list_checklist_items should return message when empty."""
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     list_items = tools[1].function
     result = await list_items()
     assert "No active checklist items" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_list_excludes_paused(test_contractor: ContractorData) -> None:
+async def test_list_excludes_paused(test_user: UserData) -> None:
     """list_checklist_items should not show paused items."""
-    store = HeartbeatStore(test_contractor.id)
+    store = HeartbeatStore(test_user.id)
     await store.add_checklist_item(description="Paused item", schedule="daily")
     # Mark it as paused
     items = await store.get_checklist()
     await store.update_checklist_item(items[0].id, status="paused")
 
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     list_items = tools[1].function
     result = await list_items()
     assert "No active checklist items" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_remove_checklist_item(test_contractor: ContractorData) -> None:
+async def test_remove_checklist_item(test_user: UserData) -> None:
     """remove_checklist_item should delete item and return confirmation."""
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     add_item = tools[0].function
     remove_item = tools[2].function
 
     await add_item(description="To remove")
 
-    store = HeartbeatStore(test_contractor.id)
+    store = HeartbeatStore(test_user.id)
     items = await store.get_checklist()
     active = [i for i in items if i.status == "active"]
     assert len(active) == 1
@@ -125,10 +125,10 @@ async def test_remove_checklist_item(test_contractor: ContractorData) -> None:
 
 @pytest.mark.asyncio()
 async def test_remove_checklist_item_not_found(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """remove_checklist_item should handle missing IDs."""
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     remove_item = tools[2].function
     result = await remove_item(item_id=999)
     assert "not found" in result.content
@@ -136,21 +136,21 @@ async def test_remove_checklist_item_not_found(
 
 
 @pytest.mark.asyncio()
-async def test_remove_scoped_to_contractor(
-    test_contractor: ContractorData,
+async def test_remove_scoped_to_user(
+    test_user: UserData,
 ) -> None:
-    """remove_checklist_item should not delete another contractor's items."""
+    """remove_checklist_item should not delete another user's items."""
     other_store = HeartbeatStore(99)
     await other_store.add_checklist_item(description="Other's item", schedule="daily")
     other_items = await other_store.get_checklist()
     assert len(other_items) == 1
 
-    tools = create_checklist_tools(test_contractor.id)
+    tools = create_checklist_tools(test_user.id)
     remove_item = tools[2].function
     result = await remove_item(item_id=other_items[0].id)
     assert "not found" in result.content
     assert result.is_error is True
 
-    # Item should still exist in other contractor's store
+    # Item should still exist in other user's store
     remaining = await other_store.get_checklist()
     assert len(remaining) == 1

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -14,9 +14,9 @@ from backend.app.agent.compaction import (
 )
 from backend.app.agent.context import load_conversation_history
 from backend.app.agent.file_store import (
-    ContractorData,
     SessionState,
     StoredMessage,
+    UserData,
 )
 from backend.app.agent.memory import get_all_memories
 from backend.app.agent.messages import AssistantMessage, UserMessage
@@ -24,11 +24,11 @@ from tests.mocks.llm import make_text_response
 
 
 @pytest.fixture()
-def session(test_contractor: ContractorData) -> SessionState:
-    """Create a SessionState for the test contractor."""
+def session(test_user: UserData) -> SessionState:
+    """Create a SessionState for the test user."""
     return SessionState(
         session_id="test-session",
-        contractor_id=test_contractor.id,
+        user_id=test_user.id,
         messages=[],
         is_active=True,
     )
@@ -50,16 +50,16 @@ def _add_messages(session: SessionState, count: int) -> None:
 
 
 def test_format_messages_basic() -> None:
-    """Format should produce readable Contractor/Assistant lines."""
+    """Format should produce readable User/Assistant lines."""
     messages = [
         UserMessage(content="I charge $45/sqft for composite decks"),
         AssistantMessage(content="Got it, I'll remember that pricing."),
         UserMessage(content="My supplier is ABC Lumber on 5th Ave"),
     ]
     result = _format_messages_for_compaction(messages)
-    assert "Contractor: I charge $45/sqft" in result
+    assert "User: I charge $45/sqft" in result
     assert "Assistant: Got it" in result
-    assert "Contractor: My supplier is ABC Lumber" in result
+    assert "User: My supplier is ABC Lumber" in result
 
 
 def test_format_messages_empty() -> None:
@@ -76,8 +76,8 @@ def test_format_messages_skips_empty_assistant() -> None:
     ]
     result = _format_messages_for_compaction(messages)
     assert "Assistant:" not in result
-    assert "Contractor: Hello" in result
-    assert "Contractor: World" in result
+    assert "User: Hello" in result
+    assert "User: World" in result
 
 
 # --- _parse_compaction_response tests ---
@@ -182,7 +182,7 @@ def test_parse_skips_non_dict_items() -> None:
 
 @pytest.mark.asyncio()
 async def test_compact_session_extracts_and_saves_facts(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """compact_session should call LLM and save extracted facts to memory."""
     llm_response_content = json.dumps(
@@ -201,7 +201,7 @@ async def test_compact_session_extracts_and_saves_facts(
     ]
 
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response) as mock_llm:
-        saved, max_seq = await compact_session(test_contractor.id, messages)
+        saved, max_seq = await compact_session(test_user.id, messages)
 
     assert len(saved) == 2
     assert saved[0]["key"] == "deck_rate"
@@ -210,7 +210,7 @@ async def test_compact_session_extracts_and_saves_facts(
     assert max_seq is None
 
     # Verify facts were persisted
-    memories = await get_all_memories(test_contractor.id)
+    memories = await get_all_memories(test_user.id)
     assert len(memories) == 2
     keys = {m.key for m in memories}
     assert "deck_rate" in keys
@@ -228,7 +228,7 @@ async def test_compact_session_extracts_and_saves_facts(
 
 @pytest.mark.asyncio()
 async def test_compact_session_returns_max_message_seq(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """compact_session should return the max_message_seq when provided."""
     mock_response = make_text_response(
@@ -238,7 +238,7 @@ async def test_compact_session_returns_max_message_seq(
     messages = [UserMessage(content="test")]
 
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
-        saved, max_seq = await compact_session(test_contractor.id, messages, max_message_seq=42)
+        saved, max_seq = await compact_session(test_user.id, messages, max_message_seq=42)
 
     assert len(saved) == 1
     assert max_seq == 42
@@ -246,11 +246,11 @@ async def test_compact_session_returns_max_message_seq(
 
 @pytest.mark.asyncio()
 async def test_compact_session_empty_messages(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """compact_session with no messages should return empty list without LLM call."""
     with patch("backend.app.agent.compaction.amessages") as mock_llm:
-        saved, max_seq = await compact_session(test_contractor.id, [])
+        saved, max_seq = await compact_session(test_user.id, [])
 
     assert saved == []
     assert max_seq is None
@@ -258,7 +258,7 @@ async def test_compact_session_empty_messages(
 
 
 @pytest.mark.asyncio()
-async def test_compact_session_disabled(test_contractor: ContractorData) -> None:
+async def test_compact_session_disabled(test_user: UserData) -> None:
     """compact_session should skip when compaction_enabled is False."""
     messages = [UserMessage(content="Some content")]
 
@@ -267,7 +267,7 @@ async def test_compact_session_disabled(test_contractor: ContractorData) -> None
         patch("backend.app.agent.compaction.amessages") as mock_llm,
     ):
         mock_settings.compaction_enabled = False
-        saved, max_seq = await compact_session(test_contractor.id, messages)
+        saved, max_seq = await compact_session(test_user.id, messages)
 
     assert saved == []
     assert max_seq is None
@@ -276,7 +276,7 @@ async def test_compact_session_disabled(test_contractor: ContractorData) -> None
 
 @pytest.mark.asyncio()
 async def test_compact_session_llm_failure_returns_empty(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """compact_session should return empty list if LLM call fails."""
     messages = [UserMessage(content="Some content")]
@@ -285,7 +285,7 @@ async def test_compact_session_llm_failure_returns_empty(
         "backend.app.agent.compaction.amessages",
         side_effect=Exception("LLM unavailable"),
     ):
-        saved, max_seq = await compact_session(test_contractor.id, messages)
+        saved, max_seq = await compact_session(test_user.id, messages)
 
     assert saved == []
     assert max_seq is None
@@ -293,7 +293,7 @@ async def test_compact_session_llm_failure_returns_empty(
 
 @pytest.mark.asyncio()
 async def test_compact_session_invalid_llm_response(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """compact_session should handle unparseable LLM responses gracefully."""
     mock_response = make_text_response("Sorry, I can't do that.")
@@ -301,7 +301,7 @@ async def test_compact_session_invalid_llm_response(
     messages = [UserMessage(content="Some content")]
 
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
-        saved, max_seq = await compact_session(test_contractor.id, messages)
+        saved, max_seq = await compact_session(test_user.id, messages)
 
     assert saved == []
     assert max_seq is None
@@ -309,7 +309,7 @@ async def test_compact_session_invalid_llm_response(
 
 @pytest.mark.asyncio()
 async def test_compact_session_no_durable_facts(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """compact_session should handle LLM returning empty array (no facts)."""
     mock_response = make_text_response("[]")
@@ -320,17 +320,17 @@ async def test_compact_session_no_durable_facts(
     ]
 
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
-        saved, max_seq = await compact_session(test_contractor.id, messages)
+        saved, max_seq = await compact_session(test_user.id, messages)
 
     assert saved == []
     assert max_seq is None
-    memories = await get_all_memories(test_contractor.id)
+    memories = await get_all_memories(test_user.id)
     assert len(memories) == 0
 
 
 @pytest.mark.asyncio()
 async def test_compact_session_uses_configured_model(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """compact_session should use compaction_model/provider when configured."""
     mock_response = make_text_response("[]")
@@ -348,7 +348,7 @@ async def test_compact_session_uses_configured_model(
         mock_settings.llm_model = "test-model"
         mock_settings.llm_provider = "test-provider"
         mock_settings.llm_api_base = None
-        await compact_session(test_contractor.id, messages)
+        await compact_session(test_user.id, messages)
 
     mock_llm.assert_called_once()
     call_kwargs = mock_llm.call_args
@@ -357,7 +357,7 @@ async def test_compact_session_uses_configured_model(
 
 @pytest.mark.asyncio()
 async def test_compact_session_falls_back_to_llm_model(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """compact_session should fall back to llm_model when compaction_model is empty."""
     mock_response = make_text_response("[]")
@@ -375,7 +375,7 @@ async def test_compact_session_falls_back_to_llm_model(
         mock_settings.llm_model = "test-model"
         mock_settings.llm_provider = "test-provider"
         mock_settings.llm_api_base = None
-        await compact_session(test_contractor.id, messages)
+        await compact_session(test_user.id, messages)
 
     call_kwargs = mock_llm.call_args
     assert call_kwargs.kwargs.get("model") == "test-model"
@@ -387,7 +387,7 @@ async def test_compact_session_falls_back_to_llm_model(
 
 @pytest.mark.asyncio()
 async def test_load_history_triggers_compaction_when_full(
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
 ) -> None:
     """When history exceeds limit, compaction should run on trimmed messages."""
@@ -402,9 +402,7 @@ async def test_load_history_triggers_compaction_when_full(
 
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
         # Use limit=5, so 3 messages are trimmed (8 total, 5 loaded, minus current = 4 history)
-        history = await load_conversation_history(
-            session, limit=5, contractor_id=test_contractor.id
-        )
+        history = await load_conversation_history(session, limit=5, user_id=test_user.id)
         # Allow the background compaction task to complete
         await asyncio.sleep(0.1)
 
@@ -412,14 +410,14 @@ async def test_load_history_triggers_compaction_when_full(
     assert len(history) == 4
 
     # Compacted fact should have been saved
-    memories = await get_all_memories(test_contractor.id)
+    memories = await get_all_memories(test_user.id)
     assert len(memories) == 1
     assert memories[0].key == "fact_from_compaction"
 
 
 @pytest.mark.asyncio()
 async def test_load_history_updates_last_compacted_seq(
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
 ) -> None:
     """Compaction should update last_compacted_seq on the session."""
@@ -430,7 +428,7 @@ async def test_load_history_updates_last_compacted_seq(
     )
 
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
-        await load_conversation_history(session, limit=5, contractor_id=test_contractor.id)
+        await load_conversation_history(session, limit=5, user_id=test_user.id)
         await asyncio.sleep(0.1)
 
     # The trimmed messages are the first 3 (8 total - 5 limit).
@@ -440,7 +438,7 @@ async def test_load_history_updates_last_compacted_seq(
 
 @pytest.mark.asyncio()
 async def test_load_history_skips_already_compacted_messages(
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
 ) -> None:
     """Messages already compacted should not be re-compacted."""
@@ -454,7 +452,7 @@ async def test_load_history_skips_already_compacted_messages(
     )
 
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response) as mock_llm:
-        await load_conversation_history(session, limit=5, contractor_id=test_contractor.id)
+        await load_conversation_history(session, limit=5, user_id=test_user.id)
         await asyncio.sleep(0.1)
 
     # LLM should have been called with only the 1 un-compacted trimmed message
@@ -472,7 +470,7 @@ async def test_load_history_skips_already_compacted_messages(
 
 @pytest.mark.asyncio()
 async def test_load_history_no_compaction_when_all_already_compacted(
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
 ) -> None:
     """When all trimmed messages are already compacted, no LLM call should happen."""
@@ -482,7 +480,7 @@ async def test_load_history_no_compaction_when_all_already_compacted(
     session.last_compacted_seq = 3
 
     with patch("backend.app.agent.compaction.amessages") as mock_llm:
-        await load_conversation_history(session, limit=5, contractor_id=test_contractor.id)
+        await load_conversation_history(session, limit=5, user_id=test_user.id)
         await asyncio.sleep(0.1)
 
     mock_llm.assert_not_called()
@@ -490,16 +488,14 @@ async def test_load_history_no_compaction_when_all_already_compacted(
 
 @pytest.mark.asyncio()
 async def test_load_history_no_compaction_when_under_limit(
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
 ) -> None:
     """When history is under limit, no compaction should occur."""
     _add_messages(session, 3)
 
     with patch("backend.app.agent.compaction.amessages") as mock_llm:
-        history = await load_conversation_history(
-            session, limit=20, contractor_id=test_contractor.id
-        )
+        history = await load_conversation_history(session, limit=20, user_id=test_user.id)
 
     # Should not call LLM since we're under the limit
     mock_llm.assert_not_called()
@@ -508,11 +504,11 @@ async def test_load_history_no_compaction_when_under_limit(
 
 
 @pytest.mark.asyncio()
-async def test_load_history_no_compaction_without_contractor_id(
-    test_contractor: ContractorData,
+async def test_load_history_no_compaction_without_user_id(
+    test_user: UserData,
     session: SessionState,
 ) -> None:
-    """Without contractor_id, compaction should not run even at limit."""
+    """Without user_id, compaction should not run even at limit."""
     _add_messages(session, 8)
 
     with patch("backend.app.agent.compaction.amessages") as mock_llm:
@@ -524,7 +520,7 @@ async def test_load_history_no_compaction_without_contractor_id(
 
 @pytest.mark.asyncio()
 async def test_load_history_compaction_failure_does_not_break_history(
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
 ) -> None:
     """Compaction failure should not prevent history from loading."""
@@ -534,9 +530,7 @@ async def test_load_history_compaction_failure_does_not_break_history(
         "backend.app.agent.compaction.amessages",
         side_effect=Exception("LLM down"),
     ):
-        history = await load_conversation_history(
-            session, limit=5, contractor_id=test_contractor.id
-        )
+        history = await load_conversation_history(session, limit=5, user_id=test_user.id)
         # Allow the background task to complete (and fail gracefully)
         await asyncio.sleep(0.1)
 
@@ -546,7 +540,7 @@ async def test_load_history_compaction_failure_does_not_break_history(
 
 @pytest.mark.asyncio()
 async def test_compaction_runs_in_background_not_blocking(
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
 ) -> None:
     """Compaction should run as a background task, not blocking history loading."""
@@ -556,7 +550,7 @@ async def test_compaction_runs_in_background_not_blocking(
     compaction_proceed = asyncio.Event()
 
     async def slow_compact(
-        contractor_id: int,
+        user_id: int,
         trimmed_messages: list[object],
         max_message_seq: int | None = None,
     ) -> tuple[list[dict[str, str]], int | None]:
@@ -565,9 +559,7 @@ async def test_compaction_runs_in_background_not_blocking(
         return [], max_message_seq
 
     with patch("backend.app.agent.context.compact_session", side_effect=slow_compact):
-        history = await load_conversation_history(
-            session, limit=5, contractor_id=test_contractor.id
-        )
+        history = await load_conversation_history(session, limit=5, user_id=test_user.id)
 
         # History should be returned immediately, even though compaction hasn't finished
         assert len(history) == 4

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,40 +1,40 @@
-"""Tests for per-contractor processing lock."""
+"""Tests for per-user processing lock."""
 
 import asyncio
 import time
 
 import pytest
 
-from backend.app.agent.concurrency import ContractorLockManager, contractor_locks
+from backend.app.agent.concurrency import UserLockManager, user_locks
 
 
-class TestContractorLockManager:
+class TestUserLockManager:
     def test_acquire_creates_lock(self) -> None:
-        """First acquire for a contractor should create a lock."""
-        mgr = ContractorLockManager()
+        """First acquire for a user should create a lock."""
+        mgr = UserLockManager()
         lock = mgr.acquire(1)
         assert isinstance(lock, asyncio.Lock)
         assert mgr.active_count == 1
 
-    def test_acquire_same_contractor_returns_same_lock(self) -> None:
-        """Multiple acquires for the same contractor should return the same lock."""
-        mgr = ContractorLockManager()
+    def test_acquire_same_user_returns_same_lock(self) -> None:
+        """Multiple acquires for the same user should return the same lock."""
+        mgr = UserLockManager()
         lock1 = mgr.acquire(1)
         lock2 = mgr.acquire(1)
         assert lock1 is lock2
 
-    def test_acquire_different_contractors_returns_different_locks(self) -> None:
-        """Different contractors should get different locks."""
-        mgr = ContractorLockManager()
+    def test_acquire_different_users_returns_different_locks(self) -> None:
+        """Different users should get different locks."""
+        mgr = UserLockManager()
         lock1 = mgr.acquire(1)
         lock2 = mgr.acquire(2)
         assert lock1 is not lock2
         assert mgr.active_count == 2
 
     @pytest.mark.asyncio
-    async def test_same_contractor_serialized(self) -> None:
-        """Two tasks for the same contractor should run sequentially."""
-        mgr = ContractorLockManager()
+    async def test_same_user_serialized(self) -> None:
+        """Two tasks for the same user should run sequentially."""
+        mgr = UserLockManager()
         order: list[str] = []
 
         async def task_a() -> None:
@@ -55,9 +55,9 @@ class TestContractorLockManager:
         assert order == ["a_start", "a_end", "b_start", "b_end"]
 
     @pytest.mark.asyncio
-    async def test_different_contractors_parallel(self) -> None:
-        """Two tasks for different contractors should run in parallel."""
-        mgr = ContractorLockManager()
+    async def test_different_users_parallel(self) -> None:
+        """Two tasks for different users should run in parallel."""
+        mgr = UserLockManager()
         order: list[str] = []
 
         async def task_a() -> None:
@@ -79,7 +79,7 @@ class TestContractorLockManager:
 
     def test_cleanup_removes_stale_locks(self) -> None:
         """Cleanup should remove locks that haven't been used recently."""
-        mgr = ContractorLockManager(expiry_seconds=0)  # Expire immediately
+        mgr = UserLockManager(expiry_seconds=0)  # Expire immediately
         mgr.acquire(1)
         mgr.acquire(2)
         assert mgr.active_count == 2
@@ -92,7 +92,7 @@ class TestContractorLockManager:
 
     def test_cleanup_keeps_recent_locks(self) -> None:
         """Cleanup should keep locks that were recently used."""
-        mgr = ContractorLockManager(expiry_seconds=3600)
+        mgr = UserLockManager(expiry_seconds=3600)
         mgr.acquire(1)
         removed = mgr.cleanup()
         assert removed == 0
@@ -101,7 +101,7 @@ class TestContractorLockManager:
     @pytest.mark.asyncio
     async def test_cleanup_skips_locked(self) -> None:
         """Cleanup should not remove locks that are currently held."""
-        mgr = ContractorLockManager(expiry_seconds=0)
+        mgr = UserLockManager(expiry_seconds=0)
         lock = mgr.acquire(1)
         await lock.acquire()
         try:
@@ -114,4 +114,4 @@ class TestContractorLockManager:
 
     def test_module_singleton_exists(self) -> None:
         """The module-level singleton should be available."""
-        assert isinstance(contractor_locks, ContractorLockManager)
+        assert isinstance(user_locks, UserLockManager)

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -8,7 +8,7 @@ from backend.app.agent.context import (
     get_or_create_conversation,
     load_conversation_history,
 )
-from backend.app.agent.file_store import ContractorData, SessionState, StoredMessage
+from backend.app.agent.file_store import SessionState, StoredMessage, UserData
 from backend.app.agent.messages import (
     AssistantMessage,
     ToolResultMessage,
@@ -17,19 +17,19 @@ from backend.app.agent.messages import (
 
 
 @pytest.fixture()
-def conversation(test_contractor: ContractorData) -> SessionState:
+def conversation(test_user: UserData) -> SessionState:
     import asyncio
 
     from backend.app.agent.file_store import get_session_store
 
-    store = get_session_store(test_contractor.id)
+    store = get_session_store(test_user.id)
     session, _is_new = asyncio.get_event_loop().run_until_complete(store.get_or_create_session())
     return session
 
 
 @pytest.mark.asyncio()
 async def test_load_history_chronological_order(
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
 ) -> None:
     """History should be in chronological order."""
@@ -123,35 +123,35 @@ async def test_load_history_single_message(
 
 @pytest.mark.asyncio()
 async def test_get_or_create_conversation_new(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Should create a new conversation when none exists."""
-    conv, is_new = await get_or_create_conversation(test_contractor.id)
+    conv, is_new = await get_or_create_conversation(test_user.id)
     assert is_new is True
-    assert conv.contractor_id == test_contractor.id
+    assert conv.user_id == test_user.id
     assert conv.is_active is True
 
 
 @pytest.mark.asyncio()
 async def test_get_or_create_conversation_existing_active(
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
 ) -> None:
     """Should return existing active conversation within timeout."""
     # The conversation fixture already created a recent session on disk
-    conv, is_new = await get_or_create_conversation(test_contractor.id)
+    conv, is_new = await get_or_create_conversation(test_user.id)
     assert is_new is False
     assert conv.session_id == conversation.session_id
 
 
 @pytest.mark.asyncio()
 async def test_get_or_create_conversation_expired(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Should create new conversation when existing one has timed out."""
     from backend.app.agent.file_store import get_session_store
 
-    store = get_session_store(test_contractor.id)
+    store = get_session_store(test_user.id)
 
     # Create an old conversation by writing the session file directly
     old_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
@@ -163,7 +163,7 @@ async def test_get_or_create_conversation_expired(
     meta = {
         "_type": "metadata",
         "session_id": old_session_id,
-        "contractor_id": test_contractor.id,
+        "user_id": test_user.id,
         "created_at": old_time.isoformat(),
         "last_message_at": old_time.isoformat(),
         "is_active": True,
@@ -171,18 +171,18 @@ async def test_get_or_create_conversation_expired(
     }
     path.write_text(json.dumps(meta, default=str) + "\n", encoding="utf-8")
 
-    conv, is_new = await get_or_create_conversation(test_contractor.id)
+    conv, is_new = await get_or_create_conversation(test_user.id)
     assert is_new is True
     assert conv.session_id != old_session_id
 
 
 @pytest.mark.asyncio()
 async def test_get_or_create_conversation_with_external_session_id(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """New conversation should store external session ID."""
     conv, is_new = await get_or_create_conversation(
-        test_contractor.id, external_session_id="session_abc123"
+        test_user.id, external_session_id="session_abc123"
     )
     assert is_new is True
     # SessionState stores external_session_id if available
@@ -191,12 +191,12 @@ async def test_get_or_create_conversation_with_external_session_id(
 
 @pytest.mark.asyncio()
 async def test_get_or_create_conversation_custom_timeout(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Custom timeout should be respected."""
     from backend.app.agent.file_store import get_session_store
 
-    store = get_session_store(test_contractor.id)
+    store = get_session_store(test_user.id)
 
     def _write_session(session_id: str, last_message_at: str) -> None:
         """Write a session JSONL file with metadata."""
@@ -205,7 +205,7 @@ async def test_get_or_create_conversation_custom_timeout(
         meta = {
             "_type": "metadata",
             "session_id": session_id,
-            "contractor_id": test_contractor.id,
+            "user_id": test_user.id,
             "created_at": last_message_at,
             "last_message_at": last_message_at,
             "is_active": True,
@@ -218,12 +218,12 @@ async def test_get_or_create_conversation_custom_timeout(
     _write_session("conv-timeout-test", old_time.isoformat())
 
     # With 1-hour timeout, should create new
-    _conv, is_new = await get_or_create_conversation(test_contractor.id, timeout_hours=1)
+    _conv, is_new = await get_or_create_conversation(test_user.id, timeout_hours=1)
     assert is_new is True
 
     # With 3-hour timeout, should reuse (re-write old session since a new one was created)
     _write_session("conv-timeout-test", old_time.isoformat())
-    _conv, is_new = await get_or_create_conversation(test_contractor.id, timeout_hours=3)
+    _conv, is_new = await get_or_create_conversation(test_user.id, timeout_hours=3)
     assert is_new is False
 
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -2,17 +2,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.app.agent.file_store import ContractorData, SessionState, StoredMessage
+from backend.app.agent.file_store import SessionState, StoredMessage, UserData
 from backend.app.agent.router import handle_inbound_message
 from backend.app.services.messaging import MessagingService
 from tests.mocks.llm import make_text_response
 
 
 @pytest.fixture()
-def conversation(test_contractor: ContractorData) -> SessionState:
+def conversation(test_user: UserData) -> SessionState:
     return SessionState(
         session_id="test-conv",
-        contractor_id=test_contractor.id,
+        user_id=test_user.id,
         is_active=True,
         messages=[
             StoredMessage(direction="inbound", body="Hello, I need help", seq=1),
@@ -44,7 +44,7 @@ def mock_messaging() -> MessagingService:
 @patch("backend.app.agent.core.amessages")
 async def test_agent_llm_failure_returns_friendly_message(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -53,7 +53,7 @@ async def test_agent_llm_failure_returns_friendly_message(
     mock_amessages.side_effect = Exception("LLM API timeout")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -68,7 +68,7 @@ async def test_agent_llm_failure_returns_friendly_message(
 @patch("backend.app.agent.core.amessages")
 async def test_all_media_download_failure_adds_note(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -78,7 +78,7 @@ async def test_all_media_download_failure_adds_note(
     mock_amessages.return_value = make_text_response("Got your message!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[("AgACAgIAAxkBAAI", "image/jpeg")],
@@ -99,7 +99,7 @@ async def test_all_media_download_failure_adds_note(
 async def test_partial_media_success(
     mock_vision: AsyncMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -121,7 +121,7 @@ async def test_partial_media_success(
     mock_amessages.return_value = make_text_response("I can see the deck!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[
@@ -140,7 +140,7 @@ async def test_partial_media_success(
 @patch("backend.app.agent.core.amessages")
 async def test_messaging_send_failure_still_stores_message(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -150,7 +150,7 @@ async def test_messaging_send_failure_still_stores_message(
     mock_messaging.send_text.side_effect = Exception("Messaging service outage")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -172,7 +172,7 @@ async def test_messaging_send_failure_still_stores_message(
 async def test_media_pipeline_failure_falls_back_to_text(
     mock_pipeline: AsyncMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -199,7 +199,7 @@ async def test_media_pipeline_failure_falls_back_to_text(
     mock_amessages.return_value = make_text_response("I can help!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[("AgACAgIAAxkBAAI", "image/jpeg")],

--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData, EstimateStore, get_contractor_store
+from backend.app.agent.file_store import EstimateStore, UserData, get_user_store
 from backend.app.agent.tools.estimate_tools import create_estimate_tools
 from tests.mocks.storage import MockStorageBackend
 
@@ -24,10 +24,10 @@ def _use_tmp_pdf_dir(tmp_path: Path) -> Generator[None]:
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_creates_records(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """generate_estimate should create Estimate and EstimateLineItem records."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -42,7 +42,7 @@ async def test_generate_estimate_creates_records(
     assert "$4,200.00" in result.content
     assert result.is_error is False
 
-    store = EstimateStore(test_contractor.id)
+    store = EstimateStore(test_user.id)
     estimates = await store.list_all()
     assert len(estimates) == 1
     assert estimates[0].total_amount == 4200.00
@@ -53,10 +53,10 @@ async def test_generate_estimate_creates_records(
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_with_client_info(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """generate_estimate should include client info."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -70,18 +70,18 @@ async def test_generate_estimate_with_client_info(
     assert "$8,500.00" in result.content
 
     # Verify estimate is filed under the client slug
-    store = EstimateStore(test_contractor.id)
+    store = EstimateStore(test_user.id)
     estimates = await store.list_all()
     assert estimates[0].client_id == "john_johnson"
 
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_pdf_generated(
-    test_contractor: ContractorData,
+    test_user: UserData,
     tmp_path: Path,
 ) -> None:
     """generate_estimate should generate a PDF (nonzero bytes)."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -91,24 +91,22 @@ async def test_generate_estimate_pdf_generated(
 
     assert ".pdf" in result.content
 
-    # Verify PDF file was actually written in the temp directory (per-contractor subdir)
-    store = EstimateStore(test_contractor.id)
+    # Verify PDF file was actually written in the temp directory (per-user subdir)
+    store = EstimateStore(test_user.id)
     estimates = await store.list_all()
     assert len(estimates) == 1
     # Without client info, PDFs go under the "unsorted" subfolder
-    pdf_path = (
-        tmp_path / "estimates" / str(test_contractor.id) / "unsorted" / f"{estimates[0].id}.pdf"
-    )
+    pdf_path = tmp_path / "estimates" / str(test_user.id) / "unsorted" / f"{estimates[0].id}.pdf"
     assert pdf_path.exists()
     assert pdf_path.stat().st_size > 0
 
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_sequential_numbers(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
-    """Estimate numbers should be sequential per contractor."""
-    tools = create_estimate_tools(test_contractor)
+    """Estimate numbers should be sequential per user."""
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result1 = await generate(
@@ -126,10 +124,10 @@ async def test_generate_estimate_sequential_numbers(
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_single_line_item(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Estimate with single line item should work."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -143,10 +141,10 @@ async def test_generate_estimate_single_line_item(
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_custom_terms(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Custom terms should be accepted."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -160,10 +158,10 @@ async def test_generate_estimate_custom_terms(
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_no_terms_omits_default(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Omitting terms should pass None to the PDF, not a hardcoded default."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     with patch(
@@ -182,10 +180,10 @@ async def test_generate_estimate_no_terms_omits_default(
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_rejects_negative_quantity(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Negative quantity should return an error instead of creating a record."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -197,16 +195,16 @@ async def test_generate_estimate_rejects_negative_quantity(
     assert "negative" in result.content.lower()
     assert result.is_error is True
 
-    store = EstimateStore(test_contractor.id)
+    store = EstimateStore(test_user.id)
     assert len(await store.list_all()) == 0
 
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_rejects_negative_price(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Negative unit_price should return an error."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -218,16 +216,16 @@ async def test_generate_estimate_rejects_negative_price(
     assert "negative" in result.content.lower()
     assert result.is_error is True
 
-    store = EstimateStore(test_contractor.id)
+    store = EstimateStore(test_user.id)
     assert len(await store.list_all()) == 0
 
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_rejects_non_numeric_values(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Non-numeric quantity/price should return an error."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -238,18 +236,18 @@ async def test_generate_estimate_rejects_non_numeric_values(
     assert "Error" in result.content
     assert result.is_error is True
 
-    store = EstimateStore(test_contractor.id)
+    store = EstimateStore(test_user.id)
     assert len(await store.list_all()) == 0
 
 
 def test_serve_estimate_pdf_endpoint(
-    client: TestClient, test_contractor: ContractorData, tmp_path: Path
+    client: TestClient, test_user: UserData, tmp_path: Path
 ) -> None:
     """GET /api/estimates/{id}/pdf should serve existing PDF for authenticated owner."""
     import asyncio
 
     # Create an estimate record via the file store
-    store = EstimateStore(test_contractor.id)
+    store = EstimateStore(test_user.id)
     estimate = asyncio.get_event_loop().run_until_complete(
         store.create(
             description="Test estimate",
@@ -259,9 +257,9 @@ def test_serve_estimate_pdf_endpoint(
 
     # Create a test PDF file in the temp directory (patched via _use_tmp_pdf_dir)
     # Estimates without client_id go under "unsorted"
-    contractor_dir = tmp_path / "estimates" / str(test_contractor.id) / "unsorted"
-    contractor_dir.mkdir(parents=True, exist_ok=True)
-    test_pdf = contractor_dir / f"{estimate.id}.pdf"
+    user_dir = tmp_path / "estimates" / str(test_user.id) / "unsorted"
+    user_dir.mkdir(parents=True, exist_ok=True)
+    test_pdf = user_dir / f"{estimate.id}.pdf"
     test_pdf.write_bytes(b"%PDF-1.4 test content")
 
     response = client.get(f"/api/estimates/{estimate.id}/pdf")
@@ -280,18 +278,18 @@ def test_serve_estimate_pdf_other_user_rejected(client: TestClient, tmp_path: Pa
     """GET /api/estimates/{id}/pdf should return 404 for another user's estimate."""
     import asyncio
 
-    # Create a different contractor
-    contractor_store = get_contractor_store()
-    other_contractor = asyncio.get_event_loop().run_until_complete(
-        contractor_store.create(
+    # Create a different user
+    user_store = get_user_store()
+    other_user = asyncio.get_event_loop().run_until_complete(
+        user_store.create(
             user_id="other-user-999",
-            name="Other Contractor",
+            name="Other User",
             phone="+15559999999",
         )
     )
 
-    # Create an estimate owned by the other contractor
-    store = EstimateStore(other_contractor.id)
+    # Create an estimate owned by the other user
+    store = EstimateStore(other_user.id)
     estimate = asyncio.get_event_loop().run_until_complete(
         store.create(
             description="Other user's estimate",
@@ -300,9 +298,9 @@ def test_serve_estimate_pdf_other_user_rejected(client: TestClient, tmp_path: Pa
     )
 
     # Create the PDF file so we can verify auth blocks access, not file absence
-    contractor_dir = tmp_path / "estimates" / str(other_contractor.id) / "unsorted"
-    contractor_dir.mkdir(parents=True, exist_ok=True)
-    test_pdf = contractor_dir / f"{estimate.id}.pdf"
+    user_dir = tmp_path / "estimates" / str(other_user.id) / "unsorted"
+    user_dir.mkdir(parents=True, exist_ok=True)
+    test_pdf = user_dir / f"{estimate.id}.pdf"
     test_pdf.write_bytes(b"%PDF-1.4 secret content")
 
     response = client.get(f"/api/estimates/{estimate.id}/pdf")
@@ -312,11 +310,11 @@ def test_serve_estimate_pdf_other_user_rejected(client: TestClient, tmp_path: Pa
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_uploads_to_cloud_storage(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """When storage is provided, estimate PDF should be uploaded to cloud storage."""
     storage = MockStorageBackend()
-    tools = create_estimate_tools(test_contractor, storage)
+    tools = create_estimate_tools(test_user, storage)
     generate = tools[0].function
 
     await generate(
@@ -335,11 +333,11 @@ async def test_generate_estimate_uploads_to_cloud_storage(
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_storage_uses_unsorted_without_client(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Without client info, estimate PDF should go to Unsorted in cloud storage."""
     storage = MockStorageBackend()
-    tools = create_estimate_tools(test_contractor, storage)
+    tools = create_estimate_tools(test_user, storage)
     generate = tools[0].function
 
     await generate(
@@ -354,11 +352,11 @@ async def test_generate_estimate_storage_uses_unsorted_without_client(
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_no_storage_still_saves_locally(
-    test_contractor: ContractorData,
+    test_user: UserData,
     tmp_path: Path,
 ) -> None:
     """Without storage backend, estimate PDF should still save to local filesystem."""
-    tools = create_estimate_tools(test_contractor)
+    tools = create_estimate_tools(test_user)
     generate = tools[0].function
 
     result = await generate(
@@ -367,12 +365,10 @@ async def test_generate_estimate_no_storage_still_saves_locally(
     )
 
     assert "EST-0001" in result.content
-    store = EstimateStore(test_contractor.id)
+    store = EstimateStore(test_user.id)
     estimates = await store.list_all()
     assert len(estimates) == 1
-    pdf_path = (
-        tmp_path / "estimates" / str(test_contractor.id) / "unsorted" / f"{estimates[0].id}.pdf"
-    )
+    pdf_path = tmp_path / "estimates" / str(test_user.id) / "unsorted" / f"{estimates[0].id}.pdf"
     assert pdf_path.exists()
 
 
@@ -392,7 +388,7 @@ def test_serve_estimate_pdf_requires_auth_dependency() -> None:
 
 @pytest.mark.asyncio()
 async def test_generate_estimate_cloud_upload_failure_does_not_kill_call(
-    test_contractor: ContractorData,
+    test_user: UserData,
     tmp_path: Path,
 ) -> None:
     """Cloud upload failure should be logged but not prevent local PDF generation."""
@@ -404,7 +400,7 @@ async def test_generate_estimate_cloud_upload_failure_does_not_kill_call(
 
     storage.upload_file = failing_upload  # type: ignore[assignment]
 
-    tools = create_estimate_tools(test_contractor, storage)
+    tools = create_estimate_tools(test_user, storage)
     generate = tools[0].function
 
     result = await generate(
@@ -418,10 +414,8 @@ async def test_generate_estimate_cloud_upload_failure_does_not_kill_call(
     assert "$2,000.00" in result.content
 
     # Verify local PDF was saved (client_name="John Smith" -> john_smith subfolder)
-    store = EstimateStore(test_contractor.id)
+    store = EstimateStore(test_user.id)
     estimates = await store.list_all()
     assert len(estimates) == 1
-    pdf_path = (
-        tmp_path / "estimates" / str(test_contractor.id) / "john_smith" / f"{estimates[0].id}.pdf"
-    )
+    pdf_path = tmp_path / "estimates" / str(test_user.id) / "john_smith" / f"{estimates[0].id}.pdf"
     assert pdf_path.exists()

--- a/tests/test_file_cataloging.py
+++ b/tests/test_file_cataloging.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend.app.agent.file_store import ContractorData, MediaStore
+from backend.app.agent.file_store import MediaStore, UserData
 from backend.app.agent.tools.file_tools import (
     _build_client_folder,
     _build_filename,
@@ -115,12 +115,12 @@ def test_build_filename_voice_note() -> None:
 
 @pytest.mark.asyncio()
 async def test_upload_creates_media_file_record(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """upload_to_storage should create a MediaData record."""
     storage = MockStorageBackend()
     tools = create_file_tools(
-        test_contractor,
+        test_user,
         storage,
         pending_media={"https://example.com/media/photo.jpg": b"fake-image-bytes"},
     )
@@ -141,12 +141,12 @@ async def test_upload_creates_media_file_record(
 
 @pytest.mark.asyncio()
 async def test_upload_to_client_folder(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Files with client info should go to the client folder."""
     storage = MockStorageBackend()
     tools = create_file_tools(
-        test_contractor,
+        test_user,
         storage,
         pending_media={"https://example.com/doc.pdf": b"pdf-bytes"},
     )
@@ -167,12 +167,12 @@ async def test_upload_to_client_folder(
 
 @pytest.mark.asyncio()
 async def test_upload_without_client_goes_to_unsorted(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Files without client info should go to Unsorted/{date}/."""
     storage = MockStorageBackend()
     tools = create_file_tools(
-        test_contractor,
+        test_user,
         storage,
         pending_media={"https://example.com/doc.pdf": b"pdf-bytes"},
     )
@@ -192,11 +192,11 @@ async def test_upload_without_client_goes_to_unsorted(
 
 @pytest.mark.asyncio()
 async def test_upload_no_media_returns_error(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Upload with no pending media should return error guiding to organize_file."""
     storage = MockStorageBackend()
-    tools = create_file_tools(test_contractor, storage, pending_media={})
+    tools = create_file_tools(test_user, storage, pending_media={})
     upload = tools[0].function
 
     result = await upload(file_category="job_photo")
@@ -207,12 +207,12 @@ async def test_upload_no_media_returns_error(
 
 @pytest.mark.asyncio()
 async def test_upload_uses_first_media_if_no_url(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """If no original_url specified, use first available media."""
     storage = MockStorageBackend()
     tools = create_file_tools(
-        test_contractor,
+        test_user,
         storage,
         pending_media={"https://example.com/media/auto.jpg": b"auto-bytes"},
     )
@@ -226,12 +226,12 @@ async def test_upload_uses_first_media_if_no_url(
 
 @pytest.mark.asyncio()
 async def test_upload_sequential_indexing(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Multiple uploads to same folder should get sequential indices."""
     storage = MockStorageBackend()
     tools = create_file_tools(
-        test_contractor,
+        test_user,
         storage,
         pending_media={
             "https://example.com/1.jpg": b"img1",
@@ -257,12 +257,12 @@ async def test_upload_sequential_indexing(
 
 @pytest.mark.asyncio()
 async def test_upload_creates_folder(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Storage folder should be created before upload."""
     storage = MockStorageBackend()
     tools = create_file_tools(
-        test_contractor,
+        test_user,
         storage,
         pending_media={"https://example.com/f.jpg": b"bytes"},
     )
@@ -281,7 +281,7 @@ async def test_upload_creates_folder(
 
 @pytest.mark.asyncio()
 async def test_auto_save_creates_media_file_records(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """auto_save_media should return storage paths for each downloaded file."""
     storage = MockStorageBackend()
@@ -300,7 +300,7 @@ async def test_auto_save_creates_media_file_records(
         ),
     ]
 
-    saved = await auto_save_media(test_contractor, storage, media)
+    saved = await auto_save_media(test_user, storage, media)
 
     assert len(saved) == 2
     assert len(storage.files) == 2
@@ -313,7 +313,7 @@ async def test_auto_save_creates_media_file_records(
 
 @pytest.mark.asyncio()
 async def test_auto_save_sequential_filenames(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """auto_save_media should produce sequential filenames."""
     storage = MockStorageBackend()
@@ -326,7 +326,7 @@ async def test_auto_save_sequential_filenames(
         ),
     ]
 
-    saved = await auto_save_media(test_contractor, storage, media)
+    saved = await auto_save_media(test_user, storage, media)
 
     assert "file_001.jpg" in saved[0]
     assert "file_002.jpg" in saved[1]
@@ -334,18 +334,18 @@ async def test_auto_save_sequential_filenames(
 
 @pytest.mark.asyncio()
 async def test_auto_save_empty_media_returns_empty(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """auto_save_media with no media should return empty list."""
     storage = MockStorageBackend()
-    saved = await auto_save_media(test_contractor, storage, [])
+    saved = await auto_save_media(test_user, storage, [])
     assert saved == []
     assert len(storage.files) == 0
 
 
 @pytest.mark.asyncio()
 async def test_auto_save_creates_unsorted_folder(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """auto_save_media should create the Unsorted/{date} folder."""
     storage = MockStorageBackend()
@@ -355,7 +355,7 @@ async def test_auto_save_creates_unsorted_folder(
         ),
     ]
 
-    await auto_save_media(test_contractor, storage, media)
+    await auto_save_media(test_user, storage, media)
 
     assert len(storage.folders) == 1
     assert storage.folders[0].startswith("/Unsorted/")
@@ -368,13 +368,13 @@ async def test_auto_save_creates_unsorted_folder(
 
 @pytest.mark.asyncio()
 async def test_organize_file_moves_to_client_folder(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """organize_file should move an auto-saved file into the client folder."""
     storage = MockStorageBackend()
     # Simulate auto-saved file in Unsorted
     await storage.upload_file(b"img-data", "/Unsorted/2026-03-02", "file_001.jpg")
-    media_store = MediaStore(test_contractor.id)
+    media_store = MediaStore(test_user.id)
     await media_store.create(
         original_url="tg_file_id_123",
         mime_type="image/jpeg",
@@ -382,7 +382,7 @@ async def test_organize_file_moves_to_client_folder(
         storage_path="/Unsorted/2026-03-02/file_001.jpg",
     )
 
-    tools = create_file_tools(test_contractor, storage)
+    tools = create_file_tools(test_user, storage)
     organize = tools[1].function
 
     result = await organize(
@@ -405,11 +405,11 @@ async def test_organize_file_moves_to_client_folder(
 
 @pytest.mark.asyncio()
 async def test_organize_file_not_found(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """organize_file should return an error if the file is not in the store."""
     storage = MockStorageBackend()
-    tools = create_file_tools(test_contractor, storage)
+    tools = create_file_tools(test_user, storage)
     organize = tools[1].function
 
     result = await organize(
@@ -423,11 +423,11 @@ async def test_organize_file_not_found(
 
 @pytest.mark.asyncio()
 async def test_organize_file_already_in_client_folder(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """organize_file should return early if the file is already in a client folder."""
     storage = MockStorageBackend()
-    media_store = MediaStore(test_contractor.id)
+    media_store = MediaStore(test_user.id)
     await media_store.create(
         original_url="tg_file_id_456",
         mime_type="image/jpeg",
@@ -435,7 +435,7 @@ async def test_organize_file_already_in_client_folder(
         storage_path="/Jane/photos/deck_001.jpg",
     )
 
-    tools = create_file_tools(test_contractor, storage)
+    tools = create_file_tools(test_user, storage)
     organize = tools[1].function
 
     result = await organize(
@@ -448,11 +448,11 @@ async def test_organize_file_already_in_client_folder(
 
 @pytest.mark.asyncio()
 async def test_organize_file_without_client_returns_error(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """organize_file without client_name or client_address should return an error."""
     storage = MockStorageBackend()
-    media_store = MediaStore(test_contractor.id)
+    media_store = MediaStore(test_user.id)
     await media_store.create(
         original_url="tg_file_id_789",
         mime_type="image/jpeg",
@@ -460,7 +460,7 @@ async def test_organize_file_without_client_returns_error(
         storage_path="/Unsorted/2026-03-02/file_001.jpg",
     )
 
-    tools = create_file_tools(test_contractor, storage)
+    tools = create_file_tools(test_user, storage)
     organize = tools[1].function
 
     result = await organize(

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -11,9 +11,9 @@ from any_llm.types.messages import MessageContentBlock, MessageResponse, Message
 
 from backend.app.agent.file_store import (
     ChecklistItem,
-    ContractorData,
     HeartbeatLogEntry,
     StoredMessage,
+    UserData,
 )
 from backend.app.agent.heartbeat import (
     COMPOSE_MESSAGE_TOOL,
@@ -31,7 +31,7 @@ from backend.app.agent.heartbeat import (
     is_within_business_hours,
     parse_frequency_to_minutes,
     run_cheap_checks,
-    run_heartbeat_for_contractor,
+    run_heartbeat_for_user,
 )
 from tests.mocks.llm import make_text_response, make_tool_call_response
 
@@ -41,8 +41,8 @@ from tests.mocks.llm import make_text_response, make_tool_call_response
 
 
 @pytest.fixture()
-def contractor() -> ContractorData:
-    return ContractorData(
+def user() -> UserData:
+    return UserData(
         id=1,
         user_id="hb-user-001",
         name="Mike the Plumber",
@@ -52,8 +52,8 @@ def contractor() -> ContractorData:
 
 
 @pytest.fixture()
-def contractor_no_hours() -> ContractorData:
-    return ContractorData(
+def user_no_hours() -> UserData:
+    return UserData(
         id=2,
         user_id="hb-user-002",
         name="Jane Electric",
@@ -63,8 +63,8 @@ def contractor_no_hours() -> ContractorData:
 
 
 @pytest.fixture()
-def contractor_with_timezone() -> ContractorData:
-    return ContractorData(
+def user_with_timezone() -> UserData:
+    return UserData(
         id=3,
         user_id="hb-user-003",
         name="Carlos Roofing",
@@ -132,37 +132,33 @@ class TestParseBusinessHours:
 
 class TestIsWithinBusinessHours:
     @patch("backend.app.agent.heartbeat.settings")
-    def test_outside_quiet_hours(
-        self, mock_settings: MagicMock, contractor: ContractorData
-    ) -> None:
+    def test_outside_quiet_hours(self, mock_settings: MagicMock, user: UserData) -> None:
         mock_settings.heartbeat_quiet_hours_start = 20
         mock_settings.heartbeat_quiet_hours_end = 7
 
         # 10 AM -- outside quiet hours, should be True
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(contractor, now) is True
+        assert is_within_business_hours(user, now) is True
 
     @patch("backend.app.agent.heartbeat.settings")
-    def test_inside_quiet_hours_evening(
-        self, mock_settings: MagicMock, contractor: ContractorData
-    ) -> None:
+    def test_inside_quiet_hours_evening(self, mock_settings: MagicMock, user: UserData) -> None:
         mock_settings.heartbeat_quiet_hours_start = 20
         mock_settings.heartbeat_quiet_hours_end = 7
 
         # 22:00 -- inside quiet hours, should be False
         now = datetime.datetime(2025, 6, 15, 22, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(contractor, now) is False
+        assert is_within_business_hours(user, now) is False
 
     @patch("backend.app.agent.heartbeat.settings")
     def test_inside_quiet_hours_early_morning(
-        self, mock_settings: MagicMock, contractor: ContractorData
+        self, mock_settings: MagicMock, user: UserData
     ) -> None:
         mock_settings.heartbeat_quiet_hours_start = 20
         mock_settings.heartbeat_quiet_hours_end = 7
 
         # 3 AM -- inside quiet hours, should be False
         now = datetime.datetime(2025, 6, 15, 3, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(contractor, now) is False
+        assert is_within_business_hours(user, now) is False
 
 
 class TestToLocalTime:
@@ -196,44 +192,42 @@ class TestIsWithinBusinessHoursTimezone:
 
     @patch("backend.app.agent.heartbeat.settings")
     def test_timezone_converts_before_quiet_check(
-        self, mock_settings: MagicMock, contractor_with_timezone: ContractorData
+        self, mock_settings: MagicMock, user_with_timezone: UserData
     ) -> None:
         mock_settings.heartbeat_quiet_hours_start = 20
         mock_settings.heartbeat_quiet_hours_end = 7
 
         # 2 PM UTC -> 7 AM Pacific (PDT). Outside quiet hours.
         now = datetime.datetime(2025, 6, 15, 14, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(contractor_with_timezone, now) is True
+        assert is_within_business_hours(user_with_timezone, now) is True
 
     @patch("backend.app.agent.heartbeat.settings")
     def test_utc_morning_is_night_in_pacific(
-        self, mock_settings: MagicMock, contractor_with_timezone: ContractorData
+        self, mock_settings: MagicMock, user_with_timezone: UserData
     ) -> None:
         mock_settings.heartbeat_quiet_hours_start = 20
         mock_settings.heartbeat_quiet_hours_end = 7
 
         # 5 AM UTC -> 10 PM Pacific (PDT, previous day). Inside quiet hours.
         now = datetime.datetime(2025, 6, 15, 5, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(contractor_with_timezone, now) is False
+        assert is_within_business_hours(user_with_timezone, now) is False
 
     @patch("backend.app.agent.heartbeat.settings")
-    def test_no_timezone_uses_utc(
-        self, mock_settings: MagicMock, contractor: ContractorData
-    ) -> None:
+    def test_no_timezone_uses_utc(self, mock_settings: MagicMock, user: UserData) -> None:
         mock_settings.heartbeat_quiet_hours_start = 20
         mock_settings.heartbeat_quiet_hours_end = 7
 
-        # Contractor without timezone uses UTC directly.
+        # User without timezone uses UTC directly.
         # 10 AM UTC, outside quiet hours.
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(contractor, now) is True
+        assert is_within_business_hours(user, now) is True
 
     @patch("backend.app.agent.heartbeat.settings")
     def test_invalid_timezone_falls_back_to_utc(self, mock_settings: MagicMock) -> None:
         mock_settings.heartbeat_quiet_hours_start = 20
         mock_settings.heartbeat_quiet_hours_end = 7
 
-        c = ContractorData(
+        c = UserData(
             id=99,
             user_id="hb-user-bad-tz",
             name="Bad TZ",
@@ -252,18 +246,18 @@ class TestIsWithinBusinessHoursTimezone:
 
 class TestRunCheapChecks:
     @pytest.mark.asyncio
-    async def test_no_flags_when_clean(self, contractor: ContractorData) -> None:
+    async def test_no_flags_when_clean(self, user: UserData) -> None:
         """No stale estimates, no checklist items, no time-sensitive memories."""
-        result = await run_cheap_checks(contractor)
+        result = await run_cheap_checks(user)
         assert not result.has_flags
         assert result.flags == []
 
     @pytest.mark.asyncio
-    async def test_stale_estimate_flagged(self, contractor: ContractorData) -> None:
+    async def test_stale_estimate_flagged(self, user: UserData) -> None:
         """Draft estimate older than 24h should be flagged."""
         from backend.app.agent.file_store import EstimateStore
 
-        store = EstimateStore(contractor.id)
+        store = EstimateStore(user.id)
         est = await store.create(
             description="Deck build for Smith",
             total_amount=3000,
@@ -276,18 +270,18 @@ class TestRunCheapChecks:
         _write_json(store._estimate_path(est.id), est.model_dump())
 
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        result = await run_cheap_checks(contractor, now=now)
+        result = await run_cheap_checks(user, now=now)
         assert result.has_flags
         assert len(result.stale_estimates) == 1
         assert "Deck build" in result.flags[0]
 
     @pytest.mark.asyncio
-    async def test_recent_draft_not_flagged(self, contractor: ContractorData) -> None:
+    async def test_recent_draft_not_flagged(self, user: UserData) -> None:
         """Draft estimate less than 24h old should NOT be flagged."""
         from backend.app.agent.file_store import EstimateStore, _write_json
 
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        store = EstimateStore(contractor.id)
+        store = EstimateStore(user.id)
         est = await store.create(
             description="Fresh estimate",
             total_amount=1000,
@@ -296,16 +290,16 @@ class TestRunCheapChecks:
         est.created_at = (now - datetime.timedelta(hours=12)).isoformat()
         _write_json(store._estimate_path(est.id), est.model_dump())
 
-        result = await run_cheap_checks(contractor, now=now)
+        result = await run_cheap_checks(user, now=now)
         assert not result.has_flags
         assert len(result.stale_estimates) == 0
 
     @pytest.mark.asyncio
-    async def test_sent_estimate_not_flagged(self, contractor: ContractorData) -> None:
+    async def test_sent_estimate_not_flagged(self, user: UserData) -> None:
         """Sent estimates should not be flagged regardless of age."""
         from backend.app.agent.file_store import EstimateStore, _write_json
 
-        store = EstimateStore(contractor.id)
+        store = EstimateStore(user.id)
         est = await store.create(
             description="Already sent",
             total_amount=5000,
@@ -315,81 +309,81 @@ class TestRunCheapChecks:
         _write_json(store._estimate_path(est.id), est.model_dump())
 
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        result = await run_cheap_checks(contractor, now=now)
+        result = await run_cheap_checks(user, now=now)
         assert not result.has_flags
 
     @pytest.mark.asyncio
-    async def test_checklist_item_due(self, contractor: ContractorData) -> None:
+    async def test_checklist_item_due(self, user: UserData) -> None:
         """Active checklist item with no last_triggered_at should be flagged."""
         from backend.app.agent.file_store import HeartbeatStore
 
-        store = HeartbeatStore(contractor.id)
+        store = HeartbeatStore(user.id)
         await store.add_checklist_item(
             description="Check material prices",
             schedule="daily",
         )
 
-        result = await run_cheap_checks(contractor)
+        result = await run_cheap_checks(user)
         assert result.has_flags
         assert len(result.due_checklist_items) == 1
         assert "material prices" in result.flags[0]
 
     @pytest.mark.asyncio
-    async def test_checklist_item_paused_not_flagged(self, contractor: ContractorData) -> None:
+    async def test_checklist_item_paused_not_flagged(self, user: UserData) -> None:
         """Paused checklist items should not be flagged."""
         from backend.app.agent.file_store import HeartbeatStore
 
-        store = HeartbeatStore(contractor.id)
+        store = HeartbeatStore(user.id)
         item = await store.add_checklist_item(
             description="Paused item",
             schedule="daily",
         )
         await store.update_checklist_item(item.id, status="paused")
 
-        result = await run_cheap_checks(contractor)
+        result = await run_cheap_checks(user)
         assert not result.has_flags
 
     @pytest.mark.asyncio
-    async def test_time_sensitive_memory_flagged(self, contractor: ContractorData) -> None:
+    async def test_time_sensitive_memory_flagged(self, user: UserData) -> None:
         """Memory facts with time-sensitive keywords should be flagged."""
         from backend.app.agent.file_store import get_memory_store
 
-        store = get_memory_store(contractor.id)
+        store = get_memory_store(user.id)
         await store.save_memory(
             key="smith_followup",
             value="Follow up with Smith about deck quote",
             category="client",
         )
 
-        result = await run_cheap_checks(contractor)
+        result = await run_cheap_checks(user)
         assert result.has_flags
         assert len(result.time_sensitive_memories) == 1
         assert "smith_followup" in result.flags[0]
 
     @pytest.mark.asyncio
-    async def test_regular_memory_not_flagged(self, contractor: ContractorData) -> None:
+    async def test_regular_memory_not_flagged(self, user: UserData) -> None:
         """Memory facts without time-sensitive keywords should not be flagged."""
         from backend.app.agent.file_store import get_memory_store
 
-        store = get_memory_store(contractor.id)
+        store = get_memory_store(user.id)
         await store.save_memory(
             key="kitchen_rate",
             value="Standard kitchen remodel rate is $150/hour",
             category="pricing",
         )
 
-        result = await run_cheap_checks(contractor)
+        result = await run_cheap_checks(user)
         assert not result.has_flags
 
     @pytest.mark.asyncio
-    async def test_multiple_flags_combined(self, contractor: ContractorData) -> None:
+    async def test_multiple_flags_combined(self, user: UserData) -> None:
         """Multiple issues should produce multiple flags."""
         from backend.app.agent.file_store import EstimateStore, HeartbeatStore, _write_json
 
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
 
         # Stale estimate
-        est_store = EstimateStore(contractor.id)
+        est_store = EstimateStore(user.id)
         est = await est_store.create(
             description="Old estimate",
             total_amount=2000,
@@ -399,23 +393,23 @@ class TestRunCheapChecks:
         _write_json(est_store._estimate_path(est.id), est.model_dump())
 
         # Due checklist item
-        hb_store = HeartbeatStore(contractor.id)
+        hb_store = HeartbeatStore(user.id)
         await hb_store.add_checklist_item(
             description="Check inbox",
             schedule="daily",
         )
 
-        result = await run_cheap_checks(contractor, now=now)
+        result = await run_cheap_checks(user, now=now)
         assert result.has_flags
         assert len(result.flags) == 2
 
     @pytest.mark.asyncio
-    async def test_idle_contractor_flagged(self, contractor: ContractorData) -> None:
-        """Contractor with last inbound message older than idle_days should be flagged."""
+    async def test_idle_user_flagged(self, user: UserData) -> None:
+        """User with last inbound message older than idle_days should be flagged."""
         from backend.app.agent.file_store import get_session_store
 
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        store = get_session_store(contractor.id)
+        store = get_session_store(user.id)
 
         session, _ = await store.get_or_create_session()
         # Write a backdated inbound message directly to the JSONL file
@@ -429,19 +423,19 @@ class TestRunCheapChecks:
         )
         _append_jsonl(store._session_path(session.session_id), msg.model_dump())
 
-        result = await run_cheap_checks(contractor, now=now)
+        result = await run_cheap_checks(user, now=now)
         assert result.has_flags
         idle_flags = [f for f in result.flags if "idle" in f.lower()]
         assert len(idle_flags) == 1
         assert "5 days" in idle_flags[0]
 
     @pytest.mark.asyncio
-    async def test_active_contractor_not_flagged_idle(self, contractor: ContractorData) -> None:
-        """Contractor with recent inbound message should not be flagged as idle."""
+    async def test_active_user_not_flagged_idle(self, user: UserData) -> None:
+        """User with recent inbound message should not be flagged as idle."""
         from backend.app.agent.file_store import _append_jsonl, get_session_store
 
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        store = get_session_store(contractor.id)
+        store = get_session_store(user.id)
 
         session, _ = await store.get_or_create_session()
         msg = StoredMessage(
@@ -452,15 +446,15 @@ class TestRunCheapChecks:
         )
         _append_jsonl(store._session_path(session.session_id), msg.model_dump())
 
-        result = await run_cheap_checks(contractor, now=now)
+        result = await run_cheap_checks(user, now=now)
         idle_flags = [f for f in result.flags if "idle" in f.lower()]
         assert len(idle_flags) == 0
 
     @pytest.mark.asyncio
-    async def test_no_messages_old_contractor_flagged(self) -> None:
-        """Contractor with no messages who was created more than idle_days ago should be flagged."""
+    async def test_no_messages_old_user_flagged(self) -> None:
+        """User with no messages who was created more than idle_days ago should be flagged."""
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        c = ContractorData(
+        c = UserData(
             id=50,
             user_id="hb-idle-001",
             name="Old Timer",
@@ -476,10 +470,10 @@ class TestRunCheapChecks:
         assert "onboarding" in idle_flags[0]
 
     @pytest.mark.asyncio
-    async def test_no_messages_new_contractor_not_flagged(self) -> None:
-        """Contractor with no messages who just onboarded should not be flagged as idle."""
+    async def test_no_messages_new_user_not_flagged(self) -> None:
+        """User with no messages who just onboarded should not be flagged as idle."""
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        c = ContractorData(
+        c = UserData(
             id=51,
             user_id="hb-new-001",
             name="Fresh Start",
@@ -493,15 +487,15 @@ class TestRunCheapChecks:
         assert len(idle_flags) == 0
 
     @pytest.mark.asyncio
-    async def test_outbound_only_still_flagged_idle(self, contractor: ContractorData) -> None:
-        """Contractor with only outbound messages (no inbound) should check created_at."""
+    async def test_outbound_only_still_flagged_idle(self, user: UserData) -> None:
+        """User with only outbound messages (no inbound) should check created_at."""
         from backend.app.agent.file_store import _append_jsonl, get_session_store
 
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        # Backdate the contractor's created_at
-        contractor.created_at = now - datetime.timedelta(days=5)
+        # Backdate the user's created_at
+        user.created_at = now - datetime.timedelta(days=5)
 
-        store = get_session_store(contractor.id)
+        store = get_session_store(user.id)
         session, _ = await store.get_or_create_session()
         msg = StoredMessage(
             direction="outbound",
@@ -511,7 +505,7 @@ class TestRunCheapChecks:
         )
         _append_jsonl(store._session_path(session.session_id), msg.model_dump())
 
-        result = await run_cheap_checks(contractor, now=now)
+        result = await run_cheap_checks(user, now=now)
         idle_flags = [f for f in result.flags if "idle" in f.lower()]
         assert len(idle_flags) == 1
         assert "onboarding" in idle_flags[0]
@@ -526,7 +520,7 @@ class TestIsChecklistItemDue:
     def test_never_triggered(self) -> None:
         """Item that has never been triggered is always due."""
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Test",
             schedule="daily",
             last_triggered_at=None,
@@ -538,7 +532,7 @@ class TestIsChecklistItemDue:
         """Daily item triggered 2 hours ago should not be due."""
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Test",
             schedule="daily",
             last_triggered_at=(now - datetime.timedelta(hours=2)).isoformat(),
@@ -549,7 +543,7 @@ class TestIsChecklistItemDue:
         """Daily item triggered 24 hours ago should be due."""
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Test",
             schedule="daily",
             last_triggered_at=(now - datetime.timedelta(hours=24)).isoformat(),
@@ -560,7 +554,7 @@ class TestIsChecklistItemDue:
         """Once-scheduled item that was already triggered is never due again."""
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Test",
             schedule="once",
             last_triggered_at=(now - datetime.timedelta(hours=1)).isoformat(),
@@ -572,7 +566,7 @@ class TestIsChecklistItemDue:
         # 2025-06-14 is a Saturday
         saturday = datetime.datetime(2025, 6, 14, 10, 0, tzinfo=datetime.UTC)
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Test",
             schedule="weekdays",
             last_triggered_at=None,
@@ -584,7 +578,7 @@ class TestIsChecklistItemDue:
         # 2025-06-16 is a Monday
         monday = datetime.datetime(2025, 6, 16, 10, 0, tzinfo=datetime.UTC)
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Test",
             schedule="weekdays",
             last_triggered_at=None,
@@ -597,7 +591,7 @@ class TestIsChecklistItemDue:
         # Simulate naive datetime as ISO string (no tz info)
         naive_last = "2025-06-14T08:00:00"
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Test",
             schedule="daily",
             last_triggered_at=naive_last,
@@ -609,14 +603,14 @@ class TestIsChecklistItemDue:
         """Weekday item should fire when UTC is Saturday but local time is still Friday.
 
         Regression test: before this fix, _is_checklist_item_due checked
-        now.weekday() in UTC. A contractor in America/Los_Angeles at 5 PM
+        now.weekday() in UTC. A user in America/Los_Angeles at 5 PM
         Friday Pacific (00:00 Saturday UTC) would have the weekday gate
         incorrectly skip the item.
         """
         # Saturday 00:00 UTC = Friday 5:00 PM Pacific (PDT, UTC-7)
         saturday_utc = datetime.datetime(2025, 6, 14, 0, 0, tzinfo=datetime.UTC)
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Weekly check-in",
             schedule="weekdays",
             last_triggered_at=None,
@@ -631,7 +625,7 @@ class TestIsChecklistItemDue:
         # Sunday 10 AM Pacific = Sunday 5 PM UTC
         sunday_utc = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
         item = ChecklistItem(
-            contractor_id=1,
+            user_id=1,
             description="Test",
             schedule="weekdays",
             last_triggered_at=None,
@@ -855,7 +849,7 @@ class TestEvaluateHeartbeatNeed:
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
         mock_settings.llm_provider = "openai"
@@ -869,7 +863,7 @@ class TestEvaluateHeartbeatNeed:
             reasoning="Nothing actionable",
             priority=1,
         )
-        action = await evaluate_heartbeat_need(contractor, ["Stale draft estimate"])
+        action = await evaluate_heartbeat_need(user, ["Stale draft estimate"])
         assert action.action_type == "no_action"
         assert action.message == ""
 
@@ -880,7 +874,7 @@ class TestEvaluateHeartbeatNeed:
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
         mock_settings.llm_provider = "openai"
@@ -894,7 +888,7 @@ class TestEvaluateHeartbeatNeed:
             reasoning="Stale draft estimate",
             priority=4,
         )
-        action = await evaluate_heartbeat_need(contractor, ["Stale draft estimate"])
+        action = await evaluate_heartbeat_need(user, ["Stale draft estimate"])
         assert action.action_type == "send_message"
         assert "draft estimate" in action.message
 
@@ -905,7 +899,7 @@ class TestEvaluateHeartbeatNeed:
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
     ) -> None:
         """When heartbeat_model is configured, it should be used instead of llm_model."""
         mock_settings.llm_model = "gpt-4o"
@@ -917,7 +911,7 @@ class TestEvaluateHeartbeatNeed:
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action", message="", reasoning="", priority=1
         )
-        await evaluate_heartbeat_need(contractor, ["test flag"])
+        await evaluate_heartbeat_need(user, ["test flag"])
 
         # Verify the cheap model was used
         call_kwargs = mock_llm.call_args
@@ -930,7 +924,7 @@ class TestEvaluateHeartbeatNeed:
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
     ) -> None:
         """Regression test: acompletion must receive api_base, not api_key."""
         mock_settings.llm_model = "gpt-4o"
@@ -942,7 +936,7 @@ class TestEvaluateHeartbeatNeed:
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action", message="", reasoning="test", priority=1
         )
-        await evaluate_heartbeat_need(contractor, ["test flag"])
+        await evaluate_heartbeat_need(user, ["test flag"])
         _, kwargs = mock_llm.call_args
         assert "api_base" in kwargs
         assert kwargs["api_base"] == "http://localhost:1234/v1"
@@ -955,7 +949,7 @@ class TestEvaluateHeartbeatNeed:
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
     ) -> None:
         """If LLM returns text instead of tool call, default to no_action."""
         mock_settings.llm_model = "gpt-4o"
@@ -965,7 +959,7 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_provider = ""
         mock_settings.llm_max_tokens_heartbeat = 256
         mock_llm.return_value = make_text_response("I'm not sure what to do {broken json")
-        action = await evaluate_heartbeat_need(contractor, ["test flag"])
+        action = await evaluate_heartbeat_need(user, ["test flag"])
         assert action.action_type == "no_action"
         assert action.priority == 0
 
@@ -976,7 +970,7 @@ class TestEvaluateHeartbeatNeed:
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
     ) -> None:
         """acompletion should receive tools=[COMPOSE_MESSAGE_TOOL]."""
         mock_settings.llm_model = "gpt-4o"
@@ -988,7 +982,7 @@ class TestEvaluateHeartbeatNeed:
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action", message="", reasoning="test", priority=1
         )
-        await evaluate_heartbeat_need(contractor, ["test flag"])
+        await evaluate_heartbeat_need(user, ["test flag"])
         _, kwargs = mock_llm.call_args
         assert "tools" in kwargs
         assert kwargs["tools"] == [COMPOSE_MESSAGE_TOOL]
@@ -1000,7 +994,7 @@ class TestEvaluateHeartbeatNeed:
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
     ) -> None:
         """System prompt should not contain 'Respond with ONLY a JSON object'."""
         mock_settings.llm_model = "gpt-4o"
@@ -1012,7 +1006,7 @@ class TestEvaluateHeartbeatNeed:
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action", message="", reasoning="test", priority=1
         )
-        await evaluate_heartbeat_need(contractor, ["test flag"])
+        await evaluate_heartbeat_need(user, ["test flag"])
         call_args = mock_llm.call_args
         system_content = call_args.kwargs["system"]
         assert "Respond with ONLY a JSON object" not in system_content
@@ -1020,15 +1014,15 @@ class TestEvaluateHeartbeatNeed:
 
 
 # ---------------------------------------------------------------------------
-# run_heartbeat_for_contractor
+# run_heartbeat_for_user
 # ---------------------------------------------------------------------------
 
 
-class TestRunHeartbeatForContractor:
+class TestRunHeartbeatForUser:
     @pytest.mark.asyncio
     async def test_skip_not_onboarded(self, mock_messaging: MagicMock) -> None:
-        c = ContractorData(id=10, user_id="hb-new", phone="+15550000000", onboarding_complete=False)
-        result = await run_heartbeat_for_contractor(c, mock_messaging, 5)
+        c = UserData(id=10, user_id="hb-new", phone="+15550000000", onboarding_complete=False)
+        result = await run_heartbeat_for_user(c, mock_messaging, 5)
         assert result is None
         mock_messaging.send_text.assert_not_called()
 
@@ -1037,10 +1031,10 @@ class TestRunHeartbeatForContractor:
     async def test_skip_outside_hours(
         self,
         _mock_hours: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
         mock_messaging: MagicMock,
     ) -> None:
-        result = await run_heartbeat_for_contractor(contractor, mock_messaging, 5)
+        result = await run_heartbeat_for_user(user, mock_messaging, 5)
         assert result is None
 
     @pytest.mark.asyncio
@@ -1050,11 +1044,11 @@ class TestRunHeartbeatForContractor:
         self,
         mock_count: AsyncMock,
         _mock_hours: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
         mock_messaging: MagicMock,
     ) -> None:
         mock_count.return_value = 5
-        result = await run_heartbeat_for_contractor(contractor, mock_messaging, 5)
+        result = await run_heartbeat_for_user(user, mock_messaging, 5)
         assert result is None
 
     @pytest.mark.asyncio
@@ -1062,11 +1056,11 @@ class TestRunHeartbeatForContractor:
     async def test_no_action_when_checks_clean(
         self,
         _mock_hours: MagicMock,
-        contractor: ContractorData,
+        user: UserData,
         mock_messaging: MagicMock,
     ) -> None:
         """When cheap checks return no flags, LLM is skipped and no message sent."""
-        result = await run_heartbeat_for_contractor(contractor, mock_messaging, 5)
+        result = await run_heartbeat_for_user(user, mock_messaging, 5)
         assert result is not None
         assert result.action_type == "no_action"
         assert "cheap checks clean" in result.reasoning
@@ -1081,7 +1075,7 @@ class TestRunHeartbeatForContractor:
         _mock_hours: MagicMock,
         mock_checks: AsyncMock,
         mock_eval: AsyncMock,
-        contractor: ContractorData,
+        user: UserData,
         mock_messaging: MagicMock,
     ) -> None:
         """When cheap checks flag something and LLM says send, message is delivered."""
@@ -1095,16 +1089,16 @@ class TestRunHeartbeatForContractor:
             reasoning="Stale draft",
             priority=4,
         )
-        result = await run_heartbeat_for_contractor(contractor, mock_messaging, 5)
+        result = await run_heartbeat_for_user(user, mock_messaging, 5)
 
         assert result is not None
         assert result.action_type == "send_message"
         mock_messaging.send_text.assert_awaited_once_with(
-            to=contractor.phone, body="Reminder: draft estimate pending!"
+            to=user.phone, body="Reminder: draft estimate pending!"
         )
         # LLM was called with the flags
         mock_eval.assert_awaited_once_with(
-            contractor, ["Stale draft estimate"], messaging_service=mock_messaging
+            user, ["Stale draft estimate"], messaging_service=mock_messaging
         )
 
     @pytest.mark.asyncio
@@ -1116,7 +1110,7 @@ class TestRunHeartbeatForContractor:
         _mock_hours: MagicMock,
         mock_checks: AsyncMock,
         mock_eval: AsyncMock,
-        contractor: ContractorData,
+        user: UserData,
         mock_messaging: MagicMock,
     ) -> None:
         mock_checks.return_value = CheapCheckResult(flags=["test flag"])
@@ -1127,7 +1121,7 @@ class TestRunHeartbeatForContractor:
             priority=3,
         )
         mock_messaging.send_text = AsyncMock(side_effect=Exception("Messaging service down"))
-        result = await run_heartbeat_for_contractor(contractor, mock_messaging, 5)
+        result = await run_heartbeat_for_user(user, mock_messaging, 5)
         # Should still return the action, just not record a message
         assert result is not None
         assert result.action_type == "send_message"
@@ -1141,14 +1135,14 @@ class TestRunHeartbeatForContractor:
         _mock_hours: MagicMock,
         mock_checks: AsyncMock,
         mock_eval: AsyncMock,
-        contractor: ContractorData,
+        user: UserData,
         mock_messaging: MagicMock,
     ) -> None:
         """After sending a message, due checklist items should be marked as triggered."""
         from backend.app.agent.file_store import HeartbeatStore
 
         # Write the item to disk so the runner can update it
-        hb_store = HeartbeatStore(contractor.id)
+        hb_store = HeartbeatStore(user.id)
         item = await hb_store.add_checklist_item(
             description="Check inbox",
             schedule="daily",
@@ -1164,7 +1158,7 @@ class TestRunHeartbeatForContractor:
             reasoning="checklist",
             priority=3,
         )
-        await run_heartbeat_for_contractor(contractor, mock_messaging, 5)
+        await run_heartbeat_for_user(user, mock_messaging, 5)
 
         # Read back from disk to verify the item was updated
         updated_items = await hb_store.get_checklist()
@@ -1181,14 +1175,14 @@ class TestRunHeartbeatForContractor:
         _mock_hours: MagicMock,
         mock_checks: AsyncMock,
         mock_eval: AsyncMock,
-        contractor: ContractorData,
+        user: UserData,
         mock_messaging: MagicMock,
     ) -> None:
         """A once-scheduled checklist item should be marked completed after triggering."""
         from backend.app.agent.file_store import HeartbeatStore
 
         # Write the item to disk so the runner can update it
-        hb_store = HeartbeatStore(contractor.id)
+        hb_store = HeartbeatStore(user.id)
         item = await hb_store.add_checklist_item(
             description="Remind about meeting",
             schedule="once",
@@ -1204,7 +1198,7 @@ class TestRunHeartbeatForContractor:
             reasoning="once item",
             priority=4,
         )
-        await run_heartbeat_for_contractor(contractor, mock_messaging, 5)
+        await run_heartbeat_for_user(user, mock_messaging, 5)
 
         # Read back from disk to verify the item was updated
         updated_items = await hb_store.get_checklist()
@@ -1220,40 +1214,40 @@ class TestRunHeartbeatForContractor:
 
 class TestGetDailyHeartbeatCount:
     @pytest.mark.asyncio
-    async def test_zero_when_no_logs(self, contractor: ContractorData) -> None:
-        assert await get_daily_heartbeat_count(contractor.id) == 0
+    async def test_zero_when_no_logs(self, user: UserData) -> None:
+        assert await get_daily_heartbeat_count(user.id) == 0
 
     @pytest.mark.asyncio
-    async def test_counts_today_only(self, contractor: ContractorData) -> None:
+    async def test_counts_today_only(self, user: UserData) -> None:
         """Logs from yesterday should not count toward today's limit."""
         from backend.app.agent.file_store import HeartbeatStore, _append_jsonl
 
-        store = HeartbeatStore(contractor.id)
+        store = HeartbeatStore(user.id)
         # Add a log from today
         await store.log_heartbeat()
         # Add a log from yesterday directly to the JSONL file
         yesterday = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
-        entry = HeartbeatLogEntry(contractor_id=contractor.id, created_at=yesterday.isoformat())
+        entry = HeartbeatLogEntry(user_id=user.id, created_at=yesterday.isoformat())
         _append_jsonl(store._log_path, entry.model_dump())
 
-        assert await get_daily_heartbeat_count(contractor.id) == 1
+        assert await get_daily_heartbeat_count(user.id) == 1
 
     @pytest.mark.asyncio
-    async def test_counts_multiple_today(self, contractor: ContractorData) -> None:
+    async def test_counts_multiple_today(self, user: UserData) -> None:
         from backend.app.agent.file_store import HeartbeatStore
 
-        store = HeartbeatStore(contractor.id)
+        store = HeartbeatStore(user.id)
         for _ in range(3):
             await store.log_heartbeat()
 
-        assert await get_daily_heartbeat_count(contractor.id) == 3
+        assert await get_daily_heartbeat_count(user.id) == 3
 
     @pytest.mark.asyncio
-    async def test_scoped_to_contractor(self, contractor: ContractorData) -> None:
-        """Logs from other contractors should not count."""
+    async def test_scoped_to_user(self, user: UserData) -> None:
+        """Logs from other users should not count."""
         from backend.app.agent.file_store import HeartbeatStore
 
-        other = ContractorData(
+        other = UserData(
             id=60,
             user_id="hb-other",
             phone="+15551112222",
@@ -1263,7 +1257,7 @@ class TestGetDailyHeartbeatCount:
         other_store = HeartbeatStore(other.id)
         await other_store.log_heartbeat()
 
-        assert await get_daily_heartbeat_count(contractor.id) == 0
+        assert await get_daily_heartbeat_count(user.id) == 0
         assert await get_daily_heartbeat_count(other.id) == 1
 
 
@@ -1274,12 +1268,12 @@ class TestGetDailyHeartbeatCount:
 
 class TestBuildHeartbeatContext:
     @pytest.mark.asyncio
-    async def test_includes_profile_and_flags(self, contractor: ContractorData) -> None:
+    async def test_includes_profile_and_flags(self, user: UserData) -> None:
         from backend.app.agent.file_store import get_session_store
         from backend.app.enums import MessageDirection
 
         # Add a session with a message so context builder works
-        store = get_session_store(contractor.id)
+        store = get_session_store(user.id)
         session, _ = await store.get_or_create_session()
         await store.add_message(
             session=session,
@@ -1288,7 +1282,7 @@ class TestBuildHeartbeatContext:
         )
 
         flags = ["Stale draft estimate: Kitchen remodel"]
-        prompt = await build_heartbeat_context(contractor, flags)
+        prompt = await build_heartbeat_context(user, flags)
 
         # build_heartbeat_context now returns a full prompt string
         assert "Plumber" in prompt
@@ -1315,12 +1309,12 @@ class TestHeartbeatScheduler:
         assert scheduler._task is None
 
     @pytest.mark.asyncio
-    @patch("backend.app.agent.heartbeat.get_contractor_store")
+    @patch("backend.app.agent.heartbeat.get_user_store")
     @patch("backend.app.agent.heartbeat.get_default_channel")
     async def test_tick_queries_onboarded(
         self, mock_messaging_cls: MagicMock, mock_get_store: MagicMock
     ) -> None:
-        """Tick should query all contractors via list_all and filter by onboarding_complete."""
+        """Tick should query all users via list_all and filter by onboarding_complete."""
         mock_store = AsyncMock()
         mock_store.list_all.return_value = []
         mock_get_store.return_value = mock_store
@@ -1331,8 +1325,8 @@ class TestHeartbeatScheduler:
         mock_store.list_all.assert_awaited_once()
 
     @pytest.mark.asyncio
-    @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
-    @patch("backend.app.agent.heartbeat.get_contractor_store")
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.get_user_store")
     @patch("backend.app.agent.heartbeat.get_default_channel")
     @patch("backend.app.agent.heartbeat.settings")
     async def test_tick_concurrent_processing(
@@ -1342,21 +1336,21 @@ class TestHeartbeatScheduler:
         mock_get_store: MagicMock,
         mock_run: AsyncMock,
     ) -> None:
-        """tick() should process multiple contractors concurrently."""
+        """tick() should process multiple users concurrently."""
         mock_settings.heartbeat_concurrency = 2
         mock_settings.heartbeat_max_daily_messages = 5
 
-        # Create mock contractors
-        contractors = []
+        # Create mock users
+        users = []
         for i in range(4):
             c = MagicMock()
             c.id = i + 1
             c.onboarding_complete = True
             c.preferred_channel = "telegram"
-            contractors.append(c)
+            users.append(c)
 
         mock_store = AsyncMock()
-        mock_store.list_all.return_value = contractors
+        mock_store.list_all.return_value = users
         mock_get_store.return_value = mock_store
 
         mock_run.return_value = None
@@ -1364,12 +1358,12 @@ class TestHeartbeatScheduler:
         scheduler = HeartbeatScheduler()
         await scheduler.tick()
 
-        # run_heartbeat_for_contractor called once per contractor
-        assert mock_run.await_count == len(contractors)
+        # run_heartbeat_for_user called once per user
+        assert mock_run.await_count == len(users)
 
     @pytest.mark.asyncio
-    @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
-    @patch("backend.app.agent.heartbeat.get_contractor_store")
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.get_user_store")
     @patch("backend.app.agent.heartbeat.get_default_channel")
     @patch("backend.app.agent.heartbeat.settings")
     async def test_tick_error_isolation(
@@ -1379,23 +1373,23 @@ class TestHeartbeatScheduler:
         mock_get_store: MagicMock,
         mock_run: AsyncMock,
     ) -> None:
-        """One contractor failure should not prevent others from being processed."""
+        """One user failure should not prevent others from being processed."""
         mock_settings.heartbeat_concurrency = 5
         mock_settings.heartbeat_max_daily_messages = 5
 
-        contractors = []
+        users = []
         for i in range(3):
             c = MagicMock()
             c.id = i + 1
             c.onboarding_complete = True
             c.preferred_channel = "telegram"
-            contractors.append(c)
+            users.append(c)
 
         mock_store = AsyncMock()
-        mock_store.list_all.return_value = contractors
+        mock_store.list_all.return_value = users
         mock_get_store.return_value = mock_store
 
-        # Second contractor raises, others succeed
+        # Second user raises, others succeed
         mock_run.side_effect = [
             HeartbeatAction("no_action", "", "clean", 0),
             RuntimeError("LLM timeout"),
@@ -1403,15 +1397,15 @@ class TestHeartbeatScheduler:
         ]
 
         scheduler = HeartbeatScheduler()
-        # Should not raise despite one contractor failing
+        # Should not raise despite one user failing
         await scheduler.tick()
 
         # All three were attempted
         assert mock_run.await_count == 3
 
     @pytest.mark.asyncio
-    @patch("backend.app.agent.heartbeat.run_heartbeat_for_contractor")
-    @patch("backend.app.agent.heartbeat.get_contractor_store")
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.get_user_store")
     @patch("backend.app.agent.heartbeat.get_default_channel")
     @patch("backend.app.agent.heartbeat.settings")
     async def test_tick_semaphore_limits_concurrency(
@@ -1421,21 +1415,21 @@ class TestHeartbeatScheduler:
         mock_get_store: MagicMock,
         mock_run: AsyncMock,
     ) -> None:
-        """Semaphore should limit the number of concurrent contractor evaluations."""
+        """Semaphore should limit the number of concurrent user evaluations."""
         concurrency_limit = 2
         mock_settings.heartbeat_concurrency = concurrency_limit
         mock_settings.heartbeat_max_daily_messages = 5
 
-        contractors = []
+        users = []
         for i in range(5):
             c = MagicMock()
             c.id = i + 1
             c.onboarding_complete = True
             c.preferred_channel = "telegram"
-            contractors.append(c)
+            users.append(c)
 
         mock_store = AsyncMock()
-        mock_store.list_all.return_value = contractors
+        mock_store.list_all.return_value = users
         mock_get_store.return_value = mock_store
 
         # Track max concurrent executions
@@ -1466,12 +1460,12 @@ class TestHeartbeatScheduler:
         assert max_concurrent <= concurrency_limit
 
     @pytest.mark.asyncio
-    @patch("backend.app.agent.heartbeat.get_contractor_store")
+    @patch("backend.app.agent.heartbeat.get_user_store")
     @patch("backend.app.agent.heartbeat.get_default_channel")
-    async def test_tick_no_contractors(
+    async def test_tick_no_users(
         self, mock_messaging_cls: MagicMock, mock_get_store: MagicMock
     ) -> None:
-        """tick() with no onboarded contractors should return early."""
+        """tick() with no onboarded users should return early."""
         mock_store = AsyncMock()
         mock_store.list_all.return_value = []
         mock_get_store.return_value = mock_store

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,10 +8,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from backend.app.agent.file_store import (
-    ContractorData,
     StoredMessage,
-    get_contractor_store,
+    UserData,
     get_session_store,
+    get_user_store,
 )
 from backend.app.agent.ingestion import InboundMessage, process_inbound_from_bus
 from backend.app.bus import message_bus
@@ -19,22 +19,22 @@ from backend.app.services.messaging import MessagingService
 from tests.mocks.llm import make_text_response
 
 
-async def _get_all_messages(contractor_id: int) -> list[StoredMessage]:
-    """Helper to retrieve all stored messages for a contractor."""
-    store = get_session_store(contractor_id)
+async def _get_all_messages(user_id: int) -> list[StoredMessage]:
+    """Helper to retrieve all stored messages for a user."""
+    store = get_session_store(user_id)
     session, _is_new = await store.get_or_create_session()
     return list(session.messages)
 
 
 @pytest.mark.asyncio
 async def test_full_message_round_trip(
-    test_contractor: ContractorData,
+    test_user: UserData,
     mock_messaging_service: MessagingService,
 ) -> None:
     """End-to-end: inbound message -> agent processes -> outbound reply stored."""
     inbound = InboundMessage(
         channel="telegram",
-        sender_id=test_contractor.channel_identifier,
+        sender_id=test_user.channel_identifier,
         text="I need a quote for a 12x12 composite deck",
     )
 
@@ -49,7 +49,7 @@ async def test_full_message_round_trip(
         await process_inbound_from_bus(inbound, mock_messaging_service)
 
     # Verify inbound message stored
-    messages = await _get_all_messages(test_contractor.id)
+    messages = await _get_all_messages(test_user.id)
     inbound_msgs = [m for m in messages if m.direction == "inbound"]
     assert len(inbound_msgs) == 1
     assert inbound_msgs[0].body == "I need a quote for a 12x12 composite deck"
@@ -70,10 +70,10 @@ async def test_full_message_round_trip(
 
 
 @pytest.mark.asyncio
-async def test_full_message_round_trip_new_contractor(
+async def test_full_message_round_trip_new_user(
     mock_messaging_service: MessagingService,
 ) -> None:
-    """New contractor sends message -> auto-created -> agent replies."""
+    """New user sends message -> auto-created -> agent replies."""
     inbound = InboundMessage(
         channel="telegram",
         sender_id="777888999",
@@ -90,13 +90,13 @@ async def test_full_message_round_trip_new_contractor(
     ):
         await process_inbound_from_bus(inbound, mock_messaging_service)
 
-    # Contractor was auto-created
-    store = get_contractor_store()
-    contractor = await store.get_by_channel("777888999")
-    assert contractor is not None
+    # User was auto-created
+    store = get_user_store()
+    user = await store.get_by_channel("777888999")
+    assert user is not None
 
     # Messages stored
-    messages = await _get_all_messages(contractor.id)
+    messages = await _get_all_messages(user.id)
     assert len(messages) == 2  # inbound + outbound
     directions = {m.direction for m in messages}
     assert directions == {"inbound", "outbound"}
@@ -104,13 +104,13 @@ async def test_full_message_round_trip_new_contractor(
 
 @pytest.mark.asyncio
 async def test_full_message_agent_failure_still_stores_inbound(
-    test_contractor: ContractorData,
+    test_user: UserData,
     mock_messaging_service: MessagingService,
 ) -> None:
     """If the agent pipeline fails, inbound is stored but fallback is not."""
     inbound = InboundMessage(
         channel="telegram",
-        sender_id=test_contractor.channel_identifier,
+        sender_id=test_user.channel_identifier,
         text="Hello",
     )
 
@@ -125,7 +125,7 @@ async def test_full_message_agent_failure_still_stores_inbound(
         await process_inbound_from_bus(inbound, mock_messaging_service)
 
     # Inbound message still stored
-    messages = await _get_all_messages(test_contractor.id)
+    messages = await _get_all_messages(test_user.id)
     inbound_msgs = [m for m in messages if m.direction == "inbound"]
     assert len(inbound_msgs) == 1
 

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -8,7 +8,7 @@ import pytest
 from any_llm.types.messages import MessageResponse, MessageUsage
 
 from backend.app.agent.core import ClawboltAgent
-from backend.app.agent.file_store import ContractorData, LLMUsageStore, _read_jsonl
+from backend.app.agent.file_store import LLMUsageStore, UserData, _read_jsonl
 from backend.app.services.llm_usage import log_llm_usage
 from tests.mocks.llm import make_text_response
 
@@ -34,21 +34,21 @@ def _make_response_with_usage(
     return resp
 
 
-def _read_usage_entries(contractor_id: int) -> list[dict[str, object]]:
-    """Read all LLM usage entries for a contractor."""
-    store = LLMUsageStore(contractor_id)
+def _read_usage_entries(user_id: int) -> list[dict[str, object]]:
+    """Read all LLM usage entries for a user."""
+    store = LLMUsageStore(user_id)
     return _read_jsonl(store._path)
 
 
-def test_log_llm_usage_saves(test_contractor: ContractorData) -> None:
+def test_log_llm_usage_saves(test_user: UserData) -> None:
     """log_llm_usage should persist token counts to the usage log."""
     response = _make_response_with_usage(prompt_tokens=200, completion_tokens=80, total_tokens=280)
 
-    log_llm_usage(test_contractor.id, "test-model", response, "agent_main")
+    log_llm_usage(test_user.id, "test-model", response, "agent_main")
 
-    entries = _read_usage_entries(test_contractor.id)
+    entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1
-    assert entries[0]["contractor_id"] == test_contractor.id
+    assert entries[0]["user_id"] == test_user.id
     assert entries[0]["model"] == "test-model"
     assert entries[0]["prompt_tokens"] == 200
     assert entries[0]["completion_tokens"] == 80
@@ -56,32 +56,32 @@ def test_log_llm_usage_saves(test_contractor: ContractorData) -> None:
     assert entries[0]["purpose"] == "agent_main"
 
 
-def test_log_llm_usage_zero_tokens(test_contractor: ContractorData) -> None:
+def test_log_llm_usage_zero_tokens(test_user: UserData) -> None:
     """log_llm_usage should handle zero token counts gracefully."""
     response = _make_response_with_usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
 
-    log_llm_usage(test_contractor.id, "test-model", response, "heartbeat")
+    log_llm_usage(test_user.id, "test-model", response, "heartbeat")
 
-    entries = _read_usage_entries(test_contractor.id)
+    entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1
     assert entries[0]["prompt_tokens"] == 0
     assert entries[0]["completion_tokens"] == 0
     assert entries[0]["total_tokens"] == 0
 
 
-def test_log_llm_usage_computes_total(test_contractor: ContractorData) -> None:
+def test_log_llm_usage_computes_total(test_user: UserData) -> None:
     """log_llm_usage should compute total_tokens as prompt + completion."""
     response = _make_response_with_usage(prompt_tokens=100, completion_tokens=50, total_tokens=0)
 
-    log_llm_usage(test_contractor.id, "test-model", response, "agent_main")
+    log_llm_usage(test_user.id, "test-model", response, "agent_main")
 
-    entries = _read_usage_entries(test_contractor.id)
+    entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1
     # total_tokens should be computed as prompt + completion
     assert entries[0]["total_tokens"] == 150
 
 
-def test_log_llm_usage_multiple_entries(test_contractor: ContractorData) -> None:
+def test_log_llm_usage_multiple_entries(test_user: UserData) -> None:
     """Multiple log_llm_usage calls should create separate entries."""
     for i in range(3):
         response = _make_response_with_usage(
@@ -89,22 +89,22 @@ def test_log_llm_usage_multiple_entries(test_contractor: ContractorData) -> None
             completion_tokens=50 * (i + 1),
             total_tokens=150 * (i + 1),
         )
-        log_llm_usage(test_contractor.id, "test-model", response, f"purpose_{i}")
+        log_llm_usage(test_user.id, "test-model", response, f"purpose_{i}")
 
-    entries = _read_usage_entries(test_contractor.id)
+    entries = _read_usage_entries(test_user.id)
     assert len(entries) == 3
     assert entries[0]["purpose"] == "purpose_0"
     assert entries[1]["purpose"] == "purpose_1"
     assert entries[2]["purpose"] == "purpose_2"
 
 
-def test_log_llm_usage_different_models(test_contractor: ContractorData) -> None:
+def test_log_llm_usage_different_models(test_user: UserData) -> None:
     """log_llm_usage should correctly record different model names."""
     for model_name in ["model-a", "model-b", "model-c"]:
         response = _make_response_with_usage()
-        log_llm_usage(test_contractor.id, model_name, response, "agent_main")
+        log_llm_usage(test_user.id, model_name, response, "agent_main")
 
-    entries = _read_usage_entries(test_contractor.id)
+    entries = _read_usage_entries(test_user.id)
     models = {r["model"] for r in entries}
     assert models == {"model-a", "model-b", "model-c"}
 
@@ -118,16 +118,16 @@ def test_log_llm_usage_different_models(test_contractor: ContractorData) -> None
 @patch("backend.app.agent.core.amessages")
 async def test_agent_process_message_logs_usage(
     mock_amessages: MagicMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """ClawboltAgent.process_message should call log_llm_usage after acompletion."""
     response = _make_response_with_usage(prompt_tokens=300, completion_tokens=120, total_tokens=420)
     mock_amessages.return_value = response
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     await agent.process_message("What is my schedule today?")
 
-    entries = _read_usage_entries(test_contractor.id)
+    entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1
     assert entries[0]["purpose"] == "agent_main"
     assert entries[0]["total_tokens"] == 420

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend.app.agent.file_store import ClientStore, ContractorData
+from backend.app.agent.file_store import ClientStore, UserData
 from backend.app.agent.memory import (
     build_memory_context,
     delete_memory,
@@ -11,10 +11,10 @@ from backend.app.agent.memory import (
 
 
 @pytest.mark.asyncio()
-async def test_save_memory_creates_new(test_contractor: ContractorData) -> None:
+async def test_save_memory_creates_new(test_user: UserData) -> None:
     """save_memory should create a new memory entry."""
     memory = await save_memory(
-        test_contractor.id,
+        test_user.id,
         key="deck_pricing",
         value="$35-45/sqft for composite",
         category="pricing",
@@ -25,84 +25,84 @@ async def test_save_memory_creates_new(test_contractor: ContractorData) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_save_memory_updates_existing(test_contractor: ContractorData) -> None:
+async def test_save_memory_updates_existing(test_user: UserData) -> None:
     """save_memory with same key should update the value."""
-    await save_memory(test_contractor.id, key="rate", value="$50/hr")
-    updated = await save_memory(test_contractor.id, key="rate", value="$55/hr")
+    await save_memory(test_user.id, key="rate", value="$50/hr")
+    updated = await save_memory(test_user.id, key="rate", value="$55/hr")
     assert updated.value == "$55/hr"
 
-    all_memories = await get_all_memories(test_contractor.id)
+    all_memories = await get_all_memories(test_user.id)
     assert len(all_memories) == 1
 
 
 @pytest.mark.asyncio()
-async def test_recall_memories_keyword_search(test_contractor: ContractorData) -> None:
+async def test_recall_memories_keyword_search(test_user: UserData) -> None:
     """recall_memories should find memories by keyword match."""
-    await save_memory(test_contractor.id, key="deck_pricing", value="$35/sqft")
-    await save_memory(test_contractor.id, key="fence_pricing", value="$20/ft")
-    await save_memory(test_contractor.id, key="supplier", value="ABC Lumber")
+    await save_memory(test_user.id, key="deck_pricing", value="$35/sqft")
+    await save_memory(test_user.id, key="fence_pricing", value="$20/ft")
+    await save_memory(test_user.id, key="supplier", value="ABC Lumber")
 
-    results = await recall_memories(test_contractor.id, query="pricing")
+    results = await recall_memories(test_user.id, query="pricing")
     assert len(results) == 2
 
 
 @pytest.mark.asyncio()
-async def test_recall_memories_by_category(test_contractor: ContractorData) -> None:
+async def test_recall_memories_by_category(test_user: UserData) -> None:
     """recall_memories with category filter should narrow results."""
-    await save_memory(test_contractor.id, key="deck", value="deck work", category="pricing")
-    await save_memory(test_contractor.id, key="client_deck", value="deck client", category="client")
+    await save_memory(test_user.id, key="deck", value="deck work", category="pricing")
+    await save_memory(test_user.id, key="client_deck", value="deck client", category="client")
 
-    results = await recall_memories(test_contractor.id, query="deck", category="pricing")
+    results = await recall_memories(test_user.id, query="deck", category="pricing")
     assert len(results) == 1
     assert results[0].category == "pricing"
 
 
 @pytest.mark.asyncio()
-async def test_get_all_memories(test_contractor: ContractorData) -> None:
-    """get_all_memories should return all memories for a contractor."""
-    await save_memory(test_contractor.id, key="a", value="1")
-    await save_memory(test_contractor.id, key="b", value="2")
+async def test_get_all_memories(test_user: UserData) -> None:
+    """get_all_memories should return all memories for a user."""
+    await save_memory(test_user.id, key="a", value="1")
+    await save_memory(test_user.id, key="b", value="2")
 
-    all_mems = await get_all_memories(test_contractor.id)
+    all_mems = await get_all_memories(test_user.id)
     assert len(all_mems) == 2
 
 
 @pytest.mark.asyncio()
-async def test_delete_memory(test_contractor: ContractorData) -> None:
+async def test_delete_memory(test_user: UserData) -> None:
     """delete_memory should remove the memory."""
-    await save_memory(test_contractor.id, key="temp", value="temporary")
-    result = await delete_memory(test_contractor.id, key="temp")
+    await save_memory(test_user.id, key="temp", value="temporary")
+    result = await delete_memory(test_user.id, key="temp")
     assert result is True
 
-    all_mems = await get_all_memories(test_contractor.id)
+    all_mems = await get_all_memories(test_user.id)
     assert len(all_mems) == 0
 
 
 @pytest.mark.asyncio()
-async def test_delete_memory_not_found(test_contractor: ContractorData) -> None:
+async def test_delete_memory_not_found(test_user: UserData) -> None:
     """delete_memory should return False if key not found."""
-    result = await delete_memory(test_contractor.id, key="nonexistent")
+    result = await delete_memory(test_user.id, key="nonexistent")
     assert result is False
 
 
 @pytest.mark.asyncio()
-async def test_build_memory_context(test_contractor: ContractorData) -> None:
+async def test_build_memory_context(test_user: UserData) -> None:
     """build_memory_context should produce formatted text."""
     await save_memory(
-        test_contractor.id,
+        test_user.id,
         key="deck_pricing",
         value="$35/sqft",
         category="pricing",
         confidence=0.9,
     )
-    client_store = ClientStore(test_contractor.id)
+    client_store = ClientStore(test_user.id)
     await client_store.create(
         name="John Smith",
         phone="555-1234",
         address="123 Oak St",
     )
 
-    context = await build_memory_context(test_contractor.id)
+    context = await build_memory_context(test_user.id)
     assert "deck_pricing" in context
     assert "$35/sqft" in context
     assert "John Smith" in context

--- a/tests/test_memory_endpoints.py
+++ b/tests/test_memory_endpoints.py
@@ -4,13 +4,13 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.config import settings
 
 
-def _seed_memory(contractor: ContractorData) -> None:
+def _seed_memory(user: UserData) -> None:
     """Create a MEMORY.md with test data."""
-    mem_dir = Path(settings.data_dir) / str(contractor.id) / "memory"
+    mem_dir = Path(settings.data_dir) / str(user.id) / "memory"
     mem_dir.mkdir(parents=True, exist_ok=True)
     (mem_dir / "MEMORY.md").write_text(
         "# Long-term Memory\n\n"
@@ -29,8 +29,8 @@ def test_list_memory_empty(client: TestClient) -> None:
     assert resp.json() == []
 
 
-def test_list_memory(client: TestClient, test_contractor: ContractorData) -> None:
-    _seed_memory(test_contractor)
+def test_list_memory(client: TestClient, test_user: UserData) -> None:
+    _seed_memory(test_user)
     resp = client.get("/api/user/memory")
     assert resp.status_code == 200
     facts = resp.json()
@@ -40,8 +40,8 @@ def test_list_memory(client: TestClient, test_contractor: ContractorData) -> Non
     assert "name" in keys
 
 
-def test_list_memory_filter_category(client: TestClient, test_contractor: ContractorData) -> None:
-    _seed_memory(test_contractor)
+def test_list_memory_filter_category(client: TestClient, test_user: UserData) -> None:
+    _seed_memory(test_user)
     resp = client.get("/api/user/memory?category=business")
     assert resp.status_code == 200
     facts = resp.json()
@@ -49,8 +49,8 @@ def test_list_memory_filter_category(client: TestClient, test_contractor: Contra
     assert all(f["category"] == "business" for f in facts)
 
 
-def test_update_memory(client: TestClient, test_contractor: ContractorData) -> None:
-    _seed_memory(test_contractor)
+def test_update_memory(client: TestClient, test_user: UserData) -> None:
+    _seed_memory(test_user)
     resp = client.put(
         "/api/user/memory/hourly_rate",
         json={"value": "85"},
@@ -61,8 +61,8 @@ def test_update_memory(client: TestClient, test_contractor: ContractorData) -> N
     assert data["key"] == "hourly_rate"
 
 
-def test_update_memory_not_found(client: TestClient, test_contractor: ContractorData) -> None:
-    _seed_memory(test_contractor)
+def test_update_memory_not_found(client: TestClient, test_user: UserData) -> None:
+    _seed_memory(test_user)
     resp = client.put(
         "/api/user/memory/nonexistent",
         json={"value": "test"},
@@ -70,8 +70,8 @@ def test_update_memory_not_found(client: TestClient, test_contractor: Contractor
     assert resp.status_code == 404
 
 
-def test_delete_memory(client: TestClient, test_contractor: ContractorData) -> None:
-    _seed_memory(test_contractor)
+def test_delete_memory(client: TestClient, test_user: UserData) -> None:
+    _seed_memory(test_user)
     resp = client.delete("/api/user/memory/hourly_rate")
     assert resp.status_code == 204
     # Verify it's gone

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -1,13 +1,13 @@
 import pytest
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.tools.memory_tools import create_memory_tools
 
 
 @pytest.mark.asyncio()
-async def test_save_fact_tool(test_contractor: ContractorData) -> None:
+async def test_save_fact_tool(test_user: UserData) -> None:
     """save_fact tool should save a memory and return confirmation."""
-    tools = create_memory_tools(test_contractor.id)
+    tools = create_memory_tools(test_user.id)
     save_fact = tools[0].function
     result = await save_fact(key="deck_rate", value="$35/sqft", category="pricing")
     assert "Saved" in result.content
@@ -16,9 +16,9 @@ async def test_save_fact_tool(test_contractor: ContractorData) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_recall_facts_tool(test_contractor: ContractorData) -> None:
+async def test_recall_facts_tool(test_user: UserData) -> None:
     """recall_facts tool should find saved memories."""
-    tools = create_memory_tools(test_contractor.id)
+    tools = create_memory_tools(test_user.id)
     save_fact = tools[0].function
     recall_facts = tools[1].function
 
@@ -29,18 +29,18 @@ async def test_recall_facts_tool(test_contractor: ContractorData) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_recall_facts_empty(test_contractor: ContractorData) -> None:
+async def test_recall_facts_empty(test_user: UserData) -> None:
     """recall_facts should return message when no facts found."""
-    tools = create_memory_tools(test_contractor.id)
+    tools = create_memory_tools(test_user.id)
     recall_facts = tools[1].function
     result = await recall_facts(query="nonexistent")
     assert "No matching facts" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_forget_fact_tool(test_contractor: ContractorData) -> None:
+async def test_forget_fact_tool(test_user: UserData) -> None:
     """forget_fact tool should delete a memory."""
-    tools = create_memory_tools(test_contractor.id)
+    tools = create_memory_tools(test_user.id)
     save_fact = tools[0].function
     forget_fact = tools[2].function
 
@@ -51,9 +51,9 @@ async def test_forget_fact_tool(test_contractor: ContractorData) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_forget_fact_not_found(test_contractor: ContractorData) -> None:
+async def test_forget_fact_not_found(test_user: UserData) -> None:
     """forget_fact should handle missing keys with is_error=True."""
-    tools = create_memory_tools(test_contractor.id)
+    tools = create_memory_tools(test_user.id)
     forget_fact = tools[2].function
     result = await forget_fact(key="nonexistent")
     assert "Not found" in result.content

--- a/tests/test_message_batcher.py
+++ b/tests/test_message_batcher.py
@@ -1,11 +1,11 @@
-"""Tests for MessageBatcher: rapid-fire message batching per contractor."""
+"""Tests for MessageBatcher: rapid-fire message batching per user."""
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.app.agent.file_store import ContractorData, SessionState, StoredMessage
+from backend.app.agent.file_store import SessionState, StoredMessage, UserData
 from backend.app.agent.ingestion import MessageBatcher
 
 
@@ -18,9 +18,9 @@ class TestMessageBatcher:
         batcher = MessageBatcher(window_ms=50)
         messaging = MagicMock()
 
-        mock_contractor = ContractorData(id=1, channel_identifier="123", phone="")
+        mock_user = UserData(id=1, channel_identifier="123", phone="")
 
-        mock_session = SessionState(session_id="sess-1", contractor_id=1)
+        mock_session = SessionState(session_id="sess-1", user_id=1)
 
         mock_message = StoredMessage(direction="inbound", body="hello")
 
@@ -29,13 +29,13 @@ class TestMessageBatcher:
                 "backend.app.agent.ingestion.handle_inbound_message",
                 new_callable=AsyncMock,
             ) as mock_handle,
-            patch("backend.app.agent.ingestion.contractor_locks") as mock_locks,
+            patch("backend.app.agent.ingestion.user_locks") as mock_locks,
         ):
             mock_locks.acquire.return_value = AsyncMock(
                 __aenter__=AsyncMock(), __aexit__=AsyncMock()
             )
 
-            await batcher.enqueue(mock_contractor, mock_session, mock_message, [], messaging)
+            await batcher.enqueue(mock_user, mock_session, mock_message, [], messaging)
             await asyncio.sleep(0.1)
 
             mock_handle.assert_called_once()
@@ -49,9 +49,9 @@ class TestMessageBatcher:
         batcher = MessageBatcher(window_ms=100)
         messaging = MagicMock()
 
-        mock_contractor = ContractorData(id=1, channel_identifier="123", phone="")
+        mock_user = UserData(id=1, channel_identifier="123", phone="")
 
-        mock_session = SessionState(session_id="sess-1", contractor_id=1)
+        mock_session = SessionState(session_id="sess-1", user_id=1)
 
         mock_msg_1 = StoredMessage(direction="inbound", body="first")
         mock_msg_2 = StoredMessage(direction="inbound", body="second")
@@ -62,7 +62,7 @@ class TestMessageBatcher:
                 "backend.app.agent.ingestion.handle_inbound_message",
                 new_callable=AsyncMock,
             ) as mock_handle,
-            patch("backend.app.agent.ingestion.contractor_locks") as mock_locks,
+            patch("backend.app.agent.ingestion.user_locks") as mock_locks,
         ):
             mock_locks.acquire.return_value = AsyncMock(
                 __aenter__=AsyncMock(), __aexit__=AsyncMock()
@@ -70,15 +70,15 @@ class TestMessageBatcher:
 
             # Enqueue 3 messages rapidly (within the batch window)
             await batcher.enqueue(
-                mock_contractor,
+                mock_user,
                 mock_session,
                 mock_msg_1,
                 [("file_a", "image/jpeg")],
                 messaging,
             )
-            await batcher.enqueue(mock_contractor, mock_session, mock_msg_2, [], messaging)
+            await batcher.enqueue(mock_user, mock_session, mock_msg_2, [], messaging)
             await batcher.enqueue(
-                mock_contractor,
+                mock_user,
                 mock_session,
                 mock_msg_3,
                 [("file_b", "audio/ogg")],
@@ -99,16 +99,16 @@ class TestMessageBatcher:
             ]
 
     @pytest.mark.asyncio
-    async def test_different_contractors_not_batched(self) -> None:
-        """Messages from different contractors should be processed independently."""
+    async def test_different_users_not_batched(self) -> None:
+        """Messages from different users should be processed independently."""
         batcher = MessageBatcher(window_ms=50)
         messaging = MagicMock()
 
-        mock_c1 = ContractorData(id=1, channel_identifier="111", phone="")
-        mock_c2 = ContractorData(id=2, channel_identifier="222", phone="")
+        mock_c1 = UserData(id=1, channel_identifier="111", phone="")
+        mock_c2 = UserData(id=2, channel_identifier="222", phone="")
 
-        mock_session_1 = SessionState(session_id="sess-1", contractor_id=1)
-        mock_session_2 = SessionState(session_id="sess-2", contractor_id=2)
+        mock_session_1 = SessionState(session_id="sess-1", user_id=1)
+        mock_session_2 = SessionState(session_id="sess-2", user_id=2)
 
         mock_msg_1 = StoredMessage(direction="inbound", body="from c1")
         mock_msg_2 = StoredMessage(direction="inbound", body="from c2")
@@ -118,7 +118,7 @@ class TestMessageBatcher:
                 "backend.app.agent.ingestion.handle_inbound_message",
                 new_callable=AsyncMock,
             ) as mock_handle,
-            patch("backend.app.agent.ingestion.contractor_locks") as mock_locks,
+            patch("backend.app.agent.ingestion.user_locks") as mock_locks,
         ):
             mock_locks.acquire.return_value = AsyncMock(
                 __aenter__=AsyncMock(), __aexit__=AsyncMock()
@@ -129,7 +129,7 @@ class TestMessageBatcher:
 
             await asyncio.sleep(0.15)
 
-            # Both contractors should get their own pipeline call
+            # Both users should get their own pipeline call
             assert mock_handle.call_count == 2
 
     @pytest.mark.asyncio
@@ -138,9 +138,9 @@ class TestMessageBatcher:
         batcher = MessageBatcher(window_ms=100)
         messaging = MagicMock()
 
-        mock_contractor = ContractorData(id=1, channel_identifier="123", phone="")
+        mock_user = UserData(id=1, channel_identifier="123", phone="")
 
-        mock_session = SessionState(session_id="sess-1", contractor_id=1)
+        mock_session = SessionState(session_id="sess-1", user_id=1)
 
         mock_msg_1 = StoredMessage(direction="inbound", body="first")
         mock_msg_2 = StoredMessage(direction="inbound", body="second")
@@ -150,21 +150,21 @@ class TestMessageBatcher:
                 "backend.app.agent.ingestion.handle_inbound_message",
                 new_callable=AsyncMock,
             ) as mock_handle,
-            patch("backend.app.agent.ingestion.contractor_locks") as mock_locks,
+            patch("backend.app.agent.ingestion.user_locks") as mock_locks,
         ):
             mock_locks.acquire.return_value = AsyncMock(
                 __aenter__=AsyncMock(), __aexit__=AsyncMock()
             )
 
             # First message
-            await batcher.enqueue(mock_contractor, mock_session, mock_msg_1, [], messaging)
+            await batcher.enqueue(mock_user, mock_session, mock_msg_1, [], messaging)
 
             # Wait 70ms (within the 100ms window)
             await asyncio.sleep(0.07)
             mock_handle.assert_not_called()
 
             # Second message resets the timer
-            await batcher.enqueue(mock_contractor, mock_session, mock_msg_2, [], messaging)
+            await batcher.enqueue(mock_user, mock_session, mock_msg_2, [], messaging)
 
             # Wait 70ms again (still within the new 100ms window)
             await asyncio.sleep(0.07)
@@ -180,9 +180,9 @@ class TestMessageBatcher:
         batcher = MessageBatcher(window_ms=0)
         messaging = MagicMock()
 
-        mock_contractor = ContractorData(id=1, channel_identifier="123", phone="")
+        mock_user = UserData(id=1, channel_identifier="123", phone="")
 
-        mock_session = SessionState(session_id="sess-1", contractor_id=1)
+        mock_session = SessionState(session_id="sess-1", user_id=1)
 
         mock_message = StoredMessage(direction="inbound", body="hello")
 
@@ -191,13 +191,13 @@ class TestMessageBatcher:
                 "backend.app.agent.ingestion.handle_inbound_message",
                 new_callable=AsyncMock,
             ) as mock_handle,
-            patch("backend.app.agent.ingestion.contractor_locks") as mock_locks,
+            patch("backend.app.agent.ingestion.user_locks") as mock_locks,
         ):
             mock_locks.acquire.return_value = AsyncMock(
                 __aenter__=AsyncMock(), __aexit__=AsyncMock()
             )
 
-            await batcher.enqueue(mock_contractor, mock_session, mock_message, [], messaging)
+            await batcher.enqueue(mock_user, mock_session, mock_message, [], messaging)
             await asyncio.sleep(0.05)
 
             mock_handle.assert_called_once()

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from any_llm import AuthenticationError, ContentFilterError
 
-from backend.app.agent.file_store import ContractorData, SessionState, StoredMessage
+from backend.app.agent.file_store import SessionState, StoredMessage, UserData
 from backend.app.agent.router import (
     AUTH_ERROR_FALLBACK,
     CONTENT_FILTER_FALLBACK,
@@ -17,10 +17,10 @@ from tests.mocks.storage import MockStorageBackend
 
 
 @pytest.fixture()
-def conversation(test_contractor: ContractorData) -> SessionState:
+def conversation(test_user: UserData) -> SessionState:
     return SessionState(
         session_id="test-conv",
-        contractor_id=test_contractor.id,
+        user_id=test_user.id,
         is_active=True,
         messages=[
             StoredMessage(
@@ -56,7 +56,7 @@ def mock_messaging() -> MessagingService:
 @patch("backend.app.agent.core.amessages")
 async def test_text_only_message(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -65,7 +65,7 @@ async def test_text_only_message(
     mock_amessages.return_value = make_text_response("I can help with that deck estimate!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -82,7 +82,7 @@ async def test_text_only_message(
 async def test_message_with_photo(
     mock_vision: AsyncMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -100,7 +100,7 @@ async def test_message_with_photo(
     mock_amessages.return_value = make_text_response("Looks like a great deck project!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[("AgACAgIAAxkBAAI", "image/jpeg")],
@@ -116,7 +116,7 @@ async def test_message_with_photo(
 @patch("backend.app.agent.core.amessages")
 async def test_stores_outbound_message(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -125,7 +125,7 @@ async def test_stores_outbound_message(
     mock_amessages.return_value = make_text_response("Reply stored!")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -141,7 +141,7 @@ async def test_stores_outbound_message(
 @patch("backend.app.agent.core.amessages")
 async def test_stores_tool_interactions_with_outbound(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -162,7 +162,7 @@ async def test_stores_tool_interactions_with_outbound(
     mock_amessages.side_effect = [tool_response, text_response]  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -184,7 +184,7 @@ async def test_stores_tool_interactions_with_outbound(
 @patch("backend.app.agent.core.amessages")
 async def test_no_tool_interactions_for_text_only_response(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -193,7 +193,7 @@ async def test_no_tool_interactions_for_text_only_response(
     mock_amessages.return_value = make_text_response("Just text!")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -209,7 +209,7 @@ async def test_no_tool_interactions_for_text_only_response(
 @patch("backend.app.agent.core.amessages")
 async def test_media_download_failure_still_processes_text(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -219,7 +219,7 @@ async def test_media_download_failure_still_processes_text(
     mock_amessages.return_value = make_text_response("Got your text!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[("AgACAgIAAxkBAAI", "image/jpeg")],
@@ -233,7 +233,7 @@ async def test_media_download_failure_still_processes_text(
 @patch("backend.app.agent.core.amessages")
 async def test_processed_context_saved_to_message(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -242,7 +242,7 @@ async def test_processed_context_saved_to_message(
     mock_amessages.return_value = make_text_response("Got it!")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -261,7 +261,7 @@ async def test_file_tools_wired_when_storage_configured(
     mock_settings: MagicMock,
     mock_get_storage: MagicMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -276,7 +276,7 @@ async def test_file_tools_wired_when_storage_configured(
     mock_amessages.return_value = make_text_response("File saved!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -293,7 +293,7 @@ async def test_file_tools_wired_when_storage_configured(
 async def test_file_tools_skipped_when_no_storage(
     mock_settings: MagicMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -307,7 +307,7 @@ async def test_file_tools_skipped_when_no_storage(
     mock_amessages.return_value = make_text_response("No file tools!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -327,7 +327,7 @@ async def test_file_tools_skipped_when_no_storage(
 async def test_pipeline_failure_note_mentions_vision(
     mock_vision: AsyncMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -361,7 +361,7 @@ async def test_pipeline_failure_note_mentions_vision(
         mock_amessages.return_value = make_text_response("I see you sent something!")  # type: ignore[union-attr]
 
         await handle_inbound_message(
-            contractor=test_contractor,
+            user=test_user,
             session=conversation,
             message=inbound_message,
             media_urls=[("AgACAgIAAxkBAAI", "image/jpeg")],
@@ -381,7 +381,7 @@ async def test_pipeline_failure_note_mentions_vision(
 @patch("backend.app.agent.core.amessages")
 async def test_media_download_failure_adds_system_note_to_context(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -391,7 +391,7 @@ async def test_media_download_failure_adds_system_note_to_context(
     mock_amessages.return_value = make_text_response("Got your text!")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[("file_id_1", "image/jpeg")],
@@ -405,7 +405,7 @@ async def test_media_download_failure_adds_system_note_to_context(
 @patch("backend.app.agent.core.amessages")
 async def test_multiple_media_partial_download_failure_no_download_note(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -427,7 +427,7 @@ async def test_multiple_media_partial_download_failure_no_download_note(
     with patch("backend.app.media.pipeline.analyze_image", new_callable=AsyncMock) as mock_vision:
         mock_vision.return_value = "A photo of a deck."
         response = await handle_inbound_message(
-            contractor=test_contractor,
+            user=test_user,
             session=conversation,
             message=inbound_message,
             media_urls=[("file_ok", "image/jpeg"), ("file_bad", "image/png")],
@@ -443,7 +443,7 @@ async def test_multiple_media_partial_download_failure_no_download_note(
 @patch("backend.app.agent.core.amessages")
 async def test_media_pipeline_failure_retries_with_empty_media(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -475,7 +475,7 @@ async def test_media_pipeline_failure_retries_with_empty_media(
         ]
 
         response = await handle_inbound_message(
-            contractor=test_contractor,
+            user=test_user,
             session=conversation,
             message=inbound_message,
             media_urls=[("AgACAgIAAxkBAAI", "image/jpeg")],
@@ -497,7 +497,7 @@ async def test_storage_exception_skips_file_tools(
     mock_settings: MagicMock,
     mock_get_storage: MagicMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -512,7 +512,7 @@ async def test_storage_exception_skips_file_tools(
     mock_amessages.return_value = make_text_response("No file tools due to error!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -528,7 +528,7 @@ async def test_storage_exception_skips_file_tools(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_processing_failure_returns_fallback_reply(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -537,7 +537,7 @@ async def test_agent_processing_failure_returns_fallback_reply(
     mock_amessages.side_effect = RuntimeError("LLM service down")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -552,7 +552,7 @@ async def test_agent_processing_failure_returns_fallback_reply(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_processing_failure_does_not_store_fallback(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -561,7 +561,7 @@ async def test_agent_processing_failure_does_not_store_fallback(
     mock_amessages.side_effect = RuntimeError("LLM down")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -576,7 +576,7 @@ async def test_agent_processing_failure_does_not_store_fallback(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_processing_failure_still_sends_reply(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -585,7 +585,7 @@ async def test_agent_processing_failure_still_sends_reply(
     mock_amessages.side_effect = RuntimeError("LLM unavailable")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -601,7 +601,7 @@ async def test_agent_processing_failure_still_sends_reply(
 @patch("backend.app.agent.core.amessages")
 async def test_send_reply_failure_still_stores_outbound(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -611,7 +611,7 @@ async def test_send_reply_failure_still_stores_outbound(
     mock_messaging.send_text.side_effect = RuntimeError("Telegram API down")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -630,7 +630,7 @@ async def test_send_reply_failure_still_stores_outbound(
 @patch("backend.app.agent.core.amessages")
 async def test_pipeline_failure_without_downloaded_media_skips_vision_note(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -656,7 +656,7 @@ async def test_pipeline_failure_without_downloaded_media_skips_vision_note(
         ]
 
         await handle_inbound_message(
-            contractor=test_contractor,
+            user=test_user,
             session=conversation,
             message=inbound_message,
             media_urls=[("file_id_1", "image/jpeg")],
@@ -677,9 +677,9 @@ async def test_empty_to_address_returns_early(
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
 ) -> None:
-    """Contractor with no channel_identifier or phone should return early."""
-    # Create contractor with empty delivery fields
-    no_addr = ContractorData(
+    """User with no channel_identifier or phone should return early."""
+    # Create user with empty delivery fields
+    no_addr = UserData(
         id=99,
         user_id="no-addr",
         channel_identifier="",
@@ -687,7 +687,7 @@ async def test_empty_to_address_returns_early(
     )
 
     response = await handle_inbound_message(
-        contractor=no_addr,
+        user=no_addr,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -704,7 +704,7 @@ async def test_empty_to_address_returns_early(
 @patch("backend.app.agent.core.amessages")
 async def test_send_media_reply_suppresses_duplicate_text(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -728,7 +728,7 @@ async def test_send_media_reply_suppresses_duplicate_text(
     mock_amessages.side_effect = [tool_response, followup_response]  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -749,7 +749,7 @@ async def test_send_media_reply_suppresses_duplicate_text(
 @patch("backend.app.agent.core.amessages")
 async def test_typing_indicator_called_before_agent_processing(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -758,7 +758,7 @@ async def test_typing_indicator_called_before_agent_processing(
     mock_amessages.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -766,7 +766,7 @@ async def test_typing_indicator_called_before_agent_processing(
     )
 
     mock_messaging.send_typing_indicator.assert_called_once_with(  # type: ignore[union-attr]
-        to=test_contractor.channel_identifier,
+        to=test_user.channel_identifier,
     )
 
 
@@ -774,7 +774,7 @@ async def test_typing_indicator_called_before_agent_processing(
 @patch("backend.app.agent.core.amessages")
 async def test_typing_indicator_failure_does_not_block_processing(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -786,7 +786,7 @@ async def test_typing_indicator_failure_does_not_block_processing(
     mock_amessages.return_value = make_text_response("Still works!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -815,7 +815,7 @@ async def test_auto_save_persists_media_to_storage(
     mock_settings: MagicMock,
     mock_get_storage: MagicMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -841,7 +841,7 @@ async def test_auto_save_persists_media_to_storage(
     with patch("backend.app.media.pipeline.analyze_image", new_callable=AsyncMock) as mock_vision:
         mock_vision.return_value = "A photo."
         await handle_inbound_message(
-            contractor=test_contractor,
+            user=test_user,
             session=conversation,
             message=inbound_message,
             media_urls=[("AgACAgIAAxkBAAI", "image/jpeg")],
@@ -860,7 +860,7 @@ async def test_auto_save_failure_does_not_block_processing(
     mock_settings: MagicMock,
     mock_get_storage: MagicMock,
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -889,7 +889,7 @@ async def test_auto_save_failure_does_not_block_processing(
     with patch("backend.app.media.pipeline.analyze_image", new_callable=AsyncMock) as mock_vision:
         mock_vision.return_value = "A photo."
         response = await handle_inbound_message(
-            contractor=test_contractor,
+            user=test_user,
             session=conversation,
             message=inbound_message,
             media_urls=[("AgACAgIAAxkBAAI", "image/jpeg")],
@@ -908,7 +908,7 @@ async def test_auto_save_failure_does_not_block_processing(
 @patch("backend.app.agent.core.amessages")
 async def test_content_filter_error_returns_rephrasing_message(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -917,7 +917,7 @@ async def test_content_filter_error_returns_rephrasing_message(
     mock_amessages.side_effect = ContentFilterError("Blocked by safety filter")
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -933,7 +933,7 @@ async def test_content_filter_error_returns_rephrasing_message(
 @patch("backend.app.agent.core.amessages")
 async def test_authentication_error_returns_config_message(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -942,7 +942,7 @@ async def test_authentication_error_returns_config_message(
     mock_amessages.side_effect = AuthenticationError("Invalid API key")
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -958,7 +958,7 @@ async def test_authentication_error_returns_config_message(
 @patch("backend.app.agent.core.amessages")
 async def test_content_filter_error_does_not_store_outbound(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -967,7 +967,7 @@ async def test_content_filter_error_does_not_store_outbound(
     mock_amessages.side_effect = ContentFilterError("Blocked")
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -982,7 +982,7 @@ async def test_content_filter_error_does_not_store_outbound(
 @patch("backend.app.agent.core.amessages")
 async def test_authentication_error_does_not_store_outbound(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -991,7 +991,7 @@ async def test_authentication_error_does_not_store_outbound(
     mock_amessages.side_effect = AuthenticationError("Bad key")
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -1011,7 +1011,7 @@ async def test_authentication_error_does_not_store_outbound(
 @patch("backend.app.agent.core.amessages")
 async def test_normal_response_still_stored_as_outbound(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -1020,7 +1020,7 @@ async def test_normal_response_still_stored_as_outbound(
     mock_amessages.return_value = make_text_response("Here's your estimate!")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],
@@ -1036,7 +1036,7 @@ async def test_normal_response_still_stored_as_outbound(
 @patch("backend.app.agent.core.amessages")
 async def test_error_fallback_sent_but_not_stored(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     conversation: SessionState,
     inbound_message: StoredMessage,
     mock_messaging: MessagingService,
@@ -1045,7 +1045,7 @@ async def test_error_fallback_sent_but_not_stored(
     mock_amessages.side_effect = RuntimeError("LLM down")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=conversation,
         message=inbound_message,
         media_urls=[],

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.app.agent.file_store import (
-    ContractorData,
     SessionState,
     StoredMessage,
-    get_contractor_store,
+    UserData,
+    get_user_store,
 )
 from backend.app.agent.onboarding import (
     REQUIRED_PROFILE_FIELDS,
@@ -21,9 +21,9 @@ from backend.app.services.messaging import MessagingService
 from tests.mocks.llm import make_text_response, make_tool_call_response
 
 
-def _ensure_session_on_disk(contractor: ContractorData, session: SessionState) -> None:
-    """Create the contractor directory and session file so file-store writes succeed."""
-    cdir = Path(settings.data_dir) / str(contractor.id)
+def _ensure_session_on_disk(user: UserData, session: SessionState) -> None:
+    """Create the user directory and session file so file-store writes succeed."""
+    cdir = Path(settings.data_dir) / str(user.id)
     sessions_dir = cdir / "sessions"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     session_path = sessions_dir / f"{session.session_id}.jsonl"
@@ -31,54 +31,54 @@ def _ensure_session_on_disk(contractor: ContractorData, session: SessionState) -
         meta = {
             "_type": "metadata",
             "session_id": session.session_id,
-            "contractor_id": contractor.id,
+            "user_id": user.id,
             "is_active": session.is_active,
         }
         lines = [json.dumps(meta)]
         for msg in session.messages:
             lines.append(json.dumps(msg.model_dump(), default=str))
         session_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    # Also write user.json so the store can reload the contractor
-    contractor_json = cdir / "user.json"
-    if not contractor_json.exists():
-        data = contractor.model_dump()
+    # Also write user.json so the store can reload the user
+    user_json = cdir / "user.json"
+    if not user_json.exists():
+        data = user.model_dump()
         data.pop("soul_text", None)
-        contractor_json.write_text(json.dumps(data, default=str), encoding="utf-8")
+        user_json.write_text(json.dumps(data, default=str), encoding="utf-8")
 
 
-def test_is_onboarding_needed_new_contractor() -> None:
-    """New contractor with no name should need onboarding."""
-    contractor = ContractorData(id=1, user_id="new-user", phone="+15550001111")
-    assert is_onboarding_needed(contractor) is True
+def test_is_onboarding_needed_new_user() -> None:
+    """New user with no name should need onboarding."""
+    user = UserData(id=1, user_id="new-user", phone="+15550001111")
+    assert is_onboarding_needed(user) is True
 
 
 def test_is_onboarding_needed_partial_profile() -> None:
-    """Contractor with name should not need onboarding (name is the only required field)."""
-    contractor = ContractorData(id=1, user_id="partial-user", phone="+15550002222", name="Mike")
-    assert is_onboarding_needed(contractor) is False
+    """User with name should not need onboarding (name is the only required field)."""
+    user = UserData(id=1, user_id="partial-user", phone="+15550002222", name="Mike")
+    assert is_onboarding_needed(user) is False
 
 
-def test_is_onboarding_needed_complete_profile(test_contractor: ContractorData) -> None:
-    """Contractor with name does not need onboarding."""
-    assert is_onboarding_needed(test_contractor) is False
+def test_is_onboarding_needed_complete_profile(test_user: UserData) -> None:
+    """User with name does not need onboarding."""
+    assert is_onboarding_needed(test_user) is False
 
 
 def test_is_onboarding_needed_respects_flag() -> None:
-    """Contractor with onboarding_complete=True should not need onboarding."""
-    contractor = ContractorData(
+    """User with onboarding_complete=True should not need onboarding."""
+    user = UserData(
         id=1,
         user_id="flagged-user",
         phone="+15550007777",
         name="",
         onboarding_complete=True,
     )
-    assert is_onboarding_needed(contractor) is False
+    assert is_onboarding_needed(user) is False
 
 
 def test_is_onboarding_needed_empty_strings() -> None:
     """Empty strings should still trigger onboarding."""
-    contractor = ContractorData(id=1, user_id="empty-user", phone="+15550003333", name="")
-    assert is_onboarding_needed(contractor) is True
+    user = UserData(id=1, user_id="empty-user", phone="+15550003333", name="")
+    assert is_onboarding_needed(user) is True
 
 
 def test_required_profile_fields_only_name() -> None:
@@ -88,27 +88,27 @@ def test_required_profile_fields_only_name() -> None:
     assert "location" not in REQUIRED_PROFILE_FIELDS
 
 
-def test_build_onboarding_system_prompt_new_contractor() -> None:
-    """Onboarding prompt for new contractor should not include known info."""
-    contractor = ContractorData(id=1, user_id="brand-new", phone="+15550004444")
+def test_build_onboarding_system_prompt_new_user() -> None:
+    """Onboarding prompt for new user should not include known info."""
+    user = UserData(id=1, user_id="brand-new", phone="+15550004444")
 
-    prompt = build_onboarding_system_prompt(contractor)
+    prompt = build_onboarding_system_prompt(user)
     assert "first conversation" in prompt
-    assert "new contractor" in prompt
+    assert "new user" in prompt
     assert "You already know" not in prompt
     assert "help them with that request FIRST" in prompt
 
 
 def test_build_onboarding_system_prompt_partial_profile() -> None:
     """Onboarding prompt should include already-known fields."""
-    contractor = ContractorData(
+    user = UserData(
         id=1,
         user_id="partial-user",
         phone="+15550005555",
         name="Sarah",
     )
 
-    prompt = build_onboarding_system_prompt(contractor)
+    prompt = build_onboarding_system_prompt(user)
     assert "You already know" in prompt
     assert "Sarah" in prompt
     assert "Don't re-ask" in prompt
@@ -116,7 +116,7 @@ def test_build_onboarding_system_prompt_partial_profile() -> None:
 
 def test_build_onboarding_system_prompt_includes_assistant_name() -> None:
     """Onboarding prompt should include custom assistant_name in known fields."""
-    contractor = ContractorData(
+    user = UserData(
         id=1,
         user_id="named-ai-user",
         phone="+15550006666",
@@ -124,7 +124,7 @@ def test_build_onboarding_system_prompt_includes_assistant_name() -> None:
         assistant_name="Bolt",
     )
 
-    prompt = build_onboarding_system_prompt(contractor)
+    prompt = build_onboarding_system_prompt(user)
     assert "You already know" in prompt
     assert "Bolt" in prompt
     assert "Don't re-ask" in prompt
@@ -168,9 +168,9 @@ def test_build_onboarding_prompt_mentions_capabilities() -> None:
 
 def test_build_onboarding_system_prompt_includes_tool_capabilities() -> None:
     """Onboarding system prompt should inject available specialist tool descriptions."""
-    contractor = ContractorData(id=1, user_id="new-user", phone="+15550001111")
+    user = UserData(id=1, user_id="new-user", phone="+15550001111")
 
-    prompt = build_onboarding_system_prompt(contractor)
+    prompt = build_onboarding_system_prompt(user)
     # Should include specialist tool summaries from the registry
     assert "specialist capabilities" in prompt.lower()
     assert "estimate" in prompt.lower()
@@ -180,9 +180,9 @@ def test_build_onboarding_system_prompt_includes_tool_capabilities() -> None:
 
 
 @pytest.fixture()
-def new_contractor() -> ContractorData:
-    """Contractor with no profile -- needs onboarding."""
-    return ContractorData(
+def new_user() -> UserData:
+    """User with no profile -- needs onboarding."""
+    return UserData(
         id=20,
         user_id="new-user-onboard",
         phone="+15559999999",
@@ -191,10 +191,10 @@ def new_contractor() -> ContractorData:
 
 
 @pytest.fixture()
-def onboarding_session(new_contractor: ContractorData) -> SessionState:
+def onboarding_session(new_user: UserData) -> SessionState:
     session = SessionState(
         session_id="onboarding-session",
-        contractor_id=new_contractor.id,
+        user_id=new_user.id,
         is_active=True,
         messages=[
             StoredMessage(
@@ -204,7 +204,7 @@ def onboarding_session(new_contractor: ContractorData) -> SessionState:
             ),
         ],
     )
-    _ensure_session_on_disk(new_contractor, session)
+    _ensure_session_on_disk(new_user, session)
     return session
 
 
@@ -235,18 +235,18 @@ def mock_messaging() -> MessagingService:
 @patch("backend.app.agent.core.amessages")
 async def test_onboarding_uses_onboarding_prompt(
     mock_amessages: object,
-    new_contractor: ContractorData,
+    new_user: UserData,
     onboarding_session: SessionState,
     onboarding_message: StoredMessage,
     mock_messaging: MessagingService,
 ) -> None:
-    """Router should use onboarding prompt for new contractors."""
+    """Router should use onboarding prompt for new users."""
     mock_amessages.return_value = make_text_response(  # type: ignore[union-attr]
         "Welcome to Clawbolt! What's your name?"
     )
 
     response = await handle_inbound_message(
-        contractor=new_contractor,
+        user=new_user,
         session=onboarding_session,
         message=onboarding_message,
         media_urls=[],
@@ -256,19 +256,19 @@ async def test_onboarding_uses_onboarding_prompt(
     assert response.reply_text == "Welcome to Clawbolt! What's your name?"
     call_args = mock_amessages.call_args  # type: ignore[union-attr]
     system_msg = call_args.kwargs["system"]
-    assert "new contractor" in system_msg
+    assert "new user" in system_msg
 
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_onboarding_extracts_profile_updates_via_update_profile(
     mock_amessages: object,
-    new_contractor: ContractorData,
+    new_user: UserData,
     onboarding_session: SessionState,
     onboarding_message: StoredMessage,
     mock_messaging: MessagingService,
 ) -> None:
-    """Profile updates from update_profile tool should be saved to contractor record."""
+    """Profile updates from update_profile tool should be saved to user record."""
     # First call returns update_profile tool call, second returns text reply
     tool_response = make_tool_call_response(
         tool_calls=[
@@ -283,15 +283,15 @@ async def test_onboarding_extracts_profile_updates_via_update_profile(
     mock_amessages.side_effect = [tool_response, text_response]  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=new_contractor,
+        user=new_user,
         session=onboarding_session,
         message=onboarding_message,
         media_urls=[],
         messaging_service=mock_messaging,
     )
 
-    store = get_contractor_store()
-    refreshed = await store.get_by_id(new_contractor.id)
+    store = get_user_store()
+    refreshed = await store.get_by_id(new_user.id)
     assert refreshed is not None
     assert refreshed.name == "Mike"
 
@@ -300,13 +300,13 @@ async def test_onboarding_extracts_profile_updates_via_update_profile(
 @patch("backend.app.agent.core.amessages")
 async def test_complete_profile_uses_normal_prompt(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     mock_messaging: MessagingService,
 ) -> None:
-    """Contractor with complete profile should use normal agent prompt."""
+    """User with complete profile should use normal agent prompt."""
     session = SessionState(
         session_id="test-session",
-        contractor_id=test_contractor.id,
+        user_id=test_user.id,
         is_active=True,
         messages=[
             StoredMessage(direction="inbound", body="How much for a deck?", seq=1),
@@ -319,7 +319,7 @@ async def test_complete_profile_uses_normal_prompt(
     )
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=session,
         message=message,
         media_urls=[],
@@ -329,7 +329,7 @@ async def test_complete_profile_uses_normal_prompt(
     assert response.reply_text == "Let me help with that estimate!"
     call_args = mock_amessages.call_args  # type: ignore[union-attr]
     system_msg = call_args.kwargs["system"]
-    assert "new contractor" not in system_msg
+    assert "new user" not in system_msg
 
 
 # ---------------------------------------------------------------------------
@@ -341,13 +341,13 @@ async def test_complete_profile_uses_normal_prompt(
 @patch("backend.app.agent.core.amessages")
 async def test_profile_updates_post_onboarding_single_field(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     mock_messaging: MessagingService,
 ) -> None:
-    """Post-onboarding update_profile calls should update ContractorData profile fields."""
+    """Post-onboarding update_profile calls should update UserData profile fields."""
     session = SessionState(
         session_id="test-session",
-        contractor_id=test_contractor.id,
+        user_id=test_user.id,
         is_active=True,
         messages=[
             StoredMessage(direction="inbound", body="My name is now Jake", seq=1),
@@ -370,15 +370,15 @@ async def test_profile_updates_post_onboarding_single_field(
     mock_amessages.side_effect = [tool_response, text_response]  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=session,
         message=message,
         media_urls=[],
         messaging_service=mock_messaging,
     )
 
-    store = get_contractor_store()
-    refreshed = await store.get_by_id(test_contractor.id)
+    store = get_user_store()
+    refreshed = await store.get_by_id(test_user.id)
     assert refreshed is not None
     assert refreshed.name == "Jake"
 
@@ -387,18 +387,18 @@ async def test_profile_updates_post_onboarding_single_field(
 @patch("backend.app.agent.core.amessages")
 async def test_profile_updates_during_onboarding_still_work(
     mock_amessages: object,
-    new_contractor: ContractorData,
+    new_user: UserData,
     onboarding_session: SessionState,
     onboarding_message: StoredMessage,
     mock_messaging: MessagingService,
 ) -> None:
     """Profile updates during onboarding still work with update_profile tool.
 
-    When a new contractor provides name via update_profile,
+    When a new user provides name via update_profile,
     onboarding should complete.
     """
-    assert is_onboarding_needed(new_contractor) is True
-    assert not new_contractor.name  # empty or None
+    assert is_onboarding_needed(new_user) is True
+    assert not new_user.name  # empty or None
 
     # LLM calls update_profile with name, then gives a text reply
     tool_response = make_tool_call_response(
@@ -419,38 +419,38 @@ async def test_profile_updates_during_onboarding_still_work(
     mock_amessages.side_effect = [tool_response, text_response]  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=new_contractor,
+        user=new_user,
         session=onboarding_session,
         message=onboarding_message,
         media_urls=[],
         messaging_service=mock_messaging,
     )
 
-    store = get_contractor_store()
-    refreshed = await store.get_by_id(new_contractor.id)
+    store = get_user_store()
+    refreshed = await store.get_by_id(new_user.id)
     assert refreshed is not None
     assert refreshed.name == "Sarah"
     assert refreshed.onboarding_complete is True
 
 
 # ---------------------------------------------------------------------------
-# Regression tests for #180: pre-populated contractors
+# Regression tests for #180: pre-populated users
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
-async def test_prepopulated_contractor_gets_onboarding_complete(
+async def test_prepopulated_user_gets_onboarding_complete(
     mock_amessages: object,
     mock_messaging: MessagingService,
 ) -> None:
-    """Contractor with pre-populated name should get onboarding_complete=True.
+    """User with pre-populated name should get onboarding_complete=True.
 
     Regression test for #180: when required profile fields are already filled,
     is_onboarding_needed() returns False but onboarding_complete was never set
     because the 'if onboarding:' block was skipped entirely.
     """
-    contractor = ContractorData(
+    user = UserData(
         id=30,
         user_id="prepopulated-user",
         name="Sarah",
@@ -460,12 +460,12 @@ async def test_prepopulated_contractor_gets_onboarding_complete(
     )
 
     # Sanity: fields are populated but flag is not set
-    assert not contractor.onboarding_complete
-    assert not is_onboarding_needed(contractor)
+    assert not user.onboarding_complete
+    assert not is_onboarding_needed(user)
 
     session = SessionState(
         session_id="test-session",
-        contractor_id=contractor.id,
+        user_id=user.id,
         is_active=True,
         messages=[
             StoredMessage(
@@ -484,18 +484,18 @@ async def test_prepopulated_contractor_gets_onboarding_complete(
     mock_amessages.return_value = make_text_response(  # type: ignore[union-attr]
         "Sure thing, Sarah!"
     )
-    _ensure_session_on_disk(contractor, session)
+    _ensure_session_on_disk(user, session)
 
     await handle_inbound_message(
-        contractor=contractor,
+        user=user,
         session=session,
         message=message,
         media_urls=[],
         messaging_service=mock_messaging,
     )
 
-    store = get_contractor_store()
-    refreshed = await store.get_by_id(contractor.id)
+    store = get_user_store()
+    refreshed = await store.get_by_id(user.id)
     assert refreshed is not None
     assert refreshed.onboarding_complete is True
 
@@ -504,16 +504,16 @@ async def test_prepopulated_contractor_gets_onboarding_complete(
 @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
 @patch("backend.app.agent.heartbeat.run_cheap_checks")
 @patch("backend.app.agent.core.amessages")
-async def test_prepopulated_contractor_included_in_heartbeat(
+async def test_prepopulated_user_included_in_heartbeat(
     mock_amessages: object,
     mock_cheap_checks: MagicMock,
     _mock_hours: MagicMock,
     mock_messaging: MessagingService,
 ) -> None:
-    """Contractor with pre-populated fields should be eligible for heartbeat after first message."""
-    from backend.app.agent.heartbeat import CheapCheckResult, run_heartbeat_for_contractor
+    """User with pre-populated fields should be eligible for heartbeat after first message."""
+    from backend.app.agent.heartbeat import CheapCheckResult, run_heartbeat_for_user
 
-    contractor = ContractorData(
+    user = UserData(
         id=31,
         user_id="prepopulated-hb-user",
         name="Jake",
@@ -525,7 +525,7 @@ async def test_prepopulated_contractor_included_in_heartbeat(
 
     session = SessionState(
         session_id="test-session",
-        contractor_id=contractor.id,
+        user_id=user.id,
         is_active=True,
         messages=[
             StoredMessage(
@@ -545,25 +545,25 @@ async def test_prepopulated_contractor_included_in_heartbeat(
     mock_amessages.return_value = make_text_response(  # type: ignore[union-attr]
         "Happy to help, Jake!"
     )
-    _ensure_session_on_disk(contractor, session)
+    _ensure_session_on_disk(user, session)
 
     await handle_inbound_message(
-        contractor=contractor,
+        user=user,
         session=session,
         message=message,
         media_urls=[],
         messaging_service=mock_messaging,
     )
 
-    store = get_contractor_store()
-    refreshed = await store.get_by_id(contractor.id)
+    store = get_user_store()
+    refreshed = await store.get_by_id(user.id)
     assert refreshed is not None
     assert refreshed.onboarding_complete is True
 
-    # Now verify heartbeat doesn't skip this contractor
+    # Now verify heartbeat doesn't skip this user
     mock_cheap_checks.return_value = CheapCheckResult(flags=[])
-    result = await run_heartbeat_for_contractor(
-        contractor=refreshed,
+    result = await run_heartbeat_for_user(
+        user=refreshed,
         messaging_service=mock_messaging,
         max_daily=5,
     )
@@ -584,8 +584,8 @@ async def test_onboarding_completion_message_appended(
     mock_messaging: MessagingService,
 ) -> None:
     """Completion summary should be appended when onboarding transitions to complete."""
-    # Contractor with no name -- needs onboarding
-    contractor = ContractorData(
+    # User with no name -- needs onboarding
+    user = UserData(
         id=32,
         user_id="completing-user",
         phone="+15550008888",
@@ -594,7 +594,7 @@ async def test_onboarding_completion_message_appended(
 
     session = SessionState(
         session_id="test-session",
-        contractor_id=contractor.id,
+        user_id=user.id,
         is_active=True,
         messages=[
             StoredMessage(
@@ -627,10 +627,10 @@ async def test_onboarding_completion_message_appended(
         make_tool_call_response(tool_calls, content=None),
         make_text_response("Great to meet you, Jake!"),
     ]
-    _ensure_session_on_disk(contractor, session)
+    _ensure_session_on_disk(user, session)
 
     response = await handle_inbound_message(
-        contractor=contractor,
+        user=user,
         session=session,
         message=message,
         media_urls=[],
@@ -647,13 +647,13 @@ async def test_onboarding_completion_message_appended(
 @patch("backend.app.agent.core.amessages")
 async def test_no_completion_message_when_already_onboarded(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     mock_messaging: MessagingService,
 ) -> None:
-    """Completion message should NOT be appended for already-onboarded contractors."""
+    """Completion message should NOT be appended for already-onboarded users."""
     session = SessionState(
         session_id="test-session",
-        contractor_id=test_contractor.id,
+        user_id=test_user.id,
         is_active=True,
         messages=[
             StoredMessage(
@@ -672,7 +672,7 @@ async def test_no_completion_message_when_already_onboarded(
     mock_amessages.return_value = make_text_response("Sure, I can help!")  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=session,
         message=message,
         media_urls=[],

--- a/tests/test_pdf_service.py
+++ b/tests/test_pdf_service.py
@@ -6,9 +6,9 @@ from backend.app.services.pdf_service import EstimatePDFData, generate_estimate_
 def _make_estimate_data(**kwargs: object) -> EstimatePDFData:
     """Create test estimate data with defaults."""
     defaults = {
-        "contractor_name": "Mike Chen",
-        "contractor_phone": "(555) 123-4567",
-        "contractor_trade": "General Contractor",
+        "owner_name": "Mike Chen",
+        "owner_phone": "(555) 123-4567",
+        "owner_trade": "General User",
         "description": "Deck construction and repair",
         "line_items": [
             {"description": "Deck framing", "quantity": 1, "unit_price": 2400, "total": 2400},

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -38,7 +38,7 @@ async def test_run_pipeline_executes_steps_in_order() -> None:
 
     # Use a minimal context; fields are unused by these test steps
     ctx = PipelineContext(
-        contractor=None,  # type: ignore[arg-type]
+        user=None,  # type: ignore[arg-type]
         session=None,  # type: ignore[arg-type]
         message=None,  # type: ignore[arg-type]
         media_urls=[],
@@ -59,7 +59,7 @@ async def test_run_pipeline_passes_context_through() -> None:
         return ctx
 
     ctx = PipelineContext(
-        contractor=None,  # type: ignore[arg-type]
+        user=None,  # type: ignore[arg-type]
         session=None,  # type: ignore[arg-type]
         message=None,  # type: ignore[arg-type]
         media_urls=[],
@@ -75,7 +75,7 @@ async def test_run_pipeline_passes_context_through() -> None:
 async def test_run_pipeline_empty_steps() -> None:
     """An empty pipeline should return the context unchanged."""
     ctx = PipelineContext(
-        contractor=None,  # type: ignore[arg-type]
+        user=None,  # type: ignore[arg-type]
         session=None,  # type: ignore[arg-type]
         message=None,  # type: ignore[arg-type]
         media_urls=[],
@@ -118,7 +118,7 @@ async def test_custom_pipeline_can_skip_steps() -> None:
         return ctx
 
     ctx = PipelineContext(
-        contractor=None,  # type: ignore[arg-type]
+        user=None,  # type: ignore[arg-type]
         session=None,  # type: ignore[arg-type]
         message=None,  # type: ignore[arg-type]
         media_urls=[],
@@ -143,7 +143,7 @@ async def test_custom_pipeline_can_add_steps() -> None:
         return ctx
 
     ctx = PipelineContext(
-        contractor=None,  # type: ignore[arg-type]
+        user=None,  # type: ignore[arg-type]
         session=None,  # type: ignore[arg-type]
         message=None,  # type: ignore[arg-type]
         media_urls=[],
@@ -172,7 +172,7 @@ async def test_custom_pipeline_can_reorder_steps() -> None:
         return ctx
 
     ctx = PipelineContext(
-        contractor=None,  # type: ignore[arg-type]
+        user=None,  # type: ignore[arg-type]
         session=None,  # type: ignore[arg-type]
         message=None,  # type: ignore[arg-type]
         media_urls=[],
@@ -197,7 +197,7 @@ async def test_pipeline_step_can_mutate_context() -> None:
         return ctx
 
     ctx = PipelineContext(
-        contractor=None,  # type: ignore[arg-type]
+        user=None,  # type: ignore[arg-type]
         session=None,  # type: ignore[arg-type]
         message=None,  # type: ignore[arg-type]
         media_urls=[],

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,41 +1,41 @@
 import pytest
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.profile import (
     build_onboarding_prompt,
     build_soul_prompt,
-    update_contractor_profile,
+    update_user_profile,
 )
 
 
 @pytest.mark.asyncio()
-async def test_update_contractor_profile(test_contractor: ContractorData) -> None:
+async def test_update_user_profile(test_user: UserData) -> None:
     """Should update allowed profile fields."""
-    updated = await update_contractor_profile(
-        test_contractor,
+    updated = await update_user_profile(
+        test_user,
         {"name": "Mike Chen"},
     )
     assert updated.name == "Mike Chen"
 
 
 @pytest.mark.asyncio()
-async def test_update_contractor_profile_ignores_unknown_fields(
-    test_contractor: ContractorData,
+async def test_update_user_profile_ignores_unknown_fields(
+    test_user: UserData,
 ) -> None:
     """Should ignore fields not in the allowed set."""
-    original_name = test_contractor.name
-    await update_contractor_profile(test_contractor, {"id": 999, "unknown_field": "bad"})
-    assert test_contractor.name == original_name
+    original_name = test_user.name
+    await update_user_profile(test_user, {"id": 999, "unknown_field": "bad"})
+    assert test_user.name == original_name
 
 
 def test_build_soul_prompt_full_profile() -> None:
     """Soul prompt should include name and soul_text."""
-    contractor = ContractorData(
+    user = UserData(
         user_id="test",
         name="Mike Chen",
         soul_text="I specialize in deck building and exterior renovations.",
     )
-    prompt = build_soul_prompt(contractor)
+    prompt = build_soul_prompt(user)
     assert "Clawbolt" in prompt  # default assistant_name
     assert "Mike Chen" in prompt
     assert "deck building" in prompt
@@ -43,31 +43,31 @@ def test_build_soul_prompt_full_profile() -> None:
 
 def test_build_soul_prompt_uses_assistant_name() -> None:
     """Soul prompt should use custom assistant_name instead of Clawbolt."""
-    contractor = ContractorData(
+    user = UserData(
         user_id="test",
         name="Jake",
         assistant_name="Bolt",
     )
-    prompt = build_soul_prompt(contractor)
+    prompt = build_soul_prompt(user)
     assert "You are Bolt, the AI assistant for Jake" in prompt
     assert "Clawbolt" not in prompt
 
 
 def test_build_soul_prompt_minimal_profile() -> None:
     """Soul prompt should work with minimal profile data."""
-    contractor = ContractorData(user_id="test", name="", phone="+15551234567")
-    prompt = build_soul_prompt(contractor)
-    assert "a contractor" in prompt
+    user = UserData(user_id="test", name="", phone="+15551234567")
+    prompt = build_soul_prompt(user)
+    assert "a user" in prompt
 
 
 def test_build_soul_prompt_with_soul_text() -> None:
     """Soul prompt should include custom soul_text."""
-    contractor = ContractorData(
+    user = UserData(
         user_id="test",
         name="Jake",
         soul_text="Direct and practical. Keep estimates tight.",
     )
-    prompt = build_soul_prompt(contractor)
+    prompt = build_soul_prompt(user)
     assert "Direct and practical" in prompt
     assert "Jake" in prompt
 
@@ -107,20 +107,20 @@ def test_build_onboarding_prompt_mentions_save_fact_for_general() -> None:
 class TestSoulPrompt:
     def test_soul_text_included(self) -> None:
         """When soul_text is set, it should appear in the prompt."""
-        contractor = ContractorData(
+        user = UserData(
             user_id="test",
             name="Sparky",
             soul_text="I focus on residential panel upgrades only.",
         )
-        prompt = build_soul_prompt(contractor)
+        prompt = build_soul_prompt(user)
         assert "residential panel upgrades" in prompt
 
     def test_no_soul_text(self) -> None:
         """When soul_text is empty, prompt should just have identity."""
-        contractor = ContractorData(
+        user = UserData(
             user_id="test",
             name="Bob",
             soul_text="",
         )
-        prompt = build_soul_prompt(contractor)
+        prompt = build_soul_prompt(user)
         assert "Bob" in prompt

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -1,4 +1,4 @@
-"""Tests for contractor profile endpoints."""
+"""Tests for user profile endpoints."""
 
 from fastapi.testclient import TestClient
 
@@ -7,7 +7,7 @@ def test_get_profile(client: TestClient) -> None:
     resp = client.get("/api/user/profile")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["name"] == "Test Contractor"
+    assert data["name"] == "Test User"
     assert data["assistant_name"] == "Clawbolt"
     assert data["onboarding_complete"] is False
     assert data["is_active"] is True

--- a/tests/test_profile_tools.py
+++ b/tests/test_profile_tools.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 import pytest
 
 from backend.app.agent.context import StoredToolInteraction
-from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.file_store import UserData, get_user_store
 from backend.app.agent.tools.base import ToolResult
 from backend.app.agent.tools.profile_tools import (
     _format_profile,
@@ -18,11 +18,9 @@ from backend.app.agent.tools.profile_tools import (
 # --- Helper to get tool functions by name ---
 
 
-def _get_tool_fn(
-    contractor: ContractorData, tool_name: str
-) -> Callable[..., Awaitable[ToolResult]]:
+def _get_tool_fn(user: UserData, tool_name: str) -> Callable[..., Awaitable[ToolResult]]:
     """Return the async function for the named tool."""
-    tools = create_profile_tools(contractor)
+    tools = create_profile_tools(user)
     for t in tools:
         if t.name == tool_name:
             return t.function
@@ -35,24 +33,24 @@ def _get_tool_fn(
 
 @pytest.mark.asyncio()
 async def test_view_profile_shows_populated_fields(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """view_profile should return all populated profile fields."""
-    view_fn = _get_tool_fn(test_contractor, "view_profile")
+    view_fn = _get_tool_fn(test_user, "view_profile")
     result = await view_fn()
     assert result.is_error is False
-    assert "Test Contractor" in result.content
+    assert "Test User" in result.content
 
 
 @pytest.mark.asyncio()
 async def test_view_profile_shows_not_set_for_empty_fields(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """view_profile should show 'Not set' for empty name."""
-    store = get_contractor_store()
-    await store.update(test_contractor.id, name="")
+    store = get_user_store()
+    await store.update(test_user.id, name="")
 
-    view_fn = _get_tool_fn(test_contractor, "view_profile")
+    view_fn = _get_tool_fn(test_user, "view_profile")
     result = await view_fn()
     assert result.is_error is False
     assert "Name: Not set" in result.content
@@ -60,36 +58,36 @@ async def test_view_profile_shows_not_set_for_empty_fields(
 
 @pytest.mark.asyncio()
 async def test_view_profile_shows_onboarding_status(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """view_profile should show onboarding completion status."""
-    store = get_contractor_store()
-    await store.update(test_contractor.id, onboarding_complete=True)
+    store = get_user_store()
+    await store.update(test_user.id, onboarding_complete=True)
 
-    view_fn = _get_tool_fn(test_contractor, "view_profile")
+    view_fn = _get_tool_fn(test_user, "view_profile")
     result = await view_fn()
     assert "Onboarding Complete: Yes" in result.content
 
 
 @pytest.mark.asyncio()
 async def test_view_profile_reflects_updates(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """view_profile should reflect changes made by update_profile."""
-    update_fn = _get_tool_fn(test_contractor, "update_profile")
+    update_fn = _get_tool_fn(test_user, "update_profile")
     await update_fn(name="Jake the Plumber")
 
-    view_fn = _get_tool_fn(test_contractor, "view_profile")
+    view_fn = _get_tool_fn(test_user, "view_profile")
     result = await view_fn()
     assert "Jake the Plumber" in result.content
 
 
 @pytest.mark.asyncio()
 async def test_view_profile_mentions_user_md(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """view_profile should mention USER.md for additional details."""
-    view_fn = _get_tool_fn(test_contractor, "view_profile")
+    view_fn = _get_tool_fn(test_user, "view_profile")
     result = await view_fn()
     assert "USER.md" in result.content
 
@@ -97,25 +95,25 @@ async def test_view_profile_mentions_user_md(
 # --- _format_profile unit tests ---
 
 
-def test_format_profile_complete(test_contractor: ContractorData) -> None:
+def test_format_profile_complete(test_user: UserData) -> None:
     """_format_profile should include core fields for a populated profile."""
-    contractor = ContractorData(
-        id=test_contractor.id,
-        user_id=test_contractor.user_id,
-        name="Test Contractor",
+    user = UserData(
+        id=test_user.id,
+        user_id=test_user.user_id,
+        name="Test User",
         assistant_name="Bolt",
     )
 
-    output = _format_profile(contractor)
-    assert "Test Contractor" in output
+    output = _format_profile(user)
+    assert "Test User" in output
     assert "Bolt" in output
 
 
-def test_format_profile_empty_contractor() -> None:
-    """_format_profile should show 'Not set' for all fields on a blank contractor."""
-    contractor = ContractorData(user_id="blank-user")
+def test_format_profile_empty_user() -> None:
+    """_format_profile should show 'Not set' for all fields on a blank user."""
+    user = UserData(user_id="blank-user")
 
-    output = _format_profile(contractor)
+    output = _format_profile(user)
     assert "Name: Not set" in output
     assert "AI Name: Clawbolt (default)" in output
 
@@ -124,52 +122,52 @@ def test_format_profile_empty_contractor() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_update_profile_name(test_contractor: ContractorData) -> None:
-    """update_profile should update contractor name."""
-    update_fn = _get_tool_fn(test_contractor, "update_profile")
+async def test_update_profile_name(test_user: UserData) -> None:
+    """update_profile should update user name."""
+    update_fn = _get_tool_fn(test_user, "update_profile")
     result = await update_fn(name="Mike Johnson")
     assert "name" in result.content
     assert result.is_error is False
-    store = get_contractor_store()
-    refreshed = await store.get_by_id(test_contractor.id)
+    store = get_user_store()
+    refreshed = await store.get_by_id(test_user.id)
     assert refreshed is not None
     assert refreshed.name == "Mike Johnson"
 
 
 @pytest.mark.asyncio()
-async def test_update_profile_assistant_name(test_contractor: ContractorData) -> None:
+async def test_update_profile_assistant_name(test_user: UserData) -> None:
     """update_profile should update assistant name."""
-    update_fn = _get_tool_fn(test_contractor, "update_profile")
+    update_fn = _get_tool_fn(test_user, "update_profile")
     result = await update_fn(assistant_name="Bolt")
     assert "assistant_name" in result.content
     assert result.is_error is False
-    store = get_contractor_store()
-    refreshed = await store.get_by_id(test_contractor.id)
+    store = get_user_store()
+    refreshed = await store.get_by_id(test_user.id)
     assert refreshed is not None
     assert refreshed.assistant_name == "Bolt"
 
 
 @pytest.mark.asyncio()
 async def test_update_profile_multiple_fields(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """update_profile should update multiple fields at once."""
-    update_fn = _get_tool_fn(test_contractor, "update_profile")
+    update_fn = _get_tool_fn(test_user, "update_profile")
     result = await update_fn(name="Jake", assistant_name="Bolt")
     assert result.is_error is False
     assert "name" in result.content
     assert "assistant_name" in result.content
-    store = get_contractor_store()
-    refreshed = await store.get_by_id(test_contractor.id)
+    store = get_user_store()
+    refreshed = await store.get_by_id(test_user.id)
     assert refreshed is not None
     assert refreshed.name == "Jake"
     assert refreshed.assistant_name == "Bolt"
 
 
 @pytest.mark.asyncio()
-async def test_update_profile_no_fields(test_contractor: ContractorData) -> None:
+async def test_update_profile_no_fields(test_user: UserData) -> None:
     """update_profile should return error when no fields provided."""
-    update_fn = _get_tool_fn(test_contractor, "update_profile")
+    update_fn = _get_tool_fn(test_user, "update_profile")
     result = await update_fn()
     assert result.is_error is True
     assert "No fields provided" in result.content
@@ -262,27 +260,27 @@ def test_extract_all_fields() -> None:
 # --- Tool schema tests ---
 
 
-def test_tool_list_contains_both_tools(test_contractor: ContractorData) -> None:
+def test_tool_list_contains_both_tools(test_user: UserData) -> None:
     """create_profile_tools should return both view_profile and update_profile."""
-    tools = create_profile_tools(test_contractor)
+    tools = create_profile_tools(test_user)
     names = [t.name for t in tools]
     assert "view_profile" in names
     assert "update_profile" in names
     assert len(tools) == 2
 
 
-def test_view_profile_tool_schema(test_contractor: ContractorData) -> None:
+def test_view_profile_tool_schema(test_user: UserData) -> None:
     """view_profile tool should have correct name and no required parameters."""
-    tools = create_profile_tools(test_contractor)
+    tools = create_profile_tools(test_user)
     tool = next(t for t in tools if t.name == "view_profile")
     assert tool.params_model is not None
     schema = tool.params_model.model_json_schema()
     assert schema["properties"] == {}
 
 
-def test_update_profile_tool_schema(test_contractor: ContractorData) -> None:
+def test_update_profile_tool_schema(test_user: UserData) -> None:
     """update_profile tool should have correct name and params_model schema."""
-    tools = create_profile_tools(test_contractor)
+    tools = create_profile_tools(test_user)
     tool = next(t for t in tools if t.name == "update_profile")
     assert tool.name == "update_profile"
     assert tool.params_model is not None

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -38,4 +38,4 @@ def test_load_prompt_content_sanity() -> None:
     """Verify key substrings are present in a few prompts."""
     assert "concise" in load_prompt("instructions")
     assert "JSON" in load_prompt("compaction")
-    assert "onboarding" in load_prompt("onboarding") or "contractor" in load_prompt("onboarding")
+    assert "onboarding" in load_prompt("onboarding") or "user" in load_prompt("onboarding")

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData, get_contractor_store, reset_stores
+from backend.app.agent.file_store import UserData, get_user_store, reset_stores
 from backend.app.auth.dependencies import get_current_user
 from backend.app.config import settings
 from backend.app.main import app
@@ -42,8 +42,8 @@ def _rate_limited_client(tmp_path: object) -> Generator[TestClient]:
     with patch.object(settings, "data_dir", str(tmp_path)):
         reset_stores()
 
-        store = get_contractor_store()
-        contractor = asyncio.get_event_loop().run_until_complete(
+        store = get_user_store()
+        user = asyncio.get_event_loop().run_until_complete(
             store.create(
                 user_id="rl-test-user",
                 name="RL Test",
@@ -53,8 +53,8 @@ def _rate_limited_client(tmp_path: object) -> Generator[TestClient]:
             )
         )
 
-        def _override_get_current_user() -> ContractorData:
-            return contractor
+        def _override_get_current_user() -> UserData:
+            return user
 
         mock_messaging = MagicMock(spec=MessagingService)
         mock_messaging.send_text = AsyncMock(return_value="mock_msg_id")

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -3,9 +3,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.app.agent.file_store import (
-    ContractorData,
     SessionState,
     StoredMessage,
+    UserData,
 )
 from backend.app.agent.memory import recall_memories, save_memory
 from backend.app.agent.router import handle_inbound_message
@@ -14,10 +14,10 @@ from tests.mocks.llm import make_text_response, make_tool_call_response
 
 
 @pytest.fixture()
-def session(test_contractor: ContractorData) -> SessionState:
+def session(test_user: UserData) -> SessionState:
     return SessionState(
         session_id="test-session",
-        contractor_id=test_contractor.id,
+        user_id=test_user.id,
         messages=[],
         is_active=True,
     )
@@ -35,67 +35,67 @@ def mock_messaging() -> MessagingService:
 
 
 @pytest.mark.asyncio()
-async def test_recall_exact_match(test_contractor: ContractorData) -> None:
+async def test_recall_exact_match(test_user: UserData) -> None:
     """recall_facts should find exact keyword match."""
     await save_memory(
-        test_contractor.id,
+        test_user.id,
         key="johnson_deck_price",
         value="$4,500 for 12x12 composite deck",
         category="pricing",
     )
-    results = await recall_memories(test_contractor.id, query="johnson_deck_price")
+    results = await recall_memories(test_user.id, query="johnson_deck_price")
     assert len(results) == 1
     assert "4,500" in results[0].value
 
 
 @pytest.mark.asyncio()
-async def test_recall_keyword_search(test_contractor: ContractorData) -> None:
+async def test_recall_keyword_search(test_user: UserData) -> None:
     """recall_memories should find by keyword in key or value."""
     await save_memory(
-        test_contractor.id,
+        test_user.id,
         key="smith_bathroom_quote",
         value="$3,200 for full bathroom remodel",
         category="pricing",
     )
-    results = await recall_memories(test_contractor.id, query="bathroom")
+    results = await recall_memories(test_user.id, query="bathroom")
     assert len(results) >= 1
     assert any("bathroom" in m.key or "bathroom" in m.value for m in results)
 
 
 @pytest.mark.asyncio()
-async def test_recall_no_results(test_contractor: ContractorData) -> None:
+async def test_recall_no_results(test_user: UserData) -> None:
     """recall_memories should return empty list for unmatched query."""
-    results = await recall_memories(test_contractor.id, query="nonexistent_xyz_query")
+    results = await recall_memories(test_user.id, query="nonexistent_xyz_query")
     assert results == []
 
 
 @pytest.mark.asyncio()
-async def test_recall_by_category(test_contractor: ContractorData) -> None:
+async def test_recall_by_category(test_user: UserData) -> None:
     """recall_memories should filter by category."""
-    await save_memory(test_contractor.id, key="deck_rate", value="$45/sqft", category="pricing")
-    await save_memory(test_contractor.id, key="john_phone", value="555-1234", category="client")
+    await save_memory(test_user.id, key="deck_rate", value="$45/sqft", category="pricing")
+    await save_memory(test_user.id, key="john_phone", value="555-1234", category="client")
 
-    pricing_results = await recall_memories(test_contractor.id, query="deck", category="pricing")
+    pricing_results = await recall_memories(test_user.id, query="deck", category="pricing")
     assert len(pricing_results) >= 1
     assert all(m.category == "pricing" for m in pricing_results)
 
 
 @pytest.mark.asyncio()
-async def test_recall_multiple_facts(test_contractor: ContractorData) -> None:
+async def test_recall_multiple_facts(test_user: UserData) -> None:
     """recall_memories should return multiple matching facts."""
     await save_memory(
-        test_contractor.id,
+        test_user.id,
         key="deck_rate",
         value="$45/sqft for decks",
         category="pricing",
     )
     await save_memory(
-        test_contractor.id,
+        test_user.id,
         key="deck_material",
         value="Prefers Trex composite for decks",
         category="general",
     )
-    results = await recall_memories(test_contractor.id, query="deck")
+    results = await recall_memories(test_user.id, query="deck")
     assert len(results) >= 2
 
 
@@ -103,14 +103,14 @@ async def test_recall_multiple_facts(test_contractor: ContractorData) -> None:
 @patch("backend.app.agent.core.amessages")
 async def test_recall_end_to_end_save_then_query(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
     mock_messaging: MessagingService,
 ) -> None:
     """End-to-end: save a memory, then verify it's in context for next message."""
     # Step 1: Save a memory directly (simulating a previous conversation)
     await save_memory(
-        test_contractor.id,
+        test_user.id,
         key="johnson_deck",
         value="$4,500 for 12x12 composite deck",
         category="pricing",
@@ -132,7 +132,7 @@ async def test_recall_end_to_end_save_then_query(
     mock_amessages.side_effect = [tool_response, text_response]  # type: ignore[union-attr]
 
     response = await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=session,
         message=recall_msg,
         media_urls=[],
@@ -147,7 +147,7 @@ async def test_recall_end_to_end_save_then_query(
 @patch("backend.app.agent.core.amessages")
 async def test_system_prompt_includes_recall_guidance(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
     session: SessionState,
     mock_messaging: MessagingService,
 ) -> None:
@@ -162,7 +162,7 @@ async def test_system_prompt_includes_recall_guidance(
     mock_amessages.return_value = make_text_response("Let me check my memory.")  # type: ignore[union-attr]
 
     await handle_inbound_message(
-        contractor=test_contractor,
+        user=test_user,
         session=session,
         message=msg,
         media_urls=[],
@@ -178,22 +178,22 @@ async def test_system_prompt_includes_recall_guidance(
 
 @pytest.mark.asyncio()
 async def test_build_memory_context_includes_saved_facts(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """build_memory_context should include saved facts when query matches."""
     from backend.app.agent.memory import build_memory_context
 
     await save_memory(
-        test_contractor.id,
+        test_user.id,
         key="hourly_rate",
         value="$75/hour for general work",
         category="pricing",
     )
 
     # Direct keyword match on memory key
-    context = await build_memory_context(test_contractor.id, query="hourly_rate")
+    context = await build_memory_context(test_user.id, query="hourly_rate")
     assert "$75/hour" in context
 
     # No query returns all memories
-    context_all = await build_memory_context(test_contractor.id)
+    context_all = await build_memory_context(test_user.id)
     assert "$75/hour" in context_all

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import BaseModel
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.agent.tools.registry import (
@@ -83,14 +83,14 @@ class TestCreateCoreTools:
 
     def test_only_core_tools_returned(self) -> None:
         registry = _build_test_registry()
-        ctx = ToolContext(contractor=ContractorData(id=1))
+        ctx = ToolContext(user=UserData(id=1))
         tools = registry.create_core_tools(ctx)
         names = {t.name for t in tools}
         assert names == {"save_fact", "recall_facts", "send_reply", "view_profile"}
 
     def test_specialist_tools_excluded(self) -> None:
         registry = _build_test_registry()
-        ctx = ToolContext(contractor=ContractorData(id=1))
+        ctx = ToolContext(user=UserData(id=1))
         tools = registry.create_core_tools(ctx)
         names = {t.name for t in tools}
         assert "generate_estimate" not in names
@@ -106,7 +106,7 @@ class TestAvailableSpecialistSummaries:
 
         registry = _build_test_registry()
         ctx = ToolContext(
-            contractor=ContractorData(id=1),
+            user=UserData(id=1),
             storage=MagicMock(),
         )
         summaries = registry.get_available_specialist_summaries(ctx)
@@ -116,7 +116,7 @@ class TestAvailableSpecialistSummaries:
 
     def test_excludes_file_when_no_storage(self) -> None:
         registry = _build_test_registry()
-        ctx = ToolContext(contractor=ContractorData(id=1), storage=None)
+        ctx = ToolContext(user=UserData(id=1), storage=None)
         summaries = registry.get_available_specialist_summaries(ctx)
         assert "estimate" in summaries
         assert "checklist" in summaries
@@ -124,7 +124,7 @@ class TestAvailableSpecialistSummaries:
 
     def test_excludes_core_factories(self) -> None:
         registry = _build_test_registry()
-        ctx = ToolContext(contractor=ContractorData(id=1))
+        ctx = ToolContext(user=UserData(id=1))
         summaries = registry.get_available_specialist_summaries(ctx)
         assert "memory" not in summaries
         assert "messaging" not in summaries
@@ -219,9 +219,9 @@ class TestDynamicToolActivation:
         from backend.app.agent.messages import ToolCallRequest
 
         registry = _build_test_registry()
-        ctx = ToolContext(contractor=ContractorData(id=1))
+        ctx = ToolContext(user=UserData(id=1))
         agent = ClawboltAgent(
-            contractor=ContractorData(id=1),
+            user=UserData(id=1),
             tool_context=ctx,
             registry=registry,
         )
@@ -248,9 +248,9 @@ class TestDynamicToolActivation:
         from backend.app.agent.messages import ToolCallRequest
 
         registry = _build_test_registry()
-        ctx = ToolContext(contractor=ContractorData(id=1))
+        ctx = ToolContext(user=UserData(id=1))
         agent = ClawboltAgent(
-            contractor=ContractorData(id=1),
+            user=UserData(id=1),
             tool_context=ctx,
             registry=registry,
         )
@@ -276,9 +276,9 @@ class TestDynamicToolActivation:
         from backend.app.agent.messages import ToolCallRequest
 
         registry = _build_test_registry()
-        ctx = ToolContext(contractor=ContractorData(id=1))
+        ctx = ToolContext(user=UserData(id=1))
         agent = ClawboltAgent(
-            contractor=ContractorData(id=1),
+            user=UserData(id=1),
             tool_context=ctx,
             registry=registry,
         )
@@ -295,9 +295,9 @@ class TestDynamicToolActivation:
         from backend.app.agent.messages import ToolCallRequest
 
         registry = _build_test_registry()
-        ctx = ToolContext(contractor=ContractorData(id=1))
+        ctx = ToolContext(user=UserData(id=1))
         agent = ClawboltAgent(
-            contractor=ContractorData(id=1),
+            user=UserData(id=1),
             tool_context=ctx,
             registry=registry,
         )
@@ -320,7 +320,7 @@ class TestDynamicToolActivation:
         from backend.app.agent.messages import ToolCallRequest
 
         agent = ClawboltAgent(
-            contractor=ContractorData(id=1),
+            user=UserData(id=1),
         )
         calls = [
             ToolCallRequest(

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -5,15 +5,13 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.config import settings
 
 
-def _create_session(
-    contractor: ContractorData, session_id: str, messages: list[dict[str, object]]
-) -> None:
+def _create_session(user: UserData, session_id: str, messages: list[dict[str, object]]) -> None:
     """Create a test session JSONL file."""
-    base = Path(settings.data_dir) / str(contractor.id) / "sessions"
+    base = Path(settings.data_dir) / str(user.id) / "sessions"
     base.mkdir(parents=True, exist_ok=True)
     path = base / f"{session_id}.jsonl"
     lines = [
@@ -21,7 +19,7 @@ def _create_session(
             {
                 "_type": "metadata",
                 "session_id": session_id,
-                "contractor_id": contractor.id,
+                "user_id": user.id,
                 "created_at": "2025-01-15T10:00:00+00:00",
                 "last_message_at": "2025-01-15T10:05:00+00:00",
                 "is_active": True,
@@ -42,9 +40,9 @@ def test_list_sessions_empty(client: TestClient) -> None:
     assert data["total"] == 0
 
 
-def test_list_sessions(client: TestClient, test_contractor: ContractorData) -> None:
+def test_list_sessions(client: TestClient, test_user: UserData) -> None:
     _create_session(
-        test_contractor,
+        test_user,
         "1_100",
         [
             {"direction": "inbound", "body": "Hello", "timestamp": "2025-01-15T10:01:00", "seq": 1},
@@ -64,10 +62,10 @@ def test_list_sessions(client: TestClient, test_contractor: ContractorData) -> N
     assert data["sessions"][0]["id"] == "1_100"
 
 
-def test_get_session_detail(client: TestClient, test_contractor: ContractorData) -> None:
+def test_get_session_detail(client: TestClient, test_user: UserData) -> None:
     tool_json = json.dumps([{"tool": "save_fact", "input": {"key": "rate"}, "result": "saved"}])
     _create_session(
-        test_contractor,
+        test_user,
         "1_200",
         [
             {
@@ -96,10 +94,10 @@ def test_get_session_detail(client: TestClient, test_contractor: ContractorData)
     assert data["messages"][1]["tool_interactions"][0]["tool"] == "save_fact"
 
 
-def test_session_direction_values(client: TestClient, test_contractor: ContractorData) -> None:
+def test_session_direction_values(client: TestClient, test_user: UserData) -> None:
     """API response direction values must be 'inbound'/'outbound' (not 'incoming'/'outgoing')."""
     _create_session(
-        test_contractor,
+        test_user,
         "1_300",
         [
             {"direction": "inbound", "body": "Hi", "timestamp": "2025-01-15T10:01:00", "seq": 1},
@@ -123,10 +121,10 @@ def test_get_session_not_found(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
-def test_list_sessions_pagination(client: TestClient, test_contractor: ContractorData) -> None:
+def test_list_sessions_pagination(client: TestClient, test_user: UserData) -> None:
     for i in range(5):
         _create_session(
-            test_contractor,
+            test_user,
             f"1_{i}",
             [
                 {

--- a/tests/test_stats_endpoints.py
+++ b/tests/test_stats_endpoints.py
@@ -1,11 +1,11 @@
-"""Tests for contractor stats endpoint."""
+"""Tests for user stats endpoint."""
 
 import json
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.config import settings
 
 
@@ -20,15 +20,15 @@ def test_stats_empty(client: TestClient) -> None:
     assert data["last_conversation_at"] is None
 
 
-def test_stats_with_data(client: TestClient, test_contractor: ContractorData) -> None:
+def test_stats_with_data(client: TestClient, test_user: UserData) -> None:
     # Create a session with messages
-    base = Path(settings.data_dir) / str(test_contractor.id) / "sessions"
+    base = Path(settings.data_dir) / str(test_user.id) / "sessions"
     base.mkdir(parents=True, exist_ok=True)
     path = base / "1_100.jsonl"
     meta = {
         "_type": "metadata",
         "session_id": "1_100",
-        "contractor_id": test_contractor.id,
+        "user_id": test_user.id,
         "created_at": "2025-01-15T10:00:00+00:00",
         "last_message_at": "2025-01-15T10:05:00+00:00",
         "is_active": True,
@@ -41,7 +41,7 @@ def test_stats_with_data(client: TestClient, test_contractor: ContractorData) ->
     client.post("/api/user/checklist", json={"description": "Check site"})
 
     # Create memory
-    mem_dir = Path(settings.data_dir) / str(test_contractor.id) / "memory"
+    mem_dir = Path(settings.data_dir) / str(test_user.id) / "memory"
     mem_dir.mkdir(parents=True, exist_ok=True)
     (mem_dir / "MEMORY.md").write_text(
         "# Long-term Memory\n\n## General\n- rate: 85 (confidence: 1.0)\n",

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -512,14 +512,14 @@ async def test_gdrive_move_file_not_found(
 
 
 # ---------------------------------------------------------------------------
-# Per-contractor isolation tests
+# Per-user isolation tests
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio()
-async def test_local_storage_contractor_subdirectory(tmp_path: Path) -> None:
-    """LocalFileStorage with contractor_id should store files in a subdirectory."""
-    storage = LocalFileStorage(base_dir=str(tmp_path), contractor_id=42)
+async def test_local_storage_user_subdirectory(tmp_path: Path) -> None:
+    """LocalFileStorage with user_id should store files in a subdirectory."""
+    storage = LocalFileStorage(base_dir=str(tmp_path), user_id=42)
     await storage.upload_file(b"photo", "/Job Photos", "site.jpg")
     written = tmp_path / "42" / "Job Photos" / "site.jpg"
     assert written.exists()
@@ -527,10 +527,10 @@ async def test_local_storage_contractor_subdirectory(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_local_storage_contractors_are_isolated(tmp_path: Path) -> None:
-    """Files from different contractors should not be visible to each other."""
-    s1 = LocalFileStorage(base_dir=str(tmp_path), contractor_id=1)
-    s2 = LocalFileStorage(base_dir=str(tmp_path), contractor_id=2)
+async def test_local_storage_users_are_isolated(tmp_path: Path) -> None:
+    """Files from different users should not be visible to each other."""
+    s1 = LocalFileStorage(base_dir=str(tmp_path), user_id=1)
+    s2 = LocalFileStorage(base_dir=str(tmp_path), user_id=2)
 
     await s1.upload_file(b"a", "/docs", "a.txt")
     await s2.upload_file(b"b", "/docs", "b.txt")
@@ -542,30 +542,30 @@ async def test_local_storage_contractors_are_isolated(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_local_storage_no_contractor_uses_base_dir(tmp_path: Path) -> None:
-    """LocalFileStorage without contractor_id should use the base dir directly."""
+async def test_local_storage_no_user_uses_base_dir(tmp_path: Path) -> None:
+    """LocalFileStorage without user_id should use the base dir directly."""
     storage = LocalFileStorage(base_dir=str(tmp_path))
     await storage.upload_file(b"data", "/docs", "file.txt")
     written = tmp_path / "docs" / "file.txt"
     assert written.exists()
 
 
-def test_factory_passes_contractor_id_to_local(tmp_path: Path) -> None:
-    """get_storage_service should pass contractor.id to LocalFileStorage."""
+def test_factory_passes_user_id_to_local(tmp_path: Path) -> None:
+    """get_storage_service should pass user.id to LocalFileStorage."""
     mock_settings = MagicMock()
     mock_settings.storage_provider = "local"
     mock_settings.file_storage_base_dir = str(tmp_path)
 
-    contractor = MagicMock()
-    contractor.id = 99
+    user = MagicMock()
+    user.id = 99
 
-    result = get_storage_service(mock_settings, contractor=contractor)
+    result = get_storage_service(mock_settings, user=user)
     assert isinstance(result, LocalFileStorage)
     assert result.base_dir == (tmp_path / "99").resolve()
 
 
-def test_factory_no_contractor_local(tmp_path: Path) -> None:
-    """get_storage_service without contractor should not add subdirectory."""
+def test_factory_no_user_local(tmp_path: Path) -> None:
+    """get_storage_service without user should not add subdirectory."""
     mock_settings = MagicMock()
     mock_settings.storage_provider = "local"
     mock_settings.file_storage_base_dir = str(tmp_path)
@@ -575,18 +575,18 @@ def test_factory_no_contractor_local(tmp_path: Path) -> None:
     assert result.base_dir == tmp_path.resolve()
 
 
-def test_dropbox_contractor_prefixes_paths(mock_dbx_client: MagicMock) -> None:
-    """DropboxStorage with contractor_id should prefix paths."""
+def test_dropbox_user_prefixes_paths(mock_dbx_client: MagicMock) -> None:
+    """DropboxStorage with user_id should prefix paths."""
     with patch(
         "backend.app.services.storage_service.dropbox.Dropbox", return_value=mock_dbx_client
     ):
-        s = DropboxStorage(access_token="fake-token", contractor_id=42)
+        s = DropboxStorage(access_token="fake-token", user_id=42)
     assert s._path_prefix == "/42"
     assert s._prefixed("/docs") == "/42/docs"
 
 
-def test_dropbox_no_contractor_no_prefix(mock_dbx_client: MagicMock) -> None:
-    """DropboxStorage without contractor_id should not prefix paths."""
+def test_dropbox_no_user_no_prefix(mock_dbx_client: MagicMock) -> None:
+    """DropboxStorage without user_id should not prefix paths."""
     with patch(
         "backend.app.services.storage_service.dropbox.Dropbox", return_value=mock_dbx_client
     ):
@@ -595,13 +595,13 @@ def test_dropbox_no_contractor_no_prefix(mock_dbx_client: MagicMock) -> None:
     assert s._prefixed("/docs") == "/docs"
 
 
-def test_gdrive_contractor_path_prefix() -> None:
-    """GoogleDriveStorage with contractor_id should store a path prefix."""
-    s = GoogleDriveStorage(credentials_json='{"token": "fake"}', contractor_id=42)
+def test_gdrive_user_path_prefix() -> None:
+    """GoogleDriveStorage with user_id should store a path prefix."""
+    s = GoogleDriveStorage(credentials_json='{"token": "fake"}', user_id=42)
     assert s._path_prefix == "42/"
 
 
-def test_gdrive_no_contractor_no_prefix() -> None:
-    """GoogleDriveStorage without contractor_id should have empty prefix."""
+def test_gdrive_no_user_no_prefix() -> None:
+    """GoogleDriveStorage without user_id should have empty prefix."""
     s = GoogleDriveStorage(credentials_json='{"token": "fake"}')
     assert s._path_prefix == ""

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.system_prompt import (
     SystemPromptBuilder,
-    _to_contractor_time,
+    _to_user_time,
     build_agent_system_prompt,
     build_cross_session_context,
     build_date_section,
@@ -90,13 +90,13 @@ class TestSystemPromptBuilder:
 
 class TestSectionBuilders:
     def test_build_identity_section(self) -> None:
-        """Should include contractor name."""
-        contractor = MagicMock()
-        contractor.name = "Mike"
-        contractor.soul_text = None
-        contractor.preferences_json = None
-        contractor.assistant_name = "Clawbolt"
-        result = build_identity_section(contractor)
+        """Should include user name."""
+        user = MagicMock()
+        user.name = "Mike"
+        user.soul_text = None
+        user.preferences_json = None
+        user.assistant_name = "Clawbolt"
+        result = build_identity_section(user)
         assert "Mike" in result
 
     @pytest.mark.asyncio
@@ -107,7 +107,7 @@ class TestSectionBuilders:
             new_callable=AsyncMock,
             return_value="client: John Doe, deck work",
         ):
-            result = await build_memory_section(contractor_id=1)
+            result = await build_memory_section(user_id=1)
         assert "John Doe" in result
 
     @pytest.mark.asyncio
@@ -118,7 +118,7 @@ class TestSectionBuilders:
             new_callable=AsyncMock,
             return_value="",
         ):
-            result = await build_memory_section(contractor_id=1)
+            result = await build_memory_section(user_id=1)
         assert result == "(No memories saved yet)"
 
     def test_build_instructions_section(self) -> None:
@@ -165,12 +165,12 @@ class TestBuildAgentSystemPrompt:
     @pytest.mark.asyncio
     async def test_assembles_all_sections(self) -> None:
         """Full agent prompt should contain all key sections."""
-        contractor = MagicMock()
-        contractor.name = "Jake"
-        contractor.soul_text = None
-        contractor.preferences_json = None
-        contractor.assistant_name = "Clawbolt"
-        contractor.id = 1
+        user = MagicMock()
+        user.name = "Jake"
+        user.soul_text = None
+        user.preferences_json = None
+        user.assistant_name = "Clawbolt"
+        user.id = 1
 
         tool = MagicMock()
         tool.usage_hint = "Use save_fact for memories"
@@ -181,7 +181,7 @@ class TestBuildAgentSystemPrompt:
             return_value="client: Jane, roof repair",
         ):
             result = await build_agent_system_prompt(
-                contractor=contractor,
+                user=user,
                 tools=[tool],
                 message_context="how much for a roof repair?",
             )
@@ -197,12 +197,12 @@ class TestBuildAgentSystemPrompt:
     @pytest.mark.asyncio
     async def test_preamble_uses_assistant_name(self) -> None:
         """Agent prompt preamble should use custom assistant_name."""
-        contractor = MagicMock()
-        contractor.name = "Jake"
-        contractor.soul_text = None
-        contractor.preferences_json = None
-        contractor.assistant_name = "Bolt"
-        contractor.id = 1
+        user = MagicMock()
+        user.name = "Jake"
+        user.soul_text = None
+        user.preferences_json = None
+        user.assistant_name = "Bolt"
+        user.id = 1
 
         with patch(
             "backend.app.agent.system_prompt.build_memory_context",
@@ -210,7 +210,7 @@ class TestBuildAgentSystemPrompt:
             return_value="",
         ):
             result = await build_agent_system_prompt(
-                contractor=contractor,
+                user=user,
                 tools=[],
                 message_context="hello",
             )
@@ -221,12 +221,12 @@ class TestBuildAgentSystemPrompt:
     @pytest.mark.asyncio
     async def test_no_trade_guidance_in_prompt(self) -> None:
         """Agent prompt should not contain trade-specific guidance (removed from model)."""
-        contractor = MagicMock()
-        contractor.name = "Sparky"
-        contractor.soul_text = None
-        contractor.preferences_json = None
-        contractor.assistant_name = "Clawbolt"
-        contractor.id = 1
+        user = MagicMock()
+        user.name = "Sparky"
+        user.soul_text = None
+        user.preferences_json = None
+        user.assistant_name = "Clawbolt"
+        user.id = 1
 
         with patch(
             "backend.app.agent.system_prompt.build_memory_context",
@@ -234,7 +234,7 @@ class TestBuildAgentSystemPrompt:
             return_value="",
         ):
             result = await build_agent_system_prompt(
-                contractor=contractor,
+                user=user,
                 tools=[],
                 message_context="hello",
             )
@@ -244,14 +244,14 @@ class TestBuildAgentSystemPrompt:
         assert "NEC codes" not in result
 
     @pytest.mark.asyncio
-    async def test_curly_braces_in_contractor_name(self) -> None:
-        """Contractor name with curly braces should not break the prompt."""
-        contractor = MagicMock()
-        contractor.name = "Mike {The Plumber}"
-        contractor.soul_text = None
-        contractor.preferences_json = None
-        contractor.assistant_name = "Clawbolt"
-        contractor.id = 1
+    async def test_curly_braces_in_owner_name(self) -> None:
+        """User name with curly braces should not break the prompt."""
+        user = MagicMock()
+        user.name = "Mike {The Plumber}"
+        user.soul_text = None
+        user.preferences_json = None
+        user.assistant_name = "Clawbolt"
+        user.id = 1
 
         with patch(
             "backend.app.agent.system_prompt.build_memory_context",
@@ -259,7 +259,7 @@ class TestBuildAgentSystemPrompt:
             return_value="",
         ):
             result = await build_agent_system_prompt(
-                contractor=contractor,
+                user=user,
                 tools=[],
                 message_context="hello",
             )
@@ -267,21 +267,21 @@ class TestBuildAgentSystemPrompt:
         assert "Mike {The Plumber}" in result
 
 
-class TestToContractorTime:
+class TestToUserTime:
     def test_converts_to_pacific(self) -> None:
         utc = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
-        result = _to_contractor_time(utc, "America/Los_Angeles")
+        result = _to_user_time(utc, "America/Los_Angeles")
         # UTC 17:00 in June (PDT, UTC-7) -> 10:00 local
         assert result.hour == 10
 
     def test_empty_timezone_returns_utc(self) -> None:
         utc = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
-        result = _to_contractor_time(utc, "")
+        result = _to_user_time(utc, "")
         assert result.hour == 17
 
     def test_invalid_timezone_returns_utc(self) -> None:
         utc = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
-        result = _to_contractor_time(utc, "Not/A_Real_Zone")
+        result = _to_user_time(utc, "Not/A_Real_Zone")
         assert result.hour == 17
 
 
@@ -292,22 +292,22 @@ class TestBuildDateSection:
         mock_dt.datetime.now.return_value = datetime.datetime(
             2025, 6, 16, 15, 30, tzinfo=datetime.UTC
         )
-        contractor = MagicMock()
-        contractor.timezone = ""
-        result = build_date_section(contractor)
+        user = MagicMock()
+        user.timezone = ""
+        result = build_date_section(user)
         # 2025-06-16 is a Monday
         assert result == "Monday, 2025-06-16"
 
     @patch("backend.app.agent.system_prompt.datetime")
-    def test_converts_to_contractor_timezone(self, mock_dt: MagicMock) -> None:
+    def test_converts_to_user_timezone(self, mock_dt: MagicMock) -> None:
         mock_dt.UTC = datetime.UTC
         # Saturday 3 AM UTC -> Friday 8 PM Pacific (PDT)
         mock_dt.datetime.now.return_value = datetime.datetime(
             2025, 6, 14, 3, 0, tzinfo=datetime.UTC
         )
-        contractor = MagicMock()
-        contractor.timezone = "America/Los_Angeles"
-        result = build_date_section(contractor)
+        user = MagicMock()
+        user.timezone = "America/Los_Angeles"
+        result = build_date_section(user)
         # Should show Friday (local), not Saturday (UTC)
         assert result == "Friday, 2025-06-13"
 
@@ -319,9 +319,9 @@ class TestBuildLocalDatetimeSection:
         mock_dt.datetime.now.return_value = datetime.datetime(
             2025, 6, 15, 17, 30, tzinfo=datetime.UTC
         )
-        contractor = MagicMock()
-        contractor.timezone = "America/New_York"
-        result = build_local_datetime_section(contractor)
+        user = MagicMock()
+        user.timezone = "America/New_York"
+        result = build_local_datetime_section(user)
         # UTC 17:30 -> 1:30 PM EDT
         assert "01:30 PM" in result
         assert "Sunday" in result
@@ -333,9 +333,9 @@ class TestBuildLocalDatetimeSection:
         mock_dt.datetime.now.return_value = datetime.datetime(
             2025, 6, 15, 17, 30, tzinfo=datetime.UTC
         )
-        contractor = MagicMock()
-        contractor.timezone = ""
-        result = build_local_datetime_section(contractor)
+        user = MagicMock()
+        user.timezone = ""
+        result = build_local_datetime_section(user)
         assert "05:30 PM" in result
         assert "Sunday" in result
 
@@ -349,13 +349,13 @@ class TestAgentSystemPromptIncludesDate:
         mock_dt.datetime.now.return_value = datetime.datetime(
             2025, 6, 16, 15, 0, tzinfo=datetime.UTC
         )
-        contractor = MagicMock()
-        contractor.name = "Jake"
-        contractor.soul_text = None
-        contractor.preferences_json = None
-        contractor.assistant_name = "Clawbolt"
-        contractor.timezone = "America/Los_Angeles"
-        contractor.id = 1
+        user = MagicMock()
+        user.name = "Jake"
+        user.soul_text = None
+        user.preferences_json = None
+        user.assistant_name = "Clawbolt"
+        user.timezone = "America/Los_Angeles"
+        user.id = 1
 
         with patch(
             "backend.app.agent.system_prompt.build_memory_context",
@@ -363,7 +363,7 @@ class TestAgentSystemPromptIncludesDate:
             return_value="",
         ):
             result = await build_agent_system_prompt(
-                contractor=contractor,
+                user=user,
                 tools=[],
                 message_context="hello",
             )
@@ -376,23 +376,21 @@ class TestAgentSystemPromptIncludesDate:
 class TestCrossSessionContext:
     def test_returns_empty_when_no_other_sessions(
         self,
-        test_contractor: "ContractorData",
+        test_user: "UserData",
     ) -> None:
         """Should return empty string when no other sessions exist."""
-        result = build_cross_session_context(
-            test_contractor.id, current_session_id="nonexistent_999"
-        )
+        result = build_cross_session_context(test_user.id, current_session_id="nonexistent_999")
         assert result == ""
 
     @pytest.mark.asyncio()
     async def test_includes_messages_from_other_session(
         self,
-        test_contractor: "ContractorData",
+        test_user: "UserData",
     ) -> None:
         """Should include messages from sessions other than the current one."""
         from backend.app.agent.file_store import get_session_store
 
-        store = get_session_store(test_contractor.id)
+        store = get_session_store(test_user.id)
 
         # Create session A with messages
         session_a, _ = await store.get_or_create_session()
@@ -400,7 +398,7 @@ class TestCrossSessionContext:
         await store.add_message(session_a, "outbound", "Hi! How can I help?")
 
         result = build_cross_session_context(
-            test_contractor.id, current_session_id="different_session_999"
+            test_user.id, current_session_id="different_session_999"
         )
         assert "Hello from Telegram" in result
         assert "Hi! How can I help?" in result
@@ -410,36 +408,34 @@ class TestCrossSessionContext:
     @pytest.mark.asyncio()
     async def test_excludes_current_session(
         self,
-        test_contractor: "ContractorData",
+        test_user: "UserData",
     ) -> None:
         """Should not include messages from the current session."""
         from backend.app.agent.file_store import get_session_store
 
-        store = get_session_store(test_contractor.id)
+        store = get_session_store(test_user.id)
 
         session_a, _ = await store.get_or_create_session()
         await store.add_message(session_a, "inbound", "Message in session A")
 
         # When querying with session A's own ID, nothing should appear
-        result = build_cross_session_context(
-            test_contractor.id, current_session_id=session_a.session_id
-        )
+        result = build_cross_session_context(test_user.id, current_session_id=session_a.session_id)
         assert result == ""
 
     @pytest.mark.asyncio()
     async def test_truncates_long_messages(
         self,
-        test_contractor: "ContractorData",
+        test_user: "UserData",
     ) -> None:
         """Long message bodies should be truncated."""
         from backend.app.agent.file_store import get_session_store
 
-        store = get_session_store(test_contractor.id)
+        store = get_session_store(test_user.id)
         session_a, _ = await store.get_or_create_session()
         long_body = "x" * 300
         await store.add_message(session_a, "inbound", long_body)
 
-        result = build_cross_session_context(test_contractor.id, current_session_id="other_999")
+        result = build_cross_session_context(test_user.id, current_session_id="other_999")
         assert "..." in result
         # Should be truncated to ~200 chars + "..."
         assert "x" * 201 not in result
@@ -447,26 +443,26 @@ class TestCrossSessionContext:
     @pytest.mark.asyncio()
     async def test_agent_prompt_includes_cross_session_context(
         self,
-        test_contractor: "ContractorData",
+        test_user: "UserData",
     ) -> None:
         """Agent system prompt should include cross-session context when available."""
         from backend.app.agent.file_store import get_session_store
 
-        store = get_session_store(test_contractor.id)
+        store = get_session_store(test_user.id)
 
         # Create a session with messages (simulates a Telegram conversation)
         session_a, _ = await store.get_or_create_session()
         await store.add_message(session_a, "inbound", "Draft estimate for deck")
         await store.add_message(session_a, "outbound", "Sure, what size deck?")
 
-        contractor = MagicMock()
-        contractor.name = "Jake"
-        contractor.soul_text = None
-        contractor.preferences_json = None
-        contractor.assistant_name = "Clawbolt"
-        contractor.id = test_contractor.id
-        contractor.user_text = ""
-        contractor.timezone = ""
+        user = MagicMock()
+        user.name = "Jake"
+        user.soul_text = None
+        user.preferences_json = None
+        user.assistant_name = "Clawbolt"
+        user.id = test_user.id
+        user.user_text = ""
+        user.timezone = ""
 
         with patch(
             "backend.app.agent.system_prompt.build_memory_context",
@@ -474,7 +470,7 @@ class TestCrossSessionContext:
             return_value="",
         ):
             result = await build_agent_system_prompt(
-                contractor=contractor,
+                user=user,
                 tools=[],
                 message_context="hello",
                 current_session_id="webchat_session_999",

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -2,7 +2,7 @@
 
 With the message bus, the webhook handler validates, parses, checks the
 allowlist, and publishes an InboundMessage to the bus. The bus consumer
-handles contractor lookup, session creation, message persistence, and
+handles user lookup, session creation, message persistence, and
 the agent pipeline. Tests below verify the webhook's responsibilities:
 parsing, allowlist gating, idempotency, and correct bus publishing.
 """

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -4,9 +4,9 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.app.agent.file_store import (
-    ContractorData,
     ToolConfigEntry,
     ToolConfigStore,
+    UserData,
 )
 from backend.app.agent.tools.registry import (
     ToolContext,
@@ -24,20 +24,20 @@ ensure_tool_modules_imported()
 
 @pytest.mark.asyncio()
 async def test_tool_config_store_empty_on_first_load(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """First load returns an empty list when no config file exists."""
-    store = ToolConfigStore(test_contractor.id)
+    store = ToolConfigStore(test_user.id)
     entries = await store.load()
     assert entries == []
 
 
 @pytest.mark.asyncio()
 async def test_tool_config_store_save_and_load(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Saved entries can be loaded back."""
-    store = ToolConfigStore(test_contractor.id)
+    store = ToolConfigStore(test_user.id)
     entries = [
         ToolConfigEntry(name="estimate", description="Estimates", category="domain", enabled=False),
         ToolConfigEntry(name="workspace", description="Files", category="core", enabled=True),
@@ -55,10 +55,10 @@ async def test_tool_config_store_save_and_load(
 
 @pytest.mark.asyncio()
 async def test_tool_config_store_get_disabled_tool_names(
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """get_disabled_tool_names returns only disabled entries."""
-    store = ToolConfigStore(test_contractor.id)
+    store = ToolConfigStore(test_user.id)
     entries = [
         ToolConfigEntry(name="estimate", category="domain", enabled=False),
         ToolConfigEntry(name="file", category="domain", enabled=True),
@@ -77,8 +77,8 @@ async def test_tool_config_store_get_disabled_tool_names(
 
 def test_create_core_tools_excludes_disabled_factories() -> None:
     """create_core_tools should skip excluded factories."""
-    contractor = ContractorData(id=999, user_id="test")
-    ctx = ToolContext(contractor=contractor)
+    user = UserData(id=999, user_id="test")
+    ctx = ToolContext(user=user)
 
     all_core = default_registry.create_core_tools(ctx)
     excluded = default_registry.create_core_tools(ctx, excluded_factories={"memory"})
@@ -91,8 +91,8 @@ def test_create_core_tools_excludes_disabled_factories() -> None:
 
 def test_specialist_summaries_excludes_disabled_factories() -> None:
     """get_available_specialist_summaries should skip excluded factories."""
-    contractor = ContractorData(id=999, user_id="test")
-    ctx = ToolContext(contractor=contractor)
+    user = UserData(id=999, user_id="test")
+    ctx = ToolContext(user=user)
 
     all_summaries = default_registry.get_available_specialist_summaries(ctx)
     excluded_summaries = default_registry.get_available_specialist_summaries(

--- a/tests/test_tool_param_validation.py
+++ b/tests/test_tool_param_validation.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import BaseModel, Field
 
 from backend.app.agent.core import ClawboltAgent, _summarize_tool_params
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.tools.base import Tool, ToolResult, tool_to_function_schema
 from backend.app.agent.tools.checklist_tools import (
     AddChecklistItemParams,
@@ -181,7 +181,7 @@ def test_add_checklist_item_rejects_invalid_schedule() -> None:
 @patch("backend.app.agent.core.amessages")
 async def test_agent_validation_failure_returns_error_result(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """When params_model validation fails, agent should return a structured error."""
     # LLM sends wrong type for 'key' (int instead of string) to save_fact
@@ -209,7 +209,7 @@ async def test_agent_validation_failure_returns_error_result(
         params_model=TypedParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -227,7 +227,7 @@ async def test_agent_validation_failure_returns_error_result(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_validation_success_calls_tool(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """When params_model validation passes, agent should call the tool normally."""
     tool_response = make_tool_call_response(
@@ -254,7 +254,7 @@ async def test_agent_validation_success_calls_tool(
         params_model=TypedParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -267,7 +267,7 @@ async def test_agent_validation_success_calls_tool(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_validation_coerces_types(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Pydantic validation should coerce compatible types (e.g., str '42' to int)."""
     tool_response = make_tool_call_response(
@@ -294,7 +294,7 @@ async def test_agent_validation_coerces_types(
         params_model=TypedParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     await agent.process_message("test", system_prompt_override="system")
 
@@ -306,7 +306,7 @@ async def test_agent_validation_coerces_types(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_validation_wrong_type_returns_field_error(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Validation error message should include the specific field that failed."""
     tool_response = make_tool_call_response(
@@ -333,7 +333,7 @@ async def test_agent_validation_wrong_type_returns_field_error(
         params_model=TypedParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -369,7 +369,7 @@ def test_update_profile_params_accepts_all_fields() -> None:
 @patch("backend.app.agent.core.amessages")
 async def test_batch_validation_reports_all_errors_at_once(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """When multiple tool calls have invalid args, ALL errors should be returned in one round.
 
@@ -408,7 +408,7 @@ async def test_batch_validation_reports_all_errors_at_once(
     followup_response = make_text_response("I see both errors. Let me fix them.")
     mock_amessages.side_effect = [tool_response, followup_response]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -430,7 +430,7 @@ async def test_batch_validation_reports_all_errors_at_once(
 @patch("backend.app.agent.core.amessages")
 async def test_batch_validation_executes_valid_calls_alongside_invalid(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Valid tool calls should still execute even when other calls in the same batch fail."""
 
@@ -469,7 +469,7 @@ async def test_batch_validation_executes_valid_calls_alongside_invalid(
     followup_response = make_text_response("Done!")
     mock_amessages.side_effect = [tool_response, followup_response]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 
@@ -530,7 +530,7 @@ def test_summarize_tool_params_resolves_anyof_types() -> None:
 @patch("backend.app.agent.core.amessages")
 async def test_validation_error_for_missing_line_items_shows_item_structure(
     mock_amessages: AsyncMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """When line_items is missing, the error sent to the LLM should describe the item schema.
 
@@ -557,7 +557,7 @@ async def test_validation_error_for_missing_line_items_shows_item_structure(
         params_model=GenerateEstimateParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("test", system_prompt_override="system")
 

--- a/tests/test_tool_tags.py
+++ b/tests/test_tool_tags.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import BaseModel
 
 from backend.app.agent.core import ClawboltAgent
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.tools.base import Tool, ToolResult, ToolTags
 from backend.app.agent.tools.memory_tools import create_memory_tools
 from backend.app.agent.tools.messaging_tools import create_messaging_tools
@@ -115,14 +115,14 @@ def test_tool_tags_do_not_leak_between_instances() -> None:
 
 def test_memory_tools_save_fact_has_saves_memory_tag() -> None:
     """save_fact tool from create_memory_tools should have SAVES_MEMORY tag."""
-    tools = create_memory_tools(contractor_id=1)
+    tools = create_memory_tools(user_id=1)
     save_fact = next(t for t in tools if t.name == "save_fact")
     assert ToolTags.SAVES_MEMORY in save_fact.tags
 
 
 def test_memory_tools_recall_and_forget_have_no_special_tags() -> None:
     """recall_facts and forget_fact should not have SAVES_MEMORY or SENDS_REPLY tags."""
-    tools = create_memory_tools(contractor_id=1)
+    tools = create_memory_tools(user_id=1)
     for tool in tools:
         if tool.name in ("recall_facts", "forget_fact"):
             assert ToolTags.SAVES_MEMORY not in tool.tags
@@ -151,7 +151,7 @@ def test_messaging_tools_do_not_have_saves_memory_tag() -> None:
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_tool_call_records_include_tags(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Tool call records in AgentResponse should include tags from the Tool definition."""
     tool_response = make_tool_call_response(
@@ -174,7 +174,7 @@ async def test_agent_tool_call_records_include_tags(
         tags={ToolTags.SAVES_MEMORY},
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("My rate is $50/hour")
 
@@ -185,7 +185,7 @@ async def test_agent_tool_call_records_include_tags(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_memories_saved_uses_tags_not_name(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """memories_saved should be populated based on SAVES_MEMORY tag, not tool name."""
     tool_response = make_tool_call_response(
@@ -208,7 +208,7 @@ async def test_agent_memories_saved_uses_tags_not_name(
         tags={ToolTags.SAVES_MEMORY},
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("My favorite color is blue")
 
@@ -219,7 +219,7 @@ async def test_agent_memories_saved_uses_tags_not_name(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_untagged_tool_has_empty_tags(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Tool without tags should produce tool_call record with empty tags set."""
     tool_response = make_tool_call_response(
@@ -241,7 +241,7 @@ async def test_agent_untagged_tool_has_empty_tags(
         params_model=_QParams,
     )
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     agent.register_tools([tool])
     response = await agent.process_message("hello")
 
@@ -257,8 +257,8 @@ def test_update_profile_has_modifies_profile_tag() -> None:
     """update_profile tool from create_profile_tools should have MODIFIES_PROFILE tag."""
     from backend.app.agent.tools.profile_tools import create_profile_tools
 
-    contractor = ContractorData(id=1, user_id="test", name="Test")
-    tools = create_profile_tools(contractor)
+    user = UserData(id=1, user_id="test", name="Test")
+    tools = create_profile_tools(user)
     update_profile = next(t for t in tools if t.name == "update_profile")
     assert ToolTags.MODIFIES_PROFILE in update_profile.tags
 
@@ -267,7 +267,7 @@ def test_view_profile_has_no_modifies_profile_tag() -> None:
     """view_profile should not have MODIFIES_PROFILE tag."""
     from backend.app.agent.tools.profile_tools import create_profile_tools
 
-    contractor = ContractorData(id=1, user_id="test", name="Test")
-    tools = create_profile_tools(contractor)
+    user = UserData(id=1, user_id="test", name="Test")
+    tools = create_profile_tools(user)
     view_profile = next(t for t in tools if t.name == "view_profile")
     assert ToolTags.MODIFIES_PROFILE not in view_profile.tags

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import BaseModel
 
 from backend.app.agent.core import ClawboltAgent
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.heartbeat import evaluate_heartbeat_need
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.services.messaging import MessagingService
@@ -28,7 +28,7 @@ class _InputParams(BaseModel):
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_sends_typing_indicator_before_llm_call(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Agent should send a typing indicator before each acompletion call."""
     mock_amessages.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
@@ -37,7 +37,7 @@ async def test_agent_sends_typing_indicator_before_llm_call(
     mock_messaging.send_typing_indicator = AsyncMock()
 
     agent = ClawboltAgent(
-        contractor=test_contractor,
+        user=test_user,
         messaging_service=mock_messaging,
         chat_id="123456789",
     )
@@ -50,7 +50,7 @@ async def test_agent_sends_typing_indicator_before_llm_call(
 @patch("backend.app.agent.core.amessages")
 async def test_agent_sends_typing_indicator_before_each_tool_round(
     mock_amessages: object,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Agent should send typing indicator before each LLM call in multi-round tool loops."""
 
@@ -77,7 +77,7 @@ async def test_agent_sends_typing_indicator_before_each_tool_round(
     mock_messaging.send_typing_indicator = AsyncMock()
 
     agent = ClawboltAgent(
-        contractor=test_contractor,
+        user=test_user,
         messaging_service=mock_messaging,
         chat_id="123456789",
     )
@@ -93,12 +93,12 @@ async def test_agent_sends_typing_indicator_before_each_tool_round(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_works_without_messaging_service(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Agent should work correctly when no messaging_service is provided."""
     mock_amessages.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
 
-    agent = ClawboltAgent(contractor=test_contractor)
+    agent = ClawboltAgent(user=test_user)
     response = await agent.process_message("Hi there")
 
     assert response.reply_text == "Hello!"
@@ -108,7 +108,7 @@ async def test_agent_works_without_messaging_service(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_typing_indicator_failure_does_not_break_agent(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Agent should continue processing even if typing indicator fails."""
     mock_amessages.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
@@ -117,7 +117,7 @@ async def test_agent_typing_indicator_failure_does_not_break_agent(
     mock_messaging.send_typing_indicator = AsyncMock(side_effect=RuntimeError("API down"))
 
     agent = ClawboltAgent(
-        contractor=test_contractor,
+        user=test_user,
         messaging_service=mock_messaging,
         chat_id="123456789",
     )
@@ -130,7 +130,7 @@ async def test_agent_typing_indicator_failure_does_not_break_agent(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_agent_no_typing_indicator_without_chat_id(
-    mock_amessages: object, test_contractor: ContractorData
+    mock_amessages: object, test_user: UserData
 ) -> None:
     """Agent should not send typing indicator when chat_id is not provided."""
     mock_amessages.return_value = make_text_response("Hello!")  # type: ignore[union-attr]
@@ -139,7 +139,7 @@ async def test_agent_no_typing_indicator_without_chat_id(
     mock_messaging.send_typing_indicator = AsyncMock()
 
     agent = ClawboltAgent(
-        contractor=test_contractor,
+        user=test_user,
         messaging_service=mock_messaging,
         chat_id=None,
     )
@@ -159,7 +159,7 @@ async def test_agent_no_typing_indicator_without_chat_id(
 async def test_heartbeat_sends_typing_indicator_before_llm_call(
     mock_llm: AsyncMock,
     mock_settings: MagicMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Heartbeat should send typing indicator before calling the LLM."""
     mock_settings.llm_model = "test-model"
@@ -189,14 +189,12 @@ async def test_heartbeat_sends_typing_indicator_before_llm_call(
     mock_messaging.send_typing_indicator = AsyncMock()
 
     await evaluate_heartbeat_need(
-        test_contractor,
+        test_user,
         ["Stale draft estimate"],
         messaging_service=mock_messaging,
     )
 
-    mock_messaging.send_typing_indicator.assert_called_once_with(
-        to=test_contractor.channel_identifier
-    )
+    mock_messaging.send_typing_indicator.assert_called_once_with(to=test_user.channel_identifier)
 
 
 @pytest.mark.asyncio()
@@ -205,7 +203,7 @@ async def test_heartbeat_sends_typing_indicator_before_llm_call(
 async def test_heartbeat_works_without_messaging_service(
     mock_llm: AsyncMock,
     mock_settings: MagicMock,
-    test_contractor: ContractorData,
+    test_user: UserData,
 ) -> None:
     """Heartbeat should work when no messaging_service is provided."""
     mock_settings.llm_model = "test-model"
@@ -233,7 +231,7 @@ async def test_heartbeat_works_without_messaging_service(
 
     # Should not raise when no messaging_service is provided
     action = await evaluate_heartbeat_need(
-        test_contractor,
+        test_user,
         ["Stale draft estimate"],
     )
     assert action.action_type == "no_action"

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -7,24 +7,24 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData, get_contractor_store
+from backend.app.agent.file_store import UserData, get_user_store
 from backend.app.bus import OutboundMessage, message_bus
 from backend.app.config import settings
 from backend.app.main import app
 
 
 @pytest.fixture()
-async def webchat_contractor() -> ContractorData:
-    """Create a contractor for web chat tests."""
-    store = get_contractor_store()
+async def webchat_user() -> UserData:
+    """Create a user for web chat tests."""
+    store = get_user_store()
     return await store.create(
         user_id="webchat-test-user",
-        name="Test Contractor",
+        name="Test User",
     )
 
 
 @pytest.fixture()
-def webchat_client(webchat_contractor: ContractorData) -> Generator[TestClient]:
+def webchat_client(webchat_user: UserData) -> Generator[TestClient]:
     """TestClient that uses real get_current_user (no auth override).
 
     Mocks the LLM to avoid external API calls during tests.
@@ -43,7 +43,7 @@ def webchat_client(webchat_contractor: ContractorData) -> Generator[TestClient]:
 
 def test_chat_endpoint_returns_request_id(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """POST /api/user/chat should return request_id and session_id."""
     resp = webchat_client.post(
@@ -66,7 +66,7 @@ def test_chat_endpoint_missing_body(webchat_client: TestClient) -> None:
 
 def test_chat_returns_same_session(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """Multiple messages within the session timeout should use the same session."""
     resp1 = webchat_client.post(
@@ -83,7 +83,7 @@ def test_chat_returns_same_session(
 
 def test_chat_with_explicit_session_id(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """Sending session_id should resume that session."""
     resp1 = webchat_client.post(
@@ -112,7 +112,7 @@ def test_chat_with_invalid_session_id(webchat_client: TestClient) -> None:
 
 def test_chat_with_nonexistent_session_id(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """Valid-format but nonexistent session_id should create a new session."""
     resp = webchat_client.post(
@@ -132,7 +132,7 @@ def test_chat_with_nonexistent_session_id(
 
 def test_chat_with_image_upload(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """Upload an image with text; verify the request is accepted."""
     # 1x1 red PNG
@@ -156,7 +156,7 @@ def test_chat_with_image_upload(
 
 def test_chat_with_files_only(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """Upload a file without text; should still succeed."""
     resp = webchat_client.post(
@@ -176,7 +176,7 @@ def test_chat_no_message_no_files(webchat_client: TestClient) -> None:
 
 def test_chat_file_too_large(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """Oversized file should return 422."""
     with patch.object(settings, "max_media_size_bytes", 10):
@@ -192,7 +192,7 @@ def test_chat_file_too_large(
 
 def test_chat_multiple_files(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """Multiple files in one request should all be accepted."""
     resp = webchat_client.post(
@@ -216,7 +216,7 @@ def test_chat_multiple_files(
 
 def test_chat_publishes_to_bus(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """POST /api/user/chat should publish an InboundMessage to the bus."""
     with patch(
@@ -242,7 +242,7 @@ def test_chat_publishes_to_bus(
 
 def test_sse_endpoint_returns_reply(
     webchat_client: TestClient,
-    webchat_contractor: ContractorData,
+    webchat_user: UserData,
 ) -> None:
     """GET /api/user/chat/events/{request_id} should stream the reply as SSE."""
     import threading

--- a/tests/test_webhook_secret_validation.py
+++ b/tests/test_webhook_secret_validation.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
-from backend.app.agent.file_store import ContractorData, get_contractor_store, reset_stores
+from backend.app.agent.file_store import UserData, get_user_store, reset_stores
 from backend.app.auth.dependencies import get_current_user
 from backend.app.config import (
     Settings,
@@ -35,8 +35,8 @@ def _make_client(
     with patch.object(settings, "data_dir", data_dir):
         reset_stores()
 
-        store = get_contractor_store()
-        contractor = asyncio.get_event_loop().run_until_complete(
+        store = get_user_store()
+        user = asyncio.get_event_loop().run_until_complete(
             store.create(
                 user_id="secret-test-user",
                 name="Secret Test",
@@ -46,8 +46,8 @@ def _make_client(
             )
         )
 
-        def _override_get_current_user() -> ContractorData:
-            return contractor
+        def _override_get_current_user() -> UserData:
+            return user
 
         mock_messaging = MagicMock(spec=MessagingService)
         mock_messaging.send_text = AsyncMock(return_value="mock_msg_id")

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -7,15 +7,15 @@ from pathlib import Path
 
 import pytest
 
-from backend.app.agent.file_store import ContractorData
+from backend.app.agent.file_store import UserData
 from backend.app.agent.tools.base import ToolResult
 from backend.app.agent.tools.workspace_tools import create_workspace_tools
 from backend.app.config import settings
 
 
-def _get_tool_fn(contractor_id: int, tool_name: str) -> Callable[..., Awaitable[ToolResult]]:
+def _get_tool_fn(user_id: int, tool_name: str) -> Callable[..., Awaitable[ToolResult]]:
     """Return the async function for the named tool."""
-    tools = create_workspace_tools(contractor_id)
+    tools = create_workspace_tools(user_id)
     for t in tools:
         if t.name == tool_name:
             return t.function
@@ -23,48 +23,48 @@ def _get_tool_fn(contractor_id: int, tool_name: str) -> Callable[..., Awaitable[
     raise ValueError(msg)
 
 
-def _contractor_dir(contractor: ContractorData) -> Path:
-    return Path(settings.data_dir) / str(contractor.id)
+def _user_dir(user: UserData) -> Path:
+    return Path(settings.data_dir) / str(user.id)
 
 
 # --- read_file tests ---
 
 
 @pytest.mark.asyncio()
-async def test_read_file_success(test_contractor: ContractorData) -> None:
+async def test_read_file_success(test_user: UserData) -> None:
     """read_file should return file contents."""
-    cdir = _contractor_dir(test_contractor)
+    cdir = _user_dir(test_user)
     cdir.mkdir(parents=True, exist_ok=True)
     (cdir / "USER.md").write_text("# User\n\n- Name: Jake\n", encoding="utf-8")
 
-    read_fn = _get_tool_fn(test_contractor.id, "read_file")
+    read_fn = _get_tool_fn(test_user.id, "read_file")
     result = await read_fn(path="USER.md")
     assert result.is_error is False
     assert "Jake" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_read_file_not_found(test_contractor: ContractorData) -> None:
+async def test_read_file_not_found(test_user: UserData) -> None:
     """read_file should return error for missing file."""
-    read_fn = _get_tool_fn(test_contractor.id, "read_file")
+    read_fn = _get_tool_fn(test_user.id, "read_file")
     result = await read_fn(path="NONEXISTENT.md")
     assert result.is_error is True
     assert "not found" in result.content.lower()
 
 
 @pytest.mark.asyncio()
-async def test_read_file_rejects_non_markdown(test_contractor: ContractorData) -> None:
+async def test_read_file_rejects_non_markdown(test_user: UserData) -> None:
     """read_file should reject non-markdown files."""
-    read_fn = _get_tool_fn(test_contractor.id, "read_file")
-    result = await read_fn(path="contractor.json")
+    read_fn = _get_tool_fn(test_user.id, "read_file")
+    result = await read_fn(path="user.json")
     assert result.is_error is True
     assert ".md" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_read_file_rejects_path_traversal(test_contractor: ContractorData) -> None:
-    """read_file should reject paths that escape the contractor directory."""
-    read_fn = _get_tool_fn(test_contractor.id, "read_file")
+async def test_read_file_rejects_path_traversal(test_user: UserData) -> None:
+    """read_file should reject paths that escape the user directory."""
+    read_fn = _get_tool_fn(test_user.id, "read_file")
     result = await read_fn(path="../../etc/passwd.md")
     assert result.is_error is True
 
@@ -73,12 +73,12 @@ async def test_read_file_rejects_path_traversal(test_contractor: ContractorData)
 
 
 @pytest.mark.asyncio()
-async def test_write_file_creates_new(test_contractor: ContractorData) -> None:
+async def test_write_file_creates_new(test_user: UserData) -> None:
     """write_file should create a new file."""
-    cdir = _contractor_dir(test_contractor)
+    cdir = _user_dir(test_user)
     cdir.mkdir(parents=True, exist_ok=True)
 
-    write_fn = _get_tool_fn(test_contractor.id, "write_file")
+    write_fn = _get_tool_fn(test_user.id, "write_file")
     result = await write_fn(path="USER.md", content="# User\n\n- Name: Sarah\n")
     assert result.is_error is False
     assert "Wrote" in result.content
@@ -86,41 +86,41 @@ async def test_write_file_creates_new(test_contractor: ContractorData) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_write_file_overwrites(test_contractor: ContractorData) -> None:
+async def test_write_file_overwrites(test_user: UserData) -> None:
     """write_file should overwrite existing file."""
-    cdir = _contractor_dir(test_contractor)
+    cdir = _user_dir(test_user)
     cdir.mkdir(parents=True, exist_ok=True)
     (cdir / "USER.md").write_text("old content", encoding="utf-8")
 
-    write_fn = _get_tool_fn(test_contractor.id, "write_file")
+    write_fn = _get_tool_fn(test_user.id, "write_file")
     await write_fn(path="USER.md", content="new content")
     assert (cdir / "USER.md").read_text(encoding="utf-8") == "new content"
 
 
 @pytest.mark.asyncio()
-async def test_write_file_creates_subdirectory(test_contractor: ContractorData) -> None:
+async def test_write_file_creates_subdirectory(test_user: UserData) -> None:
     """write_file should create parent directories."""
-    cdir = _contractor_dir(test_contractor)
+    cdir = _user_dir(test_user)
     cdir.mkdir(parents=True, exist_ok=True)
 
-    write_fn = _get_tool_fn(test_contractor.id, "write_file")
+    write_fn = _get_tool_fn(test_user.id, "write_file")
     result = await write_fn(path="memory/NOTES.md", content="# Notes\n")
     assert result.is_error is False
     assert (cdir / "memory" / "NOTES.md").exists()
 
 
 @pytest.mark.asyncio()
-async def test_write_file_rejects_non_markdown(test_contractor: ContractorData) -> None:
+async def test_write_file_rejects_non_markdown(test_user: UserData) -> None:
     """write_file should reject non-markdown files."""
-    write_fn = _get_tool_fn(test_contractor.id, "write_file")
+    write_fn = _get_tool_fn(test_user.id, "write_file")
     result = await write_fn(path="evil.json", content="{}")
     assert result.is_error is True
 
 
 @pytest.mark.asyncio()
-async def test_write_file_rejects_path_traversal(test_contractor: ContractorData) -> None:
-    """write_file should reject paths that escape the contractor directory."""
-    write_fn = _get_tool_fn(test_contractor.id, "write_file")
+async def test_write_file_rejects_path_traversal(test_user: UserData) -> None:
+    """write_file should reject paths that escape the user directory."""
+    write_fn = _get_tool_fn(test_user.id, "write_file")
     result = await write_fn(path="../../../tmp/hack.md", content="nope")
     assert result.is_error is True
 
@@ -129,48 +129,48 @@ async def test_write_file_rejects_path_traversal(test_contractor: ContractorData
 
 
 @pytest.mark.asyncio()
-async def test_edit_file_replaces_text(test_contractor: ContractorData) -> None:
+async def test_edit_file_replaces_text(test_user: UserData) -> None:
     """edit_file should replace exact text."""
-    cdir = _contractor_dir(test_contractor)
+    cdir = _user_dir(test_user)
     cdir.mkdir(parents=True, exist_ok=True)
     (cdir / "USER.md").write_text("- Rate: $85/hr\n- Hours: 8-5\n", encoding="utf-8")
 
-    edit_fn = _get_tool_fn(test_contractor.id, "edit_file")
+    edit_fn = _get_tool_fn(test_user.id, "edit_file")
     result = await edit_fn(path="USER.md", old_text="$85/hr", new_text="$100/hr")
     assert result.is_error is False
     assert (cdir / "USER.md").read_text(encoding="utf-8") == "- Rate: $100/hr\n- Hours: 8-5\n"
 
 
 @pytest.mark.asyncio()
-async def test_edit_file_text_not_found(test_contractor: ContractorData) -> None:
+async def test_edit_file_text_not_found(test_user: UserData) -> None:
     """edit_file should return error when old_text not found."""
-    cdir = _contractor_dir(test_contractor)
+    cdir = _user_dir(test_user)
     cdir.mkdir(parents=True, exist_ok=True)
     (cdir / "USER.md").write_text("- Name: Jake\n", encoding="utf-8")
 
-    edit_fn = _get_tool_fn(test_contractor.id, "edit_file")
+    edit_fn = _get_tool_fn(test_user.id, "edit_file")
     result = await edit_fn(path="USER.md", old_text="nonexistent text", new_text="replacement")
     assert result.is_error is True
     assert "not found" in result.content.lower()
 
 
 @pytest.mark.asyncio()
-async def test_edit_file_ambiguous_match(test_contractor: ContractorData) -> None:
+async def test_edit_file_ambiguous_match(test_user: UserData) -> None:
     """edit_file should return error when old_text matches multiple times."""
-    cdir = _contractor_dir(test_contractor)
+    cdir = _user_dir(test_user)
     cdir.mkdir(parents=True, exist_ok=True)
     (cdir / "USER.md").write_text("foo bar\nfoo baz\n", encoding="utf-8")
 
-    edit_fn = _get_tool_fn(test_contractor.id, "edit_file")
+    edit_fn = _get_tool_fn(test_user.id, "edit_file")
     result = await edit_fn(path="USER.md", old_text="foo", new_text="qux")
     assert result.is_error is True
     assert "2 matches" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_edit_file_not_found(test_contractor: ContractorData) -> None:
+async def test_edit_file_not_found(test_user: UserData) -> None:
     """edit_file should return error for missing file."""
-    edit_fn = _get_tool_fn(test_contractor.id, "edit_file")
+    edit_fn = _get_tool_fn(test_user.id, "edit_file")
     result = await edit_fn(path="MISSING.md", old_text="a", new_text="b")
     assert result.is_error is True
     assert "not found" in result.content.lower()
@@ -179,9 +179,9 @@ async def test_edit_file_not_found(test_contractor: ContractorData) -> None:
 # --- Tool registration tests ---
 
 
-def test_workspace_tools_registered(test_contractor: ContractorData) -> None:
+def test_workspace_tools_registered(test_user: UserData) -> None:
     """create_workspace_tools should return read, write, and edit tools."""
-    tools = create_workspace_tools(test_contractor.id)
+    tools = create_workspace_tools(test_user.id)
     names = [t.name for t in tools]
     assert "read_file" in names
     assert "write_file" in names


### PR DESCRIPTION
## Description
Renames all instances of "contractor" to "user" across backend, tests, frontend, and documentation. Clawbolt serves plumbers, electricians, and other trades, not just contractors.

Key renames:
- `ContractorData` -> `UserData`
- `ContractorStore` -> `UserStore`
- `get_contractor_store()` -> `get_user_store()`
- `contractor_id` fields -> `user_id`
- `contractor_locks` -> `user_locks`
- All schema types: `ContractorProfileResponse` -> `UserProfileResponse`, etc.
- All variable names, parameters, comments, and docstrings

Also fixes `get_user_contractor` -> `get_scoped_user` with corrected parameter naming to avoid variable shadowing after rename.

101 files changed, 1884 insertions, 1931 deletions.

Fixes #532

## Type
- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) - 886 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code (Claude Opus 4.6). Used a Python script for the bulk rename, then manually fixed shadowing bugs and import ordering.