### PR TITLE
fix: wrap blocking file I/O in asyncio.to_thread

### DIFF
--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -893,7 +893,9 @@ class FileSessionStore:
                 timestamp=now,
                 seq=seq,
             )
-            _append_jsonl(self._session_path(session.session_id), msg.model_dump())
+            await asyncio.to_thread(
+                _append_jsonl, self._session_path(session.session_id), msg.model_dump()
+            )
             session.messages.append(msg)
             # Update last_message_at and channel (if provided)
             meta_update: dict[str, str] = {"last_message_at": now}
@@ -1402,7 +1404,7 @@ class HeartbeatStore:
     async def log_heartbeat(self) -> None:
         """Append to heartbeat log."""
         entry = HeartbeatLogEntry(user_id=self.user_id)
-        _append_jsonl(self._log_path, entry.model_dump())
+        await asyncio.to_thread(_append_jsonl, self._log_path, entry.model_dump())
 
     async def get_daily_count(self) -> int:
         """Count heartbeat messages sent today (UTC)."""

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import logging
 from pathlib import Path
@@ -140,7 +141,7 @@ def create_estimate_tools(
         pdf_dir = PDF_BASE_DIR / str(user.id) / (client_slug or "unsorted")
         pdf_dir.mkdir(parents=True, exist_ok=True)
         pdf_path = pdf_dir / f"{estimate.id}.pdf"
-        pdf_path.write_bytes(pdf_bytes)
+        await asyncio.to_thread(pdf_path.write_bytes, pdf_bytes)
 
         # Also upload to cloud storage if available
         cloud_path = ""

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -8,6 +8,7 @@ directory for safety.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -89,7 +90,8 @@ def create_workspace_tools(user_id: int) -> list[Tool]:
                 is_error=True,
                 error_kind=ToolErrorKind.NOT_FOUND,
             )
-        return ToolResult(content=resolved.read_text(encoding="utf-8"))
+        file_content = await asyncio.to_thread(resolved.read_text, "utf-8")
+        return ToolResult(content=file_content)
 
     async def write_file(path: str, content: str) -> ToolResult:
         """Write or overwrite a markdown file in the workspace."""
@@ -97,7 +99,7 @@ def create_workspace_tools(user_id: int) -> list[Tool]:
         if err:
             return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
         resolved.parent.mkdir(parents=True, exist_ok=True)
-        resolved.write_text(content, encoding="utf-8")
+        await asyncio.to_thread(resolved.write_text, content, "utf-8")
         return ToolResult(content=f"Wrote {path}")
 
     async def edit_file(path: str, old_text: str, new_text: str) -> ToolResult:
@@ -111,7 +113,7 @@ def create_workspace_tools(user_id: int) -> list[Tool]:
                 is_error=True,
                 error_kind=ToolErrorKind.NOT_FOUND,
             )
-        text = resolved.read_text(encoding="utf-8")
+        text = await asyncio.to_thread(resolved.read_text, "utf-8")
         if old_text not in text:
             return ToolResult(
                 content=f"Text not found in {path}. Read the file first to see current contents.",
@@ -126,7 +128,7 @@ def create_workspace_tools(user_id: int) -> list[Tool]:
                 error_kind=ToolErrorKind.VALIDATION,
             )
         updated = text.replace(old_text, new_text, 1)
