### PR TITLE
feat: include heartbeat send history in Phase 1 evaluator prompt

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -25,10 +25,14 @@ from any_llm.types.messages import MessageResponse
 from pydantic import BaseModel, Field, ValidationError
 
 from backend.app.agent.context import get_or_create_conversation
+from backend.app.agent.dto import HeartbeatLogEntry
 from backend.app.agent.file_store import HeartbeatStore
 from backend.app.agent.llm_parsing import get_response_text, parse_tool_calls
 from backend.app.agent.session_db import get_session_store
-from backend.app.agent.system_prompt import build_heartbeat_system_prompt, to_local_time
+from backend.app.agent.system_prompt import (
+    build_heartbeat_system_prompt,
+    to_local_time,
+)
 from backend.app.agent.tools.names import ToolName
 from backend.app.channels import get_channel, get_default_channel, get_manager
 from backend.app.config import settings
@@ -54,6 +58,9 @@ _NAMED_FREQUENCIES: dict[str, int] = {
 
 # Minimum tick resolution: the scheduler wakes up this often.
 _TICK_RESOLUTION_MINUTES = 1
+
+# How far back to look when building heartbeat history context for the LLM.
+_HISTORY_LOOKBACK_DAYS = 7
 
 
 def parse_frequency_to_minutes(freq: str) -> int | None:
@@ -266,6 +273,43 @@ def _parse_tool_call_response(response: MessageResponse) -> HeartbeatAction:
     )
 
 
