### PR TITLE
fix: heartbeat tool wiring and item repopulation guard

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -481,8 +481,10 @@ async def execute_heartbeat_tasks(
     reply text, or an empty string if the agent produced no output.
     """
     from backend.app.agent.core import AgentResponse, ClawboltAgent
+    from backend.app.agent.stores import ToolConfigStore
     from backend.app.agent.tools.registry import (
         ToolContext,
+        create_list_capabilities_tool,
         default_registry,
         ensure_tool_modules_imported,
     )
@@ -511,6 +513,20 @@ async def execute_heartbeat_tasks(
         to_address=chat_id,
     )
 
+    # Load user's disabled tool groups and sub-tools (same as the normal
+    # message flow in router.py) so the heartbeat respects the user's
+    # tool configuration.
+    tool_config_store = ToolConfigStore(user.id)
+    disabled_groups = await tool_config_store.get_disabled_tool_names()
+    disabled_sub_tools = await tool_config_store.get_disabled_sub_tool_names()
+
+    # Always exclude the messaging factory: the heartbeat system delivers
+    # the agent's final reply text, so the agent should not try to message
+    # the user directly.
+    excluded = (disabled_groups or set()) | {"messaging"}
+
+    activated_specialists: set[str] = set()
+
     agent = ClawboltAgent(
         user=user,
         channel=channel,
@@ -518,20 +534,45 @@ async def execute_heartbeat_tasks(
         chat_id=chat_id,
         tool_context=tool_context,
         registry=default_registry,
+        excluded_tool_names=disabled_sub_tools or None,
+        activated_specialists=activated_specialists,
     )
 
-    # Register ALL tools except messaging (send_reply, send_media_reply).
-    # The heartbeat system delivers the agent's final reply text, so the
-    # agent should not try to message the user directly.
-    all_factories = set(default_registry.factory_names)
-    all_factories.discard("messaging")
-    tools = default_registry.create_tools(tool_context, selected_factories=all_factories)
+    # Follow the same pattern as run_agent() in router.py:
+    # 1. Core tools (always available, respects disabled groups/sub-tools)
+    # 2. list_capabilities meta-tool for on-demand specialist activation
+    #    (QuickBooks, Calendar, etc.)
+    tools = default_registry.create_core_tools(
+        tool_context,
+        excluded_factories=excluded,
+        excluded_tool_names=disabled_sub_tools or None,
+    )
+    specialist_summaries = default_registry.get_available_specialist_summaries(
+        tool_context, excluded_factories=excluded
+    )
+    unauthenticated = default_registry.get_unauthenticated_specialists(
+        tool_context, excluded_factories=excluded
+    )
+    disabled_specialist_subs = default_registry.get_disabled_specialist_sub_tools(
+        disabled_sub_tools or set()
+    )
+    if specialist_summaries or unauthenticated:
+        tools.append(
+            create_list_capabilities_tool(
+                specialist_summaries,
+                unauthenticated=unauthenticated,
+                disabled_sub_tools=disabled_specialist_subs or None,
+                activated_specialists=activated_specialists,
+            )
+        )
     agent.register_tools(tools)
 
     logger.debug(
-        "Heartbeat Phase 2 agent for user %s initialized with %d tools",
+        "Heartbeat Phase 2 agent for user %s initialized with %d core tools, "
+        "%d specialist categories available",
         user.id,
         len(tools),
+        len(specialist_summaries),
     )
 
     # Use at least 1024 tokens for heartbeat execution so the agent can

--- a/backend/app/agent/tools/heartbeat_tools.py
+++ b/backend/app/agent/tools/heartbeat_tools.py
@@ -37,10 +37,16 @@ def create_heartbeat_tools(user_id: str) -> list[Tool]:
         return ToolResult(content=text)
 
     async def update_heartbeat(text: str) -> ToolResult:
-        """Update the user's heartbeat notes."""
+        """Update the user's heartbeat notes.
+
+        Reads the current content first so the result shows what changed.
+        """
         store = HeartbeatStore(user_id)
+        previous = store.read_heartbeat_md()
         await store.write_heartbeat_md(text)
-        return ToolResult(content="Heartbeat notes updated.")
+        if previous:
+            return ToolResult(content=f"Heartbeat notes updated.\n\nPrevious content:\n{previous}")
+        return ToolResult(content="Heartbeat notes updated (was empty).")
 
     return [
         Tool(
@@ -52,10 +58,20 @@ def create_heartbeat_tools(user_id: str) -> list[Tool]:
         ),
         Tool(
             name=ToolName.UPDATE_HEARTBEAT,
-            description="Update the user's heartbeat notes with new markdown text.",
+            description=(
+                "Update the user's heartbeat notes with new markdown text. "
+                "IMPORTANT: This overwrites the entire file. Only include items "
+                "that currently exist in the file plus whatever the user asked to "
+                "add or change. Never re-add items that are not in the current "
+                "file, even if you remember them from conversation history."
+            ),
             function=update_heartbeat,
             params_model=UpdateHeartbeatParams,
-            usage_hint="When the user wants to change heartbeat notes, update them.",
+            usage_hint=(
+                "Always call get_heartbeat first to see the current content. "
+                "Only add, remove, or change what the user explicitly asked for. "
+                "Do not restore items that were previously deleted."
+            ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.AUTO,
                 description_builder=lambda args: "Update heartbeat notes",

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1021,12 +1021,21 @@ class TestExecuteHeartbeatTasks:
             patch("backend.app.bus.message_bus") as mock_bus,
             patch("backend.app.agent.router.init_storage", return_value=None),
             patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
+            patch("backend.app.agent.stores.ToolConfigStore") as MockToolConfig,
+            patch("backend.app.agent.tools.registry.create_list_capabilities_tool"),
         ):
+            mock_tc = MagicMock()
+            mock_tc.get_disabled_tool_names = AsyncMock(return_value=set())
+            mock_tc.get_disabled_sub_tool_names = AsyncMock(return_value=set())
+            MockToolConfig.return_value = mock_tc
+
             mock_agent_instance = MagicMock()
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
-            mock_registry.factory_names = ["core", "quickbooks"]
-            mock_registry.create_tools.return_value = []
+            mock_registry.create_core_tools.return_value = []
+            mock_registry.get_available_specialist_summaries.return_value = {}
+            mock_registry.get_unauthenticated_specialists.return_value = {}
+            mock_registry.get_disabled_specialist_sub_tools.return_value = {}
             mock_bus.publish_outbound = AsyncMock()
 
             result = await execute_heartbeat_tasks(user, "Check QuickBooks for unpaid invoices")
@@ -1042,12 +1051,21 @@ class TestExecuteHeartbeatTasks:
             patch("backend.app.bus.message_bus") as mock_bus,
             patch("backend.app.agent.router.init_storage", return_value=None),
             patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
+            patch("backend.app.agent.stores.ToolConfigStore") as MockToolConfig,
+            patch("backend.app.agent.tools.registry.create_list_capabilities_tool"),
         ):
+            mock_tc = MagicMock()
+            mock_tc.get_disabled_tool_names = AsyncMock(return_value=set())
+            mock_tc.get_disabled_sub_tool_names = AsyncMock(return_value=set())
+            MockToolConfig.return_value = mock_tc
+
             mock_agent_instance = MagicMock()
             mock_agent_instance.process_message = AsyncMock(side_effect=Exception("LLM down"))
             MockAgent.return_value = mock_agent_instance
-            mock_registry.factory_names = ["core"]
-            mock_registry.create_tools.return_value = []
+            mock_registry.create_core_tools.return_value = []
+            mock_registry.get_available_specialist_summaries.return_value = {}
+            mock_registry.get_unauthenticated_specialists.return_value = {}
+            mock_registry.get_disabled_specialist_sub_tools.return_value = {}
             mock_bus.publish_outbound = AsyncMock()
 
             result = await execute_heartbeat_tasks(user, "Check something")
@@ -1066,20 +1084,29 @@ class TestExecuteHeartbeatTasks:
             patch("backend.app.bus.message_bus") as mock_bus,
             patch("backend.app.agent.router.init_storage", return_value=None),
             patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
+            patch("backend.app.agent.stores.ToolConfigStore") as MockToolConfig,
+            patch("backend.app.agent.tools.registry.create_list_capabilities_tool"),
         ):
+            mock_tc = MagicMock()
+            mock_tc.get_disabled_tool_names = AsyncMock(return_value=set())
+            mock_tc.get_disabled_sub_tool_names = AsyncMock(return_value=set())
+            MockToolConfig.return_value = mock_tc
+
             mock_agent_instance = MagicMock()
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
-            mock_registry.factory_names = ["core"]
-            mock_registry.create_tools.return_value = []
+            mock_registry.create_core_tools.return_value = []
+            mock_registry.get_available_specialist_summaries.return_value = {}
+            mock_registry.get_unauthenticated_specialists.return_value = {}
+            mock_registry.get_disabled_specialist_sub_tools.return_value = {}
             mock_bus.publish_outbound = AsyncMock()
 
             result = await execute_heartbeat_tasks(user, "Check something")
             assert result == ""
 
     @pytest.mark.asyncio
-    async def test_excludes_messaging_tools(self, user: User) -> None:
-        """Phase 2 should exclude the messaging factory so the agent cannot call send_reply."""
+    async def test_excludes_messaging_and_uses_list_capabilities(self, user: User) -> None:
+        """Phase 2 should use core tools + list_capabilities, excluding messaging."""
         from backend.app.agent.core import AgentResponse
 
         mock_response = AgentResponse(reply_text="Report")
@@ -1090,24 +1117,37 @@ class TestExecuteHeartbeatTasks:
             patch("backend.app.bus.message_bus") as mock_bus,
             patch("backend.app.agent.router.init_storage", return_value=None),
             patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
+            patch("backend.app.agent.stores.ToolConfigStore") as MockToolConfig,
+            patch(
+                "backend.app.agent.tools.registry.create_list_capabilities_tool"
+            ) as mock_list_cap,
         ):
