### PR TITLE
refactor: change showOssSettingsTabs to return visible tab keys

### DIFF
--- a/frontend/src/extensions/settings.tsx
+++ b/frontend/src/extensions/settings.tsx
@@ -13,6 +13,6 @@ export function renderPremiumSettingsTab(_key: string): ReactNode {
   return null;
 }
 
-export function showOssSettingsTabs(_isPremium: boolean): boolean {
-  return true;
+export function showOssSettingsTabs(_isPremium: boolean, _isAdmin: boolean): string[] {
+  return ['model', 'storage', 'heartbeat'];
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -35,13 +35,12 @@ export default function SettingsPage() {
   };
 
   // Build tab list
-  const ossTabs = showOssSettingsTabs(isPremium)
-    ? [
-        { key: 'model', label: 'Model' },
-        { key: 'storage', label: 'Storage' },
-        { key: 'heartbeat', label: 'Heartbeat' },
-      ]
-    : [];
+  const visibleOssKeys = showOssSettingsTabs(isPremium, isAdmin);
+  const ossTabs = [
+    { key: 'model', label: 'Model' },
+    { key: 'storage', label: 'Storage' },
+    { key: 'heartbeat', label: 'Heartbeat' },
+  ].filter((t) => visibleOssKeys.includes(t.key));
   const allTabs = [...ossTabs, ...extraTabs.map((t) => ({ key: t.key, label: t.label }))];
 
   // Premium-only tab


### PR DESCRIPTION
## Description

Changes the `showOssSettingsTabs` extension interface from returning a boolean to returning a `string[]` of visible tab keys. This allows premium to selectively hide specific OSS settings tabs (e.g. Model, Storage) for non-admin users while keeping others (Heartbeat) visible.

The OSS stub returns all tabs `['model', 'storage', 'heartbeat']` (no behavior change in OSS).

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implementation by Claude)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)