### PR TITLE
fix: load chat history on mount by discovering active session

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -17,6 +17,7 @@ import type {
   OAuthStatusResponse,
   ProviderInfo,
   SessionDetailResponse,
+  SessionListResponse,
   ToolConfigResponse,
   ToolConfigUpdateEntry,
 } from '@/types';
@@ -77,6 +78,13 @@ const api = {
     });
     if (error) _throwApiError(error, 'Failed to get session');
     return data as SessionDetailResponse;
+  },
+  listSessions: async (params?: { limit?: number; offset?: number; is_active?: boolean }) => {
+    const { data, error } = await client.GET('/api/user/sessions', {
+      params: { query: params },
+    });
+    if (error) _throwApiError(error, 'Failed to list sessions');
+    return data as SessionListResponse;
   },
 
   // Memory

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/api', () => ({
   default: {
     getSession: vi.fn(),
     sendChatMessage: vi.fn(),
+    listSessions: vi.fn().mockResolvedValue({ total: 0, items: [] }),
   },
 }));
 
@@ -113,6 +114,77 @@ describe('ChatPage tool interactions', () => {
 
     // No "Tool:" labels should appear
     expect(screen.queryByText('Tool:')).not.toBeInTheDocument();
+  });
+});
+
+describe('ChatPage session auto-discovery', () => {
+  it('discovers the most recent active session when no session is saved', async () => {
+    const sessionId = '1_3000';
+    mockApi.listSessions.mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          session_id: sessionId,
+          channel: 'webchat',
+          is_active: true,
+          message_count: 2,
+          created_at: '2025-01-01T00:00:00Z',
+          last_message_at: '2025-01-01T00:01:00Z',
+        },
+      ],
+    });
+    mockApi.getSession.mockResolvedValue({
+      session_id: sessionId,
+      user_id: '1',
+      created_at: '2025-01-01T00:00:00Z',
+      last_message_at: '2025-01-01T00:01:00Z',
+      is_active: true,
+      channel: 'webchat',
+      initial_system_prompt: '',
+      last_compacted_seq: 0,
+      messages: [
+        {
+          seq: 1,
+          direction: 'inbound',
+          body: 'Previous message',
+          timestamp: '2025-01-01T00:00:00Z',
+          tool_interactions: [],
+        },
+        {
+          seq: 2,
+          direction: 'outbound',
+          body: 'Previous reply',
+          timestamp: '2025-01-01T00:01:00Z',
+          tool_interactions: [],
+        },
+      ],
+    });
+
+    // Render without ?session= param and with empty localStorage
+    renderWithRouter(<ChatPage />, { route: '/app/chat' });
+
+    // Should discover the session and load its history
+    await waitFor(() => {
+      expect(mockApi.listSessions).toHaveBeenCalledWith({ is_active: true, limit: 1 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Previous message')).toBeInTheDocument();
+      expect(screen.getByText('Previous reply')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no active sessions exist', async () => {
+    mockApi.listSessions.mockResolvedValue({ total: 0, items: [] });
+
+    renderWithRouter(<ChatPage />, { route: '/app/chat' });
+
+    await waitFor(() => {
+      expect(mockApi.listSessions).toHaveBeenCalled();
+    });
+
+    // Should show the empty state prompt
+    expect(screen.getByText('Send a message to start chatting.')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -102,7 +102,7 @@ export default function ChatPage() {
     }
   }, []);
 
-  // Auto-attach to last active session from localStorage
+  // Auto-attach to last active session from localStorage, or discover from API
   useEffect(() => {
     if (autoAttachDone.current || searchParams.get('session')) return;
     autoAttachDone.current = true;
@@ -110,7 +110,20 @@ export default function ChatPage() {
     if (saved) {
       setActiveSessionId(saved);
       setSearchParams({ session: saved }, { replace: true });
+      return;
     }
+    // No saved session: discover the most recent active session from the backend
+    api.listSessions({ is_active: true, limit: 1 }).then((res) => {
+      if (!mountedRef.current) return;
+      const latest = res.items[0];
+      if (latest) {
+        setActiveSessionId(latest.session_id);
+        setSearchParams({ session: latest.session_id }, { replace: true });
+        saveLastSession(latest.session_id);
+      }
+    }).catch(() => {
+      // Silently ignore: user may not have any sessions yet
+    });
   }, [searchParams, setSearchParams]);
 
   // Save active session to localStorage

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,7 @@ import type { components } from '@/generated/api';
 export type UserProfileResponse = components['schemas']['UserProfileResponse'];
 export type UserProfileUpdate = components['schemas']['UserProfileUpdate'];
 export type SessionDetailResponse = components['schemas']['SessionDetailResponse'];
+export type SessionListResponse = components['schemas']['SessionListResponse'];
 export type MemoryResponse = components['schemas']['MemoryResponse'];
 export type MemoryUpdate = components['schemas']['MemoryUpdate'];
 export type ChannelConfigResponse = components['schemas']['ChannelConfigResponse'];


### PR DESCRIPTION
## Description
When the Web Chat UI loads without a session in the URL or localStorage (e.g., cleared browser data, new device, first web visit), the chat history didn't appear until the user sent the first message. The backend would find the existing active session on first send, but the frontend had no way to discover it on mount.

Now the auto-attach effect in ChatPage falls back to `GET /api/user/sessions?is_active=true&limit=1` to discover the most recent active session and loads its history immediately.

Fixes #778

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code wrote the fix, tests, and PR)
- [ ] No AI used