### PR TITLE
feat: add delete heartbeat history endpoint and UI

### DIFF
--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -17,6 +17,7 @@ from backend.app.schemas import (
     ChannelRouteListResponse,
     ChannelRouteResponse,
     ChannelRouteUpdate,
+    DeleteHeartbeatLogsResponse,
     HeartbeatLogItemResponse,
     HeartbeatLogListResponse,
     LLMUsageByPurpose,
@@ -429,6 +430,21 @@ async def get_heartbeat_logs(
             for log in logs
         ],
     )
+
+
+@router.delete("/user/heartbeat-logs", response_model=DeleteHeartbeatLogsResponse)
+async def delete_heartbeat_logs(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> DeleteHeartbeatLogsResponse:
+    """Delete all heartbeat logs for the current user."""
+    deleted: int = (
+        db.query(HeartbeatLog)
+        .filter(HeartbeatLog.user_id == current_user.id)
+        .delete(synchronize_session="fetch")
+    )
+    db.commit()
+    return DeleteHeartbeatLogsResponse(status="deleted", deleted=deleted)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -247,6 +247,11 @@ class HeartbeatLogListResponse(BaseModel):
     items: list[HeartbeatLogItemResponse]
 
 
+class DeleteHeartbeatLogsResponse(BaseModel):
+    status: str
+    deleted: int
+
+
 # ---------------------------------------------------------------------------
 # Session list (admin)
 # ---------------------------------------------------------------------------

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -795,6 +795,23 @@
             }
           }
         }
