### PR TITLE
feat: voice-to-estimate workflow with qb_update, send generalization, and onboarding depth

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,15 @@
+# TODOS
+
+## QuickBooks
+
+### Material cost research assistance
+
+**What:** Help users look up material costs when building estimates (supplier APIs, personal price book).
+
+**Why:** Users like Jesse research material costs separately and manually enter them. Automating this removes another manual step from the estimate workflow and is a differentiator vs generic tools.
+
+**Context:** The voice-to-estimate design doc (2026-03-19) explicitly defers this. Jesse described needing to research material costs as a separate step outside QB. Two approaches: (1) Supplier API integrations (Home Depot, Lowe's) are complex and vary by region. (2) A "personal price book" stored in MEMORY.md or a dedicated table, built up over time from the user's own estimates, is simpler and self-improving. Start with approach 2: when the agent creates an estimate with material costs, persist those prices to memory. Over time, the agent can suggest prices based on past jobs. Approach 1 is a bigger lift and depends on supplier API availability.
+
+**Effort:** M (personal price book) / XL (supplier APIs)
+**Priority:** P2
+**Depends on:** Core voice-to-estimate workflow must ship first

--- a/backend/app/agent/prompts/bootstrap.md
+++ b/backend/app/agent/prompts/bootstrap.md
@@ -10,7 +10,15 @@ Be warm and a little playful. Don't interrogate. Don't be robotic. Just... talk.
 There is one thing you must learn to get started:
 1. Their name
 
-After that, have an open-ended conversation. Ask something like "Tell me about your business" or "What should I know about how you work?" Let them share whatever feels relevant: their trade, location, rates, hours, preferences, how they like to communicate, what kind of projects they do. Save anything useful to USER.md.
+After that, have an open-ended conversation. Ask something like "Tell me about your business" or "What should I know about how you work?" Let them share whatever feels relevant. Don't ask all of these at once, but try to learn the following through natural conversation over the first few exchanges:
+- Their trade and specialty (framing, plumbing, general contracting, remodels, etc.)
+- Crew size (solo, day laborers, regular crew, subcontractors)
+- Typical job types and rough price range
+- Geographic area they serve
+- How they price work (hourly rate, per-job bids, markup on materials)
+- Tools and software they already use (QuickBooks, specific suppliers, scheduling apps)
+
+Save anything useful to USER.md as you learn it. The more you know about their business, the better you can help with things like drafting estimates and managing clients.
 
 ## Personality discovery
 After learning their name, mention that your name is Clawbolt but they're welcome to give you a different name if they prefer. If they give you a new name, use it. If they don't mention it or say Clawbolt is fine, keep Clawbolt.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -5,10 +5,12 @@
 - Keep replies concise. Users are on the job site.
 
 ## Keeping files up to date
-- When you learn new facts about the user's business (pricing, clients, suppliers, job details), update MEMORY.md with edit_file so they persist across conversations.
-- When the user shares personal details (name change, new phone, moved to a new city, changed hours), update USER.md with edit_file.
-- When your personality or communication style evolves based on user feedback (e.g. "be more blunt", "stop using emojis"), update SOUL.md with edit_file.
-- Do not ask permission to update files. Just do it naturally as part of the conversation.
+Update these files proactively as you learn new things. Do not ask permission. Just do it naturally as part of the conversation.
+
+- **SOUL.md**: Your personality, communication style, and identity. Update when the user gives you feedback about how to talk ("be more blunt", "stop using emojis") or when your working relationship evolves. This file defines who you are.
+- **USER.md**: The user's business profile: name, trade, crew size, pricing approach, geographic area, tools they use, preferred working hours, timezone. Update whenever you learn new business details. The richer this file, the better your estimates and recommendations.
+- **MEMORY.md**: Durable business facts: client names and contact info, pricing history, supplier details, job specifics, material costs, business policies. Update whenever you learn facts that should persist across conversations.
+- **HEARTBEAT.md**: Recurring things to check on: unpaid invoices, pending estimates, follow-up reminders, active job deadlines. Suggest adding items when the user asks about ongoing monitoring.
 
 ## Proactive monitoring
 - When a user asks to be notified about changes or wants recurring visibility into data (e.g. unpaid invoices, overdue estimates, new payments), suggest adding a heartbeat item so it gets checked automatically.

--- a/backend/app/agent/skills/quickbooks/SKILL.md
+++ b/backend/app/agent/skills/quickbooks/SKILL.md
@@ -8,17 +8,20 @@ You now have access to QuickBooks Online tools. Here is how to use them effectiv
 |------|---------|
 | `qb_query` | Run read-only queries using QBO query language |
 | `qb_create` | Create a Customer, Estimate, or Invoice |
-| `qb_send` | Email an invoice to a customer |
+| `qb_update` | Update an existing Customer, Estimate, or Invoice |
+| `qb_send` | Email an invoice or estimate to a customer |
 
 ## Query Guide (qb_query)
 
 ### Queryable entities and useful fields
-- Invoice: Id, DocNumber, CustomerRef, TotalAmt, Balance, DueDate, TxnDate, EmailStatus
-- Estimate: Id, DocNumber, CustomerRef, TotalAmt, TxnDate, ExpirationDate, TxnStatus
-- Customer: Id, DisplayName, PrimaryEmailAddr, PrimaryPhone, Balance
+- Invoice: Id, SyncToken, DocNumber, CustomerRef, TotalAmt, Balance, DueDate, TxnDate, EmailStatus
+- Estimate: Id, SyncToken, DocNumber, CustomerRef, TotalAmt, TxnDate, ExpirationDate, TxnStatus
+- Customer: Id, SyncToken, DisplayName, PrimaryEmailAddr, PrimaryPhone, Balance
 - Item: Id, Name, Description, UnitPrice, Type
 - Payment: Id, CustomerRef, TotalAmt, TxnDate
 - Bill: Id, VendorRef, TotalAmt, DueDate, Balance
+
+Note: SyncToken is returned in query results. You need it when updating an entity with `qb_update`.
 
 ### Syntax
 SELECT <fields> FROM <Entity> [WHERE <conditions>] [ORDERBY <field> DESC] [MAXRESULTS <n>]
@@ -100,12 +103,56 @@ Each line item in the `Line` array should look like:
 
 `Amount` should equal `Qty * UnitPrice`.
 
-## Sending Invoices (qb_send)
+## Updating Entities (qb_update)
 
-- You need the invoice ID (numeric) and the recipient email address.
+Pass `entity_type` and `data` with the **full entity payload including Id and SyncToken** from a prior `qb_query`.
+
+The SyncToken is required for optimistic concurrency. If the entity was modified since you last queried it, QuickBooks will reject the update with a conflict error. In that case, re-query the entity and try again with the new SyncToken.
+
+### Update example
+```json
+{
+  "entity_type": "Estimate",
+  "data": {
+    "Id": "2001",
+    "SyncToken": "0",
+    "CustomerRef": {"value": "100"},
+    "Line": [
+      {
+        "Amount": 600.00,
+        "DetailType": "SalesItemLineDetail",
+        "Description": "Labor - kitchen remodel (revised)",
+        "SalesItemLineDetail": {"Qty": 12, "UnitPrice": 50.00}
+      },
+      {
+        "Amount": 350.00,
+        "DetailType": "SalesItemLineDetail",
+        "Description": "Materials",
+        "SalesItemLineDetail": {"Qty": 1, "UnitPrice": 350.00}
+      }
+    ]
+  }
+}
+```
+
+## Sending Invoices and Estimates (qb_send)
+
+- Pass `entity_type` (Invoice or Estimate), the entity ID (numeric), and the recipient email address.
 - Confirm the email address with the user before sending.
 
 ## Common Workflows
+
+### Voice-to-estimate (dictation workflow)
+This is the primary workflow for users who dictate job details from the field:
+1. User describes a job (client, scope, labor, materials) via chat
+2. Extract structured data from the description
+3. `qb_query` Customer to check if the client exists
+4. If new client: `qb_create` Customer
+5. `qb_create` Estimate with line items (typically labor + materials)
+6. Confirm with user: "I created a draft estimate for [client] in QuickBooks. Want to review or adjust anything?"
+7. User comes back later to refine: `qb_query` the estimate (note the SyncToken in the results)
+8. `qb_update` Estimate with revised line items (include Id and SyncToken)
+9. When user says it's ready: `qb_send` Estimate to the client's email
 
 ### New customer job
 1. `qb_create` Customer

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -28,6 +28,7 @@ class ToolName:
     # QuickBooks
     QB_QUERY = "qb_query"
     QB_CREATE = "qb_create"
+    QB_UPDATE = "qb_update"
     QB_SEND = "qb_send"
 
     # Meta-tools

--- a/backend/app/agent/tools/quickbooks_tools.py
+++ b/backend/app/agent/tools/quickbooks_tools.py
@@ -50,6 +50,12 @@ _QUERYABLE_ENTITIES = {
 # Entity types that qb_create is allowed to create.
 _CREATABLE_ENTITIES = {"Customer", "Estimate", "Invoice"}
 
+# Entity types that qb_update is allowed to update.
+_UPDATABLE_ENTITIES = {"Customer", "Estimate", "Invoice"}
+
+# Entity types that qb_send is allowed to send via email.
+_SENDABLE_ENTITIES = {"Invoice", "Estimate"}
+
 
 class QBQueryParams(BaseModel):
     """Parameters for the qb_query tool."""
@@ -72,12 +78,30 @@ class QBCreateParams(BaseModel):
     )
 
 
+class QBUpdateParams(BaseModel):
+    """Parameters for the qb_update tool."""
+
+    entity_type: str = Field(
+        description="QBO entity type to update: Customer, Estimate, or Invoice"
+    )
+    data: dict[str, Any] = Field(
+        description=(
+            "Full QBO API payload including Id and SyncToken from a prior qb_query. "
+            "See SKILL.md for payload formats."
+        )
+    )
+
+
 class QBSendParams(BaseModel):
     """Parameters for the qb_send tool."""
 
-    invoice_id: str = Field(description="QuickBooks Invoice ID (numeric)")
+    entity_type: str = Field(
+        description="QBO entity type to send: Invoice or Estimate",
+        default="Invoice",
+    )
+    entity_id: str = Field(description="QuickBooks entity ID (numeric)")
     email: str = Field(
-        description="Email address to send the invoice to",
+        description="Email address to send to",
         pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$",
     )
 
@@ -92,7 +116,7 @@ def _format_results(rows: list[dict[str, Any]]) -> str:
     for row in truncated:
         parts: list[str] = []
         for key, val in row.items():
-            if key in ("domain", "sparse", "SyncToken", "MetaData"):
+            if key in ("domain", "sparse", "MetaData"):
                 continue
             if isinstance(val, dict):
                 name = val.get("name", "")
@@ -229,19 +253,69 @@ def create_quickbooks_tools(
 
         return ToolResult(content=" | ".join(parts))
 
-    async def qb_send(invoice_id: str, email: str) -> ToolResult:
-        """Send an invoice via QuickBooks email."""
-        try:
-            await qb_service.send_invoice_email(invoice_id, email)
-        except Exception as exc:
-            logger.exception("QB send invoice email failed")
+    async def qb_update(entity_type: str, data: dict[str, Any]) -> ToolResult:
+        """Update an existing entity in QuickBooks Online."""
+        if entity_type not in _UPDATABLE_ENTITIES:
             return ToolResult(
-                content=f"Failed to send invoice: {exc}",
+                content=f"Updating '{entity_type}' is not allowed. "
+                f"Allowed: {', '.join(sorted(_UPDATABLE_ENTITIES))}",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+
+        try:
+            result = await qb_service.update_entity(entity_type, data)
+        except Exception as exc:
+            logger.exception("QB update %s failed", entity_type)
+            error_str = str(exc)
+            if hasattr(exc, "response"):
+                try:
+                    error_body = exc.response.json()  # type: ignore[union-attr]
+                    error_str = json.dumps(error_body, indent=2)
+                except Exception:
+                    pass
+            return ToolResult(
+                content=f"Failed to update {entity_type}: {error_str}",
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
             )
 
-        return ToolResult(content=f"Invoice {invoice_id} sent to {email} via QuickBooks.")
+        entity_id = result.get("Id", "?")
+        doc_num = result.get("DocNumber", "")
+        total = result.get("TotalAmt")
+        display_name = result.get("DisplayName", "")
+
+        parts = [f"{entity_type} updated in QuickBooks.", f"Id: {entity_id}"]
+        if doc_num:
+            parts.append(f"DocNumber: {doc_num}")
+        if total is not None:
+            parts.append(f"Total: ${total:.2f}")
+        if display_name:
+            parts.append(f"Name: {display_name}")
+
+        return ToolResult(content=" | ".join(parts))
+
+    async def qb_send(entity_type: str, entity_id: str, email: str) -> ToolResult:
+        """Send an invoice or estimate via QuickBooks email."""
+        if entity_type not in _SENDABLE_ENTITIES:
+            return ToolResult(
+                content=f"Sending '{entity_type}' is not allowed. "
+                f"Allowed: {', '.join(sorted(_SENDABLE_ENTITIES))}",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+
+        try:
+            await qb_service.send_entity_email(entity_type, entity_id, email)
+        except Exception as exc:
+            logger.exception("QB send %s email failed", entity_type)
+            return ToolResult(
+                content=f"Failed to send {entity_type.lower()}: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+        return ToolResult(content=f"{entity_type} {entity_id} sent to {email} via QuickBooks.")
 
     return [
         Tool(
@@ -274,14 +348,32 @@ def create_quickbooks_tools(
             ),
         ),
         Tool(
+            name=ToolName.QB_UPDATE,
+            description=(
+                "Update an existing entity in QuickBooks Online. Pass the entity type "
+                "(Customer, Estimate, or Invoice) and the full QBO API payload "
+                "including Id and SyncToken from a prior qb_query. "
+                "See the QuickBooks skill for payload formats."
+            ),
+            function=qb_update,
+            params_model=QBUpdateParams,
+            usage_hint=(
+                "Update a Customer, Estimate, or Invoice in QB. "
+                "Payload must include Id and SyncToken from a prior query."
+            ),
+        ),
+        Tool(
             name=ToolName.QB_SEND,
             description=(
-                "Send an invoice to a customer via QuickBooks email. "
-                "The invoice must already exist in QuickBooks."
+                "Send an invoice or estimate to a customer via QuickBooks email. "
+                "The entity must already exist in QuickBooks."
             ),
             function=qb_send,
             params_model=QBSendParams,
-            usage_hint="Send a QB invoice by email. Confirm the email address first.",
+            usage_hint=(
+                "Send a QB invoice or estimate by email. "
+                "Confirm the email address with the user first."
+            ),
         ),
     ]
 
@@ -326,7 +418,8 @@ def _register() -> None:
         sub_tools=[
             SubToolInfo(ToolName.QB_QUERY, "Run read-only queries against QuickBooks Online"),
             SubToolInfo(ToolName.QB_CREATE, "Create entities in QuickBooks"),
-            SubToolInfo(ToolName.QB_SEND, "Send invoices via QuickBooks email"),
+            SubToolInfo(ToolName.QB_UPDATE, "Update existing entities in QuickBooks"),
+            SubToolInfo(ToolName.QB_SEND, "Send invoices or estimates via QuickBooks email"),
         ],
     )
 

--- a/backend/app/services/quickbooks_service.py
+++ b/backend/app/services/quickbooks_service.py
@@ -32,8 +32,14 @@ class QuickBooksService(ABC):
         """Create a QBO entity (Customer, Estimate, Invoice, etc.)."""
 
     @abstractmethod
-    async def send_invoice_email(self, invoice_id: str, email: str) -> dict[str, Any]:
-        """Send an invoice via QuickBooks email."""
+    async def update_entity(self, entity_type: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Update an existing QBO entity. *data* must include Id and SyncToken."""
+
+    @abstractmethod
+    async def send_entity_email(
+        self, entity_type: str, entity_id: str, email: str
+    ) -> dict[str, Any]:
+        """Send an invoice or estimate via QuickBooks email."""
 
 
 class QuickBooksOnlineService(QuickBooksService):
@@ -119,9 +125,18 @@ class QuickBooksOnlineService(QuickBooksService):
         # QBO wraps the created entity under the entity type key
         return result.get(entity_type, result)
 
-    async def send_invoice_email(self, invoice_id: str, email: str) -> dict[str, Any]:
-        if not invoice_id.strip().isdigit():
-            msg = f"Invalid invoice_id '{invoice_id}'. QuickBooks IDs must be numeric."
+    async def update_entity(self, entity_type: str, data: dict[str, Any]) -> dict[str, Any]:
+        # QBO uses the same POST endpoint for create and update.
+        # The presence of Id + SyncToken in the payload triggers an update.
+        path = f"/{entity_type.lower()}"
+        result = await self._request("POST", path, json=data)
+        return result.get(entity_type, result)
+
+    async def send_entity_email(
+        self, entity_type: str, entity_id: str, email: str
+    ) -> dict[str, Any]:
+        if not entity_id.strip().isdigit():
+            msg = f"Invalid entity_id '{entity_id}'. QuickBooks IDs must be numeric."
             raise ValueError(msg)
         import re as _re
 
@@ -130,6 +145,6 @@ class QuickBooksOnlineService(QuickBooksService):
             raise ValueError(msg)
         return await self._request(
             "POST",
-            f"/invoice/{invoice_id.strip()}/send",
+            f"/{entity_type.lower()}/{entity_id.strip()}/send",
             params={"sendTo": email},
         )

--- a/docs/src/content/docs/features/quickbooks.mdx
+++ b/docs/src/content/docs/features/quickbooks.mdx
@@ -1,25 +1,38 @@
 ---
 title: QuickBooks Online
-description: Connect Clawbolt to QuickBooks Online to look up invoices, estimates, customers, and more.
+description: Connect Clawbolt to QuickBooks Online to manage invoices, estimates, customers, and more from chat.
 ---
 
 :::caution[Experimental]
 The QuickBooks integration is experimental. Do not connect it to a production QuickBooks account. Use a sandbox company only while this feature is being developed.
 :::
 
-Clawbolt can connect to QuickBooks Online so you can look up invoices, estimates, customers, items, and more directly from the chat. Ask a question like "what invoices do I have for Amy?" and Clawbolt will query your QuickBooks data.
+Clawbolt can connect to QuickBooks Online so you can manage invoices, estimates, and customers directly from the chat. Ask a question like "what invoices do I have for Amy?" or dictate a job description and Clawbolt will create a draft estimate in QuickBooks.
 
 ## What it can do
 
-The integration provides a single read-only query tool (`qb_query`) that the agent uses to look up data in QuickBooks. It can query any entity type:
+The integration provides four tools that the agent uses to interact with QuickBooks:
 
-- **Invoices**: amounts, payment status, due dates
-- **Estimates**: totals, status, expiry dates
-- **Customers**: contact info, balances
-- **Items**: pricing catalog, descriptions
-- **Payments, Bills, and more**
+| Tool | Purpose |
+|------|---------|
+| `qb_query` | Look up invoices, estimates, customers, items, payments, and more |
+| `qb_create` | Create new customers, estimates, or invoices |
+| `qb_update` | Update existing customers, estimates, or invoices |
+| `qb_send` | Email an invoice or estimate to a customer |
 
-The agent writes the queries itself, so you just ask in plain language and it figures out how to look it up.
+The agent handles the queries and API calls itself, so you just talk in plain language.
+
+### Voice-to-estimate workflow
+
+The primary workflow for tradespeople in the field:
+
+1. Dictate a job description into your phone (your phone's speech-to-text converts it to a message)
+2. Clawbolt extracts the client, scope, labor, and materials from your description
+3. Clawbolt creates a draft estimate in QuickBooks immediately
+4. Come back later to review and refine it via chat
+5. When it's ready, Clawbolt sends it to your client by email
+
+No "computer time" required.
 
 ## Setup
 
@@ -70,10 +83,11 @@ QUICKBOOKS_REFRESH_TOKEN=your_refresh_token
 QUICKBOOKS_ENVIRONMENT=sandbox
 ```
 
-Restart Clawbolt and the QuickBooks tool will appear as a specialist capability.
+Restart Clawbolt and the QuickBooks tools will appear as a specialist capability.
 
-## Example conversation
+## Example conversations
 
+### Looking up data
 ```
 You: Do I have any invoices for Amy's Bird Sanctuary?
 
@@ -82,11 +96,19 @@ Clawbolt: Found 4 invoices for Amy's Bird Sanctuary:
           - #1012 | $650.00 (Open, $400 paid) | Due: 2024-03-15
           - #1009 | $1,250.00 (Paid) | Date: 2023-11-20
           - #1003 | $475.00 (Paid) | Date: 2023-09-05
+```
 
-You: What about estimates?
+### Creating an estimate from a dictation
+```
+You: Just left the Johnson place. They want the bathroom remodeled.
+     About 3 days of labor at 65 an hour, plus around 800 in materials
+     for tile and fixtures.
 
-Clawbolt: Found 1 estimate for Amy's Bird Sanctuary:
-          - #1004 | $2,500.00 | Status: Accepted | Date: 2024-02-01
+Clawbolt: I created a draft estimate for Johnson in QuickBooks:
+          - Labor (3 days @ $65/hr): $1,560.00
+          - Materials (tile & fixtures): $800.00
+          - Total: $2,360.00
+          Want to review or adjust anything?
 ```
 
 ## Token lifecycle

--- a/tests/mocks/quickbooks.py
+++ b/tests/mocks/quickbooks.py
@@ -47,6 +47,7 @@ _INVOICES: list[dict[str, Any]] = [
 _ESTIMATES: list[dict[str, Any]] = [
     {
         "Id": "2001",
+        "SyncToken": "0",
         "DocNumber": "EST-2001",
         "CustomerRef": {"value": "100", "name": "John Smith"},
         "TotalAmt": 3200.00,
@@ -111,5 +112,10 @@ class MockQuickBooksService(QuickBooksService):
     async def create_entity(self, entity_type: str, data: dict[str, Any]) -> dict[str, Any]:
         raise NotImplementedError("MockQuickBooksService.create_entity not implemented")
 
-    async def send_invoice_email(self, invoice_id: str, email: str) -> dict[str, Any]:
-        raise NotImplementedError("MockQuickBooksService.send_invoice_email not implemented")
+    async def update_entity(self, entity_type: str, data: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError("MockQuickBooksService.update_entity not implemented")
+
+    async def send_entity_email(
+        self, entity_type: str, entity_id: str, email: str
+    ) -> dict[str, Any]:
+        raise NotImplementedError("MockQuickBooksService.send_entity_email not implemented")

--- a/tests/test_quickbooks_tools.py
+++ b/tests/test_quickbooks_tools.py
@@ -55,12 +55,13 @@ async def test_query_customers(qb_tool: Tool) -> None:
 
 @pytest.mark.asyncio()
 async def test_query_estimates(qb_tool: Tool) -> None:
-    """Should return estimates."""
+    """Should return estimates with SyncToken visible."""
     result = await qb_tool.function(query="SELECT * FROM Estimate")
 
     assert result.is_error is False
     assert "1 result(s)" in result.content
     assert "EST-2001" in result.content
+    assert "SyncToken: 0" in result.content
 
 
 @pytest.mark.asyncio()
@@ -148,9 +149,9 @@ def test_quickbooks_tools_have_params_model(qb_service: MockQuickBooksService) -
 
 
 def test_quickbooks_tools_count(qb_service: MockQuickBooksService) -> None:
-    """create_quickbooks_tools should return 3 tools."""
+    """create_quickbooks_tools should return 4 tools."""
     tools = create_quickbooks_tools(qb_service)
-    assert len(tools) == 3
+    assert len(tools) == 4
 
 
 def test_quickbooks_factory_returns_empty_when_not_configured() -> None:

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -16,7 +16,8 @@ class FakeQBService(QuickBooksService):
 
     def __init__(self) -> None:
         self.created: list[tuple[str, dict[str, Any]]] = []
-        self.sent_invoices: list[tuple[str, str]] = []
+        self.updated: list[tuple[str, dict[str, Any]]] = []
+        self.sent: list[tuple[str, str, str]] = []
         self._next_id = 100
 
     async def query(self, query_str: str) -> list[dict[str, Any]]:
@@ -36,9 +37,21 @@ class FakeQBService(QuickBooksService):
         self.created.append((entity_type, data))
         return result
 
-    async def send_invoice_email(self, invoice_id: str, email: str) -> dict[str, Any]:
-        self.sent_invoices.append((invoice_id, email))
-        return {"Invoice": {"Id": invoice_id, "EmailStatus": "EmailSent"}}
+    async def update_entity(self, entity_type: str, data: dict[str, Any]) -> dict[str, Any]:
+        result: dict[str, Any] = {**data}
+        if entity_type == "Customer":
+            result["DisplayName"] = data.get("DisplayName", "")
+        else:
+            result["DocNumber"] = data.get("DocNumber", "")
+            result["TotalAmt"] = sum(line.get("Amount", 0) for line in data.get("Line", []))
+        self.updated.append((entity_type, data))
+        return result
+
+    async def send_entity_email(
+        self, entity_type: str, entity_id: str, email: str
+    ) -> dict[str, Any]:
+        self.sent.append((entity_type, entity_id, email))
+        return {entity_type: {"Id": entity_id, "EmailStatus": "EmailSent"}}
 
 
 def _get_tool(tools: list, name: str) -> Any:
@@ -238,31 +251,151 @@ async def test_qb_create_api_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# qb_update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_qb_update_estimate() -> None:
+    """Update an estimate with changed line items."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_update")
+
+    result = await fn(
+        entity_type="Estimate",
+        data={
+            "Id": "2001",
+            "SyncToken": "0",
+            "CustomerRef": {"value": "100"},
+            "Line": [
+                {
+                    "Amount": 600.00,
+                    "DetailType": "SalesItemLineDetail",
+                    "Description": "Labor - updated",
+                    "SalesItemLineDetail": {"Qty": 12, "UnitPrice": 50.0},
+                },
+            ],
+        },
+    )
+
+    assert result.is_error is False
+    assert "Estimate updated" in result.content
+    assert "Id: 2001" in result.content
+    assert "$600.00" in result.content
+    assert len(svc.updated) == 1
+    entity_type, body = svc.updated[0]
+    assert entity_type == "Estimate"
+    assert body["Id"] == "2001"
+    assert body["SyncToken"] == "0"
+
+
+@pytest.mark.asyncio()
+async def test_qb_update_customer() -> None:
+    """Update a customer's contact info."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_update")
+
+    result = await fn(
+        entity_type="Customer",
+        data={
+            "Id": "100",
+            "SyncToken": "1",
+            "DisplayName": "John Smith",
+            "PrimaryPhone": {"FreeFormNumber": "555-9999"},
+        },
+    )
+
+    assert result.is_error is False
+    assert "Customer updated" in result.content
+    assert "John Smith" in result.content
+    _, body = svc.updated[0]
+    assert body["PrimaryPhone"]["FreeFormNumber"] == "555-9999"
+
+
+@pytest.mark.asyncio()
+async def test_qb_update_rejects_disallowed_entity() -> None:
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_update")
+
+    result = await fn(
+        entity_type="Payment",
+        data={"Id": "1", "SyncToken": "0", "TotalAmt": 100},
+    )
+
+    assert result.is_error is True
+    assert "not allowed" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_qb_update_api_error() -> None:
+    svc = FakeQBService()
+    svc.update_entity = AsyncMock(side_effect=Exception("QB API error"))  # type: ignore[method-assign]
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_update")
+
+    result = await fn(
+        entity_type="Estimate",
+        data={"Id": "2001", "SyncToken": "0"},
+    )
+
+    assert result.is_error is True
+    assert "Failed to update Estimate" in result.content
+
+
+# ---------------------------------------------------------------------------
 # qb_send
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio()
-async def test_qb_send_success() -> None:
+async def test_qb_send_invoice_success() -> None:
     svc = FakeQBService()
     tools = create_quickbooks_tools(svc)
     fn = _get_tool(tools, "qb_send")
 
-    result = await fn(invoice_id="42", email="client@example.com")
+    result = await fn(entity_type="Invoice", entity_id="42", email="client@example.com")
 
     assert result.is_error is False
-    assert "sent to client@example.com" in result.content
-    assert svc.sent_invoices == [("42", "client@example.com")]
+    assert "Invoice 42 sent to client@example.com" in result.content
+    assert svc.sent == [("Invoice", "42", "client@example.com")]
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_estimate_success() -> None:
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_send")
+
+    result = await fn(entity_type="Estimate", entity_id="2001", email="client@example.com")
+
+    assert result.is_error is False
+    assert "Estimate 2001 sent to client@example.com" in result.content
+    assert svc.sent == [("Estimate", "2001", "client@example.com")]
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_rejects_disallowed_entity() -> None:
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_send")
+
+    result = await fn(entity_type="Customer", entity_id="100", email="test@example.com")
+
+    assert result.is_error is True
+    assert "not allowed" in result.content
 
 
 @pytest.mark.asyncio()
 async def test_qb_send_failure() -> None:
     svc = FakeQBService()
-    svc.send_invoice_email = AsyncMock(side_effect=Exception("Email failed"))  # type: ignore[method-assign]
+    svc.send_entity_email = AsyncMock(side_effect=Exception("Email failed"))  # type: ignore[method-assign]
     tools = create_quickbooks_tools(svc)
     fn = _get_tool(tools, "qb_send")
 
-    result = await fn(invoice_id="42", email="bad@email.com")
+    result = await fn(entity_type="Invoice", entity_id="42", email="bad@email.com")
 
     assert result.is_error is True
     assert "Failed to send invoice" in result.content
@@ -274,10 +407,10 @@ async def test_qb_send_failure() -> None:
 
 
 def test_quickbooks_tools_count() -> None:
-    """create_quickbooks_tools should return 3 tools."""
+    """create_quickbooks_tools should return 4 tools."""
     svc = FakeQBService()
     tools = create_quickbooks_tools(svc)
-    assert len(tools) == 3
+    assert len(tools) == 4
 
     names = {t.name for t in tools}
-    assert names == {"qb_query", "qb_create", "qb_send"}
+    assert names == {"qb_query", "qb_create", "qb_update", "qb_send"}


### PR DESCRIPTION
## Description

Implements the voice-to-estimate wedge feature from the [design doc](../designs/voice-to-estimate-design-20260319.md). Enables tradespeople to dictate job descriptions from the field and have Clawbolt create, refine, and send estimates in QuickBooks, all via Telegram chat.

**Key changes:**
- **qb_update tool**: New tool to update existing QuickBooks entities (Customer, Estimate, Invoice). Uses the same QBO POST endpoint as create, distinguished by Id + SyncToken in the payload. Includes `_UPDATABLE_ENTITIES` whitelist.
- **qb_send generalized**: Renamed from invoice-only to support both invoices and estimates. `send_invoice_email` -> `send_entity_email` with `_SENDABLE_ENTITIES` whitelist. Completes the estimate workflow end-to-end.
- **SyncToken preserved**: Stopped stripping SyncToken from `qb_query` results so the agent can pass it back when updating entities. Without this, the "pull up the Johnson estimate, change labor to $600" workflow fails.
- **Onboarding depth**: Expanded bootstrap prompt to gather trade, crew size, job types, pricing approach, geography, and tools during onboarding. Conversational, not a form.
- **File update guidance**: Added explicit SOUL/USER/MEMORY/HEARTBEAT guidance to the instructions prompt so the agent proactively maintains user context.
- **SKILL.md**: Documented the full voice-to-estimate workflow, qb_update payload format with SyncToken, and generalized qb_send docs.
- **Docs**: Updated user-facing QuickBooks docs to describe all 4 tools and the estimate workflow.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## Test coverage

7 new tests + 3 updated tests:
- `test_qb_update_estimate` / `test_qb_update_customer` - happy paths
- `test_qb_update_rejects_disallowed_entity` / `test_qb_update_api_error` - validation + errors
- `test_qb_send_invoice_success` / `test_qb_send_estimate_success` - both entity types
- `test_qb_send_rejects_disallowed_entity` / `test_qb_send_failure` - validation + errors
- `test_query_estimates` updated to assert SyncToken visible
- `test_quickbooks_tools_count` updated to expect 4 tools (both test files)

Full suite: 1021 tests pass, 0 failures.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code. Design doc generated via /office-hours, plan reviewed via /plan-eng-review, code reviewed via /review.