### PR TITLE
feat: add Playwright e2e tests for file upload and management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,48 @@ jobs:
       - run: uv sync --all-extras
       - run: uv run pytest -m e2e -v --timeout=60
 
+  e2e-playwright:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: clawbolt
+          POSTGRES_PASSWORD: clawbolt
+          POSTGRES_DB: clawbolt_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: uv sync --all-extras
+      - working-directory: frontend
+        run: npm ci
+      - working-directory: frontend
+        run: npm run build
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run e2e
+        env:
+          DATABASE_URL: postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_e2e
+          CI: true
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
   frontend-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ data/
 frontend/node_modules/
 frontend/dist/
 
+# E2E / Playwright
+node_modules/
+playwright-report/
+test-results/
+
 # Docs site
 docs/node_modules/
 docs/dist/

--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -1,0 +1,47 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/**
+ * Wait for the OSS app to be fully loaded.
+ * In OSS mode, / redirects to /app, which loads the AppShell with sidebar nav.
+ * We wait for the sidebar "Dashboard" link to render as a sign the app is ready.
+ */
+export async function waitForAppReady(page: Page): Promise<void> {
+  await expect(
+    page.getByRole('link', { name: /dashboard/i })
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Navigate to the chat page and wait for it to be ready.
+ */
+export async function navigateToChat(page: Page): Promise<void> {
+  await page.getByRole('link', { name: /chat/i }).click();
+  await expect(page.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Complete onboarding by marking onboarding_complete=true via the API.
+ * This avoids the get-started redirect so tests can go straight to /app/dashboard.
+ */
+export async function completeOnboarding(baseUrl: string): Promise<void> {
+  const res = await fetch(`${baseUrl}/api/user/profile`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ onboarding_complete: true }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to complete onboarding: ${res.status} ${await res.text()}`);
+  }
+}
+
+/**
+ * Create a small test PNG image as a Buffer for API upload tests.
+ * Returns a 1x1 red pixel PNG (67 bytes).
+ */
+export function createTestPng(): Buffer {
+  return Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+    'base64'
+  );
+}

--- a/e2e/oss/file-upload.spec.ts
+++ b/e2e/oss/file-upload.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect } from '@playwright/test';
+import {
+  waitForAppReady,
+  completeOnboarding,
+  createTestPng,
+} from '../fixtures/test-helpers';
+
+test.describe('File Upload - API Tests', () => {
+  test('POST /api/user/chat with message and file returns 200', async ({
+    request,
+    baseURL,
+  }) => {
+    const png = createTestPng();
+
+    const res = await request.post(`${baseURL}/api/user/chat`, {
+      multipart: {
+        message: 'Check this image',
+        files: {
+          name: 'test-image.png',
+          mimeType: 'image/png',
+          buffer: png,
+        },
+      },
+    });
+    expect(res.ok()).toBe(true);
+
+    const body = await res.json();
+    expect(body.request_id).toBeTruthy();
+    expect(body.session_id).toBeTruthy();
+    expect(typeof body.request_id).toBe('string');
+    expect(typeof body.session_id).toBe('string');
+  });
+
+  test('POST /api/user/chat with only a file (no message) returns 200', async ({
+    request,
+    baseURL,
+  }) => {
+    const png = createTestPng();
+
+    const res = await request.post(`${baseURL}/api/user/chat`, {
+      multipart: {
+        message: '',
+        files: {
+          name: 'photo.png',
+          mimeType: 'image/png',
+          buffer: png,
+        },
+      },
+    });
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.request_id).toBeTruthy();
+  });
+
+  test('POST /api/user/chat with no message and no files returns 422', async ({
+    request,
+    baseURL,
+  }) => {
+    const res = await request.post(`${baseURL}/api/user/chat`, {
+      multipart: {
+        message: '',
+      },
+    });
+    expect(res.status()).toBe(422);
+    const body = await res.json();
+    expect(body.detail).toContain('Either message text or files required');
+  });
+
+  test('POST /api/user/chat with oversized file returns 422', async ({
+    request,
+    baseURL,
+  }) => {
+    // max_media_size_bytes defaults to 20_971_520 (20 MB)
+    const oversized = Buffer.alloc(20_971_521, 0);
+
+    const res = await request.post(`${baseURL}/api/user/chat`, {
+      multipart: {
+        message: 'big file',
+        files: {
+          name: 'huge.bin',
+          mimeType: 'application/octet-stream',
+          buffer: oversized,
+        },
+      },
+    });
+    expect(res.status()).toBe(422);
+    const body = await res.json();
+    expect(body.detail).toContain('File too large');
+  });
+
+  test('POST /api/user/chat with message only (no files) returns 200', async ({
+    request,
+    baseURL,
+  }) => {
+    const res = await request.post(`${baseURL}/api/user/chat`, {
+      multipart: {
+        message: 'Hello assistant',
+      },
+    });
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.request_id).toBeTruthy();
+    expect(body.session_id).toBeTruthy();
+  });
+
+  test('POST /api/user/chat with invalid session_id returns 422', async ({
+    request,
+    baseURL,
+  }) => {
+    const res = await request.post(`${baseURL}/api/user/chat`, {
+      multipart: {
+        message: 'test',
+        session_id: 'invalid-format',
+      },
+    });
+    expect(res.status()).toBe(422);
+    const body = await res.json();
+    expect(body.detail).toContain('session_id must match pattern');
+  });
+});
+
+test.describe('File Upload - UI Tests', () => {
+  test.beforeEach(async ({ baseURL }) => {
+    await completeOnboarding(baseURL!);
+  });
+
+  test('chat page loads with attach button visible', async ({ page }) => {
+    await page.goto('/app/chat');
+    await expect(page.getByPlaceholder('Type a message...')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByLabel('Attach files')).toBeVisible();
+  });
+
+  test('selecting a file shows preview chip', async ({ page }) => {
+    await page.goto('/app/chat');
+    await expect(page.getByPlaceholder('Type a message...')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'test-photo.png',
+      mimeType: 'image/png',
+      buffer: createTestPng(),
+    });
+
+    await expect(page.getByText('test-photo.png')).toBeVisible();
+  });
+
+  test('selecting multiple files shows multiple preview chips', async ({
+    page,
+  }) => {
+    await page.goto('/app/chat');
+    await expect(page.getByPlaceholder('Type a message...')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles([
+      { name: 'photo1.png', mimeType: 'image/png', buffer: createTestPng() },
+      { name: 'photo2.png', mimeType: 'image/png', buffer: createTestPng() },
+    ]);
+
+    await expect(page.getByText('photo1.png')).toBeVisible();
+    await expect(page.getByText('photo2.png')).toBeVisible();
+  });
+
+  test('removing a file attachment works', async ({ page }) => {
+    await page.goto('/app/chat');
+    await expect(page.getByPlaceholder('Type a message...')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'removable.png',
+      mimeType: 'image/png',
+      buffer: createTestPng(),
+    });
+
+    await expect(page.getByText('removable.png')).toBeVisible();
+
+    await page.getByLabel('Remove removable.png').click();
+
+    await expect(page.getByText('removable.png')).not.toBeVisible();
+  });
+
+  test('image file shows thumbnail preview', async ({ page }) => {
+    await page.goto('/app/chat');
+    await expect(page.getByPlaceholder('Type a message...')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'thumb-test.png',
+      mimeType: 'image/png',
+      buffer: createTestPng(),
+    });
+
+    const thumbnail = page.locator('img[alt="thumb-test.png"]');
+    await expect(thumbnail).toBeVisible();
+  });
+});

--- a/e2e/oss/smoke.spec.ts
+++ b/e2e/oss/smoke.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { waitForAppReady, completeOnboarding } from '../fixtures/test-helpers';
+
+test.describe('OSS Smoke Tests', () => {
+  test('health endpoint returns ok', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/api/health`);
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.status).toBe('ok');
+    expect(body.database).toBe('ok');
+  });
+
+  test('auth config returns method none with required false', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/api/auth/config`);
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.method).toBe('none');
+    expect(body.required).toBe(false);
+  });
+
+  test('auto-created user profile exists', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/api/user/profile`);
+    expect(res.ok()).toBe(true);
+    const profile = await res.json();
+    expect(profile.user_id).toBe('local@clawbolt.local');
+    expect(profile.is_active).toBe(true);
+  });
+
+  test('app loads and dashboard renders after onboarding', async ({ page, baseURL }) => {
+    await completeOnboarding(baseURL!);
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    // Should have redirected to /app/dashboard
+    await page.waitForURL('**/app/dashboard', { timeout: 10_000 });
+  });
+
+  test('sidebar navigation links are visible', async ({ page, baseURL }) => {
+    await completeOnboarding(baseURL!);
+    await page.goto('/app/dashboard');
+    await waitForAppReady(page);
+
+    await expect(page.getByRole('link', { name: /chat/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /memory/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /channels/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /settings/i })).toBeVisible();
+  });
+});

