### PR TITLE
feat: streaming chat UI with intermediate tool-use indicators

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -140,6 +140,7 @@ const api = {
     message: string,
     sessionId?: string,
     files?: File[],
+    onEvent?: (event: { type: string; tool_name?: string; content?: string }) => void,
   ): Promise<ChatResponse> => {
     const formData = new FormData();
     formData.append('message', message);
@@ -200,18 +201,32 @@ const api = {
                       const payload = JSON.parse(line.slice(6)) as {
                         reply?: string;
                         error?: string;
+                        type?: string;
+                        tool_name?: string;
+                        content?: string;
                       };
                       if (payload.error) {
                         reader.cancel();
                         reject(new Error(payload.error));
                         return;
                       }
-                      reader.cancel();
-                      resolve({
-                        reply: payload.reply || '',
-                        session_id: accepted.session_id,
-                      });
-                      return;
+                      // Forward intermediate events (tool_call, thinking, etc.)
+                      if (payload.type && !payload.reply && onEvent) {
+                        onEvent({
+                          type: payload.type,
+                          tool_name: payload.tool_name,
+                          content: payload.content,
+                        });
+                        continue;
+                      }
+                      if (payload.reply !== undefined) {
+                        reader.cancel();
+                        resolve({
+                          reply: payload.reply || '',
+                          session_id: accepted.session_id,
+                        });
+                        return;
+                      }
                     } catch {
                       // Continue reading if JSON parse fails
                     }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -62,6 +62,7 @@ export default function ChatPage() {
   const [loadingSessions, setLoadingSessions] = useState(true);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [currentTool, setCurrentTool] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -203,7 +204,16 @@ export default function ChatPage() {
     setSending(true);
 
     try {
-      const res = await api.sendChatMessage(text, activeSessionId ?? undefined, filesToSend);
+      const res = await api.sendChatMessage(
+        text,
+        activeSessionId ?? undefined,
+        filesToSend,
+        (event) => {
+          if (event.type === 'tool_call') {
+            setCurrentTool(event.tool_name ?? null);
+          }
+        },
+      );
       const assistantMsg: ChatMessage = {
         id: nextId.current++,
         role: 'assistant',
@@ -226,6 +236,7 @@ export default function ChatPage() {
       toast.error(msg);
     } finally {
       setSending(false);
+      setCurrentTool(null);
       // Re-focus input on desktop only; on mobile, programmatic focus
       // triggers iOS Safari auto-zoom and forces the keyboard open.
       if (window.matchMedia('(min-width: 640px)').matches) {
@@ -390,24 +401,7 @@ export default function ChatPage() {
             ))}
 
             {sending && (
-              <div className="flex justify-start">
-                <div className="bg-card border border-border rounded-[12px_12px_12px_4px] px-4 py-3 animate-message-in">
-                  <div className="flex items-center gap-1.5">
-                    <span
-                      className="status-dot bg-muted-foreground/60"
-                      style={{ animation: 'typing-bounce 1.2s ease-in-out infinite' }}
-                    />
-                    <span
-                      className="status-dot bg-muted-foreground/60"
-                      style={{ animation: 'typing-bounce 1.2s ease-in-out 0.2s infinite' }}
-                    />
-                    <span
-                      className="status-dot bg-muted-foreground/60"
-                      style={{ animation: 'typing-bounce 1.2s ease-in-out 0.4s infinite' }}
-                    />
-                  </div>
-                </div>
-              </div>
+              <ToolUseIndicator toolName={currentTool ?? undefined} />
             )}
           </div>
         )}
@@ -504,6 +498,21 @@ export default function ChatPage() {
             </div>
           </div>
         </form>
+      </div>
+    </div>
+  );
+}
+
+function ToolUseIndicator({ toolName }: { toolName?: string }) {
+  return (
+    <div className="flex justify-start">
+      <div className="bg-card border border-border rounded-[12px_12px_12px_4px] px-4 py-3 animate-message-in">
+        <div className="flex items-center gap-2">
+          <Spinner className="w-4 h-4" />
+          <span className="text-xs text-muted-foreground">
+            {toolName ? `Using ${toolName}...` : 'Thinking...'}
+          </span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

Replace the generic bouncing dots typing indicator in the chat UI with a context-aware `ToolUseIndicator` component. When the backend sends intermediate SSE events with `tool_call` information during agent processing, the UI now displays "Using <tool_name>..." (e.g., "Using save_memory...") instead of anonymous dots. Falls back to "Thinking..." when no tool name is available.

Changes:
- **api.ts**: Add optional `onEvent` callback to `sendChatMessage` that receives intermediate SSE events (type, tool_name, content) before the final reply
- **ChatPage.tsx**: Add `currentTool` state, pass `onEvent` callback, replace bouncing dots with `ToolUseIndicator` component using Spinner + descriptive label

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used

Fixes #598