### PR TITLE
refactor: consolidate hardcoded defaults to use Settings as source of truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ PREMIUM_PLUGIN=
 
 # Messaging
 MESSAGING_PROVIDER=telegram
+DEFAULT_FOLDER_SCHEME=by_client
 TELEGRAM_BOT_TOKEN=
 # TELEGRAM_WEBHOOK_SECRET=     # Auto-derived from bot token if not set
 # Comma-separated list of allowed Telegram chat IDs, or "*" to allow all.
@@ -99,6 +100,7 @@ WHISPER_MODEL_SIZE=base
 
 # Heartbeat (proactive check-ins)
 HEARTBEAT_ENABLED=true
+HEARTBEAT_DEFAULT_FREQUENCY=30m
 HEARTBEAT_INTERVAL_MINUTES=30
 HEARTBEAT_MAX_DAILY_MESSAGES=5
 HEARTBEAT_QUIET_HOURS_START=20

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ Data classes (Pydantic BaseModel, replace ORM models):
 - `UserData`, `StoredMessage`, `SessionState`, `ClientData`
 - `EstimateData`, `MediaData`, `ChecklistItem`, `HeartbeatLogEntry`, `MemoryFact`
 
+## Backwards Compatibility
+
+Until this project has its first production release, you do not need to be concerned about backwards compatible changes.
+
 ## Coding Standards
 
 - All type annotations required

--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -67,7 +67,7 @@ class UserData(BaseModel):
     user_text: str = ""
     checklist_text: str = ""
     timezone: str = ""
-    preferred_channel: str = "telegram"
+    preferred_channel: str = Field(default_factory=lambda: settings.messaging_provider)
     channel_identifier: str = ""
     assistant_name: str = "Clawbolt"
     onboarding_complete: bool = False
@@ -75,8 +75,8 @@ class UserData(BaseModel):
     role: str = "user"
     preferences_json: str = "{}"
     heartbeat_opt_in: bool = True
-    heartbeat_frequency: str = ""
-    folder_scheme: str = "by_client"
+    heartbeat_frequency: str = Field(default_factory=lambda: settings.heartbeat_default_frequency)
+    folder_scheme: str = Field(default_factory=lambda: settings.default_folder_scheme)
     created_at: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.UTC)
     )
@@ -309,7 +309,7 @@ def _unique_slug(base_slug: str, existing_ids: set[str]) -> str:
 def make_client_slug(
     name: str = "",
     address: str = "",
-    folder_scheme: str = "by_client",
+    folder_scheme: str = "",
 ) -> str:
     """Build a client slug based on the folder scheme preference.
 
@@ -318,6 +318,7 @@ def make_client_slug(
         "by_address": slug from address
         "by_client_and_address": slug from "name address"
     """
+    folder_scheme = folder_scheme or settings.default_folder_scheme
     if folder_scheme == "by_address" and address.strip():
         return slugify(address)
     if folder_scheme == "by_client_and_address":
@@ -564,7 +565,7 @@ class UserStore:
         self,
         user_id: str,
         channel_identifier: str = "",
-        preferred_channel: str = "telegram",
+        preferred_channel: str = "",
         **kwargs: Any,
     ) -> UserData:
         """Create a new user."""
@@ -575,7 +576,7 @@ class UserStore:
                 id=cid,
                 user_id=user_id,
                 channel_identifier=channel_identifier,
-                preferred_channel=preferred_channel,
+                preferred_channel=preferred_channel or settings.messaging_provider,
                 created_at=now,
                 updated_at=now,
                 **kwargs,
@@ -1030,10 +1031,11 @@ class FileSessionStore(PerUserStore):
 
     def _collect_messages(
         self,
-        count: int = 5,
+        count: int | None = None,
         exclude_session_id: str | None = None,
     ) -> list[StoredMessage]:
         """Collect the most recent messages, optionally excluding a session."""
+        count = count if count is not None else settings.heartbeat_recent_messages_count
         all_msgs: list[StoredMessage] = []
         for path in reversed(self._list_session_files()):
             if exclude_session_id and path.stem == exclude_session_id:
@@ -1048,14 +1050,14 @@ class FileSessionStore(PerUserStore):
         all_msgs.sort(key=lambda m: m.timestamp, reverse=True)
         return list(reversed(all_msgs[:count]))
 
