### PR TITLE
fix: validate permission levels in PUT /api/user/permissions

### DIFF
--- a/backend/app/routers/user_permissions.py
+++ b/backend/app/routers/user_permissions.py
@@ -36,6 +36,48 @@ async def update_permissions(
     if not isinstance(data, dict):
         raise HTTPException(status_code=400, detail="Permissions must be a JSON object")
 
+    _validate_permissions_shape(data)
+
     store = get_approval_store()
     store._save(current_user.id, data)
     return PermissionsResponse(content=json.dumps(data, indent=2))
+
+
+_VALID_LEVELS = {"auto", "ask", "deny"}
+
+
+def _validate_permissions_shape(data: dict[str, object]) -> None:
+    """Validate that tools/resources contain only valid permission levels."""
+    tools = data.get("tools")
+    if tools is not None:
+        if not isinstance(tools, dict):
+            raise HTTPException(status_code=400, detail="'tools' must be an object")
+        bad = [str(k) for k, v in tools.items() if not isinstance(v, str) or v not in _VALID_LEVELS]
+        if bad:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid permission level for: {', '.join(bad[:5])}. "
+                f"Allowed values: auto, ask, deny",
+            )
+
+    resources = data.get("resources")
+    if resources is not None:
+        if not isinstance(resources, dict):
+            raise HTTPException(status_code=400, detail="'resources' must be an object")
+        for tool_name, res_map in resources.items():
+            if not isinstance(res_map, dict):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"'resources.{tool_name}' must be an object",
+                )
+            bad = [
+                str(k)
+                for k, v in res_map.items()
+                if not isinstance(v, str) or v not in _VALID_LEVELS
+            ]
+            if bad:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid permission level in resources.{tool_name}: "
+                    f"{', '.join(bad[:5])}. Allowed values: auto, ask, deny",
+                )

--- a/tests/test_permissions_endpoints.py
+++ b/tests/test_permissions_endpoints.py
@@ -1,0 +1,99 @@
+"""Tests for permissions endpoints (PERMISSIONS.json via API)."""
+
+import json
+
+from fastapi.testclient import TestClient
+
+from backend.app.models import User
+
+
+def test_get_permissions_returns_complete(client: TestClient, test_user: User) -> None:
+    """GET /api/user/permissions returns a complete PERMISSIONS.json."""
+    resp = client.get("/api/user/permissions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "content" in data
+    parsed = json.loads(data["content"])
+    assert "version" in parsed
+    assert "tools" in parsed
+    assert len(parsed["tools"]) > 0
+
+
+def test_update_permissions(client: TestClient, test_user: User) -> None:
+    """PUT /api/user/permissions overwrites the file and returns updated content."""
+    # Get current permissions
+    resp = client.get("/api/user/permissions")
+    parsed = json.loads(resp.json()["content"])
+
+    # Modify a permission
+    parsed["tools"]["send_reply"] = "deny"
+    resp = client.put(
+        "/api/user/permissions",
+        json={"content": json.dumps(parsed)},
+    )
+    assert resp.status_code == 200
+    updated = json.loads(resp.json()["content"])
+    assert updated["tools"]["send_reply"] == "deny"
+
+    # Verify it persisted
+    resp2 = client.get("/api/user/permissions")
+    persisted = json.loads(resp2.json()["content"])
+    assert persisted["tools"]["send_reply"] == "deny"
+
+
+def test_update_permissions_invalid_json(client: TestClient, test_user: User) -> None:
+    """PUT with invalid JSON returns 400."""
+    resp = client.put(
+        "/api/user/permissions",
+        json={"content": "not valid json{{{"},
+    )
+    assert resp.status_code == 400
+    assert "Invalid JSON" in resp.json()["detail"]
+
+
+def test_update_permissions_non_dict(client: TestClient, test_user: User) -> None:
+    """PUT with a JSON array (not object) returns 400."""
+    resp = client.put(
+        "/api/user/permissions",
+        json={"content": "[1, 2, 3]"},
+    )
+    assert resp.status_code == 400
+    assert "JSON object" in resp.json()["detail"]
+
+
+def test_update_permissions_invalid_level(client: TestClient, test_user: User) -> None:
+    """PUT with an invalid permission level returns 400."""
+    payload = {"version": 1, "tools": {"send_reply": "yolo"}, "resources": {}}
+    resp = client.put(
+        "/api/user/permissions",
+        json={"content": json.dumps(payload)},
+    )
+    assert resp.status_code == 400
+    assert "Invalid permission level" in resp.json()["detail"]
+    assert "send_reply" in resp.json()["detail"]
+
+
+def test_update_permissions_invalid_tools_type(client: TestClient, test_user: User) -> None:
+    """PUT with tools as a non-dict returns 400."""
+    payload = {"version": 1, "tools": "not_a_dict", "resources": {}}
+    resp = client.put(
+        "/api/user/permissions",
+        json={"content": json.dumps(payload)},
+    )
+    assert resp.status_code == 400
+    assert "'tools' must be an object" in resp.json()["detail"]
+
+
+def test_update_permissions_invalid_resource_level(client: TestClient, test_user: User) -> None:
+    """PUT with an invalid resource permission level returns 400."""
+    payload = {
+        "version": 1,
+        "tools": {},
+        "resources": {"web_fetch": {"evil.com": "nope"}},
+    }
+    resp = client.put(
+        "/api/user/permissions",
+        json={"content": json.dumps(payload)},
+    )
+    assert resp.status_code == 400
+    assert "Invalid permission level" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
- Adds server-side validation to `PUT /api/user/permissions` ensuring tool/resource permission values are restricted to `{auto, ask, deny}`
- Previously, arbitrary strings (e.g. `"yolo"`) were accepted and silently stored, causing `ValueError` crashes in the agent loop at runtime when `PermissionLevel(StrEnum)` rejected the value
- Adds 7 endpoint-level tests for `GET/PUT /api/user/permissions` (happy path, invalid JSON, non-dict, invalid levels, invalid types)

Follows up on #776 / #898.

## Test plan
- [x] `uv run pytest tests/test_permissions_endpoints.py -v` — 7 tests pass
- [x] `uv run ruff check && ruff format --check` — clean
- [x] Related test suites (approval, workspace_tools, permission_tools) — 96 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)