### PR TITLE
feat: simplify get started page to two steps

### DIFF
--- a/frontend/src/pages/GetStartedPage.test.tsx
+++ b/frontend/src/pages/GetStartedPage.test.tsx
@@ -54,9 +54,9 @@ describe('GetStartedPage', () => {
 
     expect(screen.getByText('Get Started')).toBeInTheDocument();
     expect(screen.getByText('Set up Telegram')).toBeInTheDocument();
-    expect(screen.getByText('Tell it about you')).toBeInTheDocument();
-    expect(screen.getByText('Customize its personality')).toBeInTheDocument();
     expect(screen.getByText('Start chatting')).toBeInTheDocument();
+    expect(screen.queryByText('Tell it about you')).not.toBeInTheDocument();
+    expect(screen.queryByText('Customize its personality')).not.toBeInTheDocument();
   });
 
   it('navigates to channels page when configure channels is clicked', async () => {

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -18,22 +18,6 @@ const STEPS = [
     icon: ChannelsIcon,
   },
   {
-    title: 'Tell it about you',
-    description:
-      'Add your name, trade, timezone, and preferences so your assistant knows who you are.',
-    link: '/app/user',
-    linkLabel: 'Edit Profile',
-    icon: UserIcon,
-  },
-  {
-    title: 'Customize its personality',
-    description:
-      'Adjust how your assistant communicates: tone, style, and what it focuses on.',
-    link: '/app/soul',
-    linkLabel: 'Edit Soul',
-    icon: SoulIcon,
-  },
-  {
     title: 'Start chatting',
     description:
       'Send your first message. Try asking for an estimate, a reminder, or just say hello.',
@@ -136,22 +120,6 @@ function ChannelsIcon() {
   return (
     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
-    </svg>
-  );
-}
-
-function UserIcon() {
-  return (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-    </svg>
-  );
-}
-
-function SoulIcon() {
-  return (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
     </svg>
   );
 }


### PR DESCRIPTION
## Description
Simplifies the Get Started onboarding page from 4 steps down to 2, per the issue request:
1. Set up Telegram
2. Start chatting

Removes the "Tell it about you" and "Customize its personality" intermediate steps along with their unused `UserIcon` and `SoulIcon` SVG components.

Fixes #740

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by Claude Code)
- [ ] No AI used