### PR TITLE
feat: add auth_check to tool factories for unauthenticated integration awareness

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -269,8 +269,13 @@ async def run_agent(
     specialist_summaries = default_registry.get_available_specialist_summaries(
         tool_context, excluded_factories=disabled_groups or None
     )
-    if specialist_summaries:
-        tools.append(create_list_capabilities_tool(specialist_summaries))
+    unauthenticated = default_registry.get_unauthenticated_specialists(
+        tool_context, excluded_factories=disabled_groups or None
+    )
+    if specialist_summaries or unauthenticated:
+        tools.append(
+            create_list_capabilities_tool(specialist_summaries, unauthenticated=unauthenticated)
+        )
     agent.register_tools(tools)
 
     # Build onboarding prompt now that tools are available, so that tool

--- a/backend/app/agent/tool_errors.py
+++ b/backend/app/agent/tool_errors.py
@@ -37,6 +37,10 @@ _ERROR_KIND_HINTS: dict[ToolErrorKind, str] = {
         " Try a different approach or inform the user.]"
     ),
     ToolErrorKind.PERMISSION: ("[You do not have permission for this operation. Inform the user.]"),
+    ToolErrorKind.AUTH: (
+        "[This integration is not connected. Do not retry."
+        " Let the user know they need to authenticate via the web dashboard.]"
+    ),
     ToolErrorKind.INTERNAL: (
         "[An internal error occurred."
         " Inform the user that this operation is temporarily unavailable.]"

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -25,6 +25,7 @@ class ToolErrorKind(StrEnum):
     SERVICE = "service"
     NOT_FOUND = "not_found"
     PERMISSION = "permission"
+    AUTH = "auth"
     INTERNAL = "internal"
 
 

--- a/backend/app/agent/tools/calendar_tools.py
+++ b/backend/app/agent/tools/calendar_tools.py
@@ -565,6 +565,24 @@ def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
 # ---------------------------------------------------------------------------
 
 
+def _calendar_auth_check(ctx: ToolContext) -> str | None:
+    """Check whether Google Calendar is configured and the user has authenticated.
+
+    Returns ``None`` when ready, or a reason string when auth is missing.
+    Returns ``None`` (not a reason) when the integration is not configured
+    at all (admin has not set credentials), so it stays completely hidden.
+    """
+    if not settings.google_calendar_client_id or not settings.google_calendar_client_secret:
+        return None
+    token = oauth_service.load_token(ctx.user.id, "google_calendar")
+    if token is not None and token.access_token:
+        return None
+    return (
+        "Google Calendar is not connected. "
+        "The user needs to authenticate via the Clawbolt web dashboard."
+    )
+
+
 def _calendar_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for calendar tools, used by the registry."""
     if not settings.google_calendar_client_id or not settings.google_calendar_client_secret:
@@ -613,6 +631,7 @@ def _register() -> None:
                 "Check calendar free/busy availability",
             ),
         ],
+        auth_check=_calendar_auth_check,
     )
 
 

--- a/backend/app/agent/tools/quickbooks_tools.py
+++ b/backend/app/agent/tools/quickbooks_tools.py
@@ -453,6 +453,24 @@ def _get_quickbooks_service_for_user(user_id: str) -> QuickBooksService | None:
     return None
 
 
+def _quickbooks_auth_check(ctx: ToolContext) -> str | None:
+    """Check whether QuickBooks is configured and the user has authenticated.
+
+    Returns ``None`` when ready, or a reason string when auth is missing.
+    Returns ``None`` (not a reason) when the integration is not configured
+    at all (admin has not set credentials), so it stays completely hidden.
+    """
+    if not settings.quickbooks_client_id or not settings.quickbooks_client_secret:
+        return None
+    token = oauth_service.load_token(ctx.user.id, "quickbooks")
+    if token and token.access_token and token.realm_id:
+        return None
+    return (
+        "QuickBooks is not connected. "
+        "The user needs to authenticate via the Clawbolt web dashboard."
+    )
+
+
 def _quickbooks_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for QuickBooks tools, used by the registry."""
     if not settings.quickbooks_client_id or not settings.quickbooks_client_secret:
@@ -480,6 +498,7 @@ def _register() -> None:
             SubToolInfo(ToolName.QB_UPDATE, "Update existing entities in QuickBooks"),
             SubToolInfo(ToolName.QB_SEND, "Send invoices or estimates via QuickBooks email"),
         ],
+        auth_check=_quickbooks_auth_check,
     )
 
 

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -64,6 +64,7 @@ class ToolFactory:
     core: bool = True
     summary: str = ""
     sub_tools: list[SubToolInfo] = field(default_factory=list)
