### PR TITLE
fix: heartbeat sends to pushable channel instead of webchat

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -34,7 +34,7 @@ from backend.app.agent.file_store import (
 from backend.app.agent.llm_parsing import get_response_text, parse_tool_calls
 from backend.app.agent.system_prompt import build_heartbeat_system_prompt
 from backend.app.agent.tools.names import ToolName
-from backend.app.channels import get_channel, get_default_channel
+from backend.app.channels import get_channel, get_default_channel, get_manager
 from backend.app.config import settings
 from backend.app.enums import (
     ChecklistSchedule,
@@ -584,6 +584,56 @@ async def run_heartbeat_for_user(
 
 
 # ---------------------------------------------------------------------------
+# Channel selection for proactive messages
+# ---------------------------------------------------------------------------
+
+# Channels that cannot deliver proactive (push) messages because the user
+# must be actively connected to receive them.  Heartbeat messages sent via
+# these channels would silently vanish.  Inspired by nanobot's
+# ``_pick_heartbeat_target()`` which skips internal/non-routable channels.
+_NON_PUSHABLE_CHANNELS: frozenset[str] = frozenset({"webchat"})
+
+
+def _pick_heartbeat_channel(user: UserData) -> MessagingService:
+    """Select the best channel for delivering a heartbeat message.
+
+    Prefers the user's ``preferred_channel`` when it can actually push
+    messages.  When the preferred channel is non-pushable (e.g. webchat),
+    falls back to the first registered pushable channel.  If no pushable
+    channel is available at all, returns the default channel as a last
+    resort (matching the previous behavior).
+    """
+    preferred = user.preferred_channel
+
+    # Happy path: preferred channel is pushable
+    if preferred not in _NON_PUSHABLE_CHANNELS:
+        try:
+            return get_channel(preferred)
+        except KeyError:
+            pass
+
+    # Preferred channel is non-pushable or not registered: find the
+    # first registered channel that can deliver proactive messages.
+    manager = get_manager()
+    for name, channel in manager.channels.items():
+        if name not in _NON_PUSHABLE_CHANNELS:
+            logger.debug(
+                "Heartbeat for user %d: preferred channel %r is non-pushable, falling back to %r",
+                user.id,
+                preferred,
+                name,
+            )
+            return channel
+
+    # No pushable channels registered at all: fall back to default
+    logger.warning(
+        "Heartbeat for user %d: no pushable channels registered, using default channel",
+        user.id,
+    )
+    return get_default_channel()
+
+
+# ---------------------------------------------------------------------------
 # Scheduler
 # ---------------------------------------------------------------------------
 
@@ -645,12 +695,11 @@ class HeartbeatScheduler:
             """Process a single user."""
             async with semaphore:
                 try:
-                    # Route to the user's preferred channel, falling
-                    # back to the first registered channel.
-                    try:
-                        messaging_service: MessagingService = get_channel(user.preferred_channel)
-                    except KeyError:
-                        messaging_service = get_default_channel()
+                    # Pick a channel that can actually push messages to
+                    # the user (e.g. Telegram), skipping non-pushable
+                    # channels like webchat where the user must be
+                    # actively connected to receive anything.
+                    messaging_service = _pick_heartbeat_channel(user)
 
                     await run_heartbeat_for_user(
                         user=user,

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -16,6 +16,7 @@ from backend.app.agent.file_store import (
     UserData,
 )
 from backend.app.agent.heartbeat import (
+    _NON_PUSHABLE_CHANNELS,
     COMPOSE_MESSAGE_TOOL,
     CheapCheckResult,
     ComposeMessageParams,
@@ -24,6 +25,7 @@ from backend.app.agent.heartbeat import (
     _is_checklist_item_due,
     _parse_business_hours,
     _parse_tool_call_response,
+    _pick_heartbeat_channel,
     _to_local_time,
     build_heartbeat_context,
     evaluate_heartbeat_need,
@@ -1521,3 +1523,142 @@ class TestParseFrequencyToMinutes:
     def test_invalid_returns_none(self) -> None:
         assert parse_frequency_to_minutes("never") is None
         assert parse_frequency_to_minutes("weekly") is None
+
+
+# ---------------------------------------------------------------------------
+# _pick_heartbeat_channel
+# ---------------------------------------------------------------------------
+
+
+class TestPickHeartbeatChannel:
+    """Heartbeat should route to a pushable channel, never to webchat."""
+
+    def test_webchat_in_non_pushable(self) -> None:
+        """webchat must be listed as a non-pushable channel."""
+        assert "webchat" in _NON_PUSHABLE_CHANNELS
+
+    @patch("backend.app.agent.heartbeat.get_channel")
+    def test_preferred_channel_is_pushable(self, mock_get_channel: MagicMock) -> None:
+        """When preferred_channel is pushable, use it directly."""
+        user = UserData(id=1, preferred_channel="telegram")
+        mock_telegram = MagicMock()
+        mock_get_channel.return_value = mock_telegram
+
+        result = _pick_heartbeat_channel(user)
+
+        mock_get_channel.assert_called_once_with("telegram")
+        assert result is mock_telegram
+
+    @patch("backend.app.agent.heartbeat.get_manager")
+    @patch("backend.app.agent.heartbeat.get_channel")
+    def test_webchat_preferred_falls_back_to_telegram(
+        self, mock_get_channel: MagicMock, mock_get_manager: MagicMock
+    ) -> None:
+        """When preferred_channel is webchat, fall back to the first pushable channel."""
+        user = UserData(id=1, preferred_channel="webchat")
+        mock_telegram = MagicMock()
+        mock_webchat = MagicMock()
+
+        mock_manager = MagicMock()
+        mock_manager.channels = {"telegram": mock_telegram, "webchat": mock_webchat}
+        mock_get_manager.return_value = mock_manager
+
+        result = _pick_heartbeat_channel(user)
+
+        mock_get_channel.assert_not_called()
+        assert result is mock_telegram
+
+    @patch("backend.app.agent.heartbeat.get_manager")
+    @patch("backend.app.agent.heartbeat.get_channel")
+    def test_unregistered_preferred_falls_back(
+        self, mock_get_channel: MagicMock, mock_get_manager: MagicMock
+    ) -> None:
+        """When preferred_channel is not registered, fall back to first pushable."""
+        user = UserData(id=1, preferred_channel="sms")
+        mock_get_channel.side_effect = KeyError("sms not registered")
+        mock_telegram = MagicMock()
+
+        mock_manager = MagicMock()
+        mock_manager.channels = {"telegram": mock_telegram}
+        mock_get_manager.return_value = mock_manager
+
+        result = _pick_heartbeat_channel(user)
+
+        assert result is mock_telegram
+
+    @patch("backend.app.agent.heartbeat.get_default_channel")
+    @patch("backend.app.agent.heartbeat.get_manager")
+    @patch("backend.app.agent.heartbeat.get_channel")
+    def test_no_pushable_channels_falls_back_to_default(
+        self,
+        mock_get_channel: MagicMock,
+        mock_get_manager: MagicMock,
+        mock_get_default: MagicMock,
+    ) -> None:
+        """When only non-pushable channels are registered, fall back to default."""
+        user = UserData(id=1, preferred_channel="webchat")
+        mock_webchat = MagicMock()
+        mock_get_default.return_value = mock_webchat
+
+        mock_manager = MagicMock()
+        mock_manager.channels = {"webchat": mock_webchat}
+        mock_get_manager.return_value = mock_manager
+
+        result = _pick_heartbeat_channel(user)
+
+        mock_get_default.assert_called_once()
+        assert result is mock_webchat
+
+    @patch("backend.app.agent.heartbeat.get_manager")
+    @patch("backend.app.agent.heartbeat.get_channel")
+    def test_webchat_skipped_even_when_first_registered(
+        self, mock_get_channel: MagicMock, mock_get_manager: MagicMock
+    ) -> None:
+        """webchat should be skipped even if it is the first registered channel."""
+        user = UserData(id=1, preferred_channel="webchat")
+        mock_webchat = MagicMock()
+        mock_telegram = MagicMock()
+
+        mock_manager = MagicMock()
+        mock_manager.channels = {"webchat": mock_webchat, "telegram": mock_telegram}
+        mock_get_manager.return_value = mock_manager
+
+        result = _pick_heartbeat_channel(user)
+
+        assert result is mock_telegram
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.get_user_store")
+    @patch("backend.app.agent.heartbeat._pick_heartbeat_channel")
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_tick_uses_pick_heartbeat_channel(
+        self,
+        mock_settings: MagicMock,
+        mock_pick_channel: MagicMock,
+        mock_get_store: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """tick() should use _pick_heartbeat_channel instead of get_channel."""
+        mock_settings.heartbeat_concurrency = 2
+        mock_settings.heartbeat_max_daily_messages = 5
+
+        mock_telegram = MagicMock()
+        mock_pick_channel.return_value = mock_telegram
+
+        user = MagicMock()
+        user.id = 1
+        user.onboarding_complete = True
+        user.preferred_channel = "webchat"
+
+        mock_store = AsyncMock()
+        mock_store.list_all.return_value = [user]
+        mock_get_store.return_value = mock_store
+
+        mock_run.return_value = None
+
+        scheduler = HeartbeatScheduler()
+        await scheduler.tick()
+
+        mock_pick_channel.assert_called_once_with(user)
+        mock_run.assert_awaited_once()


### PR DESCRIPTION
## Description
Heartbeat messages were silently lost when the user's preferred channel was `webchat` (web UI), since `WebChatChannel.send_text()` is a no-op (requires active SSE connection). Added `_pick_heartbeat_channel()` that skips non-pushable channels and falls back to the first registered pushable channel (e.g., Telegram).

Fixes #545

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with Claude Code.