### PR TITLE
feat: enforce single Telegram user ID per user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,12 +23,10 @@ PREMIUM_PLUGIN=
 MESSAGING_PROVIDER=telegram
 TELEGRAM_BOT_TOKEN=
 # TELEGRAM_WEBHOOK_SECRET=     # Auto-derived from bot token if not set
-# Comma-separated list of allowed Telegram chat IDs, or "*" to allow all.
+# Your numeric Telegram user ID, or "*" to allow all.
 # Empty = deny all incoming messages (safe default).
-TELEGRAM_ALLOWED_CHAT_IDS=
-# Comma-separated list of allowed Telegram usernames, or "*" to allow all.
-# If both are set, a message is allowed if EITHER matches.
-TELEGRAM_ALLOWED_USERNAMES=
+# Only a single ID is allowed per user.
+TELEGRAM_ALLOWED_CHAT_ID=
 
 # E2E testing
 # TELEGRAM_TEST_CHAT_ID=

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -320,19 +320,19 @@ class TelegramChannel(BaseChannel):
     def is_allowed(self, sender_id: str, username: str) -> bool:
         """Return ``True`` if the sender passes the Telegram allowlist gate.
 
-        The allowlist defaults to empty, which rejects all senders (deny by default).
-        Set to ``"*"`` to explicitly allow everyone through.
+        Only a single chat ID is supported per user. The setting defaults to
+        empty, which rejects all senders (deny by default). Set to ``"*"`` to
+        explicitly allow everyone through.
         """
-        ids_raw = settings.telegram_allowed_chat_ids.strip()
+        allowed = settings.telegram_allowed_chat_id.strip()
 
-        if not ids_raw:
+        if not allowed:
             return False
 
-        if ids_raw == "*":
+        if allowed == "*":
             return True
 
-        allowed_ids = {cid.strip() for cid in ids_raw.split(",")}
-        return sender_id in allowed_ids
+        return sender_id == allowed
 
     @staticmethod
     def parse_update(update: TelegramUpdate) -> InboundMessage | None:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -44,9 +44,7 @@ class Settings(BaseSettings):
     messaging_provider: str = "telegram"
     telegram_bot_token: str = ""
     telegram_webhook_secret: str = ""
-    telegram_allowed_chat_ids: str = (
-        ""  # Comma-separated allowlist, or "*" for all; empty = deny all
-    )
+    telegram_allowed_chat_id: str = ""  # Single numeric chat ID, or "*" for all; empty = deny all
 
     # LLM
     llm_provider: str = ""
