### PR TITLE
feat: resizable panel support for secondary sidebars

### DIFF
--- a/frontend/src/components/ui/resizable-panel.test.tsx
+++ b/frontend/src/components/ui/resizable-panel.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ResizablePanel from './resizable-panel';
+
+// Stub requestAnimationFrame to execute callbacks synchronously in tests.
+beforeEach(() => {
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0);
+    return 0;
+  });
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ResizablePanel', () => {
+  it('renders with default width', () => {
+    render(
+      <ResizablePanel side="right" defaultWidth={300} minWidth={200} maxWidth={500}>
+        <p>content</p>
+      </ResizablePanel>,
+    );
+    const panel = screen.getByTestId('resizable-panel');
+    expect(panel).toBeInTheDocument();
+    expect(panel.style.width).toBe('300px');
+  });
+
+  it('renders children', () => {
+    render(
+      <ResizablePanel side="left" defaultWidth={300} minWidth={200} maxWidth={500}>
+        <p>Hello panel</p>
+      </ResizablePanel>,
+    );
+    expect(screen.getByText('Hello panel')).toBeInTheDocument();
+  });
+
+  it('respects localStorage persisted width', () => {
+    localStorage.setItem('test-key', '400');
+    render(
+      <ResizablePanel
+        side="right"
+        defaultWidth={300}
+        minWidth={200}
+        maxWidth={500}
+        storageKey="test-key"
+      >
+        <p>content</p>
+      </ResizablePanel>,
+    );
+    expect(screen.getByTestId('resizable-panel').style.width).toBe('400px');
+  });
+
+  it('falls back to defaultWidth when localStorage has invalid value', () => {
+    localStorage.setItem('test-key', 'garbage');
+    render(
+      <ResizablePanel
+        side="right"
+        defaultWidth={300}
+        minWidth={200}
+        maxWidth={500}
+        storageKey="test-key"
+      >
+        <p>content</p>
+      </ResizablePanel>,
+    );
+    expect(screen.getByTestId('resizable-panel').style.width).toBe('300px');
+  });
+
+  it('clamps persisted width to min bound', () => {
+    localStorage.setItem('test-key', '100');
+    render(
+      <ResizablePanel
+        side="right"
+        defaultWidth={300}
+        minWidth={200}
+        maxWidth={500}
+        storageKey="test-key"
+      >
+        <p>content</p>
+      </ResizablePanel>,
+    );
+    expect(screen.getByTestId('resizable-panel').style.width).toBe('200px');
+  });
+
+  it('clamps persisted width to max bound', () => {
+    localStorage.setItem('test-key', '900');
+    render(
+      <ResizablePanel
+        side="right"
+        defaultWidth={300}
+        minWidth={200}
+        maxWidth={500}
+        storageKey="test-key"
+      >
+        <p>content</p>
+      </ResizablePanel>,
+    );
+    expect(screen.getByTestId('resizable-panel').style.width).toBe('500px');
+  });
+
+  it('clamps defaultWidth to min/max bounds', () => {
+    render(
+      <ResizablePanel side="right" defaultWidth={100} minWidth={200} maxWidth={500}>
+        <p>content</p>
+      </ResizablePanel>,
+    );
+    expect(screen.getByTestId('resizable-panel').style.width).toBe('200px');
+  });
+
+  it('drag interaction updates width (side="left")', () => {
+    render(
+      <ResizablePanel side="left" defaultWidth={300} minWidth={200} maxWidth={500}>
+        <p>content</p>
+      </ResizablePanel>,
+    );
+
+    const handle = screen.getByTestId('resizable-handle');
+    const panel = screen.getByTestId('resizable-panel');
+
+    // Start drag at x=300, move to x=350 -> delta +50 -> 350px for side="left"
+    act(() => {
+      fireEvent.mouseDown(handle, { clientX: 300 });
+    });
+    act(() => {
+      fireEvent.mouseMove(document, { clientX: 350 });
+    });
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+
+    expect(panel.style.width).toBe('350px');
+  });
+
+  it('drag interaction updates width (side="right")', () => {
+    render(
+      <ResizablePanel side="right" defaultWidth={300} minWidth={200} maxWidth={500}>
+        <p>content</p>
+      </ResizablePanel>,
+    );
+
+    const handle = screen.getByTestId('resizable-handle');
+    const panel = screen.getByTestId('resizable-panel');
+
+    // For side="right", moving left (decreasing clientX) increases width.
+    // Start at x=100, move to x=50 -> delta = 100-50 = 50 -> 350px
+    act(() => {
+      fireEvent.mouseDown(handle, { clientX: 100 });
+    });
+    act(() => {
+      fireEvent.mouseMove(document, { clientX: 50 });
+    });
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+
+    expect(panel.style.width).toBe('350px');
+  });
+
+  it('clamps drag result to min/max', () => {
+    render(
+      <ResizablePanel side="left" defaultWidth={300} minWidth={200} maxWidth={500}>
+        <p>content</p>
+      </ResizablePanel>,
+    );
+
+    const handle = screen.getByTestId('resizable-handle');
+    const panel = screen.getByTestId('resizable-panel');
+
+    // Drag far right: 300 + 500 = 800 -> clamped to 500
+    act(() => {
+      fireEvent.mouseDown(handle, { clientX: 0 });
+    });
+    act(() => {
+      fireEvent.mouseMove(document, { clientX: 500 });
+    });
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+
+    expect(panel.style.width).toBe('500px');
+  });
+
+  it('persists final width to localStorage after drag', () => {
+    render(
+      <ResizablePanel
+        side="left"
+        defaultWidth={300}
+        minWidth={200}
+        maxWidth={500}
+        storageKey="persist-test"
+      >
+        <p>content</p>
+      </ResizablePanel>,
+    );
+
+    const handle = screen.getByTestId('resizable-handle');
+
+    act(() => {
+      fireEvent.mouseDown(handle, { clientX: 0 });
+    });
+    act(() => {
+      fireEvent.mouseMove(document, { clientX: 50 });
+    });
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+
+    expect(localStorage.getItem('persist-test')).toBe('350');
+  });
+
+  it('renders handle with separator role', () => {
+    render(
+      <ResizablePanel side="right" defaultWidth={300} minWidth={200} maxWidth={500}>
+        <p>content</p>
+      </ResizablePanel>,
+    );
+
+    const handle = screen.getByRole('separator');
+    expect(handle).toBeInTheDocument();
+    expect(handle.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('applies custom className', () => {
+    render(
+      <ResizablePanel
+        side="left"
+        defaultWidth={300}
+        minWidth={200}
+        maxWidth={500}
+        className="custom-class"
+      >
+        <p>content</p>
+      </ResizablePanel>,
+    );
+    expect(screen.getByTestId('resizable-panel').className).toContain('custom-class');
+  });
+
+  it('disables CSS transition during drag', () => {
+    render(
+      <ResizablePanel side="left" defaultWidth={300} minWidth={200} maxWidth={500}>
+        <p>content</p>
+      </ResizablePanel>,
+    );
+
+    const panel = screen.getByTestId('resizable-panel');
+    const handle = screen.getByTestId('resizable-handle');
+
+    // Before drag: transition is set
+    expect(panel.style.transition).toContain('width');
+
+    // During drag: transition is none
+    act(() => {
+      fireEvent.mouseDown(handle, { clientX: 0 });
+    });
+    expect(panel.style.transition).toBe('none');
+
+    // After drag: transition is restored
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+    expect(panel.style.transition).toContain('width');
+  });
+});

--- a/frontend/src/components/ui/resizable-panel.tsx
+++ b/frontend/src/components/ui/resizable-panel.tsx
@@ -1,0 +1,203 @@
+import {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+  type CSSProperties,
+} from 'react';
+
+interface ResizablePanelProps {
+  /** Which side of the viewport the panel is on. Determines drag handle placement. */
+  side: 'left' | 'right';
+  /** Initial width in pixels when no persisted value exists. */
+  defaultWidth: number;
+  /** Minimum allowed width in pixels. */
+  minWidth: number;
+  /** Maximum allowed width in pixels. */
+  maxWidth: number;
+  /** localStorage key for persisting the panel width across sessions. */
+  storageKey?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+function readPersistedWidth(key: string | undefined): number | null {
+  if (!key) return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return null;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistWidth(key: string | undefined, width: number): void {
+  if (!key) return;
+  try {
+    localStorage.setItem(key, String(width));
+  } catch {
+    /* storage full or unavailable */
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export default function ResizablePanel({
+  side,
+  defaultWidth,
+  minWidth,
+  maxWidth,
+  storageKey,
+  children,
+  className,
+}: ResizablePanelProps) {
+  const [width, setWidth] = useState(() => {
+    const persisted = readPersistedWidth(storageKey);
+    return clamp(persisted ?? defaultWidth, minWidth, maxWidth);
+  });
+  const [dragging, setDragging] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const dragStartX = useRef(0);
+  const dragStartWidth = useRef(0);
+
+  // Persist width whenever it changes (and we are not mid-drag to avoid thrashing).
+  const pendingPersist = useRef<number | null>(null);
+  useEffect(() => {
+    if (dragging) return;
+    persistWidth(storageKey, width);
+  }, [width, dragging, storageKey]);
+
+  const handleDrag = useCallback(
+    (clientX: number) => {
+      const delta =
+        side === 'left'
+          ? clientX - dragStartX.current
+          : dragStartX.current - clientX;
+      const newWidth = clamp(dragStartWidth.current + delta, minWidth, maxWidth);
+      if (pendingPersist.current !== null) {
+        cancelAnimationFrame(pendingPersist.current);
+      }
+      pendingPersist.current = requestAnimationFrame(() => {
+        setWidth(newWidth);
+      });
+    },
+    [side, minWidth, maxWidth],
+  );
+
+  const stopDrag = useCallback(() => {
+    setDragging(false);
+  }, []);
+
+  // Global mouse/touch move and up listeners while dragging.
+  useEffect(() => {
+    if (!dragging) return;
+
+    const onMouseMove = (e: MouseEvent) => {
+      e.preventDefault();
+      handleDrag(e.clientX);
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      if (touch) handleDrag(touch.clientX);
+    };
+    const onEnd = () => stopDrag();
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onEnd);
+    document.addEventListener('touchmove', onTouchMove, { passive: true });
+    document.addEventListener('touchend', onEnd);
+    document.addEventListener('touchcancel', onEnd);
+
+    // Prevent text selection while dragging.
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onEnd);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', onEnd);
+      document.removeEventListener('touchcancel', onEnd);
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+    };
+  }, [dragging, handleDrag, stopDrag]);
+
+  const startDrag = (clientX: number) => {
+    dragStartX.current = clientX;
+    dragStartWidth.current = width;
+    setDragging(true);
+  };
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    startDrag(e.clientX);
+  };
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    if (touch) startDrag(touch.clientX);
+  };
+
+  const panelStyle: CSSProperties = {
+    width: `${width}px`,
+    flexShrink: 0,
+    transition: dragging ? 'none' : 'width 0.15s ease',
+  };
+
+  const handleStyle: CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    width: '4px',
+    cursor: 'col-resize',
+    zIndex: 10,
+    ...(side === 'left' ? { right: 0 } : { left: 0 }),
+  };
+
+  return (
+    <div
+      ref={panelRef}
+      data-testid="resizable-panel"
+      className={className}
+      style={{ ...panelStyle, position: 'relative', overflow: 'hidden' }}
+    >
+      {children}
+      <div
+        data-testid="resizable-handle"
+        role="separator"
+        aria-orientation="vertical"
+        aria-valuenow={width}
+        aria-valuemin={minWidth}
+        aria-valuemax={maxWidth}
+        style={handleStyle}
+        onMouseDown={onMouseDown}
+        onTouchStart={onTouchStart}
+      >
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: dragging
+              ? 'var(--color-primary, #2563eb)'
+              : 'transparent',
+            transition: 'background-color 0.15s ease',
+          }}
+          onMouseEnter={(e) => {
+            if (!dragging)
+              (e.currentTarget.style.backgroundColor =
+                'var(--color-border, #e5e7eb)');
+          }}
+          onMouseLeave={(e) => {
+            if (!dragging) (e.currentTarget.style.backgroundColor = 'transparent');
+          }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds a reusable `ResizablePanel` component that supports drag-to-resize with min/max constraints and localStorage persistence. Designed for secondary sidebars such as tool configuration panels, conversation detail views, or inspector panels.

### Component API
- `side`: 'left' | 'right' -- determines drag handle placement
- `defaultWidth` / `minWidth` / `maxWidth`: pixel constraints
- `storageKey`: optional localStorage key for persisting width across sessions
- `className`: pass-through for styling

### Implementation details
- 4px drag handle on the panel edge with `cursor-col-resize` on hover/drag
- Mouse events (mousedown/mousemove/mouseup) and touch events (touchstart/touchmove/touchend)
- Width clamped between minWidth and maxWidth during drag
- CSS transitions when not dragging, disabled during drag for responsiveness
- Persists to localStorage on drag end via storageKey prop
- Accessible: uses `role="separator"` with aria-orientation, aria-valuenow/min/max

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`npx vitest run src/components/ui/resizable-panel.test.tsx` -- 14 tests)
- [x] No new lint/type errors introduced (pre-existing errors in other files)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## Tests (14)
- Renders with default width
- Renders children
- Respects localStorage persisted width
- Falls back to defaultWidth for invalid localStorage values
- Clamps persisted width to min bound
- Clamps persisted width to max bound
- Clamps defaultWidth to min/max bounds
- Drag interaction updates width (side="left")
- Drag interaction updates width (side="right")
- Clamps drag result to min/max
- Persists final width to localStorage after drag
- Renders handle with separator role
- Applies custom className
- Disables CSS transition during drag

## AI Usage
- [x] AI-assisted (Claude Code implemented the component and tests)
- [ ] No AI used

Fixes #606