### PR TITLE
fix: resolve ruff lint/format failures and missing search router

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from backend.app.routers import (
     auth,
     estimates,
     health,
+    search,
     user_checklist,
     user_memory,
     user_profile,
@@ -183,6 +184,7 @@ app.include_router(user_memory.router, prefix="/api")
 app.include_router(user_checklist.router, prefix="/api")
 app.include_router(user_stats.router, prefix="/api")
 app.include_router(user_tools.router, prefix="/api")
+app.include_router(search.router, prefix="/api")
 
 # ---------------------------------------------------------------------------
 # Static file serving (built frontend)

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -1,0 +1,94 @@
+"""Unified search endpoint across sessions, memory facts, and clients."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from backend.app.agent.file_store import (
+    ClientStore,
+    UserData,
+    get_memory_store,
+    get_session_store,
+)
+from backend.app.auth.dependencies import get_current_user
+
+router = APIRouter()
+
+
+class SearchResult(BaseModel):
+    type: str
+    title: str
+    preview: str
+    url: str
+
+
+class SearchResponse(BaseModel):
+    results: list[SearchResult]
+    query: str
+
+
+@router.get("/search", response_model=SearchResponse)
+async def search(
+    q: str = Query("", min_length=0, max_length=200),
+    current_user: UserData = Depends(get_current_user),
+) -> SearchResponse:
+    """Search across conversations, memory facts, and client records."""
+    query = q.strip().lower()
+    if not query:
+        return SearchResponse(results=[], query=q)
+
+    results: list[SearchResult] = []
+
+    # Search memory facts (by key and value)
+    memory_store = get_memory_store(current_user.id)
+    facts = await memory_store.get_all_memories()
+    for fact in facts:
+        if query in fact.key.lower() or query in fact.value.lower():
+            results.append(
+                SearchResult(
+                    type="memory",
+                    title=fact.key,
+                    preview=fact.value[:120],
+                    url="/app/memory",
+                )
+            )
+
+    # Search client records (by name, email, phone, notes)
+    client_store = ClientStore(user_id=current_user.id)
+    clients = await client_store.list_all()
+    for client in clients:
+        searchable = f"{client.name} {client.email} {client.phone} {client.notes}".lower()
+        if query in searchable:
+            results.append(
+                SearchResult(
+                    type="client",
+                    title=client.name or client.id,
+                    preview=", ".join(
+                        part for part in [client.phone, client.email, client.address] if part
+                    )[:120],
+                    url="/app/memory",
+                )
+            )
+
+    # Search session messages (by body content)
+    session_store = get_session_store(current_user.id)
+    session_files = session_store._list_session_files()
+    for path in reversed(session_files[-50:]):
+        session_id = path.stem
+        session = session_store._load_session(session_id)
+        if session is None:
+            continue
+        for msg in session.messages:
+            if query in msg.body.lower():
+                results.append(
+                    SearchResult(
+                        type="conversation",
+                        title=f"Conversation {session_id}",
+                        preview=msg.body[:120],
+                        url=f"/app/conversations/{session_id}",
+                    )
+                )
+                break  # One result per session
+
+    return SearchResponse(results=results[:20], query=q)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@heroui/toast": "^2.0.22",
         "@heroui/tooltip": "^2.2.29",
         "@tailwindcss/vite": "^4.2.0",
+        "@tanstack/react-query": "^5.90.21",
         "framer-motion": "^12.35.2",
         "openapi-fetch": "^0.17.0",
         "react": "^19.0.0",
@@ -5062,6 +5063,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/tests/test_search_endpoints.py
+++ b/tests/test_search_endpoints.py
@@ -1,0 +1,162 @@
+"""Tests for the unified search endpoint."""
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.app.agent.file_store import UserData
+from backend.app.config import settings
+
+
+def _create_session(
+    user: UserData,
+    session_id: str,
+    messages: list[dict[str, object]],
+) -> None:
+    """Create a test session JSONL file."""
+    base = Path(settings.data_dir) / str(user.id) / "sessions"
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / f"{session_id}.jsonl"
+    metadata: dict[str, object] = {
+        "_type": "metadata",
+        "session_id": session_id,
+        "user_id": user.id,
+        "created_at": "2025-01-15T10:00:00+00:00",
+        "last_message_at": "2025-01-15T10:05:00+00:00",
+        "is_active": True,
+        "last_compacted_seq": 0,
+    }
+    lines = [json.dumps(metadata)]
+    for msg in messages:
+        lines.append(json.dumps(msg))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _create_memory(user: UserData, facts: list[tuple[str, str, str]]) -> None:
+    """Create a MEMORY.md file with given (key, value, category) triples."""
+    mem_dir = Path(settings.data_dir) / str(user.id) / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["# Long-term Memory\n"]
+    current_cat = ""
+    for key, value, category in facts:
+        if category != current_cat:
+            current_cat = category
+            lines.append(f"\n## {category}\n")
+        lines.append(f"- {key}: {value} (confidence: 1.0)\n")
+    (mem_dir / "MEMORY.md").write_text("".join(lines), encoding="utf-8")
+
+
+def _create_clients(user: UserData, clients: list[dict[str, str]]) -> None:
+    """Create a clients.json file."""
+    base = Path(settings.data_dir) / str(user.id)
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / "clients.json"
+    path.write_text(json.dumps(clients, indent=2), encoding="utf-8")
+
+
+def test_search_empty_query(client: TestClient) -> None:
+    resp = client.get("/api/search?q=")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["results"] == []
+    assert data["query"] == ""
+
+
+def test_search_no_results(client: TestClient) -> None:
+    resp = client.get("/api/search?q=xyznonexistent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["results"] == []
+
+
+def test_search_finds_memory_facts(client: TestClient, test_user: UserData) -> None:
+    _create_memory(
+        test_user,
+        [
+            ("hourly_rate", "$85/hr", "pricing"),
+            ("favorite_tool", "DeWalt drill", "tools"),
+        ],
+    )
+    resp = client.get("/api/search?q=dewalt")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["results"]) == 1
+    assert data["results"][0]["type"] == "memory"
+    assert data["results"][0]["title"] == "favorite_tool"
+
+
+def test_search_finds_sessions(client: TestClient, test_user: UserData) -> None:
+    _create_session(
+        test_user,
+        "1_100",
+        [
+            {
+                "direction": "inbound",
+                "body": "I need a plumbing estimate",
+                "timestamp": "2025-01-15T10:01:00",
+                "seq": 1,
+            },
+        ],
+    )
+    resp = client.get("/api/search?q=plumbing")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["results"]) == 1
+    assert data["results"][0]["type"] == "conversation"
+    assert "plumbing" in data["results"][0]["preview"].lower()
+
+
+def test_search_finds_clients(client: TestClient, test_user: UserData) -> None:
+    _create_clients(
+        test_user,
+        [
+            {
+                "id": "john-doe",
+                "name": "John Doe",
+                "phone": "555-1234",
+                "email": "",
+                "address": "",
+                "notes": "",
+            },
+        ],
+    )
+    resp = client.get("/api/search?q=john")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["results"]) == 1
+    assert data["results"][0]["type"] == "client"
+    assert data["results"][0]["title"] == "John Doe"
+
+
+def test_search_case_insensitive(client: TestClient, test_user: UserData) -> None:
+    _create_memory(test_user, [("City", "Portland", "location")])
+    resp = client.get("/api/search?q=portland")
+    assert resp.status_code == 200
+    assert len(resp.json()["results"]) == 1
+
+    resp = client.get("/api/search?q=PORTLAND")
+    assert resp.status_code == 200
+    assert len(resp.json()["results"]) == 1
+
+
+def test_search_mixed_results(client: TestClient, test_user: UserData) -> None:
+    _create_memory(test_user, [("kitchen_style", "modern kitchen", "preferences")])
+    _create_session(
+        test_user,
+        "1_200",
+        [
+            {
+                "direction": "inbound",
+                "body": "Kitchen remodel quote please",
+                "timestamp": "2025-01-15T10:01:00",
+                "seq": 1,
+            },
+        ],
+    )
+    resp = client.get("/api/search?q=kitchen")
+    assert resp.status_code == 200
+    data = resp.json()
+    types = {r["type"] for r in data["results"]}
+    assert "memory" in types
+    assert "conversation" in types


### PR DESCRIPTION
## Description
Fix lint/format failures on main and register the missing search API router.

Three issues were found and fixed:
1. **Ruff format violations** in `backend/app/routers/search.py` and `tests/test_search_endpoints.py` -- applied `ruff format`.
2. **Missing router registration** -- `backend/app/routers/search.py` existed but was never imported or registered in `main.py`, causing all `/api/search` requests to fall through to the SPA fallback (returning HTML instead of JSON). Added the import and `include_router` call.
3. **Incorrect MEMORY.md format in test helper** -- `tests/test_search_endpoints.py::_create_memory` wrote bold-wrapped keys (`**key**`) but the actual `FileMemoryStore._write_memory_md` writes plain keys. Fixed the test helper to match the store's format.
4. **Stale frontend lockfile** -- `frontend/package-lock.json` was missing the `@tanstack/react-query` entry already declared in `package.json`. Regenerated via `npm install`.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.6 diagnosed and fixed the issues)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)