### PR TITLE
fix: preserve pre-downloaded media in webchat image attach

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -349,10 +349,25 @@ async def persist_outbound(
 
 
 async def prepare_media_step(ctx: PipelineContext) -> PipelineContext:
-    """Download media and initialize storage backend."""
-    ctx.downloaded_media, ctx.storage = await prepare_media(
+    """Download media and initialize storage backend.
+
+    Preserves any already-downloaded media on the context (e.g. webchat
+    file uploads) and merges them with newly downloaded media from
+    ``media_urls`` (e.g. Telegram file-id references).
+    """
+    pre_downloaded = list(ctx.downloaded_media)
+    newly_downloaded, ctx.storage = await prepare_media(
         ctx.user, ctx.message, ctx.media_urls, download_media=ctx.download_media
     )
+    ctx.downloaded_media = pre_downloaded + newly_downloaded
+
+    # Auto-save pre-downloaded media (webchat uploads) to storage
+    if ctx.storage and pre_downloaded:
+        try:
+            await auto_save_media(ctx.user, ctx.storage, pre_downloaded)
+        except Exception:
+            logger.debug("Auto-save pre-downloaded media failed, continuing")
+
     return ctx
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from backend.app.agent.router import (
@@ -17,6 +19,7 @@ from backend.app.agent.router import (
     run_agent_step,
     run_pipeline,
 )
+from backend.app.media.download import DownloadedMedia
 
 
 @pytest.mark.asyncio
@@ -205,3 +208,43 @@ async def test_pipeline_step_can_mutate_context() -> None:
     )
 
     await run_pipeline(ctx, [set_context, check_context])
+
+
+@pytest.mark.asyncio
+async def test_prepare_media_step_preserves_pre_downloaded_media() -> None:
+    """prepare_media_step must not discard already-downloaded media.
+
+    Webchat uploads arrive as pre-populated ``downloaded_media`` on the
+    context (no ``media_urls``). Before the fix, the step overwrote
+    ``ctx.downloaded_media`` with the empty result of ``prepare_media()``,
+    silently dropping webchat image uploads.
+
+    Regression test for https://github.com/mozilla-ai/clawbolt/issues/664
+    """
+    from unittest.mock import AsyncMock
+
+    pre_downloaded = DownloadedMedia(
+        content=b"fake-image-bytes",
+        mime_type="image/png",
+        original_url="upload://photo.png",
+        filename="photo.png",
+    )
+
+    ctx = PipelineContext(
+        user=None,  # type: ignore[arg-type]
+        session=None,  # type: ignore[arg-type]
+        message=None,  # type: ignore[arg-type]
+        media_urls=[],
+        channel="webchat",
+        downloaded_media=[pre_downloaded],
+    )
+
+    with patch(
+        "backend.app.agent.router.prepare_media",
+        new_callable=AsyncMock,
+        return_value=([], None),
+    ):
+        result = await prepare_media_step(ctx)
+
+    assert len(result.downloaded_media) == 1
+    assert result.downloaded_media[0] is pre_downloaded


### PR DESCRIPTION
## Description
`prepare_media_step` unconditionally overwrote `ctx.downloaded_media` with the result of `prepare_media()`, which only downloads from `media_urls` (Telegram file-id refs). For webchat uploads, `media_urls` is empty and the pre-populated `DownloadedMedia` objects were silently discarded, causing image/file attachments to never reach the vision/audio pipeline.

Now saves pre-downloaded media before calling `prepare_media()` and merges both lists, so webchat uploads and Telegram downloads both flow through correctly.

Fixes #664

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code authored the fix and regression test)
- [ ] No AI used