@@ -134,7 +132,7 @@ TELEGRAM_API_BASE = "https://api.telegram.org"
 PERSISTABLE_SETTINGS: frozenset[str] = frozenset(
     {
         "telegram_bot_token",
-        "telegram_allowed_chat_ids",
+        "telegram_allowed_chat_id",
         "telegram_webhook_secret",
         "llm_provider",
         "llm_model",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -154,11 +154,11 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         else:
             logger.info("Webhook secret: auto-derived from bot token")
 
-    if settings.telegram_bot_token and not settings.telegram_allowed_chat_ids:
+    if settings.telegram_bot_token and not settings.telegram_allowed_chat_id:
         logger.warning(
-            "No Telegram allowlist configured (TELEGRAM_ALLOWED_CHAT_IDS). "
+            "No Telegram user ID configured (TELEGRAM_ALLOWED_CHAT_ID). "
             "All messages will be rejected. "
-            'Set to "*" to allow all users, or provide a comma-separated list of chat IDs.'
+            'Set to "*" to allow all users, or provide a single numeric chat ID.'
         )
 
     # Start all registered channels concurrently.

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -82,7 +82,7 @@ async def update_profile(
 def _build_channel_config_response() -> ChannelConfigResponse:
     return ChannelConfigResponse(
         telegram_bot_token_set=bool(settings.telegram_bot_token),
-        telegram_allowed_chat_ids=settings.telegram_allowed_chat_ids,
+        telegram_allowed_chat_id=settings.telegram_allowed_chat_id,
     )
 
 
@@ -103,6 +103,14 @@ async def update_channel_config(
     updates = {k: v for k, v in body.model_dump(exclude_unset=True).items() if v is not None}
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
+
+    # Enforce single Telegram chat ID (no comma-separated lists).
+    chat_id = updates.get("telegram_allowed_chat_id", "")
+    if chat_id and chat_id != "*" and "," in chat_id:
+        raise HTTPException(
+            status_code=422,
+            detail="Only a single Telegram user ID is allowed. Remove commas.",
+        )
 
     try:
         update_settings(updates)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -105,12 +105,12 @@ class SessionDetailResponse(BaseModel):
 
 class ChannelConfigResponse(BaseModel):
     telegram_bot_token_set: bool
-    telegram_allowed_chat_ids: str
+    telegram_allowed_chat_id: str
 
 
 class ChannelConfigUpdate(BaseModel):
     telegram_bot_token: str | None = None
-    telegram_allowed_chat_ids: str | None = None
+    telegram_allowed_chat_id: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -15,7 +15,7 @@ All available settings are listed in `.env.example` with defaults and comments. 
 | `LLM_PROVIDER` | Provider name (any provider supported by [any-llm](https://github.com/mozilla-ai/any-llm)) |
 | `LLM_MODEL` | Model identifier for the agent loop (e.g. the model name your provider expects) |
 | LLM API key | The API key env var for your chosen provider (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) |
-| `TELEGRAM_ALLOWED_CHAT_IDS` or `TELEGRAM_ALLOWED_USERNAMES` | Who can message the bot. Set to `*` to allow everyone, or a comma-separated list. **Empty = deny all** |
+| `TELEGRAM_ALLOWED_CHAT_ID` | Your numeric Telegram user ID. Set to `*` to allow everyone. **Empty = deny all** |
 
 ## Core
 
@@ -50,8 +50,7 @@ Set the API key env var for your chosen provider, or set `ANY_LLM_KEY` to use th
 | `MESSAGING_PROVIDER` | `telegram` | Messaging backend (currently only `telegram` is supported) |
 | `TELEGRAM_BOT_TOKEN` | | Bot token from @BotFather |
 | `TELEGRAM_WEBHOOK_SECRET` | (auto-derived) | Webhook validation secret. Auto-derived from bot token if not set |
-| `TELEGRAM_ALLOWED_CHAT_IDS` | (empty) | Comma-separated allowlist of Telegram chat IDs, or `*` to allow all. Empty = deny all |
-| `TELEGRAM_ALLOWED_USERNAMES` | (empty) | Comma-separated allowlist of Telegram usernames, or `*` to allow all. Empty = deny all |
+| `TELEGRAM_ALLOWED_CHAT_ID` | (empty) | Your numeric Telegram user ID, or `*` to allow all. Only a single ID is allowed per user. Empty = deny all |
 
 ## Storage settings
 

--- a/docs/src/content/docs/deployment/telegram-setup.mdx
+++ b/docs/src/content/docs/deployment/telegram-setup.mdx
@@ -28,33 +28,23 @@ You can customize your bot later with BotFather commands: `/setdescription` (bio
 
 ## 2. Configure access control
 
-Clawbolt rejects all incoming messages by default. Before starting the server, configure who is allowed to message the bot.
+Clawbolt rejects all incoming messages by default. Before starting the server, configure your Telegram user ID.
 
-### Allow by username
+### Set your chat ID
 
-The simplest option. Add Telegram usernames (without the `@`) to your `.env`:
-
-```bash
-TELEGRAM_ALLOWED_USERNAMES=johndoe,janedoe
-```
-
-### Allow by chat ID
-
-Chat IDs are numeric and never change, so they are more reliable than usernames. Add them to your `.env`:
+Chat IDs are numeric and never change. Each user can only set a single Telegram user ID. Add yours to your `.env`:
 
 ```bash
-TELEGRAM_ALLOWED_CHAT_IDS=123456789,987654321
+TELEGRAM_ALLOWED_CHAT_ID=123456789
 ```
 
 ### Allow everyone
 
-To allow any Telegram user to message the bot:
+To allow any Telegram user to message the bot (useful for development):
 
 ```bash
-TELEGRAM_ALLOWED_CHAT_IDS=*
+TELEGRAM_ALLOWED_CHAT_ID=*
 ```
-
-If both `TELEGRAM_ALLOWED_CHAT_IDS` and `TELEGRAM_ALLOWED_USERNAMES` are set, a message is allowed when **either** matches.
 
 ### Finding your chat ID
 
@@ -120,7 +110,7 @@ Then send a message to your bot on Telegram. If Clawbolt is running and configur
 
 **Bot does not respond to messages**
 
-- Check the server logs for allowlist rejections. If you see "not in allowlist, ignoring", update `TELEGRAM_ALLOWED_CHAT_IDS` or `TELEGRAM_ALLOWED_USERNAMES` in your `.env`.
+- Check the server logs for allowlist rejections. If you see "not in allowlist, ignoring", update `TELEGRAM_ALLOWED_CHAT_ID` in your `.env`.
 - Verify the webhook is registered: run the `getWebhookInfo` curl command above.
 - Make sure the server is running and reachable at the tunnel URL.
 

--- a/docs/src/content/docs/development/local-setup.mdx
+++ b/docs/src/content/docs/development/local-setup.mdx
@@ -26,7 +26,7 @@ cp .env.example .env
 Edit `.env` with your credentials. At minimum:
 - `TELEGRAM_BOT_TOKEN`
 - An LLM API key
-- `TELEGRAM_ALLOWED_CHAT_IDS` or `TELEGRAM_ALLOWED_USERNAMES` -- set to `*` to allow everyone, or a comma-separated list. **Messages are rejected by default when both are empty.**
+- `TELEGRAM_ALLOWED_CHAT_ID` -- your numeric Telegram user ID. Set to `*` to allow everyone. **Messages are rejected by default when empty.**
 
 ## Start the server
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -29,7 +29,7 @@ Edit `.env` and fill in the required credentials. See [Configuration](../configu
 At minimum you need:
 - `TELEGRAM_BOT_TOKEN` -- your Telegram bot token
 - An LLM API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
-- `TELEGRAM_ALLOWED_CHAT_IDS` or `TELEGRAM_ALLOWED_USERNAMES` -- controls who can message the bot. Set to `*` to allow everyone, or a comma-separated list of IDs/usernames. **Messages are rejected by default when both are empty.**
+- `TELEGRAM_ALLOWED_CHAT_ID` -- your numeric Telegram user ID. Set to `*` to allow everyone. **Messages are rejected by default when empty.**
 - `VISION_MODEL` -- the model used for image analysis (defaults to `LLM_MODEL` if not set)
 
 ## 3. Start the services

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -966,15 +966,15 @@
             "type": "boolean",
             "title": "Telegram Bot Token Set"
           },
-          "telegram_allowed_chat_ids": {
+          "telegram_allowed_chat_id": {
             "type": "string",
-            "title": "Telegram Allowed Chat Ids"
+            "title": "Telegram Allowed Chat Id"
           }
         },
         "type": "object",
         "required": [
           "telegram_bot_token_set",
-          "telegram_allowed_chat_ids"
+          "telegram_allowed_chat_id"
         ],
         "title": "ChannelConfigResponse"
       },
@@ -991,7 +991,7 @@
             ],
             "title": "Telegram Bot Token"
           },
-          "telegram_allowed_chat_ids": {
+          "telegram_allowed_chat_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -1000,7 +1000,7 @@
                 "type": "null"
               }
             ],
-            "title": "Telegram Allowed Chat Ids"
+            "title": "Telegram Allowed Chat Id"
           }
         },
         "type": "object",

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -481,14 +481,14 @@ export interface components {
             /** Telegram Bot Token Set */
             telegram_bot_token_set: boolean;
             /** Telegram Allowed Chat Ids */
-            telegram_allowed_chat_ids: string;
+            telegram_allowed_chat_id: string;
         };
         /** ChannelConfigUpdate */
         ChannelConfigUpdate: {
             /** Telegram Bot Token */
             telegram_bot_token?: string | null;
             /** Telegram Allowed Chat Ids */
-            telegram_allowed_chat_ids?: string | null;
+            telegram_allowed_chat_id?: string | null;
         };
         /** HTTPValidationError */
         HTTPValidationError: {

--- a/frontend/src/hooks/queries.test.tsx
+++ b/frontend/src/hooks/queries.test.tsx
@@ -97,7 +97,7 @@ describe('useToolConfig', () => {
 
 describe('useChannelConfig', () => {
   it('fetches and returns channel config', async () => {
-    const mockConfig = { telegram_bot_token_set: true, telegram_allowed_chat_ids: '*' };
+    const mockConfig = { telegram_bot_token_set: true, telegram_allowed_chat_id: '*' };
     vi.mocked(api.getChannelConfig).mockResolvedValue(mockConfig as never);
 
     const { result } = renderHook(() => useChannelConfig(), { wrapper: createWrapper() });

--- a/frontend/src/pages/ChannelsPage.tsx
+++ b/frontend/src/pages/ChannelsPage.tsx
@@ -158,14 +158,14 @@ function OssTelegramSection({
   const updateMutation = useUpdateChannelConfig();
   const [telegramUserId, setTelegramUserId] = useState<string | null>(null);
 
-  const displayedId = telegramUserId ?? config?.telegram_allowed_chat_ids ?? '';
+  const displayedId = telegramUserId ?? config?.telegram_allowed_chat_id ?? '';
 
   const handleSave = () => {
-    if (config && displayedId === config.telegram_allowed_chat_ids) {
+    if (config && displayedId === config.telegram_allowed_chat_id) {
       toast.error('No changes to save');
       return;
     }
-    updateMutation.mutate({ telegram_allowed_chat_ids: displayedId }, {
+    updateMutation.mutate({ telegram_allowed_chat_id: displayedId }, {
       onSuccess: () => {
         setTelegramUserId(null);
         toast.success('Telegram settings updated');

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def client(test_user: User) -> Generator[TestClient]:
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         # Default allowlist to "*" (allow all) so tests are not blocked.
         # Individual allowlist tests override these values.
-        patch("backend.app.channels.telegram.settings.telegram_allowed_chat_ids", "*"),
+        patch("backend.app.channels.telegram.settings.telegram_allowed_chat_id", "*"),
         # Clear bot token so auto-derived webhook secret is empty for tests that
         # don't send a secret header
         patch("backend.app.channels.telegram.settings.telegram_bot_token", ""),

--- a/tests/e2e/test_telegram_e2e.py
+++ b/tests/e2e/test_telegram_e2e.py
@@ -49,7 +49,7 @@ def e2e_client(
         # and send the secret header (the e2e focus is Telegram round-trip).
         patch("backend.app.channels.telegram.settings.telegram_bot_token", ""),
         # Allow all chat IDs through so the allowlist doesn't block e2e messages.
-        patch("backend.app.channels.telegram.settings.telegram_allowed_chat_ids", "*"),
+        patch("backend.app.channels.telegram.settings.telegram_allowed_chat_id", "*"),
         # Disable message batching so background tasks complete synchronously.
         patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
         TestClient(app) as c,

--- a/tests/test_allowlist_empty_warning.py
+++ b/tests/test_allowlist_empty_warning.py
@@ -19,7 +19,7 @@ def test_warns_when_allowlist_empty(caplog: "pytest.LogCaptureFixture") -> None:
     ):
         mock_settings.telegram_bot_token = "fake-bot-token"
         mock_settings.telegram_webhook_secret = "secret"
-        mock_settings.telegram_allowed_chat_ids = ""
+        mock_settings.telegram_allowed_chat_id = ""
         mock_settings.cors_origins = "*"
 
         with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
@@ -31,7 +31,7 @@ def test_warns_when_allowlist_empty(caplog: "pytest.LogCaptureFixture") -> None:
 
 
 def test_no_warning_when_chat_ids_set(caplog: "pytest.LogCaptureFixture") -> None:
-    """No allowlist warning when TELEGRAM_ALLOWED_CHAT_IDS is configured."""
+    """No allowlist warning when TELEGRAM_ALLOWED_CHAT_ID is configured."""
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.main.settings") as mock_settings,
@@ -40,7 +40,7 @@ def test_no_warning_when_chat_ids_set(caplog: "pytest.LogCaptureFixture") -> Non
     ):
         mock_settings.telegram_bot_token = "fake-bot-token"
         mock_settings.telegram_webhook_secret = "secret"
-        mock_settings.telegram_allowed_chat_ids = "12345"
+        mock_settings.telegram_allowed_chat_id = "12345"
         mock_settings.cors_origins = "*"
 
         with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):
@@ -63,7 +63,7 @@ def test_no_allowlist_warning_when_bot_token_not_set(
     ):
         mock_settings.telegram_bot_token = ""
         mock_settings.telegram_webhook_secret = ""
-        mock_settings.telegram_allowed_chat_ids = ""
+        mock_settings.telegram_allowed_chat_id = ""
         mock_settings.cors_origins = "*"
 
         with caplog.at_level(logging.WARNING, logger="backend.app.main"), TestClient(app):

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -104,16 +104,16 @@ def test_update_channel_config_null_token_is_ignored(
     client: TestClient, _set_bot_token: None
 ) -> None:
     """PUT with null token should be ignored, preserving the existing value."""
-    original_ids = settings.telegram_allowed_chat_ids
+    original_id = settings.telegram_allowed_chat_id
     with patch("backend.app.routers.user_profile.save_persistent_config"):
         resp = client.put(
             "/api/user/channels/config",
-            json={"telegram_bot_token": None, "telegram_allowed_chat_ids": "111"},
+            json={"telegram_bot_token": None, "telegram_allowed_chat_id": "111"},
         )
     assert resp.status_code == 200
     assert resp.json()["telegram_bot_token_set"] is True
     assert settings.telegram_bot_token == "test-token-123"
-    settings.telegram_allowed_chat_ids = original_ids
+    settings.telegram_allowed_chat_id = original_id
 
 
 def test_update_channel_config_null_only_returns_400(
@@ -141,35 +141,48 @@ def test_update_channel_config_empty_string_clears_token(
     assert settings.telegram_bot_token == ""
 
 
-def test_get_channel_config_includes_allowed_chat_ids(
+def test_get_channel_config_includes_allowed_chat_id(
     client: TestClient,
 ) -> None:
-    """GET response includes telegram_allowed_chat_ids field."""
-    original = settings.telegram_allowed_chat_ids
-    settings.telegram_allowed_chat_ids = "111,222,333"
+    """GET response includes telegram_allowed_chat_id field."""
+    original = settings.telegram_allowed_chat_id
+    settings.telegram_allowed_chat_id = "111222333"
     try:
         resp = client.get("/api/user/channels/config")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["telegram_allowed_chat_ids"] == "111,222,333"
+        assert data["telegram_allowed_chat_id"] == "111222333"
     finally:
-        settings.telegram_allowed_chat_ids = original
+        settings.telegram_allowed_chat_id = original
 
 
-def test_update_channel_config_allowed_chat_ids(
+def test_update_channel_config_allowed_chat_id(
     client: TestClient,
 ) -> None:
-    """PUT updates telegram_allowed_chat_ids in settings."""
-    original = settings.telegram_allowed_chat_ids
+    """PUT updates telegram_allowed_chat_id in settings."""
+    original = settings.telegram_allowed_chat_id
     with patch("backend.app.routers.user_profile.save_persistent_config"):
         try:
             resp = client.put(
                 "/api/user/channels/config",
-                json={"telegram_allowed_chat_ids": "444,555"},
+                json={"telegram_allowed_chat_id": "444555"},
             )
             assert resp.status_code == 200
             data = resp.json()
-            assert data["telegram_allowed_chat_ids"] == "444,555"
-            assert settings.telegram_allowed_chat_ids == "444,555"
+            assert data["telegram_allowed_chat_id"] == "444555"
+            assert settings.telegram_allowed_chat_id == "444555"
         finally:
-            settings.telegram_allowed_chat_ids = original
+            settings.telegram_allowed_chat_id = original
+
+
+def test_update_channel_config_rejects_multiple_chat_ids(
+    client: TestClient,
+) -> None:
+    """PUT rejects comma-separated chat IDs (only a single ID is allowed)."""
+    with patch("backend.app.routers.user_profile.save_persistent_config"):
+        resp = client.put(
+            "/api/user/channels/config",
+            json={"telegram_allowed_chat_id": "111,222"},
+        )
+    assert resp.status_code == 422
+    assert "single" in resp.json()["detail"].lower()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -80,7 +80,7 @@ def client(test_user: User) -> Generator[TestClient]:
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
-        patch("backend.app.channels.telegram.settings.telegram_allowed_chat_ids", "*"),
+        patch("backend.app.channels.telegram.settings.telegram_allowed_chat_id", "*"),
         patch("backend.app.channels.telegram.settings.telegram_bot_token", ""),
         patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
         TestClient(app) as c,

--- a/tests/test_persistent_config.py
+++ b/tests/test_persistent_config.py
@@ -60,7 +60,7 @@ def test_load_config_applies_values(config_path: Path) -> None:
         json.dumps(
             {
                 "telegram_bot_token": "saved-token",
-                "telegram_allowed_chat_ids": "111,222",
+                "telegram_allowed_chat_id": "111222",
             }
         )
     )
@@ -69,7 +69,7 @@ def test_load_config_applies_values(config_path: Path) -> None:
 
     assert result["telegram_bot_token"] == "saved-token"
     assert settings.telegram_bot_token == "saved-token"
-    assert settings.telegram_allowed_chat_ids == "111,222"
+    assert settings.telegram_allowed_chat_id == "111222"
 
 
 def test_load_config_env_var_takes_precedence(config_path: Path) -> None:
@@ -118,11 +118,11 @@ def test_save_merges_with_existing(config_path: Path) -> None:
     """save_persistent_config merges new keys into existing config."""
     config_path.write_text(json.dumps({"telegram_bot_token": "existing-tok"}))
 
-    save_persistent_config({"telegram_allowed_chat_ids": "111"}, path=config_path)
+    save_persistent_config({"telegram_allowed_chat_id": "111"}, path=config_path)
 
     data = json.loads(config_path.read_text())
     assert data["telegram_bot_token"] == "existing-tok"
-    assert data["telegram_allowed_chat_ids"] == "111"
+    assert data["telegram_allowed_chat_id"] == "111"
 
 
 def test_save_overwrites_existing_key(config_path: Path) -> None:
@@ -160,7 +160,7 @@ def test_load_all_persistable_settings(config_path: Path) -> None:
     """All four persistable settings can be loaded from config.json."""
     all_values = {
         "telegram_bot_token": "bot-token-value",
-        "telegram_allowed_chat_ids": "111,222",
+        "telegram_allowed_chat_id": "111222",
         "telegram_webhook_secret": "secret-value",
     }
     config_path.write_text(json.dumps(all_values))
@@ -174,18 +174,18 @@ def test_load_all_persistable_settings(config_path: Path) -> None:
 def test_round_trip_save_then_load(config_path: Path) -> None:
     """Values saved with save_persistent_config can be loaded back."""
     save_persistent_config(
-        {"telegram_bot_token": "rt-token", "telegram_allowed_chat_ids": "111"},
+        {"telegram_bot_token": "rt-token", "telegram_allowed_chat_id": "111"},
         path=config_path,
     )
 
     # Reset settings to defaults
     settings.telegram_bot_token = ""
-    settings.telegram_allowed_chat_ids = ""
+    settings.telegram_allowed_chat_id = ""
 
     load_persistent_config(path=config_path)
 
     assert settings.telegram_bot_token == "rt-token"
-    assert settings.telegram_allowed_chat_ids == "111"
+    assert settings.telegram_allowed_chat_id == "111"
 
 
 # ---------------------------------------------------------------------------
@@ -222,8 +222,8 @@ def test_update_settings_multiple_keys() -> None:
     update_settings(
         {
             "telegram_bot_token": "multi-tok",
-            "telegram_allowed_chat_ids": "111,222",
+            "telegram_allowed_chat_id": "111222",
         }
     )
     assert settings.telegram_bot_token == "multi-tok"
-    assert settings.telegram_allowed_chat_ids == "111,222"
+    assert settings.telegram_allowed_chat_id == "111222"

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -128,12 +128,12 @@ def test_webhook_survives_bus_publish_failure(client: TestClient) -> None:
 
 
 def test_allowlist_rejects_unlisted_chat_id(client: TestClient) -> None:
-    """Messages from a chat_id not in the allowlist should be silently ignored."""
+    """Messages from a chat_id not matching the configured ID should be ignored."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch(
-            "backend.app.channels.telegram.settings.telegram_allowed_chat_ids",
-            "111,222",
+            "backend.app.channels.telegram.settings.telegram_allowed_chat_id",
+            "111",
         ),
     ):
         payload = make_telegram_update_payload(chat_id=999, text="Hi")
@@ -143,13 +143,13 @@ def test_allowlist_rejects_unlisted_chat_id(client: TestClient) -> None:
     mock_pub.assert_not_called()
 
 
-def test_allowlist_accepts_listed_chat_id(client: TestClient) -> None:
-    """Messages from a chat_id on the allowlist should be published to bus."""
+def test_allowlist_accepts_matching_chat_id(client: TestClient) -> None:
+    """Messages from the configured chat ID should be published to bus."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch(
-            "backend.app.channels.telegram.settings.telegram_allowed_chat_ids",
-            "111,123456789,333",
+            "backend.app.channels.telegram.settings.telegram_allowed_chat_id",
+            "123456789",
         ),
     ):
         payload = make_telegram_update_payload(chat_id=123456789, text="Hello")
@@ -164,7 +164,7 @@ def test_allowlist_empty_denies_all(client: TestClient) -> None:
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch(
-            "backend.app.channels.telegram.settings.telegram_allowed_chat_ids",
+            "backend.app.channels.telegram.settings.telegram_allowed_chat_id",
             "",
         ),
     ):
@@ -176,11 +176,11 @@ def test_allowlist_empty_denies_all(client: TestClient) -> None:
 
 
 def test_allowlist_wildcard_allows_all(client: TestClient) -> None:
-    """Setting TELEGRAM_ALLOWED_CHAT_IDS to '*' should allow all chat IDs."""
+    """Setting TELEGRAM_ALLOWED_CHAT_ID to '*' should allow all chat IDs."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch(
-            "backend.app.channels.telegram.settings.telegram_allowed_chat_ids",
+            "backend.app.channels.telegram.settings.telegram_allowed_chat_id",
             "*",
         ),
     ):

--- a/tests/test_webhook_secret_validation.py
+++ b/tests/test_webhook_secret_validation.py
@@ -68,7 +68,7 @@ def _make_client(
                 bot_token,
             ),
             patch(
-                "backend.app.channels.telegram.settings.telegram_allowed_chat_ids",
+                "backend.app.channels.telegram.settings.telegram_allowed_chat_id",
                 "*",
             ),
             patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),


### PR DESCRIPTION
## Description

Enforce that each Clawbolt user can only set a single Telegram user ID, replacing the previous comma-separated allowlist.

- Rename `telegram_allowed_chat_ids` to `telegram_allowed_chat_id` (singular) across backend, frontend, config, and docs
- Add API validation rejecting comma-separated values (returns 422)
- Simplify `is_allowed()` to compare against a single ID instead of splitting a list
- Update docs to reflect single-ID semantics and remove stale username allowlist references

Fixes #727

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used