### PR TITLE
feat: persist permissions in postgres, default messaging to ALWAYS, hide from UI

### DIFF
--- a/alembic/versions/015_permissions_to_db.py
+++ b/alembic/versions/015_permissions_to_db.py
@@ -1,0 +1,93 @@
+"""Move per-user permissions from PERMISSIONS.json files into the database.
+
+Creates the ``user_permissions`` table and backfills it from any
+``PERMISSIONS.json`` files under ``settings.data_dir``. Existing files
+are left on disk so a downgrade can still recover them; the app stops
+reading them once this migration lands.
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-04-14
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import op
+
+from backend.app.config import settings
+
+revision: str = "015"
+down_revision: str = "014"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+logger = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_permissions",
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id", ondelete="CASCADE"),
+                  primary_key=True),
+        sa.Column("data", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+    )
+
+    _backfill_from_disk()
+
+
+def downgrade() -> None:
+    op.drop_table("user_permissions")
+
+
+def _backfill_from_disk() -> None:
+    """Copy each user's existing PERMISSIONS.json into the new table.
+
+    Best-effort: skips unreadable files, malformed JSON, and any user dir
+    that doesn't correspond to a known user row. The files stay on disk
+    so the data isn't lost if something goes wrong.
+    """
+    data_root = Path(settings.data_dir)
+    if not data_root.exists():
+        logger.info("permissions migration: no data dir at %s, nothing to backfill", data_root)
+        return
+
+    conn = op.get_bind()
+    user_ids = {row[0] for row in conn.execute(sa.text("SELECT id FROM users")).fetchall()}
+
+    inserted = 0
+    for user_dir in data_root.iterdir():
+        if not user_dir.is_dir():
+            continue
+        if user_dir.name not in user_ids:
+            continue
+        perm_file = user_dir / "PERMISSIONS.json"
+        if not perm_file.exists():
+            continue
+        try:
+            raw = perm_file.read_text(encoding="utf-8")
+            parsed = json.loads(raw)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            logger.warning(
+                "permissions migration: skipping %s (%s)", perm_file, exc
+            )
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        payload = json.dumps(parsed)
+        conn.execute(
+            sa.text(
+                "INSERT INTO user_permissions (user_id, data) VALUES (:uid, :data) "
+                "ON CONFLICT (user_id) DO UPDATE SET data = EXCLUDED.data"
+            ),
+            {"uid": user_dir.name, "data": payload},
+        )
+        inserted += 1
+
+    logger.info("permissions migration: backfilled %d row(s) from disk", inserted)

--- a/alembic/versions/015_permissions_to_db.py
+++ b/alembic/versions/015_permissions_to_db.py
@@ -32,11 +32,14 @@ logger = logging.getLogger(__name__)
 def upgrade() -> None:
     op.create_table(
         "user_permissions",
-        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id", ondelete="CASCADE"),
-                  primary_key=True),
+        sa.Column("user_id", sa.String(), primary_key=True),
         sa.Column("data", sa.Text(), nullable=False, server_default="{}"),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
-                  server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
     )
 
     _backfill_from_disk()

--- a/alembic/versions/015_permissions_to_db.py
+++ b/alembic/versions/015_permissions_to_db.py
@@ -55,6 +55,16 @@ def _backfill_from_disk() -> None:
     Best-effort: skips unreadable files, malformed JSON, and any user dir
     that doesn't correspond to a known user row. The files stay on disk
     so the data isn't lost if something goes wrong.
+
+    ``settings.data_dir`` defaults to ``"data/users"`` (relative), which
+    resolves against the alembic process's CWD. Docker images run
+    alembic from ``/app`` so it finds ``/app/data/users``. If you ever
+    run migrations from a different CWD, the backfill silently finds
+    nothing -- set an absolute ``DATA_DIR`` env var to avoid surprises.
+
+    Uses Postgres-specific ``ON CONFLICT DO UPDATE``. The project uses
+    Postgres for tests and production; if that ever changes, switch
+    this to an explicit SELECT-then-INSERT/UPDATE.
     """
     data_root = Path(settings.data_dir)
     if not data_root.exists():

--- a/alembic/versions/015_permissions_to_db.py
+++ b/alembic/versions/015_permissions_to_db.py
@@ -17,8 +17,8 @@ import logging
 from pathlib import Path
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 from backend.app.config import settings
 
 revision: str = "015"
@@ -77,9 +77,7 @@ def _backfill_from_disk() -> None:
             raw = perm_file.read_text(encoding="utf-8")
             parsed = json.loads(raw)
         except (OSError, json.JSONDecodeError, ValueError) as exc:
-            logger.warning(
-                "permissions migration: skipping %s (%s)", perm_file, exc
-            )
+            logger.warning("permissions migration: skipping %s (%s)", perm_file, exc)
             continue
         if not isinstance(parsed, dict):
             continue

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -198,6 +198,7 @@ class ApprovalStore:
             else:
                 row.data = payload
                 row.updated_at = datetime.now(UTC)
+            db.commit()
 
     def load_user_permissions(self, user_id: str) -> dict[str, Any]:
         """Load the raw permission data for a user.

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -20,9 +20,9 @@ import json
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import StrEnum
 from fnmatch import fnmatch
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from any_llm import acompletion
@@ -30,39 +30,13 @@ from any_llm.types.completion import ChatCompletion
 from pydantic import BaseModel, Field
 
 from backend.app.config import settings
+from backend.app.database import db_session
+from backend.app.models import UserPermissionSet
 
 if TYPE_CHECKING:
     from backend.app.bus import OutboundMessage
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# File I/O helpers (self-contained, no file_store dependency)
-# ---------------------------------------------------------------------------
-
-
-def _user_dir(user_id: str) -> Path:
-    """Return the directory for a specific user."""
-    return Path(settings.data_dir) / str(user_id)
-
-
-def _read_json(path: Path, default: Any = None) -> Any:
-    """Read and parse a JSON file. Returns default if missing/corrupt."""
-    if not path.exists():
-        return default
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, ValueError):
-        return default
-
-
-def _write_json(path: Path, data: Any) -> None:
-    """Write data as JSON to a file atomically."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2, default=str) + "\n", encoding="utf-8")
-    tmp.rename(path)
 
 
 # ---------------------------------------------------------------------------
@@ -196,17 +170,34 @@ class ApprovalStore:
     Resolution order: resource match (exact then glob) > tool match > policy default.
     """
 
-    def _permissions_path(self, user_id: str) -> Path:
-        return _user_dir(user_id) / "PERMISSIONS.json"
-
     def _load(self, user_id: str) -> dict[str, Any]:
-        data = _read_json(self._permissions_path(user_id), default=None)
-        if data is None or not isinstance(data, dict):
-            return {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
-        return data
+        with db_session() as db:
+            row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
+            if row is None:
+                return {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
+            try:
+                parsed = json.loads(row.data)
+            except (json.JSONDecodeError, ValueError):
+                return {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
+            if not isinstance(parsed, dict):
+                return {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
+            return parsed
 
     def _save(self, user_id: str, data: dict[str, Any]) -> None:
-        _write_json(self._permissions_path(user_id), data)
+        payload = json.dumps(data, indent=2, default=str)
+        with db_session() as db:
+            row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
+            if row is None:
+                db.add(
+                    UserPermissionSet(
+                        user_id=user_id,
+                        data=payload,
+                        updated_at=datetime.now(UTC),
+                    )
+                )
+            else:
+                row.data = payload
+                row.updated_at = datetime.now(UTC)
 
     def load_user_permissions(self, user_id: str) -> dict[str, Any]:
         """Load the raw permission data for a user.

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -20,7 +20,6 @@ import json
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 from enum import StrEnum
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -188,16 +187,11 @@ class ApprovalStore:
         with db_session() as db:
             row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
             if row is None:
-                db.add(
-                    UserPermissionSet(
-                        user_id=user_id,
-                        data=payload,
-                        updated_at=datetime.now(UTC),
-                    )
-                )
+                # `updated_at` gets its `default=` via the ORM on insert.
+                db.add(UserPermissionSet(user_id=user_id, data=payload))
             else:
+                # `updated_at` gets its `onupdate=` via the ORM on update.
                 row.data = payload
-                row.updated_at = datetime.now(UTC)
             db.commit()
 
     def load_user_permissions(self, user_id: str) -> dict[str, Any]:

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from any_llm import acompletion
 from any_llm.types.completion import ChatCompletion
 from pydantic import BaseModel, Field
+from sqlalchemy import text
 
 from backend.app.config import settings
 from backend.app.database import db_session
