### PR TITLE
feat: allow agent to stay silent when user asks not to respond

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -797,8 +797,10 @@ class ClawboltAgent:
                     messages.append(
                         UserMessage(
                             content=(
-                                "[System: you called tools but did not reply. "
-                                "Please respond to the user.]"
+                                "[System: you called tools but did not send a text reply. "
+                                "If you intentionally chose not to respond "
+                                "(e.g. the user asked for silence), return empty text. "
+                                "Otherwise, please reply to the user.]"
                             )
                         )
                     )

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -3,6 +3,7 @@
 - You can ONLY communicate via this chat. You cannot send emails, make phone calls, or contact clients directly.
 - Always be helpful, friendly, and professional.
 - Keep replies concise. Users are on the job site.
+- If the user explicitly asks you not to respond (e.g. "don't say anything back"), return empty text. It is OK to not respond when the user asks for silence.
 
 ## Keeping files up to date
 Update these files proactively as you learn new things. Do not ask permission. Just do it naturally as part of the conversation.

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -457,6 +457,16 @@ async def dispatch_reply_step(ctx: PipelineContext) -> PipelineContext:
                 request_id=ctx.request_id,
             )
             await message_bus.publish_outbound(outbound)
+        elif not sent_reply and not ctx.response.reply_text and ctx.request_id:
+            # Resolve SSE future with empty content so webchat clients
+            # know processing is complete without rendering a message.
+            outbound = OutboundMessage(
+                channel=ctx.channel,
+                chat_id=ctx.to_address,
+                content="",
+                request_id=ctx.request_id,
+            )
+            await message_bus.publish_outbound(outbound)
     return ctx
 
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -263,16 +263,20 @@ export default function ChatPage() {
         },
       );
       if (!mountedRef.current) return;
-      const assistantMsg: ChatMessage = {
-        id: nextId.current++,
-        role: 'assistant',
-        body: res.reply,
-        timestamp: new Date(),
-        toolInteractions: toolNames.length > 0
-          ? toolNames.map((name) => ({ name }))
-          : undefined,
-      };
-      setMessages((prev) => [...prev, assistantMsg]);
+      // Skip adding an assistant message when the reply is empty
+      // (the agent chose not to respond, e.g. user asked for silence).
+      if (res.reply) {
+        const assistantMsg: ChatMessage = {
+          id: nextId.current++,
+          role: 'assistant',
+          body: res.reply,
+          timestamp: new Date(),
+          toolInteractions: toolNames.length > 0
+            ? toolNames.map((name) => ({ name }))
+            : undefined,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      }
 
       // Refresh session data so full tool interactions from the DB replace
       // the partial names collected from SSE events

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -1148,6 +1148,98 @@ async def test_dispatch_reply_step_sends_when_send_reply_fails() -> None:
 
 
 # ---------------------------------------------------------------------------
+# dispatch_reply_step: empty reply handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_dispatch_reply_step_resolves_sse_on_empty_reply() -> None:
+    """When reply is empty and request_id is set (webchat), resolve SSE with empty content."""
+    from backend.app.agent.core import AgentResponse
+    from backend.app.agent.file_store import SessionState, StoredMessage
+    from backend.app.agent.router import PipelineContext, dispatch_reply_step
+
+    response = AgentResponse(reply_text="", tool_calls=[])
+    ctx = PipelineContext(
+        user=User(id="1", user_id="test"),
+        session=SessionState(session_id="s", user_id="1", is_active=True),
+        message=StoredMessage(direction="inbound", body="don't reply", seq=1),
+        media_urls=[],
+        channel="webchat",
+        to_address="123",
+        request_id="req-123",
+    )
+    ctx.response = response
+
+    await dispatch_reply_step(ctx)
+
+    outbound = message_bus.outbound.get_nowait()
+    assert outbound.content == ""
+    assert outbound.request_id == "req-123"
+
+
+@pytest.mark.asyncio()
+async def test_dispatch_reply_step_no_outbound_on_empty_reply_without_request_id() -> None:
+    """When reply is empty and there's no request_id (Telegram), nothing is published."""
+    from backend.app.agent.core import AgentResponse
+    from backend.app.agent.file_store import SessionState, StoredMessage
+    from backend.app.agent.router import PipelineContext, dispatch_reply_step
+
+    response = AgentResponse(reply_text="", tool_calls=[])
+    ctx = PipelineContext(
+        user=User(id="1", user_id="test"),
+        session=SessionState(session_id="s", user_id="1", is_active=True),
+        message=StoredMessage(direction="inbound", body="don't reply", seq=1),
+        media_urls=[],
+        channel="telegram",
+        to_address="123",
+    )
+    ctx.response = response
+
+    await dispatch_reply_step(ctx)
+
+    assert message_bus.outbound.empty()
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_empty_reply_after_tools_accepted_on_second_attempt(
+    mock_amessages: object,
+    test_user: User,
+    conversation: SessionState,
+    inbound_message: StoredMessage,
+) -> None:
+    """When LLM calls tools, returns empty, gets re-prompted, returns empty again: accept it.
+
+    The softer re-prompt allows the LLM to intentionally return empty text on the
+    second attempt. The system should accept that (3 LLM calls total, no fourth).
+    """
+    # Round 0: LLM calls a tool (e.g. read_file) -- tool is executed
+    # Round 1: LLM returns empty text -- re-prompt fires (once)
+    # Round 2: LLM returns empty again -- accepted (re-prompt already used)
+    # Round 3: should NOT happen
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response([{"name": "read_file", "arguments": {"path": "MEMORY.md"}}]),
+        make_text_response(""),  # Empty after tools -- triggers re-prompt
+        make_text_response(""),  # Empty again -- accepted (intentional silence)
+        make_text_response("Oops I replied anyway"),  # Should NOT be reached
+    ]
+
+    response = await handle_inbound_message(
+        user=test_user,
+        session=conversation,
+        message=inbound_message,
+        media_urls=[],
+        channel="telegram",
+    )
+
+    # The agent should accept the empty reply after re-prompt
+    assert response.reply_text == ""
+    # Three LLM calls: tool round + empty reply + re-prompt. No fourth call.
+    assert mock_amessages.call_count == 3  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
 # Error stop_reason: dispatched to user but NOT persisted
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Allow the agent to not respond when the user explicitly asks for silence (e.g. "don't say anything back"). Takes a minimal approach: prompt instruction + softer re-prompt + SSE fix.

- Add system prompt instruction telling the LLM it's OK to return empty text when asked for silence
- Soften the re-prompt wording so the LLM can intentionally return empty after tool calls
- Fix SSE future resolution for empty replies so webchat clients don't hang
- Skip rendering empty assistant message bubbles in the frontend

Closes #706

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used