### PR TITLE
fix: forward inputMode to HeroInput and prevent iOS zoom on all pages

### DIFF
--- a/frontend/src/components/ui/input.test.tsx
+++ b/frontend/src/components/ui/input.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import Input from './input';
+
+describe('Input', () => {
+  it('renders with placeholder', () => {
+    const { getByPlaceholderText } = render(<Input placeholder="Type here" />);
+    expect(getByPlaceholderText('Type here')).toBeInTheDocument();
+  });
+
+  it('forwards inputMode to the underlying input element', () => {
+    const { container } = render(<Input inputMode="tel" placeholder="phone" />);
+    const input = container.querySelector('input');
+    expect(input).toHaveAttribute('inputmode', 'tel');
+  });
+
+  it('forwards inputMode="numeric" to the underlying input element', () => {
+    const { container } = render(<Input inputMode="numeric" placeholder="number" />);
+    const input = container.querySelector('input');
+    expect(input).toHaveAttribute('inputmode', 'numeric');
+  });
+});

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { Input as HeroInput } from '@heroui/input';
 type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'color'>;
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, disabled, onChange, value, placeholder, type, id, autoComplete, ...rest }, ref) => {
+  ({ className, disabled, onChange, value, placeholder, type, id, autoComplete, inputMode, ...rest }, ref) => {
     void rest;
     return (
       <HeroInput
@@ -18,6 +18,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         type={type}
         id={id}
         autoComplete={autoComplete}
+        inputMode={inputMode}
         onValueChange={(val) => {
           if (onChange) {
             const syntheticEvent = {

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { Outlet, NavLink, Navigate } from 'react-router-dom';
 import { ToastProvider } from '@heroui/toast';
 import { useQueryClient } from '@tanstack/react-query';
@@ -49,6 +49,17 @@ export default function AppShell() {
   const closeSidebar = useCallback(() => setSidebarOpen(false), []);
 
   useSwipeSidebar({ isOpen: sidebarOpen, onOpen: openSidebar, onClose: closeSidebar });
+
+  // Prevent iOS Safari auto-zoom on input focus. Since iOS 10, maximum-scale=1
+  // only blocks automatic zoom (not user pinch-zoom), so accessibility is preserved.
+  // Applied only on iOS to avoid disabling pinch-zoom on Android.
+  useEffect(() => {
+    if (!/iPhone|iPad|iPod/.test(navigator.userAgent)) return;
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    if (meta && !meta.content.includes('maximum-scale')) {
+      meta.setAttribute('content', meta.content + ', maximum-scale=1');
+    }
+  }, []);
 
   const reloadProfile = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: queryKeys.profile });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -91,17 +91,6 @@ export default function ChatPage() {
     inputRef.current?.focus();
   }, []);
 
-  // Prevent iOS Safari auto-zoom on input focus. Since iOS 10, maximum-scale=1
-  // only blocks automatic zoom (not user pinch-zoom), so accessibility is preserved.
-  // Applied only on iOS to avoid disabling pinch-zoom on Android.
-  useEffect(() => {
-    if (!/iPhone|iPad|iPod/.test(navigator.userAgent)) return;
-    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
-    if (meta && !meta.content.includes('maximum-scale')) {
-      meta.setAttribute('content', meta.content + ', maximum-scale=1');
-    }
-  }, []);
-
   // Auto-attach to last active session from localStorage, or discover from API
   useEffect(() => {
     if (autoAttachDone.current || searchParams.get('session')) return;


### PR DESCRIPTION
## Description

Two fixes for mobile phone number input UX:

1. **Number pad not opening**: The `Input` wrapper component destructured `inputMode` into `...rest` which was then discarded with `void rest`. This meant `inputMode="tel"` on phone number inputs (GetStartedPage, ChannelsPage) and `inputMode="numeric"` on the Telegram ID input were silently dropped. Mobile users got a generic keyboard instead of a phone-style number pad.

2. **iOS zoom-in-after-submit**: The viewport `maximum-scale=1` fix that prevents iOS Safari auto-zoom was only applied in ChatPage. Moved it to AppShell so it applies to all pages including GetStartedPage.

Fixes #794

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code: investigated root cause, implemented fix, wrote tests)
- [ ] No AI used