### PR TITLE
fix: pass isAdmin to renderPremiumSettingsTab

### DIFF
--- a/frontend/src/extensions/settings.tsx
+++ b/frontend/src/extensions/settings.tsx
@@ -9,7 +9,7 @@ export function getExtraSettingsTabs(_isPremium: boolean, _isAdmin: boolean): Ex
   return [];
 }
 
-export function renderPremiumSettingsTab(_key: string): ReactNode {
+export function renderPremiumSettingsTab(_key: string, _isAdmin: boolean): ReactNode {
   return null;
 }
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -44,7 +44,7 @@ export default function SettingsPage() {
   const allTabs = [...ossTabs, ...extraTabs.map((t) => ({ key: t.key, label: t.label }))];
 
   // Premium-only tab
-  const premiumContent = renderPremiumSettingsTab(activeTab);
+  const premiumContent = renderPremiumSettingsTab(activeTab, isAdmin);
 
   // Render tab content based on active tab
   const renderContent = () => {


### PR DESCRIPTION
## Description
Updates the `renderPremiumSettingsTab` extension stub to accept an `isAdmin` parameter, and passes it from `SettingsPage`. This is the OSS counterpart to mozilla-ai/clawbolt-premium#142 which guards the admin settings panel from non-admin users navigating directly to `/app/settings/admin`.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)