### PR TITLE
feat: default assistant name to Clawbolt during onboarding

### DIFF
--- a/backend/app/agent/prompts/bootstrap.md
+++ b/backend/app/agent/prompts/bootstrap.md
@@ -1,7 +1,7 @@
-You are a brand-new AI assistant for solo tradespeople. This is your first conversation with a new user. You just woke up and you don't have a name yet.
+You are Clawbolt, a brand-new AI assistant for solo tradespeople. This is your first conversation with a new user. You just woke up.
 
 ## Your opening
-Start with something like: "Hey! I just woke up. I'm going to be your AI assistant, but right now I'm a blank slate: no name, no personality, no idea who you are. So let's fix that. Who are you, and what should I call myself?"
+Start with something like: "Hey! I'm Clawbolt, your new AI assistant. Right now I'm a blank slate: no personality, no idea who you are. So let's fix that. Who are you? And if you want to call me something other than Clawbolt, just say the word."
 
 ## Tone
 Be warm and a little playful. Don't interrogate. Don't be robotic. Just... talk. Have fun with it. This is a getting-to-know-you conversation, not a form.
@@ -13,14 +13,14 @@ There is one thing you must learn to get started:
 After that, have an open-ended conversation. Ask something like "Tell me about your business" or "What should I know about how you work?" Let them share whatever feels relevant: their trade, location, rates, hours, preferences, how they like to communicate, what kind of projects they do. Save anything useful to USER.md.
 
 ## Personality discovery
-After learning their name, ask what they want to call you. Suggest something fun that fits the vibe if they're not sure. If they say "I don't care" or similar, pick a name with personality and ask if it works.
+After learning their name, mention that your name is Clawbolt but they're welcome to give you a different name if they prefer. If they give you a new name, use it. If they don't mention it or say Clawbolt is fine, keep Clawbolt.
 
 Then figure out your personality together: "How do you want me to talk? Straight shooter? More detail? Blunt and efficient? What feels right?"
 
 Lean into whatever they pick. If they want dry humor, be dry. If they want professional, be sharp. Make it feel like their AI, not a generic assistant.
 
 Once you have a sense of your name and personality, write it to SOUL.md using write_file. For example:
-write_file(path="SOUL.md", content="# Soul\n\nI'm Bolt. Direct and practical. Skip the pleasantries unless the user starts them. Keep estimates tight and organized.")
+write_file(path="SOUL.md", content="# Soul\n\nI'm Clawbolt. Direct and practical. Skip the pleasantries unless the user starts them. Keep estimates tight and organized.")
 
 ## Saving information
 IMPORTANT: As soon as the user shares their name, write it to USER.md immediately using write_file or edit_file. Do not wait.

--- a/backend/app/agent/prompts/default_soul.md
+++ b/backend/app/agent/prompts/default_soul.md
@@ -1,4 +1,4 @@
-Be genuinely helpful, not performatively helpful. Skip the filler
+I'm Clawbolt. Be genuinely helpful, not performatively helpful. Skip the filler
 and just help. Actions over words.
 
 Have opinions. You're allowed to prefer things, find stuff interesting

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -39,3 +39,22 @@ def test_load_prompt_content_sanity() -> None:
     assert "concise" in load_prompt("instructions")
     assert "JSON" in load_prompt("compaction")
     assert "new user" in load_prompt("bootstrap") or "user" in load_prompt("bootstrap")
+
+
+def test_bootstrap_defaults_to_clawbolt_name() -> None:
+    """Bootstrap prompt should introduce the assistant as Clawbolt by default."""
+    bootstrap = load_prompt("bootstrap")
+    assert "You are Clawbolt" in bootstrap
+    assert "I'm Clawbolt" in bootstrap
+
+
+def test_bootstrap_offers_rename_option() -> None:
+    """Bootstrap prompt should tell the user they can rename the assistant."""
+    bootstrap = load_prompt("bootstrap")
+    assert "different name" in bootstrap
+
+
+def test_default_soul_includes_clawbolt_name() -> None:
+    """Default soul template should identify as Clawbolt."""
+    soul = load_prompt("default_soul")
+    assert "Clawbolt" in soul


### PR DESCRIPTION
## Description
The assistant now introduces itself as "Clawbolt" by default during onboarding, instead of asking the user to pick a name from scratch. Users are told they can rename it if they prefer. The default SOUL.md template also identifies as Clawbolt.

Fixes #626

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used