### PR TITLE
feat: collapse Linq and BlueBubbles into a unified "iMessage" channel

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -265,6 +265,39 @@ def save_persistent_config(updates: dict[str, str], path: Path | None = None) ->
     config_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
 
 
+def resolve_imessage_backend(s: "Settings | None" = None) -> str | None:
+    """Return the configured iMessage backend: "linq", "bluebubbles", or None.
+
+    Users of the product never see the backend name. This helper is the single
+    source of truth for which backend powers the user-facing iMessage channel.
+    """
+    s = s or settings
+    linq_set = bool(s.linq_api_token)
+    bluebubbles_set = bool(s.bluebubbles_server_url and s.bluebubbles_password)
+    if linq_set:
+        return "linq"
+    if bluebubbles_set:
+        return "bluebubbles"
+    return None
+
+
+def validate_imessage_backend(s: "Settings | None" = None) -> None:
+    """Reject startup if both iMessage backends are configured simultaneously.
+
+    The UI surfaces a single iMessage channel; allowing both backends at once
+    would make that card's behavior ambiguous. Operators must pick one.
+    """
+    s = s or settings
+    linq_set = bool(s.linq_api_token)
+    bluebubbles_set = bool(s.bluebubbles_server_url and s.bluebubbles_password)
+    if linq_set and bluebubbles_set:
+        raise RuntimeError(
+            "Two iMessage backends are configured at once. "
+            "Set only LINQ_API_TOKEN or only BLUEBUBBLES_SERVER_URL + "
+            "BLUEBUBBLES_PASSWORD, not both."
+        )
+
+
 def log_config_warnings(s: Settings | None = None) -> list[str]:
     """Log warnings for unusual but valid config values. Returns the warnings."""
     s = s or settings

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,12 @@ from backend.app.channels.bluebubbles import BlueBubblesChannel
 from backend.app.channels.linq import LinqChannel
 from backend.app.channels.telegram import TelegramChannel
 from backend.app.channels.webchat import WebChatChannel