+    auth_check: Callable[[ToolContext], str | None] | None = None
 
 
 class ListCapabilitiesParams(BaseModel):
@@ -77,6 +78,7 @@ class ListCapabilitiesParams(BaseModel):
 
 def create_list_capabilities_tool(
     specialist_summaries: dict[str, str],
+    unauthenticated: dict[str, str] | None = None,
 ) -> Tool:
     """Create the ``list_capabilities`` meta-tool.
 
@@ -87,20 +89,40 @@ def create_list_capabilities_tool(
     When a category is activated that has an associated SKILL.md, the
     skill instructions are included in the response so the LLM has
     usage guidance alongside the new tool schemas.
+
+    *unauthenticated* maps category names to human-readable reasons why
+    the integration is not yet connected (e.g. missing OAuth).  These
+    categories are listed but cannot be activated.
     """
     from backend.app.agent.skills.loader import get_skill_instructions
 
+    _unauthenticated = unauthenticated or {}
+
     async def list_capabilities(category: str | None = None) -> ToolResult:
         if category is None:
-            if not specialist_summaries:
+            if not specialist_summaries and not _unauthenticated:
                 return ToolResult(content="No additional capabilities available.")
-            lines = [
-                "Available specialist capabilities "
-                "(call list_capabilities with a category name to activate):"
-            ]
-            for name, summary in sorted(specialist_summaries.items()):
-                lines.append(f"- {name}: {summary}")
+            lines: list[str] = []
+            if specialist_summaries:
+                lines.append(
+                    "Available specialist capabilities "
+                    "(call list_capabilities with a category name to activate):"
+                )
+                for name, summary in sorted(specialist_summaries.items()):
+                    lines.append(f"- {name}: {summary}")
+            if _unauthenticated:
+                lines.append("")
+                lines.append("Not connected (user must authenticate before use):")
+                for name, reason in sorted(_unauthenticated.items()):
+                    lines.append(f"- {name}: {reason}")
             return ToolResult(content="\n".join(lines))
+
+        if category in _unauthenticated:
+            return ToolResult(
+                content=_unauthenticated[category],
+                is_error=True,
+                error_kind=ToolErrorKind.AUTH,
+            )
 
         if category not in specialist_summaries:
             available = ", ".join(sorted(specialist_summaries.keys()))
@@ -122,6 +144,15 @@ def create_list_capabilities_tool(
         f"  - {name}: {summary}" for name, summary in sorted(specialist_summaries.items())
     ]
     summary_block = "\n".join(summary_lines)
+    unauth_hint = ""
+    if _unauthenticated:
+        unauth_lines = [f"  - {name} (not connected)" for name in sorted(_unauthenticated)]
+        unauth_hint = (
+            "\nThe following integrations are configured but not yet connected:\n"
+            + "\n".join(unauth_lines)
+            + "\nDo NOT attempt to activate these. If the user asks about them, "
+            "let them know they need to connect the integration first."
+        )
     return Tool(
         name=ToolName.LIST_CAPABILITIES,
         description=(
@@ -137,6 +168,7 @@ def create_list_capabilities_tool(
             "Call list_capabilities with a category name to activate the tools "
             "before using them. Activate proactively when the user's message "
             "relates to a specialist category."
+            f"{unauth_hint}"
         ),
     )
 
@@ -157,6 +189,7 @@ class ToolRegistry:
         core: bool = True,
         summary: str = "",
         sub_tools: list[SubToolInfo] | None = None,
+        auth_check: Callable[[ToolContext], str | None] | None = None,
     ) -> None:
         """Register a tool factory by name.
 
@@ -171,6 +204,11 @@ class ToolRegistry:
             summary: One-line description shown by ``list_capabilities`` for
                 specialist factories.
             sub_tools: Static metadata for individual tools this factory creates.
+            auth_check: Optional callable that checks whether the user has
+                authenticated for this integration. Returns ``None`` when
+                ready, or a human-readable reason string when auth is
+                missing. Used to surface unauthenticated integrations to
+                the LLM so it knows not to attempt activation.
         """
         if name in self._factories:
             logger.warning("Overwriting existing tool factory: %s", name)
@@ -181,6 +219,7 @@ class ToolRegistry:
             core=core,
             summary=summary,
             sub_tools=sub_tools or [],
