### PR TITLE
fix: route MEMORY.md and HISTORY.md through MemoryDocument DB table

### DIFF
--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -5,8 +5,9 @@ directory (SOUL.md, USER.md, memory/, etc.), following the same pattern
 used by openclaw and nanobot.
 
 USER.md, SOUL.md, and HEARTBEAT.md are stored as columns on the User
-DB row and presented to the agent as virtual files. All other .md files
-(BOOTSTRAP.md, memory/*, etc.) are stored on disk.
+DB row and presented to the agent as virtual files. MEMORY.md and
+HISTORY.md are stored in the MemoryDocument table. All other .md files
+(BOOTSTRAP.md, etc.) are stored on disk.
 """
 
 from __future__ import annotations
@@ -22,7 +23,7 @@ from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTa
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
 from backend.app.database import SessionLocal
-from backend.app.models import User
+from backend.app.models import MemoryDocument, User
 
 if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
@@ -33,13 +34,19 @@ logger = logging.getLogger(__name__)
 _ALLOWED_EXTENSIONS = {".md"}
 
 # Files that cannot be deleted by the agent.
-_PROTECTED_FILES = {"USER.md", "SOUL.md", "HEARTBEAT.md"}
+_PROTECTED_FILES = {"USER.md", "SOUL.md", "HEARTBEAT.md", "MEMORY.md", "HISTORY.md"}
 
 # Files stored as DB columns on User rather than on disk.
 _DB_FILE_COLUMN: dict[str, str] = {
     "USER.md": "user_text",
     "SOUL.md": "soul_text",
     "HEARTBEAT.md": "heartbeat_text",
+}
+
+# Files stored in the MemoryDocument table (not User table).
+_MEMORY_DOC_COLUMN: dict[str, str] = {
+    "MEMORY.md": "memory_text",
+    "HISTORY.md": "history_text",
 }
 
 
@@ -144,6 +151,61 @@ def _canonical_name(relative_path: str) -> str | None:
     return name if name in _DB_FILE_COLUMN else None
 
 
+def _memory_doc_column(relative_path: str) -> str | None:
+    """Return the MemoryDocument column name if this path refers to a memory file.
+
+    Recognizes: "MEMORY.md", "memory/MEMORY.md", "./memory/MEMORY.md", etc.
+    """
+    try:
+        name = Path(relative_path).name
+    except (ValueError, OSError):
+        return None
+    if name not in _MEMORY_DOC_COLUMN:
+        return None
+    stripped = relative_path.lstrip("./")
+    if "/" in stripped:
+        parent = str(Path(stripped).parent)
+        if parent != "memory":
+            return None
+    return _MEMORY_DOC_COLUMN[name]
+
+
+def _memory_doc_read_sync(user_id: str, column: str) -> str:
+    """Read a MemoryDocument column (synchronous)."""
+    db = SessionLocal()
+    try:
+        doc = db.query(MemoryDocument).filter_by(user_id=user_id).first()
+        if doc is None:
+            return ""
+        return getattr(doc, column, "") or ""
+    finally:
+        db.close()
+
+
+async def _memory_doc_read(user_id: str, column: str) -> str:
+    """Read a MemoryDocument column."""
+    return await asyncio.to_thread(_memory_doc_read_sync, user_id, column)
+
+
+def _memory_doc_write_sync(user_id: str, column: str, content: str) -> None:
+    """Write a MemoryDocument column (synchronous)."""
+    from backend.app.database import db_session
+
+    with db_session() as db:
+        doc = db.query(MemoryDocument).filter_by(user_id=user_id).first()
+        if doc is None:
+            doc = MemoryDocument(user_id=user_id, memory_text="", history_text="")
+            db.add(doc)
+            db.flush()
+        setattr(doc, column, content)
+        db.commit()
+
+
+async def _memory_doc_write(user_id: str, column: str, content: str) -> None:
+    """Write a MemoryDocument column."""
+    await asyncio.to_thread(_memory_doc_write_sync, user_id, column, content)
+
+
 def create_workspace_tools(user_id: str) -> list[Tool]:
     """Create generic file tools scoped to the user's data directory."""
 
@@ -152,6 +214,11 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
         canon = _canonical_name(path)
         if canon:
             content = await _db_read(user_id, _DB_FILE_COLUMN[canon])
+            return ToolResult(content=content or "(empty)")
+
+        mem_col = _memory_doc_column(path)
+        if mem_col:
+            content = await _memory_doc_read(user_id, mem_col)
             return ToolResult(content=content or "(empty)")
 
         resolved, err = _resolve_path(user_id, path)
@@ -171,6 +238,11 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
         canon = _canonical_name(path)
         if canon:
             await _db_write(user_id, _DB_FILE_COLUMN[canon], content)
+            return ToolResult(content=f"Wrote {path}")
+
+        mem_col = _memory_doc_column(path)
+        if mem_col:
+            await _memory_doc_write(user_id, mem_col, content)
             return ToolResult(content=f"Wrote {path}")
 
         resolved, err = _resolve_path(user_id, path)
@@ -201,6 +273,26 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
                 )
             updated = text.replace(old_text, new_text, 1)
             await _db_write(user_id, column, updated)
+            return ToolResult(content=f"Updated {path}")
+
+        mem_col = _memory_doc_column(path)
+        if mem_col:
+            text = await _memory_doc_read(user_id, mem_col)
+            if old_text not in text:
+                return ToolResult(
+                    content=f"Text not found in {path}. Read the file first to see current contents.",
+                    is_error=True,
+                    error_kind=ToolErrorKind.NOT_FOUND,
+                )
+            count = text.count(old_text)
+            if count > 1:
+                return ToolResult(
+                    content=f"Found {count} matches in {path}. Provide more context to match uniquely.",
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
+            updated = text.replace(old_text, new_text, 1)
+            await _memory_doc_write(user_id, mem_col, updated)
             return ToolResult(content=f"Updated {path}")
 
         resolved, err = _resolve_path(user_id, path)

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -11,7 +11,7 @@ import backend.app.database as _db_module
 from backend.app.agent.tools.base import ToolResult
 from backend.app.agent.tools.workspace_tools import create_workspace_tools
 from backend.app.config import settings
-from backend.app.models import User
+from backend.app.models import MemoryDocument, User
 
 
 def _get_tool_fn(user_id: str, tool_name: str) -> Callable[..., Awaitable[ToolResult]]:
@@ -289,3 +289,114 @@ async def test_heartbeat_md_roundtrip(test_user: User) -> None:
     read_fn = _get_tool_fn(test_user.id, "read_file")
     result = await read_fn(path="HEARTBEAT.md")
     assert "Follow up with Jake" in result.content
+
+
+# --- MemoryDocument-backed virtual file tests (MEMORY.md, HISTORY.md) ---
+
+
+def _set_memory_doc(user_id: str, column: str, value: str) -> None:
+    """Set a column on MemoryDocument directly in the DB."""
+    db = _db_module.SessionLocal()
+    try:
+        doc = db.query(MemoryDocument).filter_by(user_id=user_id).first()
+        if doc is None:
+            doc = MemoryDocument(user_id=user_id, memory_text="", history_text="")
+            db.add(doc)
+            db.flush()
+        setattr(doc, column, value)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _get_memory_doc(user_id: str, column: str) -> str:
+    """Read a column from MemoryDocument in the DB."""
+    db = _db_module.SessionLocal()
+    try:
+        doc = db.query(MemoryDocument).filter_by(user_id=user_id).first()
+        if doc is None:
+            return ""
+        return getattr(doc, column, "") or ""
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio()
+async def test_read_memory_md_via_path(test_user: User) -> None:
+    """read_file('memory/MEMORY.md') should read from MemoryDocument.memory_text."""
+    _set_memory_doc(test_user.id, "memory_text", "- User prefers morning check-ins\n")
+
+    read_fn = _get_tool_fn(test_user.id, "read_file")
+    result = await read_fn(path="memory/MEMORY.md")
+    assert result.is_error is False
+    assert "morning check-ins" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_read_memory_md_top_level(test_user: User) -> None:
+    """read_file('MEMORY.md') should also read from MemoryDocument."""
+    _set_memory_doc(test_user.id, "memory_text", "- Has 3 active jobs\n")
+
+    read_fn = _get_tool_fn(test_user.id, "read_file")
+    result = await read_fn(path="MEMORY.md")
+    assert result.is_error is False
+    assert "3 active jobs" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_read_memory_md_empty(test_user: User) -> None:
+    """read_file('memory/MEMORY.md') should return '(empty)' when no MemoryDocument exists."""
+    read_fn = _get_tool_fn(test_user.id, "read_file")
+    result = await read_fn(path="memory/MEMORY.md")
+    assert result.is_error is False
+    assert result.content == "(empty)"
+
+
+@pytest.mark.asyncio()
+async def test_write_memory_md_via_path(test_user: User) -> None:
+    """write_file('memory/MEMORY.md') should write to MemoryDocument.memory_text."""
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="memory/MEMORY.md", content="- Rates: $85/hr\n")
+    assert result.is_error is False
+    assert "Wrote" in result.content
+    assert "Rates: $85/hr" in _get_memory_doc(test_user.id, "memory_text")
+
+
+@pytest.mark.asyncio()
+async def test_write_memory_md_creates_doc(test_user: User) -> None:
+    """write_file should create MemoryDocument if it doesn't exist yet."""
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    await write_fn(path="MEMORY.md", content="fresh memory")
+    assert "fresh memory" in _get_memory_doc(test_user.id, "memory_text")
+
+
+@pytest.mark.asyncio()
+async def test_edit_memory_md(test_user: User) -> None:
+    """edit_file should work on memory/MEMORY.md."""
+    _set_memory_doc(test_user.id, "memory_text", "- Rate: $85/hr\n- Hours: 8-5\n")
+
+    edit_fn = _get_tool_fn(test_user.id, "edit_file")
+    result = await edit_fn(path="memory/MEMORY.md", old_text="$85/hr", new_text="$100/hr")
+    assert result.is_error is False
+    assert "$100/hr" in _get_memory_doc(test_user.id, "memory_text")
+
+
+@pytest.mark.asyncio()
+async def test_history_md_roundtrip(test_user: User) -> None:
+    """HISTORY.md should read/write through MemoryDocument.history_text."""
+    _set_memory_doc(test_user.id, "history_text", "2026-03-18: Session compacted\n")
+
+    read_fn = _get_tool_fn(test_user.id, "read_file")
+    result = await read_fn(path="memory/HISTORY.md")
+    assert result.is_error is False
+    assert "Session compacted" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_delete_memory_md_protected(test_user: User) -> None:
+    """delete_file should reject MEMORY.md and HISTORY.md as protected files."""
+    delete_fn = _get_tool_fn(test_user.id, "delete_file")
+    for path in ("memory/MEMORY.md", "memory/HISTORY.md"):
+        result = await delete_fn(path=path)
+        assert result.is_error is True
+        assert "protected" in result.content.lower()


### PR DESCRIPTION
## Description

`read_file("memory/MEMORY.md")` was returning "File not found" because workspace_tools only had DB-backed virtual file support for USER.md, SOUL.md, and HEARTBEAT.md (stored as columns on the User model). MEMORY.md and HISTORY.md are stored in the separate `memory_documents` table, so they need their own read/write/edit path.

Adds `_MEMORY_DOC_COLUMN` mapping and corresponding DB helpers so that `read_file`, `write_file`, and `edit_file` correctly route memory paths to the MemoryDocument table. Also adds MEMORY.md and HISTORY.md to `_PROTECTED_FILES` to prevent deletion.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the bug, implemented the fix, and wrote regression tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)