### PR TITLE
fix: prevent duplicate list_capabilities output for already-activated categories

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -113,6 +113,7 @@ class ClawboltAgent:
         session_id: str = "",
         excluded_tool_names: set[str] | None = None,
         request_id: str = "",
+        activated_specialists: set[str] | None = None,
     ) -> None:
         self.user = user
         self._channel = channel
@@ -123,7 +124,9 @@ class ClawboltAgent:
         self._subscribers: list[Callable[[AgentEvent], Awaitable[None]]] = []
         self._tool_context = tool_context
         self._registry = registry
-        self._activated_specialists: set[str] = set()
+        self._activated_specialists: set[str] = (
+            activated_specialists if activated_specialists is not None else set()
+        )
         self._last_input_tokens: int = 0
         self._session_id = session_id
         self._excluded_tool_names = excluded_tool_names

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -246,6 +246,13 @@ async def run_agent(
     disabled_groups = await tool_config_store.get_disabled_tool_names()
     disabled_sub_tools = await tool_config_store.get_disabled_sub_tool_names()
 
+    # Shared mutable set so the list_capabilities tool closure and the
+    # agent loop both see the same activation state.  This prevents the
+    # tool from returning the full SKILL.md instructions a second time
+    # when the LLM redundantly calls list_capabilities for a category
+    # that was already activated in a prior round.
+    activated_specialists: set[str] = set()
+
     agent = ClawboltAgent(
         user=user,
         channel=channel,
@@ -256,6 +263,7 @@ async def run_agent(
         session_id=session_id,
         excluded_tool_names=disabled_sub_tools or None,
         request_id=request_id,
+        activated_specialists=activated_specialists,
     )
 
     # Start with core tools only; specialist tools are discovered on demand
@@ -281,6 +289,7 @@ async def run_agent(
                 specialist_summaries,
                 unauthenticated=unauthenticated,
                 disabled_sub_tools=disabled_specialist_subs or None,
+                activated_specialists=activated_specialists,
             )
         )
     agent.register_tools(tools)

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -80,6 +80,7 @@ def create_list_capabilities_tool(
     specialist_summaries: dict[str, str],
     unauthenticated: dict[str, str] | None = None,
     disabled_sub_tools: dict[str, list[SubToolInfo]] | None = None,
+    activated_specialists: set[str] | None = None,
 ) -> Tool:
     """Create the ``list_capabilities`` meta-tool.
 
@@ -104,6 +105,7 @@ def create_list_capabilities_tool(
 
     _unauthenticated = unauthenticated or {}
     _disabled_subs = disabled_sub_tools or {}
+    _activated = activated_specialists
 
     async def list_capabilities(category: str | None = None) -> ToolResult:
         if category is None:
@@ -142,6 +144,11 @@ def create_list_capabilities_tool(
                 content=f'Unknown category "{category}". Available: {available}',
                 is_error=True,
                 error_kind=ToolErrorKind.NOT_FOUND,
+            )
+
+        if _activated is not None and category in _activated:
+            return ToolResult(
+                content=f'Category "{category}" is already active. Tools are available now.',
             )
 
         activation_msg = (

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -181,6 +181,29 @@ class TestListCapabilitiesTool:
         assert "heartbeat" in tool.usage_hint
         assert "estimate" in tool.usage_hint
 
+    @pytest.mark.asyncio
+    async def test_already_activated_category_returns_short_message(self) -> None:
+        """Calling list_capabilities for an already-activated category returns a
+        short 'already active' message instead of the full SKILL.md instructions."""
+        summaries = {"estimate": "Generate estimates"}
+        activated: set[str] = set()
+        tool = create_list_capabilities_tool(summaries, activated_specialists=activated)
+
+        # First call: should return the full activation message
+        result = await tool.function(category="estimate")
+        assert "activated" in result.content.lower()
+        assert "tools are available" in result.content.lower()
+
+        # Mark as activated (normally done by the agent loop)
+        activated.add("estimate")
+
+        # Second call: should return a short message, not the full instructions
+        result2 = await tool.function(category="estimate")
+        assert "already active" in result2.content.lower()
+        assert not result2.is_error
+        # Should NOT contain the full activation message again
+        assert len(result2.content) < len(result.content)
+
 
 class TestDefaultRegistryCoreSpecialistSplit:
     """The default registry correctly classifies built-in factories."""


### PR DESCRIPTION
## Description

The `list_capabilities` tool function returned the full activation message + SKILL.md instructions every time it was called for a valid category, even if that category was already activated in a prior agent loop round. When the LLM redundantly called `list_capabilities` for the same category twice (observed in production with QuickBooks), the full SKILL.md was injected into context twice, wasting tokens.

Fix: share a mutable `set[str]` between the `list_capabilities` tool closure and the agent's `_activated_specialists` tracking. When the tool detects an already-activated category, it returns a short "already active" message instead of the full instructions.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code used for root cause investigation and fix implementation)
- [ ] No AI used