### PR TITLE
fix: resolve premium webchat user identity mismatch

### DIFF
--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -102,9 +102,7 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
         if route:
             user = db.query(User).filter_by(id=route.user_id).first()
             if user is not None:
-                logger.debug(
-                    "_get_or_create_user: found via channel route -> user %s", user.id
-                )
+                logger.debug("_get_or_create_user: found via channel route -> user %s", user.id)
                 db.expunge(user)
                 return user
 
@@ -115,9 +113,7 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
         all_users = db.query(User).all()
         if len(all_users) == 1 and not settings.premium_plugin:
             user = all_users[0]
-            logger.debug(
-                "_get_or_create_user: single-tenant reuse -> user %s", user.id
-            )
+            logger.debug("_get_or_create_user: single-tenant reuse -> user %s", user.id)
             db.add(ChannelRoute(user_id=user.id, channel=channel, channel_identifier=sender_id))
             user.channel_identifier = sender_id
             user.preferred_channel = channel

--- a/tests/integration/test_dashboard_telegram.py
+++ b/tests/integration/test_dashboard_telegram.py
@@ -358,9 +358,7 @@ class TestPremiumWebchatIdentity:
             "backend.app.agent.ingestion.settings.premium_plugin",
             "clawbolt_premium.plugin",
         ):
-            asyncio.get_event_loop().run_until_complete(
-                _get_or_create_user("webchat", original_id)
-            )
+            asyncio.get_event_loop().run_until_complete(_get_or_create_user("webchat", original_id))
 
         # A ChannelRoute should now exist
         db = _db_module.SessionLocal()


### PR DESCRIPTION
## Description

In premium mode, webchat sends `sender_id = user.id` (the UUID PK), but `_get_or_create_user` had no path to match `sender_id` against existing user PKs. The single-tenant reuse was skipped (`premium_plugin` set), so a phantom duplicate user was created. Messages were persisted under the phantom user and invisible to the JWT-authenticated user's session fetches, causing messages to "disappear" after sending.

**Fix:** Adds a PK-match lookup (`User.id == sender_id`) before the new-user-creation path. When the webchat's sender_id matches an existing user's PK, that user is reused and a `ChannelRoute` is created for future fast lookups.

**Logging:** Adds DEBUG-level logging to every code path in `_get_or_create_user` and `process_inbound_from_bus` so identity resolution issues are immediately visible in logs.

**Tests:** 4 regression tests in `TestPremiumWebchatIdentity`:
- `test_webchat_reuses_existing_user_by_pk`: sender_id = user PK resolves to existing user, no duplicate
- `test_webchat_creates_channel_route`: PK match creates a ChannelRoute for future lookups
- `test_webchat_second_message_uses_channel_route`: subsequent messages hit the fast route path
- `test_premium_skips_single_tenant_reuse`: new senders in premium mode still get their own user

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (root cause analysis, fix, regression tests, and logging added with Claude Code)
- [ ] No AI used