### PR TITLE
feat: display channel in conversation view

### DIFF
--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -108,6 +108,7 @@ class SessionMetadata(BaseModel):
     last_message_at: str = ""
     is_active: bool = True
     last_compacted_seq: int = 0
+    channel: str = ""
 
 
 class SessionState(BaseModel):
@@ -120,6 +121,7 @@ class SessionState(BaseModel):
     created_at: str = ""
     last_message_at: str = ""
     last_compacted_seq: int = 0
+    channel: str = ""
 
 
 class ClientData(BaseModel):
@@ -772,6 +774,7 @@ class FileSessionStore:
             created_at=metadata.get("created_at", ""),
             last_message_at=metadata.get("last_message_at", ""),
             last_compacted_seq=metadata.get("last_compacted_seq", 0),
+            channel=metadata.get("channel", ""),
         )
 
     def _write_metadata(self, session_id: str, meta: dict[str, Any]) -> None:
@@ -854,6 +857,7 @@ class FileSessionStore:
         media_urls_json: str = "[]",
         processed_context: str = "",
         tool_interactions_json: str = "",
+        channel: str = "",
     ) -> StoredMessage:
         """Append a message to the session JSONL file."""
         async with self._lock:
@@ -871,8 +875,12 @@ class FileSessionStore:
             )
             _append_jsonl(self._session_path(session.session_id), msg.model_dump())
             session.messages.append(msg)
-            # Update last_message_at
-            self._write_metadata(session.session_id, {"last_message_at": now})
+            # Update last_message_at and channel (if provided)
+            meta_update: dict[str, str] = {"last_message_at": now}
+            if channel:
+                meta_update["channel"] = channel
+                session.channel = channel
+            self._write_metadata(session.session_id, meta_update)
             session.last_message_at = now
             return msg
 

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -269,6 +269,7 @@ async def process_inbound_from_bus(
                 body=inbound.text,
                 external_message_id=inbound.external_message_id or "",
                 media_urls_json=json.dumps([file_id for file_id, _mime in inbound.media_refs]),
+                channel=inbound.channel,
             )
             return
 
@@ -283,6 +284,7 @@ async def process_inbound_from_bus(
         body=inbound.text,
         external_message_id=inbound.external_message_id or "",
         media_urls_json=json.dumps([file_id for file_id, _mime in inbound.media_refs]),
+        channel=inbound.channel,
     )
 
     if settings.message_batch_window_ms > 0:

--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -46,6 +46,7 @@ async def list_sessions(
                 start_time=session.created_at or session.last_message_at,
                 message_count=len(session.messages),
                 last_message_preview=preview,
+                channel=session.channel,
             )
         )
 
@@ -90,5 +91,6 @@ async def get_session(
         created_at=session.created_at,
         last_message_at=session.last_message_at,
         is_active=session.is_active,
+        channel=session.channel,
         messages=messages,
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -118,6 +118,7 @@ class SessionSummary(BaseModel):
     start_time: str
     message_count: int
     last_message_preview: str = ""
+    channel: str = ""
 
 
 class SessionListResponse(BaseModel):
@@ -141,6 +142,7 @@ class SessionDetailResponse(BaseModel):
     created_at: str
     last_message_at: str
     is_active: bool
+    channel: str = ""
     messages: list[SessionMessage]
 
 

--- a/frontend/src/pages/ConversationsPage.tsx
+++ b/frontend/src/pages/ConversationsPage.tsx
@@ -7,6 +7,15 @@ import Spinner from '@/components/ui/spinner';
 import api from '@/api';
 import type { SessionSummary, SessionDetail, SessionMessage } from '@/types';
 
+/** Map internal channel identifiers to user-friendly labels. */
+function channelLabel(channel: string): string {
+  switch (channel) {
+    case 'telegram': return 'Telegram';
+    case 'webchat': return 'Web Chat';
+    default: return channel;
+  }
+}
+
 export default function ConversationsPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
 
@@ -83,7 +92,10 @@ function SessionListView() {
                       {new Date(s.start_time).toLocaleString()}
                     </p>
                   </div>
-                  <Badge className="ml-3 shrink-0">{s.message_count} msgs</Badge>
+                  <div className="ml-3 flex items-center gap-2 shrink-0">
+                    {s.channel && <Badge variant="outline">{channelLabel(s.channel)}</Badge>}
+                    <Badge>{s.message_count} msgs</Badge>
+                  </div>
                 </div>
               </Card>
             ))}
