### PR TITLE
refactor: reduce store layer boilerplate with shared StoreCache

### DIFF
--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -8,8 +8,8 @@ user_text.
 from __future__ import annotations
 
 import logging
-from collections import OrderedDict
 
+from backend.app.agent.store_cache import StoreCache
 from backend.app.database import SessionLocal, db_session
 from backend.app.models import MemoryDocument, User
 
@@ -137,26 +137,18 @@ class MemoryStore:
 # LRU cache
 # ---------------------------------------------------------------------------
 
-_MAX_CACHED_STORES = 256
-_stores: OrderedDict[str, MemoryStore] = OrderedDict()
+_cache: StoreCache[MemoryStore] = StoreCache(MemoryStore)
 
 
 def get_memory_store(user_id: str) -> MemoryStore:
     """Get or create a MemoryStore for the given user.
 
-    Uses an LRU cache bounded to ``_MAX_CACHED_STORES`` entries to prevent
-    unbounded memory growth in multi-tenant deployments.
+    Uses an LRU cache bounded to 256 entries to prevent unbounded memory
+    growth in multi-tenant deployments.
     """
-    if user_id in _stores:
-        _stores.move_to_end(user_id)
-        return _stores[user_id]
-    store = MemoryStore(user_id)
-    _stores[user_id] = store
-    if len(_stores) > _MAX_CACHED_STORES:
-        _stores.popitem(last=False)
-    return store
+    return _cache.get(user_id)
 
 
 def reset_memory_stores() -> None:
     """Clear the memory store cache (for tests)."""
-    _stores.clear()
+    _cache.clear()

--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 import datetime
 import logging
 import uuid
-from collections import OrderedDict
 from typing import Any
 
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
 from backend.app.agent.dto import SessionState, StoredMessage
+from backend.app.agent.store_cache import StoreCache
 from backend.app.config import settings
 from backend.app.database import SessionLocal, db_session
 from backend.app.models import ChatSession, Message
@@ -404,26 +404,18 @@ class SessionStore:
 # LRU cache
 # ---------------------------------------------------------------------------
 
-_MAX_CACHED_STORES = 256
-_stores: OrderedDict[str, SessionStore] = OrderedDict()
+_cache: StoreCache[SessionStore] = StoreCache(SessionStore)
 
 
 def get_session_store(user_id: str) -> SessionStore:
     """Get or create a SessionStore for the given user.
 
-    Uses an LRU cache bounded to ``_MAX_CACHED_STORES`` entries to prevent
-    unbounded memory growth in multi-tenant deployments.
+    Uses an LRU cache bounded to 256 entries to prevent unbounded memory
+    growth in multi-tenant deployments.
     """
-    if user_id in _stores:
-        _stores.move_to_end(user_id)
-        return _stores[user_id]
-    store = SessionStore(user_id)
-    _stores[user_id] = store
-    if len(_stores) > _MAX_CACHED_STORES:
-        _stores.popitem(last=False)
-    return store
+    return _cache.get(user_id)
 
 
 def reset_session_stores() -> None:
     """Clear the session store cache (for tests)."""
-    _stores.clear()
+    _cache.clear()

--- a/backend/app/agent/store_cache.py
+++ b/backend/app/agent/store_cache.py
@@ -1,0 +1,53 @@
+"""Shared LRU cache for per-user store instances.
+
+SessionStore, MemoryStore, and other per-user stores all need an LRU cache
+bounded to a fixed number of entries to prevent unbounded memory growth in
+multi-tenant deployments. This module provides a single reusable class
+instead of duplicating the OrderedDict logic in every store module.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+_DEFAULT_MAX_SIZE = 256
+
+
+class StoreCache(Generic[T]):
+    """Bounded LRU cache for per-user store instances.
+
+    Usage::
+
+        _cache: StoreCache[SessionStore] = StoreCache(SessionStore)
+
+        def get_session_store(user_id: str) -> SessionStore:
+            return _cache.get(user_id)
+    """
+
+    def __init__(
+        self,
+        factory: Callable[[str], T],
+        max_size: int = _DEFAULT_MAX_SIZE,
+    ) -> None:
+        self._factory = factory
+        self._max_size = max_size
+        self._entries: OrderedDict[str, T] = OrderedDict()
+
+    def get(self, key: str) -> T:
+        """Return the cached store for *key*, creating it if absent."""
+        if key in self._entries:
+            self._entries.move_to_end(key)
+            return self._entries[key]
+        store = self._factory(key)
+        self._entries[key] = store
+        if len(self._entries) > self._max_size:
+            self._entries.popitem(last=False)
+        return store
+
+    def clear(self) -> None:
+        """Remove all entries (used by tests)."""
+        self._entries.clear()

--- a/backend/app/agent/user_db.py
+++ b/backend/app/agent/user_db.py
@@ -4,7 +4,7 @@ Replaces the file-based UserStore from the old file_store.py. Uses the User
 ORM model for persistence, while keeping UserData Pydantic model as the public
 API surface for backward compatibility with premium.
 
-Follows the same SessionLocal() / try-finally pattern used in session_db.py.
+Uses the db_session() context manager for all UserStore methods.
 """
 
 from __future__ import annotations
