### PR TITLE
docs: remove features section from home page

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -17,8 +17,6 @@ hero:
       variant: minimal
 ---
 
-import { Card, CardGrid } from "@astrojs/starlight/components";
-
 ## See it in action
 
 <iframe
@@ -36,24 +34,3 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 Clawbolt is a messaging-first AI assistant that helps solo tradespeople manage their business through Telegram. No app to install, no dashboard to learn. Just text.
 
 Built by [Mozilla.ai](https://mozilla.ai) using the open-core model.
-
-## Features
-
-<CardGrid stagger>
-  <Card title="Memory" icon="star">
-    Clawbolt remembers your rates, clients, preferences, and past
-    conversations.
-  </Card>
-  <Card title="Photo Analysis" icon="sun">
-    Send a job site photo and get an AI description for documentation.
-  </Card>
-  <Card title="Voice Memos" icon="comment">
-    Send a voice note, get it transcribed and processed as a message.
-  </Card>
-  <Card title="File Cataloging" icon="folder">
-    Photos and documents auto-organized in Dropbox or Google Drive.
-  </Card>
-  <Card title="Proactive Heartbeat" icon="heart">
-    Periodic check-ins with reminders about stale drafts and follow-ups.
-  </Card>
-</CardGrid>


### PR DESCRIPTION
## Description
Remove the features card grid from the docs site home page (`docs/src/content/docs/index.mdx`). Also removes the unused `Card`/`CardGrid` import.

Fixes #719

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code authored the change)
- [ ] No AI used