### PR TITLE
feat: allow sending messages while assistant is responding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
@@ -5192,6 +5193,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -212,6 +212,7 @@ const api = {
     files?: File[],
     onEvent?: (event: { type: string; tool_name?: string; content?: string }) => void,
     forceNew?: boolean,
+    onAccepted?: (accepted: ChatAccepted) => void,
   ): Promise<ChatResponse> => {
     const formData = new FormData();
     formData.append('message', message);
@@ -239,6 +240,7 @@ const api = {
       throw new Error(b.detail || `Request failed: ${submitRes.status}`);
     }
     const accepted = (await submitRes.json()) as ChatAccepted;
+    onAccepted?.(accepted);
 
     // Step 2: Open SSE connection to receive the reply
     return new Promise<ChatResponse>((resolve, reject) => {

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '@/test/test-utils';
 import ChatPage from './ChatPage';
 
@@ -126,5 +127,41 @@ describe('ChatPage tool interactions', () => {
 
     // No "Tool:" labels should appear
     expect(screen.queryByText('Tool:')).not.toBeInTheDocument();
+  });
+});
+
+describe('ChatPage concurrent messaging', () => {
+  it('keeps input and send button enabled while assistant is responding', async () => {
+    // sendChatMessage never resolves, simulating a pending response
+    mockApi.sendChatMessage.mockReturnValue(new Promise(() => {}));
+
+    renderWithRouter(<ChatPage />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    const user = userEvent.setup();
+
+    // Type and send a message
+    await user.type(textarea, 'Hello');
+    await user.keyboard('{Enter}');
+
+    // Wait for the user message to appear in the chat
+    await waitFor(() => {
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+    });
+
+    // Input should NOT be disabled while the assistant is responding
+    expect(textarea).not.toBeDisabled();
+
+    // User should be able to type a new message while waiting
+    await user.type(textarea, 'Follow up');
+    expect(textarea).toHaveValue('Follow up');
+
+    // Send button should be enabled since there is text in the input
+    const sendButton = screen.getByLabelText('Send message');
+    expect(sendButton).not.toBeDisabled();
+
+    // Attach files button should also remain enabled
+    const attachButton = screen.getByLabelText('Attach files');
+    expect(attachButton).not.toBeDisabled();
   });
 });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -60,7 +60,9 @@ export default function ChatPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
-  const [sending, setSending] = useState(false);
+  const [pendingCount, setPendingCount] = useState(0);
+  const pendingRef = useRef(0);
+  const sending = pendingCount > 0;
   const [activeSessionId, setActiveSessionId] = useState<string | null>(
     searchParams.get('session'),
   );
@@ -204,7 +206,7 @@ export default function ChatPage() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const text = input.trim();
-    if ((!text && selectedFiles.length === 0) || sending) return;
+    if (!text && selectedFiles.length === 0) return;
 
     // Build attachments for display
     const attachments: FileAttachment[] = selectedFiles.map((f) => ({
@@ -223,15 +225,20 @@ export default function ChatPage() {
     setMessages((prev) => [...prev, userMsg]);
 
     const filesToSend = selectedFiles.length > 0 ? [...selectedFiles] : undefined;
+    // Capture session state at submit time so concurrent sends use correct values
+    const submitSessionId = activeSessionId;
+    const submitForceNew = forceNewRef.current;
+    if (forceNewRef.current) forceNewRef.current = false;
     setInput('');
     setSelectedFiles([]);
-    setSending(true);
+    pendingRef.current++;
+    setPendingCount((c) => c + 1);
 
     try {
       const toolNames: string[] = [];
       const res = await api.sendChatMessage(
         text,
-        activeSessionId ?? undefined,
+        submitSessionId ?? undefined,
         filesToSend,
         (event) => {
           if (!mountedRef.current) return;
@@ -244,7 +251,16 @@ export default function ChatPage() {
             setApprovalPrompt(event.content ?? null);
           }
         },
-        forceNewRef.current,
+        submitForceNew,
+        (accepted) => {
+          if (!mountedRef.current) return;
+          // Capture session ID immediately so follow-up messages use it
+          if (!submitSessionId && accepted.session_id) {
+            setActiveSessionId(accepted.session_id);
+            setSearchParams({ session: accepted.session_id }, { replace: true });
+            saveLastSession(accepted.session_id);
+          }
+        },
       );
       if (!mountedRef.current) return;
       const assistantMsg: ChatMessage = {
@@ -258,12 +274,6 @@ export default function ChatPage() {
       };
       setMessages((prev) => [...prev, assistantMsg]);
 
-      if (!activeSessionId) {
-        setActiveSessionId(res.session_id);
-        setSearchParams({ session: res.session_id }, { replace: true });
-        saveLastSession(res.session_id);
-        forceNewRef.current = false;
-      }
       // Refresh session data so full tool interactions from the DB replace
       // the partial names collected from SSE events
       void queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
@@ -276,20 +286,17 @@ export default function ChatPage() {
       toast.error(msg);
     } finally {
       if (!mountedRef.current) return;
-      setSending(false);
-      setCurrentTool(null);
-      setApprovalPrompt(null);
-      // Re-focus input on desktop only; on mobile, programmatic focus
-      // triggers iOS Safari auto-zoom and forces the keyboard open.
-      // Deferred via requestAnimationFrame so React flushes the
-      // setSending(false) render before we focus the (now enabled) textarea.
-      if (window.matchMedia('(min-width: 640px)').matches) {
-        requestAnimationFrame(() => inputRef.current?.focus());
+      pendingRef.current--;
+      setPendingCount((c) => c - 1);
+      // Only clear indicators when all pending requests are done
+      if (pendingRef.current === 0) {
+        setCurrentTool(null);
+        setApprovalPrompt(null);
       }
     }
   };
 
-  const canSend = !sending && (input.trim().length > 0 || selectedFiles.length > 0);
+  const canSend = input.trim().length > 0 || selectedFiles.length > 0;
   const activeSession = sessions.find((s) => s.id === activeSessionId);
 
   return (
@@ -514,15 +521,14 @@ export default function ChatPage() {
                 el.style.height = Math.min(el.scrollHeight, 160) + 'px';
               }}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey && !sending) {
+                if (e.key === 'Enter' && !e.shiftKey) {
                   e.preventDefault();
                   if (canSend) handleSubmit(e);
                 }
               }}
               placeholder="Type a message..."
-              disabled={sending}
               rows={1}
-              className="w-full px-2 py-1.5 text-base sm:text-sm bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none resize-none disabled:opacity-50"
+              className="w-full px-2 py-1.5 text-base sm:text-sm bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none resize-none"
               autoComplete="off"
               style={{ height: 'auto' }}
             />
@@ -568,7 +574,6 @@ export default function ChatPage() {
                   variant="ghost"
                   size="icon"
                   onClick={() => fileInputRef.current?.click()}
-                  disabled={sending}
                   className="text-muted-foreground hover:text-foreground"
                   aria-label="Attach files"
                 >


### PR DESCRIPTION
## Description
Allow users to type and send messages while the assistant is still responding, matching the Telegram experience where you can fire off multiple texts in a row.

Previously, the chat input, send button, and file attachment button were all disabled (`disabled={sending}`) while waiting for an assistant response. This made the web chat feel locked and unresponsive compared to Telegram.

**Changes:**
- Replace boolean `sending` state with a `pendingCount` counter + ref to track in-flight requests
- Remove `disabled` from textarea, send button guard, Enter key guard, and file attachment button
- Capture `session_id` immediately from POST acceptance (via new `onAccepted` callback in `api.ts`) so follow-up messages route to the correct session
- Only clear tool/approval indicators when all pending requests complete

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code. Code changes, test writing, and validation all AI-assisted.

Fixes #704