@@ -36,6 +37,40 @@ if TYPE_CHECKING:
     from backend.app.bus import OutboundMessage
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ApprovalStore helpers
+# ---------------------------------------------------------------------------
+
+
+def _lock_user_permissions(db: Any, user_id: str) -> None:
+    """Acquire a transaction-scoped Postgres advisory lock for this user's
+    permissions row.
+
+    Serializes concurrent read-modify-write sequences across workers and
+    requests. Released automatically at COMMIT / ROLLBACK. Postgres-only;
+    the project's test + production databases are both Postgres.
+    """
+    db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+        {"k": f"user_permissions:{user_id}"},
+    )
+
+
+def _parse_row_data(row: UserPermissionSet | None) -> dict[str, Any]:
+    """Parse a UserPermissionSet.data blob into a dict, falling back to
+    the default shape on missing row or malformed JSON."""
+    default = {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
+    if row is None:
+        return default
+    try:
+        parsed = json.loads(row.data)
+    except (json.JSONDecodeError, ValueError):
+        return default
+    if not isinstance(parsed, dict):
+        return default
+    return parsed
 
 
 # ---------------------------------------------------------------------------
@@ -172,25 +207,20 @@ class ApprovalStore:
     def _load(self, user_id: str) -> dict[str, Any]:
         with db_session() as db:
             row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
-            if row is None:
-                return {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
-            try:
-                parsed = json.loads(row.data)
-            except (json.JSONDecodeError, ValueError):
-                return {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
-            if not isinstance(parsed, dict):
-                return {"version": _PERMISSIONS_VERSION, "tools": {}, "resources": {}}
-            return parsed
+            return _parse_row_data(row)
 
     def _save(self, user_id: str, data: dict[str, Any]) -> None:
+        """Wholesale replace. Serialized against concurrent writers via an
+        advisory lock keyed on the user so the dashboard PUT can't race
+        with set_permission or a workspace_tools write on the same row.
+        """
         payload = json.dumps(data, indent=2, default=str)
         with db_session() as db:
+            _lock_user_permissions(db, user_id)
             row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
             if row is None:
-                # `updated_at` gets its `default=` via the ORM on insert.
                 db.add(UserPermissionSet(user_id=user_id, data=payload))
             else:
-                # `updated_at` gets its `onupdate=` via the ORM on update.
                 row.data = payload
             db.commit()
 
@@ -281,19 +311,39 @@ class ApprovalStore:
         level: PermissionLevel,
         resource: str | None = None,
     ) -> None:
-        """Store a permission override for a tool or resource.
+        """Store a permission override atomically.
 
-        Backfills the complete tool list first so that setting one
-        permission does not lose other entries.
+        Runs the read-modify-write inside a single transaction guarded by
+        a Postgres advisory lock keyed on the user. Otherwise two
+        concurrent callers (the approval gate persisting an Always, the
+        dashboard PUT, and/or an agent edit_file) could read the same
+        snapshot and overwrite each other -- classic lost update. The
+        lock plus same-transaction read+write closes the window.
+
+        Backfills the complete tool list before writing so setting one
+        permission doesn't drop other entries.
         """
-        data = self.ensure_complete(user_id)
-        if resource is not None:
-            resources = data.setdefault("resources", {})
-            tool_resources = resources.setdefault(tool_name, {})
-            tool_resources[resource] = str(level)
-        else:
-            data.setdefault("tools", {})[tool_name] = str(level)
-        self._save(user_id, data)
+        with db_session() as db:
+            _lock_user_permissions(db, user_id)
+            row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
+            data = _parse_row_data(row)
+
+            # ensure_complete-style backfill: fill missing tool defaults.
+            defaults = self.generate_defaults(user_id)
+            for tname, default_level in defaults["tools"].items():
+                data.setdefault("tools", {}).setdefault(tname, default_level)
+
+            if resource is not None:
+                data.setdefault("resources", {}).setdefault(tool_name, {})[resource] = str(level)
+            else:
+                data.setdefault("tools", {})[tool_name] = str(level)
+
+            payload = json.dumps(data, indent=2, default=str)
+            if row is None:
+                db.add(UserPermissionSet(user_id=user_id, data=payload))
+            else:
+                row.data = payload
+            db.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import random
 import time
@@ -221,43 +222,44 @@ class ClawboltAgent:
 
         return level, resource, description
 
-    async def _record_permission_update(
+    async def _record_permissions_edit(
         self,
-        tool_name: str,
-        level: str,
-        resource: str | None,
         tool_call_records: list[StoredToolInteraction],
     ) -> None:
-        """Record an approval-system permission change as a synthetic tool call.
+        """Surface an approval-system permissions change as a synthetic
+        ``write_file("PERMISSIONS.json", ...)`` record.
 
-        When the user says "Always" / "Never" to an approval prompt, the gate
-        persists the permission silently. Without this record, the chat
-        transcript only shows the raw "Always" reply and the tool it approved,
-        with no indication that the permission was remembered. Emit a fake
-        ``update_permission`` record so it renders alongside real tool calls
-        in the dashboard and session history.
+        When the user says "Always" / "Never" to an approval prompt, the
+        gate quietly persists the permission. Without a visible record,
+        the chat transcript only shows the raw "Always" reply and the
+        tool it approved, hiding the state change. Emitting a
+        ``write_file`` record (rather than a bespoke ``update_permission``
+        tool) keeps the vocabulary consistent: users who ``read_file
+        PERMISSIONS.json`` see exactly what changed, and there's no
+        parallel notion to maintain.
         """
-        args: dict[str, Any] = {"tool": tool_name, "level": level}
-        if resource:
-            args["resource"] = resource
-        verb = "always run" if level == "always" else "never run"
-        result = f"Saved: {tool_name} will {verb} without asking."
-        call_id = f"perm_{tool_name}_{level}_{int(time.monotonic() * 1000)}"
+        store = get_approval_store()
+        try:
+            snapshot = json.dumps(store.ensure_complete(self.user.id), indent=2)
+        except Exception:
+            logger.warning("Failed to snapshot PERMISSIONS.json for history record")
+            return
+        args: dict[str, Any] = {"path": "PERMISSIONS.json", "content": snapshot}
+        result = "Wrote PERMISSIONS.json"
+        call_id = f"perm_write_{int(time.monotonic() * 1000)}"
         tool_call_records.append(
             StoredToolInteraction(
                 tool_call_id=call_id,
-                name=ToolName.UPDATE_PERMISSION,
+                name=ToolName.WRITE_FILE,
                 args=args,
                 result=result,
                 is_error=False,
             )
         )
-        await self._emit(
-            ToolExecutionStartEvent(tool_name=ToolName.UPDATE_PERMISSION, arguments=args)
-        )
+        await self._emit(ToolExecutionStartEvent(tool_name=ToolName.WRITE_FILE, arguments=args))
         await self._emit(
             ToolExecutionEndEvent(
-                tool_name=ToolName.UPDATE_PERMISSION,
+                tool_name=ToolName.WRITE_FILE,
                 result=result,
                 is_error=False,
                 duration_ms=0.0,
@@ -669,9 +671,7 @@ class ClawboltAgent:
                         except Exception:
                             logger.warning("Failed to persist ALWAYS for tool %s", tool_obj.name)
                         else:
-                            await self._record_permission_update(
-                                tool_obj.name, "always", resource, tool_call_records
-                            )
+                            await self._record_permissions_edit(tool_call_records)
 
                 elif decision == ApprovalDecision.INTERRUPTED:
                     # User changed subject. Error this entry + all remaining.
@@ -711,9 +711,7 @@ class ClawboltAgent:
                         except Exception:
                             logger.warning("Failed to persist DENY for tool %s", tool_obj.name)
                         else:
-                            await self._record_permission_update(
-                                tool_obj.name, "deny", resource, tool_call_records
-                            )
+                            await self._record_permissions_edit(tool_call_records)
 
                     tool_tags = self._get_tool_tags(tc_req.name)
                     hint = _ERROR_KIND_HINTS[ToolErrorKind.PERMISSION]

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import random
 import time
@@ -221,63 +220,6 @@ class ClawboltAgent:
             description = policy.description_builder(validated_args)
 
         return level, resource, description
-
-    def _snapshot_permissions(self) -> str:
-        """Serialize the current PERMISSIONS.json content (empty on failure)."""
-        store = get_approval_store()
-        try:
-            return json.dumps(store.ensure_complete(self.user.id), indent=2)
-        except Exception:
-            logger.warning("Failed to snapshot PERMISSIONS.json")
-            return ""
-
-    async def _record_permissions_edit(
-        self,
-        before: str,
-        tool_call_records: list[StoredToolInteraction],
-    ) -> None:
-        """Surface an approval-system permissions change as a synthetic
-        ``edit_file("PERMISSIONS.json", ...)`` record.
-
-        When the user says "Always" / "Never" to an approval prompt, the
-        gate quietly persists the permission. Without a visible record,
-        the chat transcript only shows the raw "Always" reply and the
-        tool it approved, hiding the state change. Emitting an
-        ``edit_file`` record (rather than a bespoke ``update_permission``
-        tool) keeps the vocabulary consistent: one verb for "this file
-        changed" whether the agent did it via edit_file, the user edited
-        it in the dashboard, or the approval gate persisted an Always.
-        The ``old_text`` + ``new_text`` pair gives a full-file diff the
-        UI can render straightforwardly.
-        """
-        after = self._snapshot_permissions()
-        if not after or after == before:
-            return
-        args: dict[str, Any] = {
-            "path": "PERMISSIONS.json",
-            "old_text": before,
-            "new_text": after,
-        }
-        result = "Updated PERMISSIONS.json"
-        call_id = f"perm_edit_{int(time.monotonic() * 1000)}"
-        tool_call_records.append(
-            StoredToolInteraction(
-                tool_call_id=call_id,
-                name=ToolName.EDIT_FILE,
-                args=args,
-                result=result,
-                is_error=False,
-            )
-        )
-        await self._emit(ToolExecutionStartEvent(tool_name=ToolName.EDIT_FILE, arguments=args))
-        await self._emit(
-            ToolExecutionEndEvent(
-                tool_name=ToolName.EDIT_FILE,
-                result=result,
-                is_error=False,
-                duration_ms=0.0,
-            )
-        )
 
     def register_tools(self, tools: list[Tool]) -> None:
         """Register available tools for this agent session."""
@@ -677,15 +619,12 @@ class ClawboltAgent:
                 if decision in (ApprovalDecision.APPROVED, ApprovalDecision.ALWAYS_ALLOW):
                     approved_entries.append(entry)
                     if decision == ApprovalDecision.ALWAYS_ALLOW:
-                        before = self._snapshot_permissions()
                         try:
                             store.set_permission(
                                 self.user.id, tool_obj.name, PermissionLevel.ALWAYS, resource
                             )
                         except Exception:
                             logger.warning("Failed to persist ALWAYS for tool %s", tool_obj.name)
-                        else:
-                            await self._record_permissions_edit(before, tool_call_records)
 
                 elif decision == ApprovalDecision.INTERRUPTED:
                     # User changed subject. Error this entry + all remaining.
@@ -718,15 +657,12 @@ class ClawboltAgent:
 
                 else:  # DENIED / ALWAYS_DENY
                     if decision == ApprovalDecision.ALWAYS_DENY:
-                        before = self._snapshot_permissions()
                         try:
                             store.set_permission(
                                 self.user.id, tool_obj.name, PermissionLevel.DENY, resource
                             )
                         except Exception:
                             logger.warning("Failed to persist DENY for tool %s", tool_obj.name)
-                        else:
-                            await self._record_permissions_edit(before, tool_call_records)
 
                     tool_tags = self._get_tool_tags(tc_req.name)
                     hint = _ERROR_KIND_HINTS[ToolErrorKind.PERMISSION]

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -222,44 +222,57 @@ class ClawboltAgent:
 
         return level, resource, description
 
+    def _snapshot_permissions(self) -> str:
+        """Serialize the current PERMISSIONS.json content (empty on failure)."""
+        store = get_approval_store()
+        try:
+            return json.dumps(store.ensure_complete(self.user.id), indent=2)
+        except Exception:
+            logger.warning("Failed to snapshot PERMISSIONS.json")
+            return ""
+
     async def _record_permissions_edit(
         self,
+        before: str,
         tool_call_records: list[StoredToolInteraction],
     ) -> None:
         """Surface an approval-system permissions change as a synthetic
-        ``write_file("PERMISSIONS.json", ...)`` record.
+        ``edit_file("PERMISSIONS.json", ...)`` record.
 
         When the user says "Always" / "Never" to an approval prompt, the
         gate quietly persists the permission. Without a visible record,
         the chat transcript only shows the raw "Always" reply and the
-        tool it approved, hiding the state change. Emitting a
-        ``write_file`` record (rather than a bespoke ``update_permission``
-        tool) keeps the vocabulary consistent: users who ``read_file
-        PERMISSIONS.json`` see exactly what changed, and there's no
-        parallel notion to maintain.
+        tool it approved, hiding the state change. Emitting an
+        ``edit_file`` record (rather than a bespoke ``update_permission``
+        tool) keeps the vocabulary consistent: one verb for "this file
+        changed" whether the agent did it via edit_file, the user edited
+        it in the dashboard, or the approval gate persisted an Always.
+        The ``old_text`` + ``new_text`` pair gives a full-file diff the
+        UI can render straightforwardly.
         """
-        store = get_approval_store()
-        try:
-            snapshot = json.dumps(store.ensure_complete(self.user.id), indent=2)
-        except Exception:
-            logger.warning("Failed to snapshot PERMISSIONS.json for history record")
+        after = self._snapshot_permissions()
+        if not after or after == before:
             return
-        args: dict[str, Any] = {"path": "PERMISSIONS.json", "content": snapshot}
-        result = "Wrote PERMISSIONS.json"
-        call_id = f"perm_write_{int(time.monotonic() * 1000)}"
+        args: dict[str, Any] = {
+            "path": "PERMISSIONS.json",
+            "old_text": before,
+            "new_text": after,
+        }
+        result = "Updated PERMISSIONS.json"
+        call_id = f"perm_edit_{int(time.monotonic() * 1000)}"
         tool_call_records.append(
             StoredToolInteraction(
                 tool_call_id=call_id,
-                name=ToolName.WRITE_FILE,
+                name=ToolName.EDIT_FILE,
                 args=args,
                 result=result,
                 is_error=False,
             )
         )
-        await self._emit(ToolExecutionStartEvent(tool_name=ToolName.WRITE_FILE, arguments=args))
+        await self._emit(ToolExecutionStartEvent(tool_name=ToolName.EDIT_FILE, arguments=args))
         await self._emit(
             ToolExecutionEndEvent(
-                tool_name=ToolName.WRITE_FILE,
+                tool_name=ToolName.EDIT_FILE,
                 result=result,
                 is_error=False,
                 duration_ms=0.0,
@@ -664,6 +677,7 @@ class ClawboltAgent:
                 if decision in (ApprovalDecision.APPROVED, ApprovalDecision.ALWAYS_ALLOW):
                     approved_entries.append(entry)
                     if decision == ApprovalDecision.ALWAYS_ALLOW:
+                        before = self._snapshot_permissions()
                         try:
                             store.set_permission(
                                 self.user.id, tool_obj.name, PermissionLevel.ALWAYS, resource
@@ -671,7 +685,7 @@ class ClawboltAgent:
                         except Exception:
                             logger.warning("Failed to persist ALWAYS for tool %s", tool_obj.name)
                         else:
-                            await self._record_permissions_edit(tool_call_records)
+                            await self._record_permissions_edit(before, tool_call_records)
 
                 elif decision == ApprovalDecision.INTERRUPTED:
                     # User changed subject. Error this entry + all remaining.
@@ -704,6 +718,7 @@ class ClawboltAgent:
 
                 else:  # DENIED / ALWAYS_DENY
                     if decision == ApprovalDecision.ALWAYS_DENY:
+                        before = self._snapshot_permissions()
                         try:
                             store.set_permission(
                                 self.user.id, tool_obj.name, PermissionLevel.DENY, resource
@@ -711,7 +726,7 @@ class ClawboltAgent:
                         except Exception:
                             logger.warning("Failed to persist DENY for tool %s", tool_obj.name)
                         else:
-                            await self._record_permissions_edit(tool_call_records)
+                            await self._record_permissions_edit(before, tool_call_records)
 
                     tool_tags = self._get_tool_tags(tc_req.name)
                     hint = _ERROR_KIND_HINTS[ToolErrorKind.PERMISSION]

--- a/backend/app/agent/dto.py
+++ b/backend/app/agent/dto.py
@@ -118,6 +118,7 @@ class SubToolEntry(BaseModel):
     description: str = ""
     enabled: bool = True
     permission_level: str = "always"
+    hidden_in_permissions: bool = False
 
 
 class ToolConfigEntry(BaseModel):

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -32,7 +32,9 @@ Your tool permissions are stored in PERMISSIONS.json. Each tool has a level:
 
 When a tool is set to "ask", the system handles the approval prompt for you. Do not ask the user conversationally before calling a tool -- just call it. If approval is needed, the system will prompt them and wait for their response.
 
-PERMISSIONS.json is read-only for you. The system writes it when the user replies "Always" or "Never" to an approval prompt, and users edit it directly through the dashboard. You can call read_file("PERMISSIONS.json") to answer questions like "what are my permissions?" but write_file and edit_file on this path will return an error. If a user asks you to change a permission in chat, tell them to reply "Always" the next time the prompt appears, or to open the Permissions page in the dashboard.
+The system automatically saves "Always" / "Never" replies to those prompts. Do not follow up with an edit_file or write_file on PERMISSIONS.json to "officialize" what the user just said -- the change is already persisted. Doing it anyway wipes the per-resource overrides the system just wrote and forces another prompt next round.
+
+Only edit PERMISSIONS.json yourself when the user asks a plain-chat question or gives a plain-chat directive -- for example, "what are my permissions?" (read_file) or "set qb_query to ask for all entities" (edit_file). Never in response to an Always / Never reply.
 
 ## File uploads
 When the user sends a photo, document, or other file attachment and file storage is enabled, call upload_to_storage. Do not ask "want me to save this?" in chat first. The permission system handles the approval prompt; a conversational pre-check creates a frustrating double-confirmation.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -30,14 +30,11 @@ Your tool permissions are stored in PERMISSIONS.json. Each tool has a level:
 - "ask": prompts the user automatically before running
 - "deny": blocked, will not run
 
-When a tool is set to "ask", the system handles the approval prompt for you. Do not ask the user conversationally before calling a tool. Just call it. If approval is needed, the system will prompt them and wait for their response. Asking first and then having the system also ask creates a frustrating double-confirmation.
+When a tool is set to "ask", the system handles the approval prompt for you. Do not ask the user conversationally before calling a tool. Just call it. If approval is needed, the system will prompt them and wait for their response.
 
-To view permissions: read_file("PERMISSIONS.json")
-To change a permission: edit_file("PERMISSIONS.json", old_text, new_text)
-To reset all permissions: write the default PERMISSIONS.json
+"Always" / "Never" replies to those prompts are persisted by the system automatically. Do not follow up with an edit_file or write_file on PERMISSIONS.json -- the change is already saved. Double-editing wipes the resources section and causes the next call to re-prompt.
 
-When the user asks about permissions, approval settings, what you can do freely,
-or wants to change how you handle actions, use PERMISSIONS.json.
+Only touch PERMISSIONS.json yourself when the user asks a plain-chat question about permissions (e.g. "what are my permissions?" -> read_file) or issues a plain-chat directive to change one (e.g. "set qb_query to ask" -> edit_file). Never in response to an approval-prompt reply.
 
 ## File uploads
 When the user sends a photo, document, or other file attachment and file storage is enabled, call upload_to_storage. Do not ask "want me to save this?" in chat first. The permission system handles the approval prompt; a conversational pre-check creates a frustrating double-confirmation.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -30,11 +30,9 @@ Your tool permissions are stored in PERMISSIONS.json. Each tool has a level:
 - "ask": prompts the user automatically before running
 - "deny": blocked, will not run
 
-When a tool is set to "ask", the system handles the approval prompt for you. Do not ask the user conversationally before calling a tool. Just call it. If approval is needed, the system will prompt them and wait for their response.
+When a tool is set to "ask", the system handles the approval prompt for you. Do not ask the user conversationally before calling a tool -- just call it. If approval is needed, the system will prompt them and wait for their response.
 
-"Always" / "Never" replies to those prompts are persisted by the system automatically. Do not follow up with an edit_file or write_file on PERMISSIONS.json -- the change is already saved. Double-editing wipes the resources section and causes the next call to re-prompt.
-
-Only touch PERMISSIONS.json yourself when the user asks a plain-chat question about permissions (e.g. "what are my permissions?" -> read_file) or issues a plain-chat directive to change one (e.g. "set qb_query to ask" -> edit_file). Never in response to an approval-prompt reply.
+PERMISSIONS.json is read-only for you. The system writes it when the user replies "Always" or "Never" to an approval prompt, and users edit it directly through the dashboard. You can call read_file("PERMISSIONS.json") to answer questions like "what are my permissions?" but write_file and edit_file on this path will return an error. If a user asks you to change a permission in chat, tell them to reply "Always" the next time the prompt appears, or to open the Permissions page in the dashboard.
 
 ## File uploads
 When the user sends a photo, document, or other file attachment and file storage is enabled, call upload_to_storage. Do not ask "want me to save this?" in chat first. The permission system handles the approval prompt; a conversational pre-check creates a frustrating double-confirmation.

--- a/backend/app/agent/tools/messaging_tools.py
+++ b/backend/app/agent/tools/messaging_tools.py
@@ -85,7 +85,7 @@ def create_messaging_tools(
             tags={ToolTags.SENDS_REPLY},
             usage_hint="Use this to send a text message to the user.",
             approval_policy=ApprovalPolicy(
-                default_level=PermissionLevel.ASK,
+                default_level=PermissionLevel.ALWAYS,
                 description_builder=lambda args: "Send a text message",
             ),
         ),
@@ -97,7 +97,7 @@ def create_messaging_tools(
             tags={ToolTags.SENDS_REPLY},
             usage_hint=("When sending estimates or files, use this to send media to the user."),
             approval_policy=ApprovalPolicy(
-                default_level=PermissionLevel.ASK,
+                default_level=PermissionLevel.ALWAYS,
                 description_builder=lambda args: "Send a file attachment",
             ),
         ),
@@ -121,12 +121,16 @@ def _register() -> None:
         requires_outbound=True,
         sub_tools=[
             SubToolInfo(
-                ToolName.SEND_REPLY, "Send text replies to the user", default_permission="ask"
+                ToolName.SEND_REPLY,
+                "Send text replies to the user",
+                default_permission="always",
+                hidden_in_permissions=True,
             ),
             SubToolInfo(
                 ToolName.SEND_MEDIA_REPLY,
                 "Send replies with media attachments",
-                default_permission="ask",
+                default_permission="always",
+                hidden_in_permissions=True,
             ),
         ],
     )

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -46,11 +46,6 @@ class ToolName:
     LIST_CAPABILITIES = "list_capabilities"
     MANAGE_INTEGRATION = "manage_integration"
 
-    # Synthetic records (not LLM-callable; emitted by the approval system
-    # so permission remembers show up in chat history alongside real tool
-    # calls.)
-    UPDATE_PERMISSION = "update_permission"
-
     # Heartbeat (not registered in the main tool registry)
     COMPOSE_MESSAGE = "compose_message"
     HEARTBEAT_DECISION = "heartbeat_decision"

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -55,6 +55,13 @@ class SubToolInfo:
     name: str
     description: str
     default_permission: str = "always"
+    # When True, this sub-tool is omitted from the dashboard Permissions
+    # page. The tool still runs normally and still respects stored
+    # permission overrides -- the flag only hides UI chrome for tools the
+    # user shouldn't have to think about (e.g. send_reply, whose default
+    # level should always be ALWAYS because it's the agent's core
+    # messaging path).
+    hidden_in_permissions: bool = False
 
     def __post_init__(self) -> None:
         PermissionLevel(self.default_permission)  # validates at registration time

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -254,15 +254,33 @@ async def _permissions_read(user_id: str) -> str:
 
 
 def _permissions_write_sync(user_id: str, content: str) -> None:
+    """Persist PERMISSIONS.json content, normalizing to indented JSON.
+
+    Stable pretty-printing matters: the approval store pretty-prints on
+    every set_permission, and edit_file old_text matching breaks if one
+    writer leaves minified JSON around. We parse + re-serialize so every
+    reader sees the same shape regardless of what the caller passed in.
+    Malformed JSON is stored verbatim so a user who's mid-edit can
+    recover, but this is the narrow escape hatch, not the hot path.
+    """
+    import json as _json
+
     from backend.app.database import db_session
     from backend.app.models import UserPermissionSet
+
+    try:
+        parsed = _json.loads(content)
+    except (_json.JSONDecodeError, ValueError):
+        payload = content
+    else:
+        payload = _json.dumps(parsed, indent=2, default=str)
 
     with db_session() as db:
         row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
         if row is None:
-            db.add(UserPermissionSet(user_id=user_id, data=content))
+            db.add(UserPermissionSet(user_id=user_id, data=payload))
         else:
-            row.data = content
+            row.data = payload
         db.commit()
 
 

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -57,10 +57,21 @@ _MEMORY_DOC_COLUMN: dict[str, str] = {
     "HISTORY.md": "history_text",
 }
 
-# Files routed to the UserPermissionSet table instead of disk. The
-# ApprovalStore uses the same row, so read_file/write_file/edit_file and
-# the approval gate share a single source of truth.
+# PERMISSIONS.json is read-only from the agent's side: the approval
+# system writes it when the user replies Always/Never to a prompt, and
+# the dashboard's permissions page writes it when the user toggles
+# entries. Letting the agent write it caused cascading bugs -- the LLM
+# treated a user's "always" as a cue to edit the file itself, clobbering
+# the per-resource overrides the gate just wrote, which triggered a
+# second approval prompt in the next round.
 _PERMISSIONS_FILE = "PERMISSIONS.json"
+_PERMISSIONS_READONLY_MSG = (
+    "PERMISSIONS.json is read-only for the agent. The approval system "
+    "saves 'always' / 'never' replies automatically, and users manage "
+    "permissions through the dashboard. To see current permissions, use "
+    "read_file. To change them, ask the user to update them in the "
+    "dashboard or reply to an approval prompt."
+)
 
 
 class ReadFileParams(BaseModel):
@@ -253,41 +264,6 @@ async def _permissions_read(user_id: str) -> str:
     return await asyncio.to_thread(_permissions_read_sync, user_id)
 
 
-def _permissions_write_sync(user_id: str, content: str) -> None:
-    """Persist PERMISSIONS.json content, normalizing to indented JSON.
-
-    Stable pretty-printing matters: the approval store pretty-prints on
-    every set_permission, and edit_file old_text matching breaks if one
-    writer leaves minified JSON around. We parse + re-serialize so every
-    reader sees the same shape regardless of what the caller passed in.
-    Malformed JSON is stored verbatim so a user who's mid-edit can
-    recover, but this is the narrow escape hatch, not the hot path.
-    """
-    import json as _json
-
-    from backend.app.database import db_session
-    from backend.app.models import UserPermissionSet
-
-    try:
-        parsed = _json.loads(content)
-    except (_json.JSONDecodeError, ValueError):
-        payload = content
-    else:
-        payload = _json.dumps(parsed, indent=2, default=str)
-
-    with db_session() as db:
-        row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
-        if row is None:
-            db.add(UserPermissionSet(user_id=user_id, data=payload))
-        else:
-            row.data = payload
-        db.commit()
-
-
-async def _permissions_write(user_id: str, content: str) -> None:
-    await asyncio.to_thread(_permissions_write_sync, user_id, content)
-
-
 def create_workspace_tools(user_id: str) -> list[Tool]:
     """Create generic file tools scoped to the user's data directory."""
 
@@ -332,8 +308,11 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
             return ToolResult(content=f"Wrote {path}")
 
         if _is_permissions_path(path):
-            await _permissions_write(user_id, content)
-            return ToolResult(content=f"Wrote {path}")
+            return ToolResult(
+                content=_PERMISSIONS_READONLY_MSG,
+                is_error=True,
+                error_kind=ToolErrorKind.PERMISSION,
+            )
 
         resolved, err = _resolve_path(user_id, path)
         if err:
@@ -386,25 +365,11 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
             return ToolResult(content=f"Updated {path}")
 
         if _is_permissions_path(path):
-            text = await _permissions_read(user_id)
-            if old_text not in text:
-                return ToolResult(
-                    content=f"Text not found in {path}. Read the file first to see current contents.",
-                    is_error=True,
-                    error_kind=ToolErrorKind.NOT_FOUND,
-                )
-            count = text.count(old_text)
-            if count > 1:
-                return ToolResult(
-                    content=(
-                        f"Found {count} matches in {path}. Provide more context to match uniquely."
-                    ),
-                    is_error=True,
-                    error_kind=ToolErrorKind.VALIDATION,
-                )
-            updated = text.replace(old_text, new_text, 1)
-            await _permissions_write(user_id, updated)
-            return ToolResult(content=f"Updated {path}")
+            return ToolResult(
+                content=_PERMISSIONS_READONLY_MSG,
+                is_error=True,
+                error_kind=ToolErrorKind.PERMISSION,
+            )
 
         resolved, err = _resolve_path(user_id, path)
         if err:

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -267,9 +267,13 @@ def _permissions_write_sync(user_id: str, content: str) -> None:
     writer leaves a minified blob. Parse + re-serialize so every reader
     sees the same shape regardless of what the caller passed in.
     Malformed JSON is stored verbatim as a narrow escape hatch.
+
+    Uses the same advisory lock as ApprovalStore so workspace writes
+    serialize correctly against set_permission / dashboard PUT.
     """
     import json as _json
 
+    from backend.app.agent.approval import _lock_user_permissions
     from backend.app.database import db_session
     from backend.app.models import UserPermissionSet
 
@@ -281,6 +285,7 @@ def _permissions_write_sync(user_id: str, content: str) -> None:
         payload = _json.dumps(parsed, indent=2, default=str)
 
     with db_session() as db:
+        _lock_user_permissions(db, user_id)
         row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
         if row is None:
             db.add(UserPermissionSet(user_id=user_id, data=payload))
@@ -291,6 +296,51 @@ def _permissions_write_sync(user_id: str, content: str) -> None:
 
 async def _permissions_write(user_id: str, content: str) -> None:
     await asyncio.to_thread(_permissions_write_sync, user_id, content)
+
+
+def _permissions_edit_sync(user_id: str, old_text: str, new_text: str) -> tuple[bool, str]:
+    """Atomic text replace on PERMISSIONS.json.
+
+    Returns ``(ok, detail)``: ``ok=True`` with ``detail=""`` on success,
+    ``ok=False`` with a user-facing error string otherwise. All work
+    runs in a single locked transaction so concurrent set_permission /
+    dashboard PUT / write_file calls can't steal the row between our
+    read and write.
+    """
+    import json as _json
+
+    from backend.app.agent.approval import _lock_user_permissions
+    from backend.app.database import db_session
+    from backend.app.models import UserPermissionSet
+
+    with db_session() as db:
+        _lock_user_permissions(db, user_id)
+        row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
+        current = (row.data if row is not None else "") or ""
+
+        if old_text not in current:
+            return (False, "text_not_found")
+        if current.count(old_text) > 1:
+            return (False, "ambiguous")
+
+        updated = current.replace(old_text, new_text, 1)
+        try:
+            parsed = _json.loads(updated)
+        except (_json.JSONDecodeError, ValueError):
+            payload = updated
+        else:
+            payload = _json.dumps(parsed, indent=2, default=str)
+
+        if row is None:
+            db.add(UserPermissionSet(user_id=user_id, data=payload))
+        else:
+            row.data = payload
+        db.commit()
+    return (True, "")
+
+
+async def _permissions_edit(user_id: str, old_text: str, new_text: str) -> tuple[bool, str]:
+    return await asyncio.to_thread(_permissions_edit_sync, user_id, old_text, new_text)
 
 
 def create_workspace_tools(user_id: str) -> list[Tool]:
@@ -391,25 +441,30 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
             return ToolResult(content=f"Updated {path}")
 
         if _is_permissions_path(path):
-            text = await _permissions_read(user_id)
-            if old_text not in text:
+            ok, detail = await _permissions_edit(user_id, old_text, new_text)
+            if ok:
+                return ToolResult(content=f"Updated {path}")
+            if detail == "text_not_found":
                 return ToolResult(
-                    content=f"Text not found in {path}. Read the file first to see current contents.",
+                    content=(
+                        f"Text not found in {path}. Read the file first to see current contents."
+                    ),
                     is_error=True,
                     error_kind=ToolErrorKind.NOT_FOUND,
                 )
-            count = text.count(old_text)
-            if count > 1:
+            if detail == "ambiguous":
                 return ToolResult(
                     content=(
-                        f"Found {count} matches in {path}. Provide more context to match uniquely."
+                        f"Found multiple matches in {path}. Provide more context to match uniquely."
                     ),
                     is_error=True,
                     error_kind=ToolErrorKind.VALIDATION,
                 )
-            updated = text.replace(old_text, new_text, 1)
-            await _permissions_write(user_id, updated)
-            return ToolResult(content=f"Updated {path}")
+            return ToolResult(
+                content=f"Failed to edit {path}",
+                is_error=True,
+                error_kind=ToolErrorKind.INTERNAL,
+            )
 
         resolved, err = _resolve_path(user_id, path)
         if err:

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -57,21 +57,11 @@ _MEMORY_DOC_COLUMN: dict[str, str] = {
     "HISTORY.md": "history_text",
 }
 
-# PERMISSIONS.json is read-only from the agent's side: the approval
-# system writes it when the user replies Always/Never to a prompt, and
-# the dashboard's permissions page writes it when the user toggles
-# entries. Letting the agent write it caused cascading bugs -- the LLM
-# treated a user's "always" as a cue to edit the file itself, clobbering
-# the per-resource overrides the gate just wrote, which triggered a
-# second approval prompt in the next round.
+# PERMISSIONS.json is routed to the UserPermissionSet DB row rather
+# than the per-user filesystem directory. ApprovalStore writes the same
+# row, so the typed approval API and the raw read/write/edit tools
+# share a single source of truth.
 _PERMISSIONS_FILE = "PERMISSIONS.json"
-_PERMISSIONS_READONLY_MSG = (
-    "PERMISSIONS.json is read-only for the agent. The approval system "
-    "saves 'always' / 'never' replies automatically, and users manage "
-    "permissions through the dashboard. To see current permissions, use "
-    "read_file. To change them, ask the user to update them in the "
-    "dashboard or reply to an approval prompt."
-)
 
 
 class ReadFileParams(BaseModel):
@@ -269,6 +259,40 @@ async def _permissions_read(user_id: str) -> str:
     return await asyncio.to_thread(_permissions_read_sync, user_id)
 
 
+def _permissions_write_sync(user_id: str, content: str) -> None:
+    """Persist PERMISSIONS.json content, normalizing to indented JSON.
+
+    Stable pretty-printing matters: ApprovalStore pretty-prints on every
+    set_permission, and edit_file's old_text matching breaks if one
+    writer leaves a minified blob. Parse + re-serialize so every reader
+    sees the same shape regardless of what the caller passed in.
+    Malformed JSON is stored verbatim as a narrow escape hatch.
+    """
+    import json as _json
+
+    from backend.app.database import db_session
+    from backend.app.models import UserPermissionSet
+
+    try:
+        parsed = _json.loads(content)
+    except (_json.JSONDecodeError, ValueError):
+        payload = content
+    else:
+        payload = _json.dumps(parsed, indent=2, default=str)
+
+    with db_session() as db:
+        row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
+        if row is None:
+            db.add(UserPermissionSet(user_id=user_id, data=payload))
+        else:
+            row.data = payload
+        db.commit()
+
+
+async def _permissions_write(user_id: str, content: str) -> None:
+    await asyncio.to_thread(_permissions_write_sync, user_id, content)
+
+
 def create_workspace_tools(user_id: str) -> list[Tool]:
     """Create generic file tools scoped to the user's data directory."""
 
@@ -313,11 +337,8 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
             return ToolResult(content=f"Wrote {path}")
 
         if _is_permissions_path(path):
-            return ToolResult(
-                content=_PERMISSIONS_READONLY_MSG,
-                is_error=True,
-                error_kind=ToolErrorKind.PERMISSION,
-            )
+            await _permissions_write(user_id, content)
+            return ToolResult(content=f"Wrote {path}")
 
         resolved, err = _resolve_path(user_id, path)
         if err:
@@ -370,11 +391,25 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
             return ToolResult(content=f"Updated {path}")
 
         if _is_permissions_path(path):
-            return ToolResult(
-                content=_PERMISSIONS_READONLY_MSG,
-                is_error=True,
-                error_kind=ToolErrorKind.PERMISSION,
-            )
+            text = await _permissions_read(user_id)
+            if old_text not in text:
+                return ToolResult(
+                    content=f"Text not found in {path}. Read the file first to see current contents.",
+                    is_error=True,
+                    error_kind=ToolErrorKind.NOT_FOUND,
+                )
+            count = text.count(old_text)
+            if count > 1:
+                return ToolResult(
+                    content=(
+                        f"Found {count} matches in {path}. Provide more context to match uniquely."
+                    ),
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
+            updated = text.replace(old_text, new_text, 1)
+            await _permissions_write(user_id, updated)
+            return ToolResult(content=f"Updated {path}")
 
         resolved, err = _resolve_path(user_id, path)
         if err:

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -236,12 +236,17 @@ async def _memory_doc_write(user_id: str, column: str, content: str) -> None:
 
 
 def _is_permissions_path(relative_path: str) -> bool:
-    """Return True if ``relative_path`` refers to the top-level PERMISSIONS.json."""
+    """Return True if ``relative_path`` refers to the top-level PERMISSIONS.json.
+
+    Case-insensitive on the filename so a lowercase ``permissions.json``
+    from the LLM doesn't fall through to the disk path (where it would
+    be unprotected and writable).
+    """
     try:
         name = Path(relative_path).name
     except (ValueError, OSError):
         return False
-    if name != _PERMISSIONS_FILE:
+    if name.casefold() != _PERMISSIONS_FILE.casefold():
         return False
     stripped = relative_path.lstrip("./")
     return not ("/" in stripped or relative_path.startswith(".."))

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -57,6 +57,11 @@ _MEMORY_DOC_COLUMN: dict[str, str] = {
     "HISTORY.md": "history_text",
 }
 
+# Files routed to the UserPermissionSet table instead of disk. The
+# ApprovalStore uses the same row, so read_file/write_file/edit_file and
+# the approval gate share a single source of truth.
+_PERMISSIONS_FILE = "PERMISSIONS.json"
+
 
 class ReadFileParams(BaseModel):
     """Parameters for the read_file tool."""
@@ -219,6 +224,51 @@ async def _memory_doc_write(user_id: str, column: str, content: str) -> None:
     await asyncio.to_thread(_memory_doc_write_sync, user_id, column, content)
 
 
+def _is_permissions_path(relative_path: str) -> bool:
+    """Return True if ``relative_path`` refers to the top-level PERMISSIONS.json."""
+    try:
+        name = Path(relative_path).name
+    except (ValueError, OSError):
+        return False
+    if name != _PERMISSIONS_FILE:
+        return False
+    stripped = relative_path.lstrip("./")
+    return not ("/" in stripped or relative_path.startswith(".."))
+
+
+def _permissions_read_sync(user_id: str) -> str:
+    from backend.app.models import UserPermissionSet
+
+    db = SessionLocal()
+    try:
+        row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
+        if row is None:
+            return ""
+        return row.data or ""
+    finally:
+        db.close()
+
+
+async def _permissions_read(user_id: str) -> str:
+    return await asyncio.to_thread(_permissions_read_sync, user_id)
+
+
+def _permissions_write_sync(user_id: str, content: str) -> None:
+    from backend.app.database import db_session
+    from backend.app.models import UserPermissionSet
+
+    with db_session() as db:
+        row = db.query(UserPermissionSet).filter_by(user_id=user_id).first()
+        if row is None:
+            db.add(UserPermissionSet(user_id=user_id, data=content))
+        else:
+            row.data = content
+
+
+async def _permissions_write(user_id: str, content: str) -> None:
+    await asyncio.to_thread(_permissions_write_sync, user_id, content)
+
+
 def create_workspace_tools(user_id: str) -> list[Tool]:
     """Create generic file tools scoped to the user's data directory."""
 
@@ -232,6 +282,10 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
         mem_col = _memory_doc_column(path)
         if mem_col:
             content = await _memory_doc_read(user_id, mem_col)
+            return ToolResult(content=content or "(empty)")
+
+        if _is_permissions_path(path):
+            content = await _permissions_read(user_id)
             return ToolResult(content=content or "(empty)")
 
         resolved, err = _resolve_path(user_id, path)
@@ -256,6 +310,10 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
         mem_col = _memory_doc_column(path)
         if mem_col:
             await _memory_doc_write(user_id, mem_col, content)
+            return ToolResult(content=f"Wrote {path}")
+
+        if _is_permissions_path(path):
+            await _permissions_write(user_id, content)
             return ToolResult(content=f"Wrote {path}")
 
         resolved, err = _resolve_path(user_id, path)
@@ -306,6 +364,27 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
                 )
             updated = text.replace(old_text, new_text, 1)
             await _memory_doc_write(user_id, mem_col, updated)
+            return ToolResult(content=f"Updated {path}")
+
+        if _is_permissions_path(path):
+            text = await _permissions_read(user_id)
+            if old_text not in text:
+                return ToolResult(
+                    content=f"Text not found in {path}. Read the file first to see current contents.",
+                    is_error=True,
+                    error_kind=ToolErrorKind.NOT_FOUND,
+                )
+            count = text.count(old_text)
+            if count > 1:
+                return ToolResult(
+                    content=(
+                        f"Found {count} matches in {path}. Provide more context to match uniquely."
+                    ),
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
+            updated = text.replace(old_text, new_text, 1)
+            await _permissions_write(user_id, updated)
             return ToolResult(content=f"Updated {path}")
 
         resolved, err = _resolve_path(user_id, path)

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -263,6 +263,7 @@ def _permissions_write_sync(user_id: str, content: str) -> None:
             db.add(UserPermissionSet(user_id=user_id, data=content))
         else:
             row.data = content
+        db.commit()
 
 
 async def _permissions_write(user_id: str, content: str) -> None:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -190,6 +190,12 @@ class User(Base):
     oauth_tokens: Mapped[list["OAuthToken"]] = relationship(
         "OAuthToken", back_populates="user", cascade="all, delete-orphan"
     )
+    permission_set: Mapped["UserPermissionSet | None"] = relationship(
+        "UserPermissionSet",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
 
 
 class ChannelRoute(Base):
@@ -435,3 +441,26 @@ class OAuthToken(Base):
     )
 
     user: Mapped["User"] = relationship("User", back_populates="oauth_tokens")
+
+
+class UserPermissionSet(Base):
+    """Per-user tool/resource permission overrides (formerly PERMISSIONS.json).
+
+    Stores the full permissions document as a JSON-encoded string so the
+    app-layer shape matches the legacy file format unchanged. One row per
+    user; ``ApprovalStore`` reads/writes this instead of the filesystem.
+    """
+
+    __tablename__ = "user_permissions"
+
+    user_id: Mapped[str] = mapped_column(
+        String, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    data: Mapped[str] = mapped_column(Text, default="{}")
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    user: Mapped["User"] = relationship("User", back_populates="permission_set")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -190,12 +190,6 @@ class User(Base):
     oauth_tokens: Mapped[list["OAuthToken"]] = relationship(
         "OAuthToken", back_populates="user", cascade="all, delete-orphan"
     )
-    permission_set: Mapped["UserPermissionSet | None"] = relationship(
-        "UserPermissionSet",
-        back_populates="user",
-        cascade="all, delete-orphan",
-        uselist=False,
-    )
 
 
 class ChannelRoute(Base):
@@ -449,18 +443,20 @@ class UserPermissionSet(Base):
     Stores the full permissions document as a JSON-encoded string so the
     app-layer shape matches the legacy file format unchanged. One row per
     user; ``ApprovalStore`` reads/writes this instead of the filesystem.
+
+    No FK / ORM relationship to ``User``: the approval store is exercised
+    by lightweight unit tests that don't insert a ``User`` row, and
+    production uses soft-delete (``is_active = False``) rather than hard
+    row deletion, so cascade cleanup would never fire anyway. Orphan
+    hygiene, if ever needed, is handled explicitly at the call site.
     """
 
     __tablename__ = "user_permissions"
 
-    user_id: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
-    )
+    user_id: Mapped[str] = mapped_column(String, primary_key=True)
     data: Mapped[str] = mapped_column(Text, default="{}")
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
     )
-
-    user: Mapped["User"] = relationship("User", back_populates="permission_set")

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -116,6 +116,7 @@ def _build_tool_list(
                 )
                 if perm_data is not None
                 else st.default_permission,
+                hidden_in_permissions=st.hidden_in_permissions,
             )
             for st in factory_sub_tools
         ]
@@ -186,6 +187,7 @@ def _entry_to_response(
                 description=st.description,
                 enabled=st.enabled,
                 permission_level=st.permission_level,
+                hidden_in_permissions=st.hidden_in_permissions,
             )
             for st in e.sub_tools
         ],

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -208,6 +208,7 @@ class SubToolEntryResponse(BaseModel):
     description: str
     enabled: bool
     permission_level: str = "always"
+    hidden_in_permissions: bool = False
 
 
 class ToolConfigEntryResponse(BaseModel):

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2541,6 +2541,11 @@
             "type": "string",
             "title": "Permission Level",
             "default": "always"
+          },
+          "hidden_in_permissions": {
+            "type": "boolean",
+            "title": "Hidden In Permissions",
+            "default": false
           }
         },
         "type": "object",

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1194,6 +1194,11 @@ export interface components {
              * @default always
              */
             permission_level: string;
+            /**
+             * Hidden In Permissions
+             * @default false
+             */
+            hidden_in_permissions: boolean;
         };
         /** TelegramBotInfoResponse */
         TelegramBotInfoResponse: {

--- a/frontend/src/pages/PermissionsPage.tsx
+++ b/frontend/src/pages/PermissionsPage.tsx
@@ -49,13 +49,23 @@ export default function PermissionsPage() {
     }
   }, [rawContent]);
 
+  const visibleTools = useMemo(() => {
+    // Exclude sub-tools flagged hidden_in_permissions (e.g. send_reply) and
+    // then drop any tool group left without visible sub-tools.
+    return tools
+      .map((t) => ({
+        ...t,
+        sub_tools: (t.sub_tools ?? []).filter((st) => !st.hidden_in_permissions),
+      }))
+      .filter((t) => t.sub_tools.length > 0);
+  }, [tools]);
   const coreTools = useMemo(
-    () => tools.filter((t) => t.category === 'core' && (t.sub_tools?.length ?? 0) > 0),
-    [tools],
+    () => visibleTools.filter((t) => t.category === 'core'),
+    [visibleTools],
   );
   const domainTools = useMemo(
-    () => tools.filter((t) => t.category === 'domain' && (t.sub_tools?.length ?? 0) > 0),
-    [tools],
+    () => visibleTools.filter((t) => t.category === 'domain'),
+    [visibleTools],
   );
 
   const toggleCollapsed = (name: string) => {

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -382,17 +382,22 @@ async def test_always_deny_does_not_emit_synthetic_tool_record(test_user: User) 
 
 @pytest.mark.asyncio()
 async def test_permissions_path_match_is_case_insensitive(test_user: User) -> None:
-    """_is_permissions_path guards against lowercase / mixed-case filename
-    variants so the LLM can't slip a write past the read-only barrier."""
+    """Case variants of the filename all hit the DB row rather than
+    falling through to an unintended on-disk write."""
     from backend.app.agent.tools.workspace_tools import create_workspace_tools
 
     tools = create_workspace_tools(test_user.id)
-    write_tool = next(t for t in tools if t.name == "write_file")
+    read_tool = next(t for t in tools if t.name == "read_file")
+
+    # Seed via ApprovalStore.
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+    store.set_permission(test_user.id, "qb_query", PermissionLevel.ALWAYS, resource="Invoice")
 
     for variant in ("permissions.json", "Permissions.json", "PERMISSIONS.JSON"):
-        result = await write_tool.function(path=variant, content="{}")
-        assert result.is_error is True, f"{variant} should be rejected"
-        assert "read-only" in result.content.lower()
+        result = await read_tool.function(path=variant)
+        assert result.is_error is False, f"{variant} should resolve to the DB row"
+        assert '"Invoice": "always"' in result.content
 
 
 @pytest.mark.asyncio()
@@ -616,14 +621,11 @@ async def test_permissions_json_readable_via_workspace_tools(test_user: User) ->
 
 
 @pytest.mark.asyncio()
-async def test_permissions_json_write_is_rejected(test_user: User) -> None:
-    """PERMISSIONS.json is read-only for the agent: write_file must refuse.
-
-    The LLM, following old instructions, would 'officialize' an Always
-    reply by rewriting PERMISSIONS.json -- which clobbered the
-    per-resource overrides the approval gate had just written and forced
-    a second approval prompt. Making writes impossible removes the
-    failure mode entirely."""
+async def test_permissions_json_write_flows_into_approval_store(test_user: User) -> None:
+    """write_file on PERMISSIONS.json persists through the same DB row
+    ApprovalStore uses, so the dashboard / chat / approval gate all see
+    the same data. Agents and users who legitimately need to edit
+    permissions (via plain-chat requests or the dashboard) can."""
     from backend.app.agent.tools.workspace_tools import create_workspace_tools
 
     store = get_approval_store()
@@ -631,25 +633,42 @@ async def test_permissions_json_write_is_rejected(test_user: User) -> None:
     store.set_permission(test_user.id, "qb_query", PermissionLevel.ALWAYS, resource="Invoice")
 
     tools = create_workspace_tools(test_user.id)
-    write_tool = next(t for t in tools if t.name == "write_file")
+    read_tool = next(t for t in tools if t.name == "read_file")
     edit_tool = next(t for t in tools if t.name == "edit_file")
 
-    write_result = await write_tool.function(
-        path="PERMISSIONS.json", content='{"tools": {"qb_query": "always"}, "resources": {}}'
-    )
-    assert write_result.is_error is True
-    assert "read-only" in write_result.content.lower()
+    before = await read_tool.function(path="PERMISSIONS.json")
+    assert '"Invoice": "always"' in before.content
 
     edit_result = await edit_tool.function(
         path="PERMISSIONS.json",
-        old_text='"qb_query": "ask"',
-        new_text='"qb_query": "always"',
+        old_text='"Invoice": "always"',
+        new_text='"Invoice": "deny"',
     )
-    assert edit_result.is_error is True
-    assert "read-only" in edit_result.content.lower()
+    assert edit_result.is_error is False
 
-    # Store state is untouched.
     level = store.check_permission(
         test_user.id, "qb_query", resource="Invoice", default=PermissionLevel.ASK
     )
-    assert level == PermissionLevel.ALWAYS
+    assert level == PermissionLevel.DENY
+
+
+@pytest.mark.asyncio()
+async def test_permissions_write_normalizes_minified_json(test_user: User) -> None:
+    """Minified JSON from write_file gets normalized to indented form so
+    subsequent edit_file calls have stable text to match against."""
+    from backend.app.agent.tools.workspace_tools import create_workspace_tools
+
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+
+    tools = create_workspace_tools(test_user.id)
+    write_tool = next(t for t in tools if t.name == "write_file")
+    read_tool = next(t for t in tools if t.name == "read_file")
+
+    minified = '{"version": 1, "tools": {"qb_query": "always"}, "resources": {}}'
+    await write_tool.function(path="PERMISSIONS.json", content=minified)
+
+    result = await read_tool.function(path="PERMISSIONS.json")
+    assert "\n" in result.content
+    assert '  "tools"' in result.content
+    assert '"qb_query": "always"' in result.content

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -330,8 +330,8 @@ async def test_always_allow_for_upload_to_storage_persists_globally(
 
 
 @pytest.mark.asyncio()
-async def test_always_allow_emits_write_file_permissions_record(test_user: User) -> None:
-    """ALWAYS_ALLOW must surface as a synthetic write_file record targeting
+async def test_always_allow_emits_edit_file_permissions_record(test_user: User) -> None:
+    """ALWAYS_ALLOW must surface as a synthetic edit_file record targeting
     PERMISSIONS.json so the chat panel shows that the file was updated,
     matching the same vocabulary users see when they edit it by hand."""
     from backend.app.agent.context import StoredToolInteraction
@@ -381,17 +381,19 @@ async def test_always_allow_emits_write_file_permissions_record(test_user: User)
     perm_records = [
         r
         for r in records
-        if r.name == ToolName.WRITE_FILE and r.args.get("path") == "PERMISSIONS.json"
+        if r.name == ToolName.EDIT_FILE and r.args.get("path") == "PERMISSIONS.json"
     ]
     assert len(perm_records) == 1
     assert perm_records[0].is_error is False
-    # Serialized snapshot should reflect the new ALWAYS permission.
-    content = perm_records[0].args["content"]
-    assert '"upload_to_storage": "always"' in content
+    # Full-file diff: old shows the pre-change content, new reflects ALWAYS.
+    old_text = perm_records[0].args["old_text"]
+    new_text = perm_records[0].args["new_text"]
+    assert '"upload_to_storage": "ask"' in old_text
+    assert '"upload_to_storage": "always"' in new_text
 
 
 @pytest.mark.asyncio()
-async def test_always_deny_emits_write_file_permissions_record(test_user: User) -> None:
+async def test_always_deny_emits_edit_file_permissions_record(test_user: User) -> None:
     """Same treatment for ALWAYS_DENY ('Never')."""
     from backend.app.agent.context import StoredToolInteraction
     from backend.app.agent.llm_parsing import ParsedToolCall
@@ -436,11 +438,11 @@ async def test_always_deny_emits_write_file_permissions_record(test_user: User) 
     perm_records = [
         r
         for r in records
-        if r.name == ToolName.WRITE_FILE and r.args.get("path") == "PERMISSIONS.json"
+        if r.name == ToolName.EDIT_FILE and r.args.get("path") == "PERMISSIONS.json"
     ]
     assert len(perm_records) == 1
-    content = perm_records[0].args["content"]
-    assert '"upload_to_storage": "deny"' in content
+    new_text = perm_records[0].args["new_text"]
+    assert '"upload_to_storage": "deny"' in new_text
 
 
 @pytest.mark.asyncio()

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -330,6 +330,72 @@ async def test_always_allow_for_upload_to_storage_persists_globally(
 
 
 @pytest.mark.asyncio()
+async def test_always_deny_does_not_emit_synthetic_tool_record(test_user: User) -> None:
+    """Symmetric to the ALWAYS_ALLOW test: ALWAYS_DENY persists silently
+    to the DB and must NOT surface as a synthetic PERMISSIONS.json tool
+    record (the old pattern taught the agent to double-manage the file)."""
+    from backend.app.agent.context import StoredToolInteraction
+    from backend.app.agent.llm_parsing import ParsedToolCall
+    from backend.app.agent.messages import ToolCallRequest
+    from backend.app.agent.tools.file_tools import create_file_tools
+
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+
+    gate = get_approval_gate()
+    gate.request_approval = AsyncMock(return_value=ApprovalDecision.ALWAYS_DENY)  # type: ignore[method-assign]
+
+    async def _publish(_msg: object) -> None:
+        return None
+
+    storage = MockStorageBackend()
+    tools = create_file_tools(test_user, storage, pending_media={"bb_photo": b"bytes"})
+    upload_tool = next(t for t in tools if t.name == "upload_to_storage")
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="bluebubbles",
+        publish_outbound=_publish,
+        chat_id="+1234567890",
+        session_id="",
+    )
+    agent.register_tools([upload_tool])
+
+    args = {"file_category": "job_photo", "client_name": "Jane", "original_url": "bb_photo"}
+    parsed = [ToolCallRequest(id="call_0", name="upload_to_storage", arguments=args)]
+    raw = [ParsedToolCall(id="call_0", name="upload_to_storage", arguments=args)]
+    records: list[StoredToolInteraction] = []
+    await agent._execute_tool_round(
+        parsed_calls=parsed,
+        parsed_raw=raw,
+        actions_taken=[],
+        memories_saved=[],
+        tool_call_records=records,
+    )
+
+    perm_records = [r for r in records if r.args.get("path") == "PERMISSIONS.json"]
+    assert perm_records == []
+    # And the DENY must be persisted.
+    level = store.check_permission(test_user.id, "upload_to_storage", default=PermissionLevel.ASK)
+    assert level == PermissionLevel.DENY
+
+
+@pytest.mark.asyncio()
+async def test_permissions_path_match_is_case_insensitive(test_user: User) -> None:
+    """_is_permissions_path guards against lowercase / mixed-case filename
+    variants so the LLM can't slip a write past the read-only barrier."""
+    from backend.app.agent.tools.workspace_tools import create_workspace_tools
+
+    tools = create_workspace_tools(test_user.id)
+    write_tool = next(t for t in tools if t.name == "write_file")
+
+    for variant in ("permissions.json", "Permissions.json", "PERMISSIONS.JSON"):
+        result = await write_tool.function(path=variant, content="{}")
+        assert result.is_error is True, f"{variant} should be rejected"
+        assert "read-only" in result.content.lower()
+
+
+@pytest.mark.asyncio()
 async def test_always_allow_does_not_emit_synthetic_tool_record(test_user: User) -> None:
     """ALWAYS_ALLOW persists silently to the DB. The chat should NOT contain
     a synthetic tool record that mimics the agent editing PERMISSIONS.json

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -330,15 +330,16 @@ async def test_always_allow_for_upload_to_storage_persists_globally(
 
 
 @pytest.mark.asyncio()
-async def test_always_allow_emits_edit_file_permissions_record(test_user: User) -> None:
-    """ALWAYS_ALLOW must surface as a synthetic edit_file record targeting
-    PERMISSIONS.json so the chat panel shows that the file was updated,
-    matching the same vocabulary users see when they edit it by hand."""
+async def test_always_allow_does_not_emit_synthetic_tool_record(test_user: User) -> None:
+    """ALWAYS_ALLOW persists silently to the DB. The chat should NOT contain
+    a synthetic tool record that mimics the agent editing PERMISSIONS.json
+    -- that pattern taught the agent to double-manage the file, clobbering
+    per-resource overrides. Visible feedback comes from the absence of
+    future prompts and the dashboard Permissions page instead."""
     from backend.app.agent.context import StoredToolInteraction
     from backend.app.agent.llm_parsing import ParsedToolCall
     from backend.app.agent.messages import ToolCallRequest
     from backend.app.agent.tools.file_tools import create_file_tools
-    from backend.app.agent.tools.names import ToolName
 
     store = get_approval_store()
     store.reset_permissions(test_user.id)
@@ -378,71 +379,11 @@ async def test_always_allow_emits_edit_file_permissions_record(test_user: User) 
         tool_call_records=records,
     )
 
-    perm_records = [
-        r
-        for r in records
-        if r.name == ToolName.EDIT_FILE and r.args.get("path") == "PERMISSIONS.json"
-    ]
-    assert len(perm_records) == 1
-    assert perm_records[0].is_error is False
-    # Full-file diff: old shows the pre-change content, new reflects ALWAYS.
-    old_text = perm_records[0].args["old_text"]
-    new_text = perm_records[0].args["new_text"]
-    assert '"upload_to_storage": "ask"' in old_text
-    assert '"upload_to_storage": "always"' in new_text
-
-
-@pytest.mark.asyncio()
-async def test_always_deny_emits_edit_file_permissions_record(test_user: User) -> None:
-    """Same treatment for ALWAYS_DENY ('Never')."""
-    from backend.app.agent.context import StoredToolInteraction
-    from backend.app.agent.llm_parsing import ParsedToolCall
-    from backend.app.agent.messages import ToolCallRequest
-    from backend.app.agent.tools.file_tools import create_file_tools
-    from backend.app.agent.tools.names import ToolName
-
-    store = get_approval_store()
-    store.reset_permissions(test_user.id)
-
-    gate = get_approval_gate()
-    gate.request_approval = AsyncMock(return_value=ApprovalDecision.ALWAYS_DENY)  # type: ignore[method-assign]
-
-    async def _publish(_msg: object) -> None:
-        return None
-
-    storage = MockStorageBackend()
-    tools = create_file_tools(test_user, storage, pending_media={"bb_photo": b"bytes"})
-    upload_tool = next(t for t in tools if t.name == "upload_to_storage")
-
-    agent = ClawboltAgent(
-        user=test_user,
-        channel="bluebubbles",
-        publish_outbound=_publish,
-        chat_id="+1234567890",
-        session_id="",
-    )
-    agent.register_tools([upload_tool])
-
-    args = {"file_category": "job_photo", "client_name": "Jane", "original_url": "bb_photo"}
-    parsed = [ToolCallRequest(id="call_0", name="upload_to_storage", arguments=args)]
-    raw = [ParsedToolCall(id="call_0", name="upload_to_storage", arguments=args)]
-    records: list[StoredToolInteraction] = []
-    await agent._execute_tool_round(
-        parsed_calls=parsed,
-        parsed_raw=raw,
-        actions_taken=[],
-        memories_saved=[],
-        tool_call_records=records,
-    )
-
-    perm_records = [
-        r
-        for r in records
-        if r.name == ToolName.EDIT_FILE and r.args.get("path") == "PERMISSIONS.json"
-    ]
-    assert len(perm_records) == 1
-    new_text = perm_records[0].args["new_text"]
-    assert '"upload_to_storage": "deny"' in new_text
+    perm_records = [r for r in records if r.args.get("path") == "PERMISSIONS.json"]
+    assert perm_records == []
+    # And the permission must still be persisted.
+    level = store.check_permission(test_user.id, "upload_to_storage", default=PermissionLevel.ASK)
+    assert level == PermissionLevel.ALWAYS
 
 
 @pytest.mark.asyncio()
@@ -619,3 +560,30 @@ async def test_permissions_json_shared_between_approval_store_and_workspace(
         test_user.id, "qb_query", resource="Invoice", default=PermissionLevel.ASK
     )
     assert level == PermissionLevel.DENY
+
+
+@pytest.mark.asyncio()
+async def test_permissions_write_normalizes_minified_json(test_user: User) -> None:
+    """If the agent writes minified PERMISSIONS.json (no newlines) via
+    write_file, the store should normalize it to indented JSON so
+    subsequent edit_file calls have stable formatting to match against.
+    Regression for the bug where one minified write broke every later
+    edit_file because old_text assumed pretty-printed content."""
+    from backend.app.agent.tools.workspace_tools import create_workspace_tools
+
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+
+    tools = create_workspace_tools(test_user.id)
+    write_tool = next(t for t in tools if t.name == "write_file")
+    read_tool = next(t for t in tools if t.name == "read_file")
+
+    minified = '{"version": 1, "tools": {"qb_query": "always"}, "resources": {}}'
+    await write_tool.function(path="PERMISSIONS.json", content=minified)
+
+    result = await read_tool.function(path="PERMISSIONS.json")
+    assert result.is_error is False
+    # Indented form has newlines and leading spaces on nested keys.
+    assert "\n" in result.content
+    assert '  "tools"' in result.content
+    assert '"qb_query": "always"' in result.content

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -330,10 +330,10 @@ async def test_always_allow_for_upload_to_storage_persists_globally(
 
 
 @pytest.mark.asyncio()
-async def test_always_allow_emits_update_permission_record(test_user: User) -> None:
-    """ALWAYS_ALLOW must surface as a synthetic update_permission record in
-    tool_call_records so the chat panel shows that the permission was
-    remembered, not just the tool the user approved."""
+async def test_always_allow_emits_write_file_permissions_record(test_user: User) -> None:
+    """ALWAYS_ALLOW must surface as a synthetic write_file record targeting
+    PERMISSIONS.json so the chat panel shows that the file was updated,
+    matching the same vocabulary users see when they edit it by hand."""
     from backend.app.agent.context import StoredToolInteraction
     from backend.app.agent.llm_parsing import ParsedToolCall
     from backend.app.agent.messages import ToolCallRequest
@@ -378,16 +378,20 @@ async def test_always_allow_emits_update_permission_record(test_user: User) -> N
         tool_call_records=records,
     )
 
-    perm_records = [r for r in records if r.name == ToolName.UPDATE_PERMISSION]
+    perm_records = [
+        r
+        for r in records
+        if r.name == ToolName.WRITE_FILE and r.args.get("path") == "PERMISSIONS.json"
+    ]
     assert len(perm_records) == 1
-    assert perm_records[0].args == {"tool": "upload_to_storage", "level": "always"}
     assert perm_records[0].is_error is False
-    assert "upload_to_storage" in perm_records[0].result
-    assert "always run" in perm_records[0].result
+    # Serialized snapshot should reflect the new ALWAYS permission.
+    content = perm_records[0].args["content"]
+    assert '"upload_to_storage": "always"' in content
 
 
 @pytest.mark.asyncio()
-async def test_always_deny_emits_update_permission_record(test_user: User) -> None:
+async def test_always_deny_emits_write_file_permissions_record(test_user: User) -> None:
     """Same treatment for ALWAYS_DENY ('Never')."""
     from backend.app.agent.context import StoredToolInteraction
     from backend.app.agent.llm_parsing import ParsedToolCall
@@ -429,10 +433,14 @@ async def test_always_deny_emits_update_permission_record(test_user: User) -> No
         tool_call_records=records,
     )
 
-    perm_records = [r for r in records if r.name == ToolName.UPDATE_PERMISSION]
+    perm_records = [
+        r
+        for r in records
+        if r.name == ToolName.WRITE_FILE and r.args.get("path") == "PERMISSIONS.json"
+    ]
     assert len(perm_records) == 1
-    assert perm_records[0].args["level"] == "deny"
-    assert "never run" in perm_records[0].result
+    content = perm_records[0].args["content"]
+    assert '"upload_to_storage": "deny"' in content
 
 
 @pytest.mark.asyncio()
@@ -577,3 +585,35 @@ async def test_denied_short_circuits_sibling_ask_entries(test_user: User) -> Non
     )
 
     assert gate.request_approval.await_count == 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio()
+async def test_permissions_json_shared_between_approval_store_and_workspace(
+    test_user: User,
+) -> None:
+    """ApprovalStore and read_file/write_file must hit the same DB row so
+    the chat vocabulary ('PERMISSIONS.json') and the typed approval API
+    can't drift apart."""
+    from backend.app.agent.tools.workspace_tools import create_workspace_tools
+
+    store = get_approval_store()
+    store.reset_permissions(test_user.id)
+    store.set_permission(test_user.id, "qb_query", PermissionLevel.ALWAYS, resource="Invoice")
+
+    tools = create_workspace_tools(test_user.id)
+    read_tool = next(t for t in tools if t.name == "read_file")
+    write_tool = next(t for t in tools if t.name == "write_file")
+
+    result = await read_tool.function(path="PERMISSIONS.json")
+    assert result.is_error is False
+    assert '"qb_query"' in result.content
+    assert '"Invoice": "always"' in result.content
+
+    # Editing through workspace_tools must flow back into ApprovalStore.
+    overridden = result.content.replace('"Invoice": "always"', '"Invoice": "deny"')
+    await write_tool.function(path="PERMISSIONS.json", content=overridden)
+
+    level = store.check_permission(
+        test_user.id, "qb_query", resource="Invoice", default=PermissionLevel.ASK
+    )
+    assert level == PermissionLevel.DENY

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -531,12 +531,9 @@ async def test_denied_short_circuits_sibling_ask_entries(test_user: User) -> Non
 
 
 @pytest.mark.asyncio()
-async def test_permissions_json_shared_between_approval_store_and_workspace(
-    test_user: User,
-) -> None:
-    """ApprovalStore and read_file/write_file must hit the same DB row so
-    the chat vocabulary ('PERMISSIONS.json') and the typed approval API
-    can't drift apart."""
+async def test_permissions_json_readable_via_workspace_tools(test_user: User) -> None:
+    """read_file("PERMISSIONS.json") hits the same DB row as ApprovalStore
+    so the agent can answer "what are my permissions?" correctly."""
     from backend.app.agent.tools.workspace_tools import create_workspace_tools
 
     store = get_approval_store()
@@ -545,45 +542,48 @@ async def test_permissions_json_shared_between_approval_store_and_workspace(
 
     tools = create_workspace_tools(test_user.id)
     read_tool = next(t for t in tools if t.name == "read_file")
-    write_tool = next(t for t in tools if t.name == "write_file")
 
     result = await read_tool.function(path="PERMISSIONS.json")
     assert result.is_error is False
     assert '"qb_query"' in result.content
     assert '"Invoice": "always"' in result.content
 
-    # Editing through workspace_tools must flow back into ApprovalStore.
-    overridden = result.content.replace('"Invoice": "always"', '"Invoice": "deny"')
-    await write_tool.function(path="PERMISSIONS.json", content=overridden)
-
-    level = store.check_permission(
-        test_user.id, "qb_query", resource="Invoice", default=PermissionLevel.ASK
-    )
-    assert level == PermissionLevel.DENY
-
 
 @pytest.mark.asyncio()
-async def test_permissions_write_normalizes_minified_json(test_user: User) -> None:
-    """If the agent writes minified PERMISSIONS.json (no newlines) via
-    write_file, the store should normalize it to indented JSON so
-    subsequent edit_file calls have stable formatting to match against.
-    Regression for the bug where one minified write broke every later
-    edit_file because old_text assumed pretty-printed content."""
+async def test_permissions_json_write_is_rejected(test_user: User) -> None:
+    """PERMISSIONS.json is read-only for the agent: write_file must refuse.
+
+    The LLM, following old instructions, would 'officialize' an Always
+    reply by rewriting PERMISSIONS.json -- which clobbered the
+    per-resource overrides the approval gate had just written and forced
+    a second approval prompt. Making writes impossible removes the
+    failure mode entirely."""
     from backend.app.agent.tools.workspace_tools import create_workspace_tools
 
     store = get_approval_store()
     store.reset_permissions(test_user.id)
+    store.set_permission(test_user.id, "qb_query", PermissionLevel.ALWAYS, resource="Invoice")
 
     tools = create_workspace_tools(test_user.id)
     write_tool = next(t for t in tools if t.name == "write_file")
-    read_tool = next(t for t in tools if t.name == "read_file")
+    edit_tool = next(t for t in tools if t.name == "edit_file")
 
-    minified = '{"version": 1, "tools": {"qb_query": "always"}, "resources": {}}'
-    await write_tool.function(path="PERMISSIONS.json", content=minified)
+    write_result = await write_tool.function(
+        path="PERMISSIONS.json", content='{"tools": {"qb_query": "always"}, "resources": {}}'
+    )
+    assert write_result.is_error is True
+    assert "read-only" in write_result.content.lower()
 
-    result = await read_tool.function(path="PERMISSIONS.json")
-    assert result.is_error is False
-    # Indented form has newlines and leading spaces on nested keys.
-    assert "\n" in result.content
-    assert '  "tools"' in result.content
-    assert '"qb_query": "always"' in result.content
+    edit_result = await edit_tool.function(
+        path="PERMISSIONS.json",
+        old_text='"qb_query": "ask"',
+        new_text='"qb_query": "always"',
+    )
+    assert edit_result.is_error is True
+    assert "read-only" in edit_result.content.lower()
+
+    # Store state is untouched.
+    level = store.check_permission(
+        test_user.id, "qb_query", resource="Invoice", default=PermissionLevel.ASK
+    )
+    assert level == PermissionLevel.ALWAYS

--- a/tests/test_permission_tools.py
+++ b/tests/test_permission_tools.py
@@ -59,9 +59,8 @@ async def test_read_permissions_json(tmp_path: object) -> None:
     assert "version" in data
 
 
-async def test_edit_permissions_json_rejected(tmp_path: object) -> None:
-    """edit_file on PERMISSIONS.json is rejected: the file is managed by
-    the approval system and the dashboard, not the agent."""
+async def test_edit_permissions_json(tmp_path: object) -> None:
+    """edit_file on PERMISSIONS.json flows through ApprovalStore's DB row."""
     user_id = "test-ws-perm-edit"
     store = get_approval_store()
     store.ensure_complete(user_id)
@@ -70,35 +69,47 @@ async def test_edit_permissions_json_rejected(tmp_path: object) -> None:
     read_tool = next(t for t in tools if t.name == ToolName.READ_FILE)
     edit_tool = next(t for t in tools if t.name == ToolName.EDIT_FILE)
 
-    # Sanity: read still works.
+    # Sanity: read returns the default-seeded send_reply level.
     result = await read_tool.function("PERMISSIONS.json")
     assert not result.is_error
-    original_content = result.content
+    # send_reply defaults to always since the messaging-tools flip.
+    original = json.loads(result.content)
+    assert original["tools"]["send_reply"] == "always"
 
+    # Flip send_reply from always to deny.
     result = await edit_tool.function(
         "PERMISSIONS.json", '"send_reply": "always"', '"send_reply": "deny"'
     )
-    assert result.is_error
-    assert "read-only" in result.content.lower()
+    assert not result.is_error
+    assert "Updated" in result.content
 
-    # Store state unchanged.
-    after = await read_tool.function("PERMISSIONS.json")
-    assert after.content == original_content
+    result = await read_tool.function("PERMISSIONS.json")
+    data = json.loads(result.content)
+    assert data["tools"]["send_reply"] == "deny"
 
 
-async def test_write_permissions_json_rejected(tmp_path: object) -> None:
-    """write_file on PERMISSIONS.json is rejected."""
+async def test_write_permissions_json(tmp_path: object) -> None:
+    """write_file can overwrite PERMISSIONS.json; content is normalized."""
     user_id = "test-ws-perm-write"
     store = get_approval_store()
     store.ensure_complete(user_id)
 
     tools = create_workspace_tools(user_id)
     write_tool = next(t for t in tools if t.name == ToolName.WRITE_FILE)
+    read_tool = next(t for t in tools if t.name == ToolName.READ_FILE)
 
-    new_content = json.dumps({"version": 1, "tools": {"send_reply": "deny"}, "resources": {}})
-    result = await write_tool.function("PERMISSIONS.json", new_content)
-    assert result.is_error
-    assert "read-only" in result.content.lower()
+    # Minified input must be stored as indented JSON so later edit_file
+    # calls have a stable shape to match against.
+    minified = '{"version": 1, "tools": {"send_reply": "deny"}, "resources": {}}'
+    result = await write_tool.function("PERMISSIONS.json", minified)
+    assert not result.is_error
+
+    result = await read_tool.function("PERMISSIONS.json")
+    data = json.loads(result.content)
+    assert data["tools"]["send_reply"] == "deny"
+    # Indented: newlines plus a 2-space prefix on nested keys.
+    assert "\n" in result.content
+    assert '  "tools"' in result.content
 
 
 async def test_delete_permissions_json_blocked(tmp_path: object) -> None:

--- a/tests/test_permission_tools.py
+++ b/tests/test_permission_tools.py
@@ -59,8 +59,9 @@ async def test_read_permissions_json(tmp_path: object) -> None:
     assert "version" in data
 
 
-async def test_edit_permissions_json(tmp_path: object) -> None:
-    """edit_file can change a permission level in PERMISSIONS.json."""
+async def test_edit_permissions_json_rejected(tmp_path: object) -> None:
+    """edit_file on PERMISSIONS.json is rejected: the file is managed by
+    the approval system and the dashboard, not the agent."""
     user_id = "test-ws-perm-edit"
     store = get_approval_store()
     store.ensure_complete(user_id)
@@ -69,41 +70,35 @@ async def test_edit_permissions_json(tmp_path: object) -> None:
     read_tool = next(t for t in tools if t.name == ToolName.READ_FILE)
     edit_tool = next(t for t in tools if t.name == ToolName.EDIT_FILE)
 
-    # Read current content to find the send_reply entry
+    # Sanity: read still works.
     result = await read_tool.function("PERMISSIONS.json")
     assert not result.is_error
-    assert '"send_reply": "ask"' in result.content
+    original_content = result.content
 
-    # Edit send_reply from ask to always
     result = await edit_tool.function(
-        "PERMISSIONS.json", '"send_reply": "ask"', '"send_reply": "always"'
+        "PERMISSIONS.json", '"send_reply": "always"', '"send_reply": "deny"'
     )
-    assert not result.is_error
-    assert "Updated" in result.content
+    assert result.is_error
+    assert "read-only" in result.content.lower()
 
-    # Verify the change
-    result = await read_tool.function("PERMISSIONS.json")
-    data = json.loads(result.content)
-    assert data["tools"]["send_reply"] == "always"
+    # Store state unchanged.
+    after = await read_tool.function("PERMISSIONS.json")
+    assert after.content == original_content
 
 
-async def test_write_permissions_json(tmp_path: object) -> None:
-    """write_file can overwrite PERMISSIONS.json."""
+async def test_write_permissions_json_rejected(tmp_path: object) -> None:
+    """write_file on PERMISSIONS.json is rejected."""
     user_id = "test-ws-perm-write"
     store = get_approval_store()
     store.ensure_complete(user_id)
 
     tools = create_workspace_tools(user_id)
     write_tool = next(t for t in tools if t.name == ToolName.WRITE_FILE)
-    read_tool = next(t for t in tools if t.name == ToolName.READ_FILE)
 
     new_content = json.dumps({"version": 1, "tools": {"send_reply": "deny"}, "resources": {}})
     result = await write_tool.function("PERMISSIONS.json", new_content)
-    assert not result.is_error
-
-    result = await read_tool.function("PERMISSIONS.json")
-    data = json.loads(result.content)
-    assert data["tools"]["send_reply"] == "deny"
+    assert result.is_error
+    assert "read-only" in result.content.lower()
 
 
 async def test_delete_permissions_json_blocked(tmp_path: object) -> None:

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -328,9 +328,12 @@ def test_sub_tool_info_default_permission() -> None:
     assert ws_sub_tools["write_file"].default_permission == "always"
     assert ws_sub_tools["delete_file"].default_permission == "ask"
 
-    # messaging tools are all ask
+    # messaging tools default to always and are hidden from the Permissions UI
     msg_sub_tools = {st.name: st for st in default_registry.get_factory_sub_tools("messaging")}
-    assert msg_sub_tools["send_reply"].default_permission == "ask"
+    assert msg_sub_tools["send_reply"].default_permission == "always"
+    assert msg_sub_tools["send_reply"].hidden_in_permissions is True
+    assert msg_sub_tools["send_media_reply"].default_permission == "always"
+    assert msg_sub_tools["send_media_reply"].hidden_in_permissions is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_policies.py
+++ b/tests/test_tool_policies.py
@@ -51,17 +51,17 @@ class TestWorkspaceToolPolicies:
 
 
 class TestMessagingToolPolicies:
-    def test_send_reply_is_ask(self) -> None:
+    def test_send_reply_is_always(self) -> None:
         tools = create_messaging_tools(AsyncMock(), "telegram", "123")
         tool = _find_tool(tools, ToolName.SEND_REPLY)
         assert tool.approval_policy is not None
-        assert tool.approval_policy.default_level == PermissionLevel.ASK
+        assert tool.approval_policy.default_level == PermissionLevel.ALWAYS
 
-    def test_send_media_reply_is_ask(self) -> None:
+    def test_send_media_reply_is_always(self) -> None:
         tools = create_messaging_tools(AsyncMock(), "telegram", "123")
         tool = _find_tool(tools, ToolName.SEND_MEDIA_REPLY)
         assert tool.approval_policy is not None
-        assert tool.approval_policy.default_level == PermissionLevel.ASK
+        assert tool.approval_policy.default_level == PermissionLevel.ALWAYS
 
     def test_send_media_description_builder(self) -> None:
         tools = create_messaging_tools(AsyncMock(), "telegram", "123")


### PR DESCRIPTION
## Description

Three connected fixes to the permissions system. User reported: "I redeployed on Railway and now the QuickBooks special overrides were gone as were some other permissions updates I made."

### 1. PERMISSIONS.json now lives in postgres

\`ApprovalStore\` used to write \`data/users/<user_id>/PERMISSIONS.json\` to the local filesystem. On Railway — and in local docker-compose — that path isn't on a persistent volume, so every redeploy wiped every override the user had granted.

- New \`user_permissions\` table (one row per user, JSON blob in \`TEXT\`).
- Alembic migration \`015\` creates it and best-effort backfills any surviving on-disk files.
- \`ApprovalStore._load\` / \`_save\` read and write the row directly.
- \`workspace_tools\` (\`read_file\` / \`write_file\` / \`edit_file\`) also routes \`PERMISSIONS.json\` through that same row (new \`_is_permissions_path\` / \`_permissions_read\` / \`_permissions_write\` — same dispatch shape as the existing \`USER.md\` / \`MEMORY.md\` branches).

So the typed \`set_permission\` API and the agent's \`read_file("PERMISSIONS.json")\` share one source of truth. No more drift.

### 2. Dropped \`ToolName.UPDATE_PERMISSION\`

Previously, ALWAYS_ALLOW / ALWAYS_DENY emitted a synthetic \`update_permission\` tool record so the chat would show "Saved: X will always run". Separate vocabulary for the same concept — the file changed.

Now \`core.py._record_permissions_edit\` emits a synthetic \`write_file(path="PERMISSIONS.json", content=<new snapshot>)\` record instead. One verb for "the file changed", whether the agent did it via \`edit_file\`, the user edited it on the dashboard, or the approval gate persisted an Always.

### 3. Messaging tools default to ALWAYS and are hidden from the UI

Normal chat replies return as the agent's final text string — they don't go through \`send_reply\`. That tool is only called for proactive / cross-channel sends (heartbeat, different-channel delivery). ASK was a safety valve for a narrow path the user shouldn't have to babysit on the Permissions page.

- \`send_reply\` / \`send_media_reply\` \`ApprovalPolicy.default_level = ALWAYS\`.
- \`SubToolInfo(default_permission="always", hidden_in_permissions=True)\`.
- New \`hidden_in_permissions: bool\` field on \`SubToolInfo\`, propagated through \`SubToolEntry\` -> \`SubToolEntryResponse\` -> frontend.
- \`PermissionsPage.tsx\` filters out hidden sub-tools and drops any tool card left with no visible sub-tools.

## Type
- [x] Feature

## Tests

- \`test_always_allow_emits_write_file_permissions_record\` and \`test_always_deny_emits_write_file_permissions_record\` — replace the old \`update_permission\` assertions; check that ALWAYS_ALLOW / ALWAYS_DENY land as \`write_file\` records on \`PERMISSIONS.json\` with the new snapshot in \`content\`.
- \`test_permissions_json_shared_between_approval_store_and_workspace\` — seeds the store with \`qb_query + Invoice = always\`, reads \`PERMISSIONS.json\` via workspace, edits the content, and asserts \`ApprovalStore.check_permission\` reflects the change.
- \`test_tool_policies.py\` / \`test_tool_config.py\` — updated assertions: messaging tools default to ALWAYS, hidden_in_permissions is True.

Local pytest was hanging in the sandbox, so I stopped re-running it and am letting CI do the final check per your call.

## Checklist
- [x] Lint + format + type check clean (backend + frontend)
- [x] Frontend \`tsc --noEmit\` + \`knip\` clean
- [x] \`openapi.json\` + \`api.d.ts\` regenerated
- [ ] Tests — to be verified by CI

## AI Usage
- [x] AI-assisted — Claude Opus 4.6 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)