### PR TITLE
feat: infinite scroll for conversations list

### DIFF
--- a/frontend/src/pages/ConversationsPage.test.tsx
+++ b/frontend/src/pages/ConversationsPage.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ConversationsPage from './ConversationsPage';
+import type { SessionListResponse, SessionSummary } from '@/types';
+
+// --- IntersectionObserver mock ---
+
+type ObserverCallback = (entries: IntersectionObserverEntry[]) => void;
+let observerCallback: ObserverCallback | null = null;
+
+class MockIntersectionObserver {
+  constructor(callback: ObserverCallback) {
+    observerCallback = callback;
+  }
+  observe(_el: Element) { /* no-op */ }
+  unobserve() { /* no-op */ }
+  disconnect() {
+    observerCallback = null;
+  }
+}
+
+beforeAll(() => {
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+// --- Helpers ---
+
+function makeSession(id: string): SessionSummary {
+  return {
+    id,
+    start_time: '2025-01-01T00:00:00Z',
+    message_count: 3,
+    last_message_preview: `Preview ${id}`,
+    channel: 'webchat',
+  };
+}
+
+function makeResponse(
+  sessions: SessionSummary[],
+  total: number,
+  offset: number,
+): SessionListResponse {
+  return { sessions, total, offset, limit: 20 };
+}
+
+function mockFetchResponses(...responses: SessionListResponse[]) {
+  const mock = vi.spyOn(globalThis, 'fetch');
+  for (const resp of responses) {
+    mock.mockResolvedValueOnce(
+      new Response(JSON.stringify(resp), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  }
+  return mock;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/app/conversations']}>
+      <ConversationsPage />
+    </MemoryRouter>,
+  );
+}
+
+// --- Tests ---
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  observerCallback = null;
+});
+
+describe('ConversationsPage - infinite scroll', () => {
+  it('renders initial sessions and shows total count', async () => {
+    const sessions = Array.from({ length: 5 }, (_, i) => makeSession(`s${i}`));
+    mockFetchResponses(makeResponse(sessions, 5, 0));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('5 conversations')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Preview s0')).toBeInTheDocument();
+    expect(screen.getByText('Preview s4')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no sessions exist', async () => {
+    mockFetchResponses(makeResponse([], 0, 0));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No conversations yet/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('loads more sessions when sentinel becomes visible', async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeSession(`s${i}`));
+    const page2 = Array.from({ length: 5 }, (_, i) => makeSession(`s${i + 20}`));
+
+    const fetchMock = mockFetchResponses(
+      makeResponse(page1, 25, 0),
+      makeResponse(page2, 25, 20),
+    );
+
+    renderPage();
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getByText('25 conversations')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Preview s0')).toBeInTheDocument();
+
+    // Verify the sentinel is in the DOM
+    expect(screen.getByTestId('scroll-sentinel')).toBeInTheDocument();
+
+    // Simulate intersection (sentinel becomes visible)
+    await act(async () => {
+      observerCallback?.([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
+
+    // Wait for second page to load
+    await waitFor(() => {
+      expect(screen.getByText('Preview s20')).toBeInTheDocument();
+    });
+
+    // Second fetch should have been called with offset=20
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondCallUrl = fetchMock.mock.calls[1]?.[0] as string;
+    expect(secondCallUrl).toContain('offset=20');
+  });
+
+  it('shows "All conversations loaded" when all pages fetched', async () => {
+    // More than PAGE_SIZE (20) sessions total, but all loaded after two pages
+    const page1 = Array.from({ length: 20 }, (_, i) => makeSession(`s${i}`));
+    const page2 = Array.from({ length: 5 }, (_, i) => makeSession(`s${i + 20}`));
+
+    mockFetchResponses(
+      makeResponse(page1, 25, 0),
+      makeResponse(page2, 25, 20),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('25 conversations')).toBeInTheDocument();
+    });
+
+    // Trigger intersection
+    await act(async () => {
+      observerCallback?.([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('All conversations loaded')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show pagination buttons', async () => {
+    const sessions = Array.from({ length: 20 }, (_, i) => makeSession(`s${i}`));
+    mockFetchResponses(makeResponse(sessions, 40, 0));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('40 conversations')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Previous')).not.toBeInTheDocument();
+    expect(screen.queryByText('Next')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
+  });
+
+  it('does not fetch more when already at end', async () => {
+    const sessions = Array.from({ length: 5 }, (_, i) => makeSession(`s${i}`));
+    const fetchMock = mockFetchResponses(makeResponse(sessions, 5, 0));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('5 conversations')).toBeInTheDocument();
+    });
+
+    // The observer should not trigger a second fetch since hasMore is false
+    // (sessions.length === total)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error state with retry button', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: 'Server error' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Retry')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ConversationsPage.tsx
+++ b/frontend/src/pages/ConversationsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import Card from '@/components/ui/card';
 import Badge from '@/components/ui/badge';
@@ -27,32 +27,60 @@ export default function ConversationsPage() {
 
 // --- Session List ---
 
+const PAGE_SIZE = 20;
+
 function SessionListView() {
   const navigate = useNavigate();
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [total, setTotal] = useState(0);
-  const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const limit = 20;
+  const loaderRef = useRef<HTMLDivElement | null>(null);
 
-  const load = useCallback((off: number) => {
+  const hasMore = sessions.length < total;
+
+  // Initial load
+  const loadInitial = useCallback(() => {
     setLoading(true);
     setError(null);
-    api.listSessions(off, limit)
+    api.listSessions(0, PAGE_SIZE)
       .then((res) => {
         setSessions(res.sessions);
         setTotal(res.total);
-        setOffset(res.offset);
       })
       .catch((e: Error) => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
 
-  useEffect(() => { load(0); }, [load]);
+  useEffect(() => { loadInitial(); }, [loadInitial]);
 
-  const totalPages = Math.max(1, Math.ceil(total / limit));
-  const currentPage = Math.floor(offset / limit) + 1;
+  // Load next page (append to existing sessions)
+  const loadMore = useCallback(() => {
+    if (loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    api.listSessions(sessions.length, PAGE_SIZE)
+      .then((res) => {
+        setSessions((prev) => [...prev, ...res.sessions]);
+        setTotal(res.total);
+      })
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoadingMore(false));
+  }, [loadingMore, hasMore, sessions.length]);
+
+  // IntersectionObserver triggers loadMore when sentinel is visible
+  useEffect(() => {
+    const node = loaderRef.current;
+    if (!node || !hasMore || loadingMore) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(node);
+    return () => { observer.disconnect(); };
+  }, [hasMore, loadingMore, loadMore]);
 
   return (
     <div>
@@ -68,14 +96,22 @@ function SessionListView() {
       ) : error ? (
         <Card className="text-center py-8">
           <p className="text-sm text-danger">{error}</p>
-          <Button variant="secondary" size="sm" className="mt-2" onClick={() => load(offset)}>Retry</Button>
+          <Button variant="secondary" size="sm" className="mt-2" onClick={() => loadInitial()}>
+            Retry
+          </Button>
         </Card>
       ) : sessions.length === 0 ? (
         <Card className="text-center py-8">
-          <p className="text-sm text-muted-foreground">No conversations yet. Start chatting via the Chat page or Telegram!</p>
+          <p className="text-sm text-muted-foreground">
+            No conversations yet. Start chatting via the Chat page or Telegram!
+          </p>
         </Card>
       ) : (
         <>
+          <p className="text-sm text-muted-foreground mb-3">
+            {total} conversation{total !== 1 ? 's' : ''}
+          </p>
+
           <div className="space-y-2">
             {sessions.map((s) => (
               <Card
@@ -101,30 +137,17 @@ function SessionListView() {
             ))}
           </div>
 
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between mt-4 text-sm text-muted-foreground">
-              <span>{total} conversation{total !== 1 ? 's' : ''}</span>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  disabled={offset === 0}
-                  onClick={() => load(offset - limit)}
-                >
-                  Previous
-                </Button>
-                <span>Page {currentPage} of {totalPages}</span>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  disabled={currentPage >= totalPages}
-                  onClick={() => load(offset + limit)}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
-          )}
+          {/* Infinite scroll sentinel */}
+          <div
+            ref={loaderRef}
+            className="flex justify-center py-4"
+            data-testid="scroll-sentinel"
+          >
+            {loadingMore && <Spinner />}
+            {!hasMore && sessions.length > PAGE_SIZE && (
+              <p className="text-xs text-muted-foreground">All conversations loaded</p>
+            )}
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
## Description
Replace manual Previous/Next page buttons on the Conversations page with IntersectionObserver-based infinite scroll. Sessions load in batches of 20 and are appended as the user scrolls down. A sentinel div at the bottom triggers loading via IntersectionObserver with a 200px root margin for seamless pre-fetching. The total conversation count is displayed at the top, a spinner shows while loading more, and an "All conversations loaded" message appears when the end is reached.

Fixes #601

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation generated by Claude Code (Claude Opus 4.6).