### PR TITLE
fix: resolve organize_file by storage_url/path, not just original_url

### DIFF
--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -14,7 +14,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -279,12 +279,29 @@ class MediaStore:
             return _media_to_dto(m)
 
     async def get_by_url(self, original_url: str) -> MediaData | None:
-        """Query a MediaFile by original_url."""
+        """Query a MediaFile by any of its stored URLs or paths.
+
+        Matches ``original_url`` (channel attachment id, e.g. ``bb_<guid>``),
+        ``storage_url`` (backend-emitted URL shown to the LLM in upload
+        results, e.g. ``file:///...``), or ``storage_path`` (the folder path).
+        The agent only sees ``storage_url`` in upload_to_storage's result and
+        will pass that back to organize_file later; matching on all three
+        lets the lookup succeed regardless of which identifier the LLM used.
+        """
+        if not original_url:
+            return None
         db = SessionLocal()
         try:
             m = (
                 db.query(MediaFile)
-                .filter_by(user_id=self.user_id, original_url=original_url)
+                .filter(MediaFile.user_id == self.user_id)
+                .filter(
+                    or_(
+                        MediaFile.original_url == original_url,
+                        MediaFile.storage_url == original_url,
+                        MediaFile.storage_path == original_url,
+                    )
+                )
                 .first()
             )
             return _media_to_dto(m) if m else None

--- a/tests/test_file_cataloging.py
+++ b/tests/test_file_cataloging.py
@@ -461,3 +461,68 @@ async def test_organize_file_without_client_returns_error(
     assert "Error" in result.content
     assert "client_name or client_address is required" in result.content
     assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_organize_file_resolves_by_storage_url(
+    test_user: User,
+) -> None:
+    """organize_file should find the record when the agent passes storage_url
+    as original_url. This is the real-world case: upload_to_storage's tool
+    result surfaces storage_url (e.g. ``file:///...``) to the LLM, not the
+    channel attachment id (e.g. ``bb_<guid>``) that we stored on the record.
+    Later calls to organize_file pass back the storage_url because that's
+    the only URL the LLM has seen."""
+    storage = MockStorageBackend()
+    await storage.upload_file(b"img-data", "/Unsorted/2026-03-02", "file_001.jpg")
+    media_store = MediaStore(test_user.id)
+    await media_store.create(
+        original_url="bb_abc-guid",  # channel attachment id, hidden from LLM
+        mime_type="image/jpeg",
+        storage_url="file:///app/data/.../Unsorted/2026-03-02/file_001.jpg",
+        storage_path="/Unsorted/2026-03-02/file_001.jpg",
+    )
+
+    tools = create_file_tools(test_user, storage)
+    organize = tools[1].function
+
+    # LLM only ever saw the storage_url in the upload result; it passes that.
+    result = await organize(
+        original_url="file:///app/data/.../Unsorted/2026-03-02/file_001.jpg",
+        file_category="job_photo",
+        client_name="Ralph Smith",
+        description="tile installation reference photo",
+    )
+
+    assert result.is_error is False
+    assert "Moved" in result.content
+    assert "Ralph Smith" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_organize_file_resolves_by_storage_path(
+    test_user: User,
+) -> None:
+    """organize_file should also find the record by storage_path, in case
+    the LLM echoes the path fragment instead of the full URL."""
+    storage = MockStorageBackend()
+    await storage.upload_file(b"img-data", "/Unsorted/2026-03-02", "file_002.jpg")
+    media_store = MediaStore(test_user.id)
+    await media_store.create(
+        original_url="bb_xyz-guid",
+        mime_type="image/jpeg",
+        storage_url="https://mock-storage.example.com/Unsorted/2026-03-02/file_002.jpg",
+        storage_path="/Unsorted/2026-03-02/file_002.jpg",
+    )
+
+    tools = create_file_tools(test_user, storage)
+    organize = tools[1].function
+
+    result = await organize(
+        original_url="/Unsorted/2026-03-02/file_002.jpg",
+        file_category="job_photo",
+        client_name="Ralph Smith",
+    )
+
+    assert result.is_error is False
+    assert "Moved" in result.content


### PR DESCRIPTION
## Description

User sent a photo, said "Always" to move it to Ralph Smith's folder, and saw:

> File not found for URL: file:///app/data/storage/.../Unsorted/2026-04-14/tile_installation_reference_ph_003.jpg

Even though the upload moments earlier had succeeded.

## Root cause

\`upload_to_storage\` saves the \`MediaFile\` row with \`original_url = "bb_<guid>"\` (the BlueBubbles attachment id). Its success string shown to the LLM surfaces the \`storage_url\` (\`file:///...\`), not the channel id. When the LLM later invokes \`organize_file\`, it passes back the only URL it has seen — the \`storage_url\` — as the \`original_url\` argument. \`MediaStore.get_by_url()\` filtered only on the \`original_url\` column, so the lookup missed and returned NOT_FOUND.

## Fix

Widen \`MediaStore.get_by_url()\` to match \`original_url\` OR \`storage_url\` OR \`storage_path\`. Only one caller (\`organize_file\`), checked via grep — no semantics depend on the narrow match.

## Type
- [x] Bug fix

## Tests

- New: \`test_organize_file_resolves_by_storage_url\` and \`test_organize_file_resolves_by_storage_path\` — store a record with the channel guid as \`original_url\`, call \`organize_file\` with the \`storage_url\` / \`storage_path\`, assert success. Fail on main.
- Full suite: **1583 passed, 13 deselected.**

## Checklist
- [x] Tests pass
- [x] Lint + format clean
- [x] Regression tests added

## AI Usage
- [x] AI-assisted — Claude Opus 4.6 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)