### PR TITLE
fix: switch Telegram formatting to MarkdownV2

### DIFF
--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import hmac
-import html
 import logging
 import mimetypes
 import re
@@ -94,57 +93,119 @@ class _InvalidSecret(Exception):
 
 
 # ---------------------------------------------------------------------------
-# Markdown -> Telegram HTML conversion
+# Markdown -> Telegram MarkdownV2 conversion
 # ---------------------------------------------------------------------------
 
-_FENCED_CODE_RE = re.compile(r"```(?:\w*)\n(.*?)```", re.DOTALL)
+# Characters that must be escaped in MarkdownV2 outside of code/pre blocks.
+# See https://core.telegram.org/bots/api#markdownv2-style
+_MDV2_ESCAPE_CHARS = r"_*[]()~`>#+=|{}.!-"
+_MDV2_ESCAPE_RE = re.compile(r"([" + re.escape(_MDV2_ESCAPE_CHARS) + r"])")
+
+# Characters that must be escaped inside code/pre blocks (only ` and \).
+_MDV2_CODE_ESCAPE_RE = re.compile(r"([`\\])")
+
+_FENCED_CODE_RE = re.compile(r"```(\w*)\n(.*?)```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
-_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
-_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", re.DOTALL)
 _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _HEADING_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
 
 
-def markdown_to_telegram_html(text: str) -> str:
-    """Convert common Markdown to Telegram-supported HTML.
+def _escape_mdv2(text: str) -> str:
+    """Escape special characters for MarkdownV2 outside code blocks."""
+    return _MDV2_ESCAPE_RE.sub(r"\\\1", text)
 
-    Handles fenced code blocks, inline code, bold, italic, links, and headings.
-    Telegram supports: <b>, <i>, <code>, <pre>, <a href="">.
+
+def _escape_mdv2_code(text: str) -> str:
+    """Escape special characters for MarkdownV2 inside code/pre blocks."""
+    return _MDV2_CODE_ESCAPE_RE.sub(r"\\\1", text)
+
+
+def markdown_to_telegram_mdv2(text: str) -> str:
+    """Convert standard Markdown to Telegram MarkdownV2.
+
+    Standard Markdown uses ``**bold**`` and ``*italic*``.
+    Telegram MarkdownV2 uses ``*bold*`` and ``_italic_``, plus requires
+    escaping many special characters in literal text.
     """
-    # Protect fenced code blocks first - extract them before escaping
+    # 1. Stash fenced code blocks (different escape rules)
     code_blocks: list[str] = []
 
     def _stash_code(m: re.Match[str]) -> str:
-        code_blocks.append(html.escape(m.group(1).strip()))
+        lang = m.group(1)
+        code = _escape_mdv2_code(m.group(2).strip())
+        code_blocks.append(f"```{lang}\n{code}\n```" if lang else f"```\n{code}\n```")
         return f"\x00CODEBLOCK{len(code_blocks) - 1}\x00"
 
     text = _FENCED_CODE_RE.sub(_stash_code, text)
 
-    # Protect inline code
+    # 2. Stash inline code
     inline_codes: list[str] = []
 
     def _stash_inline(m: re.Match[str]) -> str:
-        inline_codes.append(html.escape(m.group(1)))
+        inline_codes.append(f"`{_escape_mdv2_code(m.group(1))}`")
         return f"\x00INLINE{len(inline_codes) - 1}\x00"
 
     text = _INLINE_CODE_RE.sub(_stash_inline, text)
 
-    # Escape HTML in remaining text
-    text = html.escape(text)
+    # 3. Extract formatting spans before escaping
+    bold_spans: list[str] = []
 
-    # Convert markdown patterns to HTML
-    text = _BOLD_RE.sub(r"<b>\1</b>", text)
-    text = _ITALIC_RE.sub(r"<i>\1</i>", text)
-    text = _LINK_RE.sub(r'<a href="\2">\1</a>', text)
-    text = _HEADING_RE.sub(r"<b>\1</b>", text)
+    def _stash_bold(m: re.Match[str]) -> str:
+        bold_spans.append(m.group(1))
+        return f"\x00BOLD{len(bold_spans) - 1}\x00"
 
-    # Restore inline code
+    text = _BOLD_RE.sub(_stash_bold, text)
+
+    italic_spans: list[str] = []
+
+    def _stash_italic(m: re.Match[str]) -> str:
+        italic_spans.append(m.group(1))
+        return f"\x00ITALIC{len(italic_spans) - 1}\x00"
+
+    text = _ITALIC_RE.sub(_stash_italic, text)
+
+    link_spans: list[tuple[str, str]] = []
+
+    def _stash_link(m: re.Match[str]) -> str:
+        link_spans.append((m.group(1), m.group(2)))
+        return f"\x00LINK{len(link_spans) - 1}\x00"
+
+    text = _LINK_RE.sub(_stash_link, text)
+
+    heading_spans: list[str] = []
+
+    def _stash_heading(m: re.Match[str]) -> str:
+        heading_spans.append(m.group(1))
+        return f"\x00HEADING{len(heading_spans) - 1}\x00"
+
+    text = _HEADING_RE.sub(_stash_heading, text)
+
+    # 4. Escape all special characters in the remaining literal text
+    text = _escape_mdv2(text)
+
+    # 5. Restore formatting with MarkdownV2 syntax
+    for i, content in enumerate(heading_spans):
+        text = text.replace(f"\x00HEADING{i}\x00", f"*{_escape_mdv2(content)}*")
+
+    for i, content in enumerate(bold_spans):
+        text = text.replace(f"\x00BOLD{i}\x00", f"*{_escape_mdv2(content)}*")
+
+    for i, content in enumerate(italic_spans):
+        text = text.replace(f"\x00ITALIC{i}\x00", f"_{_escape_mdv2(content)}_")
+
+    for i, (label, url) in enumerate(link_spans):
+        escaped_label = _escape_mdv2(label)
+        # Inside (...) only ) and \ need escaping
+        escaped_url = url.replace("\\", "\\\\").replace(")", "\\)")
+        text = text.replace(f"\x00LINK{i}\x00", f"[{escaped_label}]({escaped_url})")
+
     for i, code in enumerate(inline_codes):
-        text = text.replace(f"\x00INLINE{i}\x00", f"<code>{code}</code>")
+        text = text.replace(f"\x00INLINE{i}\x00", code)
 
-    # Restore code blocks
     for i, code in enumerate(code_blocks):
-        text = text.replace(f"\x00CODEBLOCK{i}\x00", f"<pre>{code}</pre>")
+        text = text.replace(f"\x00CODEBLOCK{i}\x00", code)
 
     return text
 
@@ -396,11 +457,11 @@ class TelegramChannel(BaseChannel):
         try:
             msg = await self.bot.send_message(
                 chat_id=self._parse_chat_id(to),
-                text=markdown_to_telegram_html(body),
-                parse_mode="HTML",
+                text=markdown_to_telegram_mdv2(body),
+                parse_mode="MarkdownV2",
             )
         except Exception:
-            # Fall back to plain text if HTML conversion/parsing fails
+            # Fall back to plain text if MarkdownV2 conversion fails
             msg = await self.bot.send_message(chat_id=self._parse_chat_id(to), text=body)
         return str(msg.message_id)
 
@@ -432,22 +493,22 @@ class TelegramChannel(BaseChannel):
             )
             raise ValueError(msg)
 
-        caption_html = markdown_to_telegram_html(body) if body else ""
+        caption_mdv2 = markdown_to_telegram_mdv2(body) if body else ""
         if content_type.startswith("image/"):
             msg = await self.bot.send_photo(
                 chat_id=chat_id,
                 photo=data,
-                caption=caption_html,
+                caption=caption_mdv2,
                 filename=filename,
-                parse_mode="HTML",
+                parse_mode="MarkdownV2",
             )
         else:
             msg = await self.bot.send_document(
                 chat_id=chat_id,
                 document=data,
-                caption=caption_html,
+                caption=caption_mdv2,
                 filename=filename,
-                parse_mode="HTML",
+                parse_mode="MarkdownV2",
             )
         return str(msg.message_id)
 

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.app.channels.telegram import TelegramChannel, markdown_to_telegram_html
+from backend.app.channels.telegram import TelegramChannel, markdown_to_telegram_mdv2
 
 # ---------------------------------------------------------------------------
 # _parse_chat_id
@@ -49,12 +49,13 @@ def telegram_service(mock_bot: MagicMock) -> TelegramChannel:
 
 @pytest.mark.asyncio()
 async def test_send_text(telegram_service: TelegramChannel, mock_bot: MagicMock) -> None:
-    """send_text should call bot.send_message with correct params."""
+    """send_text should call bot.send_message with MarkdownV2."""
     msg_id = await telegram_service.send_text(to="123456789", body="Your estimate is ready")
     assert msg_id == "42"
-    mock_bot.send_message.assert_called_once_with(
-        chat_id=123456789, text="Your estimate is ready", parse_mode="HTML"
-    )
+    call_kwargs = mock_bot.send_message.call_args.kwargs
+    assert call_kwargs["chat_id"] == 123456789
+    assert call_kwargs["parse_mode"] == "MarkdownV2"
+    assert call_kwargs["text"] == markdown_to_telegram_mdv2("Your estimate is ready")
 
 
 @pytest.mark.asyncio()
@@ -133,9 +134,10 @@ async def test_send_message_text_only(
     """send_message without media_urls should send text."""
     msg_id = await telegram_service.send_message(to="123456789", body="Hello")
     assert msg_id == "42"
-    mock_bot.send_message.assert_called_once_with(
-        chat_id=123456789, text="Hello", parse_mode="HTML"
-    )
+    call_kwargs = mock_bot.send_message.call_args.kwargs
+    assert call_kwargs["chat_id"] == 123456789
+    assert call_kwargs["parse_mode"] == "MarkdownV2"
+    assert call_kwargs["text"] == markdown_to_telegram_mdv2("Hello")
 
 
 @pytest.mark.asyncio()
@@ -196,40 +198,56 @@ async def test_send_typing_indicator_failure_does_not_raise(
 
 
 # ---------------------------------------------------------------------------
-# markdown_to_telegram_html
+# markdown_to_telegram_mdv2
 # ---------------------------------------------------------------------------
 
 
-class TestMarkdownToTelegramHtml:
+class TestMarkdownToTelegramMdv2:
     def test_bold(self) -> None:
-        assert markdown_to_telegram_html("**hello**") == "<b>hello</b>"
+        assert markdown_to_telegram_mdv2("**hello**") == "*hello*"
 
     def test_italic(self) -> None:
-        assert markdown_to_telegram_html("*hello*") == "<i>hello</i>"
+        assert markdown_to_telegram_mdv2("*hello*") == "_hello_"
 
     def test_inline_code(self) -> None:
-        assert markdown_to_telegram_html("`foo()`") == "<code>foo()</code>"
+        assert markdown_to_telegram_mdv2("`foo()`") == "`foo()`"
 
     def test_fenced_code_block(self) -> None:
         md = "```python\nprint('hi')\n```"
-        assert markdown_to_telegram_html(md) == "<pre>print(&#x27;hi&#x27;)</pre>"
+        result = markdown_to_telegram_mdv2(md)
+        assert result.startswith("```python\n")
+        assert result.endswith("\n```")
+        assert "print('hi')" in result
 
     def test_link(self) -> None:
-        assert markdown_to_telegram_html("[click](https://x.com)") == (
-            '<a href="https://x.com">click</a>'
-        )
+        assert markdown_to_telegram_mdv2("[click](https://x.com)") == "[click](https://x.com)"
 
     def test_heading_becomes_bold(self) -> None:
-        assert markdown_to_telegram_html("## My heading") == "<b>My heading</b>"
+        result = markdown_to_telegram_mdv2("## My heading")
+        assert result == "*My heading*"
 
-    def test_html_entities_escaped(self) -> None:
-        assert "&lt;" in markdown_to_telegram_html("use <div> tags")
+    def test_special_chars_escaped(self) -> None:
+        result = markdown_to_telegram_mdv2("Price is $50.00!")
+        assert "\\." in result
+        assert "\\!" in result
 
-    def test_plain_text_unchanged(self) -> None:
-        assert markdown_to_telegram_html("just text") == "just text"
+    def test_plain_text_no_special_chars(self) -> None:
+        assert markdown_to_telegram_mdv2("just text") == "just text"
 
     def test_mixed_formatting(self) -> None:
-        result = markdown_to_telegram_html("**bold** and *italic* and `code`")
-        assert "<b>bold</b>" in result
-        assert "<i>italic</i>" in result
-        assert "<code>code</code>" in result
+        result = markdown_to_telegram_mdv2("**bold** and *italic* and `code`")
+        assert "*bold*" in result
+        assert "_italic_" in result
+        assert "`code`" in result
+
+    def test_code_block_no_over_escaping(self) -> None:
+        """Special chars inside code blocks should not be escaped."""
+        md = "```\nx = 1 + 2\n```"
+        result = markdown_to_telegram_mdv2(md)
+        # + should NOT be escaped inside code blocks
+        assert "\\+" not in result
+        assert "x = 1 + 2" in result
+
+    def test_url_parens_escaped(self) -> None:
+        result = markdown_to_telegram_mdv2("[text](https://x.com/a_(b))")
+        assert "\\)" in result


### PR DESCRIPTION
## Description

Replaces the markdown-to-HTML converter with a markdown-to-MarkdownV2 converter per the [Telegram Bot API spec](https://core.telegram.org/bots/api#markdownv2-style).

The converter translates standard markdown (what the LLM outputs) to Telegram MarkdownV2:
- `**bold**` -> `*bold*` (MarkdownV2 bold)
- `*italic*` -> `_italic_` (MarkdownV2 italic)
- Inline code and fenced code blocks preserved with proper escaping
- `[text](url)` links with parenthesis escaping in URLs
- `# headings` -> `*heading*` (bold, since Telegram has no heading)
- Special characters (`_*[]()~>#+\-=|{}.!\`) properly escaped in literal text
- Code blocks use separate escaping rules (only `` ` `` and `\`)
- Falls back to plain text if MarkdownV2 conversion fails

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the changes)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)