-        resolved.write_text(updated, encoding="utf-8")
+        await asyncio.to_thread(resolved.write_text, updated, "utf-8")
         return ToolResult(content=f"Updated {path}")
 
     return [

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -344,7 +344,7 @@ class TelegramChannel(BaseChannel):
 
         local_path = Path(media_url)
         if local_path.is_file():
-            data = local_path.read_bytes()
+            data = await asyncio.to_thread(local_path.read_bytes)
             content_type = mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
             filename = local_path.name
         else:

--- a/backend/app/routers/estimates.py
+++ b/backend/app/routers/estimates.py
@@ -1,5 +1,6 @@
 """Endpoints for estimate PDF serving."""
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -38,8 +39,9 @@ async def serve_estimate_pdf(
     if not pdf_path.exists():
         raise HTTPException(status_code=404, detail="Estimate PDF not found")
 
+    content = await asyncio.to_thread(pdf_path.read_bytes)
     return Response(
-        content=pdf_path.read_bytes(),
+        content=content,
         media_type="application/pdf",
         headers={"Content-Disposition": f"inline; filename=estimate-{estimate_id}.pdf"},
     )

--- a/tests/test_async_file_io.py
+++ b/tests/test_async_file_io.py
@@ -1,0 +1,168 @@
+"""Regression tests for asyncio.to_thread wrapping of blocking file I/O.
+
+Verifies that blocking file operations in async code paths are delegated
+to a thread via asyncio.to_thread() rather than blocking the event loop.
+
+These tests inspect the source code to verify asyncio.to_thread is used
+at the correct locations, and run functional tests to ensure correctness.
+
+Fixes #553.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.app.agent.file_store import (
+    FileSessionStore,
+    HeartbeatStore,
+    UserData,
+)
+from backend.app.agent.tools.workspace_tools import create_workspace_tools
+from backend.app.config import settings
+
+# ---------------------------------------------------------------------------
+# Source-level checks: verify asyncio.to_thread is used in the right places
+# ---------------------------------------------------------------------------
+
+
+def _source_of(module_path: str) -> str:
+    """Read source code of a module relative to the project root."""
+    path = Path(__file__).parent.parent / module_path
+    return path.read_text(encoding="utf-8")
+
+
+def test_estimates_router_uses_to_thread_for_read_bytes() -> None:
+    """estimates.py should use asyncio.to_thread for pdf_path.read_bytes."""
+    source = _source_of("backend/app/routers/estimates.py")
+    assert "asyncio.to_thread" in source, "estimates.py must use asyncio.to_thread"
+    assert "pdf_path.read_bytes()" not in source, (
+        "estimates.py should not call pdf_path.read_bytes() directly"
+    )
+
+
+def test_estimate_tools_uses_to_thread_for_write_bytes() -> None:
+    """estimate_tools.py should use asyncio.to_thread for pdf_path.write_bytes."""
+    source = _source_of("backend/app/agent/tools/estimate_tools.py")
+    assert "asyncio.to_thread" in source, "estimate_tools.py must use asyncio.to_thread"
+    assert "pdf_path.write_bytes(pdf_bytes)" not in source, (
+        "estimate_tools.py should not call pdf_path.write_bytes() directly"
+    )
+
+
+def test_telegram_uses_to_thread_for_read_bytes() -> None:
+    """telegram.py should use asyncio.to_thread for local_path.read_bytes."""
+    source = _source_of("backend/app/channels/telegram.py")
+    assert "asyncio.to_thread(local_path.read_bytes)" in source, (
+        "telegram.py must use asyncio.to_thread for local_path.read_bytes"
+    )
+    assert "local_path.read_bytes()" not in source, (
+        "telegram.py should not call local_path.read_bytes() directly"
+    )
+
+
+def test_file_store_add_message_uses_to_thread() -> None:
+    """FileSessionStore.add_message should use asyncio.to_thread for _append_jsonl."""
+    source = _source_of("backend/app/agent/file_store.py")
+    assert (
+        "asyncio.to_thread(\n                _append_jsonl" in source
+        or "asyncio.to_thread(_append_jsonl" in source
+    ), "add_message should use asyncio.to_thread for _append_jsonl"
+
+
+def test_file_store_log_heartbeat_uses_to_thread() -> None:
+    """HeartbeatStore.log_heartbeat should use asyncio.to_thread for _append_jsonl."""
+    source = _source_of("backend/app/agent/file_store.py")
+    assert "await asyncio.to_thread(_append_jsonl, self._log_path" in source, (
+        "log_heartbeat should use asyncio.to_thread for _append_jsonl"
+    )
+
+
+def test_workspace_tools_use_to_thread() -> None:
+    """workspace_tools.py should use asyncio.to_thread for file I/O."""
+    source = _source_of("backend/app/agent/tools/workspace_tools.py")
+    assert "asyncio.to_thread(resolved.read_text" in source, (
+        "workspace_tools.py should use asyncio.to_thread for read_text"
+    )
+    assert "asyncio.to_thread(resolved.write_text" in source, (
+        "workspace_tools.py should use asyncio.to_thread for write_text"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Functional tests: verify the changes do not break existing behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_session_store_add_message_still_works(
+    test_user: UserData,
+) -> None:
+    """FileSessionStore.add_message should still append messages correctly."""
+    store = FileSessionStore(test_user.id)
+    session, _ = await store.get_or_create_session()
+    msg = await store.add_message(session, direction="inbound", body="Hello from test")
+    assert msg.body == "Hello from test"
+    assert msg.direction == "inbound"
+    assert len(session.messages) == 1
+
+
+@pytest.mark.asyncio()
+async def test_heartbeat_log_still_works(
+    test_user: UserData,
+) -> None:
+    """HeartbeatStore.log_heartbeat should still log entries correctly."""
+    store = HeartbeatStore(test_user.id)
+    await store.log_heartbeat()
+    count = await store.get_daily_count()
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+async def test_workspace_read_file_still_works(
+    test_user: UserData,
+) -> None:
+    """Workspace read_file should still read files correctly."""
+    cdir = Path(settings.data_dir) / str(test_user.id)
+    cdir.mkdir(parents=True, exist_ok=True)
+    (cdir / "USER.md").write_text("# User\n\n- Name: Jake\n", encoding="utf-8")
+
+    tools = create_workspace_tools(test_user.id)
+    read_fn = next(t.function for t in tools if t.name == "read_file")
+    result = await read_fn(path="USER.md")
+    assert result.is_error is False
+    assert "Jake" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_workspace_write_file_still_works(
+    test_user: UserData,
+) -> None:
+    """Workspace write_file should still write files correctly."""
+    cdir = Path(settings.data_dir) / str(test_user.id)
+    cdir.mkdir(parents=True, exist_ok=True)
+
+    tools = create_workspace_tools(test_user.id)
+    write_fn = next(t.function for t in tools if t.name == "write_file")
+    result = await write_fn(path="USER.md", content="# User\n\n- Name: Sarah\n")
+    assert result.is_error is False
+    written = (cdir / "USER.md").read_text(encoding="utf-8")
+    assert "Sarah" in written
+
+
+@pytest.mark.asyncio()
+async def test_workspace_edit_file_still_works(
+    test_user: UserData,
+) -> None:
+    """Workspace edit_file should still edit files correctly."""
+    cdir = Path(settings.data_dir) / str(test_user.id)
+    cdir.mkdir(parents=True, exist_ok=True)
+    (cdir / "USER.md").write_text("- Rate: $85/hr\n", encoding="utf-8")
+
+    tools = create_workspace_tools(test_user.id)
+    edit_fn = next(t.function for t in tools if t.name == "edit_file")
+    result = await edit_fn(path="USER.md", old_text="$85/hr", new_text="$100/hr")
+    assert result.is_error is False
+    assert "$100/hr" in (cdir / "USER.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Description

Wrap blocking file I/O calls in `asyncio.to_thread()` across all async code paths to prevent event loop stalls under concurrent load. Without this fix, operations like PDF reads/writes, JSONL appends, and workspace file access block the entire asyncio event loop, causing latency spikes for all concurrent users.

**Changes:**
- `estimates.py`: `pdf_path.read_bytes()` in async route handler
- `estimate_tools.py`: `pdf_path.write_bytes()` in async tool function
- `telegram.py`: `local_path.read_bytes()` in async `send_media()`
- `file_store.py`: `_append_jsonl()` in `add_message()` and `log_heartbeat()`
- `workspace_tools.py`: `read_text()`/`write_text()` in all three async tool functions (found during audit)

Fixes #553

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)