### PR TITLE
fix: stage media bytes across turns and coalesce approval prompts

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -131,6 +131,11 @@ class ClawboltAgent:
         self._excluded_tool_names = excluded_tool_names
         self._request_id = request_id
         self._reactive_trim_dropped: list[AgentMessage] = []
+        # Remembers ASK decisions within a single agent run so the user is not
+        # re-prompted for the same (tool, resource) if the LLM retries or
+        # chains calls. ALWAYS_ALLOW is persisted to PERMISSIONS.json and does
+        # not need this cache.
+        self._approval_cache: dict[tuple[str, str | None], ApprovalDecision] = {}
 
     def subscribe(self, callback: Callable[[AgentEvent], Awaitable[None]]) -> None:
         """Register an event subscriber.
@@ -569,7 +574,17 @@ class ClawboltAgent:
                 idx, tool_obj, v_args = entry
                 tc_req = parsed_calls[idx]
 
-                if self._publish_outbound is not None and self._chat_id is not None:
+                cache_key = (tool_obj.name, resource)
+                cached_decision = self._approval_cache.get(cache_key)
+                if cached_decision is not None:
+                    logger.debug(
+                        "Reusing approval for %s (resource=%r) from this turn: %s",
+                        tool_obj.name,
+                        resource,
+                        cached_decision,
+                    )
+                    decision = cached_decision
+                elif self._publish_outbound is not None and self._chat_id is not None:
                     prompt = format_approval_message(tool_obj.name, description)
 
                     if self._session_id:
@@ -593,6 +608,8 @@ class ClawboltAgent:
                         chat_id=self._chat_id,
                         prompt=prompt,
                     )
+                    if decision == ApprovalDecision.APPROVED:
+                        self._approval_cache[cache_key] = ApprovalDecision.APPROVED
                 else:
                     decision = ApprovalDecision.DENIED
 

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -1,0 +1,64 @@
+"""In-memory staging cache for inbound media bytes.
+
+Holds downloaded media content keyed by (user_id, original_url) for a short
+TTL so tools like ``upload_to_storage`` can find the bytes even when the
+agent calls them on a turn after the attachment arrived. Scoped per-user
+and per-process; not durable.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+STAGING_TTL_SECONDS = 3600
+
+
+_cache: dict[str, dict[str, tuple[bytes, str, float]]] = {}
+
+
+def stage(user_id: str, original_url: str, content: bytes, mime_type: str) -> None:
+    """Cache media bytes for later retrieval within the TTL window."""
+    if not original_url or not content:
+        return
+    expires_at = time.monotonic() + STAGING_TTL_SECONDS
+    _cache.setdefault(user_id, {})[original_url] = (content, mime_type, expires_at)
+    _purge_expired()
+
+
+def get_all_for_user(user_id: str) -> dict[str, bytes]:
+    """Return non-expired staged bytes for a user as ``{original_url: bytes}``."""
+    _purge_expired()
+    now = time.monotonic()
+    return {
+        url: content for url, (content, _mime, exp) in _cache.get(user_id, {}).items() if exp > now
+    }
+
+
+def evict(user_id: str, original_url: str) -> None:
+    """Remove a staged entry (call after successful upload or explicit deny)."""
+    user_items = _cache.get(user_id)
+    if user_items:
+        user_items.pop(original_url, None)
+        if not user_items:
+            _cache.pop(user_id, None)
+
+
+def clear_user(user_id: str) -> None:
+    """Drop all staged media for a user (primarily for tests)."""
+    _cache.pop(user_id, None)
+
+
+def _purge_expired() -> None:
+    now = time.monotonic()
+    empty_users: list[str] = []
+    for user_id, items in _cache.items():
+        expired = [url for url, (_c, _m, exp) in items.items() if exp <= now]
+        for url in expired:
+            del items[url]
+        if not items:
+            empty_users.append(user_id)
+    for user_id in empty_users:
+        del _cache[user_id]

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -8,10 +8,7 @@ and per-process; not durable.
 
 from __future__ import annotations
 
-import logging
 import time
-
-logger = logging.getLogger(__name__)
 
 STAGING_TTL_SECONDS = 3600
 
