### PR TITLE
fix: bind SSE request_id to user to prevent cross-user stream access

### DIFF
--- a/backend/app/bus.py
+++ b/backend/app/bus.py
@@ -50,6 +50,7 @@ class MessageBus:
         self._response_futures: dict[str, asyncio.Future[OutboundMessage]] = {}
         self._event_queues: dict[str, asyncio.Queue[dict[str, Any]]] = {}
         self._cleanup_tasks: set[asyncio.Task[None]] = set()
+        self._request_owners: dict[str, str] = {}
 
     async def publish_inbound(self, msg: InboundMessage) -> None:
         """Publish a message from a channel to the agent."""
@@ -67,6 +68,15 @@ class MessageBus:
         """Consume the next outbound message (blocks until available)."""
         return await self.outbound.get()
 
+    def set_request_owner(self, request_id: str, user_id: str) -> None:
+        """Associate a request_id with the user who created it."""
+        self._request_owners[request_id] = user_id
+
+    def check_request_owner(self, request_id: str, user_id: str) -> bool:
+        """Return True if *user_id* owns *request_id* (or if no owner is recorded)."""
+        owner = self._request_owners.get(request_id)
+        return owner is None or owner == user_id
+
     def register_response_future(
         self, request_id: str, ttl: float = 300
     ) -> asyncio.Future[OutboundMessage]:
@@ -83,6 +93,7 @@ class MessageBus:
         async def _cleanup() -> None:
             await asyncio.sleep(ttl)
             stale = self._response_futures.pop(request_id, None)
+            self._request_owners.pop(request_id, None)
             if stale is not None and not stale.done():
                 stale.cancel()
                 logger.debug("Cleaned up stale response future for request %s", request_id)
@@ -118,8 +129,9 @@ class MessageBus:
             await queue.put(event)
 
     def remove_event_queue(self, request_id: str) -> None:
-        """Remove the event queue for *request_id*."""
+        """Remove the event queue and owner mapping for *request_id*."""
         self._event_queues.pop(request_id, None)
+        self._request_owners.pop(request_id, None)
 
     def get_response_future(self, request_id: str) -> asyncio.Future[OutboundMessage] | None:
         """Return the pending response future for *request_id*, or ``None``."""
@@ -148,6 +160,7 @@ class MessageBus:
         self.outbound = asyncio.Queue()
         self._response_futures.clear()
         self._event_queues.clear()
+        self._request_owners.clear()
 
     @property
     def inbound_size(self) -> int:

--- a/backend/app/channels/webchat.py
+++ b/backend/app/channels/webchat.py
@@ -118,6 +118,7 @@ class WebChatChannel(BaseChannel):
 
             # Register response future and event queue before publishing so
             # the dispatcher can resolve it even if processing is very fast.
+            message_bus.set_request_owner(request_id, str(user.id))
             message_bus.register_response_future(request_id)
             message_bus.register_event_queue(request_id)
 
@@ -136,9 +137,11 @@ class WebChatChannel(BaseChannel):
         @router.get("/user/chat/events/{request_id}")
         async def chat_events(
             request_id: str,
-            _user: User = Depends(get_current_user),
+            user: User = Depends(get_current_user),
         ) -> StreamingResponse:
             """SSE endpoint: streams tool-call events then the final reply."""
+            if not message_bus.check_request_owner(request_id, str(user.id)):
+                raise HTTPException(status_code=403, detail="Not your request")
 
             async def event_stream() -> collections.abc.AsyncIterator[str]:
                 queue = message_bus.register_event_queue(request_id)

--- a/tests/test_webchat.py
+++ b/tests/test_webchat.py
@@ -352,6 +352,58 @@ def test_sse_streams_tool_call_events(
     assert text.index("search_clients") < text.index("Done!")
 
 
+def test_sse_rejects_wrong_user(
+    webchat_user: User,
+) -> None:
+    """A different user must not be able to subscribe to another user's SSE stream."""
+    # Create a second user
+    db = _db_module.SessionLocal()
+    try:
+        user_b = User(user_id="webchat-other-user")
+        db.add(user_b)
+        db.commit()
+        db.refresh(user_b)
+        db.expunge(user_b)
+    finally:
+        db.close()
+
+    # We need to switch get_current_user between requests, so track which
+    # user should be returned.
+    current = {"user": webchat_user}
+
+    async def _override_get_current_user() -> User:
+        return current["user"]
+
+    from backend.app.auth.dependencies import get_current_user
+
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+
+    with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.stop"),
+        patch("backend.app.channels.telegram.settings.telegram_bot_token", ""),
+        patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
+        patch(
+            "backend.app.channels.webchat.message_bus.publish_inbound",
+            new_callable=AsyncMock,
+        ),
+        TestClient(app) as client,
+    ):
+        # User A creates a request
+        current["user"] = webchat_user
+        resp = client.post("/api/user/chat", data={"message": "private"})
+        assert resp.status_code == 200
+        request_id = resp.json()["request_id"]
+
+        # User B tries to subscribe to User A's SSE stream
+        current["user"] = user_b
+        sse_resp = client.get(f"/api/user/chat/events/{request_id}")
+        assert sse_resp.status_code == 403
+
+    app.dependency_overrides.clear()
+
+
 def test_bus_event_queue_lifecycle() -> None:
     """Event queues are created, receive events, and get cleaned up."""
     import asyncio


### PR DESCRIPTION
## Description

The webchat SSE endpoint (`/api/user/chat/events/{request_id}`) authenticated the user but did not verify the `request_id` belonged to them. If an attacker learned a UUID4 request_id (e.g. via logs or shoulder surfing), they could subscribe to another user's response stream.

This adds ownership tracking in the `MessageBus` and a 403 check on the SSE endpoint:
- `bus.set_request_owner(request_id, user_id)` called when the chat POST creates the request
- `bus.check_request_owner(request_id, user_id)` validated when the SSE endpoint connects
- Owner mapping cleaned up alongside response futures and event queues

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (security audit + fix by Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)