### PR TITLE
fix: iOS Safari chat page layout collapse due to missing min-h-0

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -230,7 +230,7 @@
     font-family: var(--font-ui);
     background: var(--color-background);
     color: var(--color-foreground);
-    min-height: 100vh;
+    min-height: 100dvh;
     line-height: 1.5;
     overflow-x: hidden;
   }

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -77,6 +77,17 @@ describe('AppShell', () => {
     expect(screen.queryByText('Conversations')).not.toBeInTheDocument();
   });
 
+  it('main element has min-h-0 for iOS Safari flex layout fix', async () => {
+    renderWithRouter(<AppShell />, { route: '/app' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Chat')).toBeInTheDocument();
+    });
+
+    const main = document.querySelector('main');
+    expect(main).toHaveClass('min-h-0');
+  });
+
   it('shows error state when profile fails to load', async () => {
     mockApi.getProfile.mockRejectedValue(new Error('Network error'));
 

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -219,7 +219,7 @@ export default function AppShell() {
           <h1 className="text-lg font-bold font-display text-foreground">Clawbolt</h1>
         </header>
 
-        <main className="flex-1 overflow-y-auto p-4 sm:p-6 max-w-5xl w-full mx-auto">
+        <main className="flex-1 min-h-0 overflow-y-auto p-4 sm:p-6 max-w-5xl w-full mx-auto">
           <Outlet context={ctx} />
         </main>
       </div>


### PR DESCRIPTION
## Description
Fix iOS Safari chat page showing no messages by adding `min-h-0` to the `<main>` flex container in AppShell and updating body `min-height` from `100vh` to `100dvh`.

On iOS Safari, flex items default to `min-height: auto`, which prevents `<main>` from shrinking below its content height. This breaks the nested flex/overflow layout chain in ChatPage, causing the messages area to collapse to zero height. Adding `min-h-0` fixes this. The `100vh` to `100dvh` change ensures body min-height matches the `h-dvh` used on AppShell root, avoiding address-bar mismatch on mobile Safari.

Fixes #769

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented fix and regression test with Claude Code)
- [ ] No AI used