+      },
+      "delete": {
+        "summary": "Delete Heartbeat Logs",
+        "description": "Delete all heartbeat logs for the current user.",
+        "operationId": "delete_heartbeat_logs_api_user_heartbeat_logs_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteHeartbeatLogsResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/user/llm-usage": {
@@ -1313,6 +1330,24 @@
           "enabled"
         ],
         "title": "ChannelRouteUpdate"
+      },
+      "DeleteHeartbeatLogsResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "deleted": {
+            "type": "integer",
+            "title": "Deleted"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "deleted"
+        ],
+        "title": "DeleteHeartbeatLogsResponse"
       },
       "DeleteMessagesResponse": {
         "properties": {

--- a/frontend/src/extensions/admin/admin-api.ts
+++ b/frontend/src/extensions/admin/admin-api.ts
@@ -55,6 +55,12 @@ export async function getHeartbeatLogs(limit: number = 50): Promise<HeartbeatLog
   return data as HeartbeatLogList;
 }
 
+export async function deleteHeartbeatLogs(): Promise<{ status: string; deleted: number }> {
+  const { data, error } = await client.DELETE('/api/user/heartbeat-logs' as never);
+  if (error) throwApiError(error, 'Failed to delete heartbeat logs');
+  return data as { status: string; deleted: number };
+}
+
 export async function getLLMUsage(days: number = 30): Promise<LLMUsageSummary> {
   const { data, error } = await client.GET(
     `/api/user/llm-usage?days=${days}` as never,

--- a/frontend/src/extensions/admin/tabs/heartbeats.tsx
+++ b/frontend/src/extensions/admin/tabs/heartbeats.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
+  deleteHeartbeatLogs,
   getHeartbeatLogs,
   type HeartbeatLogItem,
 } from '../admin-api';
@@ -57,6 +58,7 @@ export default function HeartbeatsTab() {
   const [logs, setLogs] = useState<HeartbeatLogItem[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [clearing, setClearing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(() => {
@@ -66,6 +68,15 @@ export default function HeartbeatsTab() {
       .then((res) => { setLogs(res.items); setTotal(res.total); })
       .catch((e: Error) => setError(e.message))
       .finally(() => setLoading(false));
+  }, []);
+
+  const handleClear = useCallback(() => {
+    if (!confirm('Delete all heartbeat history? This cannot be undone.')) return;
+    setClearing(true);
+    deleteHeartbeatLogs()
+      .then(() => { setLogs([]); setTotal(0); })
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setClearing(false));
   }, []);
 
   useEffect(() => { load(); }, [load]);
@@ -91,9 +102,18 @@ export default function HeartbeatsTab() {
 
   return (
     <div>
-      <p className="text-xs text-muted-foreground mb-2">
-        {total} total heartbeat event{total !== 1 ? 's' : ''}
-      </p>
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs text-muted-foreground">
+          {total} total heartbeat event{total !== 1 ? 's' : ''}
+        </p>
+        <button
+          className="text-xs text-danger hover:underline disabled:opacity-50"
+          onClick={handleClear}
+          disabled={clearing}
+        >
+          {clearing ? 'Clearing...' : 'Clear history'}
+        </button>
+      </div>
       <div className="space-y-2">
         {logs.map(log => (
           <HeartbeatEntry key={log.id} log={log} />

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -445,7 +445,11 @@ export interface paths {
         get: operations["get_heartbeat_logs_api_user_heartbeat_logs_get"];
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete Heartbeat Logs
+         * @description Delete all heartbeat logs for the current user.
+         */
+        delete: operations["delete_heartbeat_logs_api_user_heartbeat_logs_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -671,6 +675,13 @@ export interface components {
         ChannelRouteUpdate: {
             /** Enabled */
             enabled: boolean;
+        };
+        /** DeleteHeartbeatLogsResponse */
+        DeleteHeartbeatLogsResponse: {
+            /** Status */
+            status: string;
+            /** Deleted */
+            deleted: number;
         };
         /** DeleteMessagesResponse */
         DeleteMessagesResponse: {
@@ -1738,6 +1749,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_heartbeat_logs_api_user_heartbeat_logs_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteHeartbeatLogsResponse"];
                 };
             };
         };

--- a/tests/test_heartbeat_logs_endpoint.py
+++ b/tests/test_heartbeat_logs_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for GET /api/user/heartbeat-logs endpoint."""
+"""Tests for /api/user/heartbeat-logs endpoints (GET and DELETE)."""
 
 import uuid
 from datetime import UTC, datetime
@@ -137,3 +137,53 @@ def test_heartbeat_logs_enriched_fields(client: TestClient, test_user: User) -> 
     assert send_item["channel"] == "telegram"
     assert send_item["reasoning"] == "User has a pending task"
     assert send_item["tasks"] == "Check invoice status"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/user/heartbeat-logs
+# ---------------------------------------------------------------------------
+
+
+def test_delete_heartbeat_logs(client: TestClient, test_user: User) -> None:
+    """Deletes all heartbeat logs for the current user and returns count."""
+    _create_heartbeat_log(test_user.id, message_text="msg1")
+    _create_heartbeat_log(test_user.id, message_text="msg2")
+    _create_heartbeat_log(test_user.id, action_type="skip")
+
+    resp = client.delete("/api/user/heartbeat-logs")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "deleted"
+    assert data["deleted"] == 3
+
+    # Verify logs are gone
+    get_resp = client.get("/api/user/heartbeat-logs")
+    assert get_resp.json()["total"] == 0
+
+
+def test_delete_heartbeat_logs_empty(client: TestClient) -> None:
+    """Returns 0 when there are no logs to delete."""
+    resp = client.delete("/api/user/heartbeat-logs")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "deleted"
+    assert data["deleted"] == 0
+
+
+def test_delete_heartbeat_logs_cross_user_isolation(client: TestClient, test_user: User) -> None:
+    """Only deletes logs belonging to the authenticated user."""
+    other_id = _create_other_user()
+    _create_heartbeat_log(test_user.id, message_text="mine")
+    _create_heartbeat_log(other_id, message_text="theirs")
+
+    resp = client.delete("/api/user/heartbeat-logs")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == 1
+
+    # Other user's logs should still exist
+    db = _db_module.SessionLocal()
+    try:
+        remaining = db.query(HeartbeatLog).filter(HeartbeatLog.user_id == other_id).count()
+        assert remaining == 1
+    finally:
+        db.close()


### PR DESCRIPTION
## Description

Add the ability to delete heartbeat history (Fixes #853).

- New `DELETE /api/user/heartbeat-logs` endpoint that removes all heartbeat logs for the authenticated user, scoped by `user_id`
- New `DeleteHeartbeatLogsResponse` schema returning `status` and `deleted` count
- Frontend "Clear history" button on the heartbeats admin tab with a confirmation dialog
- Regenerated OpenAPI types

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the feature end-to-end)
- [ ] No AI used