### PR TITLE
fix: remove assistant prefill from compaction LLM call

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -130,9 +130,6 @@ async def compact_session(
 
     messages: list[dict[str, Any]] = [
         {"role": "user", "content": "\n".join(user_prompt_parts)},
-        # Assistant prefill forces the model to produce JSON instead of
-        # continuing the conversation it just read.
-        {"role": "assistant", "content": "{"},
     ]
 
     try:

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -184,12 +184,12 @@ async def test_compact_session_rewrites_memory(test_user: UserData) -> None:
     content = store.read_memory()
     assert "Deck: $45/sqft" in content
 
-    # Verify LLM was called with the system prompt and assistant prefill
+    # Verify LLM was called with the system prompt
     mock_llm.assert_called_once()
     call_kwargs = mock_llm.call_args
     assert call_kwargs.kwargs.get("system") == COMPACTION_SYSTEM_PROMPT
     llm_messages = call_kwargs.kwargs["messages"]
-    assert llm_messages[-1] == {"role": "assistant", "content": "{"}
+    assert llm_messages[-1]["role"] == "user"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description
Remove assistant message prefill from `compact_session()`. Claude 4.x models (`claude-sonnet-4-6`) reject prefill with `invalid_request_error: This model does not support assistant message prefill`. The system prompt already instructs "Return ONLY the JSON object, no other text," so the prefill is unnecessary.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- 1066 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (root cause analysis and fix by Claude Code)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)