### PR TITLE
feat: manage integrations over chat via manage_integration tool

### DIFF
--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -36,3 +36,14 @@ To reset all permissions: write the default PERMISSIONS.json
 
 When the user asks about permissions, approval settings, what you can do freely,
 or wants to change how you handle actions, use PERMISSIONS.json.
+
+## Integrations
+You can manage integrations directly in this chat using manage_integration:
+- To see all integrations and their status: manage_integration(action="status")
+- To enable or disable a tool group: manage_integration(action="enable", target="calendar")
+- To connect an OAuth integration: manage_integration(action="connect", target="google_calendar")
+- To disconnect: manage_integration(action="disconnect", target="google_calendar")
+
+When a user asks about connecting an integration, generate a link for them.
+They can tap it to complete the setup in their browser, then come back here.
+When a user asks what tools or integrations are available, use the status action.

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -495,6 +495,32 @@ class ToolConfigStore:
         finally:
             db.close()
 
+    async def set_enabled(self, name: str, enabled: bool) -> None:
+        """Set a single tool group's enabled state.
+
+        Creates or updates a ToolConfig row for the given factory name.
+        Only stores the name and enabled flag; the router fills in display
+        metadata from the registry when building the full tool list.
+        """
+        with db_session() as db:
+            existing = db.query(ToolConfig).filter_by(user_id=self.user_id, name=name).first()
+            if existing:
+                existing.enabled = enabled
+            else:
+                db.add(
+                    ToolConfig(
+                        user_id=self.user_id,
+                        name=name,
+                        description="",
+                        category="domain",
+                        domain_group="",
+                        domain_group_order=0,
+                        enabled=enabled,
+                        disabled_sub_tools="",
+                    )
+                )
+            db.commit()
+
     async def get_disabled_sub_tool_names(self) -> set[str]:
         """Return the union of all disabled sub-tool names across all groups."""
         db = SessionLocal()

--- a/backend/app/agent/tools/calendar_tools.py
+++ b/backend/app/agent/tools/calendar_tools.py
@@ -878,7 +878,8 @@ def _calendar_auth_check(ctx: ToolContext) -> str | None:
         return None
     return (
         "Google Calendar is not connected. "
-        "The user needs to authenticate via the Clawbolt web dashboard."
+        "Use manage_integration(action='connect', target='google_calendar') "
+        "to generate a connection link for the user."
     )
 
 

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -18,14 +18,9 @@ from backend.app.agent.tools.names import ToolName
 from backend.app.services.oauth import get_oauth_config, list_oauth_integrations, oauth_service
 
 if TYPE_CHECKING:
-    from backend.app.agent.tools.registry import ToolContext
+    from backend.app.agent.tools.registry import ToolContext, ToolRegistry
 
 logger = logging.getLogger(__name__)
