### PR TITLE
feat: sequential per-tool approval instead of batched all-or-nothing

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -8,9 +8,9 @@ Three permission levels: ALWAYS (execute freely), ASK (prompt user first),
 DENY (never execute). Users can respond with yes/always/no/never to
 control both immediate and future behavior.
 
-Batch plan approval: when a user request triggers multiple tools, the
-system presents a single plan message grouping auto and pending steps.
-The user approves or rejects the entire batch with one response.
+Sequential approval: when a user request triggers multiple tools, each
+tool that requires approval gets its own prompt. The user approves or
+rejects each tool independently.
 """
 
 from __future__ import annotations
@@ -366,7 +366,7 @@ class ApprovalGate:
         self._pending[user_id] = pending
 
         if prompt is None:
-            prompt = _format_approval_message(tool_name, description)
+            prompt = format_approval_message(tool_name, description)
         try:
             from backend.app.bus import OutboundMessage as OMsg
 
@@ -506,7 +506,7 @@ async def classify_approval_response(text: str) -> ApprovalDecision | None:
     return result
 
 
-def _format_approval_message(tool_name: str, description: str) -> str:
+def format_approval_message(tool_name: str, description: str) -> str:
     """Build a plain-text approval prompt for the user."""
     return f"I'd like to: {description}\n\nReply yes or no (always/never to remember your choice)"
 

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 from backend.app.agent.approval import (
     ApprovalDecision,
     PermissionLevel,
-    _format_approval_message,
+    format_approval_message,
     get_approval_gate,
     get_approval_store,
 )
@@ -570,7 +570,7 @@ class ClawboltAgent:
                 tc_req = parsed_calls[idx]
 
                 if self._publish_outbound is not None and self._chat_id is not None:
-                    prompt = _format_approval_message(tool_obj.name, description)
+                    prompt = format_approval_message(tool_obj.name, description)
 
                     if self._session_id:
                         await self._persist_approval_prompt(prompt)

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -19,8 +19,7 @@ from pydantic import ValidationError
 from backend.app.agent.approval import (
     ApprovalDecision,
     PermissionLevel,
-    PlanStep,
-    format_plan_message,
+    _format_approval_message,
     get_approval_gate,
     get_approval_store,
 )
@@ -516,11 +515,11 @@ class ClawboltAgent:
 
             pre_validated.append((i, tool_obj, validated_args))
 
-        # -- Phase 2: batch approval then execute --------------------------
+        # -- Phase 2: approve then execute ------------------------------------
         #
         # Partition validated tools by permission level. Tools that need
-        # approval are batched into a single plan message so the user
-        # responds once (not once per tool).
+        # approval are prompted individually so the user can approve or
+        # deny each one independently.
 
         _ToolEntry = tuple[int, Tool, dict[str, Any]]
 
@@ -563,92 +562,81 @@ class ClawboltAgent:
         approved_entries: list[_ToolEntry] = list(auto_entries)
 
         if ask_entries:
-            auto_steps = [
-                PlanStep(
-                    tool_name=t.name,
-                    description=self._get_tool_permission(t, a)[2],
-                    level=PermissionLevel.ALWAYS,
-                )
-                for _, t, a in auto_entries
-            ]
-            ask_steps = [
-                PlanStep(tool_name=e[1].name, description=desc, level=PermissionLevel.ASK)
-                for e, _res, desc in ask_entries
-            ]
-
-            plan_msg = format_plan_message("Here's what I need to do:", auto_steps, ask_steps)
-
-            # Persist the approval prompt to session history so it is
-            # visible in the web UI regardless of which channel
-            # originated the conversation.
-            if self._session_id:
-                await self._persist_approval_prompt(plan_msg)
-
-            if self._publish_outbound is not None and self._chat_id is not None:
-                # Publish approval prompt as SSE event for webchat clients.
-                # The publish_outbound path works for Telegram but is a no-op
-                # for webchat (WebChatChannel.send_text returns "").
-                if self._request_id:
-                    from backend.app.bus import message_bus
-
-                    await message_bus.publish_event(
-                        self._request_id,
-                        {"type": "approval_request", "content": plan_msg},
-                    )
-
-                gate = get_approval_gate()
-                decision = await gate.request_approval(
-                    user_id=self.user.id,
-                    tool_name=ask_entries[0][0][1].name,
-                    description=plan_msg,
-                    publish_outbound=self._publish_outbound,
-                    channel=self._channel,
-                    chat_id=self._chat_id,
-                    prompt=plan_msg,
-                )
-            else:
-                decision = ApprovalDecision.DENIED
-
             store = get_approval_store()
-            if decision in (ApprovalDecision.APPROVED, ApprovalDecision.ALWAYS_ALLOW):
-                approved_entries.extend(e for e, _res, _desc in ask_entries)
-                if decision == ApprovalDecision.ALWAYS_ALLOW:
-                    for (_, tool_obj, _a), resource, _desc in ask_entries:
+            indexed_entries = list(enumerate(ask_entries))
+
+            for pos, (entry, resource, description) in indexed_entries:
+                idx, tool_obj, v_args = entry
+                tc_req = parsed_calls[idx]
+
+                if self._publish_outbound is not None and self._chat_id is not None:
+                    prompt = _format_approval_message(tool_obj.name, description)
+
+                    if self._session_id:
+                        await self._persist_approval_prompt(prompt)
+
+                    if self._request_id:
+                        from backend.app.bus import message_bus
+
+                        await message_bus.publish_event(
+                            self._request_id,
+                            {"type": "approval_request", "content": prompt},
+                        )
+
+                    gate = get_approval_gate()
+                    decision = await gate.request_approval(
+                        user_id=self.user.id,
+                        tool_name=tool_obj.name,
+                        description=description,
+                        publish_outbound=self._publish_outbound,
+                        channel=self._channel,
+                        chat_id=self._chat_id,
+                        prompt=prompt,
+                    )
+                else:
+                    decision = ApprovalDecision.DENIED
+
+                if decision in (ApprovalDecision.APPROVED, ApprovalDecision.ALWAYS_ALLOW):
+                    approved_entries.append(entry)
+                    if decision == ApprovalDecision.ALWAYS_ALLOW:
                         try:
                             store.set_permission(
                                 self.user.id, tool_obj.name, PermissionLevel.ALWAYS, resource
                             )
                         except Exception:
                             logger.warning("Failed to persist ALWAYS for tool %s", tool_obj.name)
-            elif decision == ApprovalDecision.INTERRUPTED:
-                # User changed the subject. Don't persist any permission.
-                for (idx, _tool_obj, v_args), _resource, desc in ask_entries:
-                    tc_req = parsed_calls[idx]
-                    tool_tags = self._get_tool_tags(tc_req.name)
-                    hint = _ERROR_KIND_HINTS[ToolErrorKind.INTERRUPTED]
-                    msg = (
-                        f"Tool request interrupted: the user moved on to a "
-                        f'different topic instead of approving "{desc}". '
-                        f"Do not proactively retry this tool; only call it "
-                        f"again if the user explicitly asks.\n\n{hint}"
-                    )
-                    actions_taken.append(f"Interrupted: {tc_req.name}")
-                    tool_call_records.append(
-                        StoredToolInteraction(
-                            tool_call_id=tc_req.id,
-                            name=tc_req.name,
-                            args=v_args,
-                            result=msg,
-                            is_error=True,
-                            tags=set(tool_tags),
+
+                elif decision == ApprovalDecision.INTERRUPTED:
+                    # User changed subject. Error this entry + all remaining.
+                    for _p, (e, _r, d) in indexed_entries[pos:]:
+                        i_rem, _t_rem, va_rem = e
+                        tc_rem = parsed_calls[i_rem]
+                        rem_tags = self._get_tool_tags(tc_rem.name)
+                        hint = _ERROR_KIND_HINTS[ToolErrorKind.INTERRUPTED]
+                        msg = (
+                            f"Tool request interrupted: the user moved on to a "
+                            f'different topic instead of approving "{d}". '
+                            f"Do not proactively retry this tool; only call it "
+                            f"again if the user explicitly asks.\n\n{hint}"
                         )
-                    )
-                    tool_results.append(
-                        ToolResultMessage(tool_call_id=tc_req.id, content=msg, is_error=True)
-                    )
-            else:
-                if decision == ApprovalDecision.ALWAYS_DENY:
-                    for (_, tool_obj, _a), resource, _desc in ask_entries:
+                        actions_taken.append(f"Interrupted: {tc_rem.name}")
+                        tool_call_records.append(
+                            StoredToolInteraction(
+                                tool_call_id=tc_rem.id,
+                                name=tc_rem.name,
+                                args=va_rem,
+                                result=msg,
+                                is_error=True,
+                                tags=set(rem_tags),
+                            )
+                        )
+                        tool_results.append(
+                            ToolResultMessage(tool_call_id=tc_rem.id, content=msg, is_error=True)
+                        )
+                    break
+
+                else:  # DENIED / ALWAYS_DENY
+                    if decision == ApprovalDecision.ALWAYS_DENY:
                         try:
                             store.set_permission(
                                 self.user.id, tool_obj.name, PermissionLevel.DENY, resource
@@ -656,8 +644,6 @@ class ClawboltAgent:
                         except Exception:
                             logger.warning("Failed to persist DENY for tool %s", tool_obj.name)
 
-                for (idx, _tool_obj, v_args), _resource, _desc in ask_entries:
-                    tc_req = parsed_calls[idx]
                     tool_tags = self._get_tool_tags(tc_req.name)
                     hint = _ERROR_KIND_HINTS[ToolErrorKind.PERMISSION]
                     deny_msg = f"Error: permission denied for tool '{tc_req.name}'\n\n{hint}"

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -12,8 +12,8 @@ from backend.app.agent.approval import (
     ApprovalPolicy,
     ApprovalStore,
     PermissionLevel,
-    _format_approval_message,
     _parse_approval_response,
+    format_approval_message,
     get_approval_gate,
     get_approval_store,
     reset_approval_gate,
@@ -234,13 +234,13 @@ class TestParseApprovalResponse:
 
 
 # ---------------------------------------------------------------------------
-# _format_approval_message
+# format_approval_message
 # ---------------------------------------------------------------------------
 
 
 class TestFormatApprovalMessage:
     def test_output_format(self) -> None:
-        msg = _format_approval_message("web_fetch", "fetch content from https://example.com")
+        msg = format_approval_message("web_fetch", "fetch content from https://example.com")
         assert "fetch content from https://example.com" in msg
         assert "yes" in msg
         assert "no" in msg

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -606,7 +606,7 @@ class TestBatchApproval:
         assert len(approval_msgs) == 1
         # "Reply yes or no" should appear exactly once (not double-wrapped)
         assert approval_msgs[0].count("Reply yes or no") == 1
-        # Should not contain the _format_approval_message wrapper
+        # Should not contain the format_approval_message wrapper
         assert "wants to use the tool" not in approval_msgs[0]
 
     @pytest.mark.asyncio()

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -1,4 +1,4 @@
-"""Tests for batch plan approval in the agent tool execution pipeline."""
+"""Tests for per-tool sequential approval in the agent tool execution pipeline."""
 
 import asyncio
 from unittest.mock import AsyncMock, patch
@@ -215,13 +215,13 @@ class TestBatchApproval:
         assert any(tc.name == "reader" and not tc.is_error for tc in response.tool_calls)
         assert any(tc.name == "writer" and not tc.is_error for tc in response.tool_calls)
 
-        # A plan message should have been sent
-        plan_sent = False
+        # An approval prompt should have been sent
+        prompt_sent = False
         for call in mock_publish.call_args_list:
             msg = call.args[0] if call.args else call.kwargs.get("msg")
-            if isinstance(msg, OutboundMessage) and "approval" in msg.content.lower():
-                plan_sent = True
-        assert plan_sent
+            if isinstance(msg, OutboundMessage) and "reply yes or no" in msg.content.lower():
+                prompt_sent = True
+        assert prompt_sent
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
@@ -266,10 +266,8 @@ class TestBatchApproval:
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
-    async def test_always_persists_auto_for_all_ask_tools(
-        self, mock_amessages: object, test_user: User
-    ) -> None:
-        """'always' on a batch plan persists ALWAYS for ALL ask tools."""
+    async def test_always_persists_per_tool(self, mock_amessages: object, test_user: User) -> None:
+        """'always' persists ALWAYS for each tool individually."""
         mock_publish = AsyncMock()
 
         mock_amessages.side_effect = [  # type: ignore[union-attr]
@@ -284,10 +282,14 @@ class TestBatchApproval:
 
         gate = get_approval_gate()
 
-        async def _always_soon() -> None:
-            while not gate.has_pending(test_user.id):
-                await asyncio.sleep(0.005)
-            gate.resolve(test_user.id, ApprovalDecision.ALWAYS_ALLOW)
+        async def _always_each() -> None:
+            for _ in range(2):
+                while not gate.has_pending(test_user.id):
+                    await asyncio.sleep(0.005)
+                gate.resolve(test_user.id, ApprovalDecision.ALWAYS_ALLOW)
+                # Let the main loop process the resolution and move to
+                # the next entry before we check for it.
+                await asyncio.sleep(0.02)
 
         agent = ClawboltAgent(
             user=test_user,
@@ -302,7 +304,7 @@ class TestBatchApproval:
             ]
         )
 
-        task = asyncio.create_task(_always_soon())
+        task = asyncio.create_task(_always_each())
         await agent.process_message("write and send")
         await task
 
@@ -313,10 +315,10 @@ class TestBatchApproval:
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
-    async def test_never_persists_deny_for_all_ask_tools(
+    async def test_never_persists_deny_per_tool(
         self, mock_amessages: object, test_user: User
     ) -> None:
-        """'never' on a batch plan persists DENY for ALL ask tools."""
+        """'never' persists DENY for each tool individually."""
         mock_publish = AsyncMock()
 
         mock_amessages.side_effect = [  # type: ignore[union-attr]
@@ -331,10 +333,12 @@ class TestBatchApproval:
 
         gate = get_approval_gate()
 
-        async def _never_soon() -> None:
-            while not gate.has_pending(test_user.id):
-                await asyncio.sleep(0.005)
-            gate.resolve(test_user.id, ApprovalDecision.ALWAYS_DENY)
+        async def _never_each() -> None:
+            for _ in range(2):
+                while not gate.has_pending(test_user.id):
+                    await asyncio.sleep(0.005)
+                gate.resolve(test_user.id, ApprovalDecision.ALWAYS_DENY)
+                await asyncio.sleep(0.02)
 
         agent = ClawboltAgent(
             user=test_user,
@@ -349,7 +353,7 @@ class TestBatchApproval:
             ]
         )
 
-        task = asyncio.create_task(_never_soon())
+        task = asyncio.create_task(_never_each())
         await agent.process_message("write and send")
         await task
 
@@ -359,10 +363,64 @@ class TestBatchApproval:
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
-    async def test_interrupted_returns_error_for_all_ask_tools(
+    async def test_selective_approval(self, mock_amessages: object, test_user: User) -> None:
+        """Sequential approval: approve some tools, deny others."""
+        mock_publish = AsyncMock()
+
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [
+                    {"name": "writer", "arguments": {"text": "data"}},
+                    {"name": "sender", "arguments": {"text": "msg"}},
+                    {"name": "deleter", "arguments": {"text": "old"}},
+                ]
+            ),
+            make_text_response("Partially done!"),
+        ]
+
+        gate = get_approval_gate()
+        decisions = [
+            ApprovalDecision.APPROVED,
+            ApprovalDecision.DENIED,
+            ApprovalDecision.APPROVED,
+        ]
+
+        async def _resolve_each() -> None:
+            for decision in decisions:
+                while not gate.has_pending(test_user.id):
+                    await asyncio.sleep(0.005)
+                gate.resolve(test_user.id, decision)
+                await asyncio.sleep(0.02)
+
+        agent = ClawboltAgent(
+            user=test_user,
+            channel="telegram",
+            publish_outbound=mock_publish,
+            chat_id="chat_1",
+        )
+        agent.register_tools(
+            [
+                _ask_tool("writer", "Write"),
+                _ask_tool("sender", "Send"),
+                _ask_tool("deleter", "Delete"),
+            ]
+        )
+
+        task = asyncio.create_task(_resolve_each())
+        response = await agent.process_message("write, send, and delete")
+        await task
+
+        # writer approved, sender denied, deleter approved
+        assert any(tc.name == "writer" and not tc.is_error for tc in response.tool_calls)
+        assert any(tc.name == "sender" and tc.is_error for tc in response.tool_calls)
+        assert any(tc.name == "deleter" and not tc.is_error for tc in response.tool_calls)
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_interrupted_stops_remaining(
         self, mock_amessages: object, test_user: User
     ) -> None:
-        """INTERRUPTED on a batch plan returns errors for all ASK tools, no permission persisted."""
+        """INTERRUPTED on sequential approval errors current + all remaining ASK tools."""
         mock_publish = AsyncMock()
 
         mock_amessages.side_effect = [  # type: ignore[union-attr]
@@ -500,11 +558,11 @@ class TestBatchApproval:
 
         # Tool should execute without any plan prompt
         assert any(tc.name == "writer" and not tc.is_error for tc in response.tool_calls)
-        # No plan message sent (only typing indicators)
+        # No approval prompt sent (only typing indicators)
         for call in mock_publish.call_args_list:
             msg = call.args[0] if call.args else call.kwargs.get("msg")
             if isinstance(msg, OutboundMessage):
-                assert "approval" not in msg.content.lower()
+                assert "reply yes or no" not in msg.content.lower()
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
@@ -660,6 +718,6 @@ class TestBatchApproval:
         session = store.load_session(session_id)
         assert session is not None
         outbound_msgs = [m for m in session.messages if m.direction == "outbound"]
-        assert any("approval" in m.body.lower() for m in outbound_msgs), (
+        assert any("reply yes or no" in m.body.lower() for m in outbound_msgs), (
             "Approval prompt not found in session history"
         )


### PR DESCRIPTION
## Description

Replaces the batched approval prompt (approve all or deny all) with sequential per-tool prompts. Users can now approve or deny each tool independently when the agent requests multiple actions in a single round.

**Before:** "I need your approval for: Send text, Create calendar event, Upload file. Yes or no?" (all-or-nothing)

**After:** Three individual prompts, each with "I'd like to: X. Yes or no?" The user can approve sending the text, deny the calendar event, and approve the upload.

Key behaviors:
- APPROVED/DENIED: applies to the current tool only, continues to next
- ALWAYS/NEVER: persists permission for that specific tool, continues to next
- INTERRUPTED (user changes subject): errors current + all remaining tools, stops asking

Closes #777

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (`test_selective_approval`)
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code planned and implemented the change)