--- a/e2e/oss/storage-config.spec.ts
+++ b/e2e/oss/storage-config.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Storage Config - API Tests', () => {
+  test('GET /api/user/storage/config returns current config', async ({
+    request,
+    baseURL,
+  }) => {
+    const res = await request.get(`${baseURL}/api/user/storage/config`);
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.storage_provider).toBe('local');
+    expect(body.file_storage_base_dir).toBeTruthy();
+    expect(typeof body.dropbox_access_token_set).toBe('boolean');
+    expect(typeof body.google_drive_credentials_json_set).toBe('boolean');
+  });
+
+  test('PUT /api/user/storage/config updates provider to local', async ({
+    request,
+    baseURL,
+  }) => {
+    const res = await request.put(`${baseURL}/api/user/storage/config`, {
+      data: { storage_provider: 'local' },
+    });
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.storage_provider).toBe('local');
+  });
+
+  test('PUT /api/user/storage/config rejects invalid provider', async ({
+    request,
+    baseURL,
+  }) => {
+    const res = await request.put(`${baseURL}/api/user/storage/config`, {
+      data: { storage_provider: 'invalid_provider' },
+    });
+    expect(res.status()).toBe(422);
+    const body = await res.json();
+    expect(body.detail).toContain('Invalid storage_provider');
+  });
+
+  test('PUT /api/user/storage/config with empty body returns 400', async ({
+    request,
+    baseURL,
+  }) => {
+    const res = await request.put(`${baseURL}/api/user/storage/config`, {
+      data: {},
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.detail).toContain('No fields to update');
+  });
+});

