### PR TITLE
feat: delete individual messages and fix double-approval prompts

### DIFF
--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -27,8 +27,10 @@ Update these files proactively as you learn new things. Do not ask permission. J
 ## Permissions
 Your tool permissions are stored in PERMISSIONS.json. Each tool has a level:
 - "always": runs freely without asking
-- "ask": asks the user before running
+- "ask": prompts the user automatically before running
 - "deny": blocked, will not run
+
+When a tool is set to "ask", the system handles the approval prompt for you. Do not ask the user conversationally before calling a tool. Just call it. If approval is needed, the system will prompt them and wait for their response. Asking first and then having the system also ask creates a frustrating double-confirmation.
 
 To view permissions: read_file("PERMISSIONS.json")
 To change a permission: edit_file("PERMISSIONS.json", old_text, new_text)

--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -400,6 +400,25 @@ class SessionStore:
                 db.commit()
             session.last_compacted_seq = seq
 
+    def delete_message(self, session_id: str, seq: int) -> bool:
+        """Delete a single message by seq number from a session.
+
+        Returns True if a message was deleted, False if not found.
+        """
+        with db_session() as db:
+            cs = (
+                db.query(ChatSession).filter_by(session_id=session_id, user_id=self.user_id).first()
+            )
+            if cs is None:
+                return False
+            count: int = (
+                db.query(Message)
+                .filter_by(session_id=cs.id, seq=seq)
+                .delete(synchronize_session="fetch")
+            )
+            db.commit()
+            return count > 0
+
     def delete_messages(self, session_id: str) -> int:
         """Delete all messages from a session and reset its compaction pointer.
 

--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -13,6 +13,7 @@ from backend.app.auth.dependencies import get_current_user
 from backend.app.database import get_db
 from backend.app.models import ChatSession, Message, User
 from backend.app.schemas import (
+    DeleteMessageResponse,
     DeleteMessagesResponse,
     SessionDetailResponse,
     SessionListItem,
@@ -104,6 +105,27 @@ async def get_session(
         last_compacted_seq=session.last_compacted_seq,
         messages=messages,
     )
+
+
+@router.delete(
+    "/user/sessions/{session_id}/messages/{seq}",
+    response_model=DeleteMessageResponse,
+)
+async def delete_single_message(
+    session_id: str,
+    seq: int,
+    current_user: User = Depends(get_current_user),
+) -> DeleteMessageResponse:
+    """Delete a single message from a session by its sequence number."""
+    store = get_session_store(current_user.id)
+    async with user_locks.acquire(current_user.id):
+        session = store.load_session(session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        deleted = store.delete_message(session_id, seq)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Message not found")
+    return DeleteMessageResponse(status="deleted", seq=seq)
 
 
 @router.delete(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -286,6 +286,11 @@ class DeleteMessagesResponse(BaseModel):
     messages_deleted: int
 
 
+class DeleteMessageResponse(BaseModel):
+    status: str
+    seq: int
+
+
 # ---------------------------------------------------------------------------
 # LLM usage summary (admin)
 # ---------------------------------------------------------------------------

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -986,6 +986,55 @@
         }
       }
     },
+    "/api/user/sessions/{session_id}/messages/{seq}": {
+      "delete": {
+        "summary": "Delete Single Message",
+        "description": "Delete a single message from a session by its sequence number.",
+        "operationId": "delete_single_message_api_user_sessions__session_id__messages__seq__delete",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "seq",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Seq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/user/sessions/{session_id}/messages": {
       "delete": {
         "summary": "Delete Conversation History",
@@ -1663,6 +1712,24 @@
           "deleted"
         ],
         "title": "DeleteHeartbeatLogsResponse"
+      },
+      "DeleteMessageResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "seq": {
+            "type": "integer",
+            "title": "Seq"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "seq"
+        ],
+        "title": "DeleteMessageResponse"
       },
       "DeleteMessagesResponse": {
         "properties": {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -98,6 +98,13 @@ const api = {
     if (error) _throwApiError(error, 'Failed to delete conversation history');
   },
 
+  deleteMessage: async (sessionId: string, seq: number) => {
+    const { error } = await client.DELETE('/api/user/sessions/{session_id}/messages/{seq}' as never, {
+      params: { path: { session_id: sessionId, seq } },
+    } as never);
+    if (error) _throwApiError(error, 'Failed to delete message');
+  },
+
   // Memory
   getMemory: async () => {
     const { data, error } = await client.GET('/api/user/memory');

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -546,6 +546,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/user/sessions/{session_id}/messages/{seq}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Single Message
+         * @description Delete a single message from a session by its sequence number.
+         */
+        delete: operations["delete_single_message_api_user_sessions__session_id__messages__seq__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/user/sessions/{session_id}/messages": {
         parameters: {
             query?: never;
@@ -850,6 +870,13 @@ export interface components {
             status: string;
             /** Deleted */
             deleted: number;
+        };
+        /** DeleteMessageResponse */
+        DeleteMessageResponse: {
+            /** Status */
+            status: string;
+            /** Seq */
+            seq: number;
         };
         /** DeleteMessagesResponse */
         DeleteMessagesResponse: {
@@ -2068,6 +2095,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SessionDetailResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_single_message_api_user_sessions__session_id__messages__seq__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+                seq: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteMessageResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -147,6 +147,12 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+@keyframes message-out {
+  from { opacity: 1; transform: scale(1); max-height: 500px; margin-bottom: 0; }
+  50% { opacity: 0; transform: scale(0.95); }
+  to { opacity: 0; transform: scale(0.95); max-height: 0; margin-bottom: -12px; overflow: hidden; }
+}
+
 @keyframes typing-bounce {
   0%, 60%, 100% { transform: translateY(0); }
   30% { transform: translateY(-4px); }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -56,6 +56,7 @@ export default function ChatPage() {
   const [agentBusy, setAgentBusy] = useState(false);
   const [waitingForApproval, setWaitingForApproval] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deletingMsgId, setDeletingMsgId] = useState<number | null>(null);
   const [systemPromptOpen, setSystemPromptOpen] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -302,6 +303,26 @@ export default function ChatPage() {
     });
   };
 
+  const handleDeleteMessage = async (msg: ChatMessage) => {
+    if (!activeSessionId || !msg.seq || deletingMsgId !== null) return;
+    setDeletingMsgId(msg.id);
+    // Play exit animation, then remove after it completes
+    await new Promise((r) => setTimeout(r, 250));
+    try {
+      await api.deleteMessage(activeSessionId, msg.seq);
+      setMessages((prev) => prev.filter((m) => m.id !== msg.id));
+      void queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.sessions.detail(activeSessionId),
+      });
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : 'Failed to delete message';
+      toast.error(errMsg);
+    } finally {
+      setDeletingMsgId(null);
+    }
+  };
+
   const canSend = input.trim().length > 0 || selectedFiles.length > 0;
 
   return (
@@ -387,10 +408,25 @@ export default function ChatPage() {
                 msg.seq !== undefined &&
                 msg.seq > lastCompactedSeq &&
                 (idx === 0 || prevSeq <= lastCompactedSeq);
+              const isExiting = deletingMsgId === msg.id;
               return (
-                <div key={msg.id}>
+                <div
+                  key={msg.id}
+                  style={isExiting ? { animation: 'message-out 250ms ease-in forwards' } : undefined}
+                >
                   {showCompactionMarker && <CompactionMarker />}
-                  <div className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                  <div className={`group/msg flex items-center gap-1.5 ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                    {msg.role === 'user' && msg.seq && (
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteMessage(msg)}
+                        disabled={deletingMsgId !== null}
+                        className="opacity-0 group-hover/msg:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 p-1 rounded text-muted-foreground hover:text-danger shrink-0"
+                        aria-label="Delete message"
+                      >
+                        <SmallTrashIcon />
+                      </button>
+                    )}
                 <div
                   className={`max-w-[80%] px-4 py-2.5 animate-message-in ${
                     msg.role === 'user'
@@ -534,6 +570,17 @@ export default function ChatPage() {
                     {msg.timestamp.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
                   </p>
                 </div>
+                    {msg.role === 'assistant' && msg.seq && (
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteMessage(msg)}
+                        disabled={deletingMsgId !== null}
+                        className="opacity-0 group-hover/msg:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 p-1 rounded text-muted-foreground hover:text-danger shrink-0"
+                        aria-label="Delete message"
+                      >
+                        <SmallTrashIcon />
+                      </button>
+                    )}
               </div>
                 </div>
               );
@@ -748,6 +795,19 @@ function ChevronIcon({ open }: { open: boolean }) {
       viewBox="0 0 24 24"
     >
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+    </svg>
+  );
+}
+
+function SmallTrashIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+      />
     </svg>
   );
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -305,12 +305,13 @@ export default function ChatPage() {
 
   const handleDeleteMessage = async (msg: ChatMessage) => {
     if (!activeSessionId || !msg.seq || deletingMsgId !== null) return;
-    setDeletingMsgId(msg.id);
-    // Play exit animation, then remove after it completes
-    await new Promise((r) => setTimeout(r, 250));
     try {
       await api.deleteMessage(activeSessionId, msg.seq);
+      // API succeeded: play exit animation, then remove from state
+      setDeletingMsgId(msg.id);
+      await new Promise((r) => setTimeout(r, 250));
       setMessages((prev) => prev.filter((m) => m.id !== msg.id));
+      setDeletingMsgId(null);
       void queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
       void queryClient.invalidateQueries({
         queryKey: queryKeys.sessions.detail(activeSessionId),
@@ -318,8 +319,6 @@ export default function ChatPage() {
     } catch (err: unknown) {
       const errMsg = err instanceof Error ? err.message : 'Failed to delete message';
       toast.error(errMsg);
-    } finally {
-      setDeletingMsgId(null);
     }
   };
 

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -185,9 +185,7 @@ def test_delete_single_message_not_found_seq(client: TestClient, test_user: User
     assert resp.status_code == 404
 
 
-def test_delete_single_message_cross_user_isolation(
-    client: TestClient, test_user: User
-) -> None:
+def test_delete_single_message_cross_user_isolation(client: TestClient, test_user: User) -> None:
     """A user cannot delete a message from another user's session."""
     other_user_id = "other-user-single-delete-test"
     db = _db_module.SessionLocal()

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -133,6 +133,112 @@ def test_session_channel_defaults_empty(client: TestClient, test_user: User) -> 
 
 
 # ---------------------------------------------------------------------------
