### PR TITLE
fix: respect per-user heartbeat frequency from settings UI

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
@@ -35,6 +36,44 @@ from backend.app.enums import MessageDirection
 from backend.app.services.llm_usage import log_llm_usage
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Frequency parsing
+# ---------------------------------------------------------------------------
+
+_FREQ_RE = re.compile(r"^(\d+)\s*([mhd])$", re.IGNORECASE)
+
+_NAMED_FREQUENCIES: dict[str, int] = {
+    "daily": 1440,
+    "weekdays": 1440,
+    "weekly": 10080,
+}
+
+# Minimum tick resolution: the scheduler wakes up this often.
+_TICK_RESOLUTION_MINUTES = 1
+
+
+def parse_frequency_to_minutes(freq: str) -> int | None:
+    """Convert a frequency string like ``15m``, ``2h``, ``1d`` to minutes.
+
+    Named presets (``daily``, ``weekdays``, ``weekly``) are also supported.
+    Returns *None* if the string cannot be parsed.
+    """
+    freq = freq.strip().lower()
+    if freq in _NAMED_FREQUENCIES:
+        return _NAMED_FREQUENCIES[freq]
+    m = _FREQ_RE.match(freq)
+    if not m:
+        return None
+    value, unit = int(m.group(1)), m.group(2)
+    if unit == "m":
+        return max(value, 1)
+    if unit == "h":
+        return value * 60
+    if unit == "d":
+        return value * 1440
+    return None  # pragma: no cover
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -363,10 +402,16 @@ def _pick_heartbeat_channel(user: UserData) -> str:
 
 
 class HeartbeatScheduler:
-    """Manages the periodic heartbeat loop as an asyncio background task."""
+    """Manages the periodic heartbeat loop as an asyncio background task.
+
+    The scheduler wakes up every ``_TICK_RESOLUTION_MINUTES`` and evaluates
+    each user only when their individual ``heartbeat_frequency`` interval has
+    elapsed since their last evaluation.
+    """
 
     def __init__(self) -> None:
         self._task: asyncio.Task[None] | None = None
+        self._last_tick: dict[int, datetime.datetime] = {}
 
     # -- public API --
 
@@ -379,8 +424,8 @@ class HeartbeatScheduler:
             return
         self._task = asyncio.get_running_loop().create_task(self._run())
         logger.info(
-            "Heartbeat started (interval=%dm, max_daily=%d)",
-            settings.heartbeat_interval_minutes,
+            "Heartbeat started (tick_resolution=%dm, max_daily=%d)",
+            _TICK_RESOLUTION_MINUTES,
             settings.heartbeat_max_daily_messages,
         )
 
@@ -394,7 +439,7 @@ class HeartbeatScheduler:
     # -- internals --
 
     async def _run(self) -> None:
-        """Loop forever, running one tick per interval."""
+        """Loop forever, running one tick per resolution interval."""
         while True:
             try:
                 await self.tick()
@@ -402,15 +447,36 @@ class HeartbeatScheduler:
                 raise
             except Exception:
                 logger.exception("Heartbeat tick failed")
-            await asyncio.sleep(settings.heartbeat_interval_minutes * 60)
+            await asyncio.sleep(_TICK_RESOLUTION_MINUTES * 60)
+
+    def _user_interval_minutes(self, user: UserData) -> int:
+        """Return the heartbeat interval in minutes for a given user."""
+        parsed = parse_frequency_to_minutes(user.heartbeat_frequency)
+        if parsed is not None:
+            return parsed
+        return settings.heartbeat_interval_minutes
+
+    def _is_user_due(self, user: UserData, now: datetime.datetime) -> bool:
+        """Return True if enough time has elapsed since the last tick for this user."""
+        last = self._last_tick.get(user.id)
+        if last is None:
+            return True
+        interval = self._user_interval_minutes(user)
+        return (now - last).total_seconds() >= interval * 60
 
     async def tick(self) -> None:
-        """Single heartbeat pass: evaluate every onboarded user concurrently."""
+        """Single heartbeat pass: evaluate due users concurrently."""
         store = get_user_store()
         all_users = await store.list_all()
         users = [c for c in all_users if c.onboarding_complete]
 
         if not users:
