### PR TITLE
fix: check BlueBubbles reachability even when PaaS webhook is pre-registered

### DIFF
--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -220,18 +220,23 @@ class BlueBubblesChannel(BaseChannel):
 
         await asyncio.sleep(STARTUP_DELAY_SECONDS)
 
-        # If a PaaS webhook was already registered (e.g. via premium on
-        # Railway), skip the tunnel discovery retry loop entirely.
-        if self.webhook_registered:
-            return
-
-        # Verify the server is actually reachable before advertising as configured.
+        # Verify the server is actually reachable before advertising as
+        # configured. Do this regardless of who registered the inbound
+        # webhook: on premium the PaaS lifespan registers a webhook on the
+        # BlueBubbles server, but that doesn't tell us whether the user's
+        # Mac is actually up and reachable; the dashboard still needs the
+        # reachability signal so it doesn't gray out a working channel.
         self.server_reachable = await self._check_server_reachable()
         if not self.server_reachable:
             logger.warning(
                 "BlueBubbles server not reachable at %s",
                 settings.bluebubbles_server_url,
             )
+            return
+
+        # If a PaaS webhook was already registered (e.g. via premium on
+        # Railway), skip the tunnel discovery retry loop entirely.
+        if self.webhook_registered:
             return
 
         tunnel_url = await discover_tunnel_url()

--- a/tests/test_bluebubbles_channel.py
+++ b/tests/test_bluebubbles_channel.py
@@ -754,6 +754,47 @@ async def test_start_marks_unreachable_when_server_down() -> None:
     mock_register.assert_not_called()
 
 
+async def test_start_checks_reachability_even_with_paas_webhook_registered() -> None:
+    """On premium, the PaaS lifespan sets webhook_registered=True before
+    start() runs the tunnel loop. Reachability must still be checked so
+    is_bluebubbles_configured() returns True and the dashboard doesn't
+    gray out a working channel.
+
+    Regression test: earlier code short-circuited start() on
+    webhook_registered, leaving server_reachable=False on premium
+    deployments even when the user's BlueBubbles server was up.
+    """
+    channel = BlueBubblesChannel()
+    channel.webhook_registered = True
+
+    with (
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_server_url",
+            "https://bb.example.com",
+        ),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "test-pw"),
+        patch("backend.app.channels.bluebubbles.asyncio.sleep", new_callable=AsyncMock),
+        patch.object(
+            channel, "_check_server_reachable", new_callable=AsyncMock, return_value=True
+        ) as mock_check,
+        patch(
+            "backend.app.channels.bluebubbles.discover_tunnel_url",
+            new_callable=AsyncMock,
+        ) as mock_discover,
+        patch(
+            "backend.app.channels.bluebubbles.register_bluebubbles_webhook",
+            new_callable=AsyncMock,
+        ) as mock_register,
+    ):
+        await channel.start()
+
+    assert channel.server_reachable is True
+    mock_check.assert_awaited_once()
+    # Tunnel discovery must still be skipped: the PaaS webhook is already in place.
+    mock_discover.assert_not_called()
+    mock_register.assert_not_called()
+
+
 async def test_check_server_reachable_success() -> None:
     """_check_server_reachable returns True when server responds."""
     channel = BlueBubblesChannel()


### PR DESCRIPTION
## Description

Deployed clawbolt-premium on Railway; the dashboard Channels page showed BlueBubbles as "Not available" (grayed out), but inbound webhooks and outbound sends worked fine.

Root cause: \`BlueBubblesChannel.start()\` had \`if self.webhook_registered: return\` **before** \`_check_server_reachable()\`. On premium, the lifespan hook in \`clawbolt_premium/app.py\` sets \`channel.webhook_registered = True\` during PaaS webhook registration, so the OSS \`start()\` short-circuits and never runs the reachability probe. \`server_reachable\` stays \`False\`, \`is_bluebubbles_configured()\` returns \`False\`, dashboard paints it unavailable.

## Fix

Reorder \`start()\`: run the reachability check first (it's orthogonal to who registered the webhook), then keep the \`webhook_registered\` short-circuit to skip tunnel discovery + OSS webhook registration.

## Type
- [x] Bug fix

## Tests

- New: \`test_start_checks_reachability_even_with_paas_webhook_registered\` — with \`webhook_registered=True\` and a reachable server, asserts \`server_reachable=True\` while tunnel discovery + registration stay skipped. Fails on main.
- Full suite: **1579 passed, 13 deselected.**

## Checklist
- [x] Tests pass
- [x] Lint + format clean
- [x] Regression test added

## AI Usage
- [x] AI-assisted — Claude Opus 4.6 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)