### PR TITLE
feat: add renderSidebarFooter extension hook in AppShell

### DIFF
--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -26,3 +26,5 @@ export type {
   PlanInfo,
 } from './types';
 export { QuotaBanner, OnboardingBanner, isQuotaError } from './quota';
+export { renderSidebarFooter } from './sidebar-footer';
+export type { SidebarFooterProps } from './sidebar-footer';

--- a/frontend/src/extensions/sidebar-footer.ts
+++ b/frontend/src/extensions/sidebar-footer.ts
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+export interface SidebarFooterProps {
+  isPremium: boolean;
+  handleLogout: () => void;
+  closeSidebar: () => void;
+}
+
+export function renderSidebarFooter(_props: SidebarFooterProps): ReactNode {
+  return null;
+}

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -97,4 +97,14 @@ describe('AppShell', () => {
       expect(screen.getByText(/unable to load your profile/i)).toBeInTheDocument();
     });
   });
+
+  it('renders default sidebar footer when renderSidebarFooter stub returns null', async () => {
+    renderWithRouter(<AppShell />, { route: '/app' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Get Started')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Report issue')).toBeInTheDocument();
+    expect(screen.getByText('Feature request')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Tooltip } from '@heroui/tooltip';
 import { Link } from '@heroui/link';
 import { Divider } from '@heroui/divider';
-import { getFeatureRequestUrl, getReportIssueUrl, getExtraNavItems } from '@/extensions';
+import { getFeatureRequestUrl, getReportIssueUrl, getExtraNavItems, renderSidebarFooter } from '@/extensions';
 import useSwipeSidebar from '@/hooks/useSwipeSidebar';
 import { useProfile } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
@@ -161,53 +161,55 @@ export default function AppShell() {
 
         <div className="flex-1" />
 
-        <div className="p-2 text-xs text-muted-foreground space-y-1">
-          <Divider className="mb-1" />
-          <NavLink
-            to="/app/get-started"
-            onClick={closeSidebar}
-            className={({ isActive }) =>
-              `flex items-center gap-2 px-3 py-2 rounded-md text-xs transition-all duration-150 ${
-                isActive
-                  ? 'text-primary font-medium'
-                  : 'text-muted-foreground can-hover:hover:text-foreground'
-              }`
-            }
-          >
-            <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            Get Started
-          </NavLink>
-          <div className="flex gap-2 px-3 py-1">
-            <Link
-              href={getReportIssueUrl()}
-              isExternal
-              size="sm"
-              className="text-xs text-muted-foreground can-hover:hover:text-foreground transition-all duration-150"
+        {renderSidebarFooter({ isPremium, handleLogout, closeSidebar }) ?? (
+          <div className="p-2 text-xs text-muted-foreground space-y-1">
+            <Divider className="mb-1" />
+            <NavLink
+              to="/app/get-started"
+              onClick={closeSidebar}
+              className={({ isActive }) =>
+                `flex items-center gap-2 px-3 py-2 rounded-md text-xs transition-all duration-150 ${
+                  isActive
+                    ? 'text-primary font-medium'
+                    : 'text-muted-foreground can-hover:hover:text-foreground'
+                }`
+              }
             >
-              Report issue
-            </Link>
-            <Link
-              href={getFeatureRequestUrl()}
-              isExternal
-              size="sm"
-              className="text-xs text-muted-foreground can-hover:hover:text-foreground transition-all duration-150"
-            >
-              Feature request
-            </Link>
+              <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Get Started
+            </NavLink>
+            <div className="flex gap-2 px-3 py-1">
+              <Link
+                href={getReportIssueUrl()}
+                isExternal
+                size="sm"
+                className="text-xs text-muted-foreground can-hover:hover:text-foreground transition-all duration-150"
+              >
+                Report issue
+              </Link>
+              <Link
+                href={getFeatureRequestUrl()}
+                isExternal
+                size="sm"
+                className="text-xs text-muted-foreground can-hover:hover:text-foreground transition-all duration-150"
+              >
+                Feature request
+              </Link>
+            </div>
+            {isPremium && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleLogout}
+                className="w-full justify-start text-xs text-muted-foreground font-normal px-3"
+              >
+                Log out
+              </Button>
+            )}
           </div>
-          {isPremium && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleLogout}
-              className="w-full justify-start text-xs text-muted-foreground font-normal px-3"
-            >
-              Log out
-            </Button>
-          )}
-        </div>
+        )}
       </aside>
 
       {/* Main content */}


### PR DESCRIPTION
## Description
Add a `renderSidebarFooter` extension hook so the premium layer can customize the sidebar footer without overriding the entire `AppShell.tsx` file. Follows the existing extension pattern (`getExtraNavItems`, `renderPremiumSettingsTab`, etc.).

- New stub `frontend/src/extensions/sidebar-footer.ts` with `SidebarFooterProps` interface and `renderSidebarFooter()` returning `null`
- Re-exported from `frontend/src/extensions/index.ts`
- `AppShell.tsx` wraps the footer in `renderSidebarFooter({...}) ?? (default footer)`
- When the stub returns `null` (OSS), existing footer renders unchanged

Fixes #830

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the feature, wrote tests, and ran all checks)
- [ ] No AI used