### PR TITLE
docs: remove outdated database references from DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,23 +7,25 @@ pip install uv
 uv sync
 cp .env.example .env
 # Edit .env with your credentials
-uv run alembic upgrade head
 uv run uvicorn backend.app.main:app --reload
 ```
 
-You'll need a PostgreSQL instance running locally, or set `DATABASE_URL` accordingly.
+No database is required. All data is stored as files (JSON, JSONL, Markdown) under
+`data/users/` by default. Set the `DATA_DIR` environment variable to change the
+storage location.
 
 ## Running Tests
 
 ```bash
 uv sync --all-extras
-DATABASE_URL=sqlite:// uv run pytest -v
+uv run pytest -v
 uv run ruff check backend/ tests/
 uv run ruff format --check backend/ tests/
 uv run ty check --python .venv backend/ tests/
 ```
 
-Tests use in-memory SQLite, so no database setup is needed.
+Tests use temporary directories for file-based storage, so no external services
+are needed.
 
 ## More
 


### PR DESCRIPTION
## Description
Remove outdated PostgreSQL, DATABASE_URL, and alembic references from DEVELOPMENT.md.
The OSS version uses file-based storage (JSON, JSONL, Markdown under `data/users/`),
not a database. The setup instructions and test commands now match the actual
file-based storage architecture documented in CLAUDE.md and AGENTS.md.

Changes:
- Remove `uv run alembic upgrade head` from setup steps
- Remove "PostgreSQL instance running locally" note and `DATABASE_URL` mention
- Remove `DATABASE_URL=sqlite://` prefix from test command
- Replace database descriptions with accurate file-based storage documentation
- Reference `DATA_DIR` environment variable for configuring storage location

Fixes #556

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Opus 4.6 via Claude Code.