### PR TITLE
feat: add reasoning effort control for LLM calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ TELEGRAM_ALLOWED_USERNAMES=
 LLM_PROVIDER=
 LLM_MODEL=
 # LLM_API_BASE=              # Custom API base URL (e.g. http://localhost:1234/v1 for LM Studio)
+# REASONING_EFFORT=auto      # none, minimal, low, medium, high, xhigh, auto
 # VISION_MODEL=              # empty = fall back to LLM_MODEL
 # VISION_PROVIDER=           # empty = fall back to LLM_PROVIDER
 

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -22,6 +22,7 @@ from backend.app.agent.memory_db import get_memory_store
 from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
 from backend.app.agent.prompts import load_prompt
 from backend.app.config import settings
+from backend.app.services.llm_service import reasoning_effort_to_thinking
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +145,7 @@ async def compact_session(
                 system=COMPACTION_SYSTEM_PROMPT,
                 messages=messages,
                 max_tokens=settings.compaction_max_tokens,
+                thinking=reasoning_effort_to_thinking(settings.reasoning_effort),
             ),
         )
     except Exception:

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -60,6 +60,7 @@ from backend.app.agent.tools.registry import ToolContext, ToolRegistry
 from backend.app.agent.trimming import trim_messages
 from backend.app.config import settings
 from backend.app.models import User
+from backend.app.services.llm_service import reasoning_effort_to_thinking
 from backend.app.services.llm_usage import log_llm_usage
 
 logger = logging.getLogger(__name__)
@@ -321,6 +322,7 @@ class ClawboltAgent:
         effective_max_tokens = max_tokens or settings.llm_max_tokens_agent
         system, msg_dicts = messages_to_messages_api(messages)
         tool_count = len(tool_schemas) if tool_schemas else 0
+        thinking = reasoning_effort_to_thinking(settings.reasoning_effort)
         logger.debug(
             "Calling LLM: model=%s provider=%s messages=%d tools=%d max_tokens=%d",
             settings.llm_model,
@@ -341,6 +343,7 @@ class ClawboltAgent:
                         messages=msg_dicts,
                         tools=tool_schemas,
                         max_tokens=effective_max_tokens,
+                        thinking=thinking,
                         **llm_kwargs,
                     ),
                 )
@@ -376,6 +379,7 @@ class ClawboltAgent:
                         messages=trimmed_dicts,
                         tools=tool_schemas,
                         max_tokens=effective_max_tokens,
+                        thinking=thinking,
                         **llm_kwargs,
                     ),
                 )

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -35,6 +35,7 @@ from backend.app.config import settings
 from backend.app.database import SessionLocal
 from backend.app.enums import MessageDirection
 from backend.app.models import ChannelRoute, User
+from backend.app.services.llm_service import reasoning_effort_to_thinking
 from backend.app.services.llm_usage import log_llm_usage
 
 logger = logging.getLogger(__name__)
@@ -336,6 +337,7 @@ async def evaluate_heartbeat_need(
             ],
             tools=[HEARTBEAT_DECISION_TOOL],
             max_tokens=settings.llm_max_tokens_heartbeat,
+            thinking=reasoning_effort_to_thinking(settings.reasoning_effort),
         ),
     )
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -57,6 +57,7 @@ class Settings(BaseSettings):
     llm_api_base: str | None = None
     vision_model: str = ""  # empty = fall back to llm_model
     vision_provider: str = ""  # empty = fall back to llm_provider
+    reasoning_effort: str = "auto"  # none, minimal, low, medium, high, xhigh, auto
     llm_max_tokens_agent: int = Field(default=500, ge=1)
     llm_max_tokens_heartbeat: int = Field(default=300, ge=1)
     llm_max_tokens_vision: int = Field(default=1000, ge=1)
@@ -148,6 +149,7 @@ PERSISTABLE_SETTINGS: frozenset[str] = frozenset(
         "heartbeat_provider",
         "compaction_model",
         "compaction_provider",
+        "reasoning_effort",
     }
 )
 

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -7,6 +7,7 @@ from any_llm.types.messages import MessageResponse
 
 from backend.app.agent.llm_parsing import get_response_text
 from backend.app.config import settings
+from backend.app.services.llm_service import reasoning_effort_to_thinking
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +62,7 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
                 {"role": "user", "content": user_content},
             ],
             max_tokens=settings.llm_max_tokens_vision,
+            thinking=reasoning_effort_to_thinking(settings.reasoning_effort),
         ),
     )
     logger.debug("Vision LLM response received for mime_type=%s", mime_type)

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -142,6 +142,7 @@ def _build_model_config_response() -> ModelConfigResponse:
         heartbeat_provider=settings.heartbeat_provider,
         compaction_model=settings.compaction_model,
         compaction_provider=settings.compaction_provider,
+        reasoning_effort=settings.reasoning_effort,
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -137,6 +137,7 @@ class ModelConfigResponse(BaseModel):
     heartbeat_provider: str
     compaction_model: str
     compaction_provider: str
+    reasoning_effort: str
 
 
 class ModelConfigUpdate(BaseModel):
@@ -149,6 +150,7 @@ class ModelConfigUpdate(BaseModel):
     heartbeat_provider: str | None = None
     compaction_model: str | None = None
     compaction_provider: str | None = None
+    reasoning_effort: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -2,9 +2,40 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from any_llm import LLMProvider, alist_models
 
 from backend.app.schemas import ProviderInfo
