### PR TITLE
fix: add mobile-friendly formatting rules to system prompt

### DIFF
--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -5,6 +5,13 @@
 - Keep replies concise. Users are on the job site.
 - If the user explicitly asks you not to respond (e.g. "don't say anything back"), return empty text. It is OK to not respond when the user asks for silence.
 
+## Formatting
+Your replies are read on a phone. Format for mobile text messages:
+- Never use markdown tables. Present tabular data as a simple list with one item per line.
+- Never use bold markers (**text**), italic markers (*text*), or heading markers (## text).
+- Use line breaks and short dashes (-) for structure instead.
+- Keep lines short. Text wraps awkwardly on small screens.
+
 ## Keeping files up to date
 Update these files proactively as you learn new things. Do not ask permission. Just do it naturally as part of the conversation.
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -200,6 +200,23 @@ async def test_system_prompt_skips_tools_without_hints(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
+async def test_system_prompt_includes_mobile_formatting_rules(
+    mock_amessages: object, test_user: User
+) -> None:
+    """System prompt should include mobile-friendly formatting rules."""
+    mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
+
+    agent = ClawboltAgent(user=test_user)
+    await agent.process_message("Hello")
+
+    call_args = mock_amessages.call_args  # type: ignore[union-attr]
+    system_prompt = call_args.kwargs["system"]
+    assert "Never use markdown tables" in system_prompt
+    assert "Never use bold markers" in system_prompt
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
 async def test_agent_does_not_pass_api_key(mock_amessages: object, test_user: User) -> None:
     """acompletion should be called without api_key so the SDK resolves keys from env."""
     mock_amessages.return_value = make_text_response("Hi!")  # type: ignore[union-attr]


### PR DESCRIPTION
## Description
The LLM was generating markdown (tables, `**bold**`, `## headings`) in replies that render fine in Telegram and webchat but appear as raw markup in SMS/iMessage text messages. This adds formatting rules to the instructions prompt telling the LLM to always format for mobile: no markdown tables, no bold/italic markers, no headings, short lines.

Fixes #804

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the fix)
- [ ] No AI used