### PR TITLE
fix: make markdown editor textareas fill viewport height

### DIFF
--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -3,10 +3,12 @@ import { Textarea as HeroTextarea } from '@heroui/input';
 
 type TextareaProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size' | 'color'> & {
   maxRows?: number;
+  /** HeroUI slot classNames, e.g. { input: 'min-h-[65vh]' } */
+  classNames?: Record<string, string>;
 };
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, disabled, onChange, value, placeholder, rows, maxRows, id, ...rest }, ref) => {
+  ({ className, classNames, disabled, onChange, value, placeholder, rows, maxRows, id, ...rest }, ref) => {
     void rest;
     return (
       <HeroTextarea
@@ -29,6 +31,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           }
         }}
         className={className}
+        classNames={classNames}
       />
     );
   },

--- a/frontend/src/pages/ChecklistPage.tsx
+++ b/frontend/src/pages/ChecklistPage.tsx
@@ -52,7 +52,8 @@ export default function ChecklistPage() {
       <Textarea
         value={checklistText}
         onChange={(e) => setChecklistText(e.target.value)}
-        rows={28}
+        rows={6}
+        classNames={{ input: '!min-h-[65vh]' }}
         placeholder="Track tasks and to-dos in markdown format, e.g. - [ ] Follow up with new leads"
       />
     </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -156,7 +156,8 @@ function MarkdownSettingsTab({
       <Textarea
         value={text}
         onChange={(e) => setText(e.target.value)}
-        rows={28}
+        rows={6}
+        classNames={{ input: '!min-h-[65vh]' }}
         placeholder={placeholder}
       />
     </div>


### PR DESCRIPTION
## Description

The markdown editors (USER.md, SOUL.md, HEARTBEAT.md/Checklist) were too short because HeroUI's textarea auto-sizing via `react-textarea-autosize` only uses `minRows` to compute a small inline height (~280px for 28 rows).

This switches to CSS-based height: `min-h-[65vh]` applied to the HeroUI textarea `input` slot, so the editors fill ~65% of the viewport regardless of content. Also exposes the `classNames` prop on the Textarea wrapper for slot-level styling.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Authored by Claude Code.