### PR TITLE
fix: compress oversized images before sending to vision API

### DIFF
--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -1,9 +1,11 @@
 import base64
+import io
 import logging
 from typing import Any, cast
 
 from any_llm import amessages
 from any_llm.types.messages import MessageResponse
+from PIL import Image
 
 from backend.app.agent.llm_parsing import get_response_text
 from backend.app.config import settings
@@ -13,6 +15,64 @@ from backend.app.services.llm_service import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Anthropic API limit: base64-encoded image must be under 5 MB.
+# base64 inflates size by ~4/3, so raw bytes must stay under ~3.75 MB.
+# Use a conservative raw-byte target to leave headroom.
+_MAX_BASE64_BYTES = 5_242_880
+_MAX_RAW_BYTES = (_MAX_BASE64_BYTES * 3) // 4  # ~3,932,160
+
+_JPEG_QUALITY_STEPS = [85, 70, 50, 30]
+_RESIZE_SCALES = [0.75, 0.5, 0.35]
+
+
+def compress_image_for_api(image_bytes: bytes, mime_type: str) -> tuple[bytes, str]:
+    """Compress an image so its base64 encoding stays under the API size limit.
+
+    Returns the (possibly compressed) bytes and the output MIME type.
+    If the image already fits, the original bytes and MIME type are returned unchanged.
+    """
+    if len(image_bytes) <= _MAX_RAW_BYTES:
+        return image_bytes, mime_type
+
+    logger.info(
+        "Image too large for API (%d bytes, limit %d). Compressing.",
+        len(image_bytes),
+        _MAX_RAW_BYTES,
+    )
+
+    img = Image.open(io.BytesIO(image_bytes))
+    if img.mode in ("RGBA", "P", "LA"):
+        img = img.convert("RGB")
+
+    # Try progressively lower JPEG quality at the original resolution.
+    for quality in _JPEG_QUALITY_STEPS:
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=quality, optimize=True)
+        if buf.tell() <= _MAX_RAW_BYTES:
+            logger.info("Compressed to %d bytes at quality=%d", buf.tell(), quality)
+            return buf.getvalue(), "image/jpeg"
+
+    # If quality reduction alone is insufficient, also scale down.
+    for scale in _RESIZE_SCALES:
+        new_size = (int(img.width * scale), int(img.height * scale))
+        resized = img.resize(new_size, Image.Resampling.LANCZOS)
+        for quality in _JPEG_QUALITY_STEPS:
+            buf = io.BytesIO()
+            resized.save(buf, format="JPEG", quality=quality, optimize=True)
+            if buf.tell() <= _MAX_RAW_BYTES:
+                logger.info(
+                    "Compressed to %d bytes at scale=%.2f, quality=%d",
+                    buf.tell(),
+                    scale,
+                    quality,
+                )
+                return buf.getvalue(), "image/jpeg"
+
+    # Last resort: return the smallest version we produced.
+    logger.warning("Could not compress image below %d bytes; using smallest result", _MAX_RAW_BYTES)
+    return buf.getvalue(), "image/jpeg"
+
 
 VISION_SYSTEM_PROMPT = (
     "You are analyzing an image sent by a user. "
@@ -47,6 +107,7 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
     logger.info(
         "Sending image to vision LLM: mime_type=%s, size=%d bytes", mime_type, len(image_bytes)
     )
+    image_bytes, mime_type = compress_image_for_api(image_bytes, mime_type)
     b64_image = base64.b64encode(image_bytes).decode("utf-8")
     user_content = _build_vision_content(b64_image, mime_type, context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "alembic>=1.13",
     "cryptography>=42.0",
     "cachetools>=5.3",
+    "Pillow>=10.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,10 +1,23 @@
+import base64
+import io
+import os
 from unittest.mock import patch
 
 import pytest
 from any_llm.types.messages import MessageResponse, MessageUsage, TextBlock
+from PIL import Image
 
-from backend.app.media.vision import analyze_image
+from backend.app.media.vision import _MAX_RAW_BYTES, analyze_image, compress_image_for_api
 from tests.mocks.llm import make_vision_response
+
+
+def _make_noisy_jpeg(width: int = 100, height: int = 100, quality: int = 95) -> bytes:
+    """Create a JPEG with random pixel data (resists compression)."""
+    data = os.urandom(width * height * 3)
+    img = Image.frombytes("RGB", (width, height), data)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=quality)
+    return buf.getvalue()
 
 
 @pytest.mark.asyncio()
@@ -126,3 +139,73 @@ def test_build_vision_content_with_context() -> None:
     assert blocks[0] == {"type": "text", "text": "Describe this"}
     assert blocks[1]["type"] == "image"
     assert blocks[1]["source"]["data"] == "BBBB"
+
+
+# -- compress_image_for_api tests --
+
+
+def test_compress_small_image_unchanged() -> None:
+    """Images already under the size limit should be returned unchanged."""
+    small_jpeg = _make_noisy_jpeg(100, 100)
+    assert len(small_jpeg) < _MAX_RAW_BYTES
+
+    result_bytes, result_mime = compress_image_for_api(small_jpeg, "image/jpeg")
+    assert result_bytes is small_jpeg
+    assert result_mime == "image/jpeg"
+
+
+def test_compress_large_image_fits_under_limit() -> None:
+    """A large image should be compressed to fit under the API limit."""
+    # Random noise at high quality produces a large JPEG.
+    large_jpeg = _make_noisy_jpeg(4000, 3000, quality=98)
+    assert len(large_jpeg) > _MAX_RAW_BYTES, (
+        f"Test setup: need image > {_MAX_RAW_BYTES}, got {len(large_jpeg)}"
+    )
+
+    result_bytes, result_mime = compress_image_for_api(large_jpeg, "image/jpeg")
+    assert len(result_bytes) <= _MAX_RAW_BYTES
+    assert result_mime == "image/jpeg"
+    # Verify it's a valid JPEG
+    img = Image.open(io.BytesIO(result_bytes))
+    assert img.format == "JPEG"
+
+
+def test_compress_png_rgba_converts_to_jpeg() -> None:
+    """An oversized RGBA PNG should be converted to JPEG (RGB)."""
+    # Random noise in RGBA PNG is large and incompressible.
+    data = os.urandom(2000 * 2000 * 4)
+    img = Image.frombytes("RGBA", (2000, 2000), data)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    large_png = buf.getvalue()
+    assert len(large_png) > _MAX_RAW_BYTES, (
+        f"Test setup: need image > {_MAX_RAW_BYTES}, got {len(large_png)}"
+    )
+
+    result_bytes, result_mime = compress_image_for_api(large_png, "image/png")
+    assert len(result_bytes) <= _MAX_RAW_BYTES
+    assert result_mime == "image/jpeg"
+    result_img = Image.open(io.BytesIO(result_bytes))
+    assert result_img.mode == "RGB"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.media.vision.amessages")
+async def test_analyze_image_compresses_oversized_image(mock_amessages: object) -> None:
+    """analyze_image should compress oversized images before sending to the API."""
+    mock_amessages.return_value = make_vision_response("Noisy image.")  # type: ignore[union-attr]
+
+    large_jpeg = _make_noisy_jpeg(4000, 3000, quality=98)
+    assert len(large_jpeg) > _MAX_RAW_BYTES
+
+    result = await analyze_image(large_jpeg, "image/jpeg")
+    assert result == "Noisy image."
+
+    # Verify the image sent to the LLM was compressed
+    call_args = mock_amessages.call_args  # type: ignore[union-attr]
+    messages = call_args.kwargs["messages"]
+    user_content = messages[0]["content"]
+    image_parts = [p for p in user_content if p.get("type") == "image"]
+    assert len(image_parts) == 1
+    sent_bytes = base64.b64decode(image_parts[0]["source"]["data"])
+    assert len(sent_bytes) <= _MAX_RAW_BYTES

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-30T09:21:12.716689055Z"
+exclude-newer = "2026-04-06T15:17:23.4486175Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -546,6 +546,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
     { name = "httpx" },
+    { name = "pillow" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -577,6 +578,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "pillow", specifier = ">=10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.0" },


### PR DESCRIPTION
## Description
Images larger than ~3.75 MB raw (which becomes >5 MB after base64 encoding) were rejected by the Anthropic API with a `BadRequestError`. This adds a `compress_image_for_api()` function in `backend/app/media/vision.py` that progressively reduces JPEG quality and resolution until the image fits under the API limit. RGBA/P/LA images are converted to RGB for JPEG compatibility. Adds `Pillow>=10.0` as a dependency.

Fixes #936

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the fix, tests, and PR)
- [ ] No AI used