@@ -157,6 +169,7 @@ function SessionDetailView({ sessionId }: { sessionId: string }) {
         <>
           <div className="mb-4 flex items-center gap-3">
             <h2 className="text-xl font-semibold">Conversation</h2>
+            {session.channel && <Badge variant="outline">{channelLabel(session.channel)}</Badge>}
             {session.is_active && <Badge>Active</Badge>}
             <Button
               variant="secondary"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -35,6 +35,7 @@ export interface SessionSummary {
   start_time: string;
   message_count: number;
   last_message_preview: string;
+  channel: string;
 }
 
 export interface SessionListResponse {
@@ -62,6 +63,7 @@ export interface SessionDetail {
   created_at: string;
   last_message_at: string;
   is_active: boolean;
+  channel: string;
   messages: SessionMessage[];
 }
 

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -9,24 +9,28 @@ from backend.app.agent.file_store import UserData
 from backend.app.config import settings
 
 
-def _create_session(user: UserData, session_id: str, messages: list[dict[str, object]]) -> None:
+def _create_session(
+    user: UserData,
+    session_id: str,
+    messages: list[dict[str, object]],
+    channel: str = "",
+) -> None:
     """Create a test session JSONL file."""
     base = Path(settings.data_dir) / str(user.id) / "sessions"
     base.mkdir(parents=True, exist_ok=True)
     path = base / f"{session_id}.jsonl"
-    lines = [
-        json.dumps(
-            {
-                "_type": "metadata",
-                "session_id": session_id,
-                "user_id": user.id,
-                "created_at": "2025-01-15T10:00:00+00:00",
-                "last_message_at": "2025-01-15T10:05:00+00:00",
-                "is_active": True,
-                "last_compacted_seq": 0,
-            }
-        )
-    ]
+    metadata: dict[str, object] = {
+        "_type": "metadata",
+        "session_id": session_id,
+        "user_id": user.id,
+        "created_at": "2025-01-15T10:00:00+00:00",
+        "last_message_at": "2025-01-15T10:05:00+00:00",
+        "is_active": True,
+        "last_compacted_seq": 0,
+    }
+    if channel:
+        metadata["channel"] = channel
+    lines = [json.dumps(metadata)]
     for msg in messages:
         lines.append(json.dumps(msg))
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -139,3 +143,49 @@ def test_list_sessions_pagination(client: TestClient, test_user: UserData) -> No
     data = resp.json()
     assert data["total"] == 5
     assert len(data["sessions"]) == 2
+
+
+def test_session_list_includes_channel(client: TestClient, test_user: UserData) -> None:
+    """Session list should include the channel field when present in metadata."""
+    _create_session(
+        test_user,
+        "1_400",
+        [{"direction": "inbound", "body": "Hi", "timestamp": "2025-01-15T10:01:00", "seq": 1}],
+        channel="telegram",
+    )
+    resp = client.get("/api/user/sessions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sessions"][0]["channel"] == "telegram"
+
+
+def test_session_detail_includes_channel(client: TestClient, test_user: UserData) -> None:
+    """Session detail should include the channel field when present in metadata."""
+    _create_session(
+        test_user,
+        "1_500",
+        [{"direction": "inbound", "body": "Hello", "timestamp": "2025-01-15T10:01:00", "seq": 1}],
+        channel="webchat",
+    )
+    resp = client.get("/api/user/sessions/1_500")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["channel"] == "webchat"
+
+
+def test_session_channel_defaults_empty(client: TestClient, test_user: UserData) -> None:
+    """Sessions without channel metadata should return an empty string."""
+    _create_session(
+        test_user,
+        "1_600",
+        [{"direction": "inbound", "body": "Hey", "timestamp": "2025-01-15T10:01:00", "seq": 1}],
+    )
+    resp = client.get("/api/user/sessions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sessions"][0]["channel"] == ""
+
+    resp = client.get("/api/user/sessions/1_600")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["channel"] == ""


### PR DESCRIPTION
## Description
Add channel display to the web UI conversation view so users can see which channel (Telegram, Web Chat, etc.) each conversation is happening on. Inspired by how nanobot uses `channel:chat_id` session keys and how openclaw has explicit `channelLabel()` functions for user-friendly display.

**Backend changes:**
- Add `channel` field to `SessionMetadata` and `SessionState` data classes in the file store
- Persist the channel in session JSONL metadata whenever a message arrives via `add_message()`
- Include `channel` in `SessionSummary` and `SessionDetailResponse` API schemas
- Pass `channel` through the ingestion pipeline from `InboundMessage` to session storage

**Frontend changes:**
- Add `channel` field to `SessionSummary` and `SessionDetail` TypeScript types
- Display a channel badge (outline variant) next to the message count in the conversation list
- Display a channel badge in the conversation detail header
- Add `channelLabel()` helper to map internal identifiers (`telegram`, `webchat`) to user-friendly names

**Backward compatible:** Sessions created before this change will have an empty channel string, and no badge is shown (the badge only renders when `channel` is truthy).

Fixes #546

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation was AI-assisted using Claude Code. Referenced nanobot's session key pattern (`channel:chat_id`) and openclaw's `channelLabel()` approach for design inspiration.