### PR TITLE
feat: auto-focus chat input on navigation

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -21,6 +21,17 @@ beforeEach(() => {
   localStorage.clear();
 });
 
+describe('ChatPage auto-focus', () => {
+  it('focuses the chat input on mount', async () => {
+    renderWithRouter(<ChatPage />);
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await waitFor(() => {
+      expect(document.activeElement).toBe(textarea);
+    });
+  });
+});
+
 describe('ChatPage tool interactions', () => {
   it('displays tool interactions when loading session history', async () => {
     const sessionId = '1_1000';

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -84,6 +84,11 @@ export default function ChatPage() {
     scrollToBottom();
   }, [messages, scrollToBottom]);
 
+  // Auto-focus the chat input when the page mounts or is navigated to
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
   // Prevent iOS Safari auto-zoom on input focus. Since iOS 10, maximum-scale=1
   // only blocks automatic zoom (not user pinch-zoom), so accessibility is preserved.
   // Applied only on iOS to avoid disabling pinch-zoom on Android.


### PR DESCRIPTION
## Description
Auto-focus the chat textarea when ChatPage mounts so users can start typing immediately without clicking the input first.

Fixes #744

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the change and wrote the test)
- [ ] No AI used