### PR TITLE
fix: address production log issues (webhook auth, polling, caching)

### DIFF
--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -116,19 +116,21 @@ def init_storage(user: User) -> StorageBackend | None:
 
     Returns the storage backend if configured, or ``None`` otherwise.
     """
-    try:
-        has_storage = (
-            settings.storage_provider == "local"
-            or (settings.storage_provider == "dropbox" and settings.dropbox_access_token)
-            or (
-                settings.storage_provider == "google_drive"
-                and settings.google_drive_credentials_json
-            )
+    has_storage = (
+        settings.storage_provider == "local"
+        or (settings.storage_provider == "dropbox" and settings.dropbox_access_token)
+        or (settings.storage_provider == "google_drive" and settings.google_drive_credentials_json)
+    )
+    if not has_storage:
+        logger.debug(
+            "Storage not configured (provider=%r), skipping file features",
+            settings.storage_provider,
         )
-        if has_storage:
-            return get_storage_service(user=user)
+        return None
+    try:
+        return get_storage_service(user=user)
     except Exception:
-        logger.debug("Storage not configured, skipping file features")
+        logger.exception("Storage backend %r failed to initialize", settings.storage_provider)
     return None
 
 

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -27,31 +27,61 @@ class SystemPromptBuilder:
     into a single string with Markdown-style ``## Heading`` separators.
     No ``str.format()`` is used, so user-supplied content with curly
     braces is safe.
+
+    Sections may be marked ``dynamic=True`` to indicate their content
+    changes between calls (e.g. memory, cross-session context).
+    ``build_content_blocks()`` uses this flag to split the prompt into
+    a cacheable stable prefix and a non-cached dynamic suffix so that
+    Anthropic prompt caching can reuse the stable prefix across turns.
     """
 
     def __init__(self) -> None:
         self._preamble: str = ""
-        self._sections: list[tuple[str, str]] = []
+        self._sections: list[tuple[str, str, bool]] = []  # (heading, content, dynamic)
 
     def set_preamble(self, text: str) -> SystemPromptBuilder:
         """Set the opening line(s) before any sections."""
         self._preamble = text
         return self
 
-    def add_section(self, heading: str, content: str) -> SystemPromptBuilder:
-        """Append a named section.  Empty content sections are skipped in output."""
-        self._sections.append((heading, content))
+    def add_section(
+        self,
+        heading: str,
+        content: str,
+        *,
+        dynamic: bool = False,
+    ) -> SystemPromptBuilder:
+        """Append a named section.  Empty content sections are skipped in output.
+
+        Mark ``dynamic=True`` for sections whose content changes between
+        turns (memory, cross-session context) so they are excluded from
+        the prompt cache prefix.
+        """
+        self._sections.append((heading, content, dynamic))
         return self
 
+    # Marker inserted between stable and dynamic sections so the caching
+    # layer can split the prompt into a cacheable prefix and a dynamic suffix.
+    CACHE_BOUNDARY = "\n<!-- CACHE_BOUNDARY -->\n"
+
     def build(self) -> str:
-        """Assemble all sections into the final prompt string."""
+        """Assemble all sections into the final prompt string.
+
+        A ``CACHE_BOUNDARY`` marker is inserted before the first dynamic
+        section so ``prepare_system_with_caching()`` can split the prompt
+        into a cacheable stable prefix and a non-cached dynamic suffix.
+        """
         parts: list[str] = []
         if self._preamble:
             parts.append(self._preamble)
 
-        for heading, content in self._sections:
+        hit_dynamic = False
+        for heading, content, dynamic in self._sections:
             if not content:
                 continue
+            if dynamic and not hit_dynamic:
+                hit_dynamic = True
+                parts.append(self.CACHE_BOUNDARY.strip())
             parts.append(f"## {heading}\n{content}")
 
         return "\n\n".join(parts)
