### PR TITLE
feat: surface approval 'Always'/'Never' as update_permission tool records

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -221,6 +221,49 @@ class ClawboltAgent:
 
         return level, resource, description
 
+    async def _record_permission_update(
+        self,
+        tool_name: str,
+        level: str,
+        resource: str | None,
+        tool_call_records: list[StoredToolInteraction],
+    ) -> None:
+        """Record an approval-system permission change as a synthetic tool call.
+
+        When the user says "Always" / "Never" to an approval prompt, the gate
+        persists the permission silently. Without this record, the chat
+        transcript only shows the raw "Always" reply and the tool it approved,
+        with no indication that the permission was remembered. Emit a fake
+        ``update_permission`` record so it renders alongside real tool calls
+        in the dashboard and session history.
+        """
+        args: dict[str, Any] = {"tool": tool_name, "level": level}
+        if resource:
+            args["resource"] = resource
+        verb = "always run" if level == "always" else "never run"
+        result = f"Saved: {tool_name} will {verb} without asking."
+        call_id = f"perm_{tool_name}_{level}_{int(time.monotonic() * 1000)}"
+        tool_call_records.append(
+            StoredToolInteraction(
+                tool_call_id=call_id,
+                name=ToolName.UPDATE_PERMISSION,
+                args=args,
+                result=result,
+                is_error=False,
+            )
+        )
+        await self._emit(
+            ToolExecutionStartEvent(tool_name=ToolName.UPDATE_PERMISSION, arguments=args)
+        )
+        await self._emit(
+            ToolExecutionEndEvent(
+                tool_name=ToolName.UPDATE_PERMISSION,
+                result=result,
+                is_error=False,
+                duration_ms=0.0,
+            )
+        )
+
     def register_tools(self, tools: list[Tool]) -> None:
         """Register available tools for this agent session."""
         self.tools = tools
@@ -622,6 +665,10 @@ class ClawboltAgent:
                             )
                         except Exception:
                             logger.warning("Failed to persist ALWAYS for tool %s", tool_obj.name)
+                        else:
+                            await self._record_permission_update(
+                                tool_obj.name, "always", resource, tool_call_records
+                            )
 
                 elif decision == ApprovalDecision.INTERRUPTED:
                     # User changed subject. Error this entry + all remaining.
@@ -660,6 +707,10 @@ class ClawboltAgent:
                             )
                         except Exception:
                             logger.warning("Failed to persist DENY for tool %s", tool_obj.name)
+                        else:
+                            await self._record_permission_update(
+                                tool_obj.name, "deny", resource, tool_call_records
+                            )
 
                     tool_tags = self._get_tool_tags(tc_req.name)
                     hint = _ERROR_KIND_HINTS[ToolErrorKind.PERMISSION]

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -46,6 +46,11 @@ class ToolName:
     LIST_CAPABILITIES = "list_capabilities"
     MANAGE_INTEGRATION = "manage_integration"
 
+    # Synthetic records (not LLM-callable; emitted by the approval system
+    # so permission remembers show up in chat history alongside real tool
+    # calls.)
+    UPDATE_PERMISSION = "update_permission"
+
     # Heartbeat (not registered in the main tool registry)
     COMPOSE_MESSAGE = "compose_message"
     HEARTBEAT_DECISION = "heartbeat_decision"

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -327,3 +327,109 @@ async def test_always_allow_for_upload_to_storage_persists_globally(
     )
     assert level_global == PermissionLevel.ALWAYS
     assert level_different_client == PermissionLevel.ALWAYS
