### PR TITLE
refactor: extract heartbeat helpers and add build_pipeline()

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -728,6 +728,34 @@ def _pick_heartbeat_channel(user: User) -> str:
 # ---------------------------------------------------------------------------
 
 
+def user_interval_minutes(user: User) -> int:
+    """Return the heartbeat interval in minutes for a given user.
+
+    Parses the user's ``heartbeat_frequency`` string (e.g. "30m", "2h"),
+    falling back to the global ``settings.heartbeat_interval_minutes``.
+    """
+    parsed = parse_frequency_to_minutes(user.heartbeat_frequency)
+    if parsed is not None:
+        return parsed
+    return settings.heartbeat_interval_minutes
+
+
+def is_user_due(
+    user: User,
+    now: datetime.datetime,
+    last_tick: dict[str, datetime.datetime],
+) -> bool:
+    """Return True if enough time has elapsed since the last tick for this user.
+
+    ``last_tick`` maps user IDs to the last evaluation timestamp.
+    """
+    last = last_tick.get(user.id)
+    if last is None:
+        return True
+    interval = user_interval_minutes(user)
+    return (now - last).total_seconds() >= interval * 60
+
+
 class HeartbeatScheduler:
     """Manages the periodic heartbeat loop as an asyncio background task.
 
@@ -776,20 +804,14 @@ class HeartbeatScheduler:
                 logger.exception("Heartbeat tick failed")
             await asyncio.sleep(_TICK_RESOLUTION_MINUTES * 60)
 
-    def _user_interval_minutes(self, user: User) -> int:
+    @staticmethod
+    def _user_interval_minutes(user: User) -> int:
         """Return the heartbeat interval in minutes for a given user."""
-        parsed = parse_frequency_to_minutes(user.heartbeat_frequency)
-        if parsed is not None:
-            return parsed
-        return settings.heartbeat_interval_minutes
+        return user_interval_minutes(user)
 
     def _is_user_due(self, user: User, now: datetime.datetime) -> bool:
         """Return True if enough time has elapsed since the last tick for this user."""
-        last = self._last_tick.get(user.id)
-        if last is None:
-            return True
-        interval = self._user_interval_minutes(user)
-        return (now - last).total_seconds() >= interval * 60
+        return is_user_due(user, now, self._last_tick)
 
     async def tick(self) -> None:
         """Single heartbeat pass: evaluate due users concurrently."""

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -543,6 +543,35 @@ def get_active_pipeline() -> list[PipelineStep]:
     return _pipeline_override if _pipeline_override is not None else DEFAULT_PIPELINE
 
 
+def build_pipeline(
+    *,
+    replace: dict[PipelineStep, PipelineStep] | None = None,
+    insert_before: dict[PipelineStep, list[PipelineStep]] | None = None,
+    insert_after: dict[PipelineStep, list[PipelineStep]] | None = None,
+) -> list[PipelineStep]:
+    """Build a pipeline by modifying ``DEFAULT_PIPELINE``.
+
+    This allows plugins (e.g. premium) to define their pipeline relative
+    to the OSS default instead of hardcoding the full list.
+
+    * ``replace``: swap one step for another
+    * ``insert_before``: inject steps immediately before a given step
+    * ``insert_after``: inject steps immediately after a given step
+    """
+    replace = replace or {}
+    insert_before = insert_before or {}
+    insert_after = insert_after or {}
+
+    result: list[PipelineStep] = []
+    for step in DEFAULT_PIPELINE:
+        if step in insert_before:
+            result.extend(insert_before[step])
+        result.append(replace.get(step, step))
+        if step in insert_after:
+            result.extend(insert_after[step])
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,6 +11,7 @@ from backend.app.agent.router import (
     PipelineContext,
     PipelineStep,
     build_context_step,
+    build_pipeline,
     dispatch_reply_step,
     finalize_onboarding_step,
     load_history_step,
@@ -250,3 +251,78 @@ async def test_prepare_media_step_preserves_pre_downloaded_media() -> None:
 
     assert len(result.downloaded_media) == 1
     assert result.downloaded_media[0] is pre_downloaded
+
+
+# ---------------------------------------------------------------------------
+# build_pipeline() tests
+# ---------------------------------------------------------------------------
+
+
+async def _noop_step(ctx: PipelineContext) -> PipelineContext:
+    return ctx
+
+
+def test_build_pipeline_no_modifications() -> None:
+    """build_pipeline() with no args returns a copy of DEFAULT_PIPELINE."""
+    result = build_pipeline()
+    assert result == DEFAULT_PIPELINE
+    assert result is not DEFAULT_PIPELINE
+
+
+def test_build_pipeline_replace() -> None:
+    """build_pipeline(replace=...) should swap a step."""
+    result = build_pipeline(replace={run_agent_step: _noop_step})
+    assert _noop_step in result
+    assert run_agent_step not in result
+    assert len(result) == len(DEFAULT_PIPELINE)
+
+
+def test_build_pipeline_insert_before() -> None:
+    """build_pipeline(insert_before=...) should inject steps before a target."""
+    result = build_pipeline(insert_before={run_agent_step: [_noop_step]})
+    idx_noop = result.index(_noop_step)
+    idx_agent = result.index(run_agent_step)
+    assert idx_noop == idx_agent - 1
+    assert len(result) == len(DEFAULT_PIPELINE) + 1
+
+
+def test_build_pipeline_insert_after() -> None:
+    """build_pipeline(insert_after=...) should inject steps after a target."""
+    result = build_pipeline(insert_after={persist_outbound_step: [_noop_step]})
+    idx_persist = result.index(persist_outbound_step)
+    idx_noop = result.index(_noop_step)
+    assert idx_noop == idx_persist + 1
+    assert len(result) == len(DEFAULT_PIPELINE) + 1
+
+
+def test_build_pipeline_combined() -> None:
+    """build_pipeline with replace + insert_before + insert_after."""
+
+    async def quota_step(ctx: PipelineContext) -> PipelineContext:
+        return ctx
+
+    async def guarded_agent(ctx: PipelineContext) -> PipelineContext:
+        return ctx
+
+    async def track_step(ctx: PipelineContext) -> PipelineContext:
+        return ctx
+
+    result = build_pipeline(
+        insert_before={run_agent_step: [quota_step]},
+        replace={run_agent_step: guarded_agent},
+        insert_after={persist_outbound_step: [track_step]},
+    )
+
+    # All default steps except run_agent_step should still be present
+    for step in DEFAULT_PIPELINE:
+        if step is not run_agent_step:
+            assert step in result
+
+    # The three injected steps should be present
+    assert quota_step in result
+    assert guarded_agent in result
+    assert track_step in result
+
+    # Order: quota_step before guarded_agent, track_step after persist_outbound
+    assert result.index(quota_step) < result.index(guarded_agent)
+    assert result.index(persist_outbound_step) < result.index(track_step)


### PR DESCRIPTION
## Description

OSS side of #201 + #202 (heartbeat + pipeline deduplication):

- **#201**: Extracted `user_interval_minutes()` and `is_user_due()` as module-level functions in `heartbeat.py` so premium can import them instead of duplicating the logic. Class methods now delegate to these functions.
- **#202**: Added `build_pipeline()` helper in `router.py` that constructs a pipeline relative to `DEFAULT_PIPELINE` using `replace`, `insert_before`, and `insert_after` dicts. Premium uses this to compose its pipeline without hardcoding the full step list.

Companion PR: mozilla-ai/clawbolt-premium#208

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation generated by Claude Code following a reviewed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)