### PR TITLE
feat: better web UI for core tools

### DIFF
--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -209,6 +209,7 @@ class ToolConfigEntry(BaseModel):
     description: str = ""
     category: str = "domain"
     domain_group: str = ""
+    domain_group_order: int = 0
     enabled: bool = True
 
 

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -4,6 +4,8 @@ Users can view and toggle domain-specific agent tools. Core tools
 (workspace, profile, memory, messaging) are always enabled.
 """
 
+from typing import NamedTuple
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from backend.app.agent.file_store import (
@@ -30,22 +32,36 @@ ensure_tool_modules_imported()
 # Factories whose tools are always available and cannot be disabled.
 _CORE_FACTORIES: frozenset[str] = frozenset({"workspace", "profile", "memory", "messaging"})
 
-# Human-readable descriptions for each factory group.
-_FACTORY_DESCRIPTIONS: dict[str, str] = {
-    "workspace": "Read, write, and edit markdown files in the workspace",
-    "profile": "View and update user profile information",
-    "memory": "Save, recall, and forget long-term facts",
-    "messaging": "Send text and media replies to the user",
-    "estimate": "Generate professional estimates and quotes with PDF output",
-    "file": "Upload and organize files in cloud storage",
-    "checklist": "Manage recurring reminders and task checklists",
-}
+# Consolidated metadata for each factory group: description, display group,
+# and sort order.  Adding a new tool only requires one entry here.
 
-# Display group for domain-specific factories. Core factories have no group.
-_FACTORY_GROUPS: dict[str, str] = {
-    "estimate": "Local Management",
-    "file": "Local Management",
-    "checklist": "Local Management",
+
+class _FactoryMeta(NamedTuple):
+    description: str
+    domain_group: str = ""
+    domain_group_order: int = 0
+
+
+_FACTORY_META: dict[str, _FactoryMeta] = {
+    "workspace": _FactoryMeta("Read, write, and edit markdown files in the workspace"),
+    "profile": _FactoryMeta("View and update user profile information"),
+    "memory": _FactoryMeta("Save, recall, and forget long-term facts"),
+    "messaging": _FactoryMeta("Send text and media replies to the user"),
+    "estimate": _FactoryMeta(
+        "Generate professional estimates and quotes with PDF output",
+        domain_group="Local Management",
+        domain_group_order=1,
+    ),
+    "file": _FactoryMeta(
+        "Upload and organize files in cloud storage",
+        domain_group="Local Management",
+        domain_group_order=1,
+    ),
+    "checklist": _FactoryMeta(
+        "Manage recurring reminders and task checklists",
+        domain_group="Local Management",
+        domain_group_order=1,
+    ),
 }
 
 
@@ -61,12 +77,14 @@ def _build_tool_list(
     entries: list[ToolConfigEntry] = []
     for name in sorted(default_registry.factory_names):
         is_core = name in _CORE_FACTORIES
+        meta = _FACTORY_META.get(name)
         entries.append(
             ToolConfigEntry(
                 name=name,
-                description=_FACTORY_DESCRIPTIONS.get(name, ""),
+                description=meta.description if meta else "",
                 category="core" if is_core else "domain",
-                domain_group=_FACTORY_GROUPS.get(name, ""),
+                domain_group=meta.domain_group if meta else "",
+                domain_group_order=meta.domain_group_order if meta else 0,
                 enabled=True if is_core else name not in disabled_names,
             )
         )
@@ -89,6 +107,7 @@ async def get_tool_config(
                 description=e.description,
                 category=e.category,
                 domain_group=e.domain_group,
+                domain_group_order=e.domain_group_order,
                 enabled=e.enabled,
             )
             for e in entries
@@ -141,6 +160,7 @@ async def update_tool_config(
                 description=e.description,
                 category=e.category,
                 domain_group=e.domain_group,
+                domain_group_order=e.domain_group_order,
                 enabled=e.enabled,
             )
             for e in entries

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -224,6 +224,7 @@ class ToolConfigEntryResponse(BaseModel):
     description: str
     category: str
     domain_group: str = ""
+    domain_group_order: int = 0
     enabled: bool
 
 

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -46,16 +46,20 @@ export default function ToolsPage() {
   const coreTools = tools.filter((t) => t.category === 'core');
   const domainTools = tools.filter((t) => t.category === 'domain');
 
-  // Group domain tools by domain_group
+  // Group domain tools by domain_group, sorted by domain_group_order
   const domainGroups: Record<string, ToolConfigEntry[]> = {};
+  const groupOrder: Record<string, number> = {};
   for (const tool of domainTools) {
     const group = tool.domain_group || 'Other';
     if (!domainGroups[group]) {
       domainGroups[group] = [];
+      groupOrder[group] = tool.domain_group_order;
     }
     domainGroups[group].push(tool);
   }
-  const groupNames = Object.keys(domainGroups).sort();
+  const groupNames = Object.keys(domainGroups).sort(
+    (a, b) => (groupOrder[a] ?? 0) - (groupOrder[b] ?? 0) || a.localeCompare(b),
+  );
 
   return (
     <div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -130,6 +130,7 @@ export interface ToolConfigEntry {
   description: string;
   category: string;
   domain_group: string;
+  domain_group_order: number;
   enabled: boolean;
 }
 

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -122,6 +122,7 @@ def test_get_tool_config(client: TestClient) -> None:
         assert "description" in tool
         assert "category" in tool
         assert "domain_group" in tool
+        assert "domain_group_order" in tool
         assert "enabled" in tool
         assert tool["category"] in ("core", "domain")
 
@@ -144,15 +145,17 @@ def test_get_tool_config_domain_group(client: TestClient) -> None:
     data = response.json()
     tools = data["tools"]
 
-    # Domain tools should have a non-empty domain_group
+    # Domain tools should have a non-empty domain_group and positive order
     domain_tools = [t for t in tools if t["category"] == "domain"]
     for t in domain_tools:
         assert t["domain_group"] != "", f"{t['name']} missing domain_group"
+        assert t["domain_group_order"] > 0, f"{t['name']} missing domain_group_order"
 
-    # Core tools should have an empty domain_group
+    # Core tools should have an empty domain_group and zero order
     core_tools = [t for t in tools if t["category"] == "core"]
     for t in core_tools:
         assert t["domain_group"] == "", f"{t['name']} should not have domain_group"
+        assert t["domain_group_order"] == 0, f"{t['name']} should have zero order"
 
 
 def test_put_tool_config_disable_domain_tool(client: TestClient) -> None:


### PR DESCRIPTION
## Description
Reorganize the Tools page to improve UX per #539:

- **Domain tools at top, grouped by section**: Domain-specific tools (estimate, file, checklist) are now grouped under labeled headings via a new `domain_group` field. Currently all grouped under "Local Management". Future integrations (e.g. QuickBooks) will get their own section automatically.
- **Core tools in collapsible section at bottom**: Core tools (workspace, profile, memory, messaging) that cannot be disabled are moved to a collapsible section at the bottom of the page, collapsed by default, with descriptions visible when expanded.
- **New `domain_group` field**: Added to `ToolConfigEntry` (file store), `ToolConfigEntryResponse` (API schema), and frontend types. Backend router maps each domain factory to its group via `_FACTORY_GROUPS`.

Fixes #539

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented with Claude Code)
- [ ] No AI used