### PR TITLE
chore: add supply chain attack guards for npm and uv

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,1 @@
+exclude-newer = "7 days"


### PR DESCRIPTION
## Description
Reject packages published less than 7 days ago to protect against supply chain attacks. Adds project-level config for both package managers:

- `frontend/.npmrc`: `min-release-age=7` (requires npm >= 11.10.0; ignored with a warning on older versions)
- `uv.toml`: `exclude-newer = "7 days"` (works on uv 0.10+)

Fixes #889

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation and research done with Claude Code.