### PR TITLE
fix: prevent error LLM responses from poisoning session history

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -69,6 +69,14 @@ RATE_LIMIT_RETRY_DELAY = settings.rate_limit_retry_delay
 # Conservative default; most models support 128K+ but we leave room for output
 MAX_INPUT_TOKENS = settings.max_input_tokens
 
+# Stop reasons that represent a valid, non-error LLM response.
+# Anything outside this set indicates a provider-level error and the
+# response should *not* be persisted to session history to avoid
+# context poisoning.
+_VALID_STOP_REASONS: set[str | None] = {"end_turn", "max_tokens", "tool_use", "stop_sequence", None}
+
+_LLM_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
+
 
 @dataclass
 class AgentResponse:
@@ -643,6 +651,31 @@ class ClawboltAgent:
                     "LLM usage: input_tokens=%d output_tokens=%d",
                     response.usage.input_tokens,
                     response.usage.output_tokens or 0,
+                )
+
+            # Guard: skip error responses to prevent context poisoning.
+            # The user still sees the error fallback text, but the response
+            # is NOT persisted to session history.
+            if response.stop_reason not in _VALID_STOP_REASONS:
+                logger.warning(
+                    "Round %d: LLM returned error stop_reason=%r, aborting loop",
+                    _round,
+                    response.stop_reason,
+                )
+                total_duration = (time.monotonic() - agent_start_time) * 1000
+                await self._emit(
+                    AgentEndEvent(
+                        reply_text=_LLM_ERROR_FALLBACK,
+                        actions_taken=actions_taken,
+                        total_duration_ms=total_duration,
+                    )
+                )
+                return AgentResponse(
+                    reply_text=_LLM_ERROR_FALLBACK,
+                    actions_taken=actions_taken,
+                    memories_saved=memories_saved,
+                    tool_calls=tool_call_records,
+                    is_error_fallback=True,
                 )
 
             # Parse tool calls via shared parser

--- a/tests/mocks/llm.py
+++ b/tests/mocks/llm.py
@@ -55,6 +55,27 @@ def make_tool_call_response(
     )
 
 
+def make_error_response(
+    stop_reason: str = "error",
+    content: str = "",
+) -> MessageResponse:
+    """Build a mock MessageResponse with an error stop_reason.
+
+    Simulates an LLM response that completed but with an error status,
+    such as ``stop_reason="error"`` from certain providers.
+    """
+    blocks: list[MessageContentBlock] = []
+    if content:
+        blocks.append(MessageContentBlock(type="text", text=content))
+    return MessageResponse(
+        id="msg_mock",
+        content=blocks,
+        model="mock-model",
+        stop_reason=stop_reason,
+        usage=MessageUsage(input_tokens=0, output_tokens=0),
+    )
+
+
 def _make_text_message_response(content: str) -> MessageResponse:
     """Build a mock MessageResponse with a single text block."""
     return MessageResponse(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -25,7 +25,7 @@ from backend.app.agent.messages import (
 )
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.trimming import trim_messages
-from tests.mocks.llm import make_text_response, make_tool_call_response
+from tests.mocks.llm import make_error_response, make_text_response, make_tool_call_response
 
 
 class _EmptyParams(BaseModel):
@@ -1737,3 +1737,115 @@ async def test_agent_emits_debug_logs_for_full_loop(
     assert any("Agent finished" in m for m in debug_messages)
     # LLM call
     assert any("Calling LLM" in m for m in debug_messages)
+
+
+# ---------------------------------------------------------------------------
+# Error stop_reason guard (context poisoning prevention)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_error_stop_reason_sets_is_error_fallback(
+    mock_amessages: object, test_user: UserData
+) -> None:
+    """LLM response with an error stop_reason should set is_error_fallback."""
+    mock_amessages.return_value = make_error_response(stop_reason="error")  # type: ignore[union-attr]
+
+    agent = ClawboltAgent(user=test_user)
+    response = await agent.process_message("Hello")
+
+    assert response.is_error_fallback is True
+    assert response.reply_text  # should have a fallback message
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_error_stop_reason_mid_loop_preserves_earlier_tool_calls(
+    mock_amessages: object, test_user: UserData
+) -> None:
+    """Error stop_reason after a successful tool round should preserve tool records."""
+    tool_func = AsyncMock(return_value=ToolResult(content="saved"))
+    tool = Tool(
+        name="save_fact",
+        description="save",
+        function=tool_func,
+        params_model=_KeyValueParams,
+    )
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(
+            [{"name": "save_fact", "arguments": {"key": "color", "value": "blue"}}]
+        ),
+        # Second LLM call returns an error
+        make_error_response(stop_reason="error"),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    response = await agent.process_message("Remember blue")
+
+    assert response.is_error_fallback is True
+    # The successful tool call from round 0 should still be in the records
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].name == "save_fact"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_tool_errors_still_returned_to_llm_in_loop(
+    mock_amessages: object, test_user: UserData
+) -> None:
+    """Tool-level errors should still be fed back to the LLM for self-correction."""
+    tool_func = AsyncMock(return_value=ToolResult(content="saved"))
+    tool = Tool(
+        name="save_fact",
+        description="save",
+        function=tool_func,
+        params_model=_KeyValueParams,
+    )
+    # Round 0: LLM calls an unknown tool (error result returned)
+    # Round 1: LLM self-corrects and calls the right tool
+    # Round 2: LLM produces final text reply
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(
+            [{"name": "nonexistent_tool", "arguments": {"key": "a", "value": "b"}}]
+        ),
+        make_tool_call_response(
+            [{"name": "save_fact", "arguments": {"key": "color", "value": "blue"}}]
+        ),
+        make_text_response("Done!"),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    response = await agent.process_message("Remember blue")
+
+    # The agent should NOT be flagged as error (the loop recovered)
+    assert response.is_error_fallback is False
+    assert response.reply_text == "Done!"
+    # The LLM was called 3 times (error feedback allowed self-correction)
+    assert mock_amessages.call_count == 3  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_valid_stop_reasons_not_treated_as_error(
+    mock_amessages: object, test_user: UserData
+) -> None:
+    """Responses with valid stop_reasons should be processed normally."""
+    for stop_reason in ("end_turn", "max_tokens", "stop_sequence"):
+        from any_llm.types.messages import MessageContentBlock, MessageResponse, MessageUsage
+
+        mock_amessages.return_value = MessageResponse(  # type: ignore[union-attr]
+            id="msg_mock",
+            content=[MessageContentBlock(type="text", text="Reply!")],
+            model="mock-model",
+            stop_reason=stop_reason,
+            usage=MessageUsage(input_tokens=0, output_tokens=0),
+        )
+
+        agent = ClawboltAgent(user=test_user)
+        response = await agent.process_message("Hello")
+
+        assert response.is_error_fallback is False, f"stop_reason={stop_reason} was wrongly error"
+        assert response.reply_text == "Reply!"

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -11,7 +11,7 @@ from backend.app.agent.router import (
     handle_inbound_message,
 )
 from backend.app.bus import message_bus
