### PR TITLE
fix: increase tap target size for Get Started link on mobile

### DIFF
--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -156,7 +156,7 @@ export default function AppShell() {
             to="/app/get-started"
             onClick={closeSidebar}
             className={({ isActive }) =>
-              `flex items-center gap-2 px-3 py-1 rounded-md text-xs transition-all duration-150 ${
+              `flex items-center gap-2 px-3 py-2 rounded-md text-xs transition-all duration-150 ${
                 isActive
                   ? 'text-primary font-medium'
                   : 'text-muted-foreground can-hover:hover:text-foreground'


### PR DESCRIPTION
## Description
The "Get Started" sidebar link used `py-1` (4px vertical padding), making it difficult to tap on mobile. Increased to `py-2` (8px) to match the main navigation items.

Fixes #793

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the fix)
- [ ] No AI used