### PR TITLE
fix: regenerate openapi.json and api.d.ts for optional OAuth params

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -105,24 +105,26 @@
     "/api/oauth/callback": {
       "get": {
         "summary": "Oauth Callback",
-        "description": "Handle OAuth provider redirect after user authorization.\n\nThe provider redirects here with an authorization code and the state\nparameter we generated earlier. We exchange the code for tokens,\npersist them, and redirect the user to the frontend success page.",
+        "description": "Handle OAuth provider redirect after user authorization.\n\nThe provider redirects here with an authorization code and the state\nparameter we generated earlier. We exchange the code for tokens,\npersist them, and redirect the user to the frontend success page.\n\nAll parameters are optional because OAuth providers may redirect with\nonly error parameters (no code/state) when the user denies access.\n\nWhen the flow was initiated from chat (source=\"chat\"), a standalone\nHTML page is returned instead of redirecting to the SPA, so users\non SMS/iMessage see a \"you can close this tab\" message.",
         "operationId": "oauth_callback_api_oauth_callback_get",
         "parameters": [
           {
             "name": "code",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
+              "default": "",
               "title": "Code"
             }
           },
           {
             "name": "state",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
+              "default": "",
               "title": "State"
             }
           },

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -92,6 +92,13 @@ export interface paths {
          *     The provider redirects here with an authorization code and the state
          *     parameter we generated earlier. We exchange the code for tokens,
          *     persist them, and redirect the user to the frontend success page.
+         *
+         *     All parameters are optional because OAuth providers may redirect with
+         *     only error parameters (no code/state) when the user denies access.
+         *
+         *     When the flow was initiated from chat (source="chat"), a standalone
+         *     HTML page is returned instead of redirecting to the SPA, so users
+         *     on SMS/iMessage see a "you can close this tab" message.
          */
         get: operations["oauth_callback_api_oauth_callback_get"];
         put?: never;
@@ -1378,9 +1385,9 @@ export interface operations {
     };
     oauth_callback_api_oauth_callback_get: {
         parameters: {
-            query: {
-                code: string;
-                state: string;
+            query?: {
+                code?: string;
+                state?: string;
                 realmId?: string;
                 error?: string;
                 error_description?: string;


### PR DESCRIPTION
## Summary
- Regenerates `frontend/openapi.json` and `frontend/src/generated/api.d.ts` to match the backend changes from #869 where `code` and `state` became optional on the OAuth callback endpoint.

## Test plan
- [ ] CI `frontend-lint` check passes (the "generated types are up to date" step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)