-from tests.mocks.llm import make_text_response, make_tool_call_response
+from tests.mocks.llm import make_error_response, make_text_response, make_tool_call_response
 from tests.mocks.storage import MockStorageBackend
 
 
@@ -1132,3 +1132,56 @@ async def test_dispatch_reply_step_sends_when_send_reply_fails() -> None:
     outbound = message_bus.outbound.get_nowait()
     assert outbound.content == "Fallback text"
     assert outbound.chat_id == "123"
+
+
+# ---------------------------------------------------------------------------
+# Error stop_reason: dispatched to user but NOT persisted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_error_stop_reason_not_persisted_to_session(
+    mock_amessages: object,
+    test_user: UserData,
+    conversation: SessionState,
+    inbound_message: StoredMessage,
+) -> None:
+    """LLM error stop_reason should NOT be stored in session history."""
+    mock_amessages.return_value = make_error_response(stop_reason="error")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        user=test_user,
+        session=conversation,
+        message=inbound_message,
+        media_urls=[],
+        channel="telegram",
+    )
+
+    assert response.is_error_fallback is True
+    # No outbound message should be persisted
+    outbound_msgs = [m for m in conversation.messages if m.direction == "outbound"]
+    assert len(outbound_msgs) == 0
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_error_stop_reason_still_dispatches_reply_to_user(
+    mock_amessages: object,
+    test_user: UserData,
+    conversation: SessionState,
+    inbound_message: StoredMessage,
+) -> None:
+    """Error fallback should still be dispatched via the bus so the user sees a message."""
+    mock_amessages.return_value = make_error_response(stop_reason="error")  # type: ignore[union-attr]
+
+    response = await handle_inbound_message(
+        user=test_user,
+        session=conversation,
+        message=inbound_message,
+        media_urls=[],
+        channel="telegram",
+    )
+
+    assert response.is_error_fallback is True
+    assert response.reply_text  # user gets a fallback message


### PR DESCRIPTION
## Description

When the LLM returns a response with an error `stop_reason` (e.g. `"error"` from certain providers), clawbolt previously persisted it to session history. This caused context poisoning where subsequent LLM calls would see the bad response and reproduce or compound the error.

This PR adds a `stop_reason` guard in the agent loop that checks each LLM response against a set of valid stop reasons (`end_turn`, `max_tokens`, `tool_use`, `stop_sequence`, `None`). When an invalid stop_reason is detected, the response is flagged with `is_error_fallback=True`, which the existing `persist_outbound` guard uses to skip persistence. The user still sees a friendly fallback message.

Tool-level errors (validation failures, unknown tools, execution errors) are unaffected and still fed back to the LLM within the agent loop so it can self-correct.

Fixes #565

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code, full implementation and tests)
- [ ] No AI used