### PR TITLE
fix: add timeout to per-user processing lock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,7 @@ WHISPER_MODEL_SIZE=base
 
 # Agent loop
 # APPROVAL_TIMEOUT_SECONDS=120  # Seconds to wait for user approval before denying
+# AGENT_PROCESSING_TIMEOUT_SECONDS=300  # Max seconds for agent processing (includes lock wait)
 # MESSAGE_BATCH_WINDOW_MS=1500  # Batch rapid-fire messages per user (0 to disable)
 # MAX_TOOL_ROUNDS=10
 # MAX_INPUT_TOKENS=120000

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -372,34 +372,44 @@ class MessageBatcher:
                 last_entry.message.seq,
             )
 
-        async with user_locks.acquire(user_id):
-            try:
-                # Reload user in case it was updated
-                db = SessionLocal()
-                try:
-                    fresh = db.query(User).filter_by(id=user_id).first()
-                    if fresh is not None:
-                        db.expunge(fresh)
-                        user = fresh
-                finally:
-                    db.close()
-                await handle_inbound_message(
-                    user=user,
-                    session=last_entry.session,
-                    message=last_entry.message,
-                    media_urls=all_media,
-                    downloaded_media=all_downloaded or None,
-                    channel=state.channel,
-                    request_id=state.request_id,
-                    download_media=state.download_media,
-                )
-            except Exception:
-                logger.exception(
-                    "Agent pipeline failed for message seq %d (user %s)",
-                    last_entry.message.seq,
-                    user_id,
-                )
-                await _send_error_fallback(state.channel, user, user_id)
+        try:
+            async with asyncio.timeout(settings.agent_processing_timeout_seconds):
+                async with user_locks.acquire(user_id):
+                    try:
+                        # Reload user in case it was updated
+                        db = SessionLocal()
+                        try:
+                            fresh = db.query(User).filter_by(id=user_id).first()
+                            if fresh is not None:
+                                db.expunge(fresh)
+                                user = fresh
+                        finally:
+                            db.close()
+                        await handle_inbound_message(
+                            user=user,
+                            session=last_entry.session,
+                            message=last_entry.message,
+                            media_urls=all_media,
+                            downloaded_media=all_downloaded or None,
+                            channel=state.channel,
+                            request_id=state.request_id,
+                            download_media=state.download_media,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Agent pipeline failed for message seq %d (user %s)",
+                            last_entry.message.seq,
+                            user_id,
+                        )
+                        await _send_error_fallback(state.channel, user, user_id)
+        except TimeoutError:
+            logger.error(
+                "Agent processing timed out after %.0fs for message seq %d (user %s)",
+                settings.agent_processing_timeout_seconds,
+                last_entry.message.seq,
+                user_id,
+            )
+            await _send_error_fallback(state.channel, user, user_id)
 
 
 # Module-level singleton
@@ -557,30 +567,40 @@ async def process_inbound_from_bus(
             download_media=download_media,
         )
     else:
-        async with user_locks.acquire(user.id):
-            try:
-                db = SessionLocal()
-                try:
-                    fresh = db.query(User).filter_by(id=user.id).first()
-                    if fresh is not None:
-                        db.expunge(fresh)
-                        user = fresh
-                finally:
-                    db.close()
-                await handle_inbound_message(
-                    user=user,
-                    session=session,
-                    message=message,
-                    media_urls=inbound.media_refs,
-                    downloaded_media=inbound.downloaded_media,
-                    channel=inbound.channel,
-                    request_id=inbound.request_id,
-                    download_media=download_media,
-                )
-            except Exception:
-                logger.exception(
-                    "Agent pipeline failed for message seq %d (user %s)",
-                    message.seq,
-                    user.id,
-                )
-                await _send_error_fallback(inbound.channel, user, user.id)
+        try:
+            async with asyncio.timeout(settings.agent_processing_timeout_seconds):
+                async with user_locks.acquire(user.id):
+                    try:
+                        db = SessionLocal()
+                        try:
+                            fresh = db.query(User).filter_by(id=user.id).first()
+                            if fresh is not None:
+                                db.expunge(fresh)
+                                user = fresh
+                        finally:
+                            db.close()
+                        await handle_inbound_message(
+                            user=user,
+                            session=session,
+                            message=message,
+                            media_urls=inbound.media_refs,
+                            downloaded_media=inbound.downloaded_media,
+                            channel=inbound.channel,
+                            request_id=inbound.request_id,
+                            download_media=download_media,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Agent pipeline failed for message seq %d (user %s)",
+                            message.seq,
+                            user.id,
+                        )
+                        await _send_error_fallback(inbound.channel, user, user.id)
+        except TimeoutError:
+            logger.error(
+                "Agent processing timed out after %.0fs for message seq %d (user %s)",
+                settings.agent_processing_timeout_seconds,
+                message.seq,
+                user.id,
+            )
+            await _send_error_fallback(inbound.channel, user, user.id)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -65,6 +65,7 @@ class Settings(BaseSettings):
 
     # Agent loop
     approval_timeout_seconds: int = Field(default=120, ge=1)