+            return
+
+        now = datetime.datetime.now(datetime.UTC)
+        due_users = [u for u in users if self._is_user_due(u, now)]
+
+        if not due_users:
             return
 
         semaphore = asyncio.Semaphore(settings.heartbeat_concurrency)
@@ -428,11 +494,12 @@ class HeartbeatScheduler:
                         chat_id=chat_id,
                         max_daily=settings.heartbeat_max_daily_messages,
                     )
+                    self._last_tick[user.id] = now
                 except Exception:
                     logger.exception("Heartbeat failed for user %d", user.id)
 
         results = await asyncio.gather(
-            *[_process_one(c) for c in users],
+            *[_process_one(c) for c in due_users],
             return_exceptions=True,
         )
 
@@ -441,7 +508,7 @@ class HeartbeatScheduler:
             if isinstance(result, BaseException):
                 logger.error(
                     "Unhandled error in heartbeat for user %d: %s",
-                    users[i].id,
+                    due_users[i].id,
                     result,
                     exc_info=result if isinstance(result, Exception) else None,
                 )

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -24,6 +24,7 @@ from backend.app.agent.heartbeat import (
     evaluate_heartbeat_need,
     get_daily_heartbeat_count,
     is_within_business_hours,
+    parse_frequency_to_minutes,
     run_heartbeat_for_user,
 )
 from backend.app.agent.system_prompt import to_local_time
