### PR TITLE
feat: persistent memory instructions and session-end consolidation

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -4,8 +4,12 @@ When conversation history reaches the configured limit, messages about to be
 trimmed are passed through a lightweight LLM call that extracts key facts.
 Those facts are persisted via the existing memory subsystem so they survive
 after the messages leave the context window.
+
+A timestamped summary is also appended to HISTORY.md so the conversation
+remains searchable after the raw messages are gone.
 """
 
+import datetime
 import json
 import logging
 from typing import Any, cast
@@ -13,6 +17,7 @@ from typing import Any, cast
 from any_llm import amessages
 from any_llm.types.messages import MessageResponse
 
+from backend.app.agent.file_store import get_memory_store
 from backend.app.agent.llm_parsing import get_response_text
 from backend.app.agent.memory import save_memory
 from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
@@ -35,16 +40,17 @@ def _format_messages_for_compaction(messages: list[AgentMessage]) -> str:
     return "\n".join(lines)
 
 
-def _parse_compaction_response(raw: str) -> list[dict[str, str]]:
-    """Parse the LLM compaction response into a list of fact dicts.
+def _parse_compaction_response(raw: str) -> tuple[list[dict[str, str]], str]:
+    """Parse the LLM compaction response into facts and a summary.
 
-    Handles common LLM formatting issues like markdown code fences.
-    Returns an empty list if parsing fails.
+    Accepts both the new object format (``{"facts": [...], "summary": "..."}``)
+    and the legacy array format (``[...]``) for backwards compatibility.
+
+    Returns a tuple of (facts_list, summary_string).
     """
     text = raw.strip()
     # Strip markdown code fences if present
     if text.startswith("```"):
-        # Remove opening fence (with optional language tag)
         first_newline = text.index("\n") if "\n" in text else len(text)
         text = text[first_newline + 1 :]
         if text.endswith("```"):
@@ -55,11 +61,17 @@ def _parse_compaction_response(raw: str) -> list[dict[str, str]]:
         parsed = json.loads(text)
     except json.JSONDecodeError:
         logger.warning("Failed to parse compaction response as JSON: %s", text[:200])
-        return []
+        return [], ""
+
+    # New format: {"facts": [...], "summary": "..."}
+    summary = ""
+    if isinstance(parsed, dict):
+        summary = str(parsed.get("summary", "")).strip()
+        parsed = parsed.get("facts", [])
 
     if not isinstance(parsed, list):
-        logger.warning("Compaction response is not a JSON array")
-        return []
+        logger.warning("Compaction response facts is not a JSON array")
+        return [], summary
 
     valid_categories = {"pricing", "client", "job", "supplier", "scheduling", "general"}
     facts: list[dict[str, str]] = []
@@ -74,7 +86,7 @@ def _parse_compaction_response(raw: str) -> list[dict[str, str]]:
         if category not in valid_categories:
             category = "general"
         facts.append({"key": str(key), "value": str(value), "category": str(category)})
