### PR TITLE
feat: granular resource-level approval for tools, fix double prompt

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -299,8 +299,13 @@ class ApprovalGate:
         channel: str,
         chat_id: str,
         timeout: float | None = None,
+        prompt: str | None = None,
     ) -> ApprovalDecision:
         """Send an approval prompt and wait for the user's decision.
+
+        When *prompt* is provided it is sent as-is (useful when the caller
+        has already formatted a batch plan message).  Otherwise a default
+        prompt is built from *tool_name* and *description*.
 
         Returns ``DENIED`` on timeout.
         """
@@ -310,7 +315,8 @@ class ApprovalGate:
         pending = PendingApproval(tool_name=tool_name, description=description)
         self._pending[user_id] = pending
 
-        prompt = _format_approval_message(tool_name, description)
+        if prompt is None:
+            prompt = _format_approval_message(tool_name, description)
         try:
             from backend.app.bus import OutboundMessage as OMsg
 

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -558,6 +558,7 @@ class ClawboltAgent:
                     publish_outbound=self._publish_outbound,
                     channel=self._channel,
                     chat_id=self._chat_id,
+                    prompt=plan_msg,
                 )
             else:
                 decision = ApprovalDecision.DENIED

--- a/backend/app/agent/tools/quickbooks_tools.py
+++ b/backend/app/agent/tools/quickbooks_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -170,6 +171,23 @@ def _make_token_refresh_callback(user_id: str, realm_id: str) -> Any:
             logger.exception("Failed to persist refreshed QuickBooks tokens for user %s", user_id)
 
     return _persist_refreshed_tokens
