### PR TITLE
fix: remove timezone labels from LLM-facing time strings

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -295,7 +295,7 @@ def _format_heartbeat_history(
     for entry in logs:
         ts = datetime.datetime.fromisoformat(entry.created_at)
         local_ts = to_local_time(ts, tz_name)
-        formatted = local_ts.strftime("%A, %Y-%m-%d %I:%M %p %Z").strip()
+        formatted = local_ts.strftime("%A, %Y-%m-%d %I:%M %p").strip()
         delta = now - ts
         if delta.days == 0:
             ago = "today"

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -142,16 +142,12 @@ def build_time_user_context(user: User) -> str:
     """
     now = datetime.datetime.now(datetime.UTC)
     local = to_local_time(now, user.timezone)
-    formatted = local.strftime("%A, %Y-%m-%d %I:%M %p %Z").strip()
+    formatted = local.strftime("%A, %Y-%m-%d %I:%M %p").strip()
     if user.timezone:
-        return (
-            f"[Current time: {formatted} ({user.timezone}). "
-            "Always use this timezone when discussing times, scheduling, "
-            "or referring to deadlines.]"
-        )
+        return f"[Current time: {formatted}]"
     return (
         f"[Current time: {formatted}. "
-        "No timezone has been set for this user; this time is in UTC. "
+        "No timezone has been configured yet. "
         "If the user mentions their location or timezone, update USER.md "
         "with their timezone so future times are shown in their local time.]"
     )

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
 import api from '@/api';
@@ -12,10 +13,24 @@ import type {
 // --- Profile ---
 
 export function useProfile() {
-  return useQuery({
+  const query = useQuery({
     queryKey: queryKeys.profile,
     queryFn: () => api.getProfile(),
   });
+  const { mutate } = useUpdateProfile();
+  const backfilled = useRef(false);
+
+  useEffect(() => {
+    if (query.data && !query.data.timezone && !backfilled.current) {
+      backfilled.current = true;
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (tz) {
+        mutate({ timezone: tz });
+      }
+    }
+  }, [query.data, mutate]);
+
+  return query;
 }
 
 export function useUpdateProfile() {

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -337,8 +337,8 @@ class TestAgentSystemPromptExcludesTime:
 
 class TestBuildTimeUserContext:
     @patch("backend.app.agent.system_prompt.datetime")
-    def test_includes_time_and_timezone(self, mock_dt: MagicMock) -> None:
-        """Should produce a bracketed time string with IANA timezone."""
+    def test_includes_time_without_timezone_label(self, mock_dt: MagicMock) -> None:
+        """Should produce a bracketed time string without timezone abbreviation."""
         mock_dt.UTC = datetime.UTC
         mock_dt.datetime.now.return_value = datetime.datetime(
             2025, 6, 15, 17, 30, tzinfo=datetime.UTC
@@ -346,14 +346,11 @@ class TestBuildTimeUserContext:
         user = MagicMock()
         user.timezone = "America/New_York"
         result = build_time_user_context(user)
-        assert result.startswith("[Current time:")
-        assert "01:30 PM" in result
-        assert "(America/New_York)" in result
-        assert result.endswith("]")
+        assert result == "[Current time: Sunday, 2025-06-15 01:30 PM]"
 
     @patch("backend.app.agent.system_prompt.datetime")
     def test_utc_fallback_when_no_timezone(self, mock_dt: MagicMock) -> None:
-        """Should fall back to UTC and prompt for timezone."""
+        """Should fall back to UTC and prompt for timezone discovery."""
         mock_dt.UTC = datetime.UTC
         mock_dt.datetime.now.return_value = datetime.datetime(
             2025, 6, 15, 17, 30, tzinfo=datetime.UTC
@@ -362,8 +359,9 @@ class TestBuildTimeUserContext:
         user.timezone = ""
         result = build_time_user_context(user)
         assert "[Current time:" in result
-        assert "UTC" in result
-        assert "No timezone has been set" in result
+        assert "No timezone has been configured yet" in result
+        assert "EDT" not in result
+        assert "UTC" not in result
 
 
 class TestCrossSessionContext:


### PR DESCRIPTION
## Description

LLMs were doing incorrect timezone arithmetic when timestamps included abbreviations like "EDT"/"EST"/"UTC" and IANA names like "(America/New_York)". The model would try to cross-reference these against heartbeat history timestamps and get UTC-to-local conversions wrong.

This PR simplifies all LLM-facing time formats to plain local times without any timezone labels, and auto-detects browser timezone on first webchat profile load to reduce UTC fallback cases.

**Backend changes:**
- `build_time_user_context()`: removed `%Z`, IANA name suffix, and "Always use this timezone..." instruction. When timezone is set, output is just `[Current time: Wednesday, 2026-03-25 08:26 PM]`
- `_format_heartbeat_history()`: removed `%Z` from heartbeat log timestamp formatting
- No-timezone fallback simplified: removed "this time is in UTC" labeling

**Frontend changes:**
- `useProfile()` auto-detects browser timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone` and backfills it on first profile load when timezone is empty. Uses `useEffect` with a `useRef` guard for idiomatic one-shot behavior.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the changes)
- [ ] No AI used