### PR TITLE
fix: teach agent about heartbeat outreach and include current time

### DIFF
--- a/backend/app/agent/prompts/proactive.md
+++ b/backend/app/agent/prompts/proactive.md
@@ -1,4 +1,8 @@
-You will proactively reach out during active hours when something needs attention:
+You can proactively reach out to the user even when they haven't messaged you. A background heartbeat system checks in periodically and will deliver your messages to the user on your behalf.
+
+When to reach out proactively:
 - A scheduled heartbeat item is due
 - A follow-up reminder or deadline is approaching
 - You haven't heard from the user in a few days
+
+When a user asks to be reminded about something recurring (e.g. "send me a joke every week", "check on unpaid invoices daily"), you CAN do that. Add the item to HEARTBEAT.md and the heartbeat system will trigger you to follow through on schedule. Do not tell the user you cannot reach out on your own.

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -203,7 +203,7 @@ async def build_agent_system_prompt(
         instructions = build_instructions_section()
     builder.add_section("Instructions", instructions)
 
-    builder.add_section("Current date", build_date_section(user))
+    builder.add_section("Current date and time", build_local_datetime_section(user))
 
     builder.add_section("Proactive Messaging", build_proactive_section())
     builder.add_section("Recall Behavior", build_recall_section())

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -151,6 +151,12 @@ class TestSectionBuilders:
         assert "heartbeat" in result
         assert "reminder" in result
 
+    def test_build_proactive_section_explains_outreach(self) -> None:
+        """Proactive section should tell the agent it can reach out without user messaging first."""
+        result = build_proactive_section()
+        assert "proactively" in result
+        assert "HEARTBEAT.md" in result
+
     def test_build_recall_section(self) -> None:
         """Should contain recall behavior rules."""
         result = build_recall_section()
@@ -335,8 +341,8 @@ class TestBuildLocalDatetimeSection:
 class TestAgentSystemPromptIncludesDate:
     @pytest.mark.asyncio
     @patch("backend.app.agent.system_prompt.datetime")
-    async def test_agent_prompt_has_current_date(self, mock_dt: MagicMock) -> None:
-        """Main agent prompt should include a Current date section."""
+    async def test_agent_prompt_has_current_date_and_time(self, mock_dt: MagicMock) -> None:
+        """Main agent prompt should include a Current date and time section."""
         mock_dt.UTC = datetime.UTC
         mock_dt.datetime.now.return_value = datetime.datetime(
             2025, 6, 16, 15, 0, tzinfo=datetime.UTC
@@ -358,9 +364,11 @@ class TestAgentSystemPromptIncludesDate:
                 message_context="hello",
             )
 
-        assert "## Current date" in result
+        assert "## Current date and time" in result
         assert "Monday" in result
         assert "2025-06-16" in result
+        # Should include time, not just the date
+        assert "08:00 AM" in result
 
 
 class TestCrossSessionContext:


### PR DESCRIPTION
## Description
Two system prompt fixes:

1. **Heartbeat awareness**: The agent was telling users "I can only reach you when you message me first" because the proactive messaging section didn't clearly explain the heartbeat system. Updated `proactive.md` to explicitly state the agent can reach out proactively via heartbeat, and to never tell users it can't.

2. **Current time**: The agent only received the current date (no time) to avoid prompt-cache busting. Now includes hour and minute in the user's local timezone using the existing `build_local_datetime_section` function, so the agent understands local time context.

Fixes #735

## Type
- [x] Bug fix

## Checklist
- [ ] Tests pass (`uv run pytest -v`)
- [ ] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the fix)
- [ ] No AI used