@@ -212,9 +242,6 @@ async def build_agent_system_prompt(
 
     builder.add_section("About Your User", build_user_section(user))
 
-    memory = await build_memory_section(user.id, query=message_context)
-    builder.add_section("Your Memory", memory)
-
     tool_guidelines = build_tool_guidelines_section(tools)
     if tool_guidelines:
         instructions = (
@@ -227,10 +254,15 @@ async def build_agent_system_prompt(
     builder.add_section("Proactive Messaging", build_proactive_section())
     builder.add_section("Recall Behavior", build_recall_section())
 
+    # Dynamic sections: content changes between turns, placed after the
+    # stable prefix so prompt caching can reuse the stable portion.
+    memory = await build_memory_section(user.id, query=message_context)
+    builder.add_section("Your Memory", memory, dynamic=True)
+
     if current_session_id:
         cross = build_cross_session_context(user.id, current_session_id)
         if cross:
-            builder.add_section("Recent Activity (other channel)", cross)
+            builder.add_section("Recent Activity (other channel)", cross, dynamic=True)
 
     return builder.build()
 

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -30,9 +30,9 @@ class SystemPromptBuilder:
 
     Sections may be marked ``dynamic=True`` to indicate their content
     changes between calls (e.g. memory, cross-session context).
-    ``build_content_blocks()`` uses this flag to split the prompt into
-    a cacheable stable prefix and a non-cached dynamic suffix so that
-    Anthropic prompt caching can reuse the stable prefix across turns.
+    ``build()`` uses this flag to split the prompt into a cacheable
+    stable prefix and a non-cached dynamic suffix so that Anthropic
+    prompt caching can reuse the stable prefix across turns.
     """
 
     def __init__(self) -> None:

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -440,12 +440,20 @@ class ToolRegistry:
 default_registry = ToolRegistry()
 
 
+_tool_modules_imported = False
+
+
 def ensure_tool_modules_imported() -> None:
     """Auto-discover and import all tool modules that end with ``_tools``.
 
-    This is idempotent: Python's import system caches modules, so repeated
-    calls are essentially free.
+    Guarded so the discovery loop and its log messages only run once,
+    even when called from multiple import sites.
     """
+    global _tool_modules_imported
+    if _tool_modules_imported:
+        return
+    _tool_modules_imported = True
+
     package = importlib.import_module("backend.app.agent.tools")
     for _, name, _ in pkgutil.iter_modules(package.__path__, package.__name__ + "."):
         if name.endswith("_tools"):

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -293,8 +293,14 @@ class BlueBubblesChannel(BaseChannel):
             _rate_limit: None = Depends(check_webhook_rate_limit),
         ) -> JSONResponse:
             """Receive inbound messages from BlueBubbles."""
-            # Validate webhook token (derived from password; never log the raw password)
+            # Validate webhook token.  Accept either the derived ?token= or
+            # the raw ?password= (BlueBubbles appends the password to webhook
+            # URLs by default, so stale registrations use that form).
             token = request.query_params.get("token", "")
+            if not token:
+                raw_pw = request.query_params.get("password", "")
+                if raw_pw:
+                    token = _derive_webhook_token(raw_pw)
             expected = _derive_webhook_token(settings.bluebubbles_password)
             if settings.bluebubbles_password and not hmac.compare_digest(token, expected):
                 logger.warning("Invalid BlueBubbles webhook token")

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -68,13 +68,30 @@ async def get_models(
 # ---------------------------------------------------------------------------
 
 
-def prepare_system_with_caching(system: str) -> list[dict[str, Any]]:
-    """Wrap a system prompt string as a content block with cache_control.
+_CACHE_BOUNDARY = "<!-- CACHE_BOUNDARY -->"
 
-    Returns the format expected by the Anthropic Messages API for prompt
-    caching. Providers that do not support caching silently ignore the
+
+def prepare_system_with_caching(system: str) -> list[dict[str, Any]]:
+    """Wrap a system prompt string as content blocks with cache_control.
+
+    If the prompt contains a ``<!-- CACHE_BOUNDARY -->`` marker (inserted
+    by ``SystemPromptBuilder``), the text before the marker is cached and
+    the text after it is sent without caching.  This allows the stable
+    prefix (identity, instructions) to be reused across turns even when
+    dynamic sections (memory, cross-session context) change.
+
+    Providers that do not support caching silently ignore the
     ``cache_control`` key.
     """
+    if _CACHE_BOUNDARY in system:
+        stable, dynamic = system.split(_CACHE_BOUNDARY, 1)
+        blocks: list[dict[str, Any]] = [
+            {"type": "text", "text": stable.strip(), "cache_control": {"type": "ephemeral"}},
+        ]
+        dynamic = dynamic.strip()
+        if dynamic:
+            blocks.append({"type": "text", "text": dynamic})
+        return blocks
     return [{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]
 
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -97,10 +97,11 @@ export default function ChatPage() {
     return () => controller.abort();
   }, [queryClient]);
 
-  // Fetch session history via React Query (poll every 3s when idle)
+  // Fetch session history via React Query.  The activity SSE stream
+  // already invalidates queries on the "done" event, so periodic
+  // polling is unnecessary and wasteful.
   const { data: sessionDetail, isPending: loadingHistoryPending, isError: historyError } = useSession(
     activeSessionId,
-    sending ? false : 3_000,
   );
   const loadingHistory = loadingHistoryPending && !!activeSessionId;
 

--- a/tests/test_bluebubbles_channel.py
+++ b/tests/test_bluebubbles_channel.py
@@ -26,11 +26,14 @@ def _post_webhook(
     client: TestClient,
     payload: dict,
     token: str = "",
+    password: str = "",
 ) -> httpx.Response:
-    """Post a BlueBubbles webhook with optional token query param."""
+    """Post a BlueBubbles webhook with optional token or password query param."""
     url = "/api/webhooks/bluebubbles"
     if token:
         url = f"{url}?token={token}"
+    elif password:
+        url = f"{url}?password={password}"
     return client.post(url, json=payload)
 
 
@@ -159,6 +162,39 @@ def test_correct_token_publishes(bluebubbles_client: TestClient) -> None:
 
     assert resp.status_code == 200
     mock_pub.assert_called_once()
+
+
+def test_correct_password_param_publishes(bluebubbles_client: TestClient) -> None:
+    """Webhook with correct raw ?password= should also pass auth and publish."""
+    password = "correct-password"
+    with (
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_password",
+            password,
+        ),
+    ):
+        payload = make_bluebubbles_webhook_payload(text="Hi via password")
+        resp = _post_webhook(bluebubbles_client, payload, password=password)
+
+    assert resp.status_code == 200
+    mock_pub.assert_called_once()
+
+
+def test_wrong_password_param_does_not_publish(bluebubbles_client: TestClient) -> None:
+    """Webhook with incorrect raw ?password= should not publish."""
+    with (
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_password",
+            "correct-password",
+        ),
+    ):
+        payload = make_bluebubbles_webhook_payload(text="Hi")
+        resp = _post_webhook(bluebubbles_client, payload, password="wrong-password")
+
+    assert resp.status_code == 200
+    mock_pub.assert_not_called()
 
 
 def test_raw_password_never_in_webhook_url() -> None:

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -88,6 +88,72 @@ class TestSystemPromptBuilder:
         assert "## B" in result
 
 
+class TestCacheBoundary:
+    def test_boundary_inserted_before_dynamic(self) -> None:
+        """CACHE_BOUNDARY marker should appear before the first dynamic section."""
+        builder = SystemPromptBuilder()
+        builder.set_preamble("Preamble")
+        builder.add_section("Stable", "stable content")
+        builder.add_section("Dynamic", "dynamic content", dynamic=True)
+        result = builder.build()
+        assert SystemPromptBuilder.CACHE_BOUNDARY.strip() in result
+        idx = result.index(SystemPromptBuilder.CACHE_BOUNDARY.strip())
+        assert result.index("stable content") < idx
+        assert result.index("dynamic content") > idx
+
+    def test_no_boundary_when_all_stable(self) -> None:
+        """No marker should appear when no sections are dynamic."""
+        builder = SystemPromptBuilder()
+        builder.set_preamble("Preamble")
+        builder.add_section("A", "content a")
+        builder.add_section("B", "content b")
+        result = builder.build()
+        assert SystemPromptBuilder.CACHE_BOUNDARY.strip() not in result
+
+    def test_prepare_system_splits_on_boundary(self) -> None:
+        """prepare_system_with_caching should split into two blocks at the marker."""
+        from backend.app.services.llm_service import prepare_system_with_caching
+
+        builder = SystemPromptBuilder()
+        builder.set_preamble("Preamble")
+        builder.add_section("Instructions", "be helpful")
+        builder.add_section("Memory", "user likes coffee", dynamic=True)
+        prompt = builder.build()
+        blocks = prepare_system_with_caching(prompt)
+        assert len(blocks) == 2
+        assert "cache_control" in blocks[0]
+        assert "cache_control" not in blocks[1]
+        assert "be helpful" in blocks[0]["text"]
+        assert "user likes coffee" in blocks[1]["text"]
+
+    def test_prepare_system_single_block_without_boundary(self) -> None:
+        """Without a boundary marker the whole prompt is one cached block."""
+        from backend.app.services.llm_service import prepare_system_with_caching
+
+        blocks = prepare_system_with_caching("Just a plain prompt")
+        assert len(blocks) == 1
+        assert "cache_control" in blocks[0]
+
+    def test_agent_prompt_has_boundary(self) -> None:
+        """build_agent_system_prompt should include the cache boundary marker."""
+        user = MagicMock()
+        user.id = "user-123"
+        user.soul_text = "soul"
+        user.user_text = "user info"
+        user.timezone = ""
+        with patch(
+            "backend.app.agent.system_prompt.build_memory_context",
+            new_callable=AsyncMock,
+            return_value="some memory",
+        ):
+            import asyncio
+
+            prompt = asyncio.get_event_loop().run_until_complete(
+                build_agent_system_prompt(user, tools=[], message_context="hello")
+            )
+        assert SystemPromptBuilder.CACHE_BOUNDARY.strip() in prompt
+
+
 class TestSectionBuilders:
     def test_build_identity_section(self) -> None:
         """Should include soul_text content."""

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 import importlib
 from unittest.mock import patch
 
+import pytest
+
+import backend.app.agent.tools.registry as _reg
 from backend.app.agent.tools.registry import ensure_tool_modules_imported
+
+
+@pytest.fixture(autouse=True)
+def _reset_import_guard() -> None:
+    """Reset the once-only guard so each test triggers fresh discovery."""
+    _reg._tool_modules_imported = False
+
 
 EXPECTED_TOOL_MODULES: set[str] = {
     "backend.app.agent.tools.memory_tools",


### PR DESCRIPTION
## Description

Four fixes identified from production log analysis:

1. **BlueBubbles webhook accepts `?password=` param**: Stale BlueBubbles webhook registrations send the raw password instead of the derived HMAC token, causing "Invalid BlueBubbles webhook token" warnings on every delivery. The handler now derives the token from `?password=` when `?token=` is absent, so both URL forms authenticate correctly.

2. **Remove redundant 3s session polling**: The frontend polled `GET /api/user/sessions/` every 3 seconds even while the SSE activity stream was connected. The SSE `done` event already invalidates the React Query cache, so the polling was pure waste (visible in logs as a stream of 200s from multiple load balancer IPs).

3. **Tool registry runs once**: `ensure_tool_modules_imported()` was called from multiple import sites (`router.py`, `user_tools.py`), logging duplicate "Imported tool module" lines each time. Added a module-level guard so discovery and logging runs only once.

4. **Prompt cache split for stable/dynamic sections**: The system prompt was cached as a single Anthropic content block, but the memory and cross-session context sections change between turns, busting the cache every time (`cache_read=0`). Now inserts a `CACHE_BOUNDARY` marker between stable sections (identity, instructions) and dynamic sections (memory, cross-session context). `prepare_system_with_caching()` splits on this marker to produce two content blocks: the stable prefix with `cache_control` and the dynamic suffix without.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) - 1552 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests
- [x] Frontend TypeScript type check passes
- [x] Frontend dead code check passes

## AI Usage
- [x] AI-assisted: all changes authored with Claude Code
- [ ] No AI used