### PR TITLE
fix: create ChannelRoute in premium mode during onboarding

### DIFF
--- a/frontend/src/pages/GetStartedPage.test.tsx
+++ b/frontend/src/pages/GetStartedPage.test.tsx
@@ -21,12 +21,14 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+let mockIsPremium = false;
+
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
     authState: 'ready',
     currentAuthUser: { id: 1, name: 'Test User' },
     authConfig: { required: false },
-    isPremium: false,
+    isPremium: mockIsPremium,
     handleLogin: vi.fn(),
     handleLogout: vi.fn(),
   }),
@@ -130,6 +132,42 @@ describe('GetStartedPage', () => {
       expect(screen.getByText('+15559876543')).toBeInTheDocument();
     });
     expect(screen.getByText(/say hello to get started/)).toBeInTheDocument();
+  });
+
+  it('saves phone number via premium channel route when isPremium is true', async () => {
+    mockIsPremium = true;
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ phone_number: '+15551234567', connected: true }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    renderWithRouter(<GetStartedPage />);
+    const user = userEvent.setup();
+
+    const input = screen.getByPlaceholderText('e.g. +15551234567');
+    await user.type(input, '+15551234567');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      const calls = mockFetch.mock.calls.filter(
+        (args: unknown[]) =>
+          args[0] === '/api/channels/linq' &&
+          (args[1] as RequestInit | undefined)?.method === 'PUT',
+      );
+      expect(calls).toHaveLength(1);
+      const body = (calls[0]![1] as RequestInit).body as string;
+      expect(JSON.parse(body)).toEqual({
+        phone_number: '+15551234567',
+      });
+    });
+
+    // Should NOT have called the OSS channel config endpoint
+    expect(mockUpdateChannelConfig).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+    mockIsPremium = false;
   });
 
   it('shows fallback messaging when linq is not configured', async () => {

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -7,26 +7,63 @@ import Field from '@/components/ui/field';
 import TextAssistantCard from '@/components/TextAssistantCard';
 import { toast } from '@/lib/toast';
 import { useUpdateProfile, useChannelConfig, useUpdateChannelConfig } from '@/hooks/queries';
+import { useAuth } from '@/contexts/AuthContext';
+import { getAccessToken } from '@/lib/api-client';
 import type { AppShellContext } from '@/layouts/AppShell';
+
+async function setLinqLink(phoneNumber: string): Promise<void> {
+  const token = getAccessToken();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const res = await fetch('/api/channels/linq', {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ phone_number: phoneNumber }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as { detail?: string };
+    throw new Error(body.detail || `Failed to save: ${res.status}`);
+  }
+}
 
 export default function GetStartedPage() {
   const { reloadProfile } = useOutletContext<AppShellContext>();
   const navigate = useNavigate();
+  const { isPremium } = useAuth();
   const updateProfile = useUpdateProfile();
   const { data: channelConfig } = useChannelConfig();
   const updateChannelConfig = useUpdateChannelConfig();
   const [phoneNumber, setPhoneNumber] = useState('');
   const [phoneSaved, setPhoneSaved] = useState(false);
+  const [savingPhone, setSavingPhone] = useState(false);
 
   const linqConfigured = channelConfig?.linq_api_token_set ?? false;
   const fromNumber = channelConfig?.linq_from_number ?? '';
 
-  const handleSavePhone = () => {
+  const handleSavePhone = async () => {
     const trimmed = phoneNumber.trim();
     if (!trimmed) {
       toast.error('Please enter your phone number');
       return;
     }
+
+    if (isPremium) {
+      // Premium: create a ChannelRoute via PUT /api/channels/linq
+      setSavingPhone(true);
+      try {
+        await setLinqLink(trimmed);
+        updateProfile.mutate({ phone: trimmed });
+        setPhoneSaved(true);
+        toast.success('Phone number saved');
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : 'Failed to save');
+      } finally {
+        setSavingPhone(false);
+      }
+      return;
+    }
+
+    // OSS: update the channel config allowlist
     updateChannelConfig.mutate(
       { linq_allowed_numbers: trimmed },
       {
@@ -93,8 +130,8 @@ export default function GetStartedPage() {
                     {!phoneSaved ? (
                       <Button
                         onClick={handleSavePhone}
-                        disabled={updateChannelConfig.isPending || !phoneNumber.trim()}
-                        isLoading={updateChannelConfig.isPending}
+                        disabled={savingPhone || updateChannelConfig.isPending || !phoneNumber.trim()}
+                        isLoading={savingPhone || updateChannelConfig.isPending}
                       >
                         Save
                       </Button>


### PR DESCRIPTION
## Description

The GetStartedPage onboarding flow saved the phone number to the OSS `linq_allowed_numbers` setting (via `updateChannelConfig`), but in premium mode the Linq webhook handler checks the `channel_routes` table first via `_check_premium_route`. Since no `ChannelRoute` row was created during onboarding, inbound messages were rejected with "Phone not in Linq allowlist, ignoring."

Now detects premium mode and calls `PUT /api/channels/linq` (which creates the `ChannelRoute`), matching what the ChannelsPage already does in `PremiumTextMessagingSection`.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`npm run typecheck && npx vitest run`)
- [x] Lint passes (`npm run deadcode`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified root cause and implemented fix)