+            mock_tc = MagicMock()
+            mock_tc.get_disabled_tool_names = AsyncMock(return_value=set())
+            mock_tc.get_disabled_sub_tool_names = AsyncMock(return_value=set())
+            MockToolConfig.return_value = mock_tc
+
             mock_agent_instance = MagicMock()
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
-            mock_registry.factory_names = ["core", "quickbooks", "messaging"]
-            mock_registry.create_tools.return_value = []
+            mock_registry.create_core_tools.return_value = []
+            mock_registry.get_available_specialist_summaries.return_value = {
+                "quickbooks": "QB tools"
+            }
+            mock_registry.get_unauthenticated_specialists.return_value = {}
+            mock_registry.get_disabled_specialist_sub_tools.return_value = {}
             mock_bus.publish_outbound = AsyncMock()
 
             await execute_heartbeat_tasks(user, "Check QB", channel="telegram", chat_id="123")
 
-            # Verify create_tools was called with selected_factories excluding "messaging"
-            call_kwargs = mock_registry.create_tools.call_args
-            selected = call_kwargs.kwargs.get("selected_factories") or call_kwargs[1].get(
-                "selected_factories"
-            )
-            assert "messaging" not in selected
-            assert "core" in selected
-            assert "quickbooks" in selected
+            # Should use create_core_tools with messaging excluded
+            mock_registry.create_core_tools.assert_called_once()
+            call_kwargs = mock_registry.create_core_tools.call_args
+            excluded = call_kwargs.kwargs.get("excluded_factories")
+            assert "messaging" in excluded
+
+            # Should create list_capabilities since specialists are available
+            mock_list_cap.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -2446,3 +2486,119 @@ class TestHeartbeatRulesGuardHistoryPatterns:
         rules = load_prompt("heartbeat_rules")
         assert "infer" in rules.lower() or "pattern" in rules.lower()
         assert "removed" in rules.lower() or "no longer" in rules.lower()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: tool wiring (regression for #874)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_execute_heartbeat_uses_core_tools_and_list_capabilities(user: User) -> None:
+    """execute_heartbeat_tasks should use create_core_tools + list_capabilities,
+    not create_tools with all factories (regression test for #874)."""
+    mock_agent_cls = MagicMock()
+    mock_agent = MagicMock()
+    mock_agent_cls.return_value = mock_agent
+    mock_agent.register_tools = MagicMock()
+    mock_agent.process_message = AsyncMock(
+        return_value=MagicMock(is_error_fallback=False, reply_text="done", actions_taken="")
+    )
+
+    mock_registry = MagicMock()
+    mock_registry.create_core_tools.return_value = [MagicMock(name="core_tool")]
+    mock_registry.get_available_specialist_summaries.return_value = {"quickbooks": "QB tools"}
+    mock_registry.get_unauthenticated_specialists.return_value = {}
+    mock_registry.get_disabled_specialist_sub_tools.return_value = {}
+
+    mock_tool_config = MagicMock()
+    mock_tool_config.get_disabled_tool_names = AsyncMock(return_value=set())
+    mock_tool_config.get_disabled_sub_tool_names = AsyncMock(return_value=set())
+
+    with (
+        patch("backend.app.agent.core.ClawboltAgent", mock_agent_cls),
+        patch(
+            "backend.app.agent.tools.registry.default_registry",
+            mock_registry,
+        ),
+        patch(
+            "backend.app.agent.stores.ToolConfigStore",
+            return_value=mock_tool_config,
+        ),
+        patch(
+            "backend.app.agent.tools.registry.create_list_capabilities_tool",
+            return_value=MagicMock(name="list_capabilities"),
+        ) as mock_list_cap,
+        patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
+        patch("backend.app.bus.message_bus"),
+    ):
+        from backend.app.agent.heartbeat import execute_heartbeat_tasks
+
+        await execute_heartbeat_tasks(user, "Check invoices")
+
+    # Should use create_core_tools, not create_tools
+    mock_registry.create_core_tools.assert_called_once()
+    assert not hasattr(mock_registry.create_tools, "call_count") or (
+        mock_registry.create_tools.call_count == 0
+    )
+
+    # Should have created list_capabilities meta-tool
+    mock_list_cap.assert_called_once()
+
+    # "messaging" should be in the excluded factories
+    call_kwargs = mock_registry.create_core_tools.call_args
+    excluded = call_kwargs.kwargs.get("excluded_factories") or call_kwargs[1].get(
+        "excluded_factories"
+    )
+    assert "messaging" in excluded
+
+
+@pytest.mark.asyncio()
+async def test_execute_heartbeat_respects_disabled_tools(user: User) -> None:
+    """execute_heartbeat_tasks should respect user's disabled tool config (#874)."""
+    mock_agent_cls = MagicMock()
+    mock_agent = MagicMock()
+    mock_agent_cls.return_value = mock_agent
+    mock_agent.register_tools = MagicMock()
+    mock_agent.process_message = AsyncMock(
+        return_value=MagicMock(is_error_fallback=False, reply_text="done", actions_taken="")
+    )
+
+    mock_registry = MagicMock()
+    mock_registry.create_core_tools.return_value = []
+    mock_registry.get_available_specialist_summaries.return_value = {}
+    mock_registry.get_unauthenticated_specialists.return_value = {}
+    mock_registry.get_disabled_specialist_sub_tools.return_value = {}
+
+    mock_tool_config = MagicMock()
+    mock_tool_config.get_disabled_tool_names = AsyncMock(return_value={"quickbooks"})
+    mock_tool_config.get_disabled_sub_tool_names = AsyncMock(return_value={"qb_query"})
+
+    with (
+        patch("backend.app.agent.core.ClawboltAgent", mock_agent_cls),
+        patch("backend.app.agent.tools.registry.default_registry", mock_registry),
+        patch(
+            "backend.app.agent.stores.ToolConfigStore",
+            return_value=mock_tool_config,
+        ),
+        patch("backend.app.agent.tools.registry.create_list_capabilities_tool"),
+        patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
+        patch("backend.app.bus.message_bus"),
+    ):
+        from backend.app.agent.heartbeat import execute_heartbeat_tasks
+
+        await execute_heartbeat_tasks(user, "Check something")
+
+    # Disabled groups should be excluded (along with messaging)
+    call_kwargs = mock_registry.create_core_tools.call_args
+    excluded = call_kwargs.kwargs.get("excluded_factories") or call_kwargs[1].get(
+        "excluded_factories"
+    )
+    assert "quickbooks" in excluded
+    assert "messaging" in excluded
+
+    # Disabled sub-tools should be passed through
+    excluded_tools = call_kwargs.kwargs.get("excluded_tool_names") or call_kwargs[1].get(
+        "excluded_tool_names"
+    )
+    assert "qb_query" in excluded_tools

--- a/tests/test_heartbeat_tools.py
+++ b/tests/test_heartbeat_tools.py
@@ -79,6 +79,40 @@ async def test_update_then_get_roundtrip(test_user: User) -> None:
 
 
 @pytest.mark.asyncio()
+async def test_update_heartbeat_shows_previous_content(test_user: User) -> None:
+    """update_heartbeat should include previous content in the result (#873)."""
+    store = HeartbeatStore(test_user.id)
+    await store.write_heartbeat_md("- Old reminder\n- Follow up with client")
+
+    tools = create_heartbeat_tools(test_user.id)
+    update_hb = tools[1].function
+    result = await update_hb(text="- New item only")
+    assert "updated" in result.content.lower()
+    assert "Previous content:" in result.content
+    assert "Old reminder" in result.content
+    assert "Follow up with client" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_update_heartbeat_empty_previous(test_user: User) -> None:
+    """update_heartbeat on an empty file should note it was empty (#873)."""
+    tools = create_heartbeat_tools(test_user.id)
+    update_hb = tools[1].function
+    result = await update_hb(text="- First item")
+    assert "was empty" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_update_heartbeat_description_warns_about_overwrite(test_user: User) -> None:
+    """update_heartbeat tool description should warn about overwrite behavior (#873)."""
+    tools = create_heartbeat_tools(test_user.id)
+    update_tool = tools[1]
+    desc = update_tool.description.lower()
+    assert "overwrite" in desc or "overwrites" in desc
+    assert "never re-add" in desc or "do not restore" in desc
+
+
+@pytest.mark.asyncio()
 async def test_heartbeat_scoped_to_user(test_user: User) -> None:
     """Each user's heartbeat text is independent."""
     db = _db_module.SessionLocal()


### PR DESCRIPTION
## Description
Two heartbeat fixes:

**#874 — Heartbeat checks can't use OAuth-dependent tools:** `execute_heartbeat_tasks` was calling `create_tools(selected_factories=all_factories)` instead of following the normal agent pattern (`create_core_tools` + `list_capabilities` meta-tool). This meant specialist tools like QuickBooks and Calendar weren't discoverable via the `list_capabilities` flow. Now follows the same wiring as `run_agent()` in router.py, including respecting user's disabled tool config via `ToolConfigStore`.

**#873 — Deleted heartbeat items get repopulated:** The `update_heartbeat` tool did a full-text overwrite with no visibility into what was previously there. The LLM would reconstruct deleted items from conversation memory. Now the tool reads and returns previous content before overwriting, and the description explicitly instructs the LLM to only include items currently in the file.

Fixes #874
Fixes #873

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used