### PR TITLE
feat: gray out channel settings when integrations are not configured

### DIFF
--- a/frontend/src/pages/ChannelsPage.test.tsx
+++ b/frontend/src/pages/ChannelsPage.test.tsx
@@ -3,6 +3,16 @@ import { screen, waitFor } from '@testing-library/react';
 import { renderWithRouter } from '@/test/test-utils';
 import ChannelsPage from './ChannelsPage';
 
+const mockGetChannelConfig = vi.fn();
+const mockUpdateChannelConfig = vi.fn();
+
+vi.mock('@/api', () => ({
+  default: {
+    getChannelConfig: (...args: unknown[]) => mockGetChannelConfig(...args),
+    updateChannelConfig: (...args: unknown[]) => mockUpdateChannelConfig(...args),
+  },
+}));
+
 const mockProfile = {
   channel_identifier: '',
   preferred_channel: 'webchat',
@@ -18,12 +28,14 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+let mockIsPremium = true;
+
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
     authState: 'ready',
     currentAuthUser: { id: 1, name: 'Test User' },
     authConfig: { required: true, method: 'oidc' },
-    isPremium: true,
+    isPremium: mockIsPremium,
     handleLogin: vi.fn(),
     handleLogout: vi.fn(),
   }),
@@ -36,6 +48,15 @@ vi.mock('@/lib/api-client', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   mockProfile.channel_identifier = '';
+  mockIsPremium = true;
+  mockGetChannelConfig.mockResolvedValue({
+    telegram_bot_token_set: true,
+    telegram_allowed_chat_id: '*',
+    linq_api_token_set: true,
+    linq_from_number: '+15551234567',
+    linq_allowed_numbers: '*',
+    linq_preferred_service: 'iMessage',
+  });
   vi.stubGlobal('fetch', vi.fn());
 });
 
@@ -63,7 +84,16 @@ describe('ChannelsPage - PremiumTelegramSection', () => {
     });
   });
 