-
-# Tool groups that cannot be disabled (must stay in sync with user_tools.py).
-_CORE_FACTORIES: frozenset[str] = frozenset(
-    {"workspace", "profile", "memory", "messaging", "file", "heartbeat", "integration"}
-)
 
 # Human-readable display names for tool groups.
 _DISPLAY_NAMES: dict[str, str] = {
@@ -130,13 +125,9 @@ def create_integration_tools(ctx: ToolContext) -> list[Tool]:
 
 async def _handle_status(
     user_id: str,
-    registry: object,
+    registry: ToolRegistry,
 ) -> ToolResult:
     """Build a status overview of all tool groups."""
-    from backend.app.agent.tools.registry import ToolRegistry
-
-    assert isinstance(registry, ToolRegistry)
-
     store = ToolConfigStore(user_id)
     disabled_groups = await store.get_disabled_tool_names()
 
@@ -187,15 +178,13 @@ async def _handle_status(
 async def _handle_enable(
     user_id: str,
     target: str,
-    registry: object,
+    registry: ToolRegistry,
 ) -> ToolResult:
     """Enable a tool group."""
-    from backend.app.agent.tools.registry import ToolRegistry
-
-    assert isinstance(registry, ToolRegistry)
-
     if target not in registry.factory_names:
-        available = [n for n in sorted(registry.factory_names) if n not in _CORE_FACTORIES]
+        available = [
+            n for n in sorted(registry.factory_names) if n not in registry.core_factory_names
+        ]
         return ToolResult(
             content=(
                 f"Unknown tool group '{target}'. Available integrations: {', '.join(available)}"
@@ -224,15 +213,13 @@ async def _handle_enable(
 async def _handle_disable(
     user_id: str,
     target: str,
-    registry: object,
+    registry: ToolRegistry,
 ) -> ToolResult:
     """Disable a tool group."""
-    from backend.app.agent.tools.registry import ToolRegistry
-
-    assert isinstance(registry, ToolRegistry)
-
     if target not in registry.factory_names:
-        available = [n for n in sorted(registry.factory_names) if n not in _CORE_FACTORIES]
+        available = [
+            n for n in sorted(registry.factory_names) if n not in registry.core_factory_names
+        ]
         return ToolResult(
             content=(
                 f"Unknown tool group '{target}'. Available integrations: {', '.join(available)}"

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -1,0 +1,362 @@
+"""Integration management tool for chat-based control.
+
+Gives the agent the ability to view integration status, enable/disable
+tool groups, and connect/disconnect OAuth integrations, so users can
+manage everything over chat without needing the web UI.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from backend.app.agent.stores import ToolConfigStore
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.services.oauth import get_oauth_config, list_oauth_integrations, oauth_service
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+logger = logging.getLogger(__name__)
+
+# Tool groups that cannot be disabled (must stay in sync with user_tools.py).
+_CORE_FACTORIES: frozenset[str] = frozenset(
+    {"workspace", "profile", "memory", "messaging", "file", "heartbeat", "integration"}
+)
+
+# Human-readable display names for tool groups.
+_DISPLAY_NAMES: dict[str, str] = {
+    "workspace": "Workspace",
+    "profile": "Profile",
+    "memory": "Memory",
+    "messaging": "Messaging",
+    "file": "File management",
+    "heartbeat": "Heartbeat",
+    "quickbooks": "QuickBooks Online",
+    "calendar": "Google Calendar",
+    "supplier_pricing": "Home Depot pricing",
+}
+
+# Map tool group names to their OAuth integration names.
+_TOOL_OAUTH_MAP: dict[str, str] = {
+    "calendar": "google_calendar",
+    "quickbooks": "quickbooks",
+}
+
+
+class ManageIntegrationParams(BaseModel):
+    """Parameters for the manage_integration tool."""
+
+    action: Literal["status", "enable", "disable", "connect", "disconnect"] = Field(
+        description=(
+            "Action to perform: "
+            "'status' to list all integrations and their state, "
+            "'enable' or 'disable' to toggle a tool group, "
+            "'connect' to get an OAuth link for an integration, "
+            "'disconnect' to remove an OAuth connection."
+        ),
+    )
+    target: str | None = Field(
+        default=None,
+        description=(
+            "Tool group name (for enable/disable) or OAuth integration name "
+            "(for connect/disconnect). Not needed for status."
+        ),
+    )
+
+
+def create_integration_tools(ctx: ToolContext) -> list[Tool]:
+    """Create the manage_integration tool scoped to the current user."""
+    from backend.app.agent.tools.registry import default_registry, ensure_tool_modules_imported
+
+    ensure_tool_modules_imported()
+
+    user_id = ctx.user.id
+
+    async def manage_integration(
+        action: str,
+        target: str | None = None,
+    ) -> ToolResult:
+        if action == "status":
+            return await _handle_status(user_id, default_registry)
+
+        if target is None:
+            return ToolResult(
+                content=f"The '{action}' action requires a target. Specify a tool group name.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+
+        if action == "enable":
+            return await _handle_enable(user_id, target, default_registry)
+        if action == "disable":
+            return await _handle_disable(user_id, target, default_registry)
+        if action == "connect":
+            return _handle_connect(user_id, target)
+        if action == "disconnect":
+            return _handle_disconnect(user_id, target)
+
+        valid_actions = "status, enable, disable, connect, disconnect"
+        return ToolResult(
+            content=f"Unknown action '{action}'. Valid actions: {valid_actions}",
+            is_error=True,
+            error_kind=ToolErrorKind.VALIDATION,
+        )
+
+    return [
+        Tool(
+            name=ToolName.MANAGE_INTEGRATION,
+            description=(
+                "Manage integrations: view status, enable/disable tool groups, "
+                "connect/disconnect OAuth integrations. "
+                "Use this when the user asks about their integrations or wants to "
+                "change what tools are available."
+            ),
+            function=manage_integration,
+            params_model=ManageIntegrationParams,
+            usage_hint=(
+                "Use manage_integration to help users control their integrations. "
+                "Call with action='status' to see all integrations. "
+                "Call with action='connect' and target='google_calendar' or 'quickbooks' "
+                "to generate an OAuth link the user can tap to connect. "
+                "Call with action='enable'/'disable' and target=group_name to toggle tools."
+            ),
+        ),
+    ]
+
+
+async def _handle_status(
+    user_id: str,
+    registry: object,
+) -> ToolResult:
+    """Build a status overview of all tool groups."""
+    from backend.app.agent.tools.registry import ToolRegistry
+
+    assert isinstance(registry, ToolRegistry)
+
+    store = ToolConfigStore(user_id)
+    disabled_groups = await store.get_disabled_tool_names()
+
+    core_lines: list[str] = []
+    integration_lines: list[str] = []
+
+    for name in sorted(registry.factory_names):
+        factory = registry._factories.get(name)
+        if factory is None:
+            continue
+
+        display = _DISPLAY_NAMES.get(name, name)
+
+        if factory.core:
+            core_lines.append(f"- {name}: {display} (always enabled)")
+        else:
+            enabled = name not in disabled_groups
+            status_parts: list[str] = ["enabled" if enabled else "disabled"]
+
+            # Check OAuth connection status
+            oauth_name = _TOOL_OAUTH_MAP.get(name)
+            if oauth_name:
+                config = get_oauth_config(oauth_name)
+                if config is not None and config.is_configured:
+                    connected = oauth_service.is_connected(user_id, oauth_name)
+                    status_parts.append("connected" if connected else "not connected")
+                else:
+                    status_parts.append("not configured by admin")
+
+            integration_lines.append(f"- {name}: {display} ({', '.join(status_parts)})")
+
+    lines: list[str] = []
+    if core_lines:
+        lines.append("Core tools:")
+        lines.extend(core_lines)
+    if integration_lines:
+        if lines:
+            lines.append("")
+        lines.append("Integrations:")
+        lines.extend(integration_lines)
+
+    if not lines:
+        return ToolResult(content="No tool groups registered.")
+
+    return ToolResult(content="\n".join(lines))
+
+
+async def _handle_enable(
+    user_id: str,
+    target: str,
+    registry: object,
+) -> ToolResult:
+    """Enable a tool group."""
+    from backend.app.agent.tools.registry import ToolRegistry
+
+    assert isinstance(registry, ToolRegistry)
+
+    if target not in registry.factory_names:
+        available = [n for n in sorted(registry.factory_names) if n not in _CORE_FACTORIES]
+        return ToolResult(
+            content=(
+                f"Unknown tool group '{target}'. Available integrations: {', '.join(available)}"
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.NOT_FOUND,
+        )
+
+    factory = registry._factories.get(target)
+    if factory and factory.core:
+        display = _DISPLAY_NAMES.get(target, target)
+        return ToolResult(
+            content=f"{display} is a core tool and is always enabled.",
+        )
+
+    store = ToolConfigStore(user_id)
+    await store.set_enabled(target, enabled=True)
+
+    display = _DISPLAY_NAMES.get(target, target)
+    logger.info("User %s enabled tool group '%s' via chat", user_id, target)
+    return ToolResult(
+        content=f"Enabled {display} tools. They will be available starting with your next message.",
+    )
+
+
+async def _handle_disable(
+    user_id: str,
+    target: str,
+    registry: object,
+) -> ToolResult:
+    """Disable a tool group."""
+    from backend.app.agent.tools.registry import ToolRegistry
+
+    assert isinstance(registry, ToolRegistry)
+
+    if target not in registry.factory_names:
+        available = [n for n in sorted(registry.factory_names) if n not in _CORE_FACTORIES]
+        return ToolResult(
+            content=(
+                f"Unknown tool group '{target}'. Available integrations: {', '.join(available)}"
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.NOT_FOUND,
+        )
+
+    factory = registry._factories.get(target)
+    if factory and factory.core:
+        display = _DISPLAY_NAMES.get(target, target)
+        return ToolResult(
+            content=f"{display} is a core tool and cannot be disabled.",
+            is_error=True,
+            error_kind=ToolErrorKind.VALIDATION,
+        )
+
+    store = ToolConfigStore(user_id)
+    await store.set_enabled(target, enabled=False)
+
+    display = _DISPLAY_NAMES.get(target, target)
+    logger.info("User %s disabled tool group '%s' via chat", user_id, target)
+    return ToolResult(
+        content=f"Disabled {display} tools. This takes effect starting with your next message.",
+    )
+
+
+def _handle_connect(user_id: str, target: str) -> ToolResult:
+    """Generate an OAuth authorization URL for an integration."""
+    # Check if target is a tool group name that maps to an OAuth integration
+    oauth_name = _TOOL_OAUTH_MAP.get(target, target)
+
+    if oauth_name not in list_oauth_integrations():
+        return ToolResult(
+            content=(
+                f"'{target}' does not use OAuth authentication. "
+                f"OAuth integrations: {', '.join(list_oauth_integrations())}"
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.VALIDATION,
+        )
+
+    config = get_oauth_config(oauth_name)
+    if config is None or not config.is_configured:
+        display = _DISPLAY_NAMES.get(target, target)
+        return ToolResult(
+            content=(
+                f"{display} is not configured. "
+                "The admin needs to set up the integration credentials first."
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.AUTH,
+        )
+
+    if oauth_service.is_connected(user_id, oauth_name):
+        display = _DISPLAY_NAMES.get(target, target)
+        return ToolResult(
+            content=f"{display} is already connected. Use action='disconnect' first to reconnect.",
+        )
+
+    url = oauth_service.get_authorization_url(config, user_id, source="chat")
+    display = _DISPLAY_NAMES.get(target, target)
+    logger.info("User %s requested OAuth connect link for '%s' via chat", user_id, oauth_name)
+    return ToolResult(
+        content=(
+            f"To connect {display}, open this link:\n\n{url}\n\n"
+            "After you approve access, the connection will be ready "
+            "the next time you message me."
+        ),
+    )
+
+
+def _handle_disconnect(user_id: str, target: str) -> ToolResult:
+    """Remove OAuth tokens for an integration."""
+    oauth_name = _TOOL_OAUTH_MAP.get(target, target)
+
+    if oauth_name not in list_oauth_integrations():
+        return ToolResult(
+            content=(
+                f"'{target}' does not use OAuth authentication. "
+                f"OAuth integrations: {', '.join(list_oauth_integrations())}"
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.VALIDATION,
+        )
+
+    if not oauth_service.is_connected(user_id, oauth_name):
+        display = _DISPLAY_NAMES.get(target, target)
+        return ToolResult(
+            content=f"{display} is not currently connected.",
+            is_error=True,
+            error_kind=ToolErrorKind.NOT_FOUND,
+        )
+
+    oauth_service.delete_token(user_id, oauth_name)
+    display = _DISPLAY_NAMES.get(target, target)
+    logger.info("User %s disconnected OAuth for '%s' via chat", user_id, oauth_name)
+    return ToolResult(
+        content=(
+            f"Disconnected {display}. "
+            "The tools are still enabled but won't work until you reconnect."
+        ),
+    )
+
+
+def _integration_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for integration management tools, used by the registry."""
+    return create_integration_tools(ctx)
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import SubToolInfo, default_registry
+
+    default_registry.register(
+        "integration",
+        _integration_factory,
+        core=True,
+        sub_tools=[
+            SubToolInfo(
+                ToolName.MANAGE_INTEGRATION,
+                "View status, enable/disable tools, connect/disconnect integrations",
+            ),
+        ],
+    )
+
+
+_register()

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -44,6 +44,7 @@ class ToolName:
 
     # Meta-tools
     LIST_CAPABILITIES = "list_capabilities"
+    MANAGE_INTEGRATION = "manage_integration"
 
     # Heartbeat (not registered in the main tool registry)
     COMPOSE_MESSAGE = "compose_message"

--- a/backend/app/agent/tools/quickbooks_tools.py
+++ b/backend/app/agent/tools/quickbooks_tools.py
@@ -468,7 +468,8 @@ def _quickbooks_auth_check(ctx: ToolContext) -> str | None:
         return None
     return (
         "QuickBooks is not connected. "
-        "The user needs to authenticate via the Clawbolt web dashboard."
+        "Use manage_integration(action='connect', target='quickbooks') "
+        "to generate a connection link for the user."
     )
 
 

--- a/backend/app/routers/oauth.py
+++ b/backend/app/routers/oauth.py
@@ -6,7 +6,7 @@ import logging
 import urllib.parse
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from backend.app.auth.dependencies import get_current_user
 from backend.app.models import User
@@ -54,25 +54,46 @@ async def get_authorize_url(
     return OAuthAuthorizeResponse(url=url, integration=integration)
 
 
-@router.get("/oauth/callback")
+@router.get("/oauth/callback", response_model=None)
 async def oauth_callback(
-    code: str = Query(...),
-    state: str = Query(...),
+    code: str = Query(""),
+    state: str = Query(""),
     realmId: str = Query(""),  # QuickBooks sends camelCase
     error: str = Query(""),
     error_description: str = Query(""),
-) -> RedirectResponse:
+) -> RedirectResponse | HTMLResponse:
     """Handle OAuth provider redirect after user authorization.
 
     The provider redirects here with an authorization code and the state
     parameter we generated earlier. We exchange the code for tokens,
     persist them, and redirect the user to the frontend success page.
+
+    All parameters are optional because OAuth providers may redirect with
+    only error parameters (no code/state) when the user denies access.
+
+    When the flow was initiated from chat (source="chat"), a standalone
+    HTML page is returned instead of redirecting to the SPA, so users
+    on SMS/iMessage see a "you can close this tab" message.
     """
+    source = oauth_service.get_pending_state_source(state) if state else "web"
+
     if error:
         logger.warning("OAuth callback error: %s - %s", error, error_description)
-        msg = urllib.parse.quote(error_description or error)
+        msg = error_description or error
+        if source == "chat":
+            return _chat_callback_page(success=False, error_message=msg)
         return RedirectResponse(
-            f"/app/oauth/callback?status=error&error={msg}",
+            f"/app/oauth/callback?status=error&error={urllib.parse.quote(msg)}",
+            status_code=302,
+        )
+
+    if not code or not state:
+        logger.warning("OAuth callback missing code or state: code=%r state=%r", code, state)
+        msg = "Missing authorization code"
+        if source == "chat":
+            return _chat_callback_page(success=False, error_message=msg)
+        return RedirectResponse(
+            f"/app/oauth/callback?status=error&error={urllib.parse.quote(msg)}",
             status_code=302,
         )
 
@@ -82,22 +103,113 @@ async def oauth_callback(
         await oauth_service.handle_callback(state, code, realm_id=realmId)
     except ValueError as exc:
         logger.warning("OAuth callback failed: %s", exc)
-        msg = urllib.parse.quote(str(exc))
+        if source == "chat":
+            return _chat_callback_page(success=False, error_message=str(exc))
         return RedirectResponse(
-            f"/app/oauth/callback?status=error&error={msg}",
+            f"/app/oauth/callback?status=error&error={urllib.parse.quote(str(exc))}",
             status_code=302,
         )
     except Exception:
         logger.exception("OAuth token exchange failed")
+        if source == "chat":
+            return _chat_callback_page(success=False, error_message="Token exchange failed")
         return RedirectResponse(
             "/app/oauth/callback?status=error&error=Token+exchange+failed",
             status_code=302,
         )
 
+    if source == "chat":
+        return _chat_callback_page(success=True, integration=integration or "unknown")
+
     return RedirectResponse(
         f"/app/oauth/callback?status=success&integration={integration or 'unknown'}",
         status_code=302,
     )
+
+
+def _chat_callback_page(
+    *,
+    success: bool,
+    integration: str = "",
+    error_message: str = "",
+) -> HTMLResponse:
+    """Render a standalone HTML page for chat-initiated OAuth callbacks.
+
+    This page is self-contained (no SPA, no auth required) so it works
+    when users tap an OAuth link from SMS/iMessage and complete the flow
+    in their phone's browser.
+    """
+    if success:
+        title = "Connected"
+        icon = "&#10003;"
+        icon_color = "#17c964"
+        body = (
+            f"<p>{integration.replace('_', ' ').title()} has been connected successfully.</p>"
+            "<p>You can close this tab and go back to your chat.</p>"
+        )
+    else:
+        title = "Connection Failed"
+        icon = "&#10007;"
+        icon_color = "#f31260"
+        safe_error = error_message.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        body = (
+            f"<p>{safe_error or 'Something went wrong. Please try again.'}</p>"
+            "<p>Go back to your chat and ask to try connecting again.</p>"
+        )
+
+    html = f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title} - Clawbolt</title>
+<style>
+  body {{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 Helvetica, Arial, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100dvh;
+    margin: 0;
+    background: #fafafa;
+    color: #333;
+  }}
+  .card {{
+    text-align: center;
+    max-width: 360px;
+    padding: 2.5rem 2rem;
+    background: #fff;
+    border-radius: 1rem;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+  }}
+  .icon {{
+    font-size: 3rem;
+    color: {icon_color};
+    margin-bottom: 0.75rem;
+  }}
+  h1 {{
+    font-size: 1.25rem;
+    margin: 0 0 1rem;
+  }}
+  p {{
+    font-size: 0.9rem;
+    color: #666;
+    margin: 0.5rem 0;
+    line-height: 1.5;
+  }}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">{icon}</div>
+  <h1>{title}</h1>
+  {body}
+</div>
+</body>
+</html>"""
+    return HTMLResponse(content=html)
 
 
 @router.delete("/oauth/{integration}")

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -30,7 +30,7 @@ ensure_tool_modules_imported()
 
 # Factories whose tools are always available and cannot be disabled.
 _CORE_FACTORIES: frozenset[str] = frozenset(
-    {"workspace", "profile", "memory", "messaging", "file", "heartbeat"}
+    {"workspace", "profile", "memory", "messaging", "file", "heartbeat", "integration"}
 )
 
 # Consolidated metadata for each factory group: description, display group,
@@ -50,6 +50,7 @@ _FACTORY_META: dict[str, _FactoryMeta] = {
     "messaging": _FactoryMeta("Send text and media replies to the user"),
     "file": _FactoryMeta("Upload and organize files in cloud storage"),
     "heartbeat": _FactoryMeta("View and edit heartbeat notes"),
+    "integration": _FactoryMeta("Manage integrations, enable/disable tools, connect OAuth"),
     "quickbooks": _FactoryMeta(
         "Query, create, and manage QuickBooks Online entities",
         domain_group="Integrations",

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -71,6 +71,7 @@ class _PendingState:
     code_verifier: str
     redirect_uri: str
     expires_at: float
+    source: str = "web"
 
 
 @dataclass
@@ -144,8 +145,15 @@ class OAuthService:
         self,
         config: OAuthConfig,
         user_id: str,
+        source: str = "web",
     ) -> str:
-        """Build an authorization URL with PKCE and state parameter."""
+        """Build an authorization URL with PKCE and state parameter.
+
+        *source* tracks where the flow was initiated from ("web" for the
+        frontend UI, "chat" for the manage_integration tool). The callback
+        uses this to decide whether to redirect to the SPA or render a
+        standalone confirmation page.
+        """
         self._cleanup_expired_states()
 
         state = secrets.token_urlsafe(32)
@@ -160,6 +168,7 @@ class OAuthService:
             code_verifier=verifier,
             redirect_uri=redirect_uri,
             expires_at=time.time() + _STATE_TTL_SECONDS,
+            source=source,
         )
 
         params: dict[str, str] = {
@@ -599,6 +608,13 @@ class OAuthService:
         if pending is None or time.time() > pending.expires_at:
             return None
         return pending.integration
+
+    def get_pending_state_source(self, state: str) -> str:
+        """Return the source ("web" or "chat") for a pending state."""
+        pending = self._pending_states.get(state)
+        if pending is None or time.time() > pending.expires_at:
+            return "web"
+        return pending.source
 
     def _cleanup_expired_states(self) -> None:
         """Remove expired pending states."""

--- a/tests/test_integration_tools.py
+++ b/tests/test_integration_tools.py
@@ -1,0 +1,377 @@
+"""Tests for the manage_integration chat tool."""
+
+from unittest.mock import patch
+
+import pytest
+
+from backend.app.agent.stores import ToolConfigStore
+from backend.app.agent.tools.base import ToolResult
+from backend.app.agent.tools.integration_tools import create_integration_tools
+from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.registry import (
+    ToolContext,
+    default_registry,
+    ensure_tool_modules_imported,
+)
+from backend.app.models import User
+from backend.app.services.oauth import OAuthConfig
+
+ensure_tool_modules_imported()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _call(user: User, action: str, target: str | None = None) -> ToolResult:
+    """Create tools and call manage_integration with the given args."""
+    ctx = ToolContext(user=user)
+    tools = create_integration_tools(ctx)
+    tool = next(t for t in tools if t.name == ToolName.MANAGE_INTEGRATION)
+    if target is not None:
+        return await tool.function(action=action, target=target)
+    return await tool.function(action=action)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_integration_factory_registered() -> None:
+    """The integration factory should be registered as a core factory."""
+    assert "integration" in default_registry.factory_names
+    assert "integration" in default_registry.core_factory_names
+
+
+@pytest.mark.asyncio()
+async def test_manage_integration_in_core_tools() -> None:
+    """manage_integration should appear in core tools."""
+    user = User(id="test-core-int", user_id="test")
+    ctx = ToolContext(user=user)
+    core_tools = await default_registry.create_core_tools(ctx)
+    names = {t.name for t in core_tools}
+    assert ToolName.MANAGE_INTEGRATION in names
+
+
+# ---------------------------------------------------------------------------
+# Status action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_status_shows_all_groups(test_user: User) -> None:
+    """Status should list all registered tool groups."""
+    result = await _call(test_user, "status")
+    assert not result.is_error
+    # Should contain at least some known groups
+    assert "workspace" in result.content
+    assert "Core tools:" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_status_shows_enabled_disabled(test_user: User) -> None:
+    """Status should reflect disabled groups."""
+    store = ToolConfigStore(test_user.id)
+    await store.set_enabled("calendar", enabled=False)
+
+    result = await _call(test_user, "status")
+    assert not result.is_error
+    assert "disabled" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_status_shows_oauth_connection_state(test_user: User) -> None:
+    """Status should show connected/not connected for OAuth integrations."""
+    mock_config = OAuthConfig(
+        integration="google_calendar",
+        client_id="test-id",
+        client_secret="test-secret",
+        authorize_url="https://accounts.google.com/o/oauth2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        scopes=["https://www.googleapis.com/auth/calendar"],
+    )
+    with (
+        patch(
+            "backend.app.agent.tools.integration_tools.get_oauth_config",
+            return_value=mock_config,
+        ),
+        patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth,
+    ):
+        mock_oauth.is_connected.return_value = False
+        result = await _call(test_user, "status")
+        assert not result.is_error
+        assert "not connected" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Enable action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_enable_domain_tool(test_user: User) -> None:
+    """Enabling a domain tool should persist to the store."""
+    store = ToolConfigStore(test_user.id)
+    await store.set_enabled("calendar", enabled=False)
+
+    # Verify it's disabled
+    disabled = await store.get_disabled_tool_names()
+    assert "calendar" in disabled
+
+    result = await _call(test_user, "enable", "calendar")
+    assert not result.is_error
+    assert "Enabled" in result.content
+
+    disabled = await store.get_disabled_tool_names()
+    assert "calendar" not in disabled
+
+
+@pytest.mark.asyncio()
+async def test_enable_core_tool_noop(test_user: User) -> None:
+    """Enabling a core tool should return a message (it's always enabled)."""
+    result = await _call(test_user, "enable", "workspace")
+    assert not result.is_error
+    assert "always enabled" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_enable_unknown_tool_rejected(test_user: User) -> None:
+    """Enabling an unknown tool should return an error."""
+    result = await _call(test_user, "enable", "foobar")
+    assert result.is_error
+    assert "Unknown tool group" in result.content
+    assert "foobar" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Disable action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_disable_domain_tool(test_user: User) -> None:
+    """Disabling a domain tool should persist to the store."""
+    store = ToolConfigStore(test_user.id)
+
+    result = await _call(test_user, "disable", "calendar")
+    assert not result.is_error
+    assert "Disabled" in result.content
+
+    disabled = await store.get_disabled_tool_names()
+    assert "calendar" in disabled
+
+
+@pytest.mark.asyncio()
+async def test_disable_core_tool_rejected(test_user: User) -> None:
+    """Disabling a core tool should return an error."""
+    result = await _call(test_user, "disable", "workspace")
+    assert result.is_error
+    assert "cannot be disabled" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_disable_unknown_tool_rejected(test_user: User) -> None:
+    """Disabling an unknown tool should return an error."""
+    result = await _call(test_user, "disable", "foobar")
+    assert result.is_error
+    assert "Unknown tool group" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Connect action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_connect_returns_oauth_url(test_user: User) -> None:
+    """Connecting should return an OAuth URL."""
+    mock_config = OAuthConfig(
+        integration="google_calendar",
+        client_id="test-id",
+        client_secret="test-secret",
+        authorize_url="https://accounts.google.com/o/oauth2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        scopes=["https://www.googleapis.com/auth/calendar"],
+    )
+    with (
+        patch(
+            "backend.app.agent.tools.integration_tools.get_oauth_config",
+            return_value=mock_config,
+        ),
+        patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth,
+    ):
+        mock_oauth.is_connected.return_value = False
+        mock_oauth.get_authorization_url.return_value = (
+            "https://accounts.google.com/o/oauth2/auth?client_id=test"
+        )
+
+        result = await _call(test_user, "connect", "google_calendar")
+        assert not result.is_error
+        assert "https://accounts.google.com" in result.content
+        mock_oauth.get_authorization_url.assert_called_once_with(
+            mock_config, test_user.id, source="chat"
+        )
+
+
+@pytest.mark.asyncio()
+async def test_connect_via_tool_group_name(test_user: User) -> None:
+    """Connecting with tool group name 'calendar' should map to 'google_calendar'."""
+    mock_config = OAuthConfig(
+        integration="google_calendar",
+        client_id="test-id",
+        client_secret="test-secret",
+        authorize_url="https://accounts.google.com/o/oauth2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        scopes=["https://www.googleapis.com/auth/calendar"],
+    )
+    with (
+        patch(
+            "backend.app.agent.tools.integration_tools.get_oauth_config",
+            return_value=mock_config,
+        ),
+        patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth,
+    ):
+        mock_oauth.is_connected.return_value = False
+        mock_oauth.get_authorization_url.return_value = "https://example.com/auth"
+
+        result = await _call(test_user, "connect", "calendar")
+        assert not result.is_error
+        assert "https://example.com/auth" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_connect_unconfigured_integration(test_user: User) -> None:
+    """Connecting a not-configured integration should return an error."""
+    with patch(
+        "backend.app.agent.tools.integration_tools.get_oauth_config",
+        return_value=None,
+    ):
+        result = await _call(test_user, "connect", "google_calendar")
+        assert result.is_error
+        assert "not configured" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_connect_non_oauth_integration(test_user: User) -> None:
+    """Connecting a non-OAuth integration should return an error."""
+    result = await _call(test_user, "connect", "supplier_pricing")
+    assert result.is_error
+    assert "does not use OAuth" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_connect_already_connected(test_user: User) -> None:
+    """Connecting an already-connected integration should inform the user."""
+    mock_config = OAuthConfig(
+        integration="google_calendar",
+        client_id="test-id",
+        client_secret="test-secret",
+        authorize_url="https://accounts.google.com/o/oauth2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        scopes=["https://www.googleapis.com/auth/calendar"],
+    )
+    with (
+        patch(
+            "backend.app.agent.tools.integration_tools.get_oauth_config",
+            return_value=mock_config,
+        ),
+        patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth,
+    ):
+        mock_oauth.is_connected.return_value = True
+
+        result = await _call(test_user, "connect", "google_calendar")
+        assert not result.is_error
+        assert "already connected" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Disconnect action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_disconnect_removes_tokens(test_user: User) -> None:
+    """Disconnecting should call delete_token on the OAuth service."""
+    with patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth:
+        mock_oauth.is_connected.return_value = True
+        mock_oauth.delete_token.return_value = True
+
+        result = await _call(test_user, "disconnect", "google_calendar")
+        assert not result.is_error
+        assert "Disconnected" in result.content
+        mock_oauth.delete_token.assert_called_once_with(test_user.id, "google_calendar")
+
+
+@pytest.mark.asyncio()
+async def test_disconnect_not_connected(test_user: User) -> None:
+    """Disconnecting a not-connected integration should return an error."""
+    with patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth:
+        mock_oauth.is_connected.return_value = False
+
+        result = await _call(test_user, "disconnect", "google_calendar")
+        assert result.is_error
+        assert "not currently connected" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_disconnect_non_oauth(test_user: User) -> None:
+    """Disconnecting a non-OAuth integration should return an error."""
+    result = await _call(test_user, "disconnect", "supplier_pricing")
+    assert result.is_error
+    assert "does not use OAuth" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_invalid_action(test_user: User) -> None:
+    """An unknown action should return an error."""
+    result = await _call(test_user, "foobar", "calendar")
+    assert result.is_error
+    assert "Unknown action" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_missing_target_for_enable(test_user: User) -> None:
+    """Enable without a target should return an error."""
+    result = await _call(test_user, "enable")
+    assert result.is_error
+    assert "requires a target" in result.content
+
+
+# ---------------------------------------------------------------------------
+# ToolConfigStore.set_enabled unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_set_enabled_creates_new_row(test_user: User) -> None:
+    """set_enabled should create a row when none exists."""
+    store = ToolConfigStore(test_user.id)
+
+    # Initially no disabled tools
+    disabled = await store.get_disabled_tool_names()
+    assert "calendar" not in disabled
+
+    await store.set_enabled("calendar", enabled=False)
+    disabled = await store.get_disabled_tool_names()
+    assert "calendar" in disabled
+
+
+@pytest.mark.asyncio()
+async def test_set_enabled_updates_existing_row(test_user: User) -> None:
+    """set_enabled should update an existing row."""
+    store = ToolConfigStore(test_user.id)
+
+    await store.set_enabled("calendar", enabled=False)
+    disabled = await store.get_disabled_tool_names()
+    assert "calendar" in disabled
+
+    await store.set_enabled("calendar", enabled=True)
+    disabled = await store.get_disabled_tool_names()
+    assert "calendar" not in disabled

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -653,3 +653,138 @@ def test_oauth_callback_with_provider_error(client: TestClient) -> None:
     assert resp.status_code == 302
     location = resp.headers["location"]
     assert "User" in location and "denied" in location
+
+
+def test_oauth_callback_missing_code(client: TestClient) -> None:
+    """Callback without code param (e.g. user denied) should redirect with error."""
+    resp = client.get(
+        "/api/oauth/callback?error=access_denied",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "error" in resp.headers["location"]
+
+
+def test_oauth_callback_empty_code_no_error(client: TestClient) -> None:
+    """Callback with empty code and no error should redirect with error."""
+    resp = client.get(
+        "/api/oauth/callback?state=some_state",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "error" in resp.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# Chat-initiated OAuth callback (standalone HTML)
+# ---------------------------------------------------------------------------
+
+
+def test_chat_callback_success_returns_html(
+    client: TestClient, qb_config: OAuthConfig, test_user: User
+) -> None:
+    """Chat-initiated OAuth success should return HTML, not a redirect."""
+    url = oauth_service.get_authorization_url(qb_config, user_id=test_user.id, source="chat")
+    import urllib.parse as _up
+
+    state = _up.parse_qs(_up.urlparse(url).query)["state"][0]
+
+    mock_request = httpx.Request("POST", "https://example.com/token")
+    mock_response = httpx.Response(
+        200,
+        json={
+            "access_token": "at",
+            "refresh_token": "rt",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        request=mock_request,
+    )
+    with (
+        patch.object(oauth_service, "_get_http") as mock_http_fn,
+        patch(
+            "backend.app.services.oauth.get_oauth_config",
+            return_value=qb_config,
+        ),
+    ):
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_http_fn.return_value = mock_client
+
+        resp = client.get(
+            f"/api/oauth/callback?code=auth-code&state={state}&realmId=r1",
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "Connected" in resp.text
+    assert "close this tab" in resp.text
+
+
+def test_chat_callback_error_returns_html(client: TestClient) -> None:
+    """Chat-initiated OAuth error should return HTML, not a redirect."""
+    # Inject a pending state with source="chat" so the callback renders HTML
+    import time
+
+    from backend.app.services.oauth import _PendingState
+
+    state_key = "chat-error-test-state"
+    oauth_service._pending_states[state_key] = _PendingState(
+        user_id="test",
+        integration="google_calendar",
+        code_verifier="v",
+        redirect_uri="http://localhost/api/oauth/callback",
+        expires_at=time.time() + 600,
+        source="chat",
+    )
+
+    resp = client.get(
+        f"/api/oauth/callback?state={state_key}&error=access_denied"
+        "&error_description=User+denied+access",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "Connection Failed" in resp.text
+    assert "User denied access" in resp.text
+
+
+def test_web_callback_still_redirects(
+    client: TestClient, qb_config: OAuthConfig, test_user: User
+) -> None:
+    """Web-initiated OAuth success should still redirect to the SPA."""
+    url = oauth_service.get_authorization_url(qb_config, user_id=test_user.id)
+    import urllib.parse as _up
+
+    state = _up.parse_qs(_up.urlparse(url).query)["state"][0]
+
+    mock_request = httpx.Request("POST", "https://example.com/token")
+    mock_response = httpx.Response(
+        200,
+        json={
+            "access_token": "at",
+            "refresh_token": "rt",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        request=mock_request,
+    )
+    with (
+        patch.object(oauth_service, "_get_http") as mock_http_fn,
+        patch(
+            "backend.app.services.oauth.get_oauth_config",
+            return_value=qb_config,
+        ),
+    ):
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_http_fn.return_value = mock_client
+
+        resp = client.get(
+            f"/api/oauth/callback?code=auth-code&state={state}&realmId=r1",
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 302
+    assert "/app/oauth/callback?status=success" in resp.headers["location"]

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -12,6 +12,7 @@ EXPECTED_TOOL_MODULES: set[str] = {
     "backend.app.agent.tools.messaging_tools",
     "backend.app.agent.tools.heartbeat_tools",
     "backend.app.agent.tools.file_tools",
+    "backend.app.agent.tools.integration_tools",
     "backend.app.agent.tools.pricing_tools",
     "backend.app.agent.tools.quickbooks_tools",
     "backend.app.agent.tools.calendar_tools",


### PR DESCRIPTION
## Description

Adds a new `manage_integration` core agent tool so users can manage all integrations over chat (SMS/iMessage/Telegram) without needing the web UI. Closes #869.

**What the user can do now over chat:**
- "What integrations do I have?" -> agent calls `manage_integration(status)` and lists all tool groups with connection status
- "Disable QuickBooks" -> agent calls `manage_integration(disable, "quickbooks")`
- "Connect my Google Calendar" -> agent calls `manage_integration(connect, "google_calendar")` and sends a tappable OAuth link
- "Disconnect calendar" -> agent calls `manage_integration(disconnect, "google_calendar")`

**OAuth chat flow:** User taps the link in their chat app, completes OAuth in their phone browser, and sees a standalone "Connected! You can close this tab" HTML page (no SPA auth required). Web-initiated OAuth still redirects to the SPA as before.

**Also fixes:** OAuth callback returned 422 when the provider redirected with an error (no `code` param). Now handles missing `code`/`state` gracefully.

### Files changed

| File | Change |
|---|---|
| `backend/app/agent/tools/integration_tools.py` | New tool: `manage_integration` with 5 actions |
| `backend/app/agent/tools/names.py` | Add `MANAGE_INTEGRATION` constant |
| `backend/app/agent/stores.py` | Add `ToolConfigStore.set_enabled()` for single-group toggle |
| `backend/app/agent/prompts/instructions.md` | Add integration management guidance |
| `backend/app/routers/oauth.py` | Chat vs web callback branching, fix optional params |
| `backend/app/services/oauth.py` | Add `source` tracking to OAuth state |
| `backend/app/agent/tools/calendar_tools.py` | Update auth_check message |
| `backend/app/agent/tools/quickbooks_tools.py` | Update auth_check message |
| `backend/app/routers/user_tools.py` | Add `integration` to core factories |
| `tests/test_integration_tools.py` | 23 new tests |
| `tests/test_oauth.py` | 5 new tests |
| `tests/test_tool_registry.py` | Update expected modules |

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- 1545 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality -- 28 new tests
- [x] Bug fixes include regression tests -- OAuth callback 422 fix has 2 regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.6 via Claude Code for implementation, testing, and review)
- [ ] No AI used