### PR TITLE
docs: show sidebar on docs home page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ Commit both `frontend/openapi.json` and `frontend/src/generated/api.d.ts`.
 
 - Bug fixes include regression tests
 - New features evaluate whether the docs site (`docs/`) needs updates
+- Features that change how users interact with the assistant must update the user guide (`docs/src/content/docs/guide/`)
 - When you manage a pull request, you must always adhere to the pull request template at .github/pull_request_template.md
 - CI green
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -58,6 +58,20 @@ export default defineConfig({
           ],
         },
         {
+          label: "User Guide",
+          items: [
+            { label: "What is Clawbolt?", slug: "guide" },
+            { label: "First Steps", slug: "guide/getting-started" },
+            { label: "Memory", slug: "guide/memory" },
+            { label: "Photos & Files", slug: "guide/photos" },
+            { label: "Estimates", slug: "guide/estimates" },
+            { label: "Calendar", slug: "guide/calendar" },
+            { label: "Heartbeat", slug: "guide/heartbeat" },
+            { label: "Dashboard", slug: "guide/dashboard" },
+            { label: "Tips & Tricks", slug: "guide/tips" },
+          ],
+        },
+        {
           label: "Features",
           items: [
             { label: "Memory", slug: "features/memory" },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -67,6 +67,7 @@ export default defineConfig({
             { label: "Estimates", slug: "guide/estimates" },
             { label: "Calendar", slug: "guide/calendar" },
             { label: "Heartbeat", slug: "guide/heartbeat" },
+            { label: "Integrations", slug: "guide/integrations" },
             { label: "Dashboard", slug: "guide/dashboard" },
             { label: "Tips & Tricks", slug: "guide/tips" },
           ],

--- a/docs/src/content/docs/features/calendar.mdx
+++ b/docs/src/content/docs/features/calendar.mdx
@@ -56,11 +56,10 @@ APP_BASE_URL=https://your-clawbolt-domain.com
 
 ### 4. Connect your account
 
-1. Open the Clawbolt web dashboard and go to the **Tools** page (`/app/tools`)
-2. Find **Google Calendar** in the tool list
-3. Click **Connect**
-4. Sign in with your Google account and grant calendar access
-5. You will be redirected back to Clawbolt with a success message
+Users can connect their Google account in two ways:
+
+- **Over chat (preferred):** Ask the assistant "connect my Google Calendar" and it will generate an authorization link. The user taps the link, signs in, and the callback page confirms the connection.
+- **From the dashboard:** Open the **Tools** page (`/app/tools`), find Google Calendar, and click **Connect**.
 
 Once connected, the calendar tools become available to the agent.
 

--- a/docs/src/content/docs/features/quickbooks.mdx
+++ b/docs/src/content/docs/features/quickbooks.mdx
@@ -85,6 +85,11 @@ QUICKBOOKS_ENVIRONMENT=sandbox
 
 Restart Clawbolt and the QuickBooks tools will appear as a specialist capability.
 
+Once the admin credentials are configured, users can connect their QuickBooks account in two ways:
+
+- **Over chat (preferred):** Ask the assistant "connect my QuickBooks" and it will generate an authorization link.
+- **From the dashboard:** Open the **Tools** page and connect from there.
+
 ## Example conversations
 
 ### Looking up data

--- a/docs/src/content/docs/guide/calendar.mdx
+++ b/docs/src/content/docs/guide/calendar.mdx
@@ -1,0 +1,76 @@
+---
+title: Calendar
+description: Manage your schedule through chat with Google Calendar integration.
+---
+
+When your Clawbolt instance is connected to Google Calendar, you can check your schedule, book jobs, and manage appointments all through text.
+
+## Checking your schedule
+
+```
+You: What do I have tomorrow?
+
+Clawbolt: Here's your schedule for tomorrow (Tuesday):
+          - 8:00 AM: Site visit at Johnson residence
+          - 11:30 AM: Lunch with supplier
+          - 2:00 PM: Estimate walkthrough at 42 Oak St
+```
+
+## Checking availability
+
+```
+You: Am I free Friday afternoon?
+
+Clawbolt: You have a gap from 1:00 PM to 5:00 PM on Friday.
+          Want me to schedule something?
+```
+
+## Scheduling a job
+
+```
+You: Schedule a bathroom remodel at the Davis place
+     for next Monday 8am to 4pm
+
+Clawbolt: I'd like to create this event:
+          "Job: Davis - Bathroom remodel"
+          Monday March 30, 8:00 AM - 4:00 PM
+          Approve?
+
+You: Yes
+
+Clawbolt: Done! Event created on your calendar.
+```
+
+Your assistant always asks for your approval before creating, changing, or deleting calendar events. Read-only actions (checking your schedule, checking availability) happen automatically.
+
+## Updating events
+
+```
+You: Move the Davis job to Tuesday same time
+
+Clawbolt: I'd like to update the event:
+          "Job: Davis - Bathroom remodel"
+          Move from Monday to Tuesday, 8:00 AM - 4:00 PM
+          Approve?
+
+You: Go ahead
+
+Clawbolt: Updated! The Davis job is now on Tuesday.
+```
+
+## Timezone
+
+Your assistant uses your timezone when you mention times. "9am tomorrow" means 9 AM in your local time. Make sure your timezone is set correctly in the dashboard (User page) so times show up right.
+
+## Getting connected
+
+Google Calendar integration is set up from the web dashboard:
+
+1. Open the dashboard and go to the **Tools** page
+2. Find **Google Calendar** and click **Connect**
+3. Sign in with your Google account
+4. Grant calendar access
+
+Once connected, calendar tools are available to your assistant automatically. You can control which calendar actions are enabled (list, create, update, delete) from the Tools page.
+
+If the Connect button isn't available, your admin needs to configure Google Calendar credentials first. See the [Google Calendar](/features/calendar/) page for technical setup details.

--- a/docs/src/content/docs/guide/calendar.mdx
+++ b/docs/src/content/docs/guide/calendar.mdx
@@ -3,9 +3,9 @@ title: Calendar
 description: Manage your schedule through chat with Google Calendar integration.
 ---
 
-When your Clawbolt instance is connected to Google Calendar, you can check your schedule, book jobs, and manage appointments all through text.
+With Google Calendar connected, you can check your schedule, book jobs, and manage appointments through text.
 
-## Checking your schedule
+## Examples
 
 ```
 You: What do I have tomorrow?
@@ -15,17 +15,6 @@ Clawbolt: Here's your schedule for tomorrow (Tuesday):
           - 11:30 AM: Lunch with supplier
           - 2:00 PM: Estimate walkthrough at 42 Oak St
 ```
-
-## Checking availability
-
-```
-You: Am I free Friday afternoon?
-
-Clawbolt: You have a gap from 1:00 PM to 5:00 PM on Friday.
-          Want me to schedule something?
-```
-
-## Scheduling a job
 
 ```
 You: Schedule a bathroom remodel at the Davis place
@@ -41,36 +30,22 @@ You: Yes
 Clawbolt: Done! Event created on your calendar.
 ```
 
-Your assistant always asks for your approval before creating, changing, or deleting calendar events. Read-only actions (checking your schedule, checking availability) happen automatically.
-
-## Updating events
-
-```
-You: Move the Davis job to Tuesday same time
-
-Clawbolt: I'd like to update the event:
-          "Job: Davis - Bathroom remodel"
-          Move from Monday to Tuesday, 8:00 AM - 4:00 PM
-          Approve?
-
-You: Go ahead
-
-Clawbolt: Updated! The Davis job is now on Tuesday.
-```
+Your assistant always asks for approval before creating, changing, or deleting events. Read-only actions (checking schedule, checking availability) happen automatically.
 
 ## Timezone
 
-Your assistant uses your timezone when you mention times. "9am tomorrow" means 9 AM in your local time. Make sure your timezone is set correctly in the dashboard (User page) so times show up right.
+Your assistant uses your timezone when interpreting times. Make sure it's set correctly in the dashboard (User page).
 
 ## Getting connected
 
-Google Calendar integration is set up from the web dashboard:
+Ask your assistant to connect Google Calendar:
 
-1. Open the dashboard and go to the **Tools** page
-2. Find **Google Calendar** and click **Connect**
-3. Sign in with your Google account
-4. Grant calendar access
+```
+You: Connect my Google Calendar
 
-Once connected, calendar tools are available to your assistant automatically. You can control which calendar actions are enabled (list, create, update, delete) from the Tools page.
+Clawbolt: Here's a link to connect your Google account:
+          [link]
+          Tap it, sign in, and grant calendar access.
+```
 
-If the Connect button isn't available, your admin needs to configure Google Calendar credentials first. See the [Google Calendar](/features/calendar/) page for technical setup details.
+You can also connect from the Tools page in the web dashboard. You can control which calendar actions are enabled (list, create, update, delete) from there. See [Google Calendar](/features/calendar/) for technical setup details.

--- a/docs/src/content/docs/guide/dashboard.mdx
+++ b/docs/src/content/docs/guide/dashboard.mdx
@@ -3,52 +3,22 @@ title: Dashboard
 description: Using the Clawbolt web dashboard to manage your assistant.
 ---
 
-Your Clawbolt assistant comes with a web dashboard for managing settings and reviewing information. You don't need the dashboard to use Clawbolt (everything works through text), but it gives you a visual overview and more control.
+Your assistant comes with a web dashboard for managing settings and reviewing information. You don't need it for day-to-day use (everything works through text), but it gives you a visual overview and more control.
 
-## Getting to the dashboard
+## Dashboard cards
 
-Open a web browser and go to your Clawbolt URL. The exact address depends on how your instance was set up. If you're not sure, ask whoever configured Clawbolt for you.
+The main dashboard shows a card for each area: **Channels**, **Tools**, **Memory**, **Heartbeat**, **Soul**, **User**, and **Settings**. Click any card to manage that area.
 
-## Dashboard overview
+- **Channels** -- which messaging platforms your assistant listens on and their status
+- **Tools** -- integrations like Google Calendar and QuickBooks (enable/disable, connect accounts)
+- **Memory** -- preview and edit what your assistant knows about your business
+- **Heartbeat** -- toggle proactive check-ins and manage priorities
+- **Soul** -- customize your assistant's personality and communication style
+- **User** -- your name, timezone, trade, and personal details
+- **Settings** -- which AI model your assistant uses
 
-The main dashboard shows cards for each area of your assistant:
+## Other pages
 
-### Channels
-
-Shows which messaging platforms your assistant is listening on (iMessage, SMS, RCS, Telegram, web chat) and their status. Click to manage channel connections.
-
-### Tools
-
-Lists the capabilities available to your assistant, like Google Calendar and QuickBooks. You can enable or disable individual tools and connect accounts. Click to manage.
-
-### Memory
-
-A preview of what your assistant has memorized about you and your business. Click to view the full memory and edit it directly.
-
-### Heartbeat
-
-Shows whether proactive check-ins are enabled and what tasks your assistant is tracking. Click to manage your heartbeat priorities. You can also toggle check-ins on/off directly from the card.
-
-### Soul
-
-Your assistant's personality and communication style. This guides how your assistant talks, what tone it uses, and how it interacts with clients on your behalf. Click to customize.
-
-### User
-
-Information your assistant knows about you: your name, timezone, trade, and other personal details. Click to review and update.
-
-### Settings
-
-AI model and provider configuration. Shows which language model your assistant is using. Click to change models or providers.
-
-## Managing permissions
-
-Your assistant asks for your approval before taking certain actions (like creating calendar events or sending invoices). The **Permissions** page lets you review and manage which tools require approval and which can run automatically.
-
-## Web chat
-
-The **Chat** link at the bottom of the sidebar opens a web-based chat with your assistant. This works the same as texting, just in your browser.
-
-## Get Started page
-
-If you're new, the **Get Started** page walks you through connecting a messaging channel so you can text your assistant from your phone.
+- **Permissions** -- control which tools require your approval before running
+- **Chat** -- web-based chat with your assistant (same as texting, just in your browser)
+- **Get Started** -- walks you through connecting a messaging channel

--- a/docs/src/content/docs/guide/dashboard.mdx
+++ b/docs/src/content/docs/guide/dashboard.mdx
@@ -3,18 +3,20 @@ title: Dashboard
 description: Using the Clawbolt web dashboard to manage your assistant.
 ---
 
-Your assistant comes with a web dashboard for managing settings and reviewing information. You don't need it for day-to-day use (everything works through text), but it gives you a visual overview and more control.
+Everything in Clawbolt is designed to be managed through chat. Your assistant automatically updates your memory, heartbeat, personality, and profile as you talk to it. You never need to log into the dashboard.
+
+That said, the dashboard is there if you want a visual overview or prefer to make bulk edits.
 
 ## Dashboard cards
 
-The main dashboard shows a card for each area: **Channels**, **Tools**, **Memory**, **Heartbeat**, **Soul**, **User**, and **Settings**. Click any card to manage that area.
+The main dashboard shows a card for each area: **Channels**, **Tools**, **Memory**, **Heartbeat**, **Soul**, **User**, and **Settings**. Click any card to view or edit.
 
-- **Channels** -- which messaging platforms your assistant listens on and their status
-- **Tools** -- integrations like Google Calendar and QuickBooks (enable/disable, connect accounts)
-- **Memory** -- preview and edit what your assistant knows about your business
-- **Heartbeat** -- toggle proactive check-ins and manage priorities
-- **Soul** -- customize your assistant's personality and communication style
-- **User** -- your name, timezone, trade, and personal details
+- **Channels** -- messaging platforms your assistant listens on and their status
+- **Tools** -- integrations like Google Calendar and QuickBooks (also manageable [over chat](/guide/integrations/))
+- **Memory** -- what your assistant knows about your business (also managed automatically through chat)
+- **Heartbeat** -- proactive check-in priorities (also managed through chat)
+- **Soul** -- your assistant's personality and communication style (also managed through chat)
+- **User** -- your name, timezone, trade, and preferences (also managed through chat)
 - **Settings** -- which AI model your assistant uses
 
 ## Other pages

--- a/docs/src/content/docs/guide/dashboard.mdx
+++ b/docs/src/content/docs/guide/dashboard.mdx
@@ -1,0 +1,54 @@
+---
+title: Dashboard
+description: Using the Clawbolt web dashboard to manage your assistant.
+---
+
+Your Clawbolt assistant comes with a web dashboard for managing settings and reviewing information. You don't need the dashboard to use Clawbolt (everything works through text), but it gives you a visual overview and more control.
+
+## Getting to the dashboard
+
+Open a web browser and go to your Clawbolt URL. The exact address depends on how your instance was set up. If you're not sure, ask whoever configured Clawbolt for you.
+
+## Dashboard overview
+
+The main dashboard shows cards for each area of your assistant:
+
+### Channels
+
+Shows which messaging platforms your assistant is listening on (iMessage, SMS, RCS, Telegram, web chat) and their status. Click to manage channel connections.
+
+### Tools
+
+Lists the capabilities available to your assistant, like Google Calendar and QuickBooks. You can enable or disable individual tools and connect accounts. Click to manage.
+
+### Memory
+
+A preview of what your assistant has memorized about you and your business. Click to view the full memory and edit it directly.
+
+### Heartbeat
+
+Shows whether proactive check-ins are enabled and what tasks your assistant is tracking. Click to manage your heartbeat priorities. You can also toggle check-ins on/off directly from the card.
+
+### Soul
+
+Your assistant's personality and communication style. This guides how your assistant talks, what tone it uses, and how it interacts with clients on your behalf. Click to customize.
+
+### User
+
+Information your assistant knows about you: your name, timezone, trade, and other personal details. Click to review and update.
+
+### Settings
+
+AI model and provider configuration. Shows which language model your assistant is using. Click to change models or providers.
+
+## Managing permissions
+
+Your assistant asks for your approval before taking certain actions (like creating calendar events or sending invoices). The **Permissions** page lets you review and manage which tools require approval and which can run automatically.
+
+## Web chat
+
+The **Chat** link at the bottom of the sidebar opens a web-based chat with your assistant. This works the same as texting, just in your browser.
+
+## Get Started page
+
+If you're new, the **Get Started** page walks you through connecting a messaging channel so you can text your assistant from your phone.

--- a/docs/src/content/docs/guide/estimates.mdx
+++ b/docs/src/content/docs/guide/estimates.mdx
@@ -1,0 +1,75 @@
+---
+title: Estimates & Invoicing
+description: Create estimates and invoices by talking to your assistant, powered by QuickBooks Online.
+---
+
+If your Clawbolt instance is connected to QuickBooks Online, you can create estimates, look up invoices, and manage customers all through text. The signature workflow: dictate a job description from your truck and your assistant drafts an estimate in QuickBooks.
+
+## The voice-to-estimate workflow
+
+This is the fastest way to create an estimate in the field:
+
+1. **Dictate from your phone.** Tap the microphone on your keyboard and describe the job out loud.
+2. **Your assistant creates the estimate.** It extracts the client, scope, labor, and materials from your description and creates a draft in QuickBooks.
+3. **Review later.** Come back when you have time to refine the numbers.
+4. **Send it.** When it's ready, your assistant emails it to your client.
+
+```
+You: Just left the Davis place. They want the master bathroom
+     remodeled. About 3 days of labor at 65 an hour, plus
+     around 800 in materials for tile and fixtures.
+
+Clawbolt: I created a draft estimate for Davis in QuickBooks:
+          - Labor (3 days x 8 hrs x $65/hr): $1,560
+          - Materials (tile & fixtures): $800
+          - Total: $2,360
+          Want to review or adjust anything?
+```
+
+No laptop required. No "computer time" at the end of the day.
+
+## Looking up invoices
+
+Ask about a client's invoice history:
+
+```
+You: What invoices do I have for Amy's Bird Sanctuary?
+
+Clawbolt: Found 4 invoices for Amy's Bird Sanctuary:
+          - #1036 | $315.00 (Paid)
+          - #1012 | $650.00 (Open, $400 paid)
+          - #1009 | $1,250.00 (Paid)
+          - #1003 | $475.00 (Paid)
+```
+
+## Sending estimates and invoices
+
+When you're happy with an estimate or invoice, ask your assistant to send it:
+
+```
+You: Send that estimate to Davis
+
+Clawbolt: Done! I've emailed the estimate to Davis at
+          davis@email.com.
+```
+
+## Managing customers
+
+Your assistant can create new customers and update existing ones in QuickBooks:
+
+```
+You: Add a new customer: Sarah Miller, 555-0123,
+     sarah@example.com, 88 Elm Street
+
+Clawbolt: Created a new customer in QuickBooks:
+          Sarah Miller
+          555-0123
+          sarah@example.com
+          88 Elm Street
+```
+
+## Getting connected
+
+QuickBooks integration is configured by whoever set up your Clawbolt instance. Once connected, the QuickBooks tools appear automatically. Your assistant will ask for your permission before creating or modifying anything in QuickBooks.
+
+If you don't see QuickBooks capabilities, ask your admin to set up the integration. See the [QuickBooks](/features/quickbooks/) page for technical setup details.

--- a/docs/src/content/docs/guide/estimates.mdx
+++ b/docs/src/content/docs/guide/estimates.mdx
@@ -3,16 +3,11 @@ title: Estimates & Invoicing
 description: Create estimates and invoices by talking to your assistant, powered by QuickBooks Online.
 ---
 
-If your Clawbolt instance is connected to QuickBooks Online, you can create estimates, look up invoices, and manage customers all through text. The signature workflow: dictate a job description from your truck and your assistant drafts an estimate in QuickBooks.
+With QuickBooks connected, you can create estimates, look up invoices, and manage customers all through text.
 
-## The voice-to-estimate workflow
+## Voice-to-estimate
 
-This is the fastest way to create an estimate in the field:
-
-1. **Dictate from your phone.** Tap the microphone on your keyboard and describe the job out loud.
-2. **Your assistant creates the estimate.** It extracts the client, scope, labor, and materials from your description and creates a draft in QuickBooks.
-3. **Review later.** Come back when you have time to refine the numbers.
-4. **Send it.** When it's ready, your assistant emails it to your client.
+Dictate a job description from your phone and your assistant drafts an estimate in QuickBooks:
 
 ```
 You: Just left the Davis place. They want the master bathroom
@@ -30,8 +25,6 @@ No laptop required. No "computer time" at the end of the day.
 
 ## Looking up invoices
 
-Ask about a client's invoice history:
-
 ```
 You: What invoices do I have for Amy's Bird Sanctuary?
 
@@ -42,34 +35,20 @@ Clawbolt: Found 4 invoices for Amy's Bird Sanctuary:
           - #1003 | $475.00 (Paid)
 ```
 
-## Sending estimates and invoices
+## Sending and managing
 
-When you're happy with an estimate or invoice, ask your assistant to send it:
-
-```
-You: Send that estimate to Davis
-
-Clawbolt: Done! I've emailed the estimate to Davis at
-          davis@email.com.
-```
-
-## Managing customers
-
-Your assistant can create new customers and update existing ones in QuickBooks:
-
-```
-You: Add a new customer: Sarah Miller, 555-0123,
-     sarah@example.com, 88 Elm Street
-
-Clawbolt: Created a new customer in QuickBooks:
-          Sarah Miller
-          555-0123
-          sarah@example.com
-          88 Elm Street
-```
+Ask your assistant to send estimates or invoices to clients, or create and update customers in QuickBooks. Your assistant always asks for permission before creating or changing anything.
 
 ## Getting connected
 
-QuickBooks integration is configured by whoever set up your Clawbolt instance. Once connected, the QuickBooks tools appear automatically. Your assistant will ask for your permission before creating or modifying anything in QuickBooks.
+Ask your assistant to connect QuickBooks:
 
-If you don't see QuickBooks capabilities, ask your admin to set up the integration. See the [QuickBooks](/features/quickbooks/) page for technical setup details.
+```
+You: Connect my QuickBooks
+
+Clawbolt: Here's a link to connect your QuickBooks account:
+          [link]
+          Tap it, sign in, and you're all set.
+```
+
+You can also connect from the Tools page in the web dashboard. See [QuickBooks](/features/quickbooks/) for technical setup details.

--- a/docs/src/content/docs/guide/getting-started.mdx
+++ b/docs/src/content/docs/guide/getting-started.mdx
@@ -1,0 +1,60 @@
+---
+title: First Steps
+description: What to expect when you first message your Clawbolt assistant.
+---
+
+When you message your assistant for the first time, it kicks off a short conversation to get to know you and your business. This takes about 5 minutes.
+
+## The onboarding conversation
+
+Your assistant will ask you a few things:
+
+1. **Your name** -- so it knows what to call you
+2. **Your timezone** -- so times and reminders make sense for your area
+3. **Your trade** -- electrician, plumber, painter, general contractor, etc.
+4. **Your business** -- crew size, types of jobs, service area, rates
+5. **How you like to communicate** -- formal or casual, detailed or brief
+
+You don't have to answer everything at once. Your assistant picks up on details naturally as you chat. If you mention your hourly rate in conversation a week later, it remembers that too.
+
+## Your first real conversation
+
+After the intro, you can start using your assistant right away. Try something like:
+
+```
+You: Remember that my hourly rate for electrical work is $95
+
+Clawbolt: Got it! I've saved your electrical rate at $95/hour.
+```
+
+Or ask it to help with something:
+
+```
+You: I need to give Mrs. Davis a quote for painting her kitchen.
+     About 2 days of work, plus $400 in paint and supplies.
+
+Clawbolt: Based on your rate, here's what that looks like:
+          Labor (2 days x 8 hrs x $95/hr): $1,520
+          Materials: $400
+          Total: $1,920
+          Want me to save this as a draft estimate?
+```
+
+## The web dashboard
+
+Your assistant also comes with a web dashboard where you can:
+
+- Review and edit what your assistant has memorized
+- Set up proactive check-ins (heartbeat)
+- Configure your assistant's personality
+- Manage connected services (Google Calendar, QuickBooks)
+- Control which tools your assistant can use
+
+You don't need the dashboard to use Clawbolt. Everything works through text. But it's there when you want more control. [Learn more about the dashboard](/guide/dashboard/).
+
+## Tips for getting started
+
+- **Talk naturally.** Your assistant understands regular conversation. You don't need special commands.
+- **Use voice dictation.** Tap the microphone on your phone keyboard and talk instead of typing. Great for sending notes from the job site.
+- **Teach it as you go.** Every time you mention a client, a rate, or a preference, your assistant learns it for next time.
+- **Ask it anything.** If it can help, it will. If it can't, it'll tell you.

--- a/docs/src/content/docs/guide/getting-started.mdx
+++ b/docs/src/content/docs/guide/getting-started.mdx
@@ -26,9 +26,13 @@ You: Remember that my hourly rate for electrical work is $95
 Clawbolt: Got it! I've saved your electrical rate at $95/hour.
 ```
 
+## Everything happens through chat
+
+Your assistant manages everything for you as you talk. Your memory, personality, profile, heartbeat priorities, and integrations are all updated automatically through conversation. There's a [web dashboard](/guide/dashboard/) if you're curious, but you never need to open it.
+
 ## Tips for getting started
 
 - **Talk naturally.** No special commands needed.
 - **Use voice dictation.** Tap the microphone on your keyboard and talk instead of typing.
 - **Teach it as you go.** Every time you mention a client, rate, or preference, it remembers.
-- **Connect integrations over chat.** Ask "connect my Google Calendar" and your assistant sends you a link to set it up. [Learn more](/guide/integrations/)
+- **Connect integrations over chat.** Ask "connect my Google Calendar" and your assistant sends you a link. [Learn more](/guide/integrations/)

--- a/docs/src/content/docs/guide/getting-started.mdx
+++ b/docs/src/content/docs/guide/getting-started.mdx
@@ -3,23 +3,22 @@ title: First Steps
 description: What to expect when you first message your Clawbolt assistant.
 ---
 
-When you message your assistant for the first time, it kicks off a short conversation to get to know you and your business. This takes about 5 minutes.
+When you message your assistant for the first time, it starts a short conversation to get to know you and your business. Takes about 5 minutes.
 
 ## The onboarding conversation
 
-Your assistant will ask you a few things:
+Your assistant will ask for:
 
-1. **Your name** -- so it knows what to call you
-2. **Your timezone** -- so times and reminders make sense for your area
-3. **Your trade** -- electrician, plumber, painter, general contractor, etc.
-4. **Your business** -- crew size, types of jobs, service area, rates
-5. **How you like to communicate** -- formal or casual, detailed or brief
+1. **Your name and timezone**
+2. **Your trade** -- electrician, plumber, painter, general contractor, etc.
+3. **Your business** -- crew size, job types, service area, rates
+4. **Communication style** -- formal or casual, detailed or brief
 
-You don't have to answer everything at once. Your assistant picks up on details naturally as you chat. If you mention your hourly rate in conversation a week later, it remembers that too.
+You don't have to answer everything at once. Your assistant picks up on details naturally as you chat.
 
 ## Your first real conversation
 
-After the intro, you can start using your assistant right away. Try something like:
+After the intro, start using it right away:
 
 ```
 You: Remember that my hourly rate for electrical work is $95
@@ -27,34 +26,9 @@ You: Remember that my hourly rate for electrical work is $95
 Clawbolt: Got it! I've saved your electrical rate at $95/hour.
 ```
 
-Or ask it to help with something:
-
-```
-You: I need to give Mrs. Davis a quote for painting her kitchen.
-     About 2 days of work, plus $400 in paint and supplies.
-
-Clawbolt: Based on your rate, here's what that looks like:
-          Labor (2 days x 8 hrs x $95/hr): $1,520
-          Materials: $400
-          Total: $1,920
-          Want me to save this as a draft estimate?
-```
-
-## The web dashboard
-
-Your assistant also comes with a web dashboard where you can:
-
-- Review and edit what your assistant has memorized
-- Set up proactive check-ins (heartbeat)
-- Configure your assistant's personality
-- Manage connected services (Google Calendar, QuickBooks)
-- Control which tools your assistant can use
-
-You don't need the dashboard to use Clawbolt. Everything works through text. But it's there when you want more control. [Learn more about the dashboard](/guide/dashboard/).
-
 ## Tips for getting started
 
-- **Talk naturally.** Your assistant understands regular conversation. You don't need special commands.
-- **Use voice dictation.** Tap the microphone on your phone keyboard and talk instead of typing. Great for sending notes from the job site.
-- **Teach it as you go.** Every time you mention a client, a rate, or a preference, your assistant learns it for next time.
-- **Ask it anything.** If it can help, it will. If it can't, it'll tell you.
+- **Talk naturally.** No special commands needed.
+- **Use voice dictation.** Tap the microphone on your keyboard and talk instead of typing.
+- **Teach it as you go.** Every time you mention a client, rate, or preference, it remembers.
+- **Connect integrations over chat.** Ask "connect my Google Calendar" and your assistant sends you a link to set it up. [Learn more](/guide/integrations/)

--- a/docs/src/content/docs/guide/heartbeat.mdx
+++ b/docs/src/content/docs/guide/heartbeat.mdx
@@ -3,17 +3,7 @@ title: Heartbeat
 description: Your assistant proactively checks in with reminders and follow-ups.
 ---
 
-Heartbeat is your assistant's proactive check-in feature. Instead of waiting for you to message first, your assistant periodically reviews your tasks and priorities, then reaches out when there's something useful to say.
-
-## What it does
-
-When heartbeat is enabled, your assistant checks in on a schedule and looks for:
-
-- **Tasks and priorities you've set** -- things you told it to follow up on
-- **Time-sensitive items** -- deadlines, follow-ups, reminders from your memory
-- **Idle periods** -- if you haven't been in touch for a while, it might check in
-
-If it finds something worth mentioning, it sends you a message. If not, it stays quiet.
+Heartbeat lets your assistant reach out proactively. Instead of waiting for you to message first, it periodically reviews your tasks and priorities and sends you a reminder when there's something useful to say.
 
 ```
 Clawbolt: Hey! Quick reminder: you mentioned wanting to
@@ -22,16 +12,9 @@ Clawbolt: Hey! Quick reminder: you mentioned wanting to
           message to send her?
 ```
 
-## Setting up heartbeat
+## Setting it up
 
-You can enable and configure heartbeat from the web dashboard:
-
-1. Go to the **Heartbeat** page in the dashboard
-2. Toggle check-ins on
-3. Choose how often your assistant checks in (e.g., every few hours, daily)
-4. Add your current tasks and priorities
-
-You can also manage your heartbeat through chat:
+Enable heartbeat from the dashboard (Heartbeat page) or through chat:
 
 ```
 You: Add to my heartbeat: follow up with Davis about
@@ -41,39 +24,18 @@ Clawbolt: Added to your heartbeat. I'll remind you about
           the Davis estimate before Friday.
 ```
 
+Good things to add: client follow-ups, estimate deadlines, material orders, upcoming inspections.
+
 ## Business hours
 
-Your assistant respects your schedule. Check-in messages are only sent during your configured business hours (for example, 7 AM to 5 PM). Late-night messages won't happen.
-
-Make sure your timezone and business hours are set correctly in the dashboard (User page) so check-ins arrive at the right times.
-
-## What to put in your heartbeat
-
-Think of your heartbeat as your assistant's to-do list. Good things to add:
-
-- Follow-ups with clients you're waiting to hear back from
-- Deadlines for estimates or bids
-- Material orders that need to be placed
-- Jobs that need scheduling
-- Reminders about upcoming inspections
-
-```
-You: Update my heartbeat: I need to order tile for the
-     Davis bathroom by Wednesday, and I'm waiting on
-     the permit for the Johnson job
-
-Clawbolt: Updated your heartbeat with both items. I'll
-          remind you about the tile order before Wednesday
-          and keep an eye on the Johnson permit.
-```
+Check-in messages are only sent during your configured business hours. Make sure your timezone is set correctly in the dashboard (User page).
 
 ## Turning it off
 
-If you want your assistant to stop checking in, toggle heartbeat off from the dashboard or tell it:
+Toggle heartbeat off from the dashboard, or:
 
 ```
 You: Turn off heartbeat for now
 
-Clawbolt: Heartbeat check-ins are now disabled. Let me
-          know when you want to turn them back on.
+Clawbolt: Heartbeat check-ins are now disabled.
 ```

--- a/docs/src/content/docs/guide/heartbeat.mdx
+++ b/docs/src/content/docs/guide/heartbeat.mdx
@@ -1,0 +1,79 @@
+---
+title: Heartbeat
+description: Your assistant proactively checks in with reminders and follow-ups.
+---
+
+Heartbeat is your assistant's proactive check-in feature. Instead of waiting for you to message first, your assistant periodically reviews your tasks and priorities, then reaches out when there's something useful to say.
+
+## What it does
+
+When heartbeat is enabled, your assistant checks in on a schedule and looks for:
+
+- **Tasks and priorities you've set** -- things you told it to follow up on
+- **Time-sensitive items** -- deadlines, follow-ups, reminders from your memory
+- **Idle periods** -- if you haven't been in touch for a while, it might check in
+
+If it finds something worth mentioning, it sends you a message. If not, it stays quiet.
+
+```
+Clawbolt: Hey! Quick reminder: you mentioned wanting to
+          follow up with Mrs. Johnson about the kitchen
+          estimate by end of week. Want me to draft a
+          message to send her?
+```
+
+## Setting up heartbeat
+
+You can enable and configure heartbeat from the web dashboard:
+
+1. Go to the **Heartbeat** page in the dashboard
+2. Toggle check-ins on
+3. Choose how often your assistant checks in (e.g., every few hours, daily)
+4. Add your current tasks and priorities
+
+You can also manage your heartbeat through chat:
+
+```
+You: Add to my heartbeat: follow up with Davis about
+     the bathroom estimate by Friday
+
+Clawbolt: Added to your heartbeat. I'll remind you about
+          the Davis estimate before Friday.
+```
+
+## Business hours
+
+Your assistant respects your schedule. Check-in messages are only sent during your configured business hours (for example, 7 AM to 5 PM). Late-night messages won't happen.
+
+Make sure your timezone and business hours are set correctly in the dashboard (User page) so check-ins arrive at the right times.
+
+## What to put in your heartbeat
+
+Think of your heartbeat as your assistant's to-do list. Good things to add:
+
+- Follow-ups with clients you're waiting to hear back from
+- Deadlines for estimates or bids
+- Material orders that need to be placed
+- Jobs that need scheduling
+- Reminders about upcoming inspections
+
+```
+You: Update my heartbeat: I need to order tile for the
+     Davis bathroom by Wednesday, and I'm waiting on
+     the permit for the Johnson job
+
+Clawbolt: Updated your heartbeat with both items. I'll
+          remind you about the tile order before Wednesday
+          and keep an eye on the Johnson permit.
+```
+
+## Turning it off
+
+If you want your assistant to stop checking in, toggle heartbeat off from the dashboard or tell it:
+
+```
+You: Turn off heartbeat for now
+
+Clawbolt: Heartbeat check-ins are now disabled. Let me
+          know when you want to turn them back on.
+```

--- a/docs/src/content/docs/guide/heartbeat.mdx
+++ b/docs/src/content/docs/guide/heartbeat.mdx
@@ -14,7 +14,7 @@ Clawbolt: Hey! Quick reminder: you mentioned wanting to
 
 ## Setting it up
 
-Enable heartbeat from the dashboard (Heartbeat page) or through chat:
+Just tell your assistant what to track. It manages your heartbeat automatically:
 
 ```
 You: Add to my heartbeat: follow up with Davis about
@@ -24,18 +24,16 @@ Clawbolt: Added to your heartbeat. I'll remind you about
           the Davis estimate before Friday.
 ```
 
-Good things to add: client follow-ups, estimate deadlines, material orders, upcoming inspections.
-
-## Business hours
-
-Check-in messages are only sent during your configured business hours. Make sure your timezone is set correctly in the dashboard (User page).
-
-## Turning it off
-
-Toggle heartbeat off from the dashboard, or:
-
 ```
 You: Turn off heartbeat for now
 
 Clawbolt: Heartbeat check-ins are now disabled.
 ```
+
+Good things to add: client follow-ups, estimate deadlines, material orders, upcoming inspections.
+
+## Business hours
+
+Check-in messages are only sent during your configured business hours. Make sure your timezone is set correctly (just tell your assistant your timezone and it will save it).
+
+The Heartbeat page in the dashboard is available if you want a visual overview, but everything can be managed through chat.

--- a/docs/src/content/docs/guide/index.mdx
+++ b/docs/src/content/docs/guide/index.mdx
@@ -3,47 +3,31 @@ title: What is Clawbolt?
 description: Your AI assistant for running a trades business, all through text messaging.
 ---
 
-Clawbolt is an AI assistant built for contractors, handymen, and tradespeople. You text it like you'd text a friend, and it helps you run your business: remembering client details, organizing job photos, creating estimates, managing your calendar, and following up on tasks.
+Clawbolt is an AI assistant for contractors, handymen, and tradespeople. You text it like you'd text a friend, and it helps you run your business: remembering client details, organizing job photos, creating estimates, managing your calendar, and following up on tasks.
 
 No app to download. No dashboard to learn. Just send a message from your phone.
 
 ## How it works
 
-You message your assistant using whatever you already use: iMessage, SMS, RCS, Telegram, or the web chat. Your assistant reads your message, thinks about it, and texts you back.
+Message your assistant using iMessage, SMS, RCS, Telegram, or web chat. It reads your message and texts you back.
 
 ```
 You: What's Mrs. Johnson's address?
 
-Clawbolt: Mrs. Johnson's address is 42 Oak Street, Austin, TX 78701.
+Clawbolt: 42 Oak Street, Austin, TX 78701.
 ```
-
-That's it. Your assistant remembers everything you tell it and uses that knowledge to help you throughout the day.
 
 ## What it can do
 
-Here's a quick overview of what your assistant helps with:
-
-- **Remember things** -- your rates, client info, material preferences, job notes. Tell it once and it remembers. [Learn more](/guide/memory/)
-- **Organize photos** -- send a job site photo, get an AI description, and have it filed automatically in your cloud storage. [Learn more](/guide/photos/)
-- **Create estimates** -- dictate a job description from the truck and your assistant drafts an estimate in QuickBooks. [Learn more](/guide/estimates/)
-- **Manage your schedule** -- check availability, schedule jobs, get reminders, all through chat. [Learn more](/guide/calendar/)
-- **Follow up on tasks** -- your assistant checks in proactively with reminders and follow-ups so nothing falls through the cracks. [Learn more](/guide/heartbeat/)
-
-## Who it's for
-
-Clawbolt is designed for solo tradespeople and small crews:
-
-- General contractors
-- Electricians and plumbers
-- Painters and remodelers
-- Handymen
-- HVAC technicians
-- Landscapers
-
-If you spend your day at job sites and manage your business from your phone, Clawbolt is built for you.
+- **[Memory](/guide/memory/)** -- remembers your rates, clients, and preferences
+- **[Photos](/guide/photos/)** -- analyzes and organizes job site photos
+- **[Estimates](/guide/estimates/)** -- dictate a job description, get a QuickBooks estimate
+- **[Calendar](/guide/calendar/)** -- check availability, schedule jobs, get reminders
+- **[Heartbeat](/guide/heartbeat/)** -- proactive check-ins and follow-ups
+- **[Integrations](/guide/integrations/)** -- connect Google Calendar, QuickBooks, and more over chat
 
 ## Getting started
 
-If someone has already set up Clawbolt for you, head to [First Steps](/guide/getting-started/) to learn what happens when you send your first message.
+If someone already set up Clawbolt for you, head to [First Steps](/guide/getting-started/).
 
-If you're setting up Clawbolt yourself, start with the [technical setup guide](/getting-started/) and come back here once it's running.
+Setting it up yourself? Start with the [technical setup guide](/getting-started/) and come back here once it's running.

--- a/docs/src/content/docs/guide/index.mdx
+++ b/docs/src/content/docs/guide/index.mdx
@@ -1,0 +1,49 @@
+---
+title: What is Clawbolt?
+description: Your AI assistant for running a trades business, all through text messaging.
+---
+
+Clawbolt is an AI assistant built for contractors, handymen, and tradespeople. You text it like you'd text a friend, and it helps you run your business: remembering client details, organizing job photos, creating estimates, managing your calendar, and following up on tasks.
+
+No app to download. No dashboard to learn. Just send a message from your phone.
+
+## How it works
+
+You message your assistant using whatever you already use: iMessage, SMS, RCS, Telegram, or the web chat. Your assistant reads your message, thinks about it, and texts you back.
+
+```
+You: What's Mrs. Johnson's address?
+
+Clawbolt: Mrs. Johnson's address is 42 Oak Street, Austin, TX 78701.
+```
+
+That's it. Your assistant remembers everything you tell it and uses that knowledge to help you throughout the day.
+
+## What it can do
+
+Here's a quick overview of what your assistant helps with:
+
+- **Remember things** -- your rates, client info, material preferences, job notes. Tell it once and it remembers. [Learn more](/guide/memory/)
+- **Organize photos** -- send a job site photo, get an AI description, and have it filed automatically in your cloud storage. [Learn more](/guide/photos/)
+- **Create estimates** -- dictate a job description from the truck and your assistant drafts an estimate in QuickBooks. [Learn more](/guide/estimates/)
+- **Manage your schedule** -- check availability, schedule jobs, get reminders, all through chat. [Learn more](/guide/calendar/)
+- **Follow up on tasks** -- your assistant checks in proactively with reminders and follow-ups so nothing falls through the cracks. [Learn more](/guide/heartbeat/)
+
+## Who it's for
+
+Clawbolt is designed for solo tradespeople and small crews:
+
+- General contractors
+- Electricians and plumbers
+- Painters and remodelers
+- Handymen
+- HVAC technicians
+- Landscapers
+
+If you spend your day at job sites and manage your business from your phone, Clawbolt is built for you.
+
+## Getting started
+
+If someone has already set up Clawbolt for you, head to [First Steps](/guide/getting-started/) to learn what happens when you send your first message.
+
+If you're setting up Clawbolt yourself, start with the [technical setup guide](/getting-started/) and come back here once it's running.

--- a/docs/src/content/docs/guide/integrations.mdx
+++ b/docs/src/content/docs/guide/integrations.mdx
@@ -1,0 +1,54 @@
+---
+title: Integrations
+description: Connect Google Calendar, QuickBooks, and other services through chat.
+---
+
+Your assistant can connect to external services like Google Calendar and QuickBooks. The easiest way to set them up is to just ask:
+
+```
+You: Connect my Google Calendar
+
+Clawbolt: Here's a link to connect your Google account:
+          [link]
+          Tap it, sign in, and grant access. Once you're
+          done, come back here and I'll be ready to go.
+```
+
+Tap the link, complete the sign-in on your phone, and you're connected. No dashboard required.
+
+## Managing integrations
+
+Check what's connected, or enable and disable tools:
+
+```
+You: What integrations do I have?
+
+Clawbolt: Here's what's available:
+          - Google Calendar: Connected, enabled
+          - QuickBooks: Not connected
+          - Pricing Tools: Enabled
+```
+
+```
+You: Disable my calendar tools for now
+
+Clawbolt: Done. Calendar tools are disabled. You can
+          re-enable them anytime.
+```
+
+## Disconnecting
+
+```
+You: Disconnect my Google Calendar
+
+Clawbolt: Google Calendar has been disconnected.
+```
+
+## Available integrations
+
+- **Google Calendar** -- check your schedule, book jobs, manage events. [Learn more](/guide/calendar/)
+- **QuickBooks Online** -- create estimates, look up invoices, manage customers. [Learn more](/guide/estimates/)
+
+## Dashboard alternative
+
+You can also manage integrations from the **Tools** page in the web dashboard. This is useful if you prefer a visual overview or want to fine-tune which specific actions are enabled (e.g., allow calendar reads but not writes).

--- a/docs/src/content/docs/guide/memory.mdx
+++ b/docs/src/content/docs/guide/memory.mdx
@@ -1,47 +1,26 @@
 ---
 title: Memory
-description: Your assistant remembers your rates, clients, and preferences so you don't have to repeat yourself.
+description: Your assistant remembers your rates, clients, and preferences.
 ---
 
-Your assistant has a long-term memory. When you tell it something about your business, it saves that information and uses it in future conversations. You only need to say things once.
+Your assistant has long-term memory. Tell it something about your business and it saves it for future conversations. You only need to say things once.
 
 ## What it remembers
 
-Your assistant picks up on facts naturally from your messages:
+- Rates and pricing
+- Client details (names, addresses, phone numbers, job history)
+- Preferences (suppliers, materials, brands)
+- Business info (trade, crew size, service area, hours)
+- Job notes (measurements, specs, special instructions)
 
-- **Rates and pricing** -- hourly rates, markup percentages, minimum charges
-- **Client details** -- names, addresses, phone numbers, job history
-- **Preferences** -- preferred suppliers, materials you like, brands you avoid
-- **Business info** -- your trade, crew size, service area, business hours
-- **Job notes** -- measurements, specifications, special instructions
+## Saving and recalling facts
 
-## Saving facts
-
-You can tell your assistant something directly:
+Tell your assistant directly, or it picks up details from regular conversation:
 
 ```
 You: Remember that my hourly rate for plumbing is $85
 
 Clawbolt: Done! I've saved your plumbing rate at $85/hour.
-```
-
-Or it picks up on details from regular conversation:
-
-```
-You: I'm heading to Mrs. Johnson's place at 42 Oak Street
-
-Clawbolt: Got it. I've noted that Mrs. Johnson is at
-          42 Oak Street. Have a good one!
-```
-
-## Asking for information
-
-Your assistant's memory is always available. Just ask:
-
-```
-You: What's my rate for electrical work?
-
-Clawbolt: Your electrical rate is $95/hour.
 ```
 
 ```
@@ -54,9 +33,7 @@ Clawbolt: Here's what I have on the Davis project:
           - Tile: marble subway, supplier is Floor & Decor
 ```
 
-## Updating information
-
-Tell your assistant when something changes and it will update its memory:
+## Updating and forgetting
 
 ```
 You: My plumbing rate is $90 now, not $85
@@ -64,16 +41,10 @@ You: My plumbing rate is $90 now, not $85
 Clawbolt: Updated! Your plumbing rate is now $90/hour.
 ```
 
-## Forgetting information
-
-If you want your assistant to forget something:
-
 ```
 You: Forget my old supplier for drywall
 
 Clawbolt: Done. I've removed your drywall supplier from memory.
 ```
 
-## Viewing your memory
-
-You can see everything your assistant has memorized on the Memory page in the web dashboard. You can also edit it directly there if you prefer to type things out rather than chat about them.
+You can also view and edit your memory directly on the Memory page in the web dashboard.

--- a/docs/src/content/docs/guide/memory.mdx
+++ b/docs/src/content/docs/guide/memory.mdx
@@ -47,4 +47,4 @@ You: Forget my old supplier for drywall
 Clawbolt: Done. I've removed your drywall supplier from memory.
 ```
 
-You can also view and edit your memory directly on the Memory page in the web dashboard.
+Your assistant manages your memory automatically. You never need to log into the dashboard to update it. If you're curious about what's stored, the Memory page in the web dashboard lets you view and edit it directly.

--- a/docs/src/content/docs/guide/memory.mdx
+++ b/docs/src/content/docs/guide/memory.mdx
@@ -1,0 +1,79 @@
+---
+title: Memory
+description: Your assistant remembers your rates, clients, and preferences so you don't have to repeat yourself.
+---
+
+Your assistant has a long-term memory. When you tell it something about your business, it saves that information and uses it in future conversations. You only need to say things once.
+
+## What it remembers
+
+Your assistant picks up on facts naturally from your messages:
+
+- **Rates and pricing** -- hourly rates, markup percentages, minimum charges
+- **Client details** -- names, addresses, phone numbers, job history
+- **Preferences** -- preferred suppliers, materials you like, brands you avoid
+- **Business info** -- your trade, crew size, service area, business hours
+- **Job notes** -- measurements, specifications, special instructions
+
+## Saving facts
+
+You can tell your assistant something directly:
+
+```
+You: Remember that my hourly rate for plumbing is $85
+
+Clawbolt: Done! I've saved your plumbing rate at $85/hour.
+```
+
+Or it picks up on details from regular conversation:
+
+```
+You: I'm heading to Mrs. Johnson's place at 42 Oak Street
+
+Clawbolt: Got it. I've noted that Mrs. Johnson is at
+          42 Oak Street. Have a good one!
+```
+
+## Asking for information
+
+Your assistant's memory is always available. Just ask:
+
+```
+You: What's my rate for electrical work?
+
+Clawbolt: Your electrical rate is $95/hour.
+```
+
+```
+You: What do I know about the Davis job?
+
+Clawbolt: Here's what I have on the Davis project:
+          - Bathroom remodel at 18 Pine St
+          - Started March 10
+          - Budget: $12,000
+          - Tile: marble subway, supplier is Floor & Decor
+```
+
+## Updating information
+
+Tell your assistant when something changes and it will update its memory:
+
+```
+You: My plumbing rate is $90 now, not $85
+
+Clawbolt: Updated! Your plumbing rate is now $90/hour.
+```
+
+## Forgetting information
+
+If you want your assistant to forget something:
+
+```
+You: Forget my old supplier for drywall
+
+Clawbolt: Done. I've removed your drywall supplier from memory.
+```
+
+## Viewing your memory
+
+You can see everything your assistant has memorized on the Memory page in the web dashboard. You can also edit it directly there if you prefer to type things out rather than chat about them.

--- a/docs/src/content/docs/guide/photos.mdx
+++ b/docs/src/content/docs/guide/photos.mdx
@@ -1,0 +1,64 @@
+---
+title: Photos & Files
+description: Send job site photos for AI analysis and automatic organization in cloud storage.
+---
+
+Send a photo to your assistant and it will describe what it sees, store it, and organize it for you. Great for documenting job sites, tracking progress, and keeping records.
+
+## Sending a photo
+
+Take a photo at a job site and send it to your assistant just like you'd send it to anyone else. Your assistant will:
+
+1. Analyze the image using AI vision
+2. Give you a description of what it sees
+3. Upload it to your cloud storage (if configured)
+4. Organize it by date
+
+```
+You: [sends photo of kitchen before demo]
+
+Clawbolt: I can see a dated kitchen with dark wood cabinets,
+          laminate countertops, and vinyl flooring. The
+          backsplash is beige ceramic tile. Looks like a
+          full gut job. I've saved this to your Job Photos
+          folder under today's date.
+```
+
+## Use cases
+
+- **Before/after shots** -- document the state of a job site before you start and after you finish
+- **Damage documentation** -- photograph damage for insurance or client records
+- **Material identification** -- send a photo of a part or fixture and ask your assistant to help identify it
+- **Progress tracking** -- snap photos throughout a project to show progress over time
+
+## Where photos are stored
+
+When you have cloud storage connected (Dropbox or Google Drive), your assistant uploads photos and organizes them into folders:
+
+```
+Job Photos/
+  2026-03-15/
+    kitchen-before.jpg
+    kitchen-after.jpg
+  2026-03-16/
+    bathroom-tile.jpg
+```
+
+Without cloud storage, photos are kept on the server's local storage.
+
+## Asking about past photos
+
+Your assistant tracks what photos you've sent:
+
+```
+You: What photos did I take at the Johnson place?
+
+Clawbolt: You sent 3 photos for the Johnson project:
+          - Kitchen before demo (March 15)
+          - Kitchen after demo (March 15)
+          - Bathroom tile selection (March 16)
+```
+
+## Setting up cloud storage
+
+Cloud storage is configured by whoever set up your Clawbolt instance. If you want photos saved to Dropbox or Google Drive, ask your admin to set up a storage provider. See the [Storage Providers](/deployment/storage/) page for technical setup details.

--- a/docs/src/content/docs/guide/photos.mdx
+++ b/docs/src/content/docs/guide/photos.mdx
@@ -1,39 +1,28 @@
 ---
 title: Photos & Files
-description: Send job site photos for AI analysis and automatic organization in cloud storage.
+description: Send job site photos for AI analysis and automatic organization.
 ---
 
-Send a photo to your assistant and it will describe what it sees, store it, and organize it for you. Great for documenting job sites, tracking progress, and keeping records.
+Send a photo to your assistant and it will describe what it sees, store it, and organize it in your cloud storage.
 
 ## Sending a photo
 
-Take a photo at a job site and send it to your assistant just like you'd send it to anyone else. Your assistant will:
-
-1. Analyze the image using AI vision
-2. Give you a description of what it sees
-3. Upload it to your cloud storage (if configured)
-4. Organize it by date
+Send a photo like you'd send it to anyone else:
 
 ```
 You: [sends photo of kitchen before demo]
 
 Clawbolt: I can see a dated kitchen with dark wood cabinets,
-          laminate countertops, and vinyl flooring. The
-          backsplash is beige ceramic tile. Looks like a
-          full gut job. I've saved this to your Job Photos
+          laminate countertops, and vinyl flooring. Looks like
+          a full gut job. I've saved this to your Job Photos
           folder under today's date.
 ```
 
-## Use cases
-
-- **Before/after shots** -- document the state of a job site before you start and after you finish
-- **Damage documentation** -- photograph damage for insurance or client records
-- **Material identification** -- send a photo of a part or fixture and ask your assistant to help identify it
-- **Progress tracking** -- snap photos throughout a project to show progress over time
+Great for before/after documentation, damage records, material identification, and progress tracking.
 
 ## Where photos are stored
 
-When you have cloud storage connected (Dropbox or Google Drive), your assistant uploads photos and organizes them into folders:
+With cloud storage connected (Dropbox or Google Drive), photos are organized into folders by date:
 
 ```
 Job Photos/
@@ -44,21 +33,4 @@ Job Photos/
     bathroom-tile.jpg
 ```
 
-Without cloud storage, photos are kept on the server's local storage.
-
-## Asking about past photos
-
-Your assistant tracks what photos you've sent:
-
-```
-You: What photos did I take at the Johnson place?
-
-Clawbolt: You sent 3 photos for the Johnson project:
-          - Kitchen before demo (March 15)
-          - Kitchen after demo (March 15)
-          - Bathroom tile selection (March 16)
-```
-
-## Setting up cloud storage
-
-Cloud storage is configured by whoever set up your Clawbolt instance. If you want photos saved to Dropbox or Google Drive, ask your admin to set up a storage provider. See the [Storage Providers](/deployment/storage/) page for technical setup details.
+Without cloud storage, photos are kept on the server's local storage. Cloud storage is configured by whoever set up your Clawbolt instance. See [Storage Providers](/deployment/storage/) for technical details.

--- a/docs/src/content/docs/guide/tips.mdx
+++ b/docs/src/content/docs/guide/tips.mdx
@@ -1,0 +1,77 @@
+---
+title: Tips & Tricks
+description: Get the most out of your Clawbolt assistant with these practical tips.
+---
+
+## Use voice dictation
+
+The best way to use Clawbolt from a job site is voice dictation. Tap the microphone icon on your phone keyboard and just talk. Your phone converts your speech to text, and your assistant reads it like any other message.
+
+This is especially useful for:
+
+- Dictating job descriptions and estimates while driving between jobs
+- Adding notes about a client or job site while your hands are dirty
+- Sending quick updates without stopping to type
+
+```
+You: [dictated] Just finished the demo at the Davis
+     place, kitchen is gutted, plumbing looks good,
+     electrical needs updating, probably add a day
+     for that
+
+Clawbolt: Got it. I've noted the Davis kitchen demo is
+          complete. Plumbing is good, but electrical
+          needs updating, which adds about a day to
+          the timeline. Want me to update the estimate?
+```
+
+## Teach your assistant over time
+
+You don't need to sit down and enter all your information at once. Your assistant learns naturally from conversation. Every time you mention a rate, a client, or a preference, it remembers.
+
+Over time, your assistant builds up a detailed picture of your business. The more you use it, the more helpful it gets.
+
+## Be specific about what you want
+
+Your assistant works best when you're clear about what you need:
+
+- **Good:** "Give me a rough estimate for painting a 200 sq ft bedroom, my rate is $65/hour"
+- **Better:** "I need an estimate for the Miller job: paint master bedroom, about 200 sq ft, 2 coats, using Benjamin Moore Regal. Include my $65/hour rate and $150 in materials."
+
+## Ask follow-up questions
+
+Your assistant remembers the conversation, so you can build on what you've discussed:
+
+```
+You: What's the Davis estimate total?
+
+Clawbolt: The Davis bathroom remodel estimate is $2,360.
+
+You: Add $200 for the electrical update we talked about
+
+Clawbolt: Updated. New total is $2,560. Want me to update
+          the QuickBooks estimate too?
+```
+
+## Review your memory periodically
+
+Check the Memory page in the dashboard every few weeks to make sure your assistant's information is up to date. Old rates, former clients, or outdated preferences can lead to confusion. Remove anything that's no longer accurate.
+
+## Set up heartbeat for follow-ups
+
+If you tend to forget follow-ups (most people do), turn on heartbeat and add your current priorities. Your assistant will check in and remind you before things slip through the cracks. [Learn more about heartbeat](/guide/heartbeat/).
+
+## Use the dashboard for bulk edits
+
+While you can tell your assistant anything through chat, the dashboard is faster for making lots of changes at once. Want to update 10 facts in your memory? Edit them directly on the Memory page instead of sending 10 messages.
+
+## Tell your assistant how you want it to communicate
+
+Visit the Soul page in the dashboard and write out how you want your assistant to behave. Should it be casual or professional? Should it be brief or detailed? Should it use industry terms or keep it simple? Your assistant follows whatever guidance you give it.
+
+```
+You: Keep your responses short. I'm usually on a job
+     site and don't have time to read paragraphs.
+
+Clawbolt: Got it. I'll keep things brief.
+```

--- a/docs/src/content/docs/guide/tips.mdx
+++ b/docs/src/content/docs/guide/tips.mdx
@@ -40,14 +40,23 @@ Clawbolt: Updated. New total is $2,560. Want me to update
           the QuickBooks estimate too?
 ```
 
-## Review your memory periodically
+## Clean up outdated info
 
-Check the Memory page in the dashboard every few weeks. Remove outdated rates, former clients, or old preferences.
+If your rates or client details change, just tell your assistant. It updates automatically. You can also ask it to forget outdated info:
 
-## Use the dashboard for bulk edits
+```
+You: Forget everything about the old Davis job, that's done
 
-Want to update 10 facts? Edit them directly on the Memory page instead of sending 10 messages.
+Clawbolt: Done. Removed the Davis project details from memory.
+```
 
 ## Customize your assistant's personality
 
-Visit the Soul page and write out how you want your assistant to behave: casual or professional, brief or detailed, industry terms or plain language.
+Tell your assistant how you want it to communicate and it will adjust:
+
+```
+You: Keep your responses short and casual. I'm usually
+     on a job site.
+
+Clawbolt: Got it. I'll keep things brief.
+```

--- a/docs/src/content/docs/guide/tips.mdx
+++ b/docs/src/content/docs/guide/tips.mdx
@@ -1,53 +1,40 @@
 ---
 title: Tips & Tricks
-description: Get the most out of your Clawbolt assistant with these practical tips.
+description: Get the most out of your Clawbolt assistant.
 ---
 
 ## Use voice dictation
 
-The best way to use Clawbolt from a job site is voice dictation. Tap the microphone icon on your phone keyboard and just talk. Your phone converts your speech to text, and your assistant reads it like any other message.
-
-This is especially useful for:
-
-- Dictating job descriptions and estimates while driving between jobs
-- Adding notes about a client or job site while your hands are dirty
-- Sending quick updates without stopping to type
+Tap the microphone on your phone keyboard and talk. Great for dictating job descriptions from the truck, adding notes with dirty hands, or sending quick updates without typing.
 
 ```
-You: [dictated] Just finished the demo at the Davis
-     place, kitchen is gutted, plumbing looks good,
-     electrical needs updating, probably add a day
-     for that
+You: [dictated] Just finished the demo at the Davis place,
+     kitchen is gutted, plumbing looks good, electrical
+     needs updating, probably add a day for that
 
 Clawbolt: Got it. I've noted the Davis kitchen demo is
-          complete. Plumbing is good, but electrical
-          needs updating, which adds about a day to
-          the timeline. Want me to update the estimate?
+          complete. Plumbing is good, but electrical needs
+          updating, which adds about a day. Want me to
+          update the estimate?
 ```
 
-## Teach your assistant over time
+## Be specific
 
-You don't need to sit down and enter all your information at once. Your assistant learns naturally from conversation. Every time you mention a rate, a client, or a preference, it remembers.
-
-Over time, your assistant builds up a detailed picture of your business. The more you use it, the more helpful it gets.
-
-## Be specific about what you want
-
-Your assistant works best when you're clear about what you need:
+Your assistant works best with clear requests:
 
 - **Good:** "Give me a rough estimate for painting a 200 sq ft bedroom, my rate is $65/hour"
-- **Better:** "I need an estimate for the Miller job: paint master bedroom, about 200 sq ft, 2 coats, using Benjamin Moore Regal. Include my $65/hour rate and $150 in materials."
+- **Better:** "Estimate for the Miller job: paint master bedroom, 200 sq ft, 2 coats, Benjamin Moore Regal. $65/hour rate, $150 materials."
 
 ## Ask follow-up questions
 
-Your assistant remembers the conversation, so you can build on what you've discussed:
+Your assistant remembers the conversation:
 
 ```
 You: What's the Davis estimate total?
 
 Clawbolt: The Davis bathroom remodel estimate is $2,360.
 
-You: Add $200 for the electrical update we talked about
+You: Add $200 for the electrical update
 
 Clawbolt: Updated. New total is $2,560. Want me to update
           the QuickBooks estimate too?
@@ -55,23 +42,12 @@ Clawbolt: Updated. New total is $2,560. Want me to update
 
 ## Review your memory periodically
 
-Check the Memory page in the dashboard every few weeks to make sure your assistant's information is up to date. Old rates, former clients, or outdated preferences can lead to confusion. Remove anything that's no longer accurate.
-
-## Set up heartbeat for follow-ups
-
-If you tend to forget follow-ups (most people do), turn on heartbeat and add your current priorities. Your assistant will check in and remind you before things slip through the cracks. [Learn more about heartbeat](/guide/heartbeat/).
+Check the Memory page in the dashboard every few weeks. Remove outdated rates, former clients, or old preferences.
 
 ## Use the dashboard for bulk edits
 
-While you can tell your assistant anything through chat, the dashboard is faster for making lots of changes at once. Want to update 10 facts in your memory? Edit them directly on the Memory page instead of sending 10 messages.
+Want to update 10 facts? Edit them directly on the Memory page instead of sending 10 messages.
 
-## Tell your assistant how you want it to communicate
+## Customize your assistant's personality
 
-Visit the Soul page in the dashboard and write out how you want your assistant to behave. Should it be casual or professional? Should it be brief or detailed? Should it use industry terms or keep it simple? Your assistant follows whatever guidance you give it.
-
-```
-You: Keep your responses short. I'm usually on a job
-     site and don't have time to read paragraphs.
-
-Clawbolt: Got it. I'll keep things brief.
-```
+Visit the Soul page and write out how you want your assistant to behave: casual or professional, brief or detailed, industry terms or plain language.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Clawbolt
 description: AI assistant for the trades. Built by Mozilla.ai.
-template: splash
 hero:
   tagline: AI assistant for the trades. Memory, photos, and more, all through text messaging.
   image:

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -6,6 +6,7 @@ export {
   shouldRedirectRootToApp,
   getFeatureRequestUrl,
   getReportIssueUrl,
+  getDocsUrl,
 } from './routes';
 export {
   getExtraSettingsTabs,

--- a/frontend/src/extensions/routes.tsx
+++ b/frontend/src/extensions/routes.tsx
@@ -25,3 +25,7 @@ export function getFeatureRequestUrl(): string {
 export function getReportIssueUrl(): string {
   return 'https://github.com/mozilla-ai/clawbolt/issues/new?title=Bug:+&labels=bug';
 }
+
+export function getDocsUrl(): string {
+  return 'https://clawbolt.ai/guide/';
+}

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Tooltip } from '@heroui/tooltip';
 import { Link } from '@heroui/link';
 import { Divider } from '@heroui/divider';
-import { getFeatureRequestUrl, getReportIssueUrl, getExtraNavItems, renderSidebarFooter } from '@/extensions';
+import { getFeatureRequestUrl, getReportIssueUrl, getDocsUrl, getExtraNavItems, renderSidebarFooter } from '@/extensions';
 import useSwipeSidebar from '@/hooks/useSwipeSidebar';
 import { useProfile } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
@@ -226,7 +226,15 @@ export default function AppShell() {
               </svg>
               Get Started
             </NavLink>
-            <div className="flex gap-2 px-3 py-1">
+            <div className="flex gap-2 px-3 py-1 flex-wrap">
+              <Link
+                href={getDocsUrl()}
+                isExternal
+                size="sm"
+                className="text-xs text-muted-foreground can-hover:hover:text-foreground transition-all duration-150"
+              >
+                Help
+              </Link>
               <Link
                 href={getReportIssueUrl()}
                 isExternal


### PR DESCRIPTION
## Description
Remove `template: splash` from the docs home page so the sidebar is visible. The splash template hides the sidebar, making it harder to navigate from the landing page.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code)
- [ ] No AI used