-  it('shows generic text when bot-info is not available', async () => {
+  it('shows not-configured message when bot token is not set', async () => {
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: false,
+      telegram_allowed_chat_id: '',
+      linq_api_token_set: false,
+      linq_from_number: '',
+      linq_allowed_numbers: '',
+      linq_preferred_service: 'iMessage',
+    });
+
     const mockFetch = vi.fn().mockImplementation((url: string) => {
       if (url.includes('bot-info')) {
         return Promise.resolve({ ok: false, status: 404 });
@@ -78,9 +108,8 @@ describe('ChannelsPage - PremiumTelegramSection', () => {
     renderWithRouter(<ChannelsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/send a message to the bot to connect/i)).toBeInTheDocument();
+      expect(screen.getByText(/a telegram bot token must be configured/i)).toBeInTheDocument();
     });
-    expect(screen.queryByText(/@/)).not.toBeInTheDocument();
   });
 
   it('shows bot username in not-connected message when available', async () => {
@@ -102,6 +131,225 @@ describe('ChannelsPage - PremiumTelegramSection', () => {
 
     await waitFor(() => {
       expect(screen.getByText('@helper_bot', { exact: false })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ChannelsPage - disabled state when channels not configured', () => {
+  it('disables Telegram user ID input when bot token is not set (premium)', async () => {
+    mockIsPremium = true;
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: false,
+      telegram_allowed_chat_id: '',
+      linq_api_token_set: true,
+      linq_from_number: '+15551234567',
+      linq_allowed_numbers: '*',
+      linq_preferred_service: 'iMessage',
+    });
+
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('bot-info')) {
+        return Promise.resolve({ ok: false, status: 404 });
+      }
+      if (url.includes('/api/channels/linq')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ phone_number: null, connected: false }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ telegram_user_id: null, connected: false }),
+      });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Not configured')).toBeInTheDocument();
+    });
+
+    const telegramInput = screen.getByPlaceholderText('e.g. 123456789');
+    expect(telegramInput).toBeDisabled();
+  });
+
+  it('enables Telegram user ID input when bot token is set (premium)', async () => {
+    mockIsPremium = true;
+
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('bot-info')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ bot_username: 'test_bot', bot_link: 'https://t.me/test_bot' }),
+        });
+      }
+      if (url.includes('/api/channels/linq')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ phone_number: null, connected: false }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ telegram_user_id: null, connected: false }),
+      });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      const telegramInput = screen.getByPlaceholderText('e.g. 123456789');
+      expect(telegramInput).not.toBeDisabled();
+    });
+  });
+
+  it('disables Telegram user ID input when bot token is not set (OSS)', async () => {
+    mockIsPremium = false;
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: false,
+      telegram_allowed_chat_id: '',
+      linq_api_token_set: false,
+      linq_from_number: '',
+      linq_allowed_numbers: '',
+      linq_preferred_service: 'iMessage',
+    });
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      const badges = screen.getAllByText('Not configured');
+      expect(badges.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const telegramInput = screen.getByPlaceholderText('e.g. 123456789');
+    expect(telegramInput).toBeDisabled();
+  });
+
+  it('disables Linq fields when API token is not set (OSS)', async () => {
+    mockIsPremium = false;
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: true,
+      telegram_allowed_chat_id: '*',
+      linq_api_token_set: false,
+      linq_from_number: '',
+      linq_allowed_numbers: '',
+      linq_preferred_service: 'iMessage',
+    });
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Not configured')).toBeInTheDocument();
+    });
+
+    const phoneInput = screen.getByPlaceholderText('e.g. +15551234567');
+    expect(phoneInput).toBeDisabled();
+
+    const serviceSelect = screen.getByLabelText('Preferred messaging service');
+    expect(serviceSelect).toHaveAttribute('data-disabled', 'true');
+  });
+
+  it('enables Linq fields when API token is set (OSS)', async () => {
+    mockIsPremium = false;
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: true,
+      telegram_allowed_chat_id: '*',
+      linq_api_token_set: true,
+      linq_from_number: '+15551234567',
+      linq_allowed_numbers: '*',
+      linq_preferred_service: 'iMessage',
+    });
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      const badges = screen.getAllByText('Connected');
+      expect(badges.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const phoneInput = screen.getByPlaceholderText('e.g. +15551234567');
+    expect(phoneInput).not.toBeDisabled();
+
+    const serviceSelect = screen.getByLabelText('Preferred messaging service');
+    expect(serviceSelect).not.toHaveAttribute('data-disabled');
+  });
+
+  it('disables phone number input when Linq is not configured (premium)', async () => {
+    mockIsPremium = true;
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: true,
+      telegram_allowed_chat_id: '*',
+      linq_api_token_set: false,
+      linq_from_number: '',
+      linq_allowed_numbers: '',
+      linq_preferred_service: 'iMessage',
+    });
+
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('bot-info')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ bot_username: 'test_bot', bot_link: 'https://t.me/test_bot' }),
+        });
+      }
+      if (url.includes('/api/channels/linq')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ phone_number: null, connected: false }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ telegram_user_id: null, connected: false }),
+      });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Not configured')).toBeInTheDocument();
+    });
+
+    const phoneInput = screen.getByPlaceholderText('e.g. +15551234567');
+    expect(phoneInput).toBeDisabled();
+  });
+
+  it('shows setup hint for Telegram in OSS mode when not configured', async () => {
+    mockIsPremium = false;
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: false,
+      telegram_allowed_chat_id: '',
+      linq_api_token_set: false,
+      linq_from_number: '',
+      linq_allowed_numbers: '',
+      linq_preferred_service: 'iMessage',
+    });
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/TELEGRAM_BOT_TOKEN/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows setup hint for Linq in OSS mode when not configured', async () => {
+    mockIsPremium = false;
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: true,
+      telegram_allowed_chat_id: '*',
+      linq_api_token_set: false,
+      linq_from_number: '',
+      linq_allowed_numbers: '',
+      linq_preferred_service: 'iMessage',
+    });
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/LINQ_API_TOKEN/)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/ChannelsPage.tsx
+++ b/frontend/src/pages/ChannelsPage.tsx
@@ -94,10 +94,13 @@ async function setLinqLink(phoneNumber: string): Promise<LinqLinkData> {
 // --- Premium Telegram section ---
 
 function PremiumTelegramSection() {
+  const { data: channelConfig } = useChannelConfig();
   const [linkData, setLinkData] = useState<TelegramLinkData | null>(null);
   const [botInfo, setBotInfo] = useState<TelegramBotInfo | null>(null);
   const [telegramUserId, setTelegramUserId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  const isConfigured = channelConfig?.telegram_bot_token_set ?? false;
 
   useEffect(() => {
     getTelegramLink().then(setLinkData).catch(() => {});
@@ -146,14 +149,27 @@ function PremiumTelegramSection() {
       )}
 
       <Card>
-        <h3 className="text-sm font-medium mb-3">Telegram</h3>
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-medium">Telegram</h3>
+          {!isConfigured && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+              Not configured
+            </span>
+          )}
+        </div>
+        {!isConfigured && (
+          <p className="text-xs text-muted-foreground mb-4">
+            A Telegram bot token must be configured by an administrator to enable this channel.
+          </p>
+        )}
         <div className="grid gap-4">
           <TelegramUserIdField
             value={displayedId}
             onChange={(v) => setTelegramUserId(v)}
+            disabled={!isConfigured}
           />
           <div className="flex justify-end">
-            <Button onClick={handleSave} disabled={saving || linkData === null} isLoading={saving}>
+            <Button onClick={handleSave} disabled={!isConfigured || saving || linkData === null} isLoading={saving}>
               Save
             </Button>
           </div>
@@ -171,6 +187,7 @@ function OssTelegramSection() {
   const [telegramUserId, setTelegramUserId] = useState<string | null>(null);
 
   const displayedId = telegramUserId ?? config?.telegram_allowed_chat_id ?? '';
+  const isConfigured = config?.telegram_bot_token_set ?? false;
 
   const handleSave = () => {
     if (config && displayedId === config.telegram_allowed_chat_id) {
@@ -189,14 +206,26 @@ function OssTelegramSection() {
   return (
     <div className="grid gap-6">
       <Card>
-        <h3 className="text-sm font-medium mb-3">Telegram</h3>
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-medium">Telegram</h3>
+          <span className={`text-xs px-2 py-0.5 rounded-full ${isConfigured ? 'bg-success/10 text-success' : 'bg-muted text-muted-foreground'}`}>
+            {isConfigured ? 'Connected' : 'Not configured'}
+          </span>
+        </div>
+        {!isConfigured && (
+          <p className="text-xs text-muted-foreground mb-4">
+            Set <code className="font-mono text-[11px]">TELEGRAM_BOT_TOKEN</code> in your environment
+            or in <a href="/app/settings/telegram" className="underline">Settings &gt; Telegram</a> to enable.
+          </p>
+        )}
         <div className="grid gap-4">
           <TelegramUserIdField
             value={displayedId}
             onChange={(v) => setTelegramUserId(v)}
+            disabled={!isConfigured}
           />
           <div className="flex justify-end">
-            <Button onClick={handleSave} disabled={updateMutation.isPending || config === undefined} isLoading={updateMutation.isPending}>
+            <Button onClick={handleSave} disabled={!isConfigured || updateMutation.isPending || config === undefined} isLoading={updateMutation.isPending}>
               Save
             </Button>
           </div>
@@ -223,9 +252,11 @@ const TELEGRAM_ID_TOOLTIP =
 function TelegramUserIdField({
   value,
   onChange,
+  disabled,
 }: {
   value: string;
   onChange: (value: string) => void;
+  disabled?: boolean;
 }) {
   return (
     <Field label="Your Telegram User ID">
@@ -234,6 +265,7 @@ function TelegramUserIdField({
         onChange={(e) => onChange(e.target.value)}
         placeholder="e.g. 123456789"
         inputMode="numeric"
+        disabled={disabled}
       />
       <p className="text-xs text-muted-foreground mt-1">
         Your numeric Telegram user ID. Send /start to @userinfobot on Telegram to find it.{' '}
@@ -260,9 +292,12 @@ function TelegramSection() {
 // --- Premium Linq section ---
 
 function PremiumTextMessagingSection() {
+  const { data: channelConfig } = useChannelConfig();
   const [linkData, setLinkData] = useState<LinqLinkData | null>(null);
   const [phoneNumber, setPhoneNumber] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  const isConfigured = channelConfig?.linq_api_token_set ?? false;
 
   useEffect(() => {
     getLinqLink().then(setLinkData).catch(() => {});
@@ -290,7 +325,17 @@ function PremiumTextMessagingSection() {
 
   return (
     <Card>
-      <h3 className="text-sm font-medium mb-3">Text Messaging (iMessage / RCS / SMS)</h3>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium">Text Messaging (iMessage / RCS / SMS)</h3>
+        <span className={`text-xs px-2 py-0.5 rounded-full ${isConfigured ? 'bg-success/10 text-success' : 'bg-muted text-muted-foreground'}`}>
+          {isConfigured ? 'Connected' : 'Not configured'}
+        </span>
+      </div>
+      {!isConfigured && (
+        <p className="text-xs text-muted-foreground mb-4">
+          Text messaging must be configured by an administrator to enable this channel.
+        </p>
+      )}
       <div className="grid gap-4">
         <Field label="Your Phone Number">
           <Input
@@ -298,13 +343,14 @@ function PremiumTextMessagingSection() {
             onChange={(e) => setPhoneNumber(e.target.value)}
             placeholder="e.g. +15551234567"
             inputMode="tel"
+            disabled={!isConfigured}
           />
           <p className="text-xs text-muted-foreground mt-1">
             E.164 format phone number. This is the number you'll text from.
           </p>
         </Field>
         <div className="flex justify-end">
-          <Button onClick={handleSave} disabled={saving || linkData === null} isLoading={saving}>
+          <Button onClick={handleSave} disabled={!isConfigured || saving || linkData === null} isLoading={saving}>
             Save
           </Button>
         </div>
@@ -376,6 +422,7 @@ function TextMessagingSection() {
               onChange={(e) => setAllowedNumber(e.target.value)}
               placeholder="e.g. +15551234567"
               inputMode="tel"
+              disabled={!isConfigured}
             />
             <p className="text-xs text-muted-foreground mt-1">
               E.164 phone number, or * to allow all. Empty = deny all.
@@ -386,6 +433,7 @@ function TextMessagingSection() {
               value={displayedService}
               onChange={(e) => setPreferredService(e.target.value)}
               aria-label="Preferred messaging service"
+              disabled={!isConfigured}
             >
               {LINQ_SERVICES.map((svc) => (
                 <option key={svc} value={svc}>{svc}</option>
@@ -393,7 +441,7 @@ function TextMessagingSection() {
             </Select>
           </Field>
           <div className="flex justify-end">
-            <Button onClick={handleSave} disabled={updateMutation.isPending || config === undefined} isLoading={updateMutation.isPending}>
+            <Button onClick={handleSave} disabled={!isConfigured || updateMutation.isPending || config === undefined} isLoading={updateMutation.isPending}>
               Save
             </Button>
           </div>


### PR DESCRIPTION
## Description
Disables form fields and shows "Not configured" status badges on the Channels page when the underlying service tokens (Telegram bot token, Linq API token) are not set server-side. This prevents users from editing settings that have no effect until the integration is enabled.

Applies to all four channel sections:
- **OSS Telegram**: status badge + disabled User ID input + hint to set `TELEGRAM_BOT_TOKEN`
- **Premium Telegram**: status badge + disabled User ID input + admin-facing message
- **OSS Text Messaging**: disabled phone number input, service select, and save button (badge already existed)
- **Premium Text Messaging**: status badge + disabled phone number input + admin-facing message

Fixes #791

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation and tests written with Claude Code.