### PR TITLE
refactor: remove dead fields, unused scoping, and stale schemas

### DIFF
--- a/backend/app/agent/file_store.py
+++ b/backend/app/agent/file_store.py
@@ -70,8 +70,6 @@ class UserData(BaseModel):
     channel_identifier: str = ""
     onboarding_complete: bool = False
     is_active: bool = True
-    role: str = "user"
-    preferences_json: str = "{}"
     heartbeat_opt_in: bool = True
     heartbeat_frequency: str = Field(default_factory=lambda: settings.heartbeat_default_frequency)
     folder_scheme: str = Field(default_factory=lambda: settings.default_folder_scheme)

--- a/backend/app/auth/scoping.py
+++ b/backend/app/auth/scoping.py
@@ -1,10 +1,7 @@
 from fastapi import HTTPException
 
 from backend.app.agent.file_store import (
-    ClientStore,
-    EstimateStore,
     UserData,
-    get_memory_store,
     get_user_store,
 )
 
@@ -19,38 +16,3 @@ async def get_scoped_user(
     if not target or target.user_id != current_user.user_id:
         raise HTTPException(status_code=404, detail="User not found")
     return target
-
-
-async def get_user_client(
-    user: UserData,
-    client_id: str,
-) -> None:
-    """Verify a client exists and belongs to the current user. 404 on mismatch."""
-    client_store = ClientStore(user.id)
-    client = await client_store.get(client_id)
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
-
-
-async def get_user_estimate(
-    user: UserData,
-    estimate_id: str,
-) -> None:
-    """Verify an estimate exists and belongs to the current user. 404 on mismatch."""
-    estimate_store = EstimateStore(user.id)
-    estimate = await estimate_store.get(estimate_id)
-    if not estimate:
-        raise HTTPException(status_code=404, detail="Estimate not found")
-
-
-async def get_user_memory(
-    user: UserData,
-    memory_key: str,
-) -> None:
-    """Verify a memory fact exists for the current user. 404 on mismatch."""
-    memory_store = get_memory_store(user.id)
-    memories = await memory_store.get_all_memories()
-    for m in memories:
-        if m.key == memory_key:
-            return
-    raise HTTPException(status_code=404, detail="Memory not found")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -8,22 +7,6 @@ from backend.app.enums import ChecklistSchedule, EstimateStatus
 
 class HealthResponse(BaseModel):
     status: str
-
-
-class UserBase(BaseModel):
-    name: str = ""
-    phone: str = ""
-
-
-class UserCreate(UserBase):
-    user_id: str
-
-
-class UserResponse(UserBase):
-    id: int
-    user_id: str
-    created_at: datetime.datetime
-    updated_at: datetime.datetime
 
 
 class MemoryBase(BaseModel):

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -39,19 +39,7 @@ def user() -> UserData:
     return UserData(
         id=1,
         user_id="hb-user-001",
-        name="Mike the Plumber",
         phone="+15559990000",
-        onboarding_complete=True,
-    )
-
-
-@pytest.fixture()
-def user_no_hours() -> UserData:
-    return UserData(
-        id=2,
-        user_id="hb-user-002",
-        name="Jane Electric",
-        phone="+15559990001",
         onboarding_complete=True,
     )
 
@@ -61,7 +49,6 @@ def user_with_timezone() -> UserData:
     return UserData(
         id=3,
         user_id="hb-user-003",
-        name="Carlos Roofing",
         phone="+15559990002",
         timezone="America/Los_Angeles",
         onboarding_complete=True,
@@ -192,7 +179,6 @@ class TestIsWithinBusinessHoursTimezone:
         c = UserData(
             id=99,
             user_id="hb-user-bad-tz",
-            name="Bad TZ",
             timezone="Invalid/Timezone",
             onboarding_complete=True,
         )

--- a/tests/test_tool_param_validation.py
+++ b/tests/test_tool_param_validation.py
@@ -492,7 +492,7 @@ def _make_tool(name: str, params_model: type[BaseModel]) -> Tool:
     return Tool(name=name, description="test", function=dummy, params_model=params_model)
 
 
-def testsummarize_tool_params_includes_array_item_structure() -> None:
+def test_summarize_tool_params_includes_array_item_structure() -> None:
     """Validation error summary should describe array item fields, not just 'array'.
 
     Regression test for #434: when the LLM omits line_items, the error
@@ -508,7 +508,7 @@ def testsummarize_tool_params_includes_array_item_structure() -> None:
     assert '"unit_price": number' in summary
 
 
-def testsummarize_tool_params_resolves_anyof_types() -> None:
+def test_summarize_tool_params_resolves_anyof_types() -> None:
     """Optional union fields (str | None) should show the concrete type, not 'any'."""
     tool = _make_tool("generate_estimate", GenerateEstimateParams)
     summary = summarize_tool_params(tool)


### PR DESCRIPTION
## Description

Second round of dead code cleanup. Removes unused fields, functions, and schema classes identified during codebase audit.

- Remove dead `UserData` fields: `role` (never read) and `preferences_json` (never read/written)
- Remove 3 unused scoping functions from `auth/scoping.py` (`get_user_client`, `get_user_estimate`, `get_user_memory`) with zero callers
- Remove 3 unused schema classes (`UserBase`, `UserCreate`, `UserResponse`) with stale `name` field from pre-BOOTSTRAP.md era
- Fix 2 test naming bugs: `testsummarize_*` -> `test_summarize_*` (were silently skipped by pytest)
- Remove unused `user_no_hours` fixture and stale `name=` fields in test_heartbeat.py

Fixes #590

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with Claude Code.