### PR TITLE
fix: add clients.claim() to service worker for immediate takeover

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -9,7 +9,10 @@ declare const self: ServiceWorkerGlobalScope
 cleanupOutdatedCaches()
 precacheAndRoute(self.__WB_MANIFEST)
 
-// Activate new SW immediately. Combined with autoUpdate registration mode,
-// this triggers a page reload via the controllerchange event so users always
-// get the latest deploy without manual intervention.
+// Activate new SW immediately and take control of all open tabs.
+// skipWaiting() bypasses the waiting phase; clients.claim() ensures the
+// new SW controls existing tabs without requiring a second navigation.
+// Combined with autoUpdate registration mode, this triggers a page reload
+// via the controllerchange event so users always get the latest deploy.
 self.skipWaiting()
+self.addEventListener('activate', () => self.clients.claim())


### PR DESCRIPTION
## Summary
- Adds `clients.claim()` in the service worker's `activate` event so new SWs immediately control all open tabs
- Without this, stale service workers (from the old `generateSW` config) could intercept API navigations like `/api/auth/oauth/google` and serve `index.html`, causing a client-side 404
- Complements the `skipWaiting()` already in place: `skipWaiting` activates the new SW, `clients.claim` makes it take control of existing pages

## Context
The `injectManifest` fix (#714) solved the root cause (NavigationRoute intercepting API requests), but users with the old SW cached in their browser could still see the 404 until the new SW took control. `clients.claim()` eliminates this timing gap.

## Test plan
- [ ] Deploy and verify `/api/auth/oauth/google` redirects to Google consent screen (no 404)
- [ ] In DevTools > Application > Service Workers, confirm new SW activates and claims immediately
- [ ] Verify precached assets still load correctly offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)