+    agent_processing_timeout_seconds: float = Field(default=300.0, gt=0)
     message_batch_window_ms: int = Field(default=1500, ge=100)
     max_tool_rounds: int = Field(default=10, ge=1)
     max_input_tokens: int = Field(default=600_000, ge=1)

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -101,6 +101,7 @@ See [Storage Providers](../deployment/storage/) for setup instructions.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `APPROVAL_TIMEOUT_SECONDS` | `120` | Seconds to wait for user approval of a tool call before automatically denying |
+| `AGENT_PROCESSING_TIMEOUT_SECONDS` | `300` | Maximum seconds for a single message's agent processing (includes waiting for the per-user lock). Prevents one hung LLM call from blocking all subsequent messages for the same user |
 | `MESSAGE_BATCH_WINDOW_MS` | `1500` | Milliseconds to wait for more messages before processing. Groups rapid-fire messages into one agent call. Set to `0` to disable |
 | `MAX_TOOL_ROUNDS` | `10` | Maximum tool-calling rounds per agent invocation |
 | `MAX_INPUT_TOKENS` | `120000` | Max input token budget before context trimming |

--- a/tests/test_message_batcher.py
+++ b/tests/test_message_batcher.py
@@ -260,6 +260,147 @@ class TestMessageBatcher:
             await asyncio.sleep(0.15)
 
 
