### PR TITLE
feat: consume OAuth refresh token from URL hash fragment

### DIFF
--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -5,6 +5,16 @@ let _accessToken: string | null = null;
 
 const REFRESH_TOKEN_KEY = 'clawbolt_refresh_token';
 
+// Consume refresh token from URL hash fragment (set by OAuth redirect).
+// This runs once at module load, before any auth checks.
+(function _consumeHashToken() {
+  const match = window.location.hash.match(/refresh_token=([^&]+)/);
+  if (match?.[1]) {
+    localStorage.setItem(REFRESH_TOKEN_KEY, match[1]);
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+})();
+
 function _getRefreshToken(): string | null {
   return localStorage.getItem(REFRESH_TOKEN_KEY);
 }


### PR DESCRIPTION
## Description
Add hash fragment consumer to `api-client.ts` that reads `#refresh_token=<token>` from the URL on page load, stores the token in localStorage, and cleans the URL. Required for the premium OAuth callback flow which redirects to `/app#refresh_token=<token>`.

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
  - Code written with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)