### PR TITLE
fix: add explicit timezone context to agent time section

### DIFF
--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -134,10 +134,27 @@ def build_date_section(user: User) -> str:
 
 
 def build_local_datetime_section(user: User) -> str:
-    """Build a human-readable local datetime for the heartbeat evaluator."""
+    """Build a human-readable local datetime with explicit timezone context.
+
+    Includes the IANA timezone name alongside the abbreviation so the LLM
+    unambiguously knows which timezone the time is in, and a directive to
+    always use this timezone when discussing times with the user.
+    """
     now = datetime.datetime.now(datetime.UTC)
     local = to_local_time(now, user.timezone)
-    return local.strftime("%A, %Y-%m-%d %I:%M %p %Z").strip()
+    formatted = local.strftime("%A, %Y-%m-%d %I:%M %p %Z").strip()
+    if user.timezone:
+        return (
+            f"{formatted} ({user.timezone})\n"
+            "This is the user's local time. Always use this timezone when "
+            "discussing times, scheduling, or referring to deadlines."
+        )
+    return (
+        f"{formatted}\n"
+        "No timezone has been set for this user. This time is in UTC. "
+        "If the user mentions their location or timezone, update USER.md "
+        "with their timezone so future times are shown in their local time."
+    )
 
 
 def build_cross_session_context(

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -326,6 +326,19 @@ class TestBuildLocalDatetimeSection:
         assert "2025-06-15" in result
 
     @patch("backend.app.agent.system_prompt.datetime")
+    def test_includes_iana_timezone_name(self, mock_dt: MagicMock) -> None:
+        """Should include IANA timezone name for unambiguous identification."""
+        mock_dt.UTC = datetime.UTC
+        mock_dt.datetime.now.return_value = datetime.datetime(
+            2025, 6, 15, 17, 30, tzinfo=datetime.UTC
+        )
+        user = MagicMock()
+        user.timezone = "America/New_York"
+        result = build_local_datetime_section(user)
+        assert "(America/New_York)" in result
+        assert "user's local time" in result
+
+    @patch("backend.app.agent.system_prompt.datetime")
     def test_utc_fallback_when_no_timezone(self, mock_dt: MagicMock) -> None:
         mock_dt.UTC = datetime.UTC
         mock_dt.datetime.now.return_value = datetime.datetime(
@@ -336,6 +349,19 @@ class TestBuildLocalDatetimeSection:
         result = build_local_datetime_section(user)
         assert "05:30 PM" in result
         assert "Sunday" in result
+
+    @patch("backend.app.agent.system_prompt.datetime")
+    def test_utc_fallback_includes_guidance(self, mock_dt: MagicMock) -> None:
+        """When no timezone is set, should tell the agent to ask for it."""
+        mock_dt.UTC = datetime.UTC
+        mock_dt.datetime.now.return_value = datetime.datetime(
+            2025, 6, 15, 17, 30, tzinfo=datetime.UTC
+        )
+        user = MagicMock()
+        user.timezone = ""
+        result = build_local_datetime_section(user)
+        assert "UTC" in result
+        assert "No timezone has been set" in result
 
 
 class TestAgentSystemPromptIncludesDate:


### PR DESCRIPTION
## Description
The agent was presenting UTC timestamps as if they were in the user's local timezone. The `build_local_datetime_section` function produced a bare timestamp like `Monday, 2025-06-16 03:53 PM EDT` with no guidance on how to use it, causing the LLM to confuse UTC with local time.

Now the time section includes:
- The IANA timezone name alongside the abbreviation (e.g. `03:53 PM EDT (America/New_York)`) for unambiguous identification
- A directive: "This is the user's local time. Always use this timezone when discussing times, scheduling, or referring to deadlines."
- When no timezone is set, explicitly tells the agent the time is UTC and to update USER.md when the user mentions their timezone

Fixes #743

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used