-    def get_recent_messages(self, count: int = 5) -> list[StoredMessage]:
+    def get_recent_messages(self, count: int | None = None) -> list[StoredMessage]:
         """Get the most recent messages across all sessions."""
         return self._collect_messages(count)
 
     def get_other_session_messages(
         self,
         exclude_session_id: str,
-        count: int = 5,
+        count: int | None = None,
     ) -> list[StoredMessage]:
         """Get recent messages from sessions other than *exclude_session_id*."""
         return self._collect_messages(count, exclude_session_id)
@@ -1082,7 +1084,7 @@ class ClientStore(JsonListStore[ClientData]):
         email: str = "",
         address: str = "",
         notes: str = "",
-        folder_scheme: str = "by_client",
+        folder_scheme: str = "",
     ) -> ClientData:
         """Create a new client with a slug-based ID."""
         async with self._lock:

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -156,7 +156,8 @@ class MessageBatcher:
     ``_flush_delayed_entries`` pattern.
     """
 
-    def __init__(self, window_ms: int = 1500) -> None:
+    def __init__(self, window_ms: int | None = None) -> None:
+        window_ms = window_ms if window_ms is not None else settings.message_batch_window_ms
         self._window_ms = window_ms
         self._states: dict[int, _BatchState] = {}
         self._lock = asyncio.Lock()

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -147,7 +147,7 @@ def build_local_datetime_section(user: UserData) -> str:
 def build_cross_session_context(
     user_id: int,
     current_session_id: str,
-    count: int = 5,
+    count: int | None = None,
 ) -> str:
     """Build a summary of recent messages from other sessions.
 

--- a/backend/app/bus.py
+++ b/backend/app/bus.py
@@ -16,6 +16,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from backend.app.config import settings
+
 if TYPE_CHECKING:
     from backend.app.agent.ingestion import InboundMessage
 
@@ -97,11 +99,15 @@ class MessageBus:
             return True
         return False
 
-    async def wait_for_response(self, request_id: str, timeout: float = 120) -> OutboundMessage:
+    async def wait_for_response(
+        self, request_id: str, timeout: float | None = None
+    ) -> OutboundMessage:
         """Wait for the outbound reply matching *request_id*.
 
         Raises ``asyncio.TimeoutError`` if no reply arrives within *timeout* seconds.
         """
+        if timeout is None:
+            timeout = settings.approval_timeout_seconds
         fut = self._response_futures.get(request_id)
         if fut is None:
             fut = self.register_response_future(request_id)

--- a/backend/app/channels/webchat.py
+++ b/backend/app/channels/webchat.py
@@ -127,7 +127,7 @@ class WebChatChannel(BaseChannel):
 
             async def event_stream() -> collections.abc.AsyncIterator[str]:
                 try:
-                    outbound = await message_bus.wait_for_response(request_id, timeout=120)
+                    outbound = await message_bus.wait_for_response(request_id)
                     data = json.dumps({"reply": outbound.content})
                     yield f"data: {data}\n\n"
                 except TimeoutError:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
 
     # Messaging
     messaging_provider: str = "telegram"