+def _format_heartbeat_history(
+    logs: list[HeartbeatLogEntry],
+    tz_name: str,
+    now: datetime.datetime,
+) -> str:
+    """Format recent heartbeat log entries into a human-readable summary.
+
+    Shows when heartbeat messages were previously sent so the Phase 1
+    evaluator can avoid duplicate sends and reason about timing.
+    """
+    if not logs:
+        return (
+            f"You have not sent any heartbeat messages to this user "
+            f"in the last {_HISTORY_LOOKBACK_DAYS} days."
+        )
+
+    lines: list[str] = []
+    for entry in logs:
+        ts = datetime.datetime.fromisoformat(entry.created_at)
+        local_ts = to_local_time(ts, tz_name)
+        formatted = local_ts.strftime("%A, %Y-%m-%d %I:%M %p %Z").strip()
+        delta = now - ts
+        if delta.days == 0:
+            ago = "today"
+        elif delta.days == 1:
+            ago = "1 day ago"
+        else:
+            ago = f"{delta.days} days ago"
+        lines.append(f"- {formatted} ({ago})")
+
+    summary = "\n".join(lines)
+    return (
+        f"Your recent heartbeat messages to this user "
+        f"(last {_HISTORY_LOOKBACK_DAYS} days):\n{summary}"
+    )
+
+
 async def evaluate_heartbeat_need(
     user: User,
     channel: str = "",
@@ -290,7 +334,16 @@ async def evaluate_heartbeat_need(
     heartbeat_store = HeartbeatStore(user.id)
     heartbeat_md = heartbeat_store.read_heartbeat_md()
 
-    prompt = await build_heartbeat_system_prompt(user, recent_text, heartbeat_md=heartbeat_md)
+    # Fetch recent heartbeat send history so the LLM knows when it last
+    # messaged this user and can avoid duplicates or missed sends.
+    now = datetime.datetime.now(datetime.UTC)
+    since = now - datetime.timedelta(days=_HISTORY_LOOKBACK_DAYS)
+    recent_logs = await heartbeat_store.get_recent_logs(since)
+    heartbeat_history = _format_heartbeat_history(recent_logs, user.timezone, now)
+
+    prompt = await build_heartbeat_system_prompt(
+        user, recent_text, heartbeat_md=heartbeat_md, heartbeat_history=heartbeat_history
+    )
 
     logger.debug(
         "Heartbeat Phase 1 context for user %s: recent_messages=%d, "

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -237,12 +237,15 @@ async def build_heartbeat_system_prompt(
     user: User,
     recent_messages: str,
     heartbeat_md: str = "",
+    heartbeat_history: str = "",
 ) -> str:
     """Assemble the system prompt for the heartbeat evaluator.
 
     When *heartbeat_md* is provided, the raw HEARTBEAT.md content is
     included as a dedicated section so the LLM can evaluate which tasks
-    need attention.
+    need attention.  When *heartbeat_history* is provided, it shows when
+    heartbeat messages were previously sent so the evaluator can reason
+    about timing and avoid duplicates or missed sends.
     """
     builder = SystemPromptBuilder()
     builder.set_preamble(load_prompt("heartbeat_preamble"))
@@ -265,6 +268,9 @@ async def build_heartbeat_system_prompt(
         "Current time",
         build_local_datetime_section(user),
     )
+
+    if heartbeat_history:
+        builder.add_section("Recent heartbeat activity", heartbeat_history)
 
     builder.add_section("Rules", load_prompt("heartbeat_rules"))
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -10,7 +10,9 @@ import pytest
 from any_llm.types.messages import MessageContentBlock, MessageResponse, MessageUsage
 
 import backend.app.database as _db_module
+from backend.app.agent.dto import HeartbeatLogEntry
 from backend.app.agent.heartbeat import (
+    _HISTORY_LOOKBACK_DAYS,
     _NON_PUSHABLE_CHANNELS,
     COMPOSE_MESSAGE_TOOL,
     HEARTBEAT_DECISION_TOOL,
@@ -19,6 +21,7 @@ from backend.app.agent.heartbeat import (
     HeartbeatDecision,
     HeartbeatDecisionParams,
     HeartbeatScheduler,
+    _format_heartbeat_history,
     _parse_decision_response,
     _parse_tool_call_response,
     _pick_heartbeat_channel,
@@ -540,6 +543,7 @@ class TestEvaluateHeartbeatNeed:
 
         mock_hb_store = MagicMock()
         mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
         mock_build_prompt.return_value = "system prompt"
@@ -1738,3 +1742,176 @@ class TestTickChatIdLookup:
         call_kwargs = mock_run.call_args.kwargs
         # Falls back to user.channel_identifier
         assert call_kwargs["chat_id"] == "web-1"
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat history formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatHeartbeatHistory:
+    """Tests for _format_heartbeat_history."""
+
+    def test_empty_logs(self) -> None:
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        result = _format_heartbeat_history([], "America/New_York", now)
+        assert "not sent any heartbeat messages" in result
+        assert str(_HISTORY_LOOKBACK_DAYS) in result
+
+    def test_single_log_today(self) -> None:
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        log = HeartbeatLogEntry(
+            user_id="u1",
+            created_at=datetime.datetime(2026, 3, 23, 13, 15, tzinfo=datetime.UTC).isoformat(),
+        )
+        result = _format_heartbeat_history([log], "America/New_York", now)
+        assert "today" in result
+        assert "Monday" in result
+
+    def test_log_one_day_ago(self) -> None:
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        log = HeartbeatLogEntry(
+            user_id="u1",
+            created_at=datetime.datetime(2026, 3, 22, 13, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+        result = _format_heartbeat_history([log], "America/New_York", now)
+        assert "1 day ago" in result
+
+    def test_log_multiple_days_ago(self) -> None:
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        log = HeartbeatLogEntry(
+            user_id="u1",
+            created_at=datetime.datetime(2026, 3, 20, 10, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+        result = _format_heartbeat_history([log], "America/New_York", now)
+        assert "3 days ago" in result
+
+    def test_multiple_logs(self) -> None:
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        logs = [
+            HeartbeatLogEntry(
+                user_id="u1",
+                created_at=datetime.datetime(2026, 3, 22, 13, 0, tzinfo=datetime.UTC).isoformat(),
+            ),
+            HeartbeatLogEntry(
+                user_id="u1",
+                created_at=datetime.datetime(2026, 3, 23, 9, 0, tzinfo=datetime.UTC).isoformat(),
+            ),
+        ]
+        result = _format_heartbeat_history(logs, "America/New_York", now)
+        assert "1 day ago" in result
+        assert "today" in result
+
+    def test_utc_fallback_when_no_timezone(self) -> None:
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        log = HeartbeatLogEntry(
+            user_id="u1",
+            created_at=datetime.datetime(2026, 3, 23, 13, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+        result = _format_heartbeat_history([log], "", now)
+        assert "today" in result
+
+
+class TestEvaluateHeartbeatNeedPassesHistory:
+    """Test that evaluate_heartbeat_need passes heartbeat history to the prompt builder."""
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
+    @patch("backend.app.agent.heartbeat.settings")
+    @patch("backend.app.agent.heartbeat.amessages")
+    async def test_heartbeat_history_passed_to_prompt_builder(
+        self,
+        mock_llm: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
+        user: User,
+    ) -> None:
+        """Heartbeat history from recent logs must be passed to the prompt builder."""
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_api_base = None
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+        mock_settings.reasoning_effort = ""
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.get_recent_logs = AsyncMock(
+            return_value=[
+                HeartbeatLogEntry(
+                    user_id=user.id,
+                    created_at=datetime.datetime(
+                        2026, 3, 22, 9, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                ),
+            ]
+        )
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+        mock_llm.return_value = _make_decision_tool_call(action="skip", tasks="", reasoning="test")
+
+        await evaluate_heartbeat_need(user)
+
+        # Verify heartbeat_history kwarg was passed and contains log info
+        call_kwargs = mock_build_prompt.call_args
+        assert "heartbeat_history" in call_kwargs.kwargs
+        assert call_kwargs.kwargs["heartbeat_history"] != ""
+        assert "heartbeat messages" in call_kwargs.kwargs["heartbeat_history"]
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
+    @patch("backend.app.agent.heartbeat.settings")
+    @patch("backend.app.agent.heartbeat.amessages")
+    async def test_empty_history_when_no_logs(
+        self,
+        mock_llm: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
+        user: User,
+    ) -> None:
+        """When no heartbeat logs exist, history still conveys that fact."""
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_api_base = None
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+        mock_settings.reasoning_effort = ""
+
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = []
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+        mock_llm.return_value = _make_decision_tool_call(action="skip", tasks="", reasoning="test")
+
+        await evaluate_heartbeat_need(user)
+
+        call_kwargs = mock_build_prompt.call_args
+        assert "heartbeat_history" in call_kwargs.kwargs
+        assert "not sent any" in call_kwargs.kwargs["heartbeat_history"]

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -205,6 +205,7 @@ async def test_heartbeat_sends_typing_indicator_before_llm_call(
 
     mock_hb_store = MagicMock()
     mock_hb_store.read_heartbeat_md.return_value = ""
+    mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
     mock_heartbeat_store_cls.return_value = mock_hb_store
 
     mock_build_prompt.return_value = "system prompt"
@@ -275,6 +276,7 @@ async def test_heartbeat_works_without_channel(
 
     mock_hb_store = MagicMock()
     mock_hb_store.read_heartbeat_md.return_value = ""
+    mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
     mock_heartbeat_store_cls.return_value = mock_hb_store
 
     mock_build_prompt.return_value = "system prompt"


### PR DESCRIPTION
## Description

The heartbeat Phase 1 evaluator (the LLM that decides whether to proactively message the user) had no visibility into its own send history. While the `heartbeat_logs` table tracked all sends for rate limiting, this data was never surfaced in the Phase 1 prompt. The LLM couldn't reason about timing: it didn't know whether it had already sent a morning joke today, or whether it had never sent one at all.

This adds a "Recent heartbeat activity" section to the Phase 1 system prompt showing the last 7 days of heartbeat sends with timestamps in the user's local timezone and relative labels (e.g., "today", "1 day ago"), so the evaluator can make informed skip/run decisions.

### Changes
- Added `_format_heartbeat_history()` helper in `heartbeat.py` to format log entries
- Updated `evaluate_heartbeat_need()` to fetch recent logs and pass formatted history to the prompt builder
- Added `heartbeat_history` parameter to `build_heartbeat_system_prompt()` in `system_prompt.py`
- Updated test mocks in `test_heartbeat.py` and `test_typing_indicator.py`

Fixes #749

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code: root cause investigation, implementation, and test writing)
- [ ] No AI used