@@ -1230,3 +1231,191 @@ class TestPickHeartbeatChannel:
 
         mock_pick_channel.assert_called_once_with(user)
         mock_run.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# parse_frequency_to_minutes
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrequencyToMinutes:
+    def test_minutes(self) -> None:
+        assert parse_frequency_to_minutes("15m") == 15
+
+    def test_minutes_uppercase(self) -> None:
+        assert parse_frequency_to_minutes("15M") == 15
+
+    def test_hours(self) -> None:
+        assert parse_frequency_to_minutes("2h") == 120
+
+    def test_days(self) -> None:
+        assert parse_frequency_to_minutes("1d") == 1440
+
+    def test_daily(self) -> None:
+        assert parse_frequency_to_minutes("daily") == 1440
+
+    def test_weekdays(self) -> None:
+        assert parse_frequency_to_minutes("weekdays") == 1440
+
+    def test_weekly(self) -> None:
+        assert parse_frequency_to_minutes("weekly") == 10080
+
+    def test_one_minute_minimum(self) -> None:
+        assert parse_frequency_to_minutes("0m") == 1
+
+    def test_invalid_returns_none(self) -> None:
+        assert parse_frequency_to_minutes("banana") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert parse_frequency_to_minutes("") is None
+
+    def test_whitespace_trimmed(self) -> None:
+        assert parse_frequency_to_minutes("  30m  ") == 30
+
+
+# ---------------------------------------------------------------------------
+# Per-user frequency scheduling
+# ---------------------------------------------------------------------------
+
+
+class TestPerUserFrequencyScheduling:
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.get_user_store")
+    @patch("backend.app.agent.heartbeat._pick_heartbeat_channel")
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_user_skipped_when_interval_not_elapsed(
+        self,
+        mock_settings: MagicMock,
+        mock_pick_channel: MagicMock,
+        mock_get_store: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """A user whose interval has not elapsed should not be processed."""
+        mock_settings.heartbeat_concurrency = 5
+        mock_settings.heartbeat_max_daily_messages = 5
+        mock_settings.heartbeat_interval_minutes = 30
+
+        mock_pick_channel.return_value = "telegram"
+
+        user = MagicMock()
+        user.id = 1
+        user.onboarding_complete = True
+        user.heartbeat_frequency = "1h"
+        user.preferred_channel = "telegram"
+        user.channel_identifier = ""
+        user.phone = "+15559990000"
+
+        mock_store = AsyncMock()
+        mock_store.list_all.return_value = [user]
+        mock_get_store.return_value = mock_store
+        mock_run.return_value = None
+
+        scheduler = HeartbeatScheduler()
+
+        # First tick: user is due (no previous tick)
+        await scheduler.tick()
+        assert mock_run.await_count == 1
+
+        # Second tick immediately after: user interval (1h) has not elapsed
+        await scheduler.tick()
+        assert mock_run.await_count == 1  # Still 1, not called again
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.get_user_store")
+    @patch("backend.app.agent.heartbeat._pick_heartbeat_channel")
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_user_processed_when_interval_elapsed(
+        self,
+        mock_settings: MagicMock,
+        mock_pick_channel: MagicMock,
+        mock_get_store: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """A user whose interval has elapsed should be processed again."""
+        mock_settings.heartbeat_concurrency = 5
+        mock_settings.heartbeat_max_daily_messages = 5
+        mock_settings.heartbeat_interval_minutes = 30
+
+        mock_pick_channel.return_value = "telegram"
+
+        user = MagicMock()
+        user.id = 1
+        user.onboarding_complete = True
+        user.heartbeat_frequency = "15m"
+        user.preferred_channel = "telegram"
+        user.channel_identifier = ""
+        user.phone = "+15559990000"
+
+        mock_store = AsyncMock()
+        mock_store.list_all.return_value = [user]
+        mock_get_store.return_value = mock_store
+        mock_run.return_value = None
+
+        scheduler = HeartbeatScheduler()
+
+        # First tick
+        await scheduler.tick()
+        assert mock_run.await_count == 1
+
+        # Simulate time passing: set last tick to 16 minutes ago
+        scheduler._last_tick[1] = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            minutes=16
+        )
+
+        # Second tick: 16 > 15 minutes, so user is due
+        await scheduler.tick()
+        assert mock_run.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.get_user_store")
+    @patch("backend.app.agent.heartbeat._pick_heartbeat_channel")
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_invalid_frequency_falls_back_to_global(
+        self,
+        mock_settings: MagicMock,
+        mock_pick_channel: MagicMock,
+        mock_get_store: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """Invalid frequency should fall back to global heartbeat_interval_minutes."""
+        mock_settings.heartbeat_concurrency = 5
+        mock_settings.heartbeat_max_daily_messages = 5
+        mock_settings.heartbeat_interval_minutes = 30
+
+        mock_pick_channel.return_value = "telegram"
+
+        user = MagicMock()
+        user.id = 1
+        user.onboarding_complete = True
+        user.heartbeat_frequency = "invalid"
+        user.preferred_channel = "telegram"
+        user.channel_identifier = ""
+        user.phone = "+15559990000"
+
+        mock_store = AsyncMock()
+        mock_store.list_all.return_value = [user]
+        mock_get_store.return_value = mock_store
+        mock_run.return_value = None
+
+        scheduler = HeartbeatScheduler()
+
+        # First tick: always due
+        await scheduler.tick()
+        assert mock_run.await_count == 1
+
+        # Set last tick to 29 minutes ago (< 30m global default)
+        scheduler._last_tick[1] = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            minutes=29
+        )
+        await scheduler.tick()
+        assert mock_run.await_count == 1  # Not yet due
+
+        # Set last tick to 31 minutes ago (> 30m global default)
+        scheduler._last_tick[1] = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            minutes=31
+        )
+        await scheduler.tick()
+        assert mock_run.await_count == 2  # Now due


### PR DESCRIPTION
## Description

The heartbeat scheduler was ignoring the per-user `heartbeat_frequency` saved via the web UI settings and always using the global `heartbeat_interval_minutes` config (default 30m). Users who set custom intervals (e.g. "15m", "1h") in the Settings > Heartbeat tab saw no change in behavior because the scheduler never read or parsed the stored value.

**Root cause:** A previous refactor removed the `parse_frequency_to_minutes()` function and per-user frequency logic, leaving the scheduler hardcoded to the global interval.

**Fix:**
- Add `parse_frequency_to_minutes()` to convert frequency strings (`15m`, `2h`, `1d`, `daily`, `weekdays`, `weekly`) into minutes
- Change the scheduler from a single global sleep interval to a 1-minute tick resolution with per-user last-tick tracking, so each user is only evaluated when their individual interval has elapsed
- Invalid/unparseable frequencies fall back to the global `heartbeat_interval_minutes` setting

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the root cause and implemented the fix with tests)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)