@@ -35,6 +32,21 @@ def get_all_for_user(user_id: str) -> dict[str, bytes]:
     return {
         url: content for url, (content, _mime, exp) in _cache.get(user_id, {}).items() if exp > now
     }
+
+
+def get_mime_type(user_id: str, original_url: str) -> str | None:
+    """Return the staged mime type for ``original_url``, or None if not cached.
+
+    The download step knows the authoritative mime type; the LLM is guessing.
+    ``upload_to_storage`` uses this to override its argument when available.
+    """
+    _purge_expired()
+    now = time.monotonic()
+    entry = _cache.get(user_id, {}).get(original_url)
+    if entry is None:
+        return None
+    _content, mime, exp = entry
+    return mime if exp > now else None
 
 
 def evict(user_id: str, original_url: str) -> None:

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -40,7 +40,9 @@ When the user asks about permissions, approval settings, what you can do freely,
 or wants to change how you handle actions, use PERMISSIONS.json.
 
 ## File uploads
-When the user sends a photo, document, or other file attachment and file storage is enabled, use upload_to_storage to save it. Provide the best client_name and file_category you can infer from context. If the permission system prompts the user for approval, wait for their response before continuing.
+When the user sends a photo, document, or other file attachment and file storage is enabled, call upload_to_storage. Do not ask "want me to save this?" in chat first. The permission system handles the approval prompt; a conversational pre-check creates a frustrating double-confirmation.
+
+Provide the best client_name and file_category you can infer from context. If you do not yet know the client, either ask one short clarifying question OR call upload_to_storage without client_name to stage the file under Unsorted; pick one, not both.
 
 Notes:
 - If the file was already auto-saved to the Unsorted folder (you will see it in the media records), use organize_file to move it to the correct client folder instead of uploading again.

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 
 from any_llm import AuthenticationError, ContentFilterError
 
+from backend.app.agent import media_staging
 from backend.app.agent.approval import PermissionLevel, get_approval_store
 from backend.app.agent.context import load_conversation_history
 from backend.app.agent.core import AgentResponse, ClawboltAgent
