### PR TITLE
refactor: extract get_or_404 query helper

### DIFF
--- a/backend/app/query_helpers.py
+++ b/backend/app/query_helpers.py
@@ -1,0 +1,26 @@
+"""Reusable query utilities for FastAPI route handlers."""
+
+from typing import TypeVar
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+T = TypeVar("T")
+
+
+def get_or_404(
+    db: Session,
+    model: type[T],
+    detail: str = "Not found",
+    **filters: object,
+) -> T:
+    """Query for a single row by filter or raise HTTP 404.
+
+    Usage::
+
+        user = get_or_404(db, User, detail="User not found", id=user_id)
+    """
+    row = db.query(model).filter_by(**filters).first()
+    if row is None:
+        raise HTTPException(status_code=404, detail=detail)
+    return row

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -10,6 +10,7 @@ from backend.app.auth.dependencies import get_current_user
 from backend.app.config import save_persistent_config, settings, update_settings
 from backend.app.database import get_db
 from backend.app.models import HeartbeatLog, LLMUsageLog, User
+from backend.app.query_helpers import get_or_404
 from backend.app.schemas import (
     ChannelConfigResponse,
     ChannelConfigUpdate,
@@ -72,9 +73,7 @@ async def update_profile(
         raise HTTPException(status_code=400, detail="No fields to update")
 
     # Re-query user in the current session to avoid detached instance issues
-    user = db.query(User).filter_by(id=current_user.id).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+    user = get_or_404(db, User, detail="User not found", id=current_user.id)
 
     for key, value in updates.items():
         setattr(user, key, value)

--- a/tests/test_query_helpers.py
+++ b/tests/test_query_helpers.py
@@ -1,0 +1,45 @@
+"""Tests for backend.app.query_helpers."""
+
+import pytest
+from fastapi import HTTPException
+
+import backend.app.database as _db_module
+from backend.app.models import User
+from backend.app.query_helpers import get_or_404
+
+
+def test_get_or_404_returns_row() -> None:
+    """Returns the matching row when it exists."""
+    db = _db_module.SessionLocal()
+    try:
+        user = User(user_id="found@test.com")
+        db.add(user)
+        db.flush()
+
+        result = get_or_404(db, User, id=user.id)
+        assert result.user_id == "found@test.com"
+    finally:
+        db.close()
+
+
+def test_get_or_404_raises_on_missing() -> None:
+    """Raises HTTPException 404 when no row matches."""
+    db = _db_module.SessionLocal()
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            get_or_404(db, User, detail="User not found", id="nonexistent-id")
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "User not found"
+    finally:
+        db.close()
+
+
+def test_get_or_404_default_detail() -> None:
+    """Uses 'Not found' as the default detail message."""
+    db = _db_module.SessionLocal()
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            get_or_404(db, User, id="missing")
+        assert exc_info.value.detail == "Not found"
+    finally:
+        db.close()


### PR DESCRIPTION
## Description

Extract a reusable `get_or_404(db, model, detail, **filters)` utility in `backend/app/query_helpers.py` that queries for a single row or raises HTTP 404. This eliminates the repeated query-then-null-check-then-raise pattern found 21+ times across OSS and premium routers.

Applied it in `user_profile.py` as the first usage site. Premium routers can import from the same module.

Fixes #801

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code -- identified the pattern during a codebase quality audit, filed the issue, and implemented the fix.