### PR TITLE
fix: set is_error on tool results and detect truncated tool calls

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -46,6 +46,7 @@ from backend.app.agent.system_prompt import build_agent_system_prompt
 from backend.app.agent.tool_errors import (
     _DEFAULT_ERROR_HINT,
     _ERROR_KIND_HINTS,
+    _TRUNCATION_HINT,
     build_error_hint,
     format_validation_error,
 )
@@ -420,6 +421,7 @@ class ClawboltAgent:
         actions_taken: list[str],
         memories_saved: list[dict[str, str]],
         tool_call_records: list[StoredToolInteraction],
+        response_truncated: bool = False,
     ) -> list[ToolResultMessage]:
         """Validate and execute a round of tool calls.
 
@@ -445,6 +447,7 @@ class ClawboltAgent:
                     ToolResultMessage(
                         tool_call_id=tc_req.id,
                         content=f"Error: malformed arguments for {tool_name}",
+                        is_error=True,
                     )
                 )
                 actions_taken.append(f"Failed: {tool_name} (bad args)")
@@ -463,6 +466,7 @@ class ClawboltAgent:
                     ToolResultMessage(
                         tool_call_id=tc_req.id,
                         content=result_str,
+                        is_error=True,
                     )
                 )
                 continue
@@ -475,7 +479,11 @@ class ClawboltAgent:
                     validation_error,
                 )
                 tool_tags = self._get_tool_tags(tool_name)
-                hint = _ERROR_KIND_HINTS[ToolErrorKind.VALIDATION]
+                hint = (
+                    _TRUNCATION_HINT
+                    if response_truncated
+                    else _ERROR_KIND_HINTS[ToolErrorKind.VALIDATION]
+                )
                 result_str = validation_error + "\n\n" + hint
                 actions_taken.append(f"Failed: {tool_name} (validation)")
                 tool_call_records.append(
@@ -492,6 +500,7 @@ class ClawboltAgent:
                     ToolResultMessage(
                         tool_call_id=tc_req.id,
                         content=result_str,
+                        is_error=True,
                     )
                 )
                 continue
@@ -524,6 +533,7 @@ class ClawboltAgent:
                     ToolResultMessage(
                         tool_call_id=tc_req.id,
                         content=deny_msg,
+                        is_error=True,
                     )
                 )
                 continue
@@ -579,6 +589,7 @@ class ClawboltAgent:
                 ToolResultMessage(
                     tool_call_id=tc_req.id,
                     content=result_str,
+                    is_error=is_error,
                 )
             )
 
@@ -756,6 +767,10 @@ class ClawboltAgent:
                 )
             )
 
+            # Detect truncated responses: when the LLM hits max_tokens while
+            # generating a tool call, the JSON payload may be incomplete.
+            response_truncated = response.stop_reason == "max_tokens"
+
             # Execute the tool round (validate, approve, run)
             tool_results = await self._execute_tool_round(
                 parsed_calls,
@@ -763,7 +778,19 @@ class ClawboltAgent:
                 actions_taken,
                 memories_saved,
                 tool_call_records,
+                response_truncated=response_truncated,
             )
+
+            # If the response was truncated and produced validation errors,
+            # auto-increase max_tokens for the next round so the LLM has
+            # enough room to generate the full tool call payload.
+            if response_truncated and any(r.is_error for r in tool_results):
+                effective = max_tokens or settings.llm_max_tokens_agent
+                max_tokens = min(effective * 2, 4096)
+                logger.info(
+                    "Response truncated with errors, increasing max_tokens to %d",
+                    max_tokens,
+                )
 
             # Activate any specialist factories requested via list_capabilities.
             # New tool schemas will be picked up at the top of the next round.

--- a/backend/app/agent/messages.py
+++ b/backend/app/agent/messages.py
@@ -72,14 +72,18 @@ class ToolResultMessage:
 
     tool_call_id: str
     content: str
+    is_error: bool = False
 
     def to_content_block(self) -> dict[str, Any]:
         """Return a single ``tool_result`` content block."""
-        return {
+        block: dict[str, Any] = {
             "type": "tool_result",
             "tool_use_id": self.tool_call_id,
             "content": self.content,
         }
+        if self.is_error:
+            block["is_error"] = True
+        return block
 
 
 # Union of all message types the agent loop works with.

--- a/backend/app/agent/tool_errors.py
+++ b/backend/app/agent/tool_errors.py
@@ -19,6 +19,12 @@ from backend.app.agent.tools.base import (
 
 _DEFAULT_ERROR_HINT = "[Analyze the error above and try a different approach.]"
 
+_TRUNCATION_HINT = (
+    "[Your previous response was cut short (hit the token limit) and the tool call"
+    " was incomplete. Simplify your approach: use smaller payloads, break the"
+    " operation into multiple steps, or omit optional fields.]"
+)
+
 _ERROR_KIND_HINTS: dict[ToolErrorKind, str] = {
     ToolErrorKind.VALIDATION: (
         "[Check the expected parameter format and try again with corrected arguments.]"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
     vision_model: str = ""  # empty = fall back to llm_model
     vision_provider: str = ""  # empty = fall back to llm_provider
     reasoning_effort: str = "auto"  # none, minimal, low, medium, high, xhigh, auto
-    llm_max_tokens_agent: int = Field(default=500, ge=1)
+    llm_max_tokens_agent: int = Field(default=1024, ge=1)
     llm_max_tokens_heartbeat: int = Field(default=300, ge=1)
     llm_max_tokens_vision: int = Field(default=1000, ge=1)
 

--- a/tests/mocks/llm.py
+++ b/tests/mocks/llm.py
@@ -55,6 +55,25 @@ def make_tool_call_response(
     )
 
 
+def make_truncated_tool_call_response(
+    tool_calls: list[dict[str, Any]],
+    content: str | None = None,
+) -> MessageResponse:
+    """Build a mock MessageResponse with tool_use blocks and stop_reason='max_tokens'.
+
+    Simulates an LLM response that was truncated mid-tool-call due to
+    hitting the max_tokens limit.
+    """
+    resp = make_tool_call_response(tool_calls, content)
+    return MessageResponse(
+        id=resp.id,
+        content=resp.content,
+        model=resp.model,
+        stop_reason="max_tokens",
+        usage=resp.usage,
+    )
+
+
 def make_error_response(
     stop_reason: str = "error",
     content: str = "",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -30,6 +30,7 @@ from tests.mocks.llm import (
     make_error_response,
     make_text_response,
     make_tool_call_response,
+    make_truncated_tool_call_response,
 )
 
 
@@ -1961,3 +1962,112 @@ async def test_agent_empty_reply_reprompt_only_once(
     assert mock_amessages.call_count == 3  # type: ignore[union-attr]
     # Reply is empty since both attempts produced nothing
     assert response.reply_text == ""
+
+
+# ---------------------------------------------------------------------------
+# Truncation detection tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_truncated_tool_call_sends_truncation_hint(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """When a tool call is truncated (stop_reason=max_tokens) and validation
+    fails, the error message should include truncation-specific guidance
+    instead of the generic validation hint."""
+
+    async def create_entity(**kwargs: object) -> ToolResult:
+        return ToolResult(content="created")
+
+    class CreateParams(BaseModel):
+        entity_type: str
+        data: dict[str, object]
+
+    tool = Tool(
+        name="qb_create",
+        description="Create an entity",
+        function=create_entity,
+        params_model=CreateParams,
+    )
+
+    # Round 0: LLM response truncated, only entity_type (missing data)
+    # Round 1: LLM self-corrects with complete args
+    # Round 2: LLM produces final text
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_truncated_tool_call_response(
+            [{"name": "qb_create", "arguments": {"entity_type": "Customer"}}]
+        ),
+        make_tool_call_response(
+            [
+                {
+                    "name": "qb_create",
+                    "arguments": {"entity_type": "Customer", "data": {"Name": "Test"}},
+                }
+            ]
+        ),
+        make_text_response("Created the customer."),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    await agent.process_message("Create a customer", system_prompt_override="system")
+
+    # The error sent back after the truncated call should contain the
+    # truncation hint, not the generic validation hint
+    followup_call = mock_amessages.call_args_list[1]
+    msgs = followup_call.kwargs["messages"]
+    tool_msg = next(
+        m
+        for m in msgs
+        if m.get("role") == "user"
+        and isinstance(m.get("content"), list)
+        and any(b.get("type") == "tool_result" for b in m["content"])
+    )
+    content = tool_msg["content"][0]["content"]
+    assert "cut short" in content or "truncated" in content
+    assert tool_msg["content"][0].get("is_error") is True
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_truncated_response_increases_max_tokens(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """When a response is truncated with validation errors, the agent should
+    auto-increase max_tokens for the next LLM call."""
+
+    async def create_entity(**kwargs: object) -> ToolResult:
+        return ToolResult(content="created")
+
+    class CreateParams(BaseModel):
+        entity_type: str
+        data: dict[str, object]
+
+    tool = Tool(
+        name="qb_create",
+        description="Create an entity",
+        function=create_entity,
+        params_model=CreateParams,
+    )
+
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_truncated_tool_call_response(
+            [{"name": "qb_create", "arguments": {"entity_type": "Invoice"}}]
+        ),
+        make_text_response("I need more info to create that invoice."),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    await agent.process_message("Create an invoice", system_prompt_override="system")
+
+    # The second LLM call should have a higher max_tokens than the first
+    first_call = mock_amessages.call_args_list[0]
+    second_call = mock_amessages.call_args_list[1]
+    first_max = first_call.kwargs["max_tokens"]
+    second_max = second_call.kwargs["max_tokens"]
+    assert second_max > first_max

--- a/tests/test_agent_messages.py
+++ b/tests/test_agent_messages.py
@@ -66,6 +66,18 @@ def test_tool_result_message_to_content_block() -> None:
         "tool_use_id": "call_1",
         "content": "Saved successfully.",
     }
+    assert "is_error" not in block
+
+
+def test_tool_result_message_error_to_content_block() -> None:
+    msg = ToolResultMessage(tool_call_id="call_1", content="Validation error", is_error=True)
+    block = msg.to_content_block()
+    assert block == {
+        "type": "tool_result",
+        "tool_use_id": "call_1",
+        "content": "Validation error",
+        "is_error": True,
+    }
 
 
 def test_messages_to_messages_api_extracts_system() -> None:


### PR DESCRIPTION
## Description

Tool error results were not setting `is_error: true` on the API `tool_result` content block, making it harder for the LLM to recognize that a tool call failed. Additionally, when `max_tokens` truncated a response mid-tool-call, the agent sent a generic validation error ("check the expected parameter format") instead of recognizing the truncation, causing the LLM to retry the same call with the same budget in a stuck loop.

**Root cause:** `llm_max_tokens_agent=500` is too low for tool calls with substantial JSON payloads (e.g., QBO invoices). The LLM hits the ceiling, its response is cut mid-JSON, the parser extracts a partial tool call missing required fields, and validation fails. Without `is_error: true` or truncation awareness, the LLM doesn't understand what went wrong.

**Three fixes:**
- **`is_error` flag**: Added `is_error: bool` to `ToolResultMessage` and set it on all 5 error paths (malformed args, unknown tool, validation, permission denied, execution error). The Anthropic API uses this to signal tool failures to the model.
- **Truncation detection**: When `stop_reason="max_tokens"` AND validation fails, the agent now sends a truncation-specific error hint ("Your response was cut short") and auto-doubles `max_tokens` for the retry (capped at 4096).
- **Raised default**: `llm_max_tokens_agent` raised from 500 to 1024 to reduce truncation for tool-heavy calls.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code: root cause analysis, implementation, and test writing)
- [ ] No AI used