+            auth_check=auth_check,
         )
 
     def create_tools(
@@ -251,6 +290,10 @@ class ToolRegistry:
         Used by the setup code to build the ``list_capabilities`` meta-tool
         with only the categories that are actually usable.
 
+        Factories that have an ``auth_check`` returning a non-None value
+        (i.e. user has not authenticated) are excluded here. Use
+        ``get_unauthenticated_specialists`` to retrieve those separately.
+
         When *excluded_factories* is provided, factories in that set are
         skipped.
         """
@@ -264,8 +307,40 @@ class ToolRegistry:
                 continue
             if factory.requires_outbound and context.publish_outbound is None:
                 continue
+            if factory.auth_check is not None and factory.auth_check(context) is not None:
+                continue
             summaries[name] = factory.summary
         return summaries
+
+    def get_unauthenticated_specialists(
+        self,
+        context: ToolContext,
+        *,
+        excluded_factories: set[str] | None = None,
+    ) -> dict[str, str]:
+        """Return specialist factories that are configured but not authenticated.
+
+        Returns a mapping of ``{factory_name: reason}`` for specialists whose
+        ``auth_check`` returns a non-None reason string. Factories without an
+        ``auth_check`` or whose infrastructure dependencies (storage, outbound)
+        are unmet are excluded.
+        """
+        unauthenticated: dict[str, str] = {}
+        for name, factory in self._factories.items():
+            if factory.core:
+                continue
+            if excluded_factories and name in excluded_factories:
+                continue
+            if factory.requires_storage and context.storage is None:
+                continue
+            if factory.requires_outbound and context.publish_outbound is None:
+                continue
+            if factory.auth_check is None:
+                continue
+            reason = factory.auth_check(context)
+            if reason is not None:
+                unauthenticated[name] = reason
+        return unauthenticated
 
     @property
     def core_factory_names(self) -> set[str]:

--- a/tests/test_tool_auth_check.py
+++ b/tests/test_tool_auth_check.py
@@ -1,0 +1,288 @@
+"""Tests for tool factory auth_check and unauthenticated integration awareness."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.registry import (
+    ToolContext,
+    ToolRegistry,
+    create_list_capabilities_tool,
+)
+from backend.app.models import User
+
+
+class _EmptyParams(BaseModel):
+    """Minimal stand-in so the params_model check passes."""
+
+
+def _make_tool(name: str) -> Tool:
+    """Create a trivial tool for testing."""
+
+    async def noop() -> ToolResult:
+        return ToolResult(content="ok")
+
+    return Tool(name=name, description=f"test {name}", function=noop, params_model=_EmptyParams)
+
+
+def _build_auth_test_registry() -> ToolRegistry:
+    """Build a registry with auth_check-enabled specialists."""
+    registry = ToolRegistry()
+    registry.register("workspace", lambda ctx: [_make_tool("read_file")])
+    # Specialist that passes auth (authenticated)
+    registry.register(
+        "heartbeat",
+        lambda ctx: [_make_tool("get_heartbeat")],
+        core=False,
+        summary="Manage heartbeats",
+        auth_check=lambda ctx: None,  # always authenticated
+    )
+    # Specialist that fails auth (not authenticated)
+    registry.register(
+        "quickbooks",
+        lambda ctx: [],
+        core=False,
+        summary="QuickBooks accounting tools",
+        auth_check=lambda ctx: "QuickBooks is not connected. Authenticate via web dashboard.",
+    )
+    # Specialist without auth_check (legacy, always available)
+    registry.register(
+        "file",
+        lambda ctx: [_make_tool("upload_to_storage")],
+        requires_storage=True,
+        core=False,
+        summary="Upload and organize files",
+    )
+    return registry
+
+
+class TestGetAvailableSpecialistSummaries:
+    """get_available_specialist_summaries excludes unauthenticated factories."""
+
+    def test_excludes_unauthenticated_specialist(self) -> None:
+        registry = _build_auth_test_registry()
+        ctx = ToolContext(user=User(id="1"), storage=MagicMock())
+        summaries = registry.get_available_specialist_summaries(ctx)
+        assert "heartbeat" in summaries
+        assert "file" in summaries
+        assert "quickbooks" not in summaries
+
+    def test_includes_factory_without_auth_check(self) -> None:
+        registry = _build_auth_test_registry()
+        ctx = ToolContext(user=User(id="1"), storage=MagicMock())
+        summaries = registry.get_available_specialist_summaries(ctx)
+        assert "file" in summaries
+
+    def test_includes_factory_with_passing_auth_check(self) -> None:
+        registry = _build_auth_test_registry()
+        ctx = ToolContext(user=User(id="1"))
+        summaries = registry.get_available_specialist_summaries(ctx)
+        assert "heartbeat" in summaries
+
+
+class TestGetUnauthenticatedSpecialists:
+    """get_unauthenticated_specialists returns only auth-failing factories."""
+
+    def test_returns_unauthenticated_factory(self) -> None:
+        registry = _build_auth_test_registry()
+        ctx = ToolContext(user=User(id="1"), storage=MagicMock())
+        unauth = registry.get_unauthenticated_specialists(ctx)
+        assert "quickbooks" in unauth
+        assert "not connected" in unauth["quickbooks"].lower()
+
+    def test_excludes_authenticated_factory(self) -> None:
+        registry = _build_auth_test_registry()
+        ctx = ToolContext(user=User(id="1"))
+        unauth = registry.get_unauthenticated_specialists(ctx)
+        assert "heartbeat" not in unauth
+
+    def test_excludes_factory_without_auth_check(self) -> None:
+        registry = _build_auth_test_registry()
+        ctx = ToolContext(user=User(id="1"), storage=MagicMock())
+        unauth = registry.get_unauthenticated_specialists(ctx)
+        assert "file" not in unauth
+
+    def test_excludes_core_factories(self) -> None:
+        registry = _build_auth_test_registry()
+        ctx = ToolContext(user=User(id="1"))
+        unauth = registry.get_unauthenticated_specialists(ctx)
+        assert "workspace" not in unauth
+
+    def test_respects_excluded_factories(self) -> None:
+        registry = _build_auth_test_registry()
+        ctx = ToolContext(user=User(id="1"))
+        unauth = registry.get_unauthenticated_specialists(ctx, excluded_factories={"quickbooks"})
+        assert "quickbooks" not in unauth
+
+    def test_empty_when_all_authenticated(self) -> None:
+        registry = ToolRegistry()
+        registry.register(
+            "heartbeat",
+            lambda ctx: [_make_tool("get_heartbeat")],
+            core=False,
+            summary="Manage heartbeats",
+            auth_check=lambda ctx: None,
+        )
+        ctx = ToolContext(user=User(id="1"))
+        unauth = registry.get_unauthenticated_specialists(ctx)
+        assert unauth == {}
+
+
+class TestListCapabilitiesWithUnauthenticated:
+    """list_capabilities shows unauthenticated integrations and blocks activation."""
+
+    @pytest.mark.asyncio
+    async def test_listing_shows_unauthenticated_section(self) -> None:
+        summaries = {"heartbeat": "Manage heartbeats"}
+        unauth = {"quickbooks": "QuickBooks is not connected."}
+        tool = create_list_capabilities_tool(summaries, unauthenticated=unauth)
+        result = await tool.function(category=None)
+        assert "heartbeat" in result.content
+        assert "quickbooks" in result.content
+        assert "not connected" in result.content.lower()
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_activating_unauthenticated_returns_auth_error(self) -> None:
+        summaries = {"heartbeat": "Manage heartbeats"}
+        unauth = {"quickbooks": "QuickBooks is not connected. Authenticate via web dashboard."}
+        tool = create_list_capabilities_tool(summaries, unauthenticated=unauth)
+        result = await tool.function(category="quickbooks")
+        assert result.is_error
+        assert result.error_kind == ToolErrorKind.AUTH
+        assert "not connected" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_activating_authenticated_category_still_works(self) -> None:
+        summaries = {"heartbeat": "Manage heartbeats"}
+        unauth = {"quickbooks": "QuickBooks is not connected."}
+        tool = create_list_capabilities_tool(summaries, unauthenticated=unauth)
+        result = await tool.function(category="heartbeat")
+        assert not result.is_error
+        assert "activated" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_usage_hint_mentions_unauthenticated(self) -> None:
+        summaries = {"heartbeat": "Manage heartbeats"}
+        unauth = {"quickbooks": "QuickBooks is not connected."}
+        tool = create_list_capabilities_tool(summaries, unauthenticated=unauth)
+        assert "quickbooks" in tool.usage_hint.lower()
+        assert "not connected" in tool.usage_hint.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_unauthenticated_no_extra_section(self) -> None:
+        summaries = {"heartbeat": "Manage heartbeats"}
+        tool = create_list_capabilities_tool(summaries)
+        result = await tool.function(category=None)
+        assert "not connected" not in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_only_unauthenticated_still_shows_info(self) -> None:
+        tool = create_list_capabilities_tool({}, unauthenticated={"quickbooks": "Not connected."})
+        result = await tool.function(category=None)
+        assert "quickbooks" in result.content
+        assert "not connected" in result.content.lower()
+        assert not result.is_error
+
+
+class TestQuickBooksAuthCheck:
+    """QuickBooks auth_check function works correctly."""
+
+    def test_returns_none_when_not_configured(self) -> None:
+        from unittest.mock import patch
+
+        from backend.app.agent.tools.quickbooks_tools import _quickbooks_auth_check
+
+        with patch("backend.app.agent.tools.quickbooks_tools.settings") as mock_settings:
+            mock_settings.quickbooks_client_id = ""
+            mock_settings.quickbooks_client_secret = ""
+            ctx = ToolContext(user=User(id="test-user"))
+            assert _quickbooks_auth_check(ctx) is None
+
+    def test_returns_none_when_authenticated(self) -> None:
+        from unittest.mock import patch
+
+        from backend.app.agent.tools.quickbooks_tools import _quickbooks_auth_check
+
+        mock_token = MagicMock()
+        mock_token.access_token = "valid-token"
+        mock_token.realm_id = "realm-123"
+        with (
+            patch("backend.app.agent.tools.quickbooks_tools.settings") as mock_settings,
+            patch("backend.app.agent.tools.quickbooks_tools.oauth_service") as mock_oauth,
+        ):
+            mock_settings.quickbooks_client_id = "client-id"
+            mock_settings.quickbooks_client_secret = "client-secret"
+            mock_oauth.load_token.return_value = mock_token
+            ctx = ToolContext(user=User(id="test-user"))
+            assert _quickbooks_auth_check(ctx) is None
+
+    def test_returns_reason_when_no_token(self) -> None:
+        from unittest.mock import patch
+
+        from backend.app.agent.tools.quickbooks_tools import _quickbooks_auth_check
+
+        with (
+            patch("backend.app.agent.tools.quickbooks_tools.settings") as mock_settings,
+            patch("backend.app.agent.tools.quickbooks_tools.oauth_service") as mock_oauth,
+        ):
+            mock_settings.quickbooks_client_id = "client-id"
+            mock_settings.quickbooks_client_secret = "client-secret"
+            mock_oauth.load_token.return_value = None
+            ctx = ToolContext(user=User(id="test-user"))
+            reason = _quickbooks_auth_check(ctx)
+            assert reason is not None
+            assert "not connected" in reason.lower()
+
+
+class TestCalendarAuthCheck:
+    """Google Calendar auth_check function works correctly."""
+
+    def test_returns_none_when_not_configured(self) -> None:
+        from unittest.mock import patch
+
+        from backend.app.agent.tools.calendar_tools import _calendar_auth_check
+
+        with patch("backend.app.agent.tools.calendar_tools.settings") as mock_settings:
+            mock_settings.google_calendar_client_id = ""
+            mock_settings.google_calendar_client_secret = ""
+            ctx = ToolContext(user=User(id="test-user"))
+            assert _calendar_auth_check(ctx) is None
+
+    def test_returns_none_when_authenticated(self) -> None:
+        from unittest.mock import patch
+
+        from backend.app.agent.tools.calendar_tools import _calendar_auth_check
+
+        mock_token = MagicMock()
+        mock_token.access_token = "valid-token"
+        with (
+            patch("backend.app.agent.tools.calendar_tools.settings") as mock_settings,
+            patch("backend.app.agent.tools.calendar_tools.oauth_service") as mock_oauth,
+        ):
+            mock_settings.google_calendar_client_id = "client-id"
+            mock_settings.google_calendar_client_secret = "client-secret"
+            mock_oauth.load_token.return_value = mock_token
+            ctx = ToolContext(user=User(id="test-user"))
+            assert _calendar_auth_check(ctx) is None
+
+    def test_returns_reason_when_no_token(self) -> None:
+        from unittest.mock import patch
+
+        from backend.app.agent.tools.calendar_tools import _calendar_auth_check
+
+        with (
+            patch("backend.app.agent.tools.calendar_tools.settings") as mock_settings,
+            patch("backend.app.agent.tools.calendar_tools.oauth_service") as mock_oauth,
+        ):
+            mock_settings.google_calendar_client_id = "client-id"
+            mock_settings.google_calendar_client_secret = "client-secret"
+            mock_oauth.load_token.return_value = None
+            ctx = ToolContext(user=User(id="test-user"))
+            reason = _calendar_auth_check(ctx)
+            assert reason is not None
+            assert "not connected" in reason.lower()


### PR DESCRIPTION
## Description
Adds an `auth_check` mechanism to tool factories so the LLM knows which OAuth integrations (QuickBooks, Google Calendar) are configured but not yet authenticated by the user. Previously, unauthenticated tools were silently hidden but still appeared in `list_capabilities`, causing the LLM to attempt activation and get confused when no tools appeared. Now the LLM sees a clear "not connected" status and returns helpful guidance instead of wasting tool calls.

Fixes #780

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.6 via Claude Code for implementation, tests, and PR creation)
- [ ] No AI used