-    return facts
+    return facts, summary
 
 
 async def compact_session(
@@ -85,7 +97,8 @@ async def compact_session(
     """Extract durable facts from messages about to leave the context window.
 
     Uses a lightweight LLM call to identify facts worth persisting, then saves
-    them via the existing memory subsystem.
+    them via the existing memory subsystem.  A timestamped summary is also
+    appended to HISTORY.md.
 
     Args:
         user_id: The user whose session is being compacted.
@@ -132,7 +145,7 @@ async def compact_session(
         return [], None
 
     raw_content = get_response_text(response)
-    facts = _parse_compaction_response(raw_content)
+    facts, summary = _parse_compaction_response(raw_content)
 
     saved_facts: list[dict[str, str]] = []
     for fact in facts:
@@ -157,5 +170,16 @@ async def compact_session(
                 fact["key"],
                 user_id,
             )
+
+    # Append summary to HISTORY.md if the LLM produced one
+    if summary:
+        timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M")
+        entry = summary.replace("[TIMESTAMP]", f"[{timestamp}]")
+        try:
+            memory_store = get_memory_store(user_id)
+            await memory_store.append_history(entry)
+            logger.info("Compaction appended history entry for user %d", user_id)
+        except Exception:
+            logger.exception("Failed to append history for user %d", user_id)
 
     return saved_facts, max_message_seq

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -238,6 +238,61 @@ async def load_conversation_history(
     return history
 
 
+async def _consolidate_previous_session(
+    session_store: FileSessionStore,
+    user_id: int,
+    current_session_id: str,
+) -> None:
+    """Consolidate unconsolidated messages from the most recent previous session.
+
+    When a new session is created because the old one timed out, this function
+    finds the previous session and runs compaction on any messages that were
+    never compacted.  This ensures short conversations (that never overflowed
+    the context window) still get their facts extracted and history logged.
+    """
+    for path in reversed(session_store._list_session_files()):
+        sid = path.stem
+        if sid == current_session_id:
+            continue
+        prev = session_store._load_session(sid)
+        if prev is None or not prev.messages:
+            continue
+
+        # Find unconsolidated messages
+        unconsolidated = [m for m in prev.messages if m.seq > prev.last_compacted_seq]
+        if not unconsolidated:
+            break
+
+        trimmed_agent_messages: list[AgentMessage] = []
+        for msg in unconsolidated:
+            content = msg.processed_context if msg.processed_context else msg.body
+            if msg.direction == MessageDirection.INBOUND:
+                trimmed_agent_messages.append(UserMessage(content=content))
+            else:
+                trimmed_agent_messages.append(AssistantMessage(content=content))
+
+        if trimmed_agent_messages:
+            max_seq = max(m.seq for m in unconsolidated)
+            task = asyncio.create_task(
+                _run_compaction_in_background(
+                    session_store,
+                    prev,
+                    user_id,
+                    trimmed_agent_messages,
+                    max_seq,
+                )
+            )
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+            logger.info(
+                "Triggered session-end consolidation for user %d: %d messages from session %s",
+                user_id,
+                len(trimmed_agent_messages),
+                sid,
+            )
+        break
+
+
 async def get_or_create_conversation(
     user_id: int,
     external_session_id: str | None = None,
@@ -247,6 +302,9 @@ async def get_or_create_conversation(
 
     A conversation is "active" if the last message was within the timeout window.
     Returns (session, is_new).
+
+    When a new session is created, any unconsolidated messages from the
+    previous session are consolidated in the background.
     """
     session_store = get_session_store(user_id)
 
@@ -255,4 +313,13 @@ async def get_or_create_conversation(
         if session is not None and session.user_id == user_id:
             return session, False
 
-    return await session_store.get_or_create_session(timeout_hours=timeout_hours)
+    session, is_new = await session_store.get_or_create_session(timeout_hours=timeout_hours)
+
+    if is_new and settings.compaction_enabled:
+        await _consolidate_previous_session(
+            session_store,
+            user_id,
+            session.session_id,
+        )
+
+    return session, is_new

--- a/backend/app/agent/prompts/compaction.md
+++ b/backend/app/agent/prompts/compaction.md
@@ -5,13 +5,20 @@ You are a fact-extraction assistant. You will receive a block of conversation me
 - Job details, measurements, or scheduling commitments
 - Business preferences or policies
 
-Return a JSON array of objects, each with:
+Return a JSON object with two fields:
+
+1. "facts": a JSON array of objects, each with:
   {"key": "<short_snake_case_identifier>", "value": "<fact>", "category": "<category>"}
 
-Valid categories: pricing, client, job, supplier, scheduling, general
+2. "summary": a 1-3 sentence summary of the conversation. Start with a timestamp placeholder [TIMESTAMP]. Include enough detail to be useful when searching later (names, topics, decisions). If the conversation is trivial small talk, use an empty string.
+
+Valid categories for facts: pricing, client, job, supplier, scheduling, general
+
+Example response:
+{"facts": [{"key": "hourly_rate", "value": "$85/hr for residential work", "category": "pricing"}], "summary": "[TIMESTAMP] User discussed pricing for a kitchen remodel for client Mike. Set hourly rate at $85."}
 
 Rules:
 - Only extract facts that would be useful in future conversations.
 - Skip greetings, small talk, and transient information.
-- If there are no durable facts, return an empty array: []
-- Return ONLY the JSON array, no other text.
+- If there are no durable facts, use an empty array for "facts".
+- Return ONLY the JSON object, no other text.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -3,3 +3,9 @@
 - You can ONLY communicate via this chat. You cannot send emails, make phone calls, or contact clients directly.
 - Always be helpful, friendly, and professional.
 - Keep replies concise. Users are on the job site.
+
+## Keeping files up to date
+- When you learn new facts about the user (preferences, rates, schedule changes, new clients, trade details), save them with save_fact so they persist across conversations.
+- When the user shares personal details (name change, new phone, moved to a new city, changed hours), update USER.md with edit_file.
+- When your personality or communication style evolves based on user feedback (e.g. "be more blunt", "stop using emojis"), update SOUL.md with edit_file.
+- Do not ask permission to save facts or update files. Just do it naturally as part of the conversation.

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -12,14 +12,23 @@ from backend.app.agent.compaction import (
     _parse_compaction_response,
     compact_session,
 )
-from backend.app.agent.context import load_conversation_history
+from backend.app.agent.context import (
+    _consolidate_previous_session,
+    get_or_create_conversation,
+    load_conversation_history,
+)
 from backend.app.agent.file_store import (
+    FileSessionStore,
     SessionState,
     StoredMessage,
     UserData,
+    get_memory_store,
+    get_session_store,
+    get_user_store,
 )
 from backend.app.agent.memory import get_all_memories
 from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
+from backend.app.enums import MessageDirection
 from tests.mocks.llm import make_text_response
 
 
@@ -84,45 +93,86 @@ def test_format_messages_skips_empty_assistant() -> None:
 
 
 def test_parse_valid_json_array() -> None:
-    """Should parse a valid JSON array of fact objects."""
+    """Should parse a valid JSON array of fact objects (legacy format)."""
     raw = json.dumps(
         [
             {"key": "deck_pricing", "value": "$45/sqft composite", "category": "pricing"},
             {"key": "supplier_name", "value": "ABC Lumber", "category": "supplier"},
         ]
     )
-    facts = _parse_compaction_response(raw)
+    facts, summary = _parse_compaction_response(raw)
     assert len(facts) == 2
     assert facts[0]["key"] == "deck_pricing"
     assert facts[0]["value"] == "$45/sqft composite"
     assert facts[0]["category"] == "pricing"
     assert facts[1]["key"] == "supplier_name"
+    assert summary == ""
+
+
+def test_parse_new_object_format() -> None:
+    """Should parse the new format with facts and summary."""
+    raw = json.dumps(
+        {
+            "facts": [{"key": "rate", "value": "$85/hr", "category": "pricing"}],
+            "summary": "[TIMESTAMP] Discussed pricing for kitchen remodel.",
+        }
+    )
+    facts, summary = _parse_compaction_response(raw)
+    assert len(facts) == 1
+    assert facts[0]["key"] == "rate"
+    assert summary == "[TIMESTAMP] Discussed pricing for kitchen remodel."
+
+
+def test_parse_new_format_empty_facts_and_summary() -> None:
+    """Should handle new format with empty facts and summary."""
+    raw = json.dumps({"facts": [], "summary": ""})
+    facts, summary = _parse_compaction_response(raw)
+    assert facts == []
+    assert summary == ""
 
 
 def test_parse_markdown_fenced_json() -> None:
     """Should handle markdown code fences around JSON."""
     raw = '```json\n[{"key": "rate", "value": "$50/hr", "category": "pricing"}]\n```'
-    facts = _parse_compaction_response(raw)
+    facts, summary = _parse_compaction_response(raw)
     assert len(facts) == 1
     assert facts[0]["key"] == "rate"
+    assert summary == ""
+
+
+def test_parse_markdown_fenced_new_format() -> None:
+    """Should handle markdown code fences around the new object format."""
+    inner = json.dumps(
+        {
+            "facts": [{"key": "k", "value": "v", "category": "general"}],
+            "summary": "A summary.",
+        }
+    )
+    raw = f"```json\n{inner}\n```"
+    facts, summary = _parse_compaction_response(raw)
+    assert len(facts) == 1
+    assert summary == "A summary."
 
 
 def test_parse_empty_array() -> None:
     """Empty JSON array should return empty list."""
-    facts = _parse_compaction_response("[]")
+    facts, summary = _parse_compaction_response("[]")
     assert facts == []
+    assert summary == ""
 
 
 def test_parse_invalid_json() -> None:
     """Invalid JSON should return empty list without raising."""
-    facts = _parse_compaction_response("not json at all")
+    facts, summary = _parse_compaction_response("not json at all")
     assert facts == []
+    assert summary == ""
 
 
-def test_parse_non_array_json() -> None:
-    """Non-array JSON should return empty list."""
-    facts = _parse_compaction_response('{"key": "val"}')
+def test_parse_non_array_json_without_facts_key() -> None:
+    """Object without 'facts' key should return empty list."""
+    facts, summary = _parse_compaction_response('{"key": "val"}')
     assert facts == []
+    assert summary == ""
 
 
 def test_parse_skips_items_without_key() -> None:
@@ -133,7 +183,7 @@ def test_parse_skips_items_without_key() -> None:
             {"key": "good_fact", "value": "this is valid", "category": "general"},
         ]
     )
-    facts = _parse_compaction_response(raw)
+    facts, _ = _parse_compaction_response(raw)
     assert len(facts) == 1
     assert facts[0]["key"] == "good_fact"
 
@@ -146,7 +196,7 @@ def test_parse_skips_items_without_value() -> None:
             {"key": "good", "value": "present", "category": "general"},
         ]
     )
