### PR TITLE
fix: heartbeat falls back to any pushable route when preferred has none

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -698,9 +698,18 @@ def _pick_heartbeat_channel(user: User) -> str:
     if preferred not in _NON_PUSHABLE_CHANNELS:
         try:
             get_channel(preferred)
+            logger.debug(
+                "Heartbeat for user %s: using preferred channel %r",
+                user.id,
+                preferred,
+            )
             return preferred
         except KeyError:
-            pass
+            logger.debug(
+                "Heartbeat for user %s: preferred channel %r not registered, searching fallbacks",
+                user.id,
+                preferred,
+            )
 
     # Preferred channel is non-pushable or not registered: find the
     # first registered channel that can deliver proactive messages.
@@ -866,14 +875,40 @@ class HeartbeatScheduler:
                             .filter_by(user_id=user.id, channel=channel_name)
                             .first()
                         )
+
+                        # If no route for the preferred channel, try any
+                        # other pushable channel route the user has.
+                        if route is None:
+                            routes = db.query(ChannelRoute).filter_by(user_id=user.id).all()
+                            route_channels = [r.channel for r in routes]
+                            logger.debug(
+                                "Heartbeat for user %s: no %s route, searching %d route(s): %s",
+                                user.id,
+                                channel_name,
+                                len(routes),
+                                route_channels,
+                            )
+                            for r in routes:
+                                if r.channel not in _NON_PUSHABLE_CHANNELS:
+                                    try:
+                                        get_channel(r.channel)
+                                    except KeyError:
+                                        continue
+                                    route = r
+                                    channel_name = r.channel
+                                    logger.debug(
+                                        "Heartbeat for user %s: fell back to %s route",
+                                        user.id,
+                                        channel_name,
+                                    )
+                                    break
                     finally:
                         db.close()
 
                     if route is None:
                         logger.debug(
-                            "Heartbeat skipped for user %s: no %s route configured",
+                            "Heartbeat skipped for user %s: no pushable route configured",
                             user.id,
-                            channel_name,
                         )
                         return
 


### PR DESCRIPTION
## Description

When a user's `preferred_channel` is non-pushable (e.g. webchat because they last used the web UI), `_pick_heartbeat_channel` falls back to the first registered pushable channel -- which is telegram (registered first in `main.py`). If the user only has a route for a different pushable channel (e.g. linq/iMessage), the heartbeat was silently skipped with `"no telegram route configured"`.

The fix adds a fallback in the scheduler's `_process_one`: when no route exists for the picked channel, query all the user's channel routes and try any pushable one with a registered channel. Also adds debug logging throughout the channel selection path:
- `_pick_heartbeat_channel` now logs the happy path and unregistered-preferred cases
- Route fallback logs what routes exist and which one was selected

Companion PR in clawbolt-premium with the same fix + regression tests.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code pair-programmed the fix and debug logging)