### PR TITLE
fix: display tool interactions in chat UI

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '@/test/test-utils';
+import ChatPage from './ChatPage';
+
+// Mock the api module
+vi.mock('@/api', () => ({
+  default: {
+    listSessions: vi.fn().mockResolvedValue({ sessions: [], total: 0, offset: 0, limit: 50 }),
+    getSession: vi.fn(),
+    sendChatMessage: vi.fn(),
+  },
+}));
+
+// Re-import after mock so we can control return values
+import api from '@/api';
+const mockApi = vi.mocked(api);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApi.listSessions.mockResolvedValue({ sessions: [], total: 0, offset: 0, limit: 50 });
+});
+
+describe('ChatPage tool interactions', () => {
+  it('displays tool interactions when loading session history', async () => {
+    const sessionId = '1_1000';
+    mockApi.listSessions.mockResolvedValue({
+      sessions: [
+        {
+          id: sessionId,
+          start_time: '2025-01-01T00:00:00Z',
+          message_count: 2,
+          last_message_preview: 'Hello',
+          channel: 'webchat',
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    });
+    mockApi.getSession.mockResolvedValue({
+      session_id: sessionId,
+      user_id: 1,
+      created_at: '2025-01-01T00:00:00Z',
+      last_message_at: '2025-01-01T00:01:00Z',
+      is_active: true,
+      channel: 'webchat',
+      messages: [
+        {
+          seq: 1,
+          direction: 'inbound',
+          body: 'Create an estimate',
+          timestamp: '2025-01-01T00:00:00Z',
+          tool_interactions: [],
+        },
+        {
+          seq: 2,
+          direction: 'outbound',
+          body: 'I created the estimate for you.',
+          timestamp: '2025-01-01T00:01:00Z',
+          tool_interactions: [
+            { name: 'create_estimate', result: 'Estimate created successfully' },
+            { name: 'send_message', result: 'Message sent' },
+          ],
+        },
+      ],
+    });
+
+    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+
+    await waitFor(() => {
+      expect(screen.getByText('I created the estimate for you.')).toBeInTheDocument();
+    });
+
+    // Tool interactions should be visible
+    expect(screen.getByText('create_estimate')).toBeInTheDocument();
+    expect(screen.getByText('send_message')).toBeInTheDocument();
+  });
+
+  it('does not render tool section when there are no tool interactions', async () => {
+    const sessionId = '1_2000';
+    mockApi.listSessions.mockResolvedValue({
+      sessions: [
+        {
+          id: sessionId,
+          start_time: '2025-01-01T00:00:00Z',
+          message_count: 2,
+          last_message_preview: 'Hello',
+          channel: 'webchat',
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    });
+    mockApi.getSession.mockResolvedValue({
+      session_id: sessionId,
+      user_id: 1,
+      created_at: '2025-01-01T00:00:00Z',
+      last_message_at: '2025-01-01T00:01:00Z',
+      is_active: true,
+      channel: 'webchat',
+      messages: [
+        {
+          seq: 1,
+          direction: 'inbound',
+          body: 'Hello',
+          timestamp: '2025-01-01T00:00:00Z',
+          tool_interactions: [],
+        },
+        {
+          seq: 2,
+          direction: 'outbound',
+          body: 'Hi there!',
+          timestamp: '2025-01-01T00:01:00Z',
+          tool_interactions: [],
+        },
+      ],
+    });
+
+    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+
+    await waitFor(() => {
+      expect(screen.getByText('Hi there!')).toBeInTheDocument();
+    });
+
+    // No "Tool:" labels should appear
+    expect(screen.queryByText('Tool:')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -8,7 +8,7 @@ import api from '@/api';
 import { toast } from '@/lib/toast';
 import { useSessions, useSession } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
-import type { SessionSummary } from '@/types';
+import type { SessionSummary, ToolInteraction } from '@/types';
 
 interface FileAttachment {
   name: string;
@@ -22,6 +22,7 @@ interface ChatMessage {
   body: string;
   timestamp: Date;
   attachments?: FileAttachment[];
+  toolInteractions?: ToolInteraction[];
 }
 
 const ACCEPTED_FILE_TYPES = 'image/*,audio/*,application/pdf';
@@ -152,6 +153,7 @@ export default function ChatPage() {
       role: m.direction === 'inbound' ? 'user' : 'assistant',
       body: m.body,
       timestamp: new Date(m.timestamp),
+      toolInteractions: m.tool_interactions.length > 0 ? m.tool_interactions : undefined,
     }));
     setMessages(loaded);
   }, [sessionDetail]);
@@ -221,6 +223,7 @@ export default function ChatPage() {
     setSending(true);
 
     try {
+      const toolNames: string[] = [];
       const res = await api.sendChatMessage(
         text,
         activeSessionId ?? undefined,
@@ -229,6 +232,9 @@ export default function ChatPage() {
           if (!mountedRef.current) return;
           if (event.type === 'tool_call') {
             setCurrentTool(event.tool_name ?? null);
+            if (event.tool_name) {
+              toolNames.push(event.tool_name);
+            }
           }
         },
         forceNewRef.current,
@@ -239,6 +245,9 @@ export default function ChatPage() {
         role: 'assistant',
         body: res.reply,
         timestamp: new Date(),
+        toolInteractions: toolNames.length > 0
+          ? toolNames.map((name) => ({ name }))
+          : undefined,
       };
       setMessages((prev) => [...prev, assistantMsg]);
 
@@ -410,6 +419,30 @@ export default function ChatPage() {
                       <p className="text-sm whitespace-pre-wrap">{msg.body}</p>
                     </div>
                   )}
+
+                  {msg.toolInteractions && msg.toolInteractions.length > 0 && (
+                    <div className="mt-2 space-y-1">
+                      {msg.toolInteractions.map((tool, i) => (
+                        <div
+                          key={i}
+                          className={`text-xs px-2 py-1 rounded ${
+                            msg.role === 'user'
+                              ? 'bg-white/10'
+                              : 'bg-panel'
+                          }`}
+                        >
+                          <span className="font-medium">Tool: </span>
+                          {String(tool['name'] ?? tool['tool'] ?? 'unknown')}
+                          {'result' in tool && (
+                            <span className="opacity-70">
+                              {' '}- {String(tool['result']).slice(0, 100)}
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
                   <p
                     className={`text-[10px] mt-1 ${
                       msg.role === 'user' ? 'text-white/60' : 'text-muted-foreground'


### PR DESCRIPTION
## Description
The Chat page loaded session history but discarded `tool_interactions` data that was already available from the API. This adds the same tool badges shown in the Conversations view to the Chat view, both for loaded history and for live messages received via SSE.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation authored with Claude Code.

Fixes #635