### PR TITLE
fix: regenerate frontend types for renamed telegram field

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -480,14 +480,14 @@ export interface components {
         ChannelConfigResponse: {
             /** Telegram Bot Token Set */
             telegram_bot_token_set: boolean;
-            /** Telegram Allowed Chat Ids */
+            /** Telegram Allowed Chat Id */
             telegram_allowed_chat_id: string;
         };
         /** ChannelConfigUpdate */
         ChannelConfigUpdate: {
             /** Telegram Bot Token */
             telegram_bot_token?: string | null;
-            /** Telegram Allowed Chat Ids */
+            /** Telegram Allowed Chat Id */
             telegram_allowed_chat_id?: string | null;
         };
         /** HTTPValidationError */


### PR DESCRIPTION
## Description

Regenerate `frontend/src/generated/api.d.ts` to match the `telegram_allowed_chat_id` field rename from #732. Two JSDoc comments updated from plural ("Ids") to singular ("Id").

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code regenerated types)
- [ ] No AI used