### PR TITLE
fix: make tool approval messages friendly for non-technical users

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -141,10 +141,12 @@ def format_plan_message(
     if not ask_steps:
         return ""
 
+    _reply_line = "Reply yes or no (always/never to remember your choice)"
+
     # Single ask, no auto: simple prompt
     if len(ask_steps) == 1 and not auto_steps:
         desc = ask_steps[0].description
-        return f"{desc}\n\nReply: yes | no | always | never"
+        return f"{desc}\n\n{_reply_line}"
 
     # Single ask with auto steps: compact format
     if len(ask_steps) == 1:
@@ -154,7 +156,7 @@ def format_plan_message(
             f"{plan_description}\n"
             f"I'll {auto_desc.lower()} [auto]. "
             f"{ask_desc} [needs OK]\n\n"
-            "Reply: yes | no | always | never"
+            f"{_reply_line}"
         )
 
     # Multiple ask steps: full numbered plan
@@ -172,7 +174,7 @@ def format_plan_message(
         lines.append(f"  {step_num}. [needs OK] {step.description}")
 
     lines.append("")
-    lines.append("Reply: yes | no | always | never")
+    lines.append(_reply_line)
     return "\n".join(lines)
 
 
@@ -374,11 +376,7 @@ def _parse_approval_response(text: str) -> ApprovalDecision | None:
 
 def _format_approval_message(tool_name: str, description: str) -> str:
     """Build a plain-text approval prompt for the user."""
-    return (
-        f"The assistant wants to use the tool '{tool_name}':\n"
-        f"{description}\n\n"
-        "Reply: yes | no | always | never"
-    )
+    return f"I'd like to: {description}\n\nReply yes or no (always/never to remember your choice)"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/tools/calendar_tools.py
+++ b/backend/app/agent/tools/calendar_tools.py
@@ -485,7 +485,9 @@ def create_calendar_tools(
                 default_level=PermissionLevel.ASK,
                 resource_extractor=lambda args: f"update {args.get('event_id', '')}",
                 description_builder=lambda args: (
-                    f"Update calendar event {args.get('event_id', '')}"
+                    f"Update calendar event: {args['title']}"
+                    if args.get("title")
+                    else "Update a calendar event"
                 ),
             ),
         ),
@@ -501,9 +503,7 @@ def create_calendar_tools(
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
                 resource_extractor=lambda args: f"delete {args.get('event_id', '')}",
-                description_builder=lambda args: (
-                    f"Delete calendar event {args.get('event_id', '')}"
-                ),
+                description_builder=lambda args: "Delete a calendar event",
             ),
         ),
         Tool(

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -98,7 +98,7 @@ def create_messaging_tools(
             usage_hint=("When sending estimates or files, use this to send media to the user."),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
-                description_builder=lambda args: f"Send media: {args.get('media_url', 'file')}",
+                description_builder=lambda args: "Send a file attachment",
             ),
         ),
     ]

--- a/backend/app/agent/tools/quickbooks_tools.py
+++ b/backend/app/agent/tools/quickbooks_tools.py
@@ -49,6 +49,24 @@ _QUERYABLE_ENTITIES = {
     "JOURNALENTRY",
 }
 
+# Human-readable labels for queryable entities.
+_ENTITY_LABELS: dict[str, str] = {
+    "INVOICE": "invoices",
+    "ESTIMATE": "estimates",
+    "CUSTOMER": "customers",
+    "ITEM": "items",
+    "PAYMENT": "payments",
+    "BILL": "bills",
+    "VENDOR": "vendors",
+    "SALESRECEIPT": "sales receipts",
+    "CREDITMEMO": "credit memos",
+    "PURCHASEORDER": "purchase orders",
+    "TIMEACTIVITY": "time entries",
+    "DEPOSIT": "deposits",
+    "TRANSFER": "transfers",
+    "JOURNALENTRY": "journal entries",
+}
+
 # Entity types that qb_create is allowed to create.
 _CREATABLE_ENTITIES = {"Customer", "Estimate", "Invoice"}
 
@@ -178,6 +196,17 @@ def _extract_query_entity(args: dict[str, Any]) -> str | None:
     query = str(args.get("query", ""))
     match = re.search(r"\bFROM\s+(\w+)", query, re.IGNORECASE)
     return match.group(1) if match else None
+
+
+def _describe_qb_query(args: dict[str, Any]) -> str:
+    """Build a human-readable description for a QuickBooks query."""
+    query = str(args.get("query", ""))
+    match = re.search(r"\bFROM\s+(\w+)", query, re.IGNORECASE)
+    if not match:
+        return "Look up data in QuickBooks"
+    entity = match.group(1).upper()
+    label = _ENTITY_LABELS.get(entity, match.group(1).lower() + "s")
+    return f"Look up {label} in QuickBooks"
 
 
 def _extract_entity_type(args: dict[str, Any]) -> str | None:
