### PR TITLE
fix: filter inactive users from heartbeat tick

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -801,7 +801,7 @@ class HeartbeatScheduler:
                 db.expunge(u)
         finally:
             db.close()
-        users = [c for c in all_users if c.onboarding_complete]
+        users = [c for c in all_users if c.onboarding_complete and c.is_active]
 
         if not users:
             logger.debug("Heartbeat tick: no onboarded users found")

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1132,6 +1132,46 @@ class TestHeartbeatScheduler:
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
     @patch("backend.app.agent.heartbeat.settings")
+    async def test_tick_skips_inactive_user(
+        self,
+        mock_settings: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """Tick should skip users with is_active=False even if onboarding is complete (#811)."""
+        mock_settings.heartbeat_concurrency = 2
+        mock_settings.heartbeat_max_daily_messages = 5
+
+        db = _db_module.SessionLocal()
+        try:
+            user = User(
+                user_id="hb-inactive-test",
+                phone="+15550001111",
+                onboarding_complete=True,
+                is_active=False,
+                preferred_channel="telegram",
+                channel_identifier="",
+            )
+            db.add(user)
+            db.flush()
+            db.add(
+                ChannelRoute(
+                    user_id=user.id,
+                    channel="telegram",
+                    channel_identifier="inactive-chat-id",
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        scheduler = HeartbeatScheduler()
+        await scheduler.tick()
+
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.settings")
     async def test_tick_concurrent_processing(
         self,
         mock_settings: MagicMock,


### PR DESCRIPTION
## Description

Fixes #811: OSS `HeartbeatScheduler.tick()` filters by `onboarding_complete` but not `is_active`. Deactivated users still receive heartbeat messages.

Added `and c.is_active` to the user filter in `tick()`.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation generated by Claude Code following a reviewed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)