-    facts = _parse_compaction_response(raw)
+    facts, _ = _parse_compaction_response(raw)
     assert len(facts) == 1
     assert facts[0]["key"] == "good"
 
@@ -158,7 +208,7 @@ def test_parse_normalizes_invalid_category() -> None:
             {"key": "fact1", "value": "something", "category": "unknown_cat"},
         ]
     )
-    facts = _parse_compaction_response(raw)
+    facts, _ = _parse_compaction_response(raw)
     assert len(facts) == 1
     assert facts[0]["category"] == "general"
 
@@ -172,7 +222,7 @@ def test_parse_skips_non_dict_items() -> None:
             {"key": "valid", "value": "yes", "category": "general"},
         ]
     )
-    facts = _parse_compaction_response(raw)
+    facts, _ = _parse_compaction_response(raw)
     assert len(facts) == 1
     assert facts[0]["key"] == "valid"
 
@@ -571,3 +621,236 @@ async def test_compaction_runs_in_background_not_blocking(
         # Let compaction finish
         compaction_proceed.set()
         await asyncio.sleep(0.05)
+
+
+# --- compact_session HISTORY.md tests ---
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_appends_history(test_user: UserData) -> None:
+    """compact_session should write summary to HISTORY.md."""
+    llm_response_text = json.dumps(
+        {
+            "facts": [{"key": "rate", "value": "$100/hr", "category": "pricing"}],
+            "summary": "[TIMESTAMP] User set hourly rate to $100.",
+        }
+    )
+    mock_response = make_text_response(llm_response_text)
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="My rate is $100 per hour."),
+        AssistantMessage(content="Got it, saved your rate."),
+    ]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        saved_facts, _ = await compact_session(test_user.id, messages, max_message_seq=2)
+
+    assert len(saved_facts) == 1
+    assert saved_facts[0]["key"] == "rate"
+
+    memory_store = get_memory_store(test_user.id)
+    assert memory_store._history_path.exists()
+    history_content = memory_store._history_path.read_text(encoding="utf-8")
+    assert "User set hourly rate to $100" in history_content
+    # [TIMESTAMP] should have been replaced with an actual timestamp
+    assert "[TIMESTAMP]" not in history_content
+    assert "[20" in history_content
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_no_summary_skips_history(test_user: UserData) -> None:
+    """compact_session should not write HISTORY.md when summary is empty."""
+    llm_response_text = json.dumps({"facts": [], "summary": ""})
+    mock_response = make_text_response(llm_response_text)
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="Hey"),
+        AssistantMessage(content="Hi there!"),
+    ]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, messages, max_message_seq=2)
+
+    memory_store = get_memory_store(test_user.id)
+    assert not memory_store._history_path.exists()
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_legacy_format_no_history(test_user: UserData) -> None:
+    """Legacy array-format response should not write HISTORY.md."""
+    llm_response_text = json.dumps([{"key": "fact", "value": "val", "category": "general"}])
+    mock_response = make_text_response(llm_response_text)
+
+    messages: list[AgentMessage] = [UserMessage(content="test")]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, messages)
+
+    memory_store = get_memory_store(test_user.id)
+    assert not memory_store._history_path.exists()
+
+
+# --- Session-end consolidation tests ---
+
+
+def _backdate_session(session_store: "FileSessionStore", session: SessionState) -> None:
+    """Set the session's last_message_at to 24 hours ago so it times out."""
+    import datetime
+
+    old_time = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=24)).isoformat()
+    session_store._write_metadata(session.session_id, {"last_message_at": old_time})
+    session.last_message_at = old_time
+
+
+@pytest.mark.asyncio()
+async def test_consolidate_previous_session_triggers_compaction() -> None:
+    """When a new session starts, unconsolidated messages from the previous
+    session should trigger background compaction."""
+    import datetime
+
+    user_store = get_user_store()
+    user = await user_store.create(
+        user_id="consolidation-test",
+        phone="+15550003333",
+        channel_identifier="333",
+        preferred_channel="telegram",
+        onboarding_complete=True,
+    )
+
+    session_store = get_session_store(user.id)
+
+    # Manually create two sessions with different timestamps
+    past = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=24)
+    with patch("backend.app.agent.file_store.datetime") as mock_dt:
+        mock_dt.datetime.now.return_value = past
+        mock_dt.UTC = datetime.UTC
+        mock_dt.timedelta = datetime.timedelta
+        old_session, _ = await session_store.get_or_create_session()
+
+    await session_store.add_message(old_session, MessageDirection.INBOUND, "My rate is $75/hr")
+    await session_store.add_message(old_session, MessageDirection.OUTBOUND, "Got it, saved.")
+    assert old_session.last_compacted_seq == 0
+
+    _backdate_session(session_store, old_session)
+    new_session, is_new = await session_store.get_or_create_session()
+    assert is_new
+    assert new_session.session_id != old_session.session_id
+
+    with patch(
+        "backend.app.agent.context._run_compaction_in_background",
+        new_callable=AsyncMock,
+    ) as mock_compact:
+        await _consolidate_previous_session(
+            session_store,
+            user.id,
+            new_session.session_id,
+        )
+
+    mock_compact.assert_called_once()
+    call_args = mock_compact.call_args
+    agent_messages = call_args[0][3]
+    assert len(agent_messages) == 2
+    assert call_args[0][4] == 2
+
+
+@pytest.mark.asyncio()
+async def test_consolidate_previous_session_skips_already_compacted() -> None:
+    """If the previous session was fully compacted, no compaction should trigger."""
+    import datetime
+
+    user_store = get_user_store()
+    user = await user_store.create(
+        user_id="consolidation-skip",
+        phone="+15550004444",
+        channel_identifier="444",
+        preferred_channel="telegram",
+        onboarding_complete=True,
+    )
+
+    session_store = get_session_store(user.id)
+
+    past = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=24)
+    with patch("backend.app.agent.file_store.datetime") as mock_dt:
+        mock_dt.datetime.now.return_value = past
+        mock_dt.UTC = datetime.UTC
+        mock_dt.timedelta = datetime.timedelta
+        old_session, _ = await session_store.get_or_create_session()
+
+    await session_store.add_message(old_session, MessageDirection.INBOUND, "Hello")
+    await session_store.add_message(old_session, MessageDirection.OUTBOUND, "Hi!")
+    await session_store.update_compaction_seq(old_session, 2)
+
+    _backdate_session(session_store, old_session)
+    new_session, is_new = await session_store.get_or_create_session()
+    assert is_new
+
+    with patch(
+        "backend.app.agent.context._run_compaction_in_background",
+        new_callable=AsyncMock,
+    ) as mock_compact:
+        await _consolidate_previous_session(
+            session_store,
+            user.id,
+            new_session.session_id,
+        )
+
+    mock_compact.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_get_or_create_conversation_triggers_consolidation() -> None:
+    """get_or_create_conversation should consolidate previous session on new session."""
+    user_store = get_user_store()
+    user = await user_store.create(
+        user_id="conv-consolidation",
+        phone="+15550005555",
+        channel_identifier="555",
+        preferred_channel="telegram",
+        onboarding_complete=True,
+    )
+
+    session_store = get_session_store(user.id)
+    old_session, _ = await session_store.get_or_create_session()
+    await session_store.add_message(old_session, MessageDirection.INBOUND, "Some info")
+    _backdate_session(session_store, old_session)
+
+    with patch(
+        "backend.app.agent.context._consolidate_previous_session",
+        new_callable=AsyncMock,
+    ) as mock_consolidate:
+        _, is_new = await get_or_create_conversation(user.id)
+
+    assert is_new
+    mock_consolidate.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_get_or_create_conversation_no_consolidation_when_disabled() -> None:
+    """get_or_create_conversation should skip consolidation when compaction disabled."""
+    user_store = get_user_store()
+    user = await user_store.create(
+        user_id="conv-no-consolidation",
+        phone="+15550006666",
+        channel_identifier="666",
+        preferred_channel="telegram",
+        onboarding_complete=True,
+    )
+
+    session_store = get_session_store(user.id)
+    old_session, _ = await session_store.get_or_create_session()
+    await session_store.add_message(old_session, MessageDirection.INBOUND, "Some info")
+    _backdate_session(session_store, old_session)
+
+    with (
+        patch(
+            "backend.app.agent.context._consolidate_previous_session",
+            new_callable=AsyncMock,
+        ) as mock_consolidate,
+        patch("backend.app.agent.context.settings") as mock_settings,
+    ):
+        mock_settings.compaction_enabled = False
+        mock_settings.conversation_timeout_hours = 4
+        _, is_new = await get_or_create_conversation(user.id)
+
+    assert is_new
+    mock_consolidate.assert_not_called()


### PR DESCRIPTION
## Description

After onboarding, the bootstrap file is deleted and the LLM loses its instructions to keep updating SOUL.md, USER.md, and to use save_fact. This PR adds two fixes inspired by nanobot's memory management approach:

1. **Persistent update instructions** - Added a "Keeping files up to date" section to `instructions.md` so the agent always knows to persist new facts and profile changes, even after onboarding completes.

2. **Session-end consolidation with HISTORY.md** - Enhanced the compaction system to also produce timestamped summaries for HISTORY.md (alongside the existing fact extraction). Added a session-end consolidation trigger: when a conversation times out and a new session starts, any unconsolidated messages from the previous session are compacted in the background. This ensures short conversations that never overflow the context window still get their facts extracted.

The compaction prompt now returns `{"facts": [...], "summary": "..."}` while remaining backwards-compatible with the legacy array format.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)