+class TestProcessingTimeout:
+    """Tests for agent_processing_timeout_seconds on the lock scope."""
+
+    @pytest.mark.asyncio
+    async def test_batcher_flush_times_out_and_sends_fallback(self) -> None:
+        """When the pipeline exceeds the timeout, a fallback error is sent."""
+        batcher = MessageBatcher(window_ms=50)
+        mock_user = User(id="1", channel_identifier="123", phone="")
+        mock_session = SessionState(session_id="sess-1", user_id="1")
+        mock_message = StoredMessage(direction="inbound", body="hello")
+
+        async def slow_handler(**kwargs: object) -> None:
+            await asyncio.sleep(10)  # Way longer than the timeout
+
+        with (
+            patch(
+                "backend.app.agent.ingestion.handle_inbound_message",
+                new_callable=AsyncMock,
+                side_effect=slow_handler,
+            ),
+            patch("backend.app.agent.ingestion.settings") as mock_settings,
+        ):
+            mock_settings.message_batch_window_ms = 50
+            mock_settings.agent_processing_timeout_seconds = 0.1
+
+            await batcher.enqueue(mock_user, mock_session, mock_message, [], "telegram")
+            await asyncio.sleep(0.3)
+
+            # Fallback error published to bus
+            found = False
+            while not message_bus.outbound.empty():
+                outbound = message_bus.outbound.get_nowait()
+                if not outbound.is_typing_indicator:
+                    assert outbound.chat_id == "123"
+                    assert "something went wrong" in outbound.content.lower()
+                    found = True
+                    break
+            assert found
+
+    @pytest.mark.asyncio
+    async def test_timeout_releases_lock_for_next_request(self) -> None:
+        """After a timeout, the next request for the same user should proceed."""
+        batcher = MessageBatcher(window_ms=50)
+        mock_user = User(id="1", channel_identifier="123", phone="")
+        mock_session = SessionState(session_id="sess-1", user_id="1")
+        mock_msg_1 = StoredMessage(direction="inbound", body="slow request")
+        mock_msg_2 = StoredMessage(direction="inbound", body="fast request")
+
+        call_count = 0
+
+        async def handler(**kwargs: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                await asyncio.sleep(10)  # First call hangs
+
+        with (
+            patch(
+                "backend.app.agent.ingestion.handle_inbound_message",
+                new_callable=AsyncMock,
+                side_effect=handler,
+            ),
+            patch("backend.app.agent.ingestion.settings") as mock_settings,
+        ):
+            mock_settings.message_batch_window_ms = 50
+            mock_settings.agent_processing_timeout_seconds = 0.1
+
+            # First message: will timeout
+            await batcher.enqueue(mock_user, mock_session, mock_msg_1, [], "telegram")
+            await asyncio.sleep(0.3)
+
+            # Second message: should proceed (lock released after timeout)
+            await batcher.enqueue(mock_user, mock_session, mock_msg_2, [], "telegram")
+            await asyncio.sleep(0.3)
+
+            # Both calls should have been attempted
+            assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_batcher_path_times_out_and_sends_fallback(self) -> None:
+        """Timeout on the non-batcher (direct) path sends a fallback error."""
+        inbound = InboundMessage(
+            channel="telegram",
+            sender_id="456",
+            text="hi there",
+        )
+
+        mock_user = User(id="1", channel_identifier="456", phone="")
+        mock_session = SessionState(session_id="sess-1", user_id="1")
+        mock_message = StoredMessage(direction="inbound", body="hi there")
+
+        async def slow_handler(**kwargs: object) -> None:
+            await asyncio.sleep(10)
+
+        with (
+            patch(
+                "backend.app.agent.ingestion._get_or_create_user",
+                new_callable=AsyncMock,
+                return_value=mock_user,
+            ),
+            patch(
+                "backend.app.agent.ingestion.get_approval_gate",
+            ) as mock_gate,
+            patch(
+                "backend.app.agent.ingestion.get_or_create_conversation",
+                new_callable=AsyncMock,
+                return_value=(mock_session, True),
+            ),
+            patch(
+                "backend.app.agent.ingestion.get_session_store",
+            ) as mock_store_fn,
+            patch(
+                "backend.app.agent.ingestion.settings",
+            ) as mock_settings,
+            patch(
+                "backend.app.agent.ingestion.handle_inbound_message",
+                new_callable=AsyncMock,
+                side_effect=slow_handler,
+            ),
+        ):
+            mock_gate.return_value.has_pending.return_value = False
+            mock_session_store = AsyncMock()
+            mock_session_store.add_message.return_value = mock_message
+            mock_store_fn.return_value = mock_session_store
+            mock_settings.message_batch_window_ms = 0
+            mock_settings.agent_processing_timeout_seconds = 0.1
+
+            await process_inbound_from_bus(inbound)
+
+            # Fallback error published to bus
+            found = False
+            while not message_bus.outbound.empty():
+                outbound = message_bus.outbound.get_nowait()
+                if not outbound.is_typing_indicator:
+                    assert outbound.chat_id == "456"
+                    assert "something went wrong" in outbound.content.lower()
+                    found = True
+                    break
+            assert found
+
+
 class TestProcessInboundFallbackError:
     """Tests for error fallback in process_inbound_from_bus (non-batcher path)."""
 
@@ -308,6 +449,7 @@ class TestProcessInboundFallbackError:
             mock_session_store.add_message.return_value = mock_message
             mock_store_fn.return_value = mock_session_store
             mock_settings.message_batch_window_ms = 0
+            mock_settings.agent_processing_timeout_seconds = 300.0
             mock_locks.acquire.return_value = AsyncMock(
                 __aenter__=AsyncMock(), __aexit__=AsyncMock()
             )


### PR DESCRIPTION
## Description
When an LLM API call hangs (e.g., Anthropic latency spike), the per-user `asyncio.Lock` in `ingestion.py` is never released. This blocks **all** subsequent messages for the same user indefinitely, even though the Anthropic call may eventually succeed.

This was observed in production: a Linq message triggered an LLM call at 23:11:39, the call hung, and a follow-up webchat message at 23:15:45 never entered the pipeline because it was blocked waiting for the lock.

### Fix
Wraps both lock acquisition sites in `ingestion.py` with `asyncio.timeout()` (default 300s, configurable via `AGENT_PROCESSING_TIMEOUT_SECONDS`). On timeout:
1. The lock is automatically released (async context manager guarantees this)
2. A fallback error message ("something went wrong") is sent to the user
3. Subsequent messages for the same user can proceed

### Files changed
- `backend/app/config.py`: Add `agent_processing_timeout_seconds` setting (default 300s)
- `backend/app/agent/ingestion.py`: Wrap both lock scopes with `asyncio.timeout()`
- `tests/test_message_batcher.py`: 3 new regression tests (batcher timeout, lock release after timeout, non-batcher timeout) + fix existing test for new setting
- `.env.example`: Document new setting
- `docs/configuration.mdx`: Document new setting

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used