### PR TITLE
fix: skip tunnel discovery when PaaS webhook registered, clean up stale BB webhooks

### DIFF
--- a/backend/app/channels/base.py
+++ b/backend/app/channels/base.py
@@ -49,6 +49,11 @@ class BaseChannel(ABC):
     ``send_typing_indicator``, ``download_media``) to deliver messages.
     """
 
+    # Set to True after a successful PaaS webhook registration so the
+    # OSS ``start()`` method can skip the cloudflared tunnel discovery
+    # retry loop (which is only useful for local dev tunnels).
+    webhook_registered: bool = False
+
     @property
     @abstractmethod
     def name(self) -> str:

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -89,12 +89,50 @@ class BBWebhookPayload(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+async def _cleanup_stale_webhooks(server_url: str, our_endpoint: str) -> None:
+    """Remove existing BlueBubbles webhooks that point to our endpoint.
+
+    BlueBubbles accumulates webhook registrations on each startup.  This
+    lists all registered webhooks and deletes any whose URL contains our
+    endpoint path, preventing duplicate deliveries.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{server_url}/api/v1/webhook",
+                params={"password": settings.bluebubbles_password},
+                timeout=settings.http_timeout_seconds,
+            )
+            if resp.status_code >= 400:
+                return
+            data = resp.json()
+            webhooks = data if isinstance(data, list) else data.get("data", [])
+            for wh in webhooks:
+                wh_url = wh.get("url", "")
+                wh_id = wh.get("id")
+                if not wh_id or our_endpoint not in wh_url:
+                    continue
+                await client.delete(
+                    f"{server_url}/api/v1/webhook/{wh_id}",
+                    params={"password": settings.bluebubbles_password},
+                    timeout=settings.http_timeout_seconds,
+                )
+                logger.info("Removed stale BlueBubbles webhook %s", wh_id)
+    except Exception:
+        logger.debug("Could not clean up stale BlueBubbles webhooks", exc_info=True)
+
+
 async def register_bluebubbles_webhook(server_url: str, webhook_url: str) -> bool:
     """Register a webhook subscription with the BlueBubbles server.
 
-    Calls ``POST /api/v1/webhook`` to register *webhook_url* for
-    ``new-message`` events. Returns ``True`` on success.
+    Cleans up any existing webhooks for our endpoint first to prevent
+    duplicate deliveries, then calls ``POST /api/v1/webhook`` to register
+    *webhook_url* for ``new-message`` events.  Returns ``True`` on success.
     """
+    # Remove stale registrations before adding the new one
+    endpoint = webhook_url.split("?")[0]
+    await _cleanup_stale_webhooks(server_url, endpoint)
+
     url = f"{server_url}/api/v1/webhook"
     payload = {
         "url": webhook_url,
@@ -117,8 +155,7 @@ async def register_bluebubbles_webhook(server_url: str, webhook_url: str) -> boo
                 return False
 
             # Log without the token query param
-            safe_url = webhook_url.split("?")[0]
-            logger.info("BlueBubbles webhook registered: %s", safe_url)
+            logger.info("BlueBubbles webhook registered: %s", endpoint)
             return True
     except httpx.ConnectError as exc:
         logger.warning("BlueBubbles server not reachable at %s: %s", server_url, exc)
@@ -182,6 +219,11 @@ class BlueBubblesChannel(BaseChannel):
             return
 
         await asyncio.sleep(STARTUP_DELAY_SECONDS)
+
+        # If a PaaS webhook was already registered (e.g. via premium on
+        # Railway), skip the tunnel discovery retry loop entirely.
+        if self.webhook_registered:
+            return
 
         # Verify the server is actually reachable before advertising as configured.
         self.server_reachable = await self._check_server_reachable()

--- a/backend/app/channels/linq.py
+++ b/backend/app/channels/linq.py
@@ -180,6 +180,8 @@ class LinqChannel(BaseChannel):
             return
 
         await asyncio.sleep(STARTUP_DELAY_SECONDS)
+        if self.webhook_registered:
+            return
         tunnel_url = await discover_tunnel_url()
         if not tunnel_url:
             logger.debug("Cloudflare tunnel not detected: skipping Linq webhook auto-registration")

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -237,6 +237,8 @@ class TelegramChannel(BaseChannel):
         Telegram can reach the webhook URL during its validation check.
         """
         await asyncio.sleep(STARTUP_DELAY_SECONDS)
+        if self.webhook_registered:
+            return
         tunnel_url = await discover_tunnel_url()
         if not tunnel_url:
             logger.debug("Cloudflare tunnel not detected: skipping webhook auto-registration")


### PR DESCRIPTION
## Description

Two fixes for production log noise:

1. **Skip tunnel discovery on PaaS**: Added `webhook_registered` flag to `BaseChannel`. When premium sets this flag after successful PaaS webhook registration, the OSS `start()` methods skip the 20-second cloudflared retry loop entirely. Eliminates the "cloudflared not ready (attempt X/10)" spam on Railway.

2. **Clean up stale BB webhooks**: Before registering a new BlueBubbles webhook, lists existing webhooks via `GET /api/v1/webhook` and deletes any pointing to our endpoint. Prevents duplicate deliveries from accumulated registrations across container restarts.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) - 1552 passed
- [x] Lint passes
- [x] Backward compatible: `webhook_registered` defaults to `False`, so OSS-only deployments are unaffected