@@ -365,9 +394,7 @@ def create_quickbooks_tools(
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
                 resource_extractor=_extract_query_entity,
-                description_builder=lambda args: (
-                    f"Query QuickBooks: {str(args.get('query', ''))[:60]}"
-                ),
+                description_builder=_describe_qb_query,
             ),
         ),
         Tool(

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -159,12 +159,13 @@ class TestParseApprovalResponse:
 class TestFormatApprovalMessage:
     def test_output_format(self) -> None:
         msg = _format_approval_message("web_fetch", "fetch content from https://example.com")
-        assert "web_fetch" in msg
         assert "fetch content from https://example.com" in msg
         assert "yes" in msg
         assert "no" in msg
         assert "always" in msg
         assert "never" in msg
+        # Tool name should NOT appear in the user-facing message
+        assert "web_fetch" not in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_calendar_tools.py
+++ b/tests/test_calendar_tools.py
@@ -181,8 +181,13 @@ def test_update_event_description_builder(cal_tools: list[Tool]) -> None:
     tool = _get_tool(cal_tools, ToolName.CALENDAR_UPDATE_EVENT)
     assert tool.approval_policy is not None
     assert tool.approval_policy.description_builder is not None
-    desc = tool.approval_policy.description_builder({"event_id": "evt-001"})
-    assert "evt-001" in desc
+    # With title: shows the title
+    desc = tool.approval_policy.description_builder({"event_id": "evt-001", "title": "Job: Smith"})
+    assert "Job: Smith" in desc
+    # Without title: generic description, no raw event ID
+    desc_no_title = tool.approval_policy.description_builder({"event_id": "evt-001"})
+    assert "evt-001" not in desc_no_title
+    assert desc_no_title == "Update a calendar event"
 
 
 def test_delete_event_description_builder(cal_tools: list[Tool]) -> None:
@@ -190,7 +195,9 @@ def test_delete_event_description_builder(cal_tools: list[Tool]) -> None:
     assert tool.approval_policy is not None
     assert tool.approval_policy.description_builder is not None
     desc = tool.approval_policy.description_builder({"event_id": "evt-002"})
-    assert "evt-002" in desc
+    # Should not expose raw event ID
+    assert "evt-002" not in desc
+    assert desc == "Delete a calendar event"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -480,12 +480,12 @@ class TestBatchApproval:
         approval_msgs = []
         for call in mock_publish.call_args_list:
             msg = call.args[0] if call.args else call.kwargs.get("msg")
-            if isinstance(msg, OutboundMessage) and "Reply:" in msg.content:
+            if isinstance(msg, OutboundMessage) and "Reply yes or no" in msg.content:
                 approval_msgs.append(msg.content)
 
         assert len(approval_msgs) == 1
-        # "Reply:" should appear exactly once (not double-wrapped)
-        assert approval_msgs[0].count("Reply:") == 1
+        # "Reply yes or no" should appear exactly once (not double-wrapped)
+        assert approval_msgs[0].count("Reply yes or no") == 1
         # Should not contain the _format_approval_message wrapper
         assert "wants to use the tool" not in approval_msgs[0]
 

--- a/tests/test_quickbooks_tools.py
+++ b/tests/test_quickbooks_tools.py
@@ -8,6 +8,7 @@ import pytest
 
 from backend.app.agent.tools.base import Tool
 from backend.app.agent.tools.quickbooks_tools import (
+    _describe_qb_query,
     _quickbooks_factory,
     create_quickbooks_tools,
 )
@@ -198,3 +199,33 @@ def test_quickbooks_factory_returns_empty_when_not_connected() -> None:
         tools = _quickbooks_factory(ctx)
 
     assert tools == []
+
+
+# -- _describe_qb_query --
+
+
+class TestDescribeQbQuery:
+    def test_known_entity(self) -> None:
+        """Known entity returns human-readable label."""
+        desc = _describe_qb_query({"query": "SELECT * FROM Estimate ORDERBY TxnDate DESC"})
+        assert desc == "Look up estimates in QuickBooks"
+
+    def test_unknown_entity(self) -> None:
+        """Unknown entity falls back to lowercased name + 's'."""
+        desc = _describe_qb_query({"query": "SELECT * FROM Widget"})
+        assert desc == "Look up widgets in QuickBooks"
+
+    def test_no_from_clause(self) -> None:
+        """Missing FROM clause returns generic fallback."""
+        desc = _describe_qb_query({"query": "SELECT something"})
+        assert desc == "Look up data in QuickBooks"
+
+    def test_salesreceipt_label(self) -> None:
+        """Multi-word entity labels are correct."""
+        desc = _describe_qb_query({"query": "SELECT * FROM SalesReceipt"})
+        assert desc == "Look up sales receipts in QuickBooks"
+
+    def test_empty_query(self) -> None:
+        """Empty query returns generic fallback."""
+        desc = _describe_qb_query({})
+        assert desc == "Look up data in QuickBooks"

--- a/tests/test_tool_policies.py
+++ b/tests/test_tool_policies.py
@@ -71,7 +71,7 @@ class TestMessagingToolPolicies:
         desc = tool.approval_policy.description_builder(
             {"message": "hi", "media_url": "https://example.com/file.pdf"}
         )
-        assert "example.com/file.pdf" in desc
+        assert desc == "Send a file attachment"
 
 
 class TestHeartbeatToolPolicies:


### PR DESCRIPTION
## Description

Closes #820

Tool approval prompts showed raw SQL queries, Google Calendar event IDs, and media URLs that are meaningless to contractors and handymen. This PR replaces them with human-readable descriptions and makes the reply instructions conversational.

**Before:**
```
The assistant wants to use the tool 'qb_query':
Query QuickBooks: SELECT * FROM Estimate ORDERBY TxnDate DESC MAXRESULTS 20

Reply: yes | no | always | never
```

**After:**
```
I'd like to: Look up estimates in QuickBooks

Reply yes or no (always/never to remember your choice)
```

### Changes
- **QuickBooks queries**: Added `_ENTITY_LABELS` dict and `_describe_qb_query()` to produce "Look up {label} in QuickBooks" instead of raw SQL
- **Calendar update**: Shows "Update calendar event: {title}" when title present, else "Update a calendar event" (no raw event ID)
- **Calendar delete**: Static "Delete a calendar event" (no raw event ID)
- **Media attachment**: "Send a file attachment" instead of raw URL
- **Reply instructions**: "Reply yes or no (always/never to remember your choice)" across all 4 instances
- **Fallback message**: "I'd like to: {description}" instead of "The assistant wants to use the tool '{name}'"

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation by Claude Opus 4.6 from an autoplan-reviewed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)