### PR TITLE
feat: add swipe gestures for mobile sidebar

### DIFF
--- a/frontend/src/hooks/useSwipeSidebar.test.ts
+++ b/frontend/src/hooks/useSwipeSidebar.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react';
+import useSwipeSidebar from '@/hooks/useSwipeSidebar';
+
+/** Fire a touchstart followed by a touchend to simulate a swipe. */
+function simulateSwipe(startX: number, startY: number, endX: number, endY: number) {
+  const touchStartEvent = new TouchEvent('touchstart', {
+    touches: [{ clientX: startX, clientY: startY } as Touch],
+    bubbles: true,
+  });
+  const touchEndEvent = new TouchEvent('touchend', {
+    changedTouches: [{ clientX: endX, clientY: endY } as Touch],
+    bubbles: true,
+  });
+  document.dispatchEvent(touchStartEvent);
+  document.dispatchEvent(touchEndEvent);
+}
+
+describe('useSwipeSidebar', () => {
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerWidth = window.innerWidth;
+    // Simulate mobile viewport (< 768)
+    Object.defineProperty(window, 'innerWidth', { value: 400, writable: true, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: originalInnerWidth,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('calls onOpen when swiping right from the left edge while closed', () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    renderHook(() => useSwipeSidebar({ isOpen: false, onOpen, onClose }));
+
+    // Swipe starting at x=10 (inside 30px edge zone), moving right 80px
+    simulateSwipe(10, 200, 90, 200);
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when swiping left while sidebar is open', () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    renderHook(() => useSwipeSidebar({ isOpen: true, onOpen, onClose }));
+
+    // Swipe from x=200 to x=100 (leftward, -100px)
+    simulateSwipe(200, 300, 100, 300);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('ignores swipe-right that does not start in the edge zone', () => {
+    const onOpen = vi.fn();
+
+    renderHook(() => useSwipeSidebar({ isOpen: false, onOpen, onClose: vi.fn() }));
+
+    // Start at x=100, outside the 30px edge zone
+    simulateSwipe(100, 200, 200, 200);
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('ignores swipes below the distance threshold', () => {
+    const onOpen = vi.fn();
+
+    renderHook(() => useSwipeSidebar({ isOpen: false, onOpen, onClose: vi.fn() }));
+
+    // Swipe only 30px (below 50px threshold)
+    simulateSwipe(10, 200, 40, 200);
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('ignores swipes with too much vertical drift', () => {
+    const onOpen = vi.fn();
+
+    renderHook(() => useSwipeSidebar({ isOpen: false, onOpen, onClose: vi.fn() }));
+
+    // Swipe right 80px but with 100px vertical drift (over 75px limit)
+    simulateSwipe(10, 200, 90, 300);
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on desktop-width viewports', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true, configurable: true });
+
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    renderHook(() => useSwipeSidebar({ isOpen: false, onOpen, onClose }));
+
+    simulateSwipe(10, 200, 90, 200);
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('cleans up event listeners on unmount', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    const { unmount } = renderHook(() =>
+      useSwipeSidebar({ isOpen: false, onOpen: vi.fn(), onClose: vi.fn() }),
+    );
+
+    expect(addSpy).toHaveBeenCalledWith('touchstart', expect.any(Function), { passive: true });
+    expect(addSpy).toHaveBeenCalledWith('touchend', expect.any(Function), { passive: true });
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('touchstart', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('touchend', expect.any(Function));
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/useSwipeSidebar.ts
+++ b/frontend/src/hooks/useSwipeSidebar.ts
@@ -1,0 +1,83 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+/** Minimum horizontal distance (px) for a swipe to register. */
+const SWIPE_THRESHOLD = 50;
+
+/** Maximum width (px) from the left edge where a swipe-open gesture can start. */
+const EDGE_ZONE = 30;
+
+/** Maximum vertical drift (px) before the gesture is rejected (prevents scroll hijacking). */
+const MAX_VERTICAL_DRIFT = 75;
+
+/** Breakpoint (px) above which swipe is disabled (matches Tailwind md:). */
+const MD_BREAKPOINT = 768;
+
+interface UseSwipeSidebarOptions {
+  /** Whether the sidebar is currently open. */
+  isOpen: boolean;
+  /** Callback to open the sidebar. */
+  onOpen: () => void;
+  /** Callback to close the sidebar. */
+  onClose: () => void;
+}
+
+/**
+ * Adds touch-swipe gestures for the mobile sidebar.
+ *
+ * - Swipe right from the left edge of the screen to open.
+ * - Swipe left anywhere when the sidebar is open to close.
+ * - Disabled on screens wider than `md` (768px).
+ */
+export default function useSwipeSidebar({ isOpen, onOpen, onClose }: UseSwipeSidebarOptions) {
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+  const startedInEdge = useRef(false);
+
+  const handleTouchStart = useCallback(
+    (e: TouchEvent) => {
+      if (window.innerWidth >= MD_BREAKPOINT) return;
+
+      const touch = e.touches[0];
+      if (!touch) return;
+      touchStart.current = { x: touch.clientX, y: touch.clientY };
+      startedInEdge.current = touch.clientX <= EDGE_ZONE;
+    },
+    [],
+  );
+
+  const handleTouchEnd = useCallback(
+    (e: TouchEvent) => {
+      if (!touchStart.current) return;
+      if (window.innerWidth >= MD_BREAKPOINT) return;
+
+      const touch = e.changedTouches[0];
+      if (!touch) return;
+      const dx = touch.clientX - touchStart.current.x;
+      const dy = Math.abs(touch.clientY - touchStart.current.y);
+
+      // Reject if vertical drift is too large (user is scrolling, not swiping)
+      if (dy > MAX_VERTICAL_DRIFT) {
+        touchStart.current = null;
+        return;
+      }
+
+      if (!isOpen && startedInEdge.current && dx > SWIPE_THRESHOLD) {
+        onOpen();
+      } else if (isOpen && dx < -SWIPE_THRESHOLD) {
+        onClose();
+      }
+
+      touchStart.current = null;
+    },
+    [isOpen, onOpen, onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener('touchstart', handleTouchStart, { passive: true });
+    document.addEventListener('touchend', handleTouchEnd, { passive: true });
+
+    return () => {
+      document.removeEventListener('touchstart', handleTouchStart);
+      document.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [handleTouchStart, handleTouchEnd]);
+}

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/ui/button';
 import Spinner from '@/components/ui/spinner';
 import { useAuth } from '@/contexts/AuthContext';
 import { getFeatureRequestUrl, getReportIssueUrl } from '@/extensions';
+import useSwipeSidebar from '@/hooks/useSwipeSidebar';
 import type { UserProfile } from '@/types';
 
 /** Context value provided to child routes via useOutletContext(). */
@@ -31,6 +32,11 @@ export default function AppShell() {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [profileError, setProfileError] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const openSidebar = useCallback(() => setSidebarOpen(true), []);
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+
+  useSwipeSidebar({ isOpen: sidebarOpen, onOpen: openSidebar, onClose: closeSidebar });
 
   const loadProfile = useCallback(() => {
     setProfileError(false);
@@ -83,7 +89,7 @@ export default function AppShell() {
       {sidebarOpen && (
         <div
           className="fixed inset-0 z-40 bg-black/40 md:hidden"
-          onClick={() => setSidebarOpen(false)}
+          onClick={closeSidebar}
         />
       )}
 
@@ -106,7 +112,7 @@ export default function AppShell() {
               key={to}
               to={to}
               end={end}
-              onClick={() => setSidebarOpen(false)}
+              onClick={closeSidebar}
               className={({ isActive }) =>
                 `flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-all duration-150 ${
                   isActive
@@ -160,7 +166,7 @@ export default function AppShell() {
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => setSidebarOpen(true)}
+            onClick={openSidebar}
             aria-label="Open menu"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Description
Add touch swipe gesture support for the mobile sidebar in the web UI. Users can now swipe right from the left edge of the screen to open the sidebar and swipe left to close it, providing a native-feeling mobile navigation experience.

The implementation uses a new `useSwipeSidebar` custom hook that:
- Detects swipe-right from the left edge (30px zone) to open the sidebar
- Detects swipe-left anywhere to close the sidebar when open
- Requires a minimum 50px horizontal swipe distance to avoid false positives
- Rejects gestures with excessive vertical drift (>75px) to avoid hijacking scroll
- Automatically disables on desktop viewports (>=768px, matching Tailwind md: breakpoint)
- Registers passive event listeners for optimal scroll performance

The existing hamburger menu button and overlay tap-to-close continue to work as before.

Fixes #544

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implementation and tests generated with Claude Code)
- [ ] No AI used