+
+# Valid reasoning effort levels (matches any_llm.types.completion.ReasoningEffort).
+REASONING_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh", "auto")
+
+# Maps reasoning effort level to thinking budget tokens for the Messages API.
+_EFFORT_TO_BUDGET: dict[str, int] = {
+    "minimal": 1024,
+    "low": 2048,
+    "medium": 8192,
+    "high": 24576,
+    "xhigh": 32768,
+}
+
+
+def reasoning_effort_to_thinking(effort: str) -> dict[str, Any] | None:
+    """Convert a reasoning effort level to a Messages API ``thinking`` dict.
+
+    Returns ``None`` for ``"auto"`` (provider default) so callers can skip
+    the parameter entirely.
+    """
+    if not effort or effort == "auto":
+        return None
+    if effort == "none":
+        return {"type": "disabled"}
+    budget = _EFFORT_TO_BUDGET.get(effort)
+    if budget is not None:
+        return {"type": "enabled", "budget_tokens": budget}
+    return None
+
 
 # Providers that run locally (no API key needed).
 _LOCAL_PROVIDERS = {"ollama", "llamafile", "llamacpp", "lmstudio", "vllm"}

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -36,6 +36,7 @@ All available settings are listed in `.env.example` with defaults and comments. 
 | `LLM_PROVIDER` | (required) | LLM provider name (any provider supported by [any-llm](https://github.com/mozilla-ai/any-llm)) |
 | `LLM_MODEL` | (required) | Model to use for the agent loop |
 | `LLM_API_BASE` | (none) | Custom API base URL (e.g. `http://localhost:1234/v1` for LM Studio) |
+| `REASONING_EFFORT` | `auto` | Reasoning effort level: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `auto` |
 | `VISION_MODEL` | (same as `LLM_MODEL`) | Model to use for image/document analysis. Falls back to `LLM_MODEL` if not set |
 | `VISION_PROVIDER` | (same as `LLM_PROVIDER`) | Provider for the vision model. Falls back to `LLM_PROVIDER` if not set |
 | `ANY_LLM_KEY` | | [any-llm.ai](https://any-llm.ai) managed platform key (replaces individual provider keys) |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1005,6 +1005,10 @@
           "compaction_provider": {
             "type": "string",
             "title": "Compaction Provider"
+          },
+          "reasoning_effort": {
+            "type": "string",
+            "title": "Reasoning Effort"
           }
         },
         "type": "object",
@@ -1017,7 +1021,8 @@
           "heartbeat_model",
           "heartbeat_provider",
           "compaction_model",
-          "compaction_provider"
+          "compaction_provider",
+          "reasoning_effort"
         ],
         "title": "ModelConfigResponse"
       },
@@ -1121,6 +1126,17 @@
               }
             ],
             "title": "Compaction Provider"
+          },
+          "reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Effort"
           }
         },
         "type": "object",

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -491,6 +491,8 @@ export interface components {
             compaction_model: string;
             /** Compaction Provider */
             compaction_provider: string;
+            /** Reasoning Effort */
+            reasoning_effort: string;
         };
         /** ModelConfigUpdate */
         ModelConfigUpdate: {
@@ -512,6 +514,8 @@ export interface components {
             compaction_model?: string | null;
             /** Compaction Provider */
             compaction_provider?: string | null;
+            /** Reasoning Effort */
+            reasoning_effort?: string | null;
         };
         /** OAuthAuthorizeResponse */
         OAuthAuthorizeResponse: {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -205,6 +205,16 @@ function ProviderModelPicker({
   );
 }
 
+const REASONING_EFFORT_OPTIONS = [
+  { value: 'auto', label: 'Auto (provider default)' },
+  { value: 'none', label: 'None' },
+  { value: 'minimal', label: 'Minimal' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'Extra High' },
+] as const;
+
 function ModelTab() {
   const { data: config, isLoading } = useModelConfig();
   const updateConfig = useUpdateModelConfig();
@@ -220,6 +230,7 @@ function ModelTab() {
     heartbeat_provider: '',
     compaction_model: '',
     compaction_provider: '',
+    reasoning_effort: 'auto',
   });
 
   useEffect(() => {
@@ -234,6 +245,7 @@ function ModelTab() {
         heartbeat_provider: config.heartbeat_provider,
         compaction_model: config.compaction_model,
         compaction_provider: config.compaction_provider,
+        reasoning_effort: config.reasoning_effort,
       });
     }
   }, [config]);
@@ -252,6 +264,7 @@ function ModelTab() {
         heartbeat_provider: form.heartbeat_provider,
         compaction_model: form.compaction_model,
         compaction_provider: form.compaction_provider,
+        reasoning_effort: form.reasoning_effort,
       },
       {
         onSuccess: () => toast.success('Model settings saved'),
@@ -277,6 +290,19 @@ function ModelTab() {
           onApiBaseChange={(v) => set('llm_api_base', v)}
           showApiBase
         />
+        <Field label="Reasoning Effort">
+          <Select
+            value={form.reasoning_effort}
+            onChange={(e) => set('reasoning_effort', e.target.value)}
+          >
+            {REASONING_EFFORT_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </Select>
+          <p className="text-xs text-muted-foreground mt-1">
+            Controls how much reasoning the model uses. Higher values produce more thorough responses but use more tokens.
+          </p>
+        </Field>
       </Card>
 
       <Card>


### PR DESCRIPTION
## Description

Adds a configurable reasoning effort setting that controls how much reasoning/thinking the LLM uses across all call sites. The setting maps to the any-llm SDK's `ReasoningEffort` levels and is converted to the Messages API `thinking` parameter.

**Backend:**
- New `REASONING_EFFORT` setting (default: `auto`) with values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `auto`
- `reasoning_effort_to_thinking()` helper converts the setting to a Messages API `thinking` dict with appropriate `budget_tokens`
- Applied to all 4 LLM call sites: agent core, heartbeat, vision, compaction
- Persistable via `config.json` and configurable through the model config API

**Frontend:**
- Reasoning effort dropdown added to the Primary Model card in Settings > Model tab

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)