+# DELETE /api/user/sessions/{session_id}/messages/{seq}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_single_message(client: TestClient, test_user: User) -> None:
+    """Deleting a single message removes only that message."""
+    _create_session(
+        test_user,
+        "del_single_1",
+        [
+            {"direction": "inbound", "body": "Hi", "timestamp": "2025-01-15T10:01:00", "seq": 1},
+            {
+                "direction": "outbound",
+                "body": "Hello!",
+                "timestamp": "2025-01-15T10:02:00",
+                "seq": 2,
+            },
+            {"direction": "inbound", "body": "Bye", "timestamp": "2025-01-15T10:03:00", "seq": 3},
+        ],
+    )
+    # Delete message seq=2
+    resp = client.delete("/api/user/sessions/del_single_1/messages/2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "deleted"
+    assert data["seq"] == 2
+
+    # Verify only that message was removed
+    resp = client.get("/api/user/sessions/del_single_1")
+    assert resp.status_code == 200
+    detail = resp.json()
+    seqs = [m["seq"] for m in detail["messages"]]
+    assert seqs == [1, 3]
+
+
+def test_delete_single_message_not_found_session(client: TestClient) -> None:
+    """Deleting a message from a nonexistent session returns 404."""
+    resp = client.delete("/api/user/sessions/nonexistent/messages/1")
+    assert resp.status_code == 404
+
+
+def test_delete_single_message_not_found_seq(client: TestClient, test_user: User) -> None:
+    """Deleting a nonexistent seq from a valid session returns 404."""
+    _create_session(
+        test_user,
+        "del_single_noseq",
+        [{"direction": "inbound", "body": "Hi", "timestamp": "2025-01-15T10:01:00", "seq": 1}],
+    )
+    resp = client.delete("/api/user/sessions/del_single_noseq/messages/99")
+    assert resp.status_code == 404
+
+
+def test_delete_single_message_cross_user_isolation(
+    client: TestClient, test_user: User
+) -> None:
+    """A user cannot delete a message from another user's session."""
+    other_user_id = "other-user-single-delete-test"
+    db = _db_module.SessionLocal()
+    try:
+        other_user = User(
+            id=other_user_id,
+            user_id="other-user-sd",
+            phone="+15558888888",
+            channel_identifier="888888",
+        )
+        db.add(other_user)
+        db.flush()
+        cs = ChatSession(
+            session_id="other_single_del",
+            user_id=other_user_id,
+            is_active=True,
+            channel="",
+            last_compacted_seq=0,
+            created_at=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+            last_message_at=datetime(2025, 1, 15, 10, 5, 0, tzinfo=UTC),
+        )
+        db.add(cs)
+        db.flush()
+        msg = Message(
+            session_id=cs.id,
+            seq=1,
+            direction="inbound",
+            body="secret",
+            timestamp=datetime(2025, 1, 15, 10, 1, 0, tzinfo=UTC),
+        )
+        db.add(msg)
+        db.commit()
+    finally:
+        db.close()
+
+    # Authenticated as test_user, try to delete other user's message
+    resp = client.delete("/api/user/sessions/other_single_del/messages/1")
+    assert resp.status_code == 404
+
+    # Verify the message is still intact
+    db = _db_module.SessionLocal()
+    try:
+        cs = db.query(ChatSession).filter_by(session_id="other_single_del").first()
+        assert cs is not None
+        count = db.query(Message).filter_by(session_id=cs.id).count()
+        assert count == 1
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
 # DELETE /api/user/sessions/{session_id}/messages
 # ---------------------------------------------------------------------------
 

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -134,7 +134,8 @@ class TestCacheBoundary:
         assert len(blocks) == 1
         assert "cache_control" in blocks[0]
 
-    def test_agent_prompt_has_boundary(self) -> None:
+    @pytest.mark.asyncio
+    async def test_agent_prompt_has_boundary(self) -> None:
         """build_agent_system_prompt should include the cache boundary marker."""
         user = MagicMock()
         user.id = "user-123"
@@ -146,11 +147,7 @@ class TestCacheBoundary:
             new_callable=AsyncMock,
             return_value="some memory",
         ):