@@ -185,6 +186,7 @@ async def prepare_media(
             try:
                 media = await download_media(file_id)
                 downloaded_media.append(media)
+                media_staging.stage(user.id, media.original_url, media.content, media.mime_type)
                 logger.debug("Downloaded media %s (%s)", file_id, _mime_type)
             except Exception:
                 logger.exception("Failed to download media: %s", file_id)
@@ -193,7 +195,9 @@ async def prepare_media(
 
     # Auto-save inbound media only when the user allows it freely.
     # For "ask" or "deny", the agent loop handles it via the
-    # upload_to_storage tool so the approval gate can prompt.
+    # upload_to_storage tool so the approval gate can prompt. Bytes
+    # stay in media_staging across turns so the agent can still call
+    # upload_to_storage after clarifying questions.
     if storage and downloaded_media and _upload_permitted_always(user.id):
         try:
             await auto_save_media(user, storage, downloaded_media)
@@ -438,6 +442,9 @@ async def prepare_media_step(ctx: PipelineContext) -> PipelineContext:
     ``media_urls`` (e.g. Telegram file-id references).
     """
     pre_downloaded = list(ctx.downloaded_media)
+    if ctx.user is not None:
+        for media in pre_downloaded:
+            media_staging.stage(ctx.user.id, media.original_url, media.content, media.mime_type)
     newly_downloaded, ctx.storage = await prepare_media(
         ctx.user, ctx.message, ctx.media_urls, download_media=ctx.download_media
     )

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -230,6 +230,13 @@ def create_file_tools(
             file_bytes = media_map[first_url]
             original_url = original_url or first_url
 
+        # The download layer knows the real mime type; prefer that over the
+        # LLM-supplied argument so PDFs or HEICs don't get mislabeled.
+        if original_url:
+            staged_mime = media_staging.get_mime_type(user.id, original_url)
+            if staged_mime:
+                mime_type = staged_mime
+
         if not file_bytes:
             logger.warning("upload_to_storage called but no file content available")
             return ToolResult(
@@ -361,16 +368,16 @@ def create_file_tools(
         Tool(
             name=ToolName.UPLOAD_TO_STORAGE,
             description=(
-                "Upload a file attached to the CURRENT message to the user's "
-                "cloud storage. Only works when the user sent media in this "
-                "message. Files are organized by client: provide client_name or "
-                "client_address to file under their folder, otherwise files go to "
-                "Unsorted. For files received in previous messages, use "
-                "organize_file instead."
+                "Upload a file attached to the current message (or a recently "
+                "received one still in the staging cache) to the user's cloud "
+                "storage. Files are organized by client: provide client_name or "
+                "client_address to file under their folder, otherwise files go "
+                "to Unsorted. If the file was already persisted to storage in a "
+                "prior turn, use organize_file instead to move it."
             ),
             function=upload_to_storage,
             params_model=UploadToStorageParams,
-            usage_hint="Upload media from the current message to cloud storage.",
+            usage_hint="Upload a recently received file to cloud storage.",
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
                 resource_extractor=lambda args: args.get("client_name") or None,

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
+from backend.app.agent import media_staging
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.dto import slugify as _store_slugify
 from backend.app.agent.stores import MediaStore
@@ -189,6 +190,7 @@ async def auto_save_media(
             storage_path=f"{folder_path}/{filename}",
         )
         saved_urls.append(storage_url)
+        media_staging.evict(user.id, media.original_url)
 
     return saved_urls
 
@@ -203,7 +205,9 @@ def create_file_tools(
     Args:
         user: The user
         storage: Storage backend (Dropbox, Google Drive, or mock)
-        pending_media: Dict of original_url -> file bytes for media in the current message
+        pending_media: Dict of original_url -> file bytes available for upload.
+            Includes bytes from the current message and any recent staged
+            media bytes from prior turns (populated by ``_file_factory``).
     """
     media_map = pending_media or {}
 
@@ -270,6 +274,9 @@ def create_file_tools(
             storage_url=storage_url,
             storage_path=f"{folder_path}/{filename}",
         )
+
+        if original_url:
+            media_staging.evict(user.id, original_url)
 
         logger.info("File cataloged: %s/%s -> %s", folder_path, filename, storage_url)
         return ToolResult(content=f"Uploaded {filename} to {folder_path}/ ({storage_url})")
@@ -340,6 +347,8 @@ def create_file_tools(
             update_fields["processed_text"] = description
         await media_store.update(media_file.id, **update_fields)
 
+        media_staging.evict(user.id, original_url)
+
         logger.info(
             "File organized: %s -> %s/%s",
             current_path,
@@ -364,6 +373,7 @@ def create_file_tools(
             usage_hint="Upload media from the current message to cloud storage.",
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
+                resource_extractor=lambda args: args.get("client_name") or None,
                 description_builder=lambda args: (
                     f"Upload file to {args.get('client_name') or 'storage'}"
                 ),
@@ -383,6 +393,7 @@ def create_file_tools(
             usage_hint="Move an unsorted file into the correct client folder.",
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
+                resource_extractor=lambda args: args.get("client_name") or None,
                 description_builder=lambda args: (
                     f"Move file to {args.get('client_name') or 'client'} folder"
                 ),
@@ -395,6 +406,10 @@ def _file_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for file tools, used by the registry."""
     assert ctx.storage is not None
     pending_media = {m.original_url: m.content for m in ctx.downloaded_media if m.content}
+    # Fall back to recent staged bytes so upload_to_storage works even when the
+    # agent defers the call to a later turn with no attachments of its own.
+    for url, content in media_staging.get_all_for_user(ctx.user.id).items():
+        pending_media.setdefault(url, content)
     return create_file_tools(ctx.user, ctx.storage, pending_media)
 
 

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -132,6 +132,36 @@ async def test_file_factory_prefers_current_turn_over_stale_staging(
     assert any(v == b"fresh-bytes" for v in storage.files.values())
 
 
+def test_get_mime_type_returns_staged_value(test_user: User) -> None:
+    media_staging.stage(test_user.id, "bb_doc", b"pdf-bytes", "application/pdf")
+    assert media_staging.get_mime_type(test_user.id, "bb_doc") == "application/pdf"
+    assert media_staging.get_mime_type(test_user.id, "missing") is None
+
+
+@pytest.mark.asyncio()
+async def test_upload_uses_staged_mime_over_llm_argument(test_user: User) -> None:
+    """The download layer knows the real mime; the LLM-supplied value must not
+    overwrite it (e.g. agent defaults to image/jpeg but file is a PDF)."""
+    media_staging.stage(test_user.id, "bb_doc", b"pdf-bytes", "application/pdf")
+    ctx = ToolContext(
+        user=test_user,
+        storage=MockStorageBackend(),
+        downloaded_media=[],
+    )
+    tools = _file_factory(ctx)
+    upload = tools[0].function
+
+    result = await upload(
+        file_category="document",
+        original_url="bb_doc",
+        client_name="Jane",
+        mime_type="image/jpeg",  # LLM's wrong guess
+    )
+    assert result.is_error is False
+    # Filename should reflect the real mime (.pdf), not the LLM guess (.jpg).
+    assert ".pdf" in result.content
+
+
 @pytest.mark.asyncio()
 async def test_upload_evicts_staged_entry(test_user: User) -> None:
     media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -1,0 +1,237 @@
+"""Tests for media_staging cache and cross-turn upload_to_storage recovery."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Generator
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+from backend.app.agent import media_staging
+from backend.app.agent.approval import (
+    ApprovalDecision,
+    ApprovalPolicy,
+    PermissionLevel,
+    get_approval_gate,
+    get_approval_store,
+)
+from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.llm_parsing import ParsedToolCall
+from backend.app.agent.messages import ToolCallRequest
+from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.agent.tools.file_tools import _file_factory, auto_save_media, create_file_tools
+from backend.app.agent.tools.registry import ToolContext
+from backend.app.media.download import DownloadedMedia
+from backend.app.models import User
+from tests.mocks.storage import MockStorageBackend
+
+
+@pytest.fixture(autouse=True)
+def _clear_staging_between_tests(test_user: User) -> Generator[None]:
+    media_staging.clear_user(test_user.id)
+    yield
+    media_staging.clear_user(test_user.id)
+
+
+def test_stage_and_retrieve(test_user: User) -> None:
+    media_staging.stage(test_user.id, "bb_abc", b"bytes", "image/jpeg")
+    result = media_staging.get_all_for_user(test_user.id)
+    assert result == {"bb_abc": b"bytes"}
+
+
+def test_stage_ignores_empty_url_or_content(test_user: User) -> None:
+    media_staging.stage(test_user.id, "", b"bytes", "image/jpeg")
+    media_staging.stage(test_user.id, "bb_empty", b"", "image/jpeg")
+    assert media_staging.get_all_for_user(test_user.id) == {}
+
+
+def test_evict_removes_entry(test_user: User) -> None:
+    media_staging.stage(test_user.id, "bb_abc", b"bytes", "image/jpeg")
+    media_staging.evict(test_user.id, "bb_abc")
+    assert media_staging.get_all_for_user(test_user.id) == {}
+
+
+def test_expired_entries_are_purged(test_user: User, monkeypatch: pytest.MonkeyPatch) -> None:
+    media_staging.stage(test_user.id, "bb_old", b"bytes", "image/jpeg")
+    # Fast-forward past the TTL.
+    real_monotonic = time.monotonic
+    future = real_monotonic() + media_staging.STAGING_TTL_SECONDS + 1
+    monkeypatch.setattr(media_staging.time, "monotonic", lambda: future)
+    assert media_staging.get_all_for_user(test_user.id) == {}
+
+
+def test_isolation_between_users() -> None:
+    media_staging.stage("user-a", "bb_abc", b"bytes-a", "image/jpeg")
+    media_staging.stage("user-b", "bb_abc", b"bytes-b", "image/jpeg")
+    assert media_staging.get_all_for_user("user-a") == {"bb_abc": b"bytes-a"}
+    assert media_staging.get_all_for_user("user-b") == {"bb_abc": b"bytes-b"}
+    media_staging.clear_user("user-a")
+    media_staging.clear_user("user-b")
+
+
+@pytest.mark.asyncio()
+async def test_file_factory_merges_staged_bytes_when_current_turn_has_none(
+    test_user: User,
+) -> None:
+    """The agent may call upload_to_storage on a turn with no attachments; staged
+    bytes from an earlier turn must still be available so the upload succeeds."""
+    media_staging.stage(test_user.id, "bb_photo", b"photo-bytes", "image/jpeg")
+
+    ctx = ToolContext(
+        user=test_user,
+        storage=MockStorageBackend(),
+        downloaded_media=[],
+    )
+    tools = _file_factory(ctx)
+    upload = tools[0].function
+
+    result = await upload(
+        file_category="job_photo",
+        description="Tile job",
+        client_name="David Graham",
+    )
+
+    assert result.is_error is False
+    assert "Uploaded" in result.content
+    # Staging entry should be evicted after a successful upload.
+    assert media_staging.get_all_for_user(test_user.id) == {}
+
+
+@pytest.mark.asyncio()
+async def test_file_factory_prefers_current_turn_over_stale_staging(
+    test_user: User,
+) -> None:
+    """If the same URL is in both current downloaded_media and staging, the
+    current-turn bytes win (staging is fallback only)."""
+    media_staging.stage(test_user.id, "bb_photo", b"stale-bytes", "image/jpeg")
+    current = DownloadedMedia(
+        content=b"fresh-bytes",
+        mime_type="image/jpeg",
+        original_url="bb_photo",
+        filename="photo.jpg",
+    )
+    ctx = ToolContext(
+        user=test_user,
+        storage=MockStorageBackend(),
+        downloaded_media=[current],
+    )
+    tools = _file_factory(ctx)
+    upload = tools[0].function
+
+    result = await upload(
+        file_category="job_photo",
+        original_url="bb_photo",
+        client_name="David Graham",
+    )
+    assert result.is_error is False
+    # The fresh bytes should have been used; inspect the mock storage.
+    storage = ctx.storage
+    assert isinstance(storage, MockStorageBackend)
+    assert any(v == b"fresh-bytes" for v in storage.files.values())
+
+
+@pytest.mark.asyncio()
+async def test_upload_evicts_staged_entry(test_user: User) -> None:
+    media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+    storage = MockStorageBackend()
+    tools = create_file_tools(
+        test_user,
+        storage,
+        pending_media={"bb_photo": b"bytes"},
+    )
+    upload = tools[0].function
+
+    result = await upload(
+        file_category="job_photo",
+        original_url="bb_photo",
+        client_name="Jane",
+    )
+    assert result.is_error is False
+    assert media_staging.get_all_for_user(test_user.id) == {}
+
+
+@pytest.mark.asyncio()
+async def test_auto_save_evicts_staged_entry(test_user: User) -> None:
+    """Auto-save (ALWAYS permission) should also evict staged bytes."""
+    media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+
+    storage = MockStorageBackend()
+    media = DownloadedMedia(
+        content=b"bytes",
+        mime_type="image/jpeg",
+        original_url="bb_photo",
+        filename="photo.jpg",
+    )
+    await auto_save_media(test_user, storage, [media])
+    assert media_staging.get_all_for_user(test_user.id) == {}
+
+
+class _FakeUploadParams(BaseModel):
+    client_name: str = Field(default="")
+
+
+@pytest.mark.asyncio()
+async def test_approval_cache_coalesces_repeat_ask(test_user: User) -> None:
+    """When the agent calls the same ASK tool three times with the same
+    resource within one run, the user should only be prompted once."""
+    calls: list[str] = []
+
+    async def _fn(client_name: str = "") -> ToolResult:
+        calls.append(client_name)
+        return ToolResult(content=f"ok for {client_name}")
+
+    tool = Tool(
+        name="fake_upload",
+        description="fake",
+        function=_fn,
+        params_model=_FakeUploadParams,
+        usage_hint="",
+        approval_policy=ApprovalPolicy(
+            default_level=PermissionLevel.ASK,
+            resource_extractor=lambda args: args.get("client_name") or None,
+            description_builder=lambda args: f"Upload to {args.get('client_name')}",
+        ),
+    )
+
+    # Make sure ASK is the effective level (no persisted override).
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+
+    async def _publish(_msg: object) -> None:
+        return None
+
+    gate = get_approval_gate()
+    # Stub gate.request_approval so it returns APPROVED without needing a real
+    # inbound response message from a channel.
+    gate.request_approval = AsyncMock(return_value=ApprovalDecision.APPROVED)  # type: ignore[method-assign]
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="bluebubbles",
+        publish_outbound=_publish,
+        chat_id="+1234567890",
+        session_id="",
+    )
+    agent.register_tools([tool])
+
+    args = {"client_name": "David Graham"}
+    parsed_calls = [
+        ToolCallRequest(id=f"call_{i}", name="fake_upload", arguments=args) for i in range(3)
+    ]
+    parsed_raw = [
+        ParsedToolCall(id=f"call_{i}", name="fake_upload", arguments=args) for i in range(3)
+    ]
+
+    await agent._execute_tool_round(
+        parsed_calls=parsed_calls,
+        parsed_raw=parsed_raw,
+        actions_taken=[],
+        memories_saved=[],
+        tool_call_records=[],
+    )
+
+    # Three tool calls, one user approval prompt.
+    assert gate.request_approval.await_count == 1  # type: ignore[attr-defined]
+    assert calls == ["David Graham", "David Graham", "David Graham"]


### PR DESCRIPTION
## Description

Two connected bugs observed in a live BlueBubbles conversation where a photo was sent, the agent clarified "which client?", then asked for upload approval several turns later.

1. **Bytes lifecycle gap.** After #948 moved file persistence out of the pipeline for `upload_to_storage` permission levels `ask`/`deny`, the agent depends on `pending_media` to carry byte content. But `pending_media` is scoped to the current inbound message; if the agent takes a clarifying turn first, the bytes are garbage-collected and the tool fails with `"No file content available to upload"`.
2. **Approval prompt cascade.** #943 told the agent not to ask "want me to save this?" in chat first, but adherence was spotty. Combined with #937's sequential per-tool approval, chains/retries (`upload_to_storage` → fails → retry) produced 2-3 prompts for one user intent.

## Type
- [x] Bug fix

## Changes

- **`backend/app/agent/media_staging.py`** (new) -- in-memory, per-user, TTL-bounded (1h) cache keyed by `original_url`. Purges on access.
- **`router.py`** -- `prepare_media` and `prepare_media_step` stash downloaded bytes into staging regardless of permission level. Guarded with `if ctx.user is not None` to respect existing test fixtures.
- **`file_tools.py`**
  - `_file_factory` merges staged bytes into `pending_media` so `upload_to_storage` works on turns that have no attachments of their own.
  - `upload_to_storage`, `organize_file`, and `auto_save_media` evict after success.
  - Both file tools set `resource_extractor = client_name` so the approval system can key by intent.
- **`core.py`** -- per-run `_approval_cache` keyed by `(tool_name, resource)`. Repeat ASK calls with the same resource reuse the first APPROVED decision instead of re-prompting. ALWAYS_ALLOW is still persisted to PERMISSIONS.json and bypasses the cache naturally.
- **`instructions.md`** File uploads section -- explicitly forbids conversational pre-checks; tells the agent to ask one clarifying question OR call the tool, not both.

## Tests

- `tests/test_media_staging.py` (10 tests):
  - Staging lifecycle: stage, retrieve, evict, TTL purge, per-user isolation.
  - `_file_factory` cross-turn recovery: staged bytes appear in `pending_media` when current turn has no attachments.
  - Current-turn bytes win over stale staging when URLs collide.
  - Upload / auto-save evict the staged entry.
  - Approval cache coalescing: three chained `fake_upload(client_name="David Graham")` calls in one agent run produce one `gate.request_approval` call, not three.
- Full suite: **1573 passed, 13 deselected.**

## Checklist
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`ruff check backend/ tests/` + `ruff format --check`)
- [x] Type check passes (`ty check`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted -- Claude Opus 4.6 (1M context) diagnosed both bugs from production logs, designed the staging cache and approval coalescing, wrote the fix and regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)