### PR TITLE
fix: heartbeat items start empty, seeded on onboarding completion

### DIFF
--- a/backend/app/agent/onboarding.py
+++ b/backend/app/agent/onboarding.py
@@ -149,6 +149,22 @@ def build_onboarding_system_prompt(
     return builder.build()
 
 
+def _seed_default_heartbeat(user_id: str) -> None:
+    """Populate the user's heartbeat items with the default template.
+
+    Called when onboarding completes so that heartbeat items start empty
+    for new users and only get populated once the user is fully set up.
+    """
+    db = SessionLocal()
+    try:
+        db_user = db.query(User).filter_by(id=user_id).first()
+        if db_user and not db_user.heartbeat_text:
+            db_user.heartbeat_text = f"# Heartbeat\n\n{load_prompt('default_heartbeat')}\n"
+            db.commit()
+    finally:
+        db.close()
+
+
 class OnboardingSubscriber:
     """Event subscriber that detects onboarding completion after agent processing.
 
@@ -190,6 +206,7 @@ class OnboardingSubscriber:
             finally:
                 db.close()
             self._user.onboarding_complete = True
+            _seed_default_heartbeat(self._user.id)
             return
 
         # Heuristic fallback: BOOTSTRAP.md still exists but user profile
@@ -224,6 +241,7 @@ class OnboardingSubscriber:
             finally:
                 db.close()
             self._user.onboarding_complete = True
+            _seed_default_heartbeat(self._user.id)
             return
 
         # Pre-populated user: BOOTSTRAP.md doesn't exist but flag was never set
@@ -241,6 +259,7 @@ class OnboardingSubscriber:
             finally:
                 db.close()
             self._user.onboarding_complete = True
+            _seed_default_heartbeat(self._user.id)
 
     def finalize(self, response: AgentResponse) -> None:
         """No-op. Kept for API compatibility with the pipeline."""

--- a/backend/app/agent/user_db.py
+++ b/backend/app/agent/user_db.py
@@ -25,9 +25,11 @@ logger = logging.getLogger(__name__)
 def provision_user(user: User, db: object | None = None) -> None:
     """Provision a new user: seed DB defaults and create the data directory.
 
-    Seeds soul_text, user_text, and heartbeat_text DB columns with default
-    templates if empty. Creates the on-disk data directory for BOOTSTRAP.md
-    and other files that still live on the filesystem.
+    Seeds soul_text and user_text DB columns with default templates if
+    empty. Heartbeat items are NOT seeded here: they start empty and are
+    populated when onboarding completes (see ``OnboardingSubscriber``).
+    Creates the on-disk data directory for BOOTSTRAP.md and other files
+    that still live on the filesystem.
     """
     from sqlalchemy.orm import Session as SASession
 
@@ -47,16 +49,12 @@ def provision_user(user: User, db: object | None = None) -> None:
             if not db_user.user_text:
                 db_user.user_text = f"# User\n\n{load_prompt('default_user')}\n"
                 needs_commit = True
-            if not db_user.heartbeat_text:
-                db_user.heartbeat_text = f"# Heartbeat\n\n{load_prompt('default_heartbeat')}\n"
-                needs_commit = True
             if needs_commit:
                 db.commit()
                 db.refresh(db_user)
                 # Update the in-memory user object so callers see the seeded values
                 user.soul_text = db_user.soul_text
                 user.user_text = db_user.user_text
-                user.heartbeat_text = db_user.heartbeat_text
     finally:
         if own_session:
             db.close()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -117,11 +117,11 @@ def test_provision_user_creates_bootstrap_and_seeds_db() -> None:
 
         provision_user(user, db)
 
-        # DB columns should be seeded
+        # DB columns should be seeded (except heartbeat, which waits for onboarding)
         db.refresh(user)
         assert user.soul_text
         assert user.user_text
-        assert user.heartbeat_text
+        assert not user.heartbeat_text
 
         # BOOTSTRAP.md on disk
         user_dir = Path(settings.data_dir) / str(user.id)
@@ -358,6 +358,9 @@ async def test_onboarding_completes_when_bootstrap_deleted(
         db.close()
     assert refreshed is not None
     assert refreshed.onboarding_complete is True
+    # Heartbeat items should be seeded now that onboarding is complete
+    assert refreshed.heartbeat_text
+    assert "Follow up" in refreshed.heartbeat_text
 
 
 @pytest.mark.asyncio()
@@ -816,3 +819,6 @@ async def test_onboarding_completes_via_heuristic_when_bootstrap_not_deleted(
         db.close()
     assert refreshed is not None
     assert refreshed.onboarding_complete is True
+    # Heartbeat items should be seeded now that onboarding is complete
+    assert refreshed.heartbeat_text
+    assert "Follow up" in refreshed.heartbeat_text


### PR DESCRIPTION
## Description

Heartbeat items were pre-filled in `provision_user()` at user creation, causing heartbeat checks to trigger on startup as soon as onboarding completed. Now `heartbeat_text` starts empty and default items are seeded only when onboarding finishes (via `OnboardingSubscriber`), so the heartbeat system only activates for fully set-up users.

Changes:
- Removed `heartbeat_text` pre-filling from `provision_user()` in `user_db.py`
- Added `_seed_default_heartbeat()` helper in `onboarding.py`, called at all 3 onboarding completion paths (bootstrap deleted, heuristic, pre-populated user)
- Updated existing test to assert heartbeat is NOT seeded by `provision_user()`
- Added heartbeat seeding assertions to both onboarding completion tests

Fixes #685

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation by Claude Opus 4.6.