### PR TITLE
fix: validate media URLs before sending and force JSON compaction output

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -42,6 +42,10 @@ def _format_messages_for_compaction(messages: list[AgentMessage]) -> str:
 def _parse_compaction_response(raw: str) -> tuple[str, str]:
     """Parse the LLM compaction response into a memory update and summary.
 
+    The assistant prefill starts the response with ``{``, so the raw text from
+    the LLM may be missing the leading brace.  We try the text as-is first,
+    then retry with a prepended ``{`` before giving up.
+
     Returns a tuple of (memory_update, summary_string).
     """
     text = raw.strip()
@@ -53,9 +57,16 @@ def _parse_compaction_response(raw: str) -> tuple[str, str]:
             text = text[:-3]
         text = text.strip()
 
-    try:
-        parsed = json.loads(text)
-    except json.JSONDecodeError:
+    # Try parsing as-is first, then with prepended "{" (from assistant prefill)
+    parsed = None
+    for candidate in (text, "{" + text):
+        try:
+            parsed = json.loads(candidate)
+            break
+        except json.JSONDecodeError:
+            continue
+
+    if parsed is None:
         logger.warning("Failed to parse compaction response as JSON: %s", text[:200])
         return "", ""
 
@@ -118,6 +129,9 @@ async def compact_session(
 
     messages: list[dict[str, Any]] = [
         {"role": "user", "content": "\n".join(user_prompt_parts)},
+        # Assistant prefill forces the model to produce JSON instead of
+        # continuing the conversation it just read.
+        {"role": "assistant", "content": "{"},
     ]
 
     try:

--- a/backend/app/agent/tools/estimate_tools.py
+++ b/backend/app/agent/tools/estimate_tools.py
@@ -24,7 +24,7 @@ from backend.app.services.storage_service import StorageBackend
 if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
 
-PDF_BASE_DIR = Path(settings.pdf_storage_dir)
+PDF_BASE_DIR = Path(settings.pdf_storage_dir).resolve()
 
 # ---------------------------------------------------------------------------
 # Pluggable estimate quota hooks (set by premium layer)

--- a/backend/app/agent/tools/invoice_tools.py
+++ b/backend/app/agent/tools/invoice_tools.py
@@ -23,7 +23,7 @@ from backend.app.services.storage_service import StorageBackend
 if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
 
-PDF_BASE_DIR = Path(settings.pdf_storage_dir)
+PDF_BASE_DIR = Path(settings.pdf_storage_dir).resolve()
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -49,6 +49,8 @@ def create_messaging_tools(
 
     async def send_media_reply(message: str, media_url: str) -> ToolResult:
         """Send a reply with a media attachment."""
+        from pathlib import Path
+
         from backend.app.bus import OutboundMessage as OMsg
 
         if not media_url or not media_url.strip():
@@ -57,7 +59,19 @@ def create_messaging_tools(
                 is_error=True,
                 error_kind=ToolErrorKind.VALIDATION,
             )
-        outbound = OMsg(channel=channel, chat_id=to_address, content=message, media=[media_url])
+        url = media_url.strip()
+        is_url = url.startswith("http://") or url.startswith("https://")
+        is_local_file = Path(url).is_file()
+        if not is_url and not is_local_file:
+            return ToolResult(
+                content=(
+                    f"Error: media_url '{url}' is not a valid URL (must start with "
+                    f"http:// or https://) and does not exist as a local file."
+                ),
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        outbound = OMsg(channel=channel, chat_id=to_address, content=message, media=[url])
         await publish_outbound(outbound)
         return ToolResult(content="Sent media message")
 

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -347,7 +347,7 @@ class TelegramChannel(BaseChannel):
             data = await asyncio.to_thread(local_path.read_bytes)
             content_type = mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
             filename = local_path.name
-        else:
+        elif media_url.startswith("http://") or media_url.startswith("https://"):
             async with httpx.AsyncClient() as client:
                 resp = await client.get(
                     media_url, follow_redirects=True, timeout=settings.http_timeout_seconds
@@ -359,6 +359,12 @@ class TelegramChannel(BaseChannel):
                 ext = mimetypes.guess_extension(content_type) or ".bin"
                 filename = f"file{ext}"
                 data = resp.content
+        else:
+            msg = (
+                f"Cannot send media: '{media_url}' is not a reachable local file "
+                f"and is not a valid URL (missing http:// or https:// protocol)"
+            )
+            raise ValueError(msg)
 
         if content_type.startswith("image/"):
             msg = await self.bot.send_photo(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -87,7 +87,7 @@ class Settings(BaseSettings):
     compaction_enabled: bool = True
     compaction_model: str = ""  # empty = fall back to llm_model
     compaction_provider: str = ""  # empty = fall back to llm_provider
-    compaction_max_tokens: int = Field(default=500, ge=1)
+    compaction_max_tokens: int = Field(default=1500, ge=1)
 
     # Rate limiting
     webhook_rate_limit_max_requests: int = Field(default=30, ge=1)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -122,6 +122,22 @@ def test_parse_markdown_fenced_json() -> None:
     assert summary == "A summary."
 
 
+def test_parse_prefilled_response() -> None:
+    """Should parse a response missing the leading '{' from assistant prefill."""
+    # The assistant prefill starts with "{", so the LLM response may omit it
+    inner = json.dumps(
+        {
+            "memory_update": "## Notes\n- Prefers 8am starts",
+            "summary": "[TIMESTAMP] Scheduling preferences.",
+        }
+    )
+    # Strip the leading "{" to simulate what the LLM returns after prefill
+    raw_without_brace = inner.lstrip("{")
+    memory_update, summary = _parse_compaction_response(raw_without_brace)
+    assert "8am starts" in memory_update
+    assert summary == "[TIMESTAMP] Scheduling preferences."
+
+
 def test_parse_invalid_json() -> None:
     """Invalid JSON should return empty strings without raising."""
     memory_update, summary = _parse_compaction_response("not json at all")
@@ -168,10 +184,12 @@ async def test_compact_session_rewrites_memory(test_user: UserData) -> None:
     content = store.read_memory()
     assert "Deck: $45/sqft" in content
 
-    # Verify LLM was called with the system prompt
+    # Verify LLM was called with the system prompt and assistant prefill
     mock_llm.assert_called_once()
     call_kwargs = mock_llm.call_args
     assert call_kwargs.kwargs.get("system") == COMPACTION_SYSTEM_PROMPT
+    llm_messages = call_kwargs.kwargs["messages"]
+    assert llm_messages[-1] == {"role": "assistant", "content": "{"}
 
 
 @pytest.mark.asyncio()

--- a/tests/test_messaging_tools.py
+++ b/tests/test_messaging_tools.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -79,3 +80,48 @@ async def test_send_media_reply_tool(publish_outbound: AsyncMock) -> None:
     assert msg.content == "Here's your estimate"
     assert msg.media == ["https://example.com/estimate.pdf"]
     assert msg.channel == "telegram"
+
+
+@pytest.mark.asyncio()
+async def test_send_media_reply_accepts_local_file(
+    publish_outbound: AsyncMock,
+    tmp_path: Path,
+) -> None:
+    """send_media_reply should accept a local file path that exists."""
+    pdf = tmp_path / "estimate.pdf"
+    pdf.write_bytes(b"%PDF-1.4 test")
+
+    tools = create_messaging_tools(publish_outbound, channel="telegram", to_address="123456789")
+    send_media_reply = tools[1].function
+    result = await send_media_reply(message="Here's your estimate", media_url=str(pdf))
+    assert result.is_error is False
+    assert "Sent media message" in result.content
+    publish_outbound.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_send_media_reply_rejects_invalid_url(publish_outbound: AsyncMock) -> None:
+    """send_media_reply should reject a URL without protocol that isn't a local file."""
+    tools = create_messaging_tools(publish_outbound, channel="telegram", to_address="123456789")
+    send_media_reply = tools[1].function
+    result = await send_media_reply(
+        message="Here's your file",
+        media_url="data/estimates/nonexistent/EST-0001.pdf",
+    )
+    assert result.is_error is True
+    assert "not a valid URL" in result.content
+    publish_outbound.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_send_media_reply_rejects_bare_domain(publish_outbound: AsyncMock) -> None:
+    """send_media_reply should reject a URL like 'example.com/file.pdf' (no protocol)."""
+    tools = create_messaging_tools(publish_outbound, channel="telegram", to_address="123456789")
+    send_media_reply = tools[1].function
+    result = await send_media_reply(
+        message="Here's your file",
+        media_url="example.com/estimate.pdf",
+    )
+    assert result.is_error is True
+    assert "not a valid URL" in result.content
+    publish_outbound.assert_not_called()

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -112,6 +112,19 @@ async def test_send_media_document(
 
 
 @pytest.mark.asyncio()
+async def test_send_media_rejects_invalid_url(
+    telegram_service: TelegramChannel,
+) -> None:
+    """send_media should raise ValueError for a URL without protocol that isn't a local file."""
+    with pytest.raises(ValueError, match="not a reachable local file"):
+        await telegram_service.send_media(
+            to="123456789",
+            body="Here is the file",
+            media_url="data/estimates/nonexistent/EST-0001.pdf",
+        )
+
+
+@pytest.mark.asyncio()
 async def test_send_message_text_only(
     telegram_service: TelegramChannel, mock_bot: MagicMock
 ) -> None:


### PR DESCRIPTION
## Description

Two bugs fixed:

- **send_media_reply URL validation**: The tool accepted any string as `media_url`, published it to the message bus, and returned "Sent media message" before the actual send happened. The Telegram channel then failed asynchronously with `httpx.UnsupportedProtocol` and the LLM never learned the send failed. Now:
  - The tool validates `media_url` is either a valid URL (http/https) or an existing local file, returning a tool error so the LLM can self-correct
  - `telegram.py:send_media` raises `ValueError` instead of crashing with `UnsupportedProtocol`
  - Estimate and invoice tools use absolute PDF paths (`Path.resolve()`) so `is_file()` works regardless of working directory

- **Compaction JSON parsing**: The LLM sometimes returned conversational text instead of JSON because it continued the conversation it was asked to summarize. Now:
  - An assistant prefill message (`{`) forces the model to produce JSON
  - The parser handles the prefilled brace by trying both raw text and `{` + text
  - `compaction_max_tokens` increased from 500 to 1500 to avoid truncated JSON

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified both bugs, implemented fixes, and wrote regression tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)