### PR TITLE
refactor: replace raw setattr() with validated update_settings()

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
@@ -136,6 +136,30 @@ PERSISTABLE_SETTINGS: frozenset[str] = frozenset(
 )
 
 
+def update_settings(updates: dict[str, Any]) -> None:
+    """Validate and apply runtime updates to the settings singleton.
+
+    Only keys listed in ``PERSISTABLE_SETTINGS`` are accepted.  Each value is
+    validated against the Pydantic field definition before being applied, so
+    type mismatches raise ``ValueError``.
+
+    Validation runs for all keys before any are applied, so a failure on one
+    key never leaves the singleton in a partially-updated state.
+    """
+    for key, value in updates.items():
+        if key not in PERSISTABLE_SETTINGS:
+            raise ValueError(
+                f"{key!r} is not a persistable setting (allowed: {sorted(PERSISTABLE_SETTINGS)})"
+            )
+        try:
+            Settings.model_validate({key: value})
+        except ValidationError as exc:
+            raise ValueError(str(exc)) from exc
+
+    for key, value in updates.items():
+        setattr(settings, key, value)
+
+
 def _config_json_path() -> Path:
     """Return the path to config.json inside the volume-mounted data directory.
 
@@ -162,6 +186,7 @@ def load_persistent_config(path: Path | None = None) -> dict[str, Any]:
         logger.warning("Failed to read %s: %s", config_path, exc)
         return {}
 
+    filtered: dict[str, Any] = {}
     for key, value in data.items():
         if key not in PERSISTABLE_SETTINGS:
             continue
@@ -169,7 +194,10 @@ def load_persistent_config(path: Path | None = None) -> dict[str, Any]:
         env_name = key.upper()
         if os.environ.get(env_name):
             continue
-        setattr(settings, key, value)
+        filtered[key] = value
+
+    if filtered:
+        update_settings(filtered)
 
     return data
 

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from backend.app.agent.file_store import UserData, get_user_store
 from backend.app.auth.dependencies import get_current_user
-from backend.app.config import save_persistent_config, settings
+from backend.app.config import save_persistent_config, settings, update_settings
 from backend.app.schemas import (
     ChannelConfigResponse,
     ChannelConfigUpdate,
@@ -91,8 +91,10 @@ async def update_channel_config(
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
 
-    for field, value in updates.items():
-        setattr(settings, field, value)
+    try:
+        update_settings(updates)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     # Persist to config.json inside the volume-mounted data directory.
     save_persistent_config(updates)

--- a/tests/test_persistent_config.py
+++ b/tests/test_persistent_config.py
@@ -13,6 +13,7 @@ from backend.app.config import (
     load_persistent_config,
     save_persistent_config,
     settings,
+    update_settings,
 )
 
 
@@ -186,3 +187,44 @@ def test_round_trip_save_then_load(config_path: Path) -> None:
 
     assert settings.telegram_bot_token == "rt-token"
     assert settings.telegram_allowed_usernames == "rt-user"
+
+
+# ---------------------------------------------------------------------------
+# update_settings() validation
+# ---------------------------------------------------------------------------
+
+
+def test_update_settings_applies_valid_values() -> None:
+    """update_settings applies valid string values to the singleton."""
+    update_settings({"telegram_bot_token": "validated-tok"})
+    assert settings.telegram_bot_token == "validated-tok"
+
+
+def test_update_settings_rejects_non_persistable_key() -> None:
+    """update_settings raises ValueError for keys not in PERSISTABLE_SETTINGS."""
+    with pytest.raises(ValueError, match="not a persistable setting"):
+        update_settings({"log_level": "DEBUG"})
+
+
+def test_update_settings_rejects_unknown_key() -> None:
+    """update_settings raises ValueError for keys that don't exist on Settings."""
+    with pytest.raises(ValueError, match="not a persistable setting"):
+        update_settings({"totally_unknown_field": "value"})
+
+
+def test_update_settings_rejects_wrong_type() -> None:
+    """update_settings raises ValueError when the value fails Pydantic validation."""
+    with pytest.raises(ValueError):
+        update_settings({"telegram_bot_token": 12345})
+
+
+def test_update_settings_multiple_keys() -> None:
+    """update_settings can apply multiple valid keys at once."""
+    update_settings(
+        {
+            "telegram_bot_token": "multi-tok",
+            "telegram_allowed_usernames": "alice,bob",
+        }
+    )
+    assert settings.telegram_bot_token == "multi-tok"
+    assert settings.telegram_allowed_usernames == "alice,bob"


### PR DESCRIPTION
## Description

The `Settings` singleton was mutated at runtime via raw `setattr()` calls in `load_persistent_config()` and the `update_channel_config` endpoint, bypassing Pydantic validation entirely. This PR adds an `update_settings()` function that:

- Rejects keys not in `PERSISTABLE_SETTINGS`
- Validates values against Pydantic field definitions before applying
- Raises `ValueError` on type mismatches or unknown keys

Both call sites now use `update_settings()` instead of raw `setattr()`.

Fixes #594

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code authored the implementation and tests)
- [ ] No AI used