+    default_folder_scheme: str = "by_client"
     telegram_bot_token: str = ""
     telegram_webhook_secret: str = ""
     telegram_allowed_chat_ids: str = (
@@ -103,6 +104,7 @@ class Settings(BaseSettings):
 
     # Heartbeat
     heartbeat_enabled: bool = True
+    heartbeat_default_frequency: str = "30m"
     heartbeat_interval_minutes: int = Field(default=30, ge=1)
     heartbeat_max_daily_messages: int = Field(default=5, ge=1)
     heartbeat_quiet_hours_start: int = Field(default=20, ge=0, le=23)  # 8 PM

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -45,6 +45,7 @@ Set the API key env var for your chosen provider, or set `ANY_LLM_KEY` to use th
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MESSAGING_PROVIDER` | `telegram` | Messaging backend (currently only `telegram` is supported) |
+| `DEFAULT_FOLDER_SCHEME` | `by_client` | Default folder scheme for organizing client files (`by_client`, `by_address`, or `by_client_and_address`) |
 | `TELEGRAM_BOT_TOKEN` | | Bot token from @BotFather |
 | `TELEGRAM_WEBHOOK_SECRET` | (auto-derived) | Webhook validation secret. Auto-derived from bot token if not set |
 | `TELEGRAM_ALLOWED_CHAT_IDS` | (empty) | Comma-separated allowlist of Telegram chat IDs, or `*` to allow all. Empty = deny all |
@@ -116,6 +117,7 @@ See [Storage Providers](../deployment/storage/) for setup instructions.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `HEARTBEAT_ENABLED` | `true` | Enable proactive check-in messages |
+| `HEARTBEAT_DEFAULT_FREQUENCY` | `30m` | Default check-in frequency shown to new users (e.g. `15m`, `1h`, `daily`) |
 | `HEARTBEAT_INTERVAL_MINUTES` | `30` | Minutes between heartbeat evaluation ticks |
 | `HEARTBEAT_MAX_DAILY_MESSAGES` | `5` | Max proactive messages per contractor per day |
 | `HEARTBEAT_QUIET_HOURS_START` | `20` | Hour (24h) to stop sending heartbeats |

--- a/tests/test_defaults_from_settings.py
+++ b/tests/test_defaults_from_settings.py
@@ -1,0 +1,29 @@
+"""Verify that model and function defaults reference Settings, not hardcoded values."""
+
+from backend.app.agent.file_store import UserData, make_client_slug
+from backend.app.config import settings
+
+
+def test_user_data_preferred_channel_from_settings() -> None:
+    """UserData.preferred_channel should default to settings.messaging_provider."""
+    user = UserData()
+    assert user.preferred_channel == settings.messaging_provider
+
+
+def test_user_data_heartbeat_frequency_from_settings() -> None:
+    """UserData.heartbeat_frequency should default to settings.heartbeat_default_frequency."""
+    user = UserData()
+    assert user.heartbeat_frequency == settings.heartbeat_default_frequency
+
+
+def test_user_data_folder_scheme_from_settings() -> None:
+    """UserData.folder_scheme should default to settings.default_folder_scheme."""
+    user = UserData()
+    assert user.folder_scheme == settings.default_folder_scheme
+
+
+def test_make_client_slug_uses_settings_folder_scheme() -> None:
+    """make_client_slug should use settings.default_folder_scheme when not passed."""
+    slug = make_client_slug(name="John Doe")
+    expected = make_client_slug(name="John Doe", folder_scheme=settings.default_folder_scheme)
+    assert slug == expected

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -2,6 +2,8 @@
 
 from fastapi.testclient import TestClient
 
+from backend.app.config import settings
+
 
 def test_get_profile(client: TestClient) -> None:
     resp = client.get("/api/user/profile")
@@ -18,6 +20,15 @@ def test_get_profile(client: TestClient) -> None:
     assert "location" not in data
     assert "hourly_rate" not in data
     assert "business_hours" not in data
+
+
+def test_profile_defaults_from_settings(client: TestClient) -> None:
+    """New user defaults should match the Settings source of truth."""
+    resp = client.get("/api/user/profile")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["heartbeat_frequency"] == settings.heartbeat_default_frequency
+    assert data["preferred_channel"] == settings.messaging_provider
 
 
 def test_update_profile_partial(client: TestClient) -> None:


### PR DESCRIPTION
## Description
Several default values were duplicated as hardcoded literals in model fields, function signatures, and frontend code instead of referencing the `Settings` class. This causes silent drift if a default changes in one place but not others.

Consolidates all duplicated defaults to reference `Settings` as the single source of truth:
- `UserData.preferred_channel` -> `settings.messaging_provider`
- `UserData.heartbeat_frequency` -> `settings.heartbeat_default_frequency`
- `UserData.folder_scheme` -> `settings.default_folder_scheme`
- `make_client_slug()` / `ClientStore.create()` -> `settings.default_folder_scheme`
- `_collect_messages()` / `get_recent_messages()` / `get_other_session_messages()` -> `settings.heartbeat_recent_messages_count`
- `build_cross_session_context()` count passed through to session store
- `MessageBatcher.__init__()` -> `settings.message_batch_window_ms`
- `MessageBus.wait_for_response()` -> `settings.approval_timeout_seconds`
- `webchat.py` no longer hardcodes `timeout=120`

Also adds `default_folder_scheme` and `heartbeat_default_frequency` as new Settings fields, and a backwards compatibility note to AGENTS.md.

Fixes #582

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the refactor, tests, and docs updates)
- [ ] No AI used