### PR TITLE
fix: remove stale test asserting removed heartbeat_rules text

### DIFF
--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -2446,11 +2446,3 @@ class TestHeartbeatRulesGuardHistoryPatterns:
         rules = load_prompt("heartbeat_rules")
         assert "infer" in rules.lower() or "pattern" in rules.lower()
         assert "removed" in rules.lower() or "no longer" in rules.lower()
-
-    def test_rules_prohibit_time_based_initiative(self) -> None:
-        """The rules must prevent time-of-day or day-of-week driven messages
-        unless a current heartbeat item explicitly calls for it."""
-        from backend.app.agent.system_prompt import load_prompt
-
-        rules = load_prompt("heartbeat_rules")
-        assert "time of day" in rules.lower() or "day of week" in rules.lower()


### PR DESCRIPTION
## Description

PR #865 manually edited `heartbeat_rules.md` to remove "time of day" / "day of week" language for clarity and conciseness, but left `test_rules_prohibit_time_based_initiative` asserting those phrases exist. This caused CI to fail on main.

The "Do not infer patterns" rule already covers time-based initiative, and `test_rules_prohibit_pattern_inference` validates that rule. Removing the stale test.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the stale test and authored the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)