### PR TITLE
fix: use RLock to prevent deadlock in database singleton initialization

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -9,7 +9,7 @@ from .config import settings
 
 _engine: Engine | None = None
 _SessionLocal: sessionmaker[Session] | None = None
-_lock = threading.Lock()
+_lock = threading.RLock()
 
 
 def get_engine() -> Engine:


### PR DESCRIPTION
## Description

`get_engine()` and `get_session_factory()` in `backend/app/database.py` share the same `threading.Lock()`. When `SessionLocal()` is the first DB call (both singletons uninitialized), `get_session_factory()` acquires the lock then calls `get_engine()`, which tries to acquire the same non-reentrant lock, causing a deadlock.

This was masked in the OSS app because `_verify_database()` in the lifespan always pre-initializes `get_engine()`, but any consumer that calls `SessionLocal()` before `get_engine()` (e.g. clawbolt-premium) deadlocks on startup.

Fix: switch `threading.Lock()` to `threading.RLock()` (reentrant) so nested acquisition by the same thread succeeds.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude Code diagnosed the deadlock root cause through systematic middleware/request stack analysis and implemented the fix.