### PR TITLE
feat: remove default heartbeat items, let users add their own

### DIFF
--- a/backend/app/agent/onboarding.py
+++ b/backend/app/agent/onboarding.py
@@ -149,22 +149,6 @@ def build_onboarding_system_prompt(
     return builder.build()
 
 
-def _seed_default_heartbeat(user_id: str) -> None:
-    """Populate the user's heartbeat items with the default template.
-
-    Called when onboarding completes so that heartbeat items start empty
-    for new users and only get populated once the user is fully set up.
-    """
-    db = SessionLocal()
-    try:
-        db_user = db.query(User).filter_by(id=user_id).first()
-        if db_user and not db_user.heartbeat_text:
-            db_user.heartbeat_text = f"# Heartbeat\n\n{load_prompt('default_heartbeat')}\n"
-            db.commit()
-    finally:
-        db.close()
-
-
 class OnboardingSubscriber:
     """Event subscriber that detects onboarding completion after agent processing.
 
@@ -206,7 +190,6 @@ class OnboardingSubscriber:
             finally:
                 db.close()
             self._user.onboarding_complete = True
-            _seed_default_heartbeat(self._user.id)
             return
 
         # Heuristic fallback: BOOTSTRAP.md still exists but user profile
@@ -241,7 +224,6 @@ class OnboardingSubscriber:
             finally:
                 db.close()
             self._user.onboarding_complete = True
-            _seed_default_heartbeat(self._user.id)
             return
 
         # Pre-populated user: BOOTSTRAP.md doesn't exist but flag was never set
@@ -259,7 +241,6 @@ class OnboardingSubscriber:
             finally:
                 db.close()
             self._user.onboarding_complete = True
-            _seed_default_heartbeat(self._user.id)
 
     def finalize(self, response: AgentResponse) -> None:
         """No-op. Kept for API compatibility with the pipeline."""

--- a/backend/app/agent/prompts/default_heartbeat.md
+++ b/backend/app/agent/prompts/default_heartbeat.md
@@ -1,5 +1,0 @@
-Items your assistant should check on during heartbeat reminders.
-
-- [ ] Follow up with new leads
-- [ ] Check on active job sites
-- [ ] Review pending estimates

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -358,9 +358,8 @@ async def test_onboarding_completes_when_bootstrap_deleted(
         db.close()
     assert refreshed is not None
     assert refreshed.onboarding_complete is True
-    # Heartbeat items should be seeded now that onboarding is complete
-    assert refreshed.heartbeat_text
-    assert "Follow up" in refreshed.heartbeat_text
+    # Heartbeat items remain empty; users add them as needed
+    assert not refreshed.heartbeat_text
 
 
 @pytest.mark.asyncio()
@@ -819,6 +818,5 @@ async def test_onboarding_completes_via_heuristic_when_bootstrap_not_deleted(
         db.close()
     assert refreshed is not None
     assert refreshed.onboarding_complete is True
-    # Heartbeat items should be seeded now that onboarding is complete
-    assert refreshed.heartbeat_text
-    assert "Follow up" in refreshed.heartbeat_text
+    # Heartbeat items remain empty; users add them as needed
+    assert not refreshed.heartbeat_text


### PR DESCRIPTION
## Description

Default heartbeat items (follow up with leads, check job sites, review estimates) were generic placeholders that may not apply to every user. Heartbeat now starts completely empty and users add items as they need them.

Changes:
- Removed `_seed_default_heartbeat()` from `onboarding.py` and all 3 call sites in `OnboardingSubscriber`
- Deleted `default_heartbeat.md` prompt template (no longer referenced anywhere)
- Updated onboarding tests to assert heartbeat remains empty after completion

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation by Claude Opus 4.6.