### PR TITLE
fix: include pdf_path in tool results for send_media_reply

### DIFF
--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -232,8 +232,8 @@ def create_estimate_tools(
             content=(
                 f"Estimate {estimate_number} generated for ${total_amount:,.2f}. "
                 f"{len(processed_items)} line item(s). "
-                f"PDF saved. "
-                f"Use send_media_reply to send it to the user."
+                f"PDF saved at {pdf_path}. "
+                f"Use send_media_reply with media_url={pdf_path} to send it to the user."
             )
         )
 

--- a/backend/app/agent/tools/invoice_tools.py
+++ b/backend/app/agent/tools/invoice_tools.py
@@ -228,7 +228,7 @@ def create_invoice_tools(
 
         # Generate and save PDF
         try:
-            await _generate_invoice_pdf_and_save(
+            pdf_path = await _generate_invoice_pdf_and_save(
                 user=user,
                 invoice_id=invoice_number,
                 description=description,
@@ -258,8 +258,8 @@ def create_invoice_tools(
             content=(
                 f"Invoice {invoice_number} generated for ${total_amount:,.2f}. "
                 f"{len(processed_items)} line item(s). "
-                f"PDF saved. "
-                f"Use send_media_reply to send it to the user."
+                f"PDF saved at {pdf_path}. "
+                f"Use send_media_reply with media_url={pdf_path} to send it to the user."
             )
         )
 
@@ -336,7 +336,7 @@ def create_invoice_tools(
 
         # Generate and save PDF
         try:
-            await _generate_invoice_pdf_and_save(
+            pdf_path = await _generate_invoice_pdf_and_save(
                 user=user,
                 invoice_id=invoice_number,
                 description=estimate.description,
@@ -367,8 +367,8 @@ def create_invoice_tools(
                 f"Invoice {invoice_number} created from estimate {estimate_id} "
                 f"for ${estimate.total_amount:,.2f}. "
                 f"{len(processed_items)} line item(s). "
-                f"PDF saved. "
-                f"Use send_media_reply to send it to the user."
+                f"PDF saved at {pdf_path}. "
+                f"Use send_media_reply with media_url={pdf_path} to send it to the user."
             )
         )
 


### PR DESCRIPTION
## Description

The `generate_estimate`, `generate_invoice`, and `convert_estimate_to_invoice` tools told the LLM to "Use send_media_reply to send it to the user" but did not include the actual file path. The LLM would guess a URL (without `http://` protocol), which failed the local file check in `telegram.py:send_media` and fell through to the HTTP download branch, causing `httpx.UnsupportedProtocol`.

Now the tool results include the concrete `pdf_path` so the LLM passes it correctly to `send_media_reply`, where it gets resolved as a local file.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

> Note: No regression test added because the existing estimate/invoice tests already assert `"PDF saved" in result.content` which continues to pass. The bug was in the LLM's interpretation of the tool result (missing path), not in code logic. A regression test would require mocking the full agent loop to verify the LLM receives the path.

## AI Usage
- [x] AI-assisted (Claude Opus 4.6 diagnosed the root cause from logs and wrote the fix)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)