--- a/e2e/scripts/start-server.sh
+++ b/e2e/scripts/start-server.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Start the OSS server for E2E tests.
+# Usage: ./start-server.sh <port>
+#
+# Requires PostgreSQL to be running. Uses DATABASE_URL from the environment,
+# or defaults to postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_e2e.
+#
+# The script:
+# 1. Builds the frontend if dist/ doesn't exist
+# 2. Creates the e2e database if it doesn't exist
+# 3. Runs Alembic migrations
+# 4. Starts uvicorn with _verify_llm_settings monkey-patched out
+
+set -euo pipefail
+
+PORT="${1:?Usage: start-server.sh <port>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+# Build frontend if dist/ doesn't exist
+if [ ! -d "frontend/dist" ]; then
+  echo "[e2e] Building frontend..."
+  (cd frontend && npm install && npm run build)
+fi
+
+# Database setup
+export DATABASE_URL="${DATABASE_URL:-postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_e2e}"
+
+echo "[e2e] DATABASE_URL=$DATABASE_URL"
+
+# Create the e2e database if it doesn't exist.
+# Try su (sandbox) first, fall back to PGPASSWORD + createdb (CI service containers).
+DB_NAME="${DATABASE_URL##*/}"
+if ! su - postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='$DB_NAME'\" | grep -q 1 || psql -c \"CREATE DATABASE $DB_NAME OWNER clawbolt;\"" 2>/dev/null; then
+  echo "[e2e] su - postgres failed, trying PGPASSWORD + createdb..."
+  PGPASSWORD=clawbolt createdb -h localhost -U clawbolt "$DB_NAME" 2>/dev/null || true
+fi
+
+# Run Alembic migrations
+echo "[e2e] Running Alembic migrations..."
+uv run alembic upgrade head
+
+# Start the server with _verify_llm_settings monkey-patched out
+echo "[e2e] Starting server on port $PORT..."
+exec uv run python -c "
+import uvicorn
+
+async def _noop():
+    pass
+
+from backend.app import main as _main
+_main._verify_llm_settings = _noop
+from backend.app.main import app
+uvicorn.run(app, host='127.0.0.1', port=$PORT)
+"

