### PR TITLE
fix: persist 'Always' for file uploads globally, not per client

### DIFF
--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -380,7 +380,6 @@ def create_file_tools(
             usage_hint="Upload a recently received file to cloud storage.",
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
-                resource_extractor=lambda args: args.get("client_name") or None,
                 description_builder=lambda args: (
                     f"Upload file to {args.get('client_name') or 'storage'}"
                 ),
@@ -400,7 +399,6 @@ def create_file_tools(
             usage_hint="Move an unsorted file into the correct client folder.",
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
-                resource_extractor=lambda args: args.get("client_name") or None,
                 description_builder=lambda args: (
                     f"Move file to {args.get('client_name') or 'client'} folder"
                 ),

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -265,3 +265,65 @@ async def test_approval_cache_coalesces_repeat_ask(test_user: User) -> None:
     # Three tool calls, one user approval prompt.
     assert gate.request_approval.await_count == 1  # type: ignore[attr-defined]
     assert calls == ["David Graham", "David Graham", "David Graham"]
+
+
+@pytest.mark.asyncio()
+async def test_always_allow_for_upload_to_storage_persists_globally(
+    test_user: User,
+) -> None:
+    """When the user says 'Always' to an upload_to_storage prompt, the
+    permission must persist globally for the tool, not scoped per client
+    name (otherwise the user would have to say 'Always' separately for
+    every new client they ever upload for)."""
+    from backend.app.agent.llm_parsing import ParsedToolCall
+    from backend.app.agent.messages import ToolCallRequest
+    from backend.app.agent.tools.file_tools import create_file_tools
+
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+
+    gate = get_approval_gate()
+    gate.request_approval = AsyncMock(return_value=ApprovalDecision.ALWAYS_ALLOW)  # type: ignore[method-assign]
+
+    async def _publish(_msg: object) -> None:
+        return None
+
+    storage = MockStorageBackend()
+    tools = create_file_tools(test_user, storage, pending_media={"bb_photo": b"bytes"})
+    upload_tool = next(t for t in tools if t.name == "upload_to_storage")
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="bluebubbles",
+        publish_outbound=_publish,
+        chat_id="+1234567890",
+        session_id="",
+    )
+    agent.register_tools([upload_tool])
+
+    args = {
+        "file_category": "job_photo",
+        "client_name": "David Graham",
+        "original_url": "bb_photo",
+    }
+    parsed = [ToolCallRequest(id="call_0", name="upload_to_storage", arguments=args)]
+    raw = [ParsedToolCall(id="call_0", name="upload_to_storage", arguments=args)]
+    await agent._execute_tool_round(
+        parsed_calls=parsed,
+        parsed_raw=raw,
+        actions_taken=[],
+        memories_saved=[],
+        tool_call_records=[],
+    )
+
+    # Permission should now be ALWAYS for upload_to_storage globally, not
+    # scoped to David Graham only. A subsequent upload for a different
+    # client should auto-approve without another prompt.
+    level_global = store.check_permission(
+        test_user.id, "upload_to_storage", default=PermissionLevel.ASK
+    )
+    level_different_client = store.check_permission(
+        test_user.id, "upload_to_storage", resource="Other Client", default=PermissionLevel.ASK
+    )
+    assert level_global == PermissionLevel.ALWAYS
+    assert level_different_client == PermissionLevel.ALWAYS


### PR DESCRIPTION
## Description

Follow-up to #950. The user reported: "I said 'Always' but the permissions page still says 'ask'."

Root cause: PR #950 added \`resource_extractor=lambda args: args.get("client_name")\` to \`upload_to_storage\` and \`organize_file\` for per-turn approval coalescing. But \`core.py:600-605\` passes the same \`resource\` to \`store.set_permission()\` when the user picks ALWAYS_ALLOW. So "Always" recorded a per-client override (\`upload_to_storage + "David Graham" = always\`) instead of the global permission (\`upload_to_storage = always\`). The dashboard reads the global level, which stayed at "ask", and a future upload for a different client would prompt again.

## Fix

Drop \`resource_extractor\` from both file tools. The per-turn approval cache still coalesces retries of the same tool (cache key becomes \`(tool_name, None)\`, which is coarser but fine — users almost never upload for multiple different clients in one agent turn). Permissions now persist globally.

## Type
- [x] Bug fix

## Tests

- Full suite: **1576 passed, 13 deselected** (one new regression test).
- New: \`test_always_allow_for_upload_to_storage_persists_globally\` — fires \`upload_to_storage(client_name="David Graham")\` through the gate with a stubbed \`ALWAYS_ALLOW\` decision, then asserts the stored permission applies even when checked with \`resource="Other Client"\`. Fails on main.

## Checklist
- [x] Tests pass
- [x] Lint + format + type check clean
- [x] Regression test added

## AI Usage
- [x] AI-assisted — Claude Opus 4.6 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)