### PR TITLE
feat: recommend phone dictation during onboarding

### DIFF
--- a/backend/app/agent/prompts/bootstrap.md
+++ b/backend/app/agent/prompts/bootstrap.md
@@ -42,6 +42,11 @@ write_file(path="USER.md", content="# User\n\n- Name: Jake\n- What to call them:
 
 For general business facts (client names, project details, pricing notes), update MEMORY.md with edit_file.
 
+## Quick tip: phone dictation
+At some natural point during the conversation (after learning their name, or when wrapping up), mention that they can use their phone's built-in dictation to talk to you. Something like: "Quick tip: if typing feels slow, you can tap the microphone on your keyboard and just talk. Your phone turns it into text and sends it to me. I'm pretty good with typos and rough sentences, so don't worry about it being perfect."
+
+Be clear that this is their phone's keyboard dictation, not a voice message. They're not sending audio to you. Their phone converts speech to text and you read the text. Keep it casual and brief.
+
 ## Capabilities overview
 Once you've covered the basics (name, personality, business info), naturally mention what you can help with. Don't list every tool. Instead, based on what you've learned about their trade, highlight the capabilities that seem most relevant.
 

--- a/docs/src/content/docs/features/voice.mdx
+++ b/docs/src/content/docs/features/voice.mdx
@@ -20,6 +20,12 @@ Voice memos are great for:
 - **Detailed descriptions**: When typing would take too long
 - **Job descriptions**: Describe the job verbally and Clawbolt processes the details
 
+## Phone dictation
+
+You can also use your phone's built-in dictation (the microphone button on your keyboard) to compose messages. Your phone converts your speech to text locally, then sends the text to Clawbolt like any other message. This works on any channel and doesn't require any server-side setup.
+
+Dictation is great for quick messages when you don't need a full voice memo. Clawbolt handles typos and rough sentences well, so don't worry about perfect transcription.
+
 ## Requirements
 
 Voice transcription requires `ffmpeg` for audio processing. The Docker image includes ffmpeg by default. For local development, install it via your system package manager.

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -20,7 +20,7 @@ const STEPS = [
   {
     title: 'Start chatting',
     description:
-      'Send your first message. Try asking for an estimate, a reminder, or just say hello.',
+      'Send your first message. Try asking for an estimate, a reminder, or just say hello. Tip: use the microphone button on your phone keyboard to dictate instead of typing.',
     link: '/app/chat',
     linkLabel: 'Open Chat',
     icon: ChatIcon,

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -162,6 +162,16 @@ def test_build_onboarding_system_prompt_new_user() -> None:
     assert "help them with that request FIRST" in prompt
 
 
+def test_build_onboarding_system_prompt_includes_dictation_tip() -> None:
+    """Onboarding system prompt should include the phone dictation tip."""
+    user = User(id="6b", user_id="dictation-user", phone="+15550006666")
+    _create_bootstrap(user)
+
+    prompt = build_onboarding_system_prompt(user)
+    assert "dictation" in prompt.lower()
+    assert "microphone" in prompt.lower()
+
+
 def test_build_onboarding_system_prompt_includes_tool_capabilities() -> None:
     """Onboarding system prompt should inject available specialist tool descriptions."""
     user = User(id="6", user_id="new-user", phone="+15550001111")


### PR DESCRIPTION
## Description

Add a tip in the onboarding/bootstrap flow so Clawbolt naturally suggests using the phone's built-in keyboard dictation. This helps tradespeople who find typing slow on mobile. The tip is clear that this is the phone's speech-to-text keyboard feature, not sending audio to Clawbolt.

Changes:
- **bootstrap.md**: New "Quick tip: phone dictation" section with example phrasing for the onboarding conversation
- **GetStartedPage.tsx**: Brief dictation tip added to the "Start chatting" step
- **voice.mdx**: New "Phone dictation" section documenting the feature alongside voice memos
- **test_onboarding.py**: Test verifying the onboarding prompt includes the dictation tip

Fixes #787

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the changes)
- [ ] No AI used