--- a/e2e/scripts/start-server.sh
+++ b/e2e/scripts/start-server.sh
@@ -32,10 +32,11 @@ export DATABASE_URL="${DATABASE_URL:-postgresql://clawbolt:clawbolt@localhost:54
 echo "[e2e] DATABASE_URL=$DATABASE_URL"
 
 # Create the e2e database if it doesn't exist.
-# Try su (sandbox) first, fall back to PGPASSWORD + createdb (CI service containers).
+# Try su (sandbox/root) first, fall back to PGPASSWORD + createdb (CI service containers).
+# The < /dev/null prevents su from hanging on password prompt when not running as root.
 DB_NAME="${DATABASE_URL##*/}"
-if ! su - postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='$DB_NAME'\" | grep -q 1 || psql -c \"CREATE DATABASE $DB_NAME OWNER clawbolt;\"" 2>/dev/null; then
-  echo "[e2e] su - postgres failed, trying PGPASSWORD + createdb..."
+if ! su - postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='$DB_NAME'\" | grep -q 1 || psql -c \"CREATE DATABASE $DB_NAME OWNER clawbolt;\"" < /dev/null 2>/dev/null; then
+  echo "[e2e] su - postgres unavailable, trying createdb..."
   PGPASSWORD=clawbolt createdb -h localhost -U clawbolt "$DB_NAME" 2>/dev/null || true
 fi
 

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,90 @@
+{
+  "name": "clawbolt",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@playwright/test": "^1.50.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "scripts": {
+    "e2e": "playwright test",
+    "e2e:oss": "playwright test --project=oss"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const OSS_PORT = 8765;
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [['html', { open: 'never' }]],
+  use: {
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    ...devices['Desktop Chrome'],
+  },
+  projects: [
+    {
+      name: 'oss',
+      testDir: './e2e/oss',
+      use: {
+        baseURL: `http://127.0.0.1:${OSS_PORT}`,
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: `bash e2e/scripts/start-server.sh ${OSS_PORT}`,
+      port: OSS_PORT,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        DATABASE_URL:
+          process.env.DATABASE_URL ??
+          'postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_e2e',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## Description

Adds Playwright e2e testing infrastructure to OSS clawbolt with 20 tests across three spec files. Covers file/image upload via the webchat API, storage config CRUD, and basic smoke tests (health, auth, profile, navigation).

**New files:**
- `playwright.config.ts`, `package.json`: Playwright setup with webServer auto-start on port 8765
- `e2e/scripts/start-server.sh`: creates DB, runs Alembic migrations, monkey-patches LLM check
- `e2e/fixtures/test-helpers.ts`: shared utilities (waitForAppReady, completeOnboarding, createTestPng)
- `e2e/oss/smoke.spec.ts`: 5 smoke tests
- `e2e/oss/file-upload.spec.ts`: 6 API tests (upload acceptance, validation, oversized files) + 5 UI tests (attach button, file preview chips, remove, thumbnails)
- `e2e/oss/storage-config.spec.ts`: 4 storage config API tests
- `.github/workflows/ci.yml`: new `e2e-playwright` CI job with Postgres service container and artifact upload

Run locally: `cd clawbolt && npm install && npx playwright install chromium && npm run e2e`

## Type
- [x] Feature
- [x] Test
- [x] CI/CD

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code: planned and implemented the full Playwright e2e test suite)
- [ ] No AI used