+
+
+@pytest.mark.asyncio()
+async def test_always_allow_emits_update_permission_record(test_user: User) -> None:
+    """ALWAYS_ALLOW must surface as a synthetic update_permission record in
+    tool_call_records so the chat panel shows that the permission was
+    remembered, not just the tool the user approved."""
+    from backend.app.agent.context import StoredToolInteraction
+    from backend.app.agent.llm_parsing import ParsedToolCall
+    from backend.app.agent.messages import ToolCallRequest
+    from backend.app.agent.tools.file_tools import create_file_tools
+    from backend.app.agent.tools.names import ToolName
+
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+
+    gate = get_approval_gate()
+    gate.request_approval = AsyncMock(return_value=ApprovalDecision.ALWAYS_ALLOW)  # type: ignore[method-assign]
+
+    async def _publish(_msg: object) -> None:
+        return None
+
+    storage = MockStorageBackend()
+    tools = create_file_tools(test_user, storage, pending_media={"bb_photo": b"bytes"})
+    upload_tool = next(t for t in tools if t.name == "upload_to_storage")
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="bluebubbles",
+        publish_outbound=_publish,
+        chat_id="+1234567890",
+        session_id="",
+    )
+    agent.register_tools([upload_tool])
+
+    args = {
+        "file_category": "job_photo",
+        "client_name": "David Graham",
+        "original_url": "bb_photo",
+    }
+    parsed = [ToolCallRequest(id="call_0", name="upload_to_storage", arguments=args)]
+    raw = [ParsedToolCall(id="call_0", name="upload_to_storage", arguments=args)]
+    records: list[StoredToolInteraction] = []
+    await agent._execute_tool_round(
+        parsed_calls=parsed,
+        parsed_raw=raw,
+        actions_taken=[],
+        memories_saved=[],
+        tool_call_records=records,
+    )
+
+    perm_records = [r for r in records if r.name == ToolName.UPDATE_PERMISSION]
+    assert len(perm_records) == 1
+    assert perm_records[0].args == {"tool": "upload_to_storage", "level": "always"}
+    assert perm_records[0].is_error is False
+    assert "upload_to_storage" in perm_records[0].result
+    assert "always run" in perm_records[0].result
+
+
+@pytest.mark.asyncio()
+async def test_always_deny_emits_update_permission_record(test_user: User) -> None:
+    """Same treatment for ALWAYS_DENY ('Never')."""
+    from backend.app.agent.context import StoredToolInteraction
+    from backend.app.agent.llm_parsing import ParsedToolCall
+    from backend.app.agent.messages import ToolCallRequest
+    from backend.app.agent.tools.file_tools import create_file_tools
+    from backend.app.agent.tools.names import ToolName
+
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+
+    gate = get_approval_gate()
+    gate.request_approval = AsyncMock(return_value=ApprovalDecision.ALWAYS_DENY)  # type: ignore[method-assign]
+
+    async def _publish(_msg: object) -> None:
+        return None
+
+    storage = MockStorageBackend()
+    tools = create_file_tools(test_user, storage, pending_media={"bb_photo": b"bytes"})
+    upload_tool = next(t for t in tools if t.name == "upload_to_storage")
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="bluebubbles",
+        publish_outbound=_publish,
+        chat_id="+1234567890",
+        session_id="",
+    )
+    agent.register_tools([upload_tool])
+
+    args = {"file_category": "job_photo", "client_name": "Jane", "original_url": "bb_photo"}
+    parsed = [ToolCallRequest(id="call_0", name="upload_to_storage", arguments=args)]
+    raw = [ParsedToolCall(id="call_0", name="upload_to_storage", arguments=args)]
+    records: list[StoredToolInteraction] = []
+    await agent._execute_tool_round(
+        parsed_calls=parsed,
+        parsed_raw=raw,
+        actions_taken=[],
+        memories_saved=[],
+        tool_call_records=records,
+    )
+
+    perm_records = [r for r in records if r.name == ToolName.UPDATE_PERMISSION]
+    assert len(perm_records) == 1
+    assert perm_records[0].args["level"] == "deny"
+    assert "never run" in perm_records[0].result


### PR DESCRIPTION
## Description

Follow-up to #950/#951. User asked: "when I set it to always, shouldn't there be a tool call in the admin chat panel showing permissions were updated, like upload_to_storage renders?"

Yes — previously the ApprovalGate flipped PERMISSIONS.json silently. The chat showed only the user's "Always" reply and the then-executed tool; there was no record that a permission was remembered, making the state change invisible in the dashboard.

## Fix

When a prompt resolves to ALWAYS_ALLOW or ALWAYS_DENY and the permission persists successfully, emit a synthetic \`update_permission\` record:
- Appends a \`StoredToolInteraction\` (tool_name=\`update_permission\`, args include tool/level/resource, result describes what was saved) to the round's \`tool_call_records\` — so it lands in the session's \`tool_interactions_json\`.
- Emits \`ToolExecutionStartEvent\` + \`ToolExecutionEndEvent\` — so the SSE activity stream and the per-request tool_call event fire for dashboard clients.

Added \`ToolName.UPDATE_PERMISSION\` as a constant. The synthetic record is not LLM-callable (not registered in any factory); it only exists as a historical marker.

## Type
- [x] Feature

## Tests

- New: \`test_always_allow_emits_update_permission_record\` and \`test_always_deny_emits_update_permission_record\` — assert a single \`update_permission\` entry appears in \`tool_call_records\` with the expected args/result.
- Full suite: **1578 passed, 13 deselected.**

## Checklist
- [x] Tests pass
- [x] Lint + format + type check clean
- [x] Regression tests added

## AI Usage
- [x] AI-assisted — Claude Opus 4.6 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)