@@ -113,21 +113,15 @@ class UserStore:
 
     async def get_by_id(self, user_id: str | int) -> UserData | None:
         """Look up a user by primary key (id)."""
-        db = SessionLocal()
-        try:
+        with db_session() as db:
             user = db.query(User).filter_by(id=str(user_id)).first()
             return _user_to_dto(user) if user else None
-        finally:
-            db.close()
 
     async def get_by_user_id(self, user_id: str) -> UserData | None:
         """Look up a user by user_id (e.g., 'google_12345')."""
-        db = SessionLocal()
-        try:
+        with db_session() as db:
             user = db.query(User).filter_by(user_id=user_id).first()
             return _user_to_dto(user) if user else None
-        finally:
-            db.close()
 
     async def create(self, user_id: str, **fields: Any) -> UserData:
         """Create a new User row and return it as a DTO."""
@@ -153,12 +147,9 @@ class UserStore:
 
     async def list_all(self) -> list[UserData]:
         """Return all users."""
-        db = SessionLocal()
-        try:
+        with db_session() as db:
             users = db.query(User).order_by(User.created_at).all()
             return [_user_to_dto(u) for u in users]
-        finally:
-            db.close()
 
 
 _user_store: UserStore | None = None

--- a/tests/test_store_cache.py
+++ b/tests/test_store_cache.py
@@ -1,0 +1,58 @@
+"""Tests for backend.app.agent.store_cache.StoreCache."""
+
+from backend.app.agent.store_cache import StoreCache
+
+
+class _FakeStore:
+    """Minimal store for testing."""
+
+    def __init__(self, user_id: str) -> None:
+        self.user_id = user_id
+
+
+def test_get_creates_instance() -> None:
+    cache: StoreCache[_FakeStore] = StoreCache(_FakeStore)
+    store = cache.get("user-1")
+    assert store.user_id == "user-1"
+
+
+def test_get_returns_cached_instance() -> None:
+    cache: StoreCache[_FakeStore] = StoreCache(_FakeStore)
+    a = cache.get("user-1")
+    b = cache.get("user-1")
+    assert a is b
+
+
+def test_evicts_oldest_when_full() -> None:
+    cache: StoreCache[_FakeStore] = StoreCache(_FakeStore, max_size=2)
+    cache.get("a")
+    cache.get("b")
+    cache.get("c")  # evicts "a"
+    # "a" was evicted, so a new instance is returned
+    new_a = cache.get("a")
+    assert new_a.user_id == "a"
+    # "b" should have been evicted by now (LRU order: b, c -> c, a -> evict b)
+    # Actually after get("c") evicts "a": [b, c]
+    # Then get("a") evicts "b": [c, a]
+    new_b = cache.get("b")
+    assert new_b.user_id == "b"
+
+
+def test_lru_reorder_on_access() -> None:
+    cache: StoreCache[_FakeStore] = StoreCache(_FakeStore, max_size=2)
+    first_a = cache.get("a")
+    cache.get("b")
+    # Access "a" again to make it most-recently-used
+    cache.get("a")
+    # Insert "c" -- should evict "b" (least recently used), not "a"
+    cache.get("c")
+    # "a" should still be the original instance
+    assert cache.get("a") is first_a
+
+
+def test_clear_removes_all() -> None:
+    cache: StoreCache[_FakeStore] = StoreCache(_FakeStore)
+    first = cache.get("user-1")
+    cache.clear()
+    second = cache.get("user-1")
+    assert first is not second


### PR DESCRIPTION
## Description

Extract the duplicated LRU cache logic from `session_db.py` and `memory_db.py` into a reusable `StoreCache[T]` generic class in `backend/app/agent/store_cache.py`. Fix `UserStore` session management inconsistency by switching all read methods to use `db_session()` context manager.

- **StoreCache**: Replaces 13 lines of identical `OrderedDict` + `move_to_end` + `popitem` code in each store module with a 2-line usage
- **UserStore**: `get_by_id`, `get_by_user_id`, `list_all` now use `with db_session()` matching the pattern already used by `create` and `update`

Fixes #800

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code as part of a codebase quality audit.