### PR TITLE
feat: add progressive approval system for tool execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,7 @@ WHISPER_MODEL_SIZE=base
 # WHISPER_COMPUTE_TYPE=int8
 
 # Agent loop
+# APPROVAL_TIMEOUT_SECONDS=120  # Seconds to wait for user approval before denying
 # MESSAGE_BATCH_WINDOW_MS=1500  # Batch rapid-fire messages per contractor (0 to disable)
 # MAX_TOOL_ROUNDS=10
 # MAX_INPUT_TOKENS=120000

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -1,0 +1,300 @@
+"""Progressive approval system for tool execution.
+
+Provides a permission layer that lets users control what the agent can do
+autonomously vs. what requires explicit approval. Tools opt in by setting
+an ``approval_policy`` on their ``Tool`` definition.
+
+Three permission levels: AUTO (execute freely), ASK (prompt user first),
+DENY (never execute). Users can respond with yes/always/no/never to
+control both immediate and future behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from backend.app.agent.file_store import _read_json, _user_dir, _write_json
+from backend.app.config import settings
+
+if TYPE_CHECKING:
+    from backend.app.services.messaging import MessagingService
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class PermissionLevel(StrEnum):
+    """Permission level for a tool or resource."""
+
+    AUTO = "auto"
+    ASK = "ask"
+    DENY = "deny"
+
+
+class ApprovalDecision(StrEnum):
+    """User's decision when prompted for approval."""
+
+    APPROVED = "approved"
+    DENIED = "denied"
+    ALWAYS_ALLOW = "always_allow"
+    ALWAYS_DENY = "always_deny"
+
+
+# ---------------------------------------------------------------------------
+# ApprovalPolicy (attached to Tool definitions)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApprovalPolicy:
+    """Declares how a tool participates in the approval system.
+
+    Attributes:
+        default_level: Permission level when no stored override exists.
+        resource_extractor: Optional callable that extracts a resource key
+            (e.g. domain from a URL) from the tool's validated arguments.
+        description_builder: Optional callable that produces a human-readable
+            description of what the tool call will do, shown in the approval
+            prompt.
+    """
+
+    default_level: PermissionLevel = PermissionLevel.ASK
+    resource_extractor: Callable[[dict[str, Any]], str | None] | None = None
+    description_builder: Callable[[dict[str, Any]], str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# ApprovalStore (per-user JSON persistence)
+# ---------------------------------------------------------------------------
+
+_PERMISSIONS_VERSION = 1
+
+
+class ApprovalStore:
+    """Persists per-user tool permission overrides.
+
+    Storage format (``permissions.json``)::
+
+        {
+            "version": 1,
+            "tools": {"web_search": "auto", "bash_exec": "deny"},
+            "resources": {
+                "web_fetch": {"homedepot.com": "auto", "*.gov": "auto"}
+            }
+        }
+
+    Resolution order: resource match (exact then glob) > tool match > policy default.
+    """
+
+    def _permissions_path(self, user_id: int) -> Path:
+        return _user_dir(user_id) / "permissions.json"
+
+    def _load(self, user_id: int) -> dict[str, Any]:
+        data = _read_json(self._permissions_path(user_id), default=None)
+        if data is None or not isinstance(data, dict):
+            return {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
+        return data
+
+    def _save(self, user_id: int, data: dict[str, Any]) -> None:
+        _write_json(self._permissions_path(user_id), data)
+
+    def check_permission(
+        self,
+        user_id: int,
+        tool_name: str,
+        resource: str | None = None,
+        default: PermissionLevel = PermissionLevel.ASK,
+    ) -> PermissionLevel:
+        """Check the stored permission for a tool (and optional resource).
+
+        Resolution order: resource match (exact then glob) > tool match > default.
+        """
+        data = self._load(user_id)
+
+        # Resource-level check
+        if resource is not None:
+            resource_map: dict[str, str] = data.get("resources", {}).get(tool_name, {})
+            # Exact match first
+            if resource in resource_map:
+                return PermissionLevel(resource_map[resource])
+            # Glob match
+            for pattern, level in resource_map.items():
+                if fnmatch(resource, pattern):
+                    return PermissionLevel(level)
+
+        # Tool-level check
+        tools: dict[str, str] = data.get("tools", {})
+        if tool_name in tools:
+            return PermissionLevel(tools[tool_name])
+
+        return default
+
+    def set_permission(
+        self,
+        user_id: int,
+        tool_name: str,
+        level: PermissionLevel,
+        resource: str | None = None,
+    ) -> None:
+        """Store a permission override for a tool or resource."""
+        data = self._load(user_id)
+        if resource is not None:
+            resources = data.setdefault("resources", {})
+            tool_resources = resources.setdefault(tool_name, {})
+            tool_resources[resource] = str(level)
+        else:
+            data.setdefault("tools", {})[tool_name] = str(level)
+        self._save(user_id, data)
+
+
+# ---------------------------------------------------------------------------
+# ApprovalGate (async coordination)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PendingApproval:
+    """In-flight approval request waiting for user response."""
+
+    tool_name: str
+    description: str
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+    decision: ApprovalDecision | None = None
+
+
+class ApprovalGate:
+    """Manages pending approval requests keyed by user_id.
+
+    When a tool needs approval, ``request_approval()`` sends a prompt and
+    waits on an ``asyncio.Event``. When the user replies, ``resolve()``
+    sets the decision and wakes the waiting coroutine.
+    """
+
+    def __init__(self) -> None:
+        self._pending: dict[int, PendingApproval] = {}
+
+    def has_pending(self, user_id: int) -> bool:
+        """Return True if there is a pending approval for this user."""
+        return user_id in self._pending
+
+    async def request_approval(
+        self,
+        user_id: int,
+        tool_name: str,
+        description: str,
+        messaging_service: MessagingService,
+        chat_id: str,
+        timeout: float | None = None,
+    ) -> ApprovalDecision:
+        """Send an approval prompt and wait for the user's decision.
+
+        Returns ``DENIED`` on timeout.
+        """
+        if timeout is None:
+            timeout = float(settings.approval_timeout_seconds)
+
+        pending = PendingApproval(tool_name=tool_name, description=description)
+        self._pending[user_id] = pending
+
+        prompt = _format_approval_message(tool_name, description)
+        try:
+            await messaging_service.send_text(chat_id, prompt)
+        except Exception:
+            logger.exception("Failed to send approval prompt to user %d", user_id)
+            self._pending.pop(user_id, None)
+            return ApprovalDecision.DENIED
+
+        try:
+            await asyncio.wait_for(pending.event.wait(), timeout=timeout)
+        except TimeoutError:
+            logger.info("Approval timed out for user %d, tool %s", user_id, tool_name)
+            self._pending.pop(user_id, None)
+            return ApprovalDecision.DENIED
+
+        decision = pending.decision or ApprovalDecision.DENIED
+        self._pending.pop(user_id, None)
+        return decision
+
+    def resolve(self, user_id: int, decision: ApprovalDecision) -> bool:
+        """Resolve a pending approval with the user's decision.
+
+        Returns True if there was a pending approval to resolve.
+        """
+        pending = self._pending.get(user_id)
+        if pending is None:
+            return False
+        pending.decision = decision
+        pending.event.set()
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_approval_response(text: str) -> ApprovalDecision | None:
+    """Parse a user's text reply into an approval decision.
+
+    Returns None if the text is not a recognized approval response.
+    """
+    normalized = text.strip().lower()
+    mapping: dict[str, ApprovalDecision] = {
+        "yes": ApprovalDecision.APPROVED,
+        "y": ApprovalDecision.APPROVED,
+        "always": ApprovalDecision.ALWAYS_ALLOW,
+        "no": ApprovalDecision.DENIED,
+        "n": ApprovalDecision.DENIED,
+        "never": ApprovalDecision.ALWAYS_DENY,
+    }
+    return mapping.get(normalized)
+
+
+def _format_approval_message(tool_name: str, description: str) -> str:
+    """Build a plain-text approval prompt for the user."""
+    return (
+        f"The assistant wants to use the tool '{tool_name}':\n"
+        f"{description}\n\n"
+        "Reply: yes | no | always | never"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_approval_gate: ApprovalGate | None = None
+_approval_store: ApprovalStore | None = None
+
+
+def get_approval_gate() -> ApprovalGate:
+    """Get or create the global ApprovalGate."""
+    global _approval_gate
+    if _approval_gate is None:
+        _approval_gate = ApprovalGate()
+    return _approval_gate
+
+
+def get_approval_store() -> ApprovalStore:
+    """Get or create the global ApprovalStore."""
+    global _approval_store
+    if _approval_store is None:
+        _approval_store = ApprovalStore()
+    return _approval_store
+
+
+def reset_approval_gate() -> None:
+    """Reset cached approval singletons. Used by tests."""
+    global _approval_gate, _approval_store
+    _approval_gate = None
+    _approval_store = None

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -15,6 +15,12 @@ from any_llm import (
 from any_llm.types.messages import MessageResponse
 from pydantic import ValidationError
 
+from backend.app.agent.approval import (
+    ApprovalDecision,
+    PermissionLevel,
+    get_approval_gate,
+    get_approval_store,
+)
 from backend.app.agent.context import StoredToolInteraction
 from backend.app.agent.events import (
     AgentEndEvent,
@@ -277,6 +283,71 @@ class ClawboltAgent:
                 await self._messaging_service.send_typing_indicator(to=self._chat_id)
             except Exception:
                 logger.debug("Failed to send typing indicator to %s", self._chat_id)
+
+    async def _check_approval(
+        self,
+        tool_obj: Tool,
+        validated_args: dict[str, Any],
+    ) -> PermissionLevel:
+        """Check approval for a tool call.
+
+        Returns ``PermissionLevel.AUTO`` when execution should proceed,
+        or ``PermissionLevel.DENY`` when it should be blocked.
+        """
+        policy = tool_obj.approval_policy
+        if policy is None:
+            return PermissionLevel.AUTO
+
+        resource: str | None = None
+        if policy.resource_extractor is not None:
+            resource = policy.resource_extractor(validated_args)
+
+        store = get_approval_store()
+        level = store.check_permission(
+            self.user.id, tool_obj.name, resource=resource, default=policy.default_level
+        )
+
+        if level == PermissionLevel.AUTO:
+            return PermissionLevel.AUTO
+        if level == PermissionLevel.DENY:
+            return PermissionLevel.DENY
+
+        # ASK: prompt the user.  When no messaging channel is available
+        # (e.g. headless/API usage, dashboard without WebSocket reply path)
+        # we fall through to AUTO so the agent is not permanently blocked.
+        if self._messaging_service is None or self._chat_id is None:
+            return PermissionLevel.AUTO
+
+        gate = get_approval_gate()
+
+        # Only one approval prompt per user at a time.  If a prior tool in
+        # the same round is already waiting, deny this one to avoid
+        # overwriting the pending request.
+        if gate.has_pending(self.user.id):
+            return PermissionLevel.DENY
+
+        description = tool_obj.name
+        if policy.description_builder is not None:
+            description = policy.description_builder(validated_args)
+
+        decision = await gate.request_approval(
+            user_id=self.user.id,
+            tool_name=tool_obj.name,
+            description=description,
+            messaging_service=self._messaging_service,
+            chat_id=self._chat_id,
+        )
+
+        if decision == ApprovalDecision.ALWAYS_ALLOW:
+            store.set_permission(self.user.id, tool_obj.name, PermissionLevel.AUTO, resource)
+            return PermissionLevel.AUTO
+        if decision == ApprovalDecision.APPROVED:
+            return PermissionLevel.AUTO
+        if decision == ApprovalDecision.ALWAYS_DENY:
+            store.set_permission(self.user.id, tool_obj.name, PermissionLevel.DENY, resource)
+            return PermissionLevel.DENY
+        # DENIED or timeout
+        return PermissionLevel.DENY
 
     def register_tools(self, tools: list[Tool]) -> None:
         """Register available tools for this agent session."""
@@ -738,6 +809,30 @@ class ClawboltAgent:
                 tc_req = parsed_calls[i]
                 tool_name = tc_req.name
                 tool_tags = self._get_tool_tags(tool_name)
+
+                # -- Approval check --
+                approval_result = await self._check_approval(tool_obj, validated_args)
+                if approval_result == PermissionLevel.DENY:
+                    hint = _ERROR_KIND_HINTS[ToolErrorKind.PERMISSION]
+                    deny_msg = f"Error: permission denied for tool '{tool_name}'\n\n{hint}"
+                    actions_taken.append(f"Denied: {tool_name}")
+                    tool_call_records.append(
+                        StoredToolInteraction(
+                            tool_call_id=tc_req.id,
+                            name=tool_name,
+                            args=validated_args,
+                            result=deny_msg,
+                            is_error=True,
+                            tags=set(tool_tags),
+                        )
+                    )
+                    tool_results.append(
+                        ToolResultMessage(
+                            tool_call_id=tc_req.id,
+                            content=deny_msg,
+                        )
+                    )
+                    continue
 
                 await self._emit(
                     ToolExecutionStartEvent(tool_name=tool_name, arguments=validated_args)

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -15,6 +15,10 @@ import json
 import logging
 from dataclasses import dataclass, field
 
+from backend.app.agent.approval import (
+    _parse_approval_response,
+    get_approval_gate,
+)
 from backend.app.agent.concurrency import user_locks
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.file_store import (
@@ -247,6 +251,27 @@ async def process_inbound_from_bus(
     batching).
     """
     user = await _get_or_create_user(inbound.channel, inbound.sender_id)
+
+    # -- Intercept approval responses before normal processing --
+    gate = get_approval_gate()
+    if gate.has_pending(user.id) and inbound.text:
+        decision = _parse_approval_response(inbound.text)
+        if decision is not None:
+            gate.resolve(user.id, decision)
+            # Persist the reply to the session so it appears in conversation history
+            session, _is_new = await get_or_create_conversation(
+                user.id, external_session_id=inbound.session_id
+            )
+            session_store = get_session_store(user.id)
+            await session_store.add_message(
+                session=session,
+                direction=MessageDirection.INBOUND,
+                body=inbound.text,
+                external_message_id=inbound.external_message_id or "",
+                media_urls_json=json.dumps([file_id for file_id, _mime in inbound.media_refs]),
+            )
+            return
+
     session, _is_new = await get_or_create_conversation(
         user.id, external_session_id=inbound.session_id
     )

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from backend.app.agent.approval import ApprovalPolicy
 
 
 class ToolTags(StrEnum):
@@ -44,6 +49,7 @@ class Tool:
     params_model: type[BaseModel]
     tags: set[ToolTags] = field(default_factory=set)
     usage_hint: str = ""
+    approval_policy: ApprovalPolicy | None = None
 
 
 def _inline_refs(schema: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -71,6 +71,7 @@ class Settings(BaseSettings):
     whisper_compute_type: str = "int8"
 
     # Agent loop
+    approval_timeout_seconds: int = 120
     message_batch_window_ms: int = 1500  # Batch rapid-fire messages per user
     max_tool_rounds: int = 10
     max_input_tokens: int = 120_000

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -83,6 +83,7 @@ See [Storage Providers](../deployment/storage/) for setup instructions.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `APPROVAL_TIMEOUT_SECONDS` | `120` | Seconds to wait for user approval of a tool call before automatically denying |
 | `MESSAGE_BATCH_WINDOW_MS` | `1500` | Milliseconds to wait for more messages before processing. Groups rapid-fire messages into one agent call. Set to `0` to disable |
 | `MAX_TOOL_ROUNDS` | `10` | Maximum tool-calling rounds per agent invocation |
 | `MAX_INPUT_TOKENS` | `120000` | Max input token budget before context trimming |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.app.agent.approval import reset_approval_gate
 from backend.app.agent.file_store import UserData, get_user_store, reset_stores
 from backend.app.auth.dependencies import get_current_user
 from backend.app.bus import message_bus
@@ -19,8 +20,10 @@ def _isolate_file_stores(tmp_path: object) -> Generator[None]:
     """Point file stores at a temp directory and reset caches for each test."""
     with patch.object(settings, "data_dir", str(tmp_path)):
         reset_stores()
+        reset_approval_gate()
         yield
     reset_stores()
+    reset_approval_gate()
 
 
 @pytest.fixture()

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,0 +1,647 @@
+"""Tests for the progressive approval system."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from backend.app.agent.approval import (
+    ApprovalDecision,
+    ApprovalGate,
+    ApprovalPolicy,
+    ApprovalStore,
+    PermissionLevel,
+    _format_approval_message,
+    _parse_approval_response,
+    get_approval_gate,
+    get_approval_store,
+    reset_approval_gate,
+)
+from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.file_store import UserData
+from backend.app.agent.ingestion import InboundMessage, process_inbound_from_bus
+from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.services.messaging import MessagingService
+from tests.mocks.llm import make_text_response, make_tool_call_response
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _EchoParams(BaseModel):
+    text: str
+
+
+async def _echo_tool(text: str) -> ToolResult:
+    return ToolResult(content=f"echo: {text}")
+
+
+class _UrlParams(BaseModel):
+    url: str
+
+
+async def _fetch_tool(url: str) -> ToolResult:
+    return ToolResult(content=f"fetched: {url}")
+
+
+def _extract_domain(args: dict[str, object]) -> str | None:
+    from urllib.parse import urlparse
+
+    url = str(args.get("url", ""))
+    parsed = urlparse(url)
+    return parsed.netloc or None
+
+
+def _describe_fetch(args: dict[str, object]) -> str:
+    return f"fetch content from {args.get('url', 'unknown URL')}"
+
+
+# ---------------------------------------------------------------------------
+# ApprovalStore
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalStore:
+    def test_default_permission(self, tmp_path: object) -> None:
+        store = ApprovalStore()
+        level = store.check_permission(1, "web_search", default=PermissionLevel.ASK)
+        assert level == PermissionLevel.ASK
+
+    def test_tool_level_override(self, tmp_path: object) -> None:
+        store = ApprovalStore()
+        store.set_permission(1, "web_search", PermissionLevel.AUTO)
+        level = store.check_permission(1, "web_search", default=PermissionLevel.ASK)
+        assert level == PermissionLevel.AUTO
+
+    def test_resource_level_override(self, tmp_path: object) -> None:
+        store = ApprovalStore()
+        store.set_permission(1, "web_fetch", PermissionLevel.AUTO, resource="homedepot.com")
+        level = store.check_permission(
+            1, "web_fetch", resource="homedepot.com", default=PermissionLevel.ASK
+        )
+        assert level == PermissionLevel.AUTO
+
+    def test_glob_matching(self, tmp_path: object) -> None:
+        store = ApprovalStore()
+        store.set_permission(1, "web_fetch", PermissionLevel.AUTO, resource="*.gov")
+        level = store.check_permission(
+            1, "web_fetch", resource="permits.gov", default=PermissionLevel.ASK
+        )
+        assert level == PermissionLevel.AUTO
+
+    def test_resource_priority_over_tool(self, tmp_path: object) -> None:
+        store = ApprovalStore()
+        store.set_permission(1, "web_fetch", PermissionLevel.DENY)
+        store.set_permission(1, "web_fetch", PermissionLevel.AUTO, resource="safe.com")
+        level = store.check_permission(
+            1, "web_fetch", resource="safe.com", default=PermissionLevel.ASK
+        )
+        assert level == PermissionLevel.AUTO
+
+    def test_falls_through_to_tool_when_no_resource_match(self, tmp_path: object) -> None:
+        store = ApprovalStore()
+        store.set_permission(1, "web_fetch", PermissionLevel.DENY)
+        level = store.check_permission(
+            1, "web_fetch", resource="unknown.com", default=PermissionLevel.ASK
+        )
+        assert level == PermissionLevel.DENY
+
+    def test_persistence_round_trip(self, tmp_path: object) -> None:
+        store1 = ApprovalStore()
+        store1.set_permission(1, "web_search", PermissionLevel.AUTO)
+        store1.set_permission(1, "web_fetch", PermissionLevel.DENY, resource="evil.com")
+
+        store2 = ApprovalStore()
+        assert store2.check_permission(1, "web_search") == PermissionLevel.AUTO
+        assert store2.check_permission(1, "web_fetch", resource="evil.com") == PermissionLevel.DENY
+
+
+# ---------------------------------------------------------------------------
+# _parse_approval_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseApprovalResponse:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("yes", ApprovalDecision.APPROVED),
+            ("y", ApprovalDecision.APPROVED),
+            ("Yes", ApprovalDecision.APPROVED),
+            ("YES", ApprovalDecision.APPROVED),
+            ("  y  ", ApprovalDecision.APPROVED),
+            ("always", ApprovalDecision.ALWAYS_ALLOW),
+            ("Always", ApprovalDecision.ALWAYS_ALLOW),
+            ("no", ApprovalDecision.DENIED),
+            ("n", ApprovalDecision.DENIED),
+            ("No", ApprovalDecision.DENIED),
+            ("never", ApprovalDecision.ALWAYS_DENY),
+            ("Never", ApprovalDecision.ALWAYS_DENY),
+        ],
+    )
+    def test_valid_responses(self, text: str, expected: ApprovalDecision) -> None:
+        assert _parse_approval_response(text) == expected
+
+    @pytest.mark.parametrize("text", ["maybe", "sure", "ok", "hello", ""])
+    def test_unrecognized_returns_none(self, text: str) -> None:
+        assert _parse_approval_response(text) is None
+
+
+# ---------------------------------------------------------------------------
+# _format_approval_message
+# ---------------------------------------------------------------------------
+
+
+class TestFormatApprovalMessage:
+    def test_output_format(self) -> None:
+        msg = _format_approval_message("web_fetch", "fetch content from https://example.com")
+        assert "web_fetch" in msg
+        assert "fetch content from https://example.com" in msg
+        assert "yes" in msg
+        assert "no" in msg
+        assert "always" in msg
+        assert "never" in msg
+
+
+# ---------------------------------------------------------------------------
+# ApprovalGate
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalGate:
+    @pytest.mark.asyncio()
+    async def test_resolve_sets_event_and_decision(self) -> None:
+        gate = ApprovalGate()
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+
+        async def _resolve_soon() -> None:
+            await asyncio.sleep(0.01)
+            gate.resolve(1, ApprovalDecision.APPROVED)
+
+        task = asyncio.create_task(_resolve_soon())
+        decision = await gate.request_approval(
+            user_id=1,
+            tool_name="test_tool",
+            description="test description",
+            messaging_service=mock_service,
+            chat_id="chat_1",
+            timeout=5.0,
+        )
+        await task
+        assert decision == ApprovalDecision.APPROVED
+        assert not gate.has_pending(1)
+
+    @pytest.mark.asyncio()
+    async def test_timeout_returns_denied(self) -> None:
+        gate = ApprovalGate()
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+
+        decision = await gate.request_approval(
+            user_id=1,
+            tool_name="test_tool",
+            description="test description",
+            messaging_service=mock_service,
+            chat_id="chat_1",
+            timeout=0.01,
+        )
+        assert decision == ApprovalDecision.DENIED
+        assert not gate.has_pending(1)
+
+    def test_resolve_returns_false_when_nothing_pending(self) -> None:
+        gate = ApprovalGate()
+        assert gate.resolve(999, ApprovalDecision.APPROVED) is False
+
+    @pytest.mark.asyncio()
+    async def test_has_pending(self) -> None:
+        gate = ApprovalGate()
+        assert not gate.has_pending(1)
+
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+
+        async def _check_and_resolve() -> None:
+            await asyncio.sleep(0.01)
+            assert gate.has_pending(1)
+            gate.resolve(1, ApprovalDecision.DENIED)
+
+        task = asyncio.create_task(_check_and_resolve())
+        await gate.request_approval(
+            user_id=1,
+            tool_name="t",
+            description="d",
+            messaging_service=mock_service,
+            chat_id="c",
+            timeout=5.0,
+        )
+        await task
+
+
+# ---------------------------------------------------------------------------
+# Agent integration
+# ---------------------------------------------------------------------------
+
+
+class TestAgentApproval:
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_tool_without_policy_executes_normally(
+        self, mock_amessages: object, test_user: UserData
+    ) -> None:
+        """Tools without approval_policy execute unchanged."""
+        tool = Tool(
+            name="echo",
+            description="Echo text",
+            function=_echo_tool,
+            params_model=_EchoParams,
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response([{"name": "echo", "arguments": {"text": "hello"}}]),
+            make_text_response("Done!"),
+        ]
+        agent = ClawboltAgent(user=test_user)
+        agent.register_tools([tool])
+        response = await agent.process_message("echo hello")
+        assert response.reply_text == "Done!"
+        assert any(tc.name == "echo" and not tc.is_error for tc in response.tool_calls)
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_tool_with_auto_skips_gate(
+        self, mock_amessages: object, test_user: UserData
+    ) -> None:
+        """Tool with AUTO default_level executes without prompting."""
+        tool = Tool(
+            name="echo",
+            description="Echo text",
+            function=_echo_tool,
+            params_model=_EchoParams,
+            approval_policy=ApprovalPolicy(default_level=PermissionLevel.AUTO),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response([{"name": "echo", "arguments": {"text": "hello"}}]),
+            make_text_response("Done!"),
+        ]
+        agent = ClawboltAgent(user=test_user)
+        agent.register_tools([tool])
+        response = await agent.process_message("echo hello")
+        assert any(tc.name == "echo" and not tc.is_error for tc in response.tool_calls)
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_tool_with_deny_returns_error(
+        self, mock_amessages: object, test_user: UserData
+    ) -> None:
+        """Tool with DENY default_level returns a permission error."""
+        tool = Tool(
+            name="dangerous",
+            description="Dangerous tool",
+            function=_echo_tool,
+            params_model=_EchoParams,
+            approval_policy=ApprovalPolicy(default_level=PermissionLevel.DENY),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response([{"name": "dangerous", "arguments": {"text": "boom"}}]),
+            make_text_response("Denied!"),
+        ]
+        agent = ClawboltAgent(user=test_user)
+        agent.register_tools([tool])
+        response = await agent.process_message("do it")
+        assert any(tc.name == "dangerous" and tc.is_error for tc in response.tool_calls)
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_tool_with_ask_approved_executes(
+        self, mock_amessages: object, test_user: UserData
+    ) -> None:
+        """Tool with ASK that gets approved executes."""
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+        mock_service.send_typing_indicator = AsyncMock()
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch URL",
+            function=_fetch_tool,
+            params_model=_UrlParams,
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=_describe_fetch,
+            ),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [{"name": "fetcher", "arguments": {"url": "https://example.com"}}]
+            ),
+            make_text_response("Fetched!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _approve_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            gate.resolve(test_user.id, ApprovalDecision.APPROVED)
+
+        agent = ClawboltAgent(user=test_user, messaging_service=mock_service, chat_id="chat_1")
+        agent.register_tools([tool])
+
+        task = asyncio.create_task(_approve_soon())
+        response = await agent.process_message("fetch example.com")
+        await task
+
+        assert any(tc.name == "fetcher" and not tc.is_error for tc in response.tool_calls)
+        mock_service.send_text.assert_called()
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_tool_with_ask_denied_returns_error(
+        self, mock_amessages: object, test_user: UserData
+    ) -> None:
+        """Tool with ASK that gets denied returns an error."""
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+        mock_service.send_typing_indicator = AsyncMock()
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch URL",
+            function=_fetch_tool,
+            params_model=_UrlParams,
+            approval_policy=ApprovalPolicy(default_level=PermissionLevel.ASK),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [{"name": "fetcher", "arguments": {"url": "https://example.com"}}]
+            ),
+            make_text_response("Denied!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _deny_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            gate.resolve(test_user.id, ApprovalDecision.DENIED)
+
+        agent = ClawboltAgent(user=test_user, messaging_service=mock_service, chat_id="chat_1")
+        agent.register_tools([tool])
+
+        task = asyncio.create_task(_deny_soon())
+        response = await agent.process_message("fetch example.com")
+        await task
+
+        assert any(tc.name == "fetcher" and tc.is_error for tc in response.tool_calls)
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_always_persists_auto_to_store(
+        self, mock_amessages: object, test_user: UserData
+    ) -> None:
+        """'always' decision persists AUTO to the approval store."""
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+        mock_service.send_typing_indicator = AsyncMock()
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch URL",
+            function=_fetch_tool,
+            params_model=_UrlParams,
+            approval_policy=ApprovalPolicy(default_level=PermissionLevel.ASK),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [{"name": "fetcher", "arguments": {"url": "https://example.com"}}]
+            ),
+            make_text_response("Done!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _always_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            gate.resolve(test_user.id, ApprovalDecision.ALWAYS_ALLOW)
+
+        agent = ClawboltAgent(user=test_user, messaging_service=mock_service, chat_id="chat_1")
+        agent.register_tools([tool])
+
+        task = asyncio.create_task(_always_soon())
+        await agent.process_message("fetch example.com")
+        await task
+
+        store = get_approval_store()
+        level = store.check_permission(test_user.id, "fetcher")
+        assert level == PermissionLevel.AUTO
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_never_persists_deny_to_store(
+        self, mock_amessages: object, test_user: UserData
+    ) -> None:
+        """'never' decision persists DENY to the approval store."""
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+        mock_service.send_typing_indicator = AsyncMock()
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch URL",
+            function=_fetch_tool,
+            params_model=_UrlParams,
+            approval_policy=ApprovalPolicy(default_level=PermissionLevel.ASK),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [{"name": "fetcher", "arguments": {"url": "https://example.com"}}]
+            ),
+            make_text_response("Blocked!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _never_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            gate.resolve(test_user.id, ApprovalDecision.ALWAYS_DENY)
+
+        agent = ClawboltAgent(user=test_user, messaging_service=mock_service, chat_id="chat_1")
+        agent.register_tools([tool])
+
+        task = asyncio.create_task(_never_soon())
+        await agent.process_message("fetch example.com")
+        await task
+
+        store = get_approval_store()
+        level = store.check_permission(test_user.id, "fetcher")
+        assert level == PermissionLevel.DENY
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_stored_auto_skips_prompt(
+        self, mock_amessages: object, test_user: UserData
+    ) -> None:
+        """A stored AUTO permission skips the approval prompt entirely."""
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+        mock_service.send_typing_indicator = AsyncMock()
+
+        store = get_approval_store()
+        store.set_permission(test_user.id, "fetcher", PermissionLevel.AUTO)
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch URL",
+            function=_fetch_tool,
+            params_model=_UrlParams,
+            approval_policy=ApprovalPolicy(default_level=PermissionLevel.ASK),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [{"name": "fetcher", "arguments": {"url": "https://example.com"}}]
+            ),
+            make_text_response("Done!"),
+        ]
+
+        agent = ClawboltAgent(user=test_user, messaging_service=mock_service, chat_id="chat_1")
+        agent.register_tools([tool])
+
+        response = await agent.process_message("fetch example.com")
+        assert any(tc.name == "fetcher" and not tc.is_error for tc in response.tool_calls)
+        # send_text should only be called for typing indicator, not approval prompt
+        for call in mock_service.send_text.call_args_list:
+            assert "wants to use" not in str(call)
+
+
+# ---------------------------------------------------------------------------
+# Ingestion intercept
+# ---------------------------------------------------------------------------
+
+
+class TestIngestionIntercept:
+    @pytest.mark.asyncio()
+    async def test_approval_response_resolves_gate(self, test_user: UserData) -> None:
+        """An approval response resolves the gate and skips normal processing."""
+        gate = get_approval_gate()
+
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+
+        # Start a pending approval
+        async def _start_approval() -> ApprovalDecision:
+            return await gate.request_approval(
+                user_id=test_user.id,
+                tool_name="test_tool",
+                description="test",
+                messaging_service=mock_service,
+                chat_id="chat_1",
+                timeout=5.0,
+            )
+
+        approval_task = asyncio.create_task(_start_approval())
+        await asyncio.sleep(0.01)
+        assert gate.has_pending(test_user.id)
+
+        # Simulate inbound "yes" message
+        inbound = InboundMessage(
+            channel="telegram",
+            sender_id=str(test_user.id),
+            text="yes",
+        )
+
+        with patch(
+            "backend.app.agent.ingestion._get_or_create_user",
+            new_callable=AsyncMock,
+            return_value=test_user,
+        ):
+            await process_inbound_from_bus(inbound, mock_service)
+
+        decision = await approval_task
+        assert decision == ApprovalDecision.APPROVED
+        assert not gate.has_pending(test_user.id)
+
+    @pytest.mark.asyncio()
+    async def test_non_approval_text_during_pending_falls_through(
+        self, test_user: UserData
+    ) -> None:
+        """Unrecognized text while pending falls through to normal processing."""
+        gate = get_approval_gate()
+
+        mock_service = MagicMock(spec=MessagingService)
+        mock_service.send_text = AsyncMock(return_value="msg_id")
+        mock_service.send_typing_indicator = AsyncMock()
+
+        # Start a pending approval
+        async def _start_approval() -> ApprovalDecision:
+            return await gate.request_approval(
+                user_id=test_user.id,
+                tool_name="test_tool",
+                description="test",
+                messaging_service=mock_service,
+                chat_id="chat_1",
+                timeout=5.0,
+            )
+
+        approval_task = asyncio.create_task(_start_approval())
+        await asyncio.sleep(0.01)
+        assert gate.has_pending(test_user.id)
+
+        inbound = InboundMessage(
+            channel="telegram",
+            sender_id=str(test_user.id),
+            text="what is the weather?",
+        )
+
+        with (
+            patch(
+                "backend.app.agent.ingestion._get_or_create_user",
+                new_callable=AsyncMock,
+                return_value=test_user,
+            ),
+            patch(
+                "backend.app.agent.ingestion.handle_inbound_message",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend.app.agent.ingestion.settings.message_batch_window_ms",
+                0,
+            ),
+        ):
+            await process_inbound_from_bus(inbound, mock_service)
+
+        # The gate should still be pending (text was not a valid response)
+        assert gate.has_pending(test_user.id)
+
+        # Resolve the gate so the task completes
+        gate.resolve(test_user.id, ApprovalDecision.DENIED)
+        await approval_task
+
+
+# ---------------------------------------------------------------------------
+# Module-level accessors
+# ---------------------------------------------------------------------------
+
+
+class TestModuleAccessors:
+    def test_get_approval_gate_returns_singleton(self) -> None:
+        g1 = get_approval_gate()
+        g2 = get_approval_gate()
+        assert g1 is g2
+
+    def test_get_approval_store_returns_singleton(self) -> None:
+        s1 = get_approval_store()
+        s2 = get_approval_store()
+        assert s1 is s2
+
+    def test_reset_clears_singletons(self) -> None:
+        g1 = get_approval_gate()
+        s1 = get_approval_store()
+        reset_approval_gate()
+        g2 = get_approval_gate()
+        s2 = get_approval_store()
+        assert g1 is not g2
+        assert s1 is not s2


### PR DESCRIPTION
## Description

Add a channel-agnostic permission layer that lets users control what the agent can do autonomously vs. what requires explicit approval. Tools opt in by setting an `approval_policy` on their `Tool` definition; existing tools are unaffected.

Three permission levels (AUTO/ASK/DENY) with four user decisions (yes/always/no/never) that persist per-user as JSON. Async coordination via `asyncio.Event` pauses the agent loop while waiting for approval and resumes when the user replies. 42 new tests.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation authored with Claude Code.

---

## Files

| File | Change |
|------|--------|
| `backend/app/agent/approval.py` | **New** - Core module: `PermissionLevel`, `ApprovalDecision`, `ApprovalPolicy`, `ApprovalStore` (JSON persistence with fnmatch glob matching), `ApprovalGate` (async coordination), parse/format helpers |
| `backend/app/agent/tools/base.py` | Add `approval_policy` field to `Tool` dataclass |
| `backend/app/agent/core.py` | Add `_check_approval()` method and approval check in Phase 2 of `process_message()` |
| `backend/app/agent/ingestion.py` | Intercept approval responses in `process_inbound_from_bus()` before normal processing |
| `backend/app/config.py` | Add `approval_timeout_seconds` setting (default: 120s) |
| `tests/test_approval.py` | **New** - 42 tests |
| `tests/conftest.py` | Add `reset_approval_gate()` to test isolation fixture |
| `.env.example` | Document new setting |
| `docs/configuration.mdx` | Document new setting |

## How it works

1. A tool declares an `ApprovalPolicy` with a `default_level` (and optional `resource_extractor` / `description_builder`)
2. In the agent loop, before executing the tool, `_check_approval()` checks stored permissions then prompts the user if needed
3. The approval prompt is sent as plain text via `MessagingService.send_text()`
4. When the user replies, `process_inbound_from_bus()` intercepts the response, resolves the `asyncio.Event`, and the agent loop resumes
5. "always"/"never" responses persist the decision to `permissions.json` for future calls

## Follow-up issues

- #536 - Telegram inline keyboard buttons for approval prompts
- #537 - Dashboard web chat approval prompt UI component

🤖 Generated with [Claude Code](https://claude.com/claude-code)