-            import asyncio
-
-            prompt = asyncio.get_event_loop().run_until_complete(
-                build_agent_system_prompt(user, tools=[], message_context="hello")
-            )
+            prompt = await build_agent_system_prompt(user, tools=[], message_context="hello")
         assert SystemPromptBuilder.CACHE_BOUNDARY.strip() in prompt
 
 


### PR DESCRIPTION
## Description

Two improvements to the chat experience:

1. **Delete individual messages**: Users can now delete specific messages from the chat instead of only being able to clear the entire conversation. A small trash icon appears on hover next to each message bubble, with a smooth exit animation on delete.

2. **Fix double-approval on tool use**: The agent was asking conversationally ("Can I create the estimate?") and then the approval system was also prompting ("I'd like to: Create Estimate. Reply yes or no"). Updated the system prompt to instruct the agent to just call tools directly, since the approval system handles the asking.

### Backend
- `SessionStore.delete_message(session_id, seq)` for single message deletion
- `DELETE /api/user/sessions/{session_id}/messages/{seq}` endpoint
- `DeleteMessageResponse` schema

### Frontend
- Hover-reveal trash icon on each message (left of user bubbles, right of assistant bubbles)
- `message-out` CSS animation for smooth removal
- `api.deleteMessage()` client method

### Agent
- Updated `instructions.md` to tell the agent not to ask conversationally before calling tools that have approval handling

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [ ] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Generated with [Claude Code](https://claude.com/claude-code)