### PR TITLE
refactor: simplify heartbeat engine (697 -> 448 LOC)

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -1,10 +1,10 @@
 """Proactive heartbeat engine.
 
 Every ``heartbeat_interval_minutes`` the scheduler wakes up, iterates over
-onboarded users, and runs **cheap deterministic checks** first.  Only when
-a cheap check flags something actionable does the engine escalate to an LLM call
-to compose a natural-language message.  Most ticks produce **no** outbound
-messages and **no** LLM calls -- saving cost and avoiding noise.
+onboarded users, and makes a single LLM call per user to decide whether
+a proactive message is needed.  The LLM sees the user's checklist, memory,
+recent messages, and current time, then decides holistically whether to
+reach out.
 """
 
 from __future__ import annotations
@@ -12,9 +12,8 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-import re
 import zoneinfo
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 from any_llm import amessages
@@ -23,10 +22,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.file_store import (
-    ChecklistItem,
-    EstimateData,
     HeartbeatStore,
-    MemoryFact,
     UserData,
     get_session_store,
     get_user_store,
@@ -36,10 +32,7 @@ from backend.app.agent.system_prompt import build_heartbeat_system_prompt
 from backend.app.agent.tools.names import ToolName
 from backend.app.channels import get_channel, get_default_channel, get_manager
 from backend.app.config import settings
-from backend.app.enums import (
-    EstimateStatus,
-    MessageDirection,
-)
+from backend.app.enums import MessageDirection
 from backend.app.services.llm_usage import log_llm_usage
 
 logger = logging.getLogger(__name__)
@@ -68,58 +61,6 @@ COMPOSE_MESSAGE_TOOL: dict[str, Any] = {
     "input_schema": ComposeMessageParams.model_json_schema(),
 }
 
-# Keywords that suggest a memory fact is time-sensitive
-_TIME_KEYWORDS = re.compile(
-    r"\b(remind|follow.?up|tomorrow|callback|check.?in|deadline|due|urgent)\b",
-    re.IGNORECASE,
-)
-
-
-STALE_ESTIMATE_HOURS = settings.heartbeat_stale_estimate_hours
-IDLE_DAYS = settings.heartbeat_idle_days
-HEARTBEAT_RECENT_MESSAGES_COUNT = settings.heartbeat_recent_messages_count
-
-_FREQ_RE = re.compile(r"^(\d+)\s*(m|h|d)(?:in(?:utes?)?|ours?|ays?)?$", re.IGNORECASE)
-
-
-def parse_frequency_to_minutes(freq: str) -> int | None:
-    """Parse a human-friendly frequency string into minutes.
-
-    Supports formats like ``"30m"``, ``"1h"``, ``"2d"``, ``"daily"``.
-    Returns *None* when the string is empty or cannot be parsed.
-    """
-    freq = freq.strip()
-    if not freq:
-        return None
-    if freq.lower() == "daily":
-        return 1440  # 24 * 60
-    m = _FREQ_RE.match(freq)
-    if not m:
-        return None
-    value = int(m.group(1))
-    unit = m.group(2).lower()
-    if unit == "m":
-        return value
-    if unit == "h":
-        return value * 60
-    if unit == "d":
-        return value * 1440
-    return None
-
-
-@dataclass
-class CheapCheckResult:
-    """Result of deterministic pre-checks for a single user."""
-
-    flags: list[str] = field(default_factory=list)
-    stale_estimates: list[EstimateData] = field(default_factory=list)
-    due_checklist_items: list[ChecklistItem] = field(default_factory=list)
-    time_sensitive_memories: list[MemoryFact] = field(default_factory=list)
-
-    @property
-    def has_flags(self) -> bool:
-        return len(self.flags) > 0
-
 
 @dataclass
 class HeartbeatAction:
@@ -130,46 +71,8 @@ class HeartbeatAction:
 
 
 # ---------------------------------------------------------------------------
-# Business-hours helpers
+# Business-hours gate
 # ---------------------------------------------------------------------------
-
-_AMPM_RE = re.compile(
-    r"(\d{1,2})(?::(\d{2}))?\s*(am|pm)\s*[-\u2013to]+\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)",
-    re.IGNORECASE,
-)
-_24H_RE = re.compile(r"(\d{1,2}):(\d{2})\s*[-\u2013to]+\s*(\d{1,2}):(\d{2})")
-
-
-def _parse_business_hours(hours_str: str) -> tuple[int, int] | None:
-    """Parse common business-hours strings into (start_hour, end_hour).
-
-    Supports formats like ``"7am-5pm"``, ``"7:00am - 5:00pm"``, ``"08:00-17:00"``.
-    Returns *None* when the string cannot be parsed.
-    """
-    m = _AMPM_RE.search(hours_str)
-    if m:
-        start_h = int(m.group(1))
-        start_ampm = m.group(3).lower()
-        end_h = int(m.group(4))
-        end_ampm = m.group(6).lower()
-
-        if start_ampm == "pm" and start_h != 12:
-            start_h += 12
-        elif start_ampm == "am" and start_h == 12:
-            start_h = 0
-
-        if end_ampm == "pm" and end_h != 12:
-            end_h += 12
-        elif end_ampm == "am" and end_h == 12:
-            end_h = 0
-
-        return start_h, end_h
-
-    m = _24H_RE.search(hours_str)
-    if m:
-        return int(m.group(1)), int(m.group(3))
-
-    return None
 
 
 def _to_local_time(
@@ -190,17 +93,11 @@ def is_within_business_hours(
     user: UserData,
     now: datetime.datetime | None = None,
 ) -> bool:
-    """Return *True* if *now* falls within the user's business hours.
-
-    When the user has a ``timezone`` set, *now* is converted to their
-    local time before comparing against business hours or the global quiet
-    hours window.  Falls back to UTC when the timezone is empty or invalid.
-    """
+    """Return *True* if *now* falls outside the quiet-hours window."""
     now = now or datetime.datetime.now(datetime.UTC)
     local_now = _to_local_time(now, user.timezone)
     current_hour = local_now.hour
 
-    # Use global quiet hours to determine business hours.
     qstart = settings.heartbeat_quiet_hours_start
     qend = settings.heartbeat_quiet_hours_end
     if qstart > qend:
@@ -209,130 +106,6 @@ def is_within_business_hours(
     else:
         in_quiet = qstart <= current_hour < qend
     return not in_quiet
-
-
-# ---------------------------------------------------------------------------
-# Cheap checks -- deterministic, no LLM call
-# ---------------------------------------------------------------------------
-
-
-async def run_cheap_checks(
-    user: UserData,
-    now: datetime.datetime | None = None,
-) -> CheapCheckResult:
-    """Run fast, deterministic checks that don't require an LLM call.
-
-    Returns a ``CheapCheckResult`` with flags describing what needs attention.
-    If ``flags`` is empty, everything is clean and the LLM can be skipped.
-    """
-    now = now or datetime.datetime.now(datetime.UTC)
-    result = CheapCheckResult()
-
-    # 1. Stale draft estimates (older than STALE_ESTIMATE_HOURS)
-    from backend.app.agent.file_store import EstimateStore
-
-    estimate_store = EstimateStore(user.id)
-    all_estimates = await estimate_store.list_all()
-    cutoff = now - datetime.timedelta(hours=STALE_ESTIMATE_HOURS)
-    stale: list[EstimateData] = []
-    for e in all_estimates:
-        if e.status == EstimateStatus.DRAFT:
-            try:
-                created = datetime.datetime.fromisoformat(e.created_at)
-                if created.tzinfo is None:
-                    created = created.replace(tzinfo=datetime.UTC)
-                if created <= cutoff:
-                    stale.append(e)
-            except (ValueError, TypeError):
-                pass
-    if stale:
-        result.stale_estimates = stale
-        descs = ", ".join(e.description[:40] for e in stale)
-        result.flags.append(f"Stale draft estimate(s) older than 24h: {descs}")
-
-    # 2. Checklist: read HEARTBEAT.md (single source of truth) and flag
-    #    when there are unchecked items for the LLM to evaluate.
-    heartbeat_store = HeartbeatStore(user.id)
-    checklist_content = heartbeat_store.read_checklist_md()
-    if checklist_content:
-        unchecked = [
-            ln.strip()[6:]
-            for ln in checklist_content.splitlines()
-            if ln.strip().startswith("- [ ] ")
-        ]
-        if unchecked:
-            result.flags.append(f"HEARTBEAT.md has {len(unchecked)} unchecked item(s)")
-
-    # 3. Time-sensitive memory facts
-    from backend.app.agent.file_store import get_memory_store
-
-    memory_store = get_memory_store(user.id)
-    memories = await memory_store.get_all_memories()
-    for mem in memories:
-        text = f"{mem.key} {mem.value}"
-        if _TIME_KEYWORDS.search(text):
-            result.time_sensitive_memories.append(mem)
-            result.flags.append(f"Time-sensitive memory: {mem.key} = {mem.value}")
-
-    # 4. Idle user -- no inbound messages for IDLE_DAYS
-    idle_cutoff = now - datetime.timedelta(days=IDLE_DAYS)
-    session_store = get_session_store(user.id)
-    last_inbound = session_store.get_last_inbound_timestamp()
-    if last_inbound is not None:
-        if last_inbound <= idle_cutoff:
-            days = (now - last_inbound).days
-            result.flags.append(f"User idle for {days} days -- no recent messages")
-    elif user.created_at is not None:
-        created = user.created_at
-        if isinstance(created, str):
-            try:
-                created = datetime.datetime.fromisoformat(created)
-            except (ValueError, TypeError):
-                created = None
-        if created is not None:
-            if created.tzinfo is None:
-                created = created.replace(tzinfo=datetime.UTC)
-            if created <= idle_cutoff:
-                days = (now - created).days
-                result.flags.append(f"User idle for {days} days -- no messages since onboarding")
-
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Context builder
-# ---------------------------------------------------------------------------
-
-
-def _load_recent_messages(user: UserData) -> str:
-    """Load recent messages as formatted text for heartbeat context."""
-    session_store = get_session_store(user.id)
-    recent = session_store.get_recent_messages(count=HEARTBEAT_RECENT_MESSAGES_COUNT)
-    if not recent:
-        return "(no recent messages)"
-
-    lines: list[str] = []
-    for msg in recent:
-        direction = "User" if msg.direction == MessageDirection.INBOUND else "Assistant"
-        lines.append(f"[{direction}] {msg.body}")
-    return "\n".join(lines) or "(no recent messages)"
-
-
-async def build_heartbeat_context(
-    user: UserData,
-    flags: list[str],
-) -> str:
-    """Build the full heartbeat system prompt via the composable builder.
-
-    Reads HEARTBEAT.md and passes its content to the LLM as context,
-    following the same pattern nanobot uses with HEARTBEAT.md.
-    """
-    recent_messages = _load_recent_messages(user)
-    heartbeat_store = HeartbeatStore(user.id)
-    checklist_md = heartbeat_store.read_checklist_md()
-    return await build_heartbeat_system_prompt(
-        user, flags, recent_messages, checklist_md=checklist_md
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -399,23 +172,34 @@ def _parse_tool_call_response(response: MessageResponse) -> HeartbeatAction:
 
 
 # ---------------------------------------------------------------------------
-# LLM evaluation (only called when cheap checks flag something)
+# LLM evaluation
 # ---------------------------------------------------------------------------
 
 
 async def evaluate_heartbeat_need(
     user: UserData,
-    flags: list[str],
     channel: str = "",
     chat_id: str = "",
 ) -> HeartbeatAction:
-    """Ask the LLM to compose a message based on flagged items.
+    """Single LLM call to evaluate whether a proactive message is needed.
 
-    Uses the compose_message tool calling protocol instead of raw JSON parsing.
-    If the LLM does not call the tool, defaults to no_action.
-    Sends a typing indicator before the LLM call when a channel is provided.
+    The LLM sees the user's checklist, memory, recent messages, and current
+    time, and decides holistically whether to send a message.
     """
-    prompt = await build_heartbeat_context(user, flags)
+    session_store = get_session_store(user.id)
+    recent = session_store.get_recent_messages(count=settings.heartbeat_recent_messages_count)
+    recent_text = (
+        "\n".join(
+            f"[{'User' if m.direction == MessageDirection.INBOUND else 'Assistant'}] {m.body}"
+            for m in recent
+        )
+        or "(no recent messages)"
+    )
+
+    heartbeat_store = HeartbeatStore(user.id)
+    checklist_md = heartbeat_store.read_checklist_md()
+
+    prompt = await build_heartbeat_system_prompt(user, recent_text, checklist_md=checklist_md)
 
     # Send typing indicator before LLM call via the bus
     if channel and chat_id:
@@ -446,7 +230,9 @@ async def evaluate_heartbeat_need(
             messages=[
                 {
                     "role": "user",
-                    "content": "Compose a proactive message based on the flags above.",
+                    "content": (
+                        "Review the context above and decide whether to send a proactive message."
+                    ),
                 },
             ],
             tools=[COMPOSE_MESSAGE_TOOL],
@@ -464,12 +250,7 @@ async def evaluate_heartbeat_need(
 
 
 async def get_daily_heartbeat_count(user_id: int) -> int:
-    """Count heartbeat messages sent to a user today (UTC).
-
-    Queries the heartbeat log instead of relying on in-memory state
-    so that rate limits survive process restarts and work across multiple
-    workers.
-    """
+    """Count heartbeat messages sent to a user today (UTC)."""
     heartbeat_store = HeartbeatStore(user_id)
     return await heartbeat_store.get_daily_count()
 
@@ -505,31 +286,8 @@ async def run_heartbeat_for_user(
     if await get_daily_heartbeat_count(user.id) >= max_daily:
         return None
 
-    # Gate: per-user frequency override
-    freq_minutes = parse_frequency_to_minutes(user.heartbeat_frequency)
-    if freq_minutes is not None:
-        session_store = get_session_store(user.id)
-        last_outbound = session_store.get_last_outbound_timestamp()
-        if last_outbound is not None:
-            now = datetime.datetime.now(datetime.UTC)
-            elapsed = now - last_outbound
-            if elapsed < datetime.timedelta(minutes=freq_minutes):
-                return None
-
-    # Cheap checks -- skip LLM entirely if nothing is flagged
-    check_result = await run_cheap_checks(user)
-    if not check_result.has_flags:
-        return HeartbeatAction(
-            action_type="no_action",
-            message="",
-            reasoning="All cheap checks clean -- skipped LLM",
-            priority=0,
-        )
-
-    # Something was flagged -- escalate to LLM for message composition
-    action = await evaluate_heartbeat_need(
-        user, check_result.flags, channel=channel, chat_id=chat_id
-    )
+    # Single LLM call: the model evaluates all context holistically
+    action = await evaluate_heartbeat_need(user, channel=channel, chat_id=chat_id)
 
     if action.action_type != "send_message" or not action.message:
         return action
@@ -570,9 +328,7 @@ async def run_heartbeat_for_user(
 # ---------------------------------------------------------------------------
 
 # Channels that cannot deliver proactive (push) messages because the user
-# must be actively connected to receive them.  Heartbeat messages sent via
-# these channels would silently vanish.  Inspired by nanobot's
-# ``_pick_heartbeat_target()`` which skips internal/non-routable channels.
+# must be actively connected to receive them.
 _NON_PUSHABLE_CHANNELS: frozenset[str] = frozenset({"webchat"})
 
 
@@ -678,10 +434,6 @@ class HeartbeatScheduler:
             """Process a single user."""
             async with semaphore:
                 try:
-                    # Pick a channel that can actually push messages to
-                    # the user (e.g. Telegram), skipping non-pushable
-                    # channels like webchat where the user must be
-                    # actively connected to receive anything.
                     channel_name = _pick_heartbeat_channel(user)
                     chat_id = user.channel_identifier or user.phone
 

--- a/backend/app/agent/prompts/heartbeat_preamble.md
+++ b/backend/app/agent/prompts/heartbeat_preamble.md
@@ -1,1 +1,1 @@
-You are a heartbeat evaluator. Your job is to compose a short, actionable message for the user based on the flags below.
+You are a heartbeat evaluator. Review the user's checklist, memory, recent messages, and current time, then decide whether a proactive message is needed.

--- a/backend/app/agent/prompts/heartbeat_rules.md
+++ b/backend/app/agent/prompts/heartbeat_rules.md
@@ -1,6 +1,5 @@
-- The pre-checks already decided something needs attention. Your job is to compose one concise, helpful message.
-- Combine multiple flags into a single message when possible.
+- Only send a message when there is something genuinely actionable: a pending checklist item, a stale estimate, a follow-up that is due, or similar.
+- If nothing needs attention right now, choose no_action.
 - Keep the message under 160 characters.
 - Be direct and actionable, no fluff.
-- If after reviewing the flags you believe none actually warrant a message right now, you may still choose "no_action".
 - Use the compose_message tool to return your decision.

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -223,7 +223,6 @@ async def build_agent_system_prompt(
 
 async def build_heartbeat_system_prompt(
     user: UserData,
-    flags: list[str],
     recent_messages: str,
     checklist_md: str = "",
 ) -> str:
@@ -231,8 +230,7 @@ async def build_heartbeat_system_prompt(
 
     When *checklist_md* is provided, the raw HEARTBEAT.md content is
     included as a dedicated section so the LLM can evaluate which tasks
-    need attention.  This mirrors how nanobot passes HEARTBEAT.md content
-    to its heartbeat decision phase.
+    need attention.
     """
     builder = SystemPromptBuilder()
     builder.set_preamble(load_prompt("heartbeat_preamble"))
@@ -250,11 +248,6 @@ async def build_heartbeat_system_prompt(
 
     if checklist_md:
         builder.add_section("User's checklist (HEARTBEAT.md)", checklist_md)
-
-    builder.add_section(
-        "Flags raised by pre-checks",
-        "\n".join(f"- {f}" for f in flags),
-    )
 
     builder.add_section(
         "Current time",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -87,7 +87,6 @@ class Settings(BaseSettings):
     compaction_model: str = ""  # empty = fall back to llm_model
     compaction_provider: str = ""  # empty = fall back to llm_provider
     compaction_max_tokens: int = Field(default=500, ge=1)
-    heartbeat_stale_estimate_hours: int = Field(default=24, ge=1)
 
     # Rate limiting
     webhook_rate_limit_max_requests: int = Field(default=30, ge=1)
@@ -108,7 +107,6 @@ class Settings(BaseSettings):
     heartbeat_max_daily_messages: int = Field(default=5, ge=1)
     heartbeat_quiet_hours_start: int = Field(default=20, ge=0, le=23)  # 8 PM
     heartbeat_quiet_hours_end: int = Field(default=7, ge=0, le=23)  # 7 AM
-    heartbeat_idle_days: int = Field(default=3, ge=1)
     heartbeat_model: str = ""  # empty = fall back to llm_model
     heartbeat_provider: str = ""  # empty = fall back to llm_provider
     heartbeat_concurrency: int = Field(default=5, ge=1)

--- a/tests/integration/test_heartbeat_integration.py
+++ b/tests/integration/test_heartbeat_integration.py
@@ -34,8 +34,9 @@ async def test_heartbeat_evaluate_returns_valid_action(
         mock_settings.heartbeat_provider = None
         mock_settings.heartbeat_model = None
         mock_settings.llm_max_tokens_heartbeat = 300
+        mock_settings.heartbeat_recent_messages_count = 5
 
-        action = await evaluate_heartbeat_need(onboarded_user, ["Test flag: check-in needed"])
+        action = await evaluate_heartbeat_need(onboarded_user)
 
     assert action.action_type in ("send_message", "no_action")
     assert isinstance(action.reasoning, str)
@@ -79,11 +80,9 @@ async def test_heartbeat_evaluate_with_context(
         mock_settings.heartbeat_provider = None
         mock_settings.heartbeat_model = None
         mock_settings.llm_max_tokens_heartbeat = 300
+        mock_settings.heartbeat_recent_messages_count = 5
 
-        action = await evaluate_heartbeat_need(
-            onboarded_user,
-            ["Stale draft estimate: 12x12 composite deck build"],
-        )
+        action = await evaluate_heartbeat_need(onboarded_user)
 
     assert action.action_type in ("send_message", "no_action")
     # If LLM decides to send, the message should be non-empty

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -11,26 +11,20 @@ from any_llm.types.messages import MessageContentBlock, MessageResponse, Message
 
 from backend.app.agent.file_store import (
     HeartbeatLogEntry,
-    StoredMessage,
     UserData,
 )
 from backend.app.agent.heartbeat import (
     _NON_PUSHABLE_CHANNELS,
     COMPOSE_MESSAGE_TOOL,
-    CheapCheckResult,
     ComposeMessageParams,
     HeartbeatAction,
     HeartbeatScheduler,
-    _parse_business_hours,
     _parse_tool_call_response,
     _pick_heartbeat_channel,
     _to_local_time,
-    build_heartbeat_context,
     evaluate_heartbeat_need,
     get_daily_heartbeat_count,
     is_within_business_hours,
-    parse_frequency_to_minutes,
-    run_cheap_checks,
     run_heartbeat_for_user,
 )
 from tests.mocks.llm import make_text_response, make_tool_call_response
@@ -91,31 +85,6 @@ def _make_heartbeat_tool_call(
         }
     )
     return make_tool_call_response([{"name": tool_name, "arguments": args, "id": "call_mock_001"}])
-
-
-# ---------------------------------------------------------------------------
-# Business hours parsing
-# ---------------------------------------------------------------------------
-
-
-class TestParseBusinessHours:
-    def test_ampm_simple(self) -> None:
-        assert _parse_business_hours("7am-5pm") == (7, 17)
-
-    def test_ampm_with_colons(self) -> None:
-        assert _parse_business_hours("7:00am - 5:00pm") == (7, 17)
-
-    def test_24h_format(self) -> None:
-        assert _parse_business_hours("08:00-17:00") == (8, 17)
-
-    def test_noon_edge(self) -> None:
-        assert _parse_business_hours("12pm-5pm") == (12, 17)
-
-    def test_midnight_edge(self) -> None:
-        assert _parse_business_hours("12am-8am") == (0, 8)
-
-    def test_unparseable(self) -> None:
-        assert _parse_business_hours("whenever I feel like it") is None
 
 
 # ---------------------------------------------------------------------------
@@ -230,279 +199,6 @@ class TestIsWithinBusinessHoursTimezone:
         # 10 AM UTC -> falls back to UTC -> outside quiet hours
         now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
         assert is_within_business_hours(c, now) is True
-
-
-# ---------------------------------------------------------------------------
-# Cheap checks
-# ---------------------------------------------------------------------------
-
-
-class TestRunCheapChecks:
-    @pytest.mark.asyncio
-    async def test_no_flags_when_clean(self, user: UserData) -> None:
-        """No stale estimates, no checklist items, no time-sensitive memories."""
-        result = await run_cheap_checks(user)
-        assert not result.has_flags
-        assert result.flags == []
-
-    @pytest.mark.asyncio
-    async def test_stale_estimate_flagged(self, user: UserData) -> None:
-        """Draft estimate older than 24h should be flagged."""
-        from backend.app.agent.file_store import EstimateStore
-
-        store = EstimateStore(user.id)
-        est = await store.create(
-            description="Deck build for Smith",
-            total_amount=3000,
-            status="draft",
-        )
-        # Backdate created_at by rewriting the file
-        from backend.app.agent.file_store import _write_json
-
-        est.created_at = datetime.datetime(2025, 6, 13, 8, 0, tzinfo=datetime.UTC).isoformat()
-        _write_json(store._estimate_path(est.id), est.model_dump())
-
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        result = await run_cheap_checks(user, now=now)
-        assert result.has_flags
-        assert len(result.stale_estimates) == 1
-        assert "Deck build" in result.flags[0]
-
-    @pytest.mark.asyncio
-    async def test_recent_draft_not_flagged(self, user: UserData) -> None:
-        """Draft estimate less than 24h old should NOT be flagged."""
-        from backend.app.agent.file_store import EstimateStore, _write_json
-
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        store = EstimateStore(user.id)
-        est = await store.create(
-            description="Fresh estimate",
-            total_amount=1000,
-            status="draft",
-        )
-        est.created_at = (now - datetime.timedelta(hours=12)).isoformat()
-        _write_json(store._estimate_path(est.id), est.model_dump())
-
-        result = await run_cheap_checks(user, now=now)
-        assert not result.has_flags
-        assert len(result.stale_estimates) == 0
-
-    @pytest.mark.asyncio
-    async def test_sent_estimate_not_flagged(self, user: UserData) -> None:
-        """Sent estimates should not be flagged regardless of age."""
-        from backend.app.agent.file_store import EstimateStore, _write_json
-
-        store = EstimateStore(user.id)
-        est = await store.create(
-            description="Already sent",
-            total_amount=5000,
-            status="sent",
-        )
-        est.created_at = datetime.datetime(2025, 6, 10, 8, 0, tzinfo=datetime.UTC).isoformat()
-        _write_json(store._estimate_path(est.id), est.model_dump())
-
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        result = await run_cheap_checks(user, now=now)
-        assert not result.has_flags
-
-    @pytest.mark.asyncio
-    async def test_checklist_item_due(self, user: UserData) -> None:
-        """Unchecked items in HEARTBEAT.md should be flagged."""
-        from backend.app.agent.file_store import HeartbeatStore
-
-        store = HeartbeatStore(user.id)
-        await store.add_checklist_item(
-            description="Check material prices",
-            schedule="daily",
-        )
-
-        result = await run_cheap_checks(user)
-        assert result.has_flags
-        assert "HEARTBEAT.md has 1 unchecked item(s)" in result.flags[0]
-
-    @pytest.mark.asyncio
-    async def test_checked_item_not_flagged(self, user: UserData) -> None:
-        """Checked items in HEARTBEAT.md should not be flagged."""
-        from backend.app.agent.file_store import HeartbeatStore
-
-        store = HeartbeatStore(user.id)
-        item = await store.add_checklist_item(
-            description="Done item",
-            schedule="daily",
-        )
-        await store.update_checklist_item(item.id, status="completed")
-
-        result = await run_cheap_checks(user)
-        # All items are checked, so no unchecked flag
-        checklist_flags = [f for f in result.flags if "CHECKLIST" in f]
-        assert len(checklist_flags) == 0
-
-    @pytest.mark.asyncio
-    async def test_time_sensitive_memory_flagged(self, user: UserData) -> None:
-        """Memory facts with time-sensitive keywords should be flagged."""
-        from backend.app.agent.file_store import get_memory_store
-
-        store = get_memory_store(user.id)
-        await store.save_memory(
-            key="smith_followup",
-            value="Follow up with Smith about deck quote",
-            category="client",
-        )
-
-        result = await run_cheap_checks(user)
-        assert result.has_flags
-        assert len(result.time_sensitive_memories) == 1
-        assert "smith_followup" in result.flags[0]
-
-    @pytest.mark.asyncio
-    async def test_regular_memory_not_flagged(self, user: UserData) -> None:
-        """Memory facts without time-sensitive keywords should not be flagged."""
-        from backend.app.agent.file_store import get_memory_store
-
-        store = get_memory_store(user.id)
-        await store.save_memory(
-            key="kitchen_rate",
-            value="Standard kitchen remodel rate is $150/hour",
-            category="pricing",
-        )
-
-        result = await run_cheap_checks(user)
-        assert not result.has_flags
-
-    @pytest.mark.asyncio
-    async def test_multiple_flags_combined(self, user: UserData) -> None:
-        """Multiple issues should produce multiple flags."""
-        from backend.app.agent.file_store import EstimateStore, HeartbeatStore, _write_json
-
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-
-        # Stale estimate
-        est_store = EstimateStore(user.id)
-        est = await est_store.create(
-            description="Old estimate",
-            total_amount=2000,
-            status="draft",
-        )
-        est.created_at = (now - datetime.timedelta(hours=48)).isoformat()
-        _write_json(est_store._estimate_path(est.id), est.model_dump())
-
-        # Due checklist item
-        hb_store = HeartbeatStore(user.id)
-        await hb_store.add_checklist_item(
-            description="Check inbox",
-            schedule="daily",
-        )
-
-        result = await run_cheap_checks(user, now=now)
-        assert result.has_flags
-        assert len(result.flags) == 2
-
-    @pytest.mark.asyncio
-    async def test_idle_user_flagged(self, user: UserData) -> None:
-        """User with last inbound message older than idle_days should be flagged."""
-        from backend.app.agent.file_store import get_session_store
-
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        store = get_session_store(user.id)
-
-        session, _ = await store.get_or_create_session()
-        # Write a backdated inbound message directly to the JSONL file
-        from backend.app.agent.file_store import _append_jsonl
-
-        msg = StoredMessage(
-            direction="inbound",
-            body="Need a quote",
-            timestamp=(now - datetime.timedelta(days=5)).isoformat(),
-            seq=1,
-        )
-        _append_jsonl(store._session_path(session.session_id), msg.model_dump())
-
-        result = await run_cheap_checks(user, now=now)
-        assert result.has_flags
-        idle_flags = [f for f in result.flags if "idle" in f.lower()]
-        assert len(idle_flags) == 1
-        assert "5 days" in idle_flags[0]
-
-    @pytest.mark.asyncio
-    async def test_active_user_not_flagged_idle(self, user: UserData) -> None:
-        """User with recent inbound message should not be flagged as idle."""
-        from backend.app.agent.file_store import _append_jsonl, get_session_store
-
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        store = get_session_store(user.id)
-
-        session, _ = await store.get_or_create_session()
-        msg = StoredMessage(
-            direction="inbound",
-            body="Just checking in",
-            timestamp=(now - datetime.timedelta(hours=12)).isoformat(),
-            seq=1,
-        )
-        _append_jsonl(store._session_path(session.session_id), msg.model_dump())
-
-        result = await run_cheap_checks(user, now=now)
-        idle_flags = [f for f in result.flags if "idle" in f.lower()]
-        assert len(idle_flags) == 0
-
-    @pytest.mark.asyncio
-    async def test_no_messages_old_user_flagged(self) -> None:
-        """User with no messages who was created more than idle_days ago should be flagged."""
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        c = UserData(
-            id=50,
-            user_id="hb-idle-001",
-            name="Old Timer",
-            phone="+15559990099",
-            onboarding_complete=True,
-            created_at=now - datetime.timedelta(days=7),
-        )
-
-        result = await run_cheap_checks(c, now=now)
-        assert result.has_flags
-        idle_flags = [f for f in result.flags if "idle" in f.lower()]
-        assert len(idle_flags) == 1
-        assert "onboarding" in idle_flags[0]
-
-    @pytest.mark.asyncio
-    async def test_no_messages_new_user_not_flagged(self) -> None:
-        """User with no messages who just onboarded should not be flagged as idle."""
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        c = UserData(
-            id=51,
-            user_id="hb-new-001",
-            name="Fresh Start",
-            phone="+15559990098",
-            onboarding_complete=True,
-            created_at=now - datetime.timedelta(hours=6),
-        )
-
-        result = await run_cheap_checks(c, now=now)
-        idle_flags = [f for f in result.flags if "idle" in f.lower()]
-        assert len(idle_flags) == 0
-
-    @pytest.mark.asyncio
-    async def test_outbound_only_still_flagged_idle(self, user: UserData) -> None:
-        """User with only outbound messages (no inbound) should check created_at."""
-        from backend.app.agent.file_store import _append_jsonl, get_session_store
-
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        # Backdate the user's created_at
-        user.created_at = now - datetime.timedelta(days=5)
-
-        store = get_session_store(user.id)
-        session, _ = await store.get_or_create_session()
-        msg = StoredMessage(
-            direction="outbound",
-            body="Welcome!",
-            timestamp=(now - datetime.timedelta(days=4)).isoformat(),
-            seq=1,
-        )
-        _append_jsonl(store._session_path(session.session_id), msg.model_dump())
-
-        result = await run_cheap_checks(user, now=now)
-        idle_flags = [f for f in result.flags if "idle" in f.lower()]
-        assert len(idle_flags) == 1
-        assert "onboarding" in idle_flags[0]
 
 
 # ---------------------------------------------------------------------------
@@ -715,12 +411,20 @@ class TestParseToolCallResponse:
 
 class TestEvaluateHeartbeatNeed:
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.amessages")
     async def test_llm_says_no(
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
         user: UserData,
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
@@ -729,23 +433,43 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_model = ""
         mock_settings.heartbeat_provider = ""
         mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_checklist_md.return_value = ""
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action",
             message="",
             reasoning="Nothing actionable",
             priority=1,
         )
-        action = await evaluate_heartbeat_need(user, ["Stale draft estimate"])
+        action = await evaluate_heartbeat_need(user)
         assert action.action_type == "no_action"
         assert action.message == ""
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.amessages")
     async def test_llm_says_send(
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
         user: UserData,
     ) -> None:
         mock_settings.llm_model = "gpt-4o"
@@ -754,23 +478,43 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_model = ""
         mock_settings.heartbeat_provider = ""
         mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_checklist_md.return_value = ""
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="send_message",
             message="Hey Mike, you have a draft estimate sitting for 2 days.",
             reasoning="Stale draft estimate",
             priority=4,
         )
-        action = await evaluate_heartbeat_need(user, ["Stale draft estimate"])
+        action = await evaluate_heartbeat_need(user)
         assert action.action_type == "send_message"
         assert "draft estimate" in action.message
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.amessages")
     async def test_uses_heartbeat_model_when_set(
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
         user: UserData,
     ) -> None:
         """When heartbeat_model is configured, it should be used instead of llm_model."""
@@ -780,22 +524,42 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_model = "gpt-4o-mini"
         mock_settings.heartbeat_provider = "openai"
         mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_checklist_md.return_value = ""
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action", message="", reasoning="", priority=1
         )
-        await evaluate_heartbeat_need(user, ["test flag"])
+        await evaluate_heartbeat_need(user)
 
         # Verify the cheap model was used
         call_kwargs = mock_llm.call_args
         assert call_kwargs.kwargs["model"] == "gpt-4o-mini"
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.amessages")
     async def test_passes_api_base_not_api_key(
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
         user: UserData,
     ) -> None:
         """Regression test: acompletion must receive api_base, not api_key."""
@@ -805,22 +569,42 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_model = ""
         mock_settings.heartbeat_provider = ""
         mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_checklist_md.return_value = ""
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action", message="", reasoning="test", priority=1
         )
-        await evaluate_heartbeat_need(user, ["test flag"])
+        await evaluate_heartbeat_need(user)
         _, kwargs = mock_llm.call_args
         assert "api_base" in kwargs
         assert kwargs["api_base"] == "http://localhost:1234/v1"
         assert "api_key" not in kwargs
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.amessages")
     async def test_text_response_falls_back_to_no_action(
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
         user: UserData,
     ) -> None:
         """If LLM returns text instead of tool call, default to no_action."""
@@ -830,18 +614,38 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_model = ""
         mock_settings.heartbeat_provider = ""
         mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_checklist_md.return_value = ""
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+
         mock_llm.return_value = make_text_response("I'm not sure what to do {broken json")
-        action = await evaluate_heartbeat_need(user, ["test flag"])
+        action = await evaluate_heartbeat_need(user)
         assert action.action_type == "no_action"
         assert action.priority == 0
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.amessages")
     async def test_passes_tools_to_acompletion(
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
         user: UserData,
     ) -> None:
         """acompletion should receive tools=[COMPOSE_MESSAGE_TOOL]."""
@@ -851,21 +655,41 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_model = ""
         mock_settings.heartbeat_provider = ""
         mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_checklist_md.return_value = ""
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action", message="", reasoning="test", priority=1
         )
-        await evaluate_heartbeat_need(user, ["test flag"])
+        await evaluate_heartbeat_need(user)
         _, kwargs = mock_llm.call_args
         assert "tools" in kwargs
         assert kwargs["tools"] == [COMPOSE_MESSAGE_TOOL]
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.amessages")
     async def test_prompt_does_not_ask_for_raw_json(
         self,
         mock_llm: AsyncMock,
         mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
         user: UserData,
     ) -> None:
         """System prompt should not contain 'Respond with ONLY a JSON object'."""
@@ -875,10 +699,22 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_model = ""
         mock_settings.heartbeat_provider = ""
         mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_checklist_md.return_value = ""
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "Use compose_message tool to decide"
+
         mock_llm.return_value = _make_heartbeat_tool_call(
             action="no_action", message="", reasoning="test", priority=1
         )
-        await evaluate_heartbeat_need(user, ["test flag"])
+        await evaluate_heartbeat_need(user)
         call_args = mock_llm.call_args
         system_content = call_args.kwargs["system"]
         assert "Respond with ONLY a JSON object" not in system_content
@@ -921,130 +757,112 @@ class TestRunHeartbeatForUser:
         assert result is None
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
     @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
-    async def test_no_action_when_checks_clean(
+    async def test_no_action_from_llm(
         self,
         _mock_hours: MagicMock,
+        mock_count: AsyncMock,
+        mock_eval: AsyncMock,
         user: UserData,
     ) -> None:
-        """When cheap checks return no flags, LLM is skipped and no message sent."""
-        result = await run_heartbeat_for_user(user, "telegram", user.phone, 5)
+        """When LLM returns no_action, no message is sent."""
+        mock_count.return_value = 0
+        mock_eval.return_value = HeartbeatAction(
+            action_type="no_action",
+            message="",
+            reasoning="Nothing actionable right now",
+            priority=1,
+        )
+        result = await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
         assert result is not None
         assert result.action_type == "no_action"
-        assert "cheap checks clean" in result.reasoning
+        mock_eval.assert_awaited_once_with(user, channel="telegram", chat_id="+15559990000")
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
+    @patch("backend.app.agent.heartbeat.get_or_create_conversation")
+    @patch("backend.app.bus.OutboundMessage")
+    @patch("backend.app.bus.message_bus")
     @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
-    @patch("backend.app.agent.heartbeat.run_cheap_checks")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
     @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
     async def test_send_message_and_record(
         self,
         _mock_hours: MagicMock,
-        mock_checks: AsyncMock,
+        mock_count: AsyncMock,
         mock_eval: AsyncMock,
+        mock_bus: MagicMock,
+        mock_outbound_msg: MagicMock,
+        mock_get_conv: AsyncMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
         user: UserData,
     ) -> None:
-        """When cheap checks flag something and LLM says send, message is delivered."""
-        from backend.app.bus import message_bus
-
-        check_result = CheapCheckResult(
-            flags=["Stale draft estimate"],
-        )
-        mock_checks.return_value = check_result
+        """When LLM says send, message is delivered via the bus."""
+        mock_count.return_value = 0
         mock_eval.return_value = HeartbeatAction(
             action_type="send_message",
             message="Reminder: draft estimate pending!",
             reasoning="Stale draft",
             priority=4,
         )
-        result = await run_heartbeat_for_user(user, "telegram", user.phone, 5)
+        mock_bus.publish_outbound = AsyncMock()
+
+        mock_session = MagicMock()
+        mock_get_conv.return_value = (mock_session, True)
+
+        mock_session_store = MagicMock()
+        mock_session_store.add_message = AsyncMock()
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        result = await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
 
         assert result is not None
         assert result.action_type == "send_message"
-        # Check the outbound message was published to the bus
-        outbound = message_bus.outbound.get_nowait()
-        assert outbound.content == "Reminder: draft estimate pending!"
-        assert outbound.channel == "telegram"
-        assert outbound.chat_id == user.phone
-        # LLM was called with the flags and new keyword args
-        mock_eval.assert_awaited_once_with(
-            user, ["Stale draft estimate"], channel="telegram", chat_id=user.phone
+        # Verify outbound message was published to the bus
+        mock_bus.publish_outbound.assert_awaited_once()
+        mock_outbound_msg.assert_called_once_with(
+            channel="telegram",
+            chat_id="+15559990000",
+            content="Reminder: draft estimate pending!",
         )
+        # LLM was called with new keyword args (no flags)
+        mock_eval.assert_awaited_once_with(user, channel="telegram", chat_id="+15559990000")
 
     @pytest.mark.asyncio
-    @patch("backend.app.bus.message_bus.publish_outbound", side_effect=Exception("Bus down"))
+    @patch("backend.app.bus.OutboundMessage")
+    @patch("backend.app.bus.message_bus")
     @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
-    @patch("backend.app.agent.heartbeat.run_cheap_checks")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
     @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
     async def test_sms_failure_graceful(
         self,
         _mock_hours: MagicMock,
-        mock_checks: AsyncMock,
+        mock_count: AsyncMock,
         mock_eval: AsyncMock,
-        _mock_publish: AsyncMock,
+        mock_bus: MagicMock,
+        mock_outbound_msg: MagicMock,
         user: UserData,
     ) -> None:
-        mock_checks.return_value = CheapCheckResult(flags=["test flag"])
+        mock_count.return_value = 0
         mock_eval.return_value = HeartbeatAction(
             action_type="send_message",
             message="Reminder!",
             reasoning="test",
             priority=3,
         )
-        result = await run_heartbeat_for_user(user, "telegram", user.phone, 5)
+        mock_bus.publish_outbound = AsyncMock(side_effect=Exception("Bus down"))
+        result = await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
         # Should still return the action, just not record a message
         assert result is not None
         assert result.action_type == "send_message"
-
-    @pytest.mark.asyncio
-    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
-    @patch("backend.app.agent.heartbeat.run_cheap_checks")
-    @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
-    async def test_checklist_items_marked_triggered(
-        self,
-        _mock_hours: MagicMock,
-        mock_checks: AsyncMock,
-        mock_eval: AsyncMock,
-        user: UserData,
-    ) -> None:
-        """Heartbeat sends message and logs when checklist flags are raised."""
-        mock_checks.return_value = CheapCheckResult(
-            flags=["HEARTBEAT.md has 1 unchecked item(s)"],
-        )
-        mock_eval.return_value = HeartbeatAction(
-            action_type="send_message",
-            message="Time to check your inbox!",
-            reasoning="checklist",
-            priority=3,
-        )
-        action = await run_heartbeat_for_user(user, "telegram", user.phone, 5)
-        assert action is not None
-        assert action.action_type == "send_message"
-
-    @pytest.mark.asyncio
-    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
-    @patch("backend.app.agent.heartbeat.run_cheap_checks")
-    @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
-    async def test_once_item_completed_after_trigger(
-        self,
-        _mock_hours: MagicMock,
-        mock_checks: AsyncMock,
-        mock_eval: AsyncMock,
-        user: UserData,
-    ) -> None:
-        """Heartbeat sends message when flags are raised."""
-        mock_checks.return_value = CheapCheckResult(
-            flags=["HEARTBEAT.md has 1 unchecked item(s)"],
-        )
-        mock_eval.return_value = HeartbeatAction(
-            action_type="send_message",
-            message="Don't forget your meeting!",
-            reasoning="once item",
-            priority=4,
-        )
-        action = await run_heartbeat_for_user(user, "telegram", user.phone, 5)
-        assert action is not None
-        assert action.action_type == "send_message"
 
 
 # ---------------------------------------------------------------------------
@@ -1099,35 +917,6 @@ class TestGetDailyHeartbeatCount:
 
         assert await get_daily_heartbeat_count(user.id) == 0
         assert await get_daily_heartbeat_count(other.id) == 1
-
-
-# ---------------------------------------------------------------------------
-# build_heartbeat_context
-# ---------------------------------------------------------------------------
-
-
-class TestBuildHeartbeatContext:
-    @pytest.mark.asyncio
-    async def test_includes_profile_and_flags(self, user: UserData) -> None:
-        from backend.app.agent.file_store import get_session_store
-        from backend.app.enums import MessageDirection
-
-        # Add a session with a message so context builder works
-        store = get_session_store(user.id)
-        session, _ = await store.get_or_create_session()
-        await store.add_message(
-            session=session,
-            direction=MessageDirection.INBOUND,
-            body="I need a quote",
-        )
-
-        flags = ["Stale draft estimate: Kitchen remodel"]
-        prompt = await build_heartbeat_context(user, flags)
-
-        # build_heartbeat_context now returns a full prompt string
-        assert "Plumber" in prompt
-        assert "Kitchen remodel" in prompt
-        assert "I need a quote" in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -1187,6 +976,8 @@ class TestHeartbeatScheduler:
             c.id = i + 1
             c.onboarding_complete = True
             c.preferred_channel = "telegram"
+            c.channel_identifier = ""
+            c.phone = "+15559990000"
             users.append(c)
 
         mock_store = AsyncMock()
@@ -1223,6 +1014,8 @@ class TestHeartbeatScheduler:
             c.id = i + 1
             c.onboarding_complete = True
             c.preferred_channel = "telegram"
+            c.channel_identifier = ""
+            c.phone = "+15559990000"
             users.append(c)
 
         mock_store = AsyncMock()
@@ -1266,6 +1059,8 @@ class TestHeartbeatScheduler:
             c.id = i + 1
             c.onboarding_complete = True
             c.preferred_channel = "telegram"
+            c.channel_identifier = ""
+            c.phone = "+15559990000"
             users.append(c)
 
         mock_store = AsyncMock()
@@ -1314,53 +1109,6 @@ class TestHeartbeatScheduler:
         await scheduler.tick()
 
         mock_store.list_all.assert_awaited_once()
-
-
-# ---------------------------------------------------------------------------
-# parse_frequency_to_minutes
-# ---------------------------------------------------------------------------
-
-
-class TestParseFrequencyToMinutes:
-    def test_empty_string_returns_none(self) -> None:
-        assert parse_frequency_to_minutes("") is None
-
-    def test_whitespace_returns_none(self) -> None:
-        assert parse_frequency_to_minutes("   ") is None
-
-    def test_daily_keyword(self) -> None:
-        assert parse_frequency_to_minutes("daily") == 1440
-
-    def test_daily_case_insensitive(self) -> None:
-        assert parse_frequency_to_minutes("Daily") == 1440
-        assert parse_frequency_to_minutes("DAILY") == 1440
-
-    def test_minutes_short(self) -> None:
-        assert parse_frequency_to_minutes("30m") == 30
-
-    def test_hours_short(self) -> None:
-        assert parse_frequency_to_minutes("1h") == 60
-        assert parse_frequency_to_minutes("2h") == 120
-
-    def test_days_short(self) -> None:
-        assert parse_frequency_to_minutes("1d") == 1440
-        assert parse_frequency_to_minutes("2d") == 2880
-
-    def test_long_form_minutes(self) -> None:
-        assert parse_frequency_to_minutes("45minutes") == 45
-        assert parse_frequency_to_minutes("1minute") == 1
-
-    def test_long_form_hours(self) -> None:
-        assert parse_frequency_to_minutes("3hours") == 180
-        assert parse_frequency_to_minutes("1hour") == 60
-
-    def test_long_form_days(self) -> None:
-        assert parse_frequency_to_minutes("1day") == 1440
-        assert parse_frequency_to_minutes("2days") == 2880
-
-    def test_invalid_returns_none(self) -> None:
-        assert parse_frequency_to_minutes("never") is None
-        assert parse_frequency_to_minutes("weekly") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -489,15 +489,15 @@ async def test_prepopulated_user_gets_onboarding_complete(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.heartbeat.is_within_business_hours", return_value=True)
-@patch("backend.app.agent.heartbeat.run_cheap_checks")
+@patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
 @patch("backend.app.agent.core.amessages")
 async def test_prepopulated_user_included_in_heartbeat(
     mock_amessages: object,
-    mock_cheap_checks: MagicMock,
+    mock_eval: AsyncMock,
     _mock_hours: MagicMock,
 ) -> None:
     """User with pre-populated fields should be eligible for heartbeat after first message."""
-    from backend.app.agent.heartbeat import CheapCheckResult, run_heartbeat_for_user
+    from backend.app.agent.heartbeat import HeartbeatAction, run_heartbeat_for_user
 
     user = UserData(
         id=31,
@@ -547,7 +547,12 @@ async def test_prepopulated_user_included_in_heartbeat(
     assert refreshed.onboarding_complete is True
 
     # Now verify heartbeat doesn't skip this user
-    mock_cheap_checks.return_value = CheapCheckResult(flags=[])
+    mock_eval.return_value = HeartbeatAction(
+        action_type="no_action",
+        message="",
+        reasoning="Nothing actionable",
+        priority=0,
+    )
     result = await run_heartbeat_for_user(
         user=refreshed,
         channel="telegram",
@@ -556,7 +561,7 @@ async def test_prepopulated_user_included_in_heartbeat(
     )
     # Should get a result (not None which means skipped)
     assert result is not None
-    assert result.action_type == "no_action"  # Clean checks, no message needed
+    assert result.action_type == "no_action"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -173,6 +173,10 @@ async def test_agent_no_typing_indicator_without_chat_id(
 
 
 @pytest.mark.asyncio()
+@patch("backend.app.agent.heartbeat.log_llm_usage")
+@patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+@patch("backend.app.agent.heartbeat.HeartbeatStore")
+@patch("backend.app.agent.heartbeat.get_session_store")
 @patch("backend.app.agent.heartbeat.settings")
 @patch("backend.app.agent.heartbeat.amessages")
 @patch("backend.app.bus.message_bus")
@@ -180,6 +184,10 @@ async def test_heartbeat_sends_typing_indicator_before_llm_call(
     mock_bus: MagicMock,
     mock_llm: AsyncMock,
     mock_settings: MagicMock,
+    mock_get_session_store: MagicMock,
+    mock_heartbeat_store_cls: MagicMock,
+    mock_build_prompt: AsyncMock,
+    mock_log_usage: MagicMock,
     test_user: UserData,
 ) -> None:
     """Heartbeat should send typing indicator before calling the LLM."""
@@ -189,6 +197,17 @@ async def test_heartbeat_sends_typing_indicator_before_llm_call(
     mock_settings.heartbeat_model = ""
     mock_settings.heartbeat_provider = ""
     mock_settings.llm_max_tokens_heartbeat = 256
+    mock_settings.heartbeat_recent_messages_count = 5
+
+    mock_session_store = MagicMock()
+    mock_session_store.get_recent_messages.return_value = []
+    mock_get_session_store.return_value = mock_session_store
+
+    mock_hb_store = MagicMock()
+    mock_hb_store.read_checklist_md.return_value = ""
+    mock_heartbeat_store_cls.return_value = mock_hb_store
+
+    mock_build_prompt.return_value = "system prompt"
 
     mock_llm.return_value = make_tool_call_response(
         [
@@ -210,7 +229,6 @@ async def test_heartbeat_sends_typing_indicator_before_llm_call(
 
     await evaluate_heartbeat_need(
         test_user,
-        ["Stale draft estimate"],
         channel="telegram",
         chat_id=test_user.channel_identifier,
     )
@@ -227,11 +245,19 @@ async def test_heartbeat_sends_typing_indicator_before_llm_call(
 
 
 @pytest.mark.asyncio()
+@patch("backend.app.agent.heartbeat.log_llm_usage")
+@patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+@patch("backend.app.agent.heartbeat.HeartbeatStore")
+@patch("backend.app.agent.heartbeat.get_session_store")
 @patch("backend.app.agent.heartbeat.settings")
 @patch("backend.app.agent.heartbeat.amessages")
 async def test_heartbeat_works_without_channel(
     mock_llm: AsyncMock,
     mock_settings: MagicMock,
+    mock_get_session_store: MagicMock,
+    mock_heartbeat_store_cls: MagicMock,
+    mock_build_prompt: AsyncMock,
+    mock_log_usage: MagicMock,
     test_user: UserData,
 ) -> None:
     """Heartbeat should work when no channel is provided."""
@@ -241,6 +267,17 @@ async def test_heartbeat_works_without_channel(
     mock_settings.heartbeat_model = ""
     mock_settings.heartbeat_provider = ""
     mock_settings.llm_max_tokens_heartbeat = 256
+    mock_settings.heartbeat_recent_messages_count = 5
+
+    mock_session_store = MagicMock()
+    mock_session_store.get_recent_messages.return_value = []
+    mock_get_session_store.return_value = mock_session_store
+
+    mock_hb_store = MagicMock()
+    mock_hb_store.read_checklist_md.return_value = ""
+    mock_heartbeat_store_cls.return_value = mock_hb_store
+
+    mock_build_prompt.return_value = "system prompt"
 
     mock_llm.return_value = make_tool_call_response(
         [
@@ -259,8 +296,5 @@ async def test_heartbeat_works_without_channel(
     )
 
     # Should not raise when no channel is provided
-    action = await evaluate_heartbeat_need(
-        test_user,
-        ["Stale draft estimate"],
-    )
+    action = await evaluate_heartbeat_need(test_user)
     assert action.action_type == "no_action"


### PR DESCRIPTION
## Description

Simplify the heartbeat engine by replacing the 5-type "cheap checks first" cascade with a single holistic LLM call. The LLM now sees the user's checklist, memory, recent messages, and current time and decides whether to reach out.

- Remove regex-based frequency parsing, business hours string parsing, stale estimate detection, idle user detection, time-sensitive memory scanning
- Remove config settings `heartbeat_stale_estimate_hours` and `heartbeat_idle_days`
- Update prompt templates from flag-based to holistic evaluation
- heartbeat.py: 714 -> 466 lines (-35%)

Fixes #572

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)