+
+
+def _extract_query_entity(args: dict[str, Any]) -> str | None:
+    """Extract the entity name from a QBO query string (e.g. 'Invoice' from 'SELECT * FROM Invoice')."""
+    query = str(args.get("query", ""))
+    match = re.search(r"\bFROM\s+(\w+)", query, re.IGNORECASE)
+    return match.group(1) if match else None
+
+
+def _extract_entity_type(args: dict[str, Any]) -> str | None:
+    """Extract the entity_type argument."""
+    return str(args["entity_type"]) if args.get("entity_type") else None
+
+
+def _extract_send_email(args: dict[str, Any]) -> str | None:
+    """Extract the email recipient from qb_send arguments."""
+    return str(args["email"]) if args.get("email") else None
 
 
 def create_quickbooks_tools(
@@ -346,6 +364,7 @@ def create_quickbooks_tools(
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
+                resource_extractor=_extract_query_entity,
                 description_builder=lambda args: (
                     f"Query QuickBooks: {str(args.get('query', ''))[:60]}"
                 ),
@@ -366,6 +385,7 @@ def create_quickbooks_tools(
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
+                resource_extractor=_extract_entity_type,
                 description_builder=lambda args: (
                     f"Create {args.get('entity_type', 'entity')} in QuickBooks"
                 ),
@@ -387,6 +407,7 @@ def create_quickbooks_tools(
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
+                resource_extractor=_extract_entity_type,
                 description_builder=lambda args: (
                     f"Update {args.get('entity_type', 'entity')} in QuickBooks"
                 ),
@@ -406,6 +427,7 @@ def create_quickbooks_tools(
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
+                resource_extractor=_extract_send_email,
                 description_builder=lambda args: (
                     f"Send {args.get('entity_type', 'entity')} "
                     f"to {args.get('email', 'recipient')} via QuickBooks"

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -80,6 +80,11 @@ class DeleteFileParams(BaseModel):
     path: str = Field(description="Relative path within your workspace (e.g. 'BOOTSTRAP.md')")
 
 
+def _extract_path(args: dict[str, object]) -> str | None:
+    """Extract the file path from workspace tool arguments."""
+    return str(args["path"]) if args.get("path") else None
+
+
 def _resolve_path(user_id: str, relative_path: str) -> tuple[Path, str | None]:
     """Resolve a relative path to an absolute path within the user directory.
 
@@ -374,6 +379,7 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.AUTO,
+                resource_extractor=_extract_path,
                 description_builder=lambda args: f"Write to {args.get('path', 'file')}",
             ),
         ),
@@ -389,6 +395,7 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
             tags={ToolTags.MODIFIES_PROFILE},
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.AUTO,
+                resource_extractor=_extract_path,
                 description_builder=lambda args: f"Edit {args.get('path', 'file')}",
             ),
         ),
@@ -403,6 +410,7 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
             tags={ToolTags.MODIFIES_PROFILE},
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
+                resource_extractor=_extract_path,
                 description_builder=lambda args: f"Delete {args.get('path', 'file')}",
             ),
         ),

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -443,3 +443,107 @@ class TestBatchApproval:
             msg = call.args[0] if call.args else call.kwargs.get("msg")
             if isinstance(msg, OutboundMessage):
                 assert "needs OK" not in msg.content
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_plan_prompt_not_double_wrapped(
+        self, mock_amessages: object, test_user: User
+    ) -> None:
+        """The approval prompt should not wrap the plan message with a second 'Reply:' line."""
+        mock_publish = AsyncMock()
+
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response([{"name": "writer", "arguments": {"text": "data"}}]),
+            make_text_response("Done!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _approve_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            gate.resolve(test_user.id, ApprovalDecision.APPROVED)
+
+        agent = ClawboltAgent(
+            user=test_user,
+            channel="telegram",
+            publish_outbound=mock_publish,
+            chat_id="chat_1",
+        )
+        agent.register_tools([_ask_tool()])
+
+        task = asyncio.create_task(_approve_soon())
+        await agent.process_message("write it")
+        await task
+
+        # Find the approval prompt message
+        approval_msgs = []
+        for call in mock_publish.call_args_list:
+            msg = call.args[0] if call.args else call.kwargs.get("msg")
+            if isinstance(msg, OutboundMessage) and "Reply:" in msg.content:
+                approval_msgs.append(msg.content)
+
+        assert len(approval_msgs) == 1
+        # "Reply:" should appear exactly once (not double-wrapped)
+        assert approval_msgs[0].count("Reply:") == 1
+        # Should not contain the _format_approval_message wrapper
+        assert "wants to use the tool" not in approval_msgs[0]
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_always_persists_per_resource(
+        self, mock_amessages: object, test_user: User
+    ) -> None:
+        """'always' with resource_extractor persists AUTO for the specific resource only."""
+        mock_publish = AsyncMock()
+
+        def _extractor(args: dict[str, object]) -> str | None:
+            return str(args["text"]) if args.get("text") else None
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch data",
+            function=_echo_tool,
+            params_model=_EchoParams,
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                resource_extractor=_extractor,
+                description_builder=lambda args: f"Fetch {args.get('text', '')}",
+            ),
+        )
+
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response([{"name": "fetcher", "arguments": {"text": "invoices"}}]),
+            make_text_response("Done!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _always_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            gate.resolve(test_user.id, ApprovalDecision.ALWAYS_ALLOW)
+
+        agent = ClawboltAgent(
+            user=test_user,
+            channel="telegram",
+            publish_outbound=mock_publish,
+            chat_id="chat_1",
+        )
+        agent.register_tools([tool])
+
+        task = asyncio.create_task(_always_soon())
+        await agent.process_message("fetch invoices")
+        await task
+
+        # "invoices" resource should be AUTO
+        store = get_approval_store()
+        assert (
+            store.check_permission(test_user.id, "fetcher", resource="invoices")
+            == PermissionLevel.AUTO
+        )
+        # Different resource should still be ASK (the default)
+        assert (
+            store.check_permission(test_user.id, "fetcher", resource="customers")
+            == PermissionLevel.ASK
+        )

--- a/tests/test_tool_policies.py
+++ b/tests/test_tool_policies.py
@@ -87,6 +87,56 @@ class TestHeartbeatToolPolicies:
         assert tool.approval_policy.default_level == PermissionLevel.AUTO
 
 
-# QuickBooks and file tools are tested indirectly through their factory
-# functions, which require service dependencies. Their policies are
-# verified by the integration tests and manual inspection.
+class TestWorkspaceResourceExtractors:
+    def test_write_file_extracts_path(self) -> None:
+        tools = create_workspace_tools("test-user")
+        tool = _find_tool(tools, ToolName.WRITE_FILE)
+        assert tool.approval_policy is not None
+        assert tool.approval_policy.resource_extractor is not None
+        resource = tool.approval_policy.resource_extractor({"path": "USER.md", "content": "x"})
+        assert resource == "USER.md"
+
+    def test_edit_file_extracts_path(self) -> None:
+        tools = create_workspace_tools("test-user")
+        tool = _find_tool(tools, ToolName.EDIT_FILE)
+        assert tool.approval_policy is not None
+        assert tool.approval_policy.resource_extractor is not None
+        resource = tool.approval_policy.resource_extractor(
+            {"path": "SOUL.md", "old_text": "a", "new_text": "b"}
+        )
+        assert resource == "SOUL.md"
+
+    def test_delete_file_extracts_path(self) -> None:
+        tools = create_workspace_tools("test-user")
+        tool = _find_tool(tools, ToolName.DELETE_FILE)
+        assert tool.approval_policy is not None
+        assert tool.approval_policy.resource_extractor is not None
+        resource = tool.approval_policy.resource_extractor({"path": "BOOTSTRAP.md"})
+        assert resource == "BOOTSTRAP.md"
+
+    def test_read_file_has_no_extractor(self) -> None:
+        tools = create_workspace_tools("test-user")
+        tool = _find_tool(tools, ToolName.READ_FILE)
+        assert tool.approval_policy is None
+
+
+class TestQuickBooksResourceExtractors:
+    def test_qb_query_extracts_entity_from_query(self) -> None:
+        from backend.app.agent.tools.quickbooks_tools import _extract_query_entity
+
+        assert _extract_query_entity({"query": "SELECT * FROM Invoice"}) == "Invoice"
+        assert _extract_query_entity({"query": "select Id from Customer"}) == "Customer"
+        assert _extract_query_entity({"query": "bad query"}) is None
+
+    def test_qb_create_extracts_entity_type(self) -> None:
+        from backend.app.agent.tools.quickbooks_tools import _extract_entity_type
+
+        assert _extract_entity_type({"entity_type": "Invoice", "data": {}}) == "Invoice"
+        assert _extract_entity_type({"entity_type": "Customer", "data": {}}) == "Customer"
+        assert _extract_entity_type({}) is None
+
+    def test_qb_send_extracts_email(self) -> None:
+        from backend.app.agent.tools.quickbooks_tools import _extract_send_email
+
+        assert _extract_send_email({"email": "bob@example.com"}) == "bob@example.com"
+        assert _extract_send_email({}) is None


### PR DESCRIPTION
## Description

Adds resource-level granularity to the tool approval system and fixes a double-prompt bug on Telegram.

**Granular approvals:** Tools now use `resource_extractor` to pull a resource key from call arguments. When a user says "always", the permission is persisted for that specific resource only (not the entire tool). For example:
- `qb_query` extracts the entity name from the FROM clause (e.g., "Invoice") so "always" on Invoice queries doesn't auto-approve Customer queries
- `qb_create`/`qb_update` extract the `entity_type` argument
- `qb_send` extracts the email recipient
- Workspace `write_file`/`edit_file`/`delete_file` extract the file path

**Double-prompt fix:** The batch plan message already included "Reply: yes | no | always | never" but was then wrapped by `_format_approval_message()` which added a second "Reply:" line. Now the pre-formatted plan message is passed directly to the approval gate via a new `prompt` parameter.

Fixes #731

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the changes and wrote tests)
- [ ] No AI used