### PR TITLE
perf: lazy-load route components and modal content

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,15 +1,18 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AuthProvider } from '@/contexts/AuthContext';
 import App from '@/App';
 
-// Mock fetch for auth config (OSS mode: not required)
+// Mock fetch for auth config (OSS mode: not required) and subsequent API calls.
+// Each call returns a fresh Response so the body is never re-consumed.
 beforeEach(() => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify({ required: false }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }),
+  vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ required: false }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
   );
 });
 
@@ -27,5 +30,61 @@ describe('App', () => {
       </MemoryRouter>,
     );
     expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('lazy-loads ChatPage on /app/chat route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/app/chat']}>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Chat')).toBeInTheDocument();
+    });
+  });
+
+  it('lazy-loads MemoryPage on /app/memory route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/app/memory']}>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Memory / Facts')).toBeInTheDocument();
+    });
+  });
+
+  it('lazy-loads ToolsPage on /app/tools route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/app/tools']}>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Tools')).toBeInTheDocument();
+    });
+  });
+
+  it('lazy-loads ConversationsPage on /app/conversations route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/app/conversations']}>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Conversations')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,7 @@
+import { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Spinner from '@/components/ui/spinner';
 import AppShell from '@/layouts/AppShell';
-import ConversationsPage from '@/pages/ConversationsPage';
-import MemoryPage from '@/pages/MemoryPage';
-import SettingsPage from '@/pages/SettingsPage';
-import ChatPage from '@/pages/ChatPage';
-import ChecklistPage from '@/pages/ChecklistPage';
-import ChannelsPage from '@/pages/ChannelsPage';
-import ToolsPage from '@/pages/ToolsPage';
 import { useAuth } from '@/contexts/AuthContext';
 import {
   getLoginPageElement,
@@ -15,6 +9,28 @@ import {
   getDefaultSettingsTab,
   shouldRedirectRootToApp,
 } from '@/extensions';
+
+const ChatPage = lazy(() => import('@/pages/ChatPage'));
+const ConversationsPage = lazy(() => import('@/pages/ConversationsPage'));
+const MemoryPage = lazy(() => import('@/pages/MemoryPage'));
+const ChecklistPage = lazy(() => import('@/pages/ChecklistPage'));
+const ChannelsPage = lazy(() => import('@/pages/ChannelsPage'));
+const ToolsPage = lazy(() => import('@/pages/ToolsPage'));
+const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
+
+function PageSuspense({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center py-12">
+          <Spinner />
+        </div>
+      }
+    >
+      {children}
+    </Suspense>
+  );
+}
 
 export default function App() {
   const { authState, isPremium } = useAuth();
@@ -39,14 +55,14 @@ export default function App() {
       {/* Authenticated app */}
       <Route path="/app" element={<AppShell />}>
         <Route index element={<Navigate to="/app/chat" replace />} />
-        <Route path="chat" element={<ChatPage />} />
-        <Route path="conversations" element={<ConversationsPage />} />
-        <Route path="conversations/:sessionId" element={<ConversationsPage />} />
-        <Route path="memory" element={<MemoryPage />} />
-        <Route path="checklist" element={<ChecklistPage />} />
-        <Route path="channels" element={<ChannelsPage />} />
-        <Route path="tools" element={<ToolsPage />} />
-        <Route path="settings/:tab" element={<SettingsPage />} />
+        <Route path="chat" element={<PageSuspense><ChatPage /></PageSuspense>} />
+        <Route path="conversations" element={<PageSuspense><ConversationsPage /></PageSuspense>} />
+        <Route path="conversations/:sessionId" element={<PageSuspense><ConversationsPage /></PageSuspense>} />
+        <Route path="memory" element={<PageSuspense><MemoryPage /></PageSuspense>} />
+        <Route path="checklist" element={<PageSuspense><ChecklistPage /></PageSuspense>} />
+        <Route path="channels" element={<PageSuspense><ChannelsPage /></PageSuspense>} />
+        <Route path="tools" element={<PageSuspense><ToolsPage /></PageSuspense>} />
+        <Route path="settings/:tab" element={<PageSuspense><SettingsPage /></PageSuspense>} />
         <Route path="settings" element={<Navigate to={`/app/settings/${getDefaultSettingsTab(isPremium)}`} replace />} />
       </Route>
 

--- a/frontend/src/pages/EditFactForm.tsx
+++ b/frontend/src/pages/EditFactForm.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import Input from '@/components/ui/input';
+import Button from '@/components/ui/button';
+import type { MemoryFact } from '@/types';
+
+export default function EditFactForm({
+  fact,
+  onSave,
+  onCancel,
+}: {
+  fact: MemoryFact;
+  onSave: (key: string, value: string) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(fact.value);
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await onSave(fact.key, value);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+      <div>
+        <label className="section-label">Value</label>
+        <Input value={value} onChange={(e) => setValue(e.target.value)} />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={onCancel}>Cancel</Button>
+        <Button type="submit" disabled={saving || value === fact.value}>
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -1,12 +1,13 @@
-import { useState, useEffect, useCallback } from 'react';
+import { lazy, Suspense, useState, useEffect, useCallback } from 'react';
 import Card from '@/components/ui/card';
 import Badge from '@/components/ui/badge';
 import Button from '@/components/ui/button';
-import Input from '@/components/ui/input';
 import Spinner from '@/components/ui/spinner';
 import { Modal, ModalContent, ModalHeader, ModalBody } from '@heroui/modal';
 import api from '@/api';
 import type { MemoryFact } from '@/types';
+
+const EditFactForm = lazy(() => import('@/pages/EditFactForm'));
 
 export default function MemoryPage() {
   const [facts, setFacts] = useState<MemoryFact[]>([]);
@@ -162,59 +163,23 @@ export default function MemoryPage() {
         </>
       )}
 
-      {/* Edit modal */}
+      {/* Edit modal - lazy-loaded */}
       <Modal isOpen={!!editingFact} onOpenChange={(open) => { if (!open) setEditingFact(null); }}>
         <ModalContent>
           <ModalHeader>Edit Fact: {editingFact?.key}</ModalHeader>
           <ModalBody>
             {editingFact && (
-              <EditFactForm
-                fact={editingFact}
-                onSave={handleSaveEdit}
-                onCancel={() => setEditingFact(null)}
-              />
+              <Suspense fallback={null}>
+                <EditFactForm
+                  fact={editingFact}
+                  onSave={handleSaveEdit}
+                  onCancel={() => setEditingFact(null)}
+                />
+              </Suspense>
             )}
           </ModalBody>
         </ModalContent>
       </Modal>
     </div>
-  );
-}
-
-function EditFactForm({
-  fact,
-  onSave,
-  onCancel,
-}: {
-  fact: MemoryFact;
-  onSave: (key: string, value: string) => Promise<void>;
-  onCancel: () => void;
-}) {
-  const [value, setValue] = useState(fact.value);
-  const [saving, setSaving] = useState(false);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
-    try {
-      await onSave(fact.key, value);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="mt-4 space-y-4">
-      <div>
-        <label className="section-label">Value</label>
-        <Input value={value} onChange={(e) => setValue(e.target.value)} />
-      </div>
-      <div className="flex justify-end gap-2">
-        <Button type="button" variant="secondary" onClick={onCancel}>Cancel</Button>
-        <Button type="submit" disabled={saving || value === fact.value}>
-          {saving ? 'Saving...' : 'Save'}
-        </Button>
-      </div>
-    </form>
   );
 }


### PR DESCRIPTION
## Description

Use `React.lazy()` with `<Suspense>` to code-split all page components into separate chunks, reducing the initial bundle size. Also lazy-loads the `EditFactForm` modal content in `MemoryPage` so it is only fetched when the user opens the edit modal.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Changes

- **`App.tsx`**: Replace eager imports of all 7 page components (`ChatPage`, `ConversationsPage`, `MemoryPage`, `ChecklistPage`, `ChannelsPage`, `ToolsPage`, `SettingsPage`) with `React.lazy()` dynamic imports. Wrap each route element in a `<PageSuspense>` wrapper that shows a centered `<Spinner />` while the chunk loads.
- **`MemoryPage.tsx`**: Extract the inline `EditFactForm` component into its own module and lazy-load it with `React.lazy()`. The modal body uses `<Suspense fallback={null}>` so there is no visible flash when the form loads.
- **`EditFactForm.tsx`**: New file containing the extracted form component (previously a private function inside `MemoryPage.tsx`).
- **`App.test.tsx`**: Add 4 smoke tests verifying that lazy-loaded route components (`ChatPage`, `MemoryPage`, `ToolsPage`, `ConversationsPage`) render correctly after async chunk resolution. Also fix the fetch mock to use `mockImplementation` (returning a fresh `Response` per call) instead of `mockResolvedValue` (which re-uses a single `Response` whose body can only be consumed once).

## Checklist
- [x] Tests pass (`npx vitest run src/App.test.tsx` -- 5/5 pass)
- [x] Lint passes (`npm run deadcode` -- no dead code)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used

Fixes #600