### PR TITLE
refactor: pluggable is_allowed override and ingestion docstrings

### DIFF
--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -86,9 +86,26 @@ async def _send_error_fallback(
 async def _get_or_create_user(channel: str, sender_id: str) -> User:
     """Look up or create a user by channel-specific sender ID.
 
-    In single-tenant (OSS) mode there should be exactly one user shared
-    across all channels.  When a new channel arrives and a user already
-    exists, link the channel to that user instead of creating a duplicate.
+    Handles three distinct scenarios (in order of evaluation):
+
+    1. **Channel route exists** -- the sender has messaged before on this
+       channel.  Return the linked user immediately.  This is the common
+       path for both OSS and premium.
+
+    2. **Single-tenant reuse (OSS only)** -- exactly one user exists and
+       ``settings.premium_plugin`` is not set.  Link the new channel to
+       the existing user so that sessions from every channel are visible
+       in the dashboard.  Skipped in premium mode to prevent cross-tenant
+       linking.
+
+    3. **Sender ID matches an existing user PK (premium only)** -- the
+       webchat sends ``sender_id = user.id`` (the UUID primary key).
+       Link the existing user to this channel and provision defaults.
+       This avoids creating a duplicate account when a premium user
+       first opens the webchat.
+
+    If none of the above match, a new ``User`` and ``ChannelRoute`` are
+    created.  An ``IntegrityError`` race is handled by re-querying.
     """
     from sqlalchemy.exc import IntegrityError
 

--- a/backend/app/channels/base.py
+++ b/backend/app/channels/base.py
@@ -1,10 +1,30 @@
 """Abstract base class for messaging channels."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 
 from fastapi import APIRouter
 
 from backend.app.media.download import DownloadedMedia
+
+# Type for the pluggable allowlist override. The callback receives
+# (channel_name, sender_id) and returns True/False. When set, channels
+# delegate to this instead of their static allowlist.
+IsAllowedOverride = Callable[[str, str], bool]
+
+# Module-level override set by premium during plugin initialization.
+_is_allowed_override: IsAllowedOverride | None = None
+
+
+def set_is_allowed_override(fn: IsAllowedOverride) -> None:
+    """Register a global allowlist override (called by the premium plugin)."""
+    global _is_allowed_override
+    _is_allowed_override = fn
+
+
+def get_is_allowed_override() -> IsAllowedOverride | None:
+    """Return the current allowlist override, or None if not set."""
+    return _is_allowed_override
 
 
 class BaseChannel(ABC):
@@ -41,27 +61,16 @@ class BaseChannel(ABC):
         """Return ``True`` if the sender passes the channel's allowlist."""
 
     def _check_premium_route(self, sender_id: str) -> bool | None:
-        """Check for an existing ``ChannelRoute`` in premium mode.
+        """Check if a plugin-level allowlist override handles this sender.
 
-        Returns ``True``/``False`` if a premium plugin is configured,
-        or ``None`` if running in OSS mode (caller should fall through
-        to its own static allowlist logic).
+        Returns ``True``/``False`` if an override is registered (e.g. premium
+        checks ``ChannelRoute`` existence), or ``None`` if no override is set
+        (caller should fall through to its own static allowlist logic).
         """
-        from backend.app.config import settings
-
-        if not settings.premium_plugin:
+        override = _is_allowed_override
+        if override is None:
             return None
-
-        from backend.app.database import db_session
-        from backend.app.models import ChannelRoute
-
-        with db_session() as db:
-            route = (
-                db.query(ChannelRoute)
-                .filter_by(channel=self.name, channel_identifier=sender_id)
-                .first()
-            )
-            return route is not None
+        return override(self.name, sender_id)
 
     # -- Outbound --------------------------------------------------------------
 

--- a/tests/test_premium_channel_auth.py
+++ b/tests/test_premium_channel_auth.py
@@ -1,23 +1,25 @@
 """Tests for premium ChannelRoute-based auth in channels.
 
-When ``settings.premium_plugin`` is set, ``is_allowed()`` should approve
-senders that have a ``ChannelRoute`` row and reject those that do not,
-bypassing the static allowlist entirely.
+When an ``is_allowed`` override is registered (e.g. by the premium plugin),
+``is_allowed()`` should approve senders that have a ``ChannelRoute`` row and
+reject those that do not, bypassing the static allowlist entirely.
 """
 
+from collections.abc import Generator
 from unittest.mock import patch
 
+import pytest
+
+from backend.app.channels.base import set_is_allowed_override
 from backend.app.channels.linq import LinqChannel
 from backend.app.channels.telegram import TelegramChannel
 from backend.app.config import settings
-from backend.app.database import SessionLocal
+from backend.app.database import SessionLocal, db_session
 from backend.app.models import ChannelRoute, User
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_PATCH_PREMIUM = "premium_plugin"
 
 
 def _create_user_with_route(channel: str, identifier: str) -> str:
@@ -43,113 +45,120 @@ def _create_user_with_route(channel: str, identifier: str) -> str:
         db.close()
 
 
+def _route_based_override(channel_name: str, sender_id: str) -> bool:
+    """Test override that checks ChannelRoute, matching premium behavior."""
+    with db_session() as db:
+        route = (
+            db.query(ChannelRoute)
+            .filter_by(channel=channel_name, channel_identifier=sender_id)
+            .first()
+        )
+        return route is not None
+
+
+@pytest.fixture()
+def _premium_override() -> Generator[None]:
+    """Register the route-based override for the duration of the test."""
+    set_is_allowed_override(_route_based_override)
+    yield
+    set_is_allowed_override(None)  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # BaseChannel._check_premium_route
 # ---------------------------------------------------------------------------
 
 
-def test_check_premium_route_returns_none_in_oss_mode() -> None:
-    """_check_premium_route returns None when premium_plugin is not set."""
+def test_check_premium_route_returns_none_without_override() -> None:
+    """_check_premium_route returns None when no override is registered."""
+    set_is_allowed_override(None)  # type: ignore[arg-type]
     channel = TelegramChannel(bot_token="fake")
-    with patch.object(settings, _PATCH_PREMIUM, None):
-        assert channel._check_premium_route("12345") is None
+    assert channel._check_premium_route("12345") is None
 
 
-def test_check_premium_route_returns_true_when_route_exists() -> None:
+def test_check_premium_route_returns_true_when_route_exists(
+    _premium_override: None,
+) -> None:
     """_check_premium_route returns True when a matching ChannelRoute exists."""
     _create_user_with_route("telegram", "12345")
     channel = TelegramChannel(bot_token="fake")
-    with patch.object(settings, _PATCH_PREMIUM, "my_plugin"):
-        assert channel._check_premium_route("12345") is True
+    assert channel._check_premium_route("12345") is True
 
 
-def test_check_premium_route_returns_false_when_no_route() -> None:
+def test_check_premium_route_returns_false_when_no_route(
+    _premium_override: None,
+) -> None:
     """_check_premium_route returns False when no matching ChannelRoute exists."""
     channel = TelegramChannel(bot_token="fake")
-    with patch.object(settings, _PATCH_PREMIUM, "my_plugin"):
-        assert channel._check_premium_route("99999") is False
+    assert channel._check_premium_route("99999") is False
 
 
 # ---------------------------------------------------------------------------
-# TelegramChannel.is_allowed in premium mode
+# TelegramChannel.is_allowed with override
 # ---------------------------------------------------------------------------
 
 
-def test_telegram_premium_allows_routed_sender() -> None:
-    """Telegram is_allowed returns True for a sender with a ChannelRoute in premium mode."""
+def test_telegram_premium_allows_routed_sender(_premium_override: None) -> None:
+    """Telegram is_allowed returns True for a sender with a ChannelRoute."""
     _create_user_with_route("telegram", "111222333")
     channel = TelegramChannel(bot_token="fake")
-    with patch.object(settings, _PATCH_PREMIUM, "my_plugin"):
-        assert channel.is_allowed("111222333", "testuser") is True
+    assert channel.is_allowed("111222333", "testuser") is True
 
 
-def test_telegram_premium_rejects_unrouted_sender() -> None:
-    """Telegram is_allowed returns False for a sender without a ChannelRoute in premium mode."""
+def test_telegram_premium_rejects_unrouted_sender(_premium_override: None) -> None:
+    """Telegram is_allowed returns False for a sender without a ChannelRoute."""
     channel = TelegramChannel(bot_token="fake")
-    with patch.object(settings, _PATCH_PREMIUM, "my_plugin"):
-        assert channel.is_allowed("999888777", "stranger") is False
+    assert channel.is_allowed("999888777", "stranger") is False
 
 
-def test_telegram_premium_ignores_static_allowlist() -> None:
-    """In premium mode, the static allowlist setting is not consulted."""
+def test_telegram_premium_ignores_static_allowlist(_premium_override: None) -> None:
+    """With an override registered, the static allowlist setting is not consulted."""
     channel = TelegramChannel(bot_token="fake")
-    with (
-        patch.object(settings, _PATCH_PREMIUM, "my_plugin"),
-        patch.object(settings, "telegram_allowed_chat_id", "*"),
-    ):
+    with patch.object(settings, "telegram_allowed_chat_id", "*"):
         # Even though static allowlist is "*", sender without route is rejected
         assert channel.is_allowed("444555666", "") is False
 
 
 def test_telegram_oss_falls_through_to_static_allowlist() -> None:
-    """In OSS mode (no premium_plugin), the static allowlist is used as before."""
+    """Without an override (OSS mode), the static allowlist is used as before."""
+    set_is_allowed_override(None)  # type: ignore[arg-type]
     channel = TelegramChannel(bot_token="fake")
-    with (
-        patch.object(settings, _PATCH_PREMIUM, None),
-        patch.object(settings, "telegram_allowed_chat_id", "12345"),
-    ):
+    with patch.object(settings, "telegram_allowed_chat_id", "12345"):
         assert channel.is_allowed("12345", "") is True
         assert channel.is_allowed("99999", "") is False
 
 
 # ---------------------------------------------------------------------------
-# LinqChannel.is_allowed in premium mode
+# LinqChannel.is_allowed with override
 # ---------------------------------------------------------------------------
 
 
-def test_linq_premium_allows_routed_sender() -> None:
-    """Linq is_allowed returns True for a sender with a ChannelRoute in premium mode."""
+def test_linq_premium_allows_routed_sender(_premium_override: None) -> None:
+    """Linq is_allowed returns True for a sender with a ChannelRoute."""
     _create_user_with_route("linq", "+15551234567")
     channel = LinqChannel()
-    with patch.object(settings, _PATCH_PREMIUM, "my_plugin"):
-        assert channel.is_allowed("+15551234567", "") is True
+    assert channel.is_allowed("+15551234567", "") is True
 
 
-def test_linq_premium_rejects_unrouted_sender() -> None:
-    """Linq is_allowed returns False for a sender without a ChannelRoute in premium mode."""
+def test_linq_premium_rejects_unrouted_sender(_premium_override: None) -> None:
+    """Linq is_allowed returns False for a sender without a ChannelRoute."""
     channel = LinqChannel()
-    with patch.object(settings, _PATCH_PREMIUM, "my_plugin"):
-        assert channel.is_allowed("+15559999999", "") is False
+    assert channel.is_allowed("+15559999999", "") is False
 
 
-def test_linq_premium_ignores_static_allowlist() -> None:
-    """In premium mode, the static allowlist setting is not consulted."""
+def test_linq_premium_ignores_static_allowlist(_premium_override: None) -> None:
+    """With an override registered, the static allowlist setting is not consulted."""
     channel = LinqChannel()
-    with (
-        patch.object(settings, _PATCH_PREMIUM, "my_plugin"),
-        patch.object(settings, "linq_allowed_numbers", "*"),
-    ):
+    with patch.object(settings, "linq_allowed_numbers", "*"):
         # Even though static allowlist is "*", sender without route is rejected
         assert channel.is_allowed("+15550000000", "") is False
 
 
 def test_linq_oss_falls_through_to_static_allowlist() -> None:
-    """In OSS mode (no premium_plugin), the static allowlist is used as before."""
+    """Without an override (OSS mode), the static allowlist is used as before."""
+    set_is_allowed_override(None)  # type: ignore[arg-type]
     channel = LinqChannel()
-    with (
-        patch.object(settings, _PATCH_PREMIUM, None),
-        patch.object(settings, "linq_allowed_numbers", "+15551234567"),
-    ):
+    with patch.object(settings, "linq_allowed_numbers", "+15551234567"):
         assert channel.is_allowed("+15551234567", "") is True
         assert channel.is_allowed("+15559999999", "") is False
 
@@ -159,9 +168,8 @@ def test_linq_oss_falls_through_to_static_allowlist() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_premium_route_scoped_to_channel() -> None:
+def test_premium_route_scoped_to_channel(_premium_override: None) -> None:
     """A ChannelRoute for 'telegram' should not authorize the same ID on 'linq'."""
     _create_user_with_route("telegram", "+15551234567")
     linq = LinqChannel()
-    with patch.object(settings, _PATCH_PREMIUM, "my_plugin"):
-        assert linq.is_allowed("+15551234567", "") is False
+    assert linq.is_allowed("+15551234567", "") is False


### PR DESCRIPTION
## Description

OSS side of #810 + #812 (boundary cleanup):

- **#810**: Added comprehensive docstring to `_get_or_create_user()` in `ingestion.py` documenting the three code paths (single-tenant reuse, premium PK matching, new user creation).
- **#812**: Replaced `settings.premium_plugin` check in `_check_premium_route()` with a pluggable `is_allowed` override hook. Premium sets the override during plugin initialization via `set_is_allowed_override()`. Removes premium coupling from OSS channel auth.

Companion PR: mozilla-ai/clawbolt-premium#209

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation generated by Claude Code following a reviewed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)