-from backend.app.config import load_persistent_config, log_config_warnings, settings
+from backend.app.config import (
+    load_persistent_config,
+    log_config_warnings,
+    settings,
+    validate_imessage_backend,
+)
 from backend.app.database import SessionLocal, get_engine
 from backend.app.models import ChannelRoute, User
 from backend.app.routers import (
@@ -180,6 +185,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
 
     _verify_database()
     _enforce_single_channel()
+    validate_imessage_backend()
     log_config_warnings()
     await _verify_llm_settings()
     heartbeat_scheduler.start()

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -8,7 +8,12 @@ from sqlalchemy.orm import Session
 
 from backend.app.auth.dependencies import get_current_user
 from backend.app.channels import is_bluebubbles_configured, reset_channel_clients
-from backend.app.config import save_persistent_config, settings, update_settings
+from backend.app.config import (
+    resolve_imessage_backend,
+    save_persistent_config,
+    settings,
+    update_settings,
+)
 from backend.app.database import get_db
 from backend.app.models import ChannelRoute, HeartbeatLog, LLMUsageLog, User
 from backend.app.query_helpers import get_or_404
@@ -96,6 +101,7 @@ def _build_channel_config_response() -> ChannelConfigResponse:
     return ChannelConfigResponse(
         telegram_bot_token_set=bool(settings.telegram_bot_token),
         telegram_allowed_chat_id=settings.telegram_allowed_chat_id,
+        imessage_backend=resolve_imessage_backend(),
         linq_api_token_set=bool(settings.linq_api_token),
         linq_from_number=settings.linq_from_number,
         linq_allowed_numbers=settings.linq_allowed_numbers,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -102,6 +102,10 @@ class ChannelConfigResponse(BaseModel):
     bluebubbles_configured: bool = False
     bluebubbles_allowed_numbers: str = ""
     bluebubbles_imessage_address: str = ""
+    # Resolved iMessage backend ("linq" | "bluebubbles" | None).
+    # The UI uses this to render a single iMessage card without exposing which
+    # backend powers it; None means iMessage is not configured on this server.
+    imessage_backend: str | None = None
 
 
 class ChannelConfigUpdate(BaseModel):

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -84,7 +84,7 @@ Tool selection is context-aware: the registry picks relevant tools based on mess
 
 ### Channel abstraction
 
-The async message bus (`bus.py`) decouples the agent from delivery mechanics. Channels publish inbound messages to the bus and the `ChannelManager` dispatches outbound replies to the correct channel. The agent only interacts with the bus, never with channel implementations directly. Current channels are Linq (iMessage/RCS/SMS) and Telegram, and new channels can be added without modifying the agent.
+The async message bus (`bus.py`) decouples the agent from delivery mechanics. Channels publish inbound messages to the bus and the `ChannelManager` dispatches outbound replies to the correct channel. The agent only interacts with the bus, never with channel implementations directly. Current channels are Telegram and two interchangeable iMessage backends: Linq (hosted iMessage/RCS/SMS) and BlueBubbles (self-hosted iMessage bridge). Users see whichever iMessage backend the operator configures as a single unified "iMessage" option in the UI. New channels can be added without modifying the agent.
 
 ### Storage abstraction
 

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -47,12 +47,18 @@ Set the API key env var for your chosen provider, or set `ANY_LLM_KEY` to use th
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MESSAGING_PROVIDER` | `telegram` | Default messaging backend. Both Telegram and Linq channels can run simultaneously |
+| `MESSAGING_PROVIDER` | `telegram` | Default messaging backend. Telegram and iMessage channels can run simultaneously; only one iMessage backend (Linq OR BlueBubbles) may be configured at a time |
 | `TELEGRAM_BOT_TOKEN` | | Bot token from @BotFather |
 | `TELEGRAM_WEBHOOK_SECRET` | (auto-derived) | Webhook validation secret. Auto-derived from bot token if not set |
 | `TELEGRAM_ALLOWED_CHAT_ID` | (empty) | Your numeric Telegram user ID, or `*` to allow all. Only a single ID is allowed per user. Empty = deny all |
 
-## Linq settings (iMessage/RCS/SMS)
+## iMessage backends
+
+Clawbolt's user-facing "iMessage" channel is powered by one of two interchangeable
+backends. Choose one: configuring both at once will cause the app to refuse to start.
+End users see a single "iMessage" option regardless of which backend you pick.
+
+### Linq (hosted iMessage/RCS/SMS)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -62,9 +68,9 @@ Set the API key env var for your chosen provider, or set `ANY_LLM_KEY` to use th
 | `LINQ_ALLOWED_NUMBERS` | (empty) | E.164 phone number, `*` for all, or empty to deny all |
 | `LINQ_PREFERRED_SERVICE` | `iMessage` | Preferred messaging service: `iMessage`, `SMS`, or `RCS` |
 
-When `LINQ_API_TOKEN` is set, the Linq channel is active and users can text their assistant from their phone's native messaging app. Linq provides iMessage, RCS, and SMS access via [linqapp.com](https://linqapp.com).
+When `LINQ_API_TOKEN` is set, the iMessage channel is powered by Linq and users can text their assistant from their phone's native messaging app. Linq provides iMessage, RCS, and SMS access via [linqapp.com](https://linqapp.com).
 
-## BlueBubbles settings (self-hosted iMessage bridge)
+### BlueBubbles (self-hosted iMessage bridge)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -74,7 +80,7 @@ When `LINQ_API_TOKEN` is set, the Linq channel is active and users can text thei
 | `BLUEBUBBLES_SEND_METHOD` | `apple-script` | Send method: `apple-script` (default) or `private-api` |
 | `BLUEBUBBLES_IMESSAGE_ADDRESS` | (empty) | iCloud email or phone number displayed in the UI for users to text |
 
-When `BLUEBUBBLES_SERVER_URL` and `BLUEBUBBLES_PASSWORD` are set, the BlueBubbles channel is active. [BlueBubbles](https://github.com/BlueBubblesApp/bluebubbles-server) is a free, open-source iMessage bridge that runs on any Mac with iMessage signed in.
+When `BLUEBUBBLES_SERVER_URL` and `BLUEBUBBLES_PASSWORD` are set, the iMessage channel is powered by BlueBubbles. [BlueBubbles](https://github.com/BlueBubblesApp/bluebubbles-server) is a free, open-source iMessage bridge that runs on any Mac with iMessage signed in.
 
 ## Storage settings
 

--- a/docs/src/content/docs/deployment/docker.mdx
+++ b/docs/src/content/docs/deployment/docker.mdx
@@ -29,7 +29,7 @@ docker compose up --build
 On startup, the app:
 1. Runs database migrations automatically
 2. Starts the FastAPI server
-3. Auto-registers webhooks (Telegram and Linq) via the Cloudflare Tunnel URL
+3. Auto-registers webhooks via the Cloudflare Tunnel URL (Telegram and, if Linq is the configured iMessage backend, Linq)
 
 ## Data persistence
 

--- a/docs/src/content/docs/deployment/telegram-setup.mdx
+++ b/docs/src/content/docs/deployment/telegram-setup.mdx
@@ -3,7 +3,7 @@ title: Telegram Setup
 description: Create a Telegram bot and configure the webhook.
 ---
 
-Telegram is one of Clawbolt's messaging channels. If you prefer texting from your phone's native messaging app, see [Linq Setup](../linq-setup/) instead. Both channels can run simultaneously.
+Telegram is one of Clawbolt's messaging channels. If you prefer texting from your phone's native messaging app, configure an iMessage backend via [Linq Setup](../linq-setup/) (hosted iMessage/RCS/SMS) or [BlueBubbles Setup](../bluebubbles-setup/) (self-hosted iMessage) instead. Telegram can run alongside an iMessage backend.
 
 This guide walks you through creating a Telegram bot, connecting it to Clawbolt, and configuring who can use it.
 

--- a/docs/src/content/docs/development/local-setup.mdx
+++ b/docs/src/content/docs/development/local-setup.mdx
@@ -27,7 +27,7 @@ cp .env.example .env
 Edit `.env` with your credentials. At minimum:
 - An LLM API key
 - At least one messaging channel:
-  - **Texting (Linq):** `LINQ_API_TOKEN` and `LINQ_FROM_NUMBER`
+  - **iMessage:** pick one backend. Linq (`LINQ_API_TOKEN` + `LINQ_FROM_NUMBER`) for hosted iMessage/RCS/SMS, or BlueBubbles (`BLUEBUBBLES_SERVER_URL` + `BLUEBUBBLES_PASSWORD`) for a self-hosted bridge. The app surfaces either as a single "iMessage" channel to users. Configuring both at once is not supported.
   - **Telegram:** `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_CHAT_ID`
 
 ## Set up PostgreSQL
@@ -65,7 +65,7 @@ Without Docker, you need a tunnel to give messaging providers a public URL:
 cloudflared tunnel --url http://localhost:8000
 ```
 
-If using **Linq**, the webhook registers automatically when the server detects the tunnel URL.
+If using the **iMessage** channel backed by Linq, the webhook registers automatically when the server detects the tunnel URL. If using BlueBubbles as the iMessage backend, configure the webhook on your BlueBubbles server per its setup guide.
 
 If using **Telegram**, copy the tunnel URL and register the webhook manually:
 
@@ -75,4 +75,4 @@ curl -X POST "https://api.telegram.org/bot<TOKEN>/setWebhook" \
   -d '{"url": "https://<tunnel-url>/api/webhooks/telegram"}'
 ```
 
-See [Linq Setup](../../deployment/linq-setup/) or [Telegram Setup](../../deployment/telegram-setup/) for details.
+See [Linq Setup](../../deployment/linq-setup/), [BlueBubbles Setup](../../deployment/bluebubbles-setup/), or [Telegram Setup](../../deployment/telegram-setup/) for details.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -8,7 +8,7 @@ The fastest way to run Clawbolt is with Docker Compose.
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
-- A messaging channel: either a [Linq account](../deployment/linq-setup/) (iMessage/RCS/SMS) or a [Telegram bot token](../deployment/telegram-setup/)
+- A messaging channel: either an iMessage backend ([Linq](../deployment/linq-setup/) for hosted iMessage/RCS/SMS, or [BlueBubbles](../deployment/bluebubbles-setup/) for self-hosted iMessage) or a [Telegram bot token](../deployment/telegram-setup/)
 - An LLM provider API key (OpenAI, Anthropic, etc.)
 
 ## 1. Clone the repository
@@ -30,7 +30,7 @@ At minimum you need:
 - An LLM API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
 - `VISION_MODEL` -- the model used for image analysis (defaults to `LLM_MODEL` if not set)
 - At least one messaging channel configured:
-  - **Texting (recommended):** `LINQ_API_TOKEN` and `LINQ_FROM_NUMBER` for iMessage/RCS/SMS via [Linq](../deployment/linq-setup/)
+  - **iMessage (recommended):** choose one backend. Hosted iMessage/RCS/SMS via [Linq](../deployment/linq-setup/) (`LINQ_API_TOKEN` + `LINQ_FROM_NUMBER`), or self-hosted iMessage via [BlueBubbles](../deployment/bluebubbles-setup/) (`BLUEBUBBLES_SERVER_URL` + `BLUEBUBBLES_PASSWORD`). The app surfaces whichever backend you configure as a single "iMessage" channel to end users. Configuring both at once is not supported.
   - **Telegram:** `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_CHAT_ID` for Telegram via [Telegram Setup](../deployment/telegram-setup/)
 
 ## 3. Start the services
@@ -56,7 +56,7 @@ curl http://localhost:8000/api/health
 
 Docker Compose starts a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) alongside the app and registers webhooks automatically. No Cloudflare account or auth token required.
 
-Send a message to your assistant and Clawbolt will respond. If you configured Linq, text the Linq phone number from your phone. If you configured Telegram, message your bot on Telegram.
+Send a message to your assistant and Clawbolt will respond. If you configured an iMessage backend, send an iMessage (or SMS/RCS if Linq is your backend) to the configured phone number or address. If you configured Telegram, message your bot on Telegram.
 
 ## Next steps
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1570,6 +1570,17 @@
             "type": "string",
             "title": "Bluebubbles Imessage Address",
             "default": ""
+          },
+          "imessage_backend": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imessage Backend"
           }
         },
         "type": "object",

--- a/frontend/src/components/ChannelConfigForm.tsx
+++ b/frontend/src/components/ChannelConfigForm.tsx
@@ -65,17 +65,18 @@ interface PremiumLinkConfig {
 const PREMIUM_LINK_CONFIGS: Partial<Record<ChannelKey, PremiumLinkConfig>> = {
   linq: {
     channelKey: 'linq',
-    displayName: 'Text Messaging',
+    displayName: 'iMessage',
     label: 'Your Phone Number',
     placeholder: 'e.g. +15551234567',
-    helpText: "E.164 format phone number. This is the number you'll text from.",
+    helpText: "E.164 format phone number. This is the number you'll send messages from.",
     inputMode: 'tel',
     getAssistantAddress: (config) => config?.linq_from_number ?? '',
+    assistantSubtitle: 'Send an iMessage to this address to reach your assistant.',
     setLink: (id) => api.setLinqLink(id),
   },
   bluebubbles: {
     channelKey: 'bluebubbles',
-    displayName: 'BlueBubbles',
+    displayName: 'iMessage',
     label: 'Your Phone Number or iCloud Email',
     placeholder: 'e.g. +15551234567 or user@icloud.com',
     helpText: 'The phone number or iCloud email you send iMessages from.',
@@ -253,7 +254,7 @@ function OssLinqForm({ channelConfig, onSaved }: SubFormProps) {
       onSuccess: () => {
         setAllowedNumber(null);
         setPreferredService(null);
-        toast.success('Linq settings updated');
+        toast.success('iMessage settings updated');
         onSaved();
       },
       onError: (e) => toast.error(e.message),
@@ -320,7 +321,7 @@ function BlueBubblesForm({ channelConfig, onSaved }: SubFormProps) {
       onSuccess: () => {
         setAllowedNumbers(null);
         setImessageAddress(null);
-        toast.success('BlueBubbles settings updated');
+        toast.success('iMessage settings updated');
         onSaved();
       },
       onError: (e) => toast.error(e.message),

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -842,6 +842,8 @@ export interface components {
              * @default
              */
             bluebubbles_imessage_address: string;
+            /** Imessage Backend */
+            imessage_backend?: string | null;
         };
         /** ChannelConfigUpdate */
         ChannelConfigUpdate: {

--- a/frontend/src/lib/channel-utils.ts
+++ b/frontend/src/lib/channel-utils.ts
@@ -5,11 +5,31 @@ export type ChannelState = 'unavailable' | 'available' | 'configured' | 'active'
 
 export type ChannelKey = (typeof MESSAGING_CHANNELS)[number]['key'];
 
+// Real backend channel keys. `linq` and `bluebubbles` are both rendered to the
+// user as "iMessage"; which one shows up at runtime is determined by which
+// backend the admin has configured. Users never see the backend name.
 export const MESSAGING_CHANNELS = [
   { key: 'telegram', label: 'Telegram' },
-  { key: 'linq', label: 'Text Messaging (iMessage / RCS / SMS)' },
-  { key: 'bluebubbles', label: 'BlueBubbles (iMessage)' },
+  { key: 'linq', label: 'iMessage' },
+  { key: 'bluebubbles', label: 'iMessage' },
 ] as const;
+
+/** Return the subset of MESSAGING_CHANNELS the user should see, filtered by
+ * which iMessage backend (if any) the admin has configured. The mutual
+ * exclusion between Linq and BlueBubbles is enforced at server startup, so at
+ * most one of them will ever be present in the visible list. */
+export function getVisibleChannels(
+  config: ChannelConfigResponse | undefined,
+): ReadonlyArray<(typeof MESSAGING_CHANNELS)[number]> {
+  // Before the config loads we can't know which iMessage backend (if any) to
+  // render, so we show only the always-available entries. Once config arrives
+  // we include the single iMessage card matching config.imessage_backend.
+  if (!config) return MESSAGING_CHANNELS.filter((ch) => ch.key === 'telegram');
+  return MESSAGING_CHANNELS.filter((ch) => {
+    if (ch.key === 'telegram') return true;
+    return ch.key === config.imessage_backend;
+  });
+}
 
 /** Premium link data keyed by channel. Adding a channel here is all that's needed. */
 export type PremiumChannelData = {
@@ -20,8 +40,8 @@ export type PremiumChannelData = {
 /** Whether the server has the necessary credentials/config for this channel. */
 export function isServerAvailable(key: ChannelKey, config: ChannelConfigResponse): boolean {
   if (key === 'telegram') return config.telegram_bot_token_set;
-  if (key === 'linq') return config.linq_api_token_set;
-  if (key === 'bluebubbles') return config.bluebubbles_configured;
+  if (key === 'linq') return config.imessage_backend === 'linq';
+  if (key === 'bluebubbles') return config.imessage_backend === 'bluebubbles';
   return false;
 }
 

--- a/frontend/src/pages/ChannelsPage.test.tsx
+++ b/frontend/src/pages/ChannelsPage.test.tsx
@@ -70,6 +70,7 @@ beforeEach(() => {
     linq_preferred_service: 'iMessage',
     bluebubbles_configured: false,
     bluebubbles_allowed_numbers: '',
+    imessage_backend: 'linq',
   });
   mockGetChannelRoutes.mockResolvedValue({ routes: [] });
   mockToggleChannelRoute.mockResolvedValue({ channel: 'telegram', channel_identifier: '123', enabled: true, created_at: '' });
@@ -81,18 +82,42 @@ beforeEach(() => {
 });
 
 describe('ChannelsPage - Channel States', () => {
-  it('renders all three channel cards', async () => {
+  it('renders Telegram and a single unified iMessage card when linq is the backend', async () => {
     renderWithRouter(<ChannelsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Telegram')).toBeInTheDocument();
     });
-    expect(screen.getByText('Text Messaging (iMessage / RCS / SMS)')).toBeInTheDocument();
-    expect(screen.getByText('BlueBubbles (iMessage)')).toBeInTheDocument();
+    // iMessage appears once as a unified card (Linq backend is not named in the UI).
+    expect(screen.getAllByText('iMessage')).toHaveLength(1);
+    expect(screen.queryByText(/Text Messaging/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/BlueBubbles/)).not.toBeInTheDocument();
   });
 
-  it('shows "Not available" badge for unavailable channels alongside available ones', async () => {
-    // Telegram available, Linq and BB unavailable
+  it('renders the iMessage card when bluebubbles is the backend (still one card, still labeled iMessage)', async () => {
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: true,
+      telegram_allowed_chat_id: '*',
+      linq_api_token_set: false,
+      linq_from_number: '',
+      linq_allowed_numbers: '',
+      linq_preferred_service: 'iMessage',
+      bluebubbles_configured: true,
+      bluebubbles_allowed_numbers: '*',
+      imessage_backend: 'bluebubbles',
+    });
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Telegram')).toBeInTheDocument();
+    });
+    expect(screen.getAllByText('iMessage')).toHaveLength(1);
+    expect(screen.queryByText(/BlueBubbles/)).not.toBeInTheDocument();
+  });
+
+  it('hides the iMessage card entirely when no iMessage backend is configured', async () => {
+    // Telegram available, neither iMessage backend configured -> iMessage card is filtered out.
     mockGetChannelConfig.mockResolvedValue({
       telegram_bot_token_set: true,
       telegram_allowed_chat_id: '',
@@ -102,6 +127,7 @@ describe('ChannelsPage - Channel States', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: null,
     });
     mockGetTelegramLink.mockResolvedValue({ telegram_user_id: null, connected: false });
     mockGetLinqLink.mockResolvedValue({ phone_number: null, connected: false });
@@ -109,10 +135,10 @@ describe('ChannelsPage - Channel States', () => {
     renderWithRouter(<ChannelsPage />);
 
     await waitFor(() => {
-      const badges = screen.getAllByText('Not available');
-      expect(badges.length).toBe(2); // Linq and BB
+      expect(screen.getByText('Telegram')).toBeInTheDocument();
     });
-    // Telegram should show Setup needed
+    expect(screen.queryByText('iMessage')).not.toBeInTheDocument();
+    // Telegram shows "Setup needed" since the server has a bot token but the user lacks a chat id.
     expect(screen.getByText('Setup needed')).toBeInTheDocument();
   });
 
@@ -129,6 +155,7 @@ describe('ChannelsPage - Channel States', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: null,
     });
 
     renderWithRouter(<ChannelsPage />);
@@ -255,6 +282,7 @@ describe('ChannelsPage - Config Forms', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: null,
     });
 
     renderWithRouter(<ChannelsPage />);
@@ -297,8 +325,8 @@ describe('ChannelsPage - Config Forms', () => {
 });
 
 describe('ChannelsPage - Unavailable hints', () => {
-  it('shows environment variable hint for unavailable Telegram', async () => {
-    // Telegram unavailable, but Linq available so page renders channel cards (not empty state)
+  it('shows admin-contact hint for unavailable Telegram without leaking env var names', async () => {
+    // Telegram unavailable, linq is the iMessage backend so page renders channel cards (not empty state).
     mockGetChannelConfig.mockResolvedValue({
       telegram_bot_token_set: false,
       telegram_allowed_chat_id: '',
@@ -308,6 +336,7 @@ describe('ChannelsPage - Unavailable hints', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: 'linq',
     });
     mockGetTelegramLink.mockResolvedValue({ telegram_user_id: null, connected: false });
     mockGetLinqLink.mockResolvedValue({ phone_number: null, connected: false });
@@ -315,46 +344,10 @@ describe('ChannelsPage - Unavailable hints', () => {
     renderWithRouter(<ChannelsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/TELEGRAM_BOT_TOKEN/)).toBeInTheDocument();
+      expect(screen.getByText(/Contact your administrator to enable Telegram/)).toBeInTheDocument();
     });
-  });
-
-  it('shows environment variable hint for unavailable Linq', async () => {
-    mockGetChannelConfig.mockResolvedValue({
-      telegram_bot_token_set: true,
-      telegram_allowed_chat_id: '*',
-      linq_api_token_set: false,
-      linq_from_number: '',
-      linq_allowed_numbers: '',
-      linq_preferred_service: 'iMessage',
-      bluebubbles_configured: false,
-      bluebubbles_allowed_numbers: '',
-    });
-
-    renderWithRouter(<ChannelsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/LINQ_API_TOKEN/)).toBeInTheDocument();
-    });
-  });
-
-  it('shows environment variable hint for unavailable BlueBubbles', async () => {
-    mockGetChannelConfig.mockResolvedValue({
-      telegram_bot_token_set: true,
-      telegram_allowed_chat_id: '*',
-      linq_api_token_set: true,
-      linq_from_number: '+15551234567',
-      linq_allowed_numbers: '*',
-      linq_preferred_service: 'iMessage',
-      bluebubbles_configured: false,
-      bluebubbles_allowed_numbers: '',
-    });
-
-    renderWithRouter(<ChannelsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/BLUEBUBBLES_SERVER_URL/)).toBeInTheDocument();
-    });
+    // The hint must not leak the backend env var name.
+    expect(screen.queryByText(/TELEGRAM_BOT_TOKEN/)).not.toBeInTheDocument();
   });
 });
 
@@ -369,6 +362,7 @@ describe('ChannelsPage - Empty state', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: null,
     });
     mockGetTelegramLink.mockResolvedValue({ telegram_user_id: null, connected: false });
     mockGetLinqLink.mockResolvedValue({ phone_number: null, connected: false });
@@ -395,6 +389,7 @@ describe('ChannelsPage - OSS mode', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: null,
     });
 
     renderWithRouter(<ChannelsPage />);

--- a/frontend/src/pages/ChannelsPage.tsx
+++ b/frontend/src/pages/ChannelsPage.tsx
@@ -6,7 +6,7 @@ import { useToggleChannelRoute } from '@/hooks/queries';
 import { useChannelStates } from '@/hooks/useChannelStates';
 import { useAuth } from '@/contexts/AuthContext';
 import {
-  MESSAGING_CHANNELS,
+  getVisibleChannels,
   getChannelStatusDisplay,
   type ChannelKey,
   type ChannelState,
@@ -20,6 +20,7 @@ export default function ChannelsPage() {
   const { isPremium } = useAuth();
   const toggleMutation = useToggleChannelRoute();
   const { states: channelStates, channelConfig, telegramLinkData, botInfo, linkDataMap, invalidateLink } = useChannelStates();
+  const visibleChannels = getVisibleChannels(channelConfig);
 
   // Track which config form is expanded
   const [expandedChannel, setExpandedChannel] = useState<ChannelKey | null>(null);
@@ -30,7 +31,7 @@ export default function ChannelsPage() {
   const hasAutoExpanded = useRef(false);
   useEffect(() => {
     if (!channelConfig || hasAutoExpanded.current) return;
-    const needsSetup = MESSAGING_CHANNELS.find(
+    const needsSetup = visibleChannels.find(
       (ch) => channelStates[ch.key] === 'available',
     );
     if (needsSetup) {
@@ -40,7 +41,7 @@ export default function ChannelsPage() {
   }, [channelConfig, channelStates]);
 
   // Find which channel is currently active (if any)
-  const activeChannelKey = MESSAGING_CHANNELS.find(
+  const activeChannelKey = visibleChannels.find(
     (ch) => channelStates[ch.key] === 'active',
   )?.key ?? null;
 
@@ -51,7 +52,7 @@ export default function ChannelsPage() {
       {
         onSuccess: () => {
           setSwitchingChannel(null);
-          toast.success(`Switched to ${MESSAGING_CHANNELS.find((c) => c.key === key)?.label}`);
+          toast.success(`Switched to ${visibleChannels.find((c) => c.key === key)?.label}`);
         },
         onError: (e) => {
           setSwitchingChannel(null);
@@ -91,14 +92,15 @@ export default function ChannelsPage() {
 
   // Check if any channels are available at all
   const anyAvailable = channelConfig
-    ? MESSAGING_CHANNELS.some((ch) => channelStates[ch.key] !== 'unavailable')
+    ? visibleChannels.length > 0 &&
+      visibleChannels.some((ch) => channelStates[ch.key] !== 'unavailable')
     : true; // Don't show empty state while loading
 
   // Separate channels into selectable (configured/active) and non-selectable
-  const selectableChannels = MESSAGING_CHANNELS.filter(
+  const selectableChannels = visibleChannels.filter(
     (ch) => channelStates[ch.key] === 'configured' || channelStates[ch.key] === 'active',
   );
-  const nonSelectableChannels = MESSAGING_CHANNELS.filter(
+  const nonSelectableChannels = visibleChannels.filter(
     (ch) => channelStates[ch.key] === 'unavailable' || channelStates[ch.key] === 'available',
   );
 
@@ -114,8 +116,8 @@ export default function ChannelsPage() {
           <div className="text-center py-4">
             <h3 className="text-sm font-medium mb-2">No messaging channels available</h3>
             <p className="text-xs text-muted-foreground mb-4">
-              Your server doesn't have any messaging channels configured yet.
-              Ask your administrator to set up Telegram, Text Messaging, or BlueBubbles.
+              No messaging channels have been configured yet.
+              Contact your administrator to enable Telegram or iMessage.
             </p>
             <Button onClick={() => window.location.assign('/app/chat')}>Go to Chat</Button>
           </div>
@@ -407,10 +409,10 @@ function NoneIcon() {
 }
 
 function getUnavailableHint(key: ChannelKey): string {
-  if (key === 'telegram') return 'Set TELEGRAM_BOT_TOKEN in your environment to enable.';
-  if (key === 'linq') return 'Set LINQ_API_TOKEN in your environment to enable.';
-  if (key === 'bluebubbles')
-    return 'Set BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD in your environment to enable.';
+  if (key === 'telegram') return 'Contact your administrator to enable Telegram.';
+  if (key === 'linq' || key === 'bluebubbles') {
+    return 'Contact your administrator to enable iMessage.';
+  }
   return '';
 }
 
@@ -445,17 +447,10 @@ function ChannelIcon({ channelKey }: { channelKey: ChannelKey }) {
       </svg>
     );
   }
-  if (channelKey === 'linq') {
-    return (
-      <svg className="w-5 h-5 text-muted-foreground shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-      </svg>
-    );
-  }
-  // bluebubbles
+  // linq and bluebubbles both render as the unified iMessage chat bubble.
   return (
     <svg className="w-5 h-5 text-muted-foreground shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a2 2 0 01-2-2v-1M13 4H7a2 2 0 00-2 2v6a2 2 0 002 2h2v4l4-4h2a2 2 0 002-2V6a2 2 0 00-2-2z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
     </svg>
   );
 }

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -94,6 +94,7 @@ function setupMocks(overrides?: {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: 'linq',
     },
   );
   mockGetToolConfig.mockResolvedValue(
@@ -185,15 +186,17 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
   });
 
-  it('shows per-channel status lines for all channels', async () => {
+  it('shows per-channel status lines with a unified iMessage card', async () => {
     setupMocks();
     renderWithRouter(<DashboardPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Telegram')).toBeInTheDocument();
     });
-    expect(screen.getByText('Text Messaging (iMessage / RCS / SMS)')).toBeInTheDocument();
-    expect(screen.getByText('BlueBubbles (iMessage)')).toBeInTheDocument();
+    // Only one iMessage card; backend name never exposed.
+    expect(screen.getAllByText('iMessage')).toHaveLength(1);
+    expect(screen.queryByText(/Text Messaging/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/BlueBubbles/)).not.toBeInTheDocument();
   });
 
   it('shows "Setup needed" for available but unconfigured channels', async () => {
@@ -207,6 +210,7 @@ describe('DashboardPage', () => {
         linq_preferred_service: 'iMessage',
         bluebubbles_configured: false,
         bluebubbles_allowed_numbers: '',
+        imessage_backend: 'linq',
       },
       routes: { routes: [] },
     });
@@ -218,7 +222,7 @@ describe('DashboardPage', () => {
     });
   });
 
-  it('shows "Not available" for channels without server config', async () => {
+  it('hides the iMessage card entirely when no iMessage backend is configured', async () => {
     setupMocks({
       channelConfig: {
         telegram_bot_token_set: true,
@@ -229,14 +233,15 @@ describe('DashboardPage', () => {
         linq_preferred_service: 'iMessage',
         bluebubbles_configured: false,
         bluebubbles_allowed_numbers: '',
+        imessage_backend: null,
       },
     });
     renderWithRouter(<DashboardPage />);
 
     await waitFor(() => {
-      const badges = screen.getAllByText('Not available');
-      expect(badges.length).toBe(2);
+      expect(screen.getByText('Telegram')).toBeInTheDocument();
     });
+    expect(screen.queryByText('iMessage')).not.toBeInTheDocument();
   });
 
   it('shows setup prompt when no channels are available at all', async () => {
@@ -251,6 +256,7 @@ describe('DashboardPage', () => {
         linq_preferred_service: 'iMessage',
         bluebubbles_configured: false,
         bluebubbles_allowed_numbers: '',
+        imessage_backend: null,
       },
     });
     renderWithRouter(<DashboardPage />);
@@ -509,6 +515,7 @@ describe('DashboardPage', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: null,
     });
     mockGetToolConfig.mockResolvedValue({ tools: [] });
     mockGetOAuthStatus.mockResolvedValue({ integrations: [] });

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -7,7 +7,7 @@ import { Spinner } from '@heroui/spinner';
 import { toast } from '@/lib/toast';
 import { useToolConfig, useUpdateToolConfig, useOAuthStatus, useCalendarConfig, useMemory, useModelConfig, useUpdateProfile } from '@/hooks/queries';
 import { useChannelStates } from '@/hooks/useChannelStates';
-import { MESSAGING_CHANNELS, getChannelStatusDisplay } from '@/lib/channel-utils';
+import { getVisibleChannels, getChannelStatusDisplay } from '@/lib/channel-utils';
 import { displayName as toolDisplayName, getToolOAuthStatus } from '@/lib/tool-utils';
 import type { AppShellContext } from '@/layouts/AppShell';
 
@@ -105,7 +105,7 @@ export default function DashboardPage() {
   const updateProfile = useUpdateProfile();
 
   // --- Channels ---
-  const channelStates = MESSAGING_CHANNELS.flatMap((ch) => {
+  const channelStates = getVisibleChannels(channelData.channelConfig).flatMap((ch) => {
     const state = channelData.states[ch.key];
     return state ? [{ ...ch, state }] : [];
   });

--- a/frontend/src/pages/GetStartedPage.test.tsx
+++ b/frontend/src/pages/GetStartedPage.test.tsx
@@ -44,6 +44,7 @@ const mockUpdateChannelConfig = vi.fn().mockResolvedValue({
   linq_preferred_service: 'iMessage',
   bluebubbles_configured: false,
   bluebubbles_allowed_numbers: '',
+  imessage_backend: 'linq',
 });
 const mockGetChannelConfig = vi.fn().mockResolvedValue({
   telegram_bot_token_set: false,
@@ -54,6 +55,7 @@ const mockGetChannelConfig = vi.fn().mockResolvedValue({
   linq_preferred_service: 'iMessage',
   bluebubbles_configured: false,
   bluebubbles_allowed_numbers: '',
+  imessage_backend: 'linq',
 });
 const mockGetChannelRoutes = vi.fn().mockResolvedValue({ routes: [] });
 const mockToggleChannelRoute = vi.fn().mockResolvedValue({
@@ -90,12 +92,16 @@ describe('GetStartedPage', () => {
     expect(screen.getByText("You're off to the races")).toBeInTheDocument();
   });
 
-  it('renders channel selection radio options from shared MESSAGING_CHANNELS', () => {
+  it('renders channel selection radio options: Telegram, iMessage, None', async () => {
     renderWithRouter(<GetStartedPage />);
 
+    // Wait for channel config to load so getVisibleChannels can filter the list.
+    await waitFor(() => {
+      expect(screen.getAllByText('iMessage')).toHaveLength(1);
+    });
     expect(screen.getByText('Telegram')).toBeInTheDocument();
-    expect(screen.getByText('Text Messaging (iMessage / RCS / SMS)')).toBeInTheDocument();
-    expect(screen.getByText('BlueBubbles (iMessage)')).toBeInTheDocument();
+    expect(screen.queryByText(/Text Messaging/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/BlueBubbles/)).not.toBeInTheDocument();
     expect(screen.getByText('None')).toBeInTheDocument();
   });
 
@@ -114,11 +120,11 @@ describe('GetStartedPage', () => {
     renderWithRouter(<GetStartedPage />);
     const user = userEvent.setup();
 
-    const linqRadio = screen.getByDisplayValue('linq');
+    const linqRadio = await screen.findByDisplayValue('linq');
     await user.click(linqRadio);
 
     await waitFor(() => {
-      expect(screen.getByText(/Configure Text Messaging/)).toBeInTheDocument();
+      expect(screen.getByText(/Configure iMessage/)).toBeInTheDocument();
     });
     // The shared OssLinqForm shows "Allowed Phone Number" field
     expect(screen.getByPlaceholderText('e.g. +15551234567')).toBeInTheDocument();
@@ -134,6 +140,7 @@ describe('GetStartedPage', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: 'linq',
     });
 
     renderWithRouter(<GetStartedPage />);
@@ -156,7 +163,7 @@ describe('GetStartedPage', () => {
     renderWithRouter(<GetStartedPage />);
     const user = userEvent.setup();
 
-    const linqRadio = screen.getByDisplayValue('linq');
+    const linqRadio = await screen.findByDisplayValue('linq');
     await user.click(linqRadio);
 
     await waitFor(() => {
@@ -176,7 +183,7 @@ describe('GetStartedPage', () => {
     renderWithRouter(<GetStartedPage />);
     const user = userEvent.setup();
 
-    const linqRadio = screen.getByDisplayValue('linq');
+    const linqRadio = await screen.findByDisplayValue('linq');
     await user.click(linqRadio);
 
     await waitFor(() => {
@@ -184,10 +191,10 @@ describe('GetStartedPage', () => {
       const matches = screen.getAllByText('+15559876543');
       expect(matches.length).toBeGreaterThanOrEqual(1);
     });
-    expect(screen.getByText(/say hello to get started/)).toBeInTheDocument();
+    expect(screen.getByText(/Send an iMessage to this address to get started/)).toBeInTheDocument();
   });
 
-  it('shows fallback messaging when linq is not configured', async () => {
+  it('shows fallback messaging when no iMessage backend is configured', async () => {
     mockGetChannelConfig.mockResolvedValueOnce({
       telegram_bot_token_set: false,
       telegram_allowed_chat_id: '',
@@ -197,12 +204,13 @@ describe('GetStartedPage', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: null,
     });
 
     renderWithRouter(<GetStartedPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Text messaging is not configured yet/)).toBeInTheDocument();
+      expect(screen.getByText(/No messaging channel is configured yet/)).toBeInTheDocument();
     });
   });
 
@@ -216,6 +224,7 @@ describe('GetStartedPage', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: 'linq',
     });
 
     renderWithRouter(<GetStartedPage />);
@@ -258,6 +267,7 @@ describe('GetStartedPage', () => {
       linq_preferred_service: 'iMessage',
       bluebubbles_configured: false,
       bluebubbles_allowed_numbers: '',
+      imessage_backend: 'linq',
     });
     mockGetChannelRoutes.mockResolvedValue({
       routes: [{ channel: 'telegram', channel_identifier: '123', enabled: true, created_at: '' }],

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -6,7 +6,7 @@ import TextAssistantCard from '@/components/TextAssistantCard';
 import { toast } from '@/lib/toast';
 import { useUpdateProfile, useChannelConfig, useToggleChannelRoute, useChannelRoutes } from '@/hooks/queries';
 import { useAuth } from '@/contexts/AuthContext';
-import { MESSAGING_CHANNELS, isServerAvailable, type ChannelKey } from '@/lib/channel-utils';
+import { getVisibleChannels, isServerAvailable, type ChannelKey } from '@/lib/channel-utils';
 import { ChannelConfigForm, type TelegramLinkData, type PremiumLinkData } from '@/components/ChannelConfigForm';
 import api from '@/api';
 import type { AppShellContext } from '@/layouts/AppShell';
@@ -20,6 +20,7 @@ export default function GetStartedPage() {
   const updateProfile = useUpdateProfile();
   const { data: channelConfig } = useChannelConfig();
   const { data: routesData } = useChannelRoutes();
+  const visibleChannels = getVisibleChannels(channelConfig);
   const toggleChannelRoute = useToggleChannelRoute();
   const [selectedChannel, setSelectedChannel] = useState<Selection | null>(null);
   const [confirmedChannel, setConfirmedChannel] = useState<Selection | null>(null);
@@ -51,7 +52,7 @@ export default function GetStartedPage() {
   const bbConfigured = channelConfig ? isServerAvailable('bluebubbles', channelConfig) : false;
 
   // Find the currently active channel route
-  const activeChannelKey = MESSAGING_CHANNELS.find(
+  const activeChannelKey = visibleChannels.find(
     (ch) => routes.some((r) => r.channel === ch.key && r.enabled),
   )?.key ?? null;
 
@@ -139,7 +140,7 @@ export default function GetStartedPage() {
   const step2Label = selectedChannel === 'none'
     ? 'No setup needed'
     : selectedChannel
-      ? `Configure ${MESSAGING_CHANNELS.find((c) => c.key === selectedChannel)?.label ?? selectedChannel}`
+      ? `Configure ${visibleChannels.find((c) => c.key === selectedChannel)?.label ?? selectedChannel}`
       : 'Configure your channel';
 
   return (
@@ -168,7 +169,7 @@ export default function GetStartedPage() {
                 Pick how you want to talk to Clawbolt. You can change this later.
               </p>
               <div className="mt-3 grid gap-2" role="radiogroup" aria-label="Messaging channel">
-                {MESSAGING_CHANNELS.map(({ key, label }) => {
+                {visibleChannels.map(({ key, label }) => {
                   const configured = channelConfig ? isServerAvailable(key, channelConfig) : false;
                   return (
                     <ChannelRadioItem
@@ -250,15 +251,15 @@ export default function GetStartedPage() {
                 <span className="text-xs font-medium text-muted-foreground">Step 3</span>
               </div>
               <h3 className="text-sm font-semibold font-display">Send a message</h3>
-              {linqConfigured && fromNumber && selectedChannel === 'linq' ? (
+              {selectedChannel === 'linq' && linqConfigured && fromNumber ? (
                 <div className="mt-2">
                   <TextAssistantCard
                     fromNumber={fromNumber}
-                    subtitle="Just say hello to get started."
+                    subtitle="Send an iMessage to this address to get started."
                     qrSize={80}
                   />
                 </div>
-              ) : bbConfigured && bbAddress && selectedChannel === 'bluebubbles' ? (
+              ) : selectedChannel === 'bluebubbles' && bbConfigured && bbAddress ? (
                 <div className="mt-2">
                   <TextAssistantCard
                     fromNumber={bbAddress}
@@ -272,31 +273,29 @@ export default function GetStartedPage() {
                     ? 'Use the chat in the sidebar to talk to your assistant.'
                     : selectedChannel === 'telegram'
                       ? 'Open Telegram and send a message to your bot to get started.'
-                      : selectedChannel === 'bluebubbles'
-                        ? 'Send an iMessage to get started.'
-                        : linqConfigured && fromNumber
-                          ? 'Text your assistant to get started.'
-                          : (
-                              <>
-                                Text messaging is not configured yet. You can also{' '}
-                                <button
-                                  type="button"
-                                  className="text-primary hover:underline font-medium"
-                                  onClick={() => navigate('/app/chat')}
-                                >
-                                  chat from the web
-                                </button>
-                                {' '}or{' '}
-                                <button
-                                  type="button"
-                                  className="text-primary hover:underline font-medium"
-                                  onClick={() => navigate('/app/channels')}
-                                >
-                                  set up a channel
-                                </button>
-                                .
-                              </>
-                            )}
+                      : selectedChannel === 'linq' || selectedChannel === 'bluebubbles'
+                        ? 'Send an iMessage to your assistant to get started.'
+                        : (
+                            <>
+                              No messaging channel is configured yet. You can also{' '}
+                              <button
+                                type="button"
+                                className="text-primary hover:underline font-medium"
+                                onClick={() => navigate('/app/chat')}
+                              >
+                                chat from the web
+                              </button>
+                              {' '}or{' '}
+                              <button
+                                type="button"
+                                className="text-primary hover:underline font-medium"
+                                onClick={() => navigate('/app/channels')}
+                              >
+                                set up a channel
+                              </button>
+                              .
+                            </>
+                          )}
                 </p>
               )}
             </div>

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -186,3 +186,44 @@ def test_update_channel_config_rejects_multiple_chat_ids(
         )
     assert resp.status_code == 422
     assert "single" in resp.json()["detail"].lower()
+
+
+@pytest.fixture()
+def _imessage_reset() -> Iterator[None]:
+    """Reset iMessage backend settings to empty around a test."""
+    original_linq = settings.linq_api_token
+    original_bb_url = settings.bluebubbles_server_url
+    original_bb_pw = settings.bluebubbles_password
+    settings.linq_api_token = ""
+    settings.bluebubbles_server_url = ""
+    settings.bluebubbles_password = ""
+    yield
+    settings.linq_api_token = original_linq
+    settings.bluebubbles_server_url = original_bb_url
+    settings.bluebubbles_password = original_bb_pw
+
+
+def test_channel_config_imessage_backend_none(client: TestClient, _imessage_reset: None) -> None:
+    """imessage_backend is None when neither Linq nor BlueBubbles is configured."""
+    resp = client.get("/api/user/channels/config")
+    assert resp.status_code == 200
+    assert resp.json()["imessage_backend"] is None
+
+
+def test_channel_config_imessage_backend_linq(client: TestClient, _imessage_reset: None) -> None:
+    """imessage_backend reports 'linq' when only Linq is configured."""
+    settings.linq_api_token = "tok"
+    resp = client.get("/api/user/channels/config")
+    assert resp.status_code == 200
+    assert resp.json()["imessage_backend"] == "linq"
+
+
+def test_channel_config_imessage_backend_bluebubbles(
+    client: TestClient, _imessage_reset: None
+) -> None:
+    """imessage_backend reports 'bluebubbles' when only BlueBubbles is configured."""
+    settings.bluebubbles_server_url = "https://mac.ngrok.io"
+    settings.bluebubbles_password = "p"
+    resp = client.get("/api/user/channels/config")
+    assert resp.status_code == 200
+    assert resp.json()["imessage_backend"] == "bluebubbles"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -5,7 +5,12 @@ import logging
 import pytest
 from pydantic import SecretStr, ValidationError
 
-from backend.app.config import Settings, log_config_warnings
+from backend.app.config import (
+    Settings,
+    log_config_warnings,
+    resolve_imessage_backend,
+    validate_imessage_backend,
+)
 
 
 class TestFieldConstraints:
@@ -121,3 +126,67 @@ class TestLogConfigWarnings:
         with caplog.at_level(logging.WARNING):
             log_config_warnings(s)
         assert any("max_tool_rounds" in r.message for r in caplog.records)
+
+
+class TestIMessageBackend:
+    """validate_imessage_backend rejects double-configuration; resolve_imessage_backend picks the active one."""
+
+    def test_resolve_none_when_nothing_set(self) -> None:
+        s = Settings(linq_api_token="", bluebubbles_server_url="", bluebubbles_password="")
+        assert resolve_imessage_backend(s) is None
+
+    def test_resolve_linq_when_only_linq_set(self) -> None:
+        s = Settings(
+            linq_api_token="tok",
+            bluebubbles_server_url="",
+            bluebubbles_password="",
+        )
+        assert resolve_imessage_backend(s) == "linq"
+
+    def test_resolve_bluebubbles_when_only_bluebubbles_set(self) -> None:
+        s = Settings(
+            linq_api_token="",
+            bluebubbles_server_url="https://mac.ngrok.io",
+            bluebubbles_password="p",
+        )
+        assert resolve_imessage_backend(s) == "bluebubbles"
+
+    def test_bluebubbles_requires_both_url_and_password(self) -> None:
+        # Partial config is not "configured" - resolver returns None.
+        partial_url_only = Settings(
+            linq_api_token="",
+            bluebubbles_server_url="https://mac.ngrok.io",
+            bluebubbles_password="",
+        )
+        partial_pw_only = Settings(
+            linq_api_token="",
+            bluebubbles_server_url="",
+            bluebubbles_password="p",
+        )
+        assert resolve_imessage_backend(partial_url_only) is None
+        assert resolve_imessage_backend(partial_pw_only) is None
+
+    def test_validate_accepts_only_linq(self) -> None:
+        s = Settings(linq_api_token="tok", bluebubbles_server_url="", bluebubbles_password="")
+        validate_imessage_backend(s)  # must not raise
+
+    def test_validate_accepts_only_bluebubbles(self) -> None:
+        s = Settings(
+            linq_api_token="",
+            bluebubbles_server_url="https://mac.ngrok.io",
+            bluebubbles_password="p",
+        )
+        validate_imessage_backend(s)
+
+    def test_validate_accepts_neither(self) -> None:
+        s = Settings(linq_api_token="", bluebubbles_server_url="", bluebubbles_password="")
+        validate_imessage_backend(s)
+
+    def test_validate_rejects_both_configured(self) -> None:
+        s = Settings(
+            linq_api_token="tok",
+            bluebubbles_server_url="https://mac.ngrok.io",
+            bluebubbles_password="p",
+        )
+        with pytest.raises(RuntimeError, match="iMessage"):
+            validate_imessage_backend(s)


### PR DESCRIPTION
## Description
Collapses the per-backend Linq and BlueBubbles cards in the channel picker into a single unified "iMessage" card. Whichever backend the admin configures powers the card; users never see the words "Linq" or "BlueBubbles" anywhere in the UI, copy, hints, toasts, error messages, or docs.

Server now refuses to start if both iMessage backends are configured simultaneously (the UI surfaces one card; dual-configuration would make its behavior ambiguous).

`ChannelConfigResponse` gains `imessage_backend: "linq" | "bluebubbles" | null`. Existing fields, DB `ChannelRoute.channel` values, and webhook routes are unchanged, so no migration is needed. The shared OSS frontend used by `clawbolt-premium` inherits this change with zero premium-repo code changes.

User-facing docs (getting-started, configuration, architecture, telegram-setup, docker, local-setup) are swept to use the unified iMessage language. Deployment setup pages (`linq-setup.mdx`, `bluebubbles-setup.mdx`) are intentionally left per-backend so admins can find the backend they need to configure.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 1598 passed, 13 deselected
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) — clean after reformat of `tests/test_channel_config.py`
- [x] New tests added for new functionality — 8 new backend tests in `test_config_validation.py::TestIMessageBackend` and 3 in `test_channel_config.py`; frontend tests updated across `ChannelsPage`, `DashboardPage`, `GetStartedPage`
- [x] Bug fixes include regression tests — N/A (feature), but existing `test_linq_channel.py` and `test_bluebubbles_channel.py` webhook tests pass unchanged

Additional checks run:
- `uv run ty check --python .venv backend/ tests/ alembic/` — no new findings (one pre-existing warning in `tests/test_heartbeat.py:1154` predates this branch)
- `npm run typecheck` — clean
- `npx vitest run` — 130 frontend tests pass

**Not done:** Playwright visual verification (required by CLAUDE.md for frontend changes) was skipped — the sandbox has no LLM credentials to pass the startup LLM check. The 53 channel-focused vitest tests + 3 backend endpoint tests cover the UI contract; a reviewer running locally should spot-check the channel picker before merging.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Planned and implemented end-to-end by Claude Opus 4.6 via `/autoplan` and `/ship`. Premises (scope, label, mutual-exclusion rule, guiding principle that users never see backend names) were confirmed by the human at two gate points before implementation. Full decision audit trail is in the untracked `PLAN.md` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)