### PR TITLE
fix: add timestamps and task content to heartbeat evaluator context

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -304,7 +304,16 @@ def _format_heartbeat_history(
             ago = "1 day ago"
         else:
             ago = f"{delta.days} days ago"
-        lines.append(f"- {formatted} ({ago})")
+        detail = ""
+        if entry.action_type == "skip":
+            detail = " [skipped]"
+        elif entry.tasks:
+            # Truncate long task descriptions to keep the prompt concise.
+            task_preview = entry.tasks[:120]
+            if len(entry.tasks) > 120:
+                task_preview += "..."
+            detail = f' | tasks: "{task_preview}"'
+        lines.append(f"- {formatted} ({ago}){detail}")
 
     summary = "\n".join(lines)
     return (
@@ -326,13 +335,24 @@ async def evaluate_heartbeat_need(
     """
     session_store = get_session_store(user.id)
     recent = session_store.get_recent_messages(count=settings.heartbeat_recent_messages_count)
-    recent_text = (
-        "\n".join(
-            f"[{'User' if m.direction == MessageDirection.INBOUND else 'Assistant'}] {m.body}"
-            for m in recent
-        )
-        or "(no recent messages)"
-    )
+    recent_lines: list[str] = []
+    for m in recent:
+        label = "User" if m.direction == MessageDirection.INBOUND else "Assistant"
+        ts_str = ""
+        if m.timestamp:
+            try:
+                ts = datetime.datetime.fromisoformat(m.timestamp)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=datetime.UTC)
+                local_ts = to_local_time(ts, user.timezone)
+                ts_str = local_ts.strftime("%A %I:%M %p").strip()
+            except (ValueError, TypeError):
+                pass
+        if ts_str:
+            recent_lines.append(f"[{label}, {ts_str}] {m.body}")
+        else:
+            recent_lines.append(f"[{label}] {m.body}")
+    recent_text = "\n".join(recent_lines) or "(no recent messages)"
 
     heartbeat_store = HeartbeatStore(user.id)
     heartbeat_md = heartbeat_store.read_heartbeat_md()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1999,6 +1999,59 @@ class TestFormatHeartbeatHistory:
         result = _format_heartbeat_history([log], "", now)
         assert "today" in result
 
+    def test_send_entry_includes_tasks(self) -> None:
+        """Heartbeat history entries include the task description so the LLM
+        knows *what* was sent, not just *when*."""
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        log = HeartbeatLogEntry(
+            user_id="u1",
+            action_type="send",
+            tasks="Tell a morning joke",
+            created_at=datetime.datetime(2026, 3, 22, 12, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+        result = _format_heartbeat_history([log], "America/New_York", now)
+        assert 'tasks: "Tell a morning joke"' in result
+
+    def test_skip_entry_labeled(self) -> None:
+        """Skipped heartbeat entries are labeled [skipped]."""
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        log = HeartbeatLogEntry(
+            user_id="u1",
+            action_type="skip",
+            created_at=datetime.datetime(2026, 3, 23, 10, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+        result = _format_heartbeat_history([log], "America/New_York", now)
+        assert "[skipped]" in result
+
+    def test_long_tasks_truncated(self) -> None:
+        """Task descriptions longer than 120 chars are truncated with ellipsis."""
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        long_task = "A" * 200
+        log = HeartbeatLogEntry(
+            user_id="u1",
+            action_type="send",
+            tasks=long_task,
+            created_at=datetime.datetime(2026, 3, 23, 10, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+        result = _format_heartbeat_history([log], "America/New_York", now)
+        assert "..." in result
+        # Should contain the truncated prefix, not the full 200-char string
+        assert "A" * 120 in result
+        assert "A" * 200 not in result
+
+    def test_send_without_tasks_no_detail(self) -> None:
+        """Send entries with empty tasks don't show a tasks label."""
+        now = datetime.datetime(2026, 3, 23, 14, 0, tzinfo=datetime.UTC)
+        log = HeartbeatLogEntry(
+            user_id="u1",
+            action_type="send",
+            tasks="",
+            created_at=datetime.datetime(2026, 3, 23, 10, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+        result = _format_heartbeat_history([log], "America/New_York", now)
+        assert "tasks:" not in result
+        assert "[skipped]" not in result
+
 
 class TestEvaluateHeartbeatNeedPassesHistory:
     """Test that evaluate_heartbeat_need passes heartbeat history to the prompt builder."""
@@ -2103,3 +2156,112 @@ class TestEvaluateHeartbeatNeedPassesHistory:
         call_kwargs = mock_build_prompt.call_args
         assert "heartbeat_history" in call_kwargs.kwargs
         assert "not sent any" in call_kwargs.kwargs["heartbeat_history"]
+
+
+class TestRecentMessagesIncludeTimestamps:
+    """Regression: recent messages passed to the heartbeat prompt must include timestamps."""
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
+    @patch("backend.app.agent.heartbeat.settings")
+    @patch("backend.app.agent.heartbeat.amessages")
+    async def test_recent_messages_contain_timestamps(
+        self,
+        mock_llm: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
+        user: User,
+    ) -> None:
+        """Messages with timestamps should include the time in the formatted output."""
+        from backend.app.agent.dto import StoredMessage
+
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_api_base = None
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+        mock_settings.reasoning_effort = ""
+
+        msg = StoredMessage(
+            direction="outbound",
+            body="Here is your morning joke!",
+            timestamp=datetime.datetime(2026, 3, 23, 12, 30, tzinfo=datetime.UTC).isoformat(),
+        )
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = [msg]
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+        mock_llm.return_value = _make_decision_tool_call(action="skip", tasks="", reasoning="ok")
+
+        await evaluate_heartbeat_need(user)
+
+        recent_text = mock_build_prompt.call_args.args[1]
+        # Should contain a day-of-week timestamp (e.g. "Monday 08:30 AM")
+        assert "Assistant," in recent_text
+        assert "Here is your morning joke!" in recent_text
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
+    @patch("backend.app.agent.heartbeat.settings")
+    @patch("backend.app.agent.heartbeat.amessages")
+    async def test_message_without_timestamp_falls_back(
+        self,
+        mock_llm: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
+        user: User,
+    ) -> None:
+        """Messages with empty timestamp still render without crashing."""
+        from backend.app.agent.dto import StoredMessage
+
+        mock_settings.llm_model = "gpt-4o"
+        mock_settings.llm_provider = "openai"
+        mock_settings.llm_api_base = None
+        mock_settings.heartbeat_model = ""
+        mock_settings.heartbeat_provider = ""
+        mock_settings.llm_max_tokens_heartbeat = 256
+        mock_settings.heartbeat_recent_messages_count = 5
+        mock_settings.reasoning_effort = ""
+
+        msg = StoredMessage(
+            direction="inbound",
+            body="Hello!",
+            timestamp="",
+        )
+        mock_session_store = MagicMock()
+        mock_session_store.get_recent_messages.return_value = [msg]
+        mock_get_session_store.return_value = mock_session_store
+
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        mock_build_prompt.return_value = "system prompt"
+        mock_llm.return_value = _make_decision_tool_call(action="skip", tasks="", reasoning="ok")
+
+        await evaluate_heartbeat_need(user)
+
+        recent_text = mock_build_prompt.call_args.args[1]
+        # Falls back to label-only format without a timestamp
+        assert "[User] Hello!" in recent_text


### PR DESCRIPTION
## Description
The heartbeat Phase 1 evaluator (the LLM that decides whether to send a proactive message) had two blind spots that made it difficult to avoid duplicate sends:

1. **Recent messages had no timestamps** — the LLM could see message content but not when it was sent
2. **Heartbeat history had no content** — the LLM could see when messages were sent but not what they contained

This fix adds day-of-week + time to recent messages and includes task descriptions in the heartbeat history, so the evaluator can correlate what was sent with when.

Fixes #767

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude Code investigated the heartbeat system context, identified the gaps, implemented the fix, and wrote regression tests.