### PR TITLE
fix: resolve SSE future and clear spinner on error/timeout fallback

### DIFF
--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -79,8 +79,14 @@ async def _send_error_fallback(
     channel: str,
     user: User,
     user_id: str,
+    request_id: str = "",
 ) -> None:
     """Send a fallback error message to the user via the bus.
+
+    When *request_id* is provided the outbound message includes it so the
+    web chat SSE response future is resolved and the frontend spinner clears.
+    A ``done`` activity event is also published so the activity stream stops
+    showing the agent as busy.
 
     Swallows any exception so this never propagates.
     """
@@ -95,8 +101,11 @@ async def _send_error_fallback(
                 channel=channel,
                 chat_id=to_address,
                 content="Sorry, something went wrong processing your message. Please try again.",
+                request_id=request_id,
             )
         )
+        # Clear the frontend "thinking" spinner via the activity stream.
+        await message_bus.publish_activity(user_id, {"type": "done", "channel": channel})
     except Exception:
         logger.exception("Failed to send error fallback to user %s", user_id)
 
@@ -401,7 +410,12 @@ class MessageBatcher:
                             last_entry.message.seq,
                             user_id,
                         )
-                        await _send_error_fallback(state.channel, user, user_id)
+                        await _send_error_fallback(
+                            state.channel,
+                            user,
+                            user_id,
+                            request_id=state.request_id,
+                        )
         except TimeoutError:
             logger.error(
                 "Agent processing timed out after %.0fs for message seq %d (user %s)",
@@ -409,7 +423,12 @@ class MessageBatcher:
                 last_entry.message.seq,
                 user_id,
             )
-            await _send_error_fallback(state.channel, user, user_id)
+            await _send_error_fallback(
+                state.channel,
+                user,
+                user_id,
+                request_id=state.request_id,
+            )
 
 
 # Module-level singleton
@@ -595,7 +614,12 @@ async def process_inbound_from_bus(
                             message.seq,
                             user.id,
                         )
-                        await _send_error_fallback(inbound.channel, user, user.id)
+                        await _send_error_fallback(
+                            inbound.channel,
+                            user,
+                            user.id,
+                            request_id=inbound.request_id,
+                        )
         except TimeoutError:
             logger.error(
                 "Agent processing timed out after %.0fs for message seq %d (user %s)",
@@ -603,4 +627,9 @@ async def process_inbound_from_bus(
                 message.seq,
                 user.id,
             )
-            await _send_error_fallback(inbound.channel, user, user.id)
+            await _send_error_fallback(
+                inbound.channel,
+                user,
+                user.id,
+                request_id=inbound.request_id,
+            )


### PR DESCRIPTION
## Description

When the agent pipeline errors out or times out, `_send_error_fallback()` now:
1. Includes `request_id` in the outbound message so the web chat SSE response future resolves
2. Publishes a `done` activity event so the frontend "thinking" spinner clears

Previously, error/timeout fallbacks left the web UI stuck in a "thinking" state because the SSE future was never resolved and no `done` event was published.

All four call sites updated: batcher pipeline error, batcher timeout, non-batcher pipeline error, non-batcher timeout.

Fixes #876

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- 1400 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the fix)
- [ ] No AI used