### PR TITLE
fix: convert markdown to HTML for Telegram messages

### DIFF
--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import hmac
+import html
 import logging
 import mimetypes
+import re
 from pathlib import Path
 
 import httpx
@@ -89,6 +91,62 @@ class TelegramUpdate(BaseModel):
 
 class _InvalidSecret(Exception):
     pass
+
+
+# ---------------------------------------------------------------------------
+# Markdown -> Telegram HTML conversion
+# ---------------------------------------------------------------------------
+
+_FENCED_CODE_RE = re.compile(r"```(?:\w*)\n(.*?)```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
+
+
+def markdown_to_telegram_html(text: str) -> str:
+    """Convert common Markdown to Telegram-supported HTML.
+
+    Handles fenced code blocks, inline code, bold, italic, links, and headings.
+    Telegram supports: <b>, <i>, <code>, <pre>, <a href="">.
+    """
+    # Protect fenced code blocks first - extract them before escaping
+    code_blocks: list[str] = []
+
+    def _stash_code(m: re.Match[str]) -> str:
+        code_blocks.append(html.escape(m.group(1).strip()))
+        return f"\x00CODEBLOCK{len(code_blocks) - 1}\x00"
+
+    text = _FENCED_CODE_RE.sub(_stash_code, text)
+
+    # Protect inline code
+    inline_codes: list[str] = []
+
+    def _stash_inline(m: re.Match[str]) -> str:
+        inline_codes.append(html.escape(m.group(1)))
+        return f"\x00INLINE{len(inline_codes) - 1}\x00"
+
+    text = _INLINE_CODE_RE.sub(_stash_inline, text)
+
+    # Escape HTML in remaining text
+    text = html.escape(text)
+
+    # Convert markdown patterns to HTML
+    text = _BOLD_RE.sub(r"<b>\1</b>", text)
+    text = _ITALIC_RE.sub(r"<i>\1</i>", text)
+    text = _LINK_RE.sub(r'<a href="\2">\1</a>', text)
+    text = _HEADING_RE.sub(r"<b>\1</b>", text)
+
+    # Restore inline code
+    for i, code in enumerate(inline_codes):
+        text = text.replace(f"\x00INLINE{i}\x00", f"<code>{code}</code>")
+
+    # Restore code blocks
+    for i, code in enumerate(code_blocks):
+        text = text.replace(f"\x00CODEBLOCK{i}\x00", f"<pre>{code}</pre>")
+
+    return text
 
 
 class TelegramChannel(BaseChannel):
@@ -338,11 +396,11 @@ class TelegramChannel(BaseChannel):
         try:
             msg = await self.bot.send_message(
                 chat_id=self._parse_chat_id(to),
-                text=body,
-                parse_mode="Markdown",
+                text=markdown_to_telegram_html(body),
+                parse_mode="HTML",
             )
         except Exception:
-            # Fall back to plain text if Markdown parsing fails
+            # Fall back to plain text if HTML conversion/parsing fails
             msg = await self.bot.send_message(chat_id=self._parse_chat_id(to), text=body)
         return str(msg.message_id)
 
@@ -374,21 +432,22 @@ class TelegramChannel(BaseChannel):
             )
             raise ValueError(msg)
 
+        caption_html = markdown_to_telegram_html(body) if body else ""
         if content_type.startswith("image/"):
             msg = await self.bot.send_photo(
                 chat_id=chat_id,
                 photo=data,
-                caption=body,
+                caption=caption_html,
                 filename=filename,
-                parse_mode="Markdown",
+                parse_mode="HTML",
             )
         else:
             msg = await self.bot.send_document(
                 chat_id=chat_id,
                 document=data,
-                caption=body,
+                caption=caption_html,
                 filename=filename,
-                parse_mode="Markdown",
+                parse_mode="HTML",
             )
         return str(msg.message_id)
 

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.app.channels.telegram import TelegramChannel
+from backend.app.channels.telegram import TelegramChannel, markdown_to_telegram_html
 
 # ---------------------------------------------------------------------------
 # _parse_chat_id
@@ -53,7 +53,7 @@ async def test_send_text(telegram_service: TelegramChannel, mock_bot: MagicMock)
     msg_id = await telegram_service.send_text(to="123456789", body="Your estimate is ready")
     assert msg_id == "42"
     mock_bot.send_message.assert_called_once_with(
-        chat_id=123456789, text="Your estimate is ready", parse_mode="Markdown"
+        chat_id=123456789, text="Your estimate is ready", parse_mode="HTML"
     )
 
 
@@ -134,7 +134,7 @@ async def test_send_message_text_only(
     msg_id = await telegram_service.send_message(to="123456789", body="Hello")
     assert msg_id == "42"
     mock_bot.send_message.assert_called_once_with(
-        chat_id=123456789, text="Hello", parse_mode="Markdown"
+        chat_id=123456789, text="Hello", parse_mode="HTML"
     )
 
 
@@ -193,3 +193,43 @@ async def test_send_typing_indicator_failure_does_not_raise(
     mock_bot.send_chat_action.side_effect = RuntimeError("Telegram API error")
     # Should not raise
     await telegram_service.send_typing_indicator(to="123456789")
+
+
+# ---------------------------------------------------------------------------
+# markdown_to_telegram_html
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownToTelegramHtml:
+    def test_bold(self) -> None:
+        assert markdown_to_telegram_html("**hello**") == "<b>hello</b>"
+
+    def test_italic(self) -> None:
+        assert markdown_to_telegram_html("*hello*") == "<i>hello</i>"
+
+    def test_inline_code(self) -> None:
+        assert markdown_to_telegram_html("`foo()`") == "<code>foo()</code>"
+
+    def test_fenced_code_block(self) -> None:
+        md = "```python\nprint('hi')\n```"
+        assert markdown_to_telegram_html(md) == "<pre>print(&#x27;hi&#x27;)</pre>"
+
+    def test_link(self) -> None:
+        assert markdown_to_telegram_html("[click](https://x.com)") == (
+            '<a href="https://x.com">click</a>'
+        )
+
+    def test_heading_becomes_bold(self) -> None:
+        assert markdown_to_telegram_html("## My heading") == "<b>My heading</b>"
+
+    def test_html_entities_escaped(self) -> None:
+        assert "&lt;" in markdown_to_telegram_html("use <div> tags")
+
+    def test_plain_text_unchanged(self) -> None:
+        assert markdown_to_telegram_html("just text") == "just text"
+
+    def test_mixed_formatting(self) -> None:
+        result = markdown_to_telegram_html("**bold** and *italic* and `code`")
+        assert "<b>bold</b>" in result
+        assert "<i>italic</i>" in result
+        assert "<code>code</code>" in result


### PR DESCRIPTION
## Description

Telegram's legacy `parse_mode="Markdown"` parser (v1) breaks on most LLM output: underscores in words, nested formatting, unmatched asterisks, etc. This caused the fallback to fire every time, sending plain text.

This PR adds a `markdown_to_telegram_html()` converter and switches to `parse_mode="HTML"`, which Telegram handles reliably. The converter handles:
- `**bold**` -> `<b>bold</b>`
- `*italic*` -> `<i>italic</i>`
- `` `code` `` -> `<code>code</code>`
- Fenced code blocks -> `<pre>...</pre>`
- `[text](url)` -> `<a href="url">text</a>`
- `# headings` -> `<b>heading</b>` (Telegram has no heading tag)
- HTML entities in text are properly escaped
- Still falls back to plain text if anything goes wrong

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the changes)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)