### PR TITLE
fix: update preferred_channel when user messages from a different channel

### DIFF
--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -102,6 +102,12 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
         if route:
             user = db.query(User).filter_by(id=route.user_id).first()
             if user is not None:
+                # Track the most recently used channel so heartbeat and other
+                # proactive messages are delivered to the right place.
+                if user.preferred_channel != channel:
+                    user.preferred_channel = channel
+                    db.commit()
+                    db.refresh(user)
                 logger.debug("_get_or_create_user: found via channel route -> user %s", user.id)
                 db.expunge(user)
                 return user

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -872,3 +872,39 @@ async def test_oauth_user_provisioned_on_first_chat() -> None:
     assert resolved.user_text  # seeded by provision_user
     assert bootstrap_path.exists()  # created by provision_user
     assert is_onboarding_needed(resolved) is True
+
+
+@pytest.mark.asyncio()
+async def test_preferred_channel_updates_on_channel_switch() -> None:
+    """preferred_channel should update when a returning user messages from a different channel.
+
+    Regression: heartbeat used preferred_channel to pick the delivery channel,
+    but preferred_channel was never updated in premium mode when the user
+    switched from Telegram to iMessage (linq). Heartbeats kept going to the
+    old channel.
+    """
+    from backend.app.agent.ingestion import _get_or_create_user
+    from backend.app.models import ChannelRoute
+
+    # Create a user who signed up via Telegram
+    db = _db_module.SessionLocal()
+    try:
+        user = User(
+            id="channel-switch-user",
+            user_id="google_switch",
+            preferred_channel="telegram",
+            onboarding_complete=True,
+        )
+        db.add(user)
+        db.flush()
+        db.add(ChannelRoute(user_id=user.id, channel="telegram", channel_identifier="tg_123"))
+        db.add(ChannelRoute(user_id=user.id, channel="linq", channel_identifier="linq_456"))
+        db.commit()
+    finally:
+        db.close()
+
+    # User sends a message via linq (iMessage)
+    resolved = await _get_or_create_user("linq", "linq_456")
+
+    assert resolved.id == "channel-switch-user"
+    assert resolved.preferred_channel == "linq"


### PR DESCRIPTION
## Description

In premium mode, `preferred_channel` was only set at user creation time (via Google OAuth, defaulting to "telegram") and never updated when the user messaged from a different channel. This caused heartbeat messages to be delivered to the wrong channel -- e.g. Telegram instead of iMessage/linq, even though the user's most recent conversation was on iMessage.

The single-tenant OSS path (line 119) already updated `preferred_channel` on channel switch, but the premium path (found via `ChannelRoute`, lines 102-107) returned the user without updating the field.

Fix: when an existing user is resolved via `ChannelRoute` and the incoming channel differs from their `preferred_channel`, update it. This ensures heartbeat and other proactive messages go to wherever the user was last active.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code investigated the root cause and implemented the fix)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)