### PR TITLE
fix: warn at startup when iMessage backend is configured without an address

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -321,6 +321,21 @@ def log_config_warnings(s: Settings | None = None) -> list[str]:
             " trimming will never trigger"
         )
 
+    # Warn when an iMessage backend is configured but the address users are
+    # supposed to text isn't set. The channel picker UI falls back to generic
+    # copy in that case, leaving users with no idea where to send messages.
+    backend = resolve_imessage_backend(s)
+    if backend == "linq" and not s.linq_from_number:
+        warnings.append(
+            "LINQ_API_TOKEN is set but LINQ_FROM_NUMBER is empty;"
+            " the iMessage channel picker will not show an address for users to text"
+        )
+    elif backend == "bluebubbles" and not s.bluebubbles_imessage_address:
+        warnings.append(
+            "BlueBubbles is configured but BLUEBUBBLES_IMESSAGE_ADDRESS is empty;"
+            " the iMessage channel picker will not show an address for users to text"
+        )
+
     enc_key = s.encryption_key.get_secret_value()
     if not enc_key:
         warnings.append(

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -88,7 +88,17 @@ class TestLogConfigWarnings:
     """log_config_warnings emits warnings for unusual but valid values."""
 
     def test_no_warnings_with_defaults(self) -> None:
-        s = Settings(encryption_key=SecretStr("a-secure-random-key-at-least-32-chars"))
+        # Explicit overrides for env vars that leak from a local .env into
+        # tests (LINQ_*, BLUEBUBBLES_*) so this test is deterministic in
+        # any developer's shell.
+        s = Settings(
+            encryption_key=SecretStr("a-secure-random-key-at-least-32-chars"),
+            linq_api_token="",
+            linq_from_number="",
+            bluebubbles_server_url="",
+            bluebubbles_password="",
+            bluebubbles_imessage_address="",
+        )
         assert log_config_warnings(s) == []
 
     def test_warns_missing_encryption_key(self) -> None:
@@ -190,3 +200,42 @@ class TestIMessageBackend:
         )
         with pytest.raises(RuntimeError, match="iMessage"):
             validate_imessage_backend(s)
+
+
+class TestIMessageAddressWarning:
+    """log_config_warnings flags a configured iMessage backend with empty address."""
+
+    def test_warns_linq_configured_without_from_number(self) -> None:
+        s = Settings(linq_api_token="tok", linq_from_number="")
+        warnings = log_config_warnings(s)
+        assert any("LINQ_FROM_NUMBER is empty" in w for w in warnings)
+
+    def test_no_warning_when_linq_from_number_set(self) -> None:
+        s = Settings(linq_api_token="tok", linq_from_number="+15551234567")
+        warnings = log_config_warnings(s)
+        assert not any("LINQ_FROM_NUMBER" in w for w in warnings)
+
+    def test_warns_bluebubbles_configured_without_imessage_address(self) -> None:
+        s = Settings(
+            bluebubbles_server_url="https://mac.ngrok.io",
+            bluebubbles_password="p",
+            bluebubbles_imessage_address="",
+        )
+        warnings = log_config_warnings(s)
+        assert any("BLUEBUBBLES_IMESSAGE_ADDRESS is empty" in w for w in warnings)
+
+    def test_no_warning_when_bluebubbles_imessage_address_set(self) -> None:
+        s = Settings(
+            bluebubbles_server_url="https://mac.ngrok.io",
+            bluebubbles_password="p",
+            bluebubbles_imessage_address="clawbolt@icloud.com",
+        )
+        warnings = log_config_warnings(s)
+        assert not any("BLUEBUBBLES_IMESSAGE_ADDRESS" in w for w in warnings)
+
+    def test_no_warning_when_no_imessage_backend_configured(self) -> None:
+        s = Settings(linq_api_token="", bluebubbles_server_url="", bluebubbles_password="")
+        warnings = log_config_warnings(s)
+        assert not any(
+            "LINQ_FROM_NUMBER" in w or "BLUEBUBBLES_IMESSAGE_ADDRESS" in w for w in warnings
+        )


### PR DESCRIPTION
## Description
Operators hit a silent failure mode on Railway / other deploys: the iMessage backend (Linq or BlueBubbles) is configured, but the address customers are supposed to text (\`LINQ_FROM_NUMBER\` or \`BLUEBUBBLES_IMESSAGE_ADDRESS\`) is empty. In that state the channel picker falls back to generic copy (\"Send an iMessage to your assistant to get started\") with no address shown, and users have no idea where to send their messages.

This PR adds a startup warning in \`log_config_warnings\` so operators see the misconfiguration in their deploy logs instead of having to dogfood the UI to find it. The warning names the exact env var that needs to be set:

- \`LINQ_API_TOKEN is set but LINQ_FROM_NUMBER is empty; the iMessage channel picker will not show an address for users to text\`
- \`BlueBubbles is configured but BLUEBUBBLES_IMESSAGE_ADDRESS is empty; the iMessage channel picker will not show an address for users to text\`

Drive-by: \`test_no_warnings_with_defaults\` was brittle to any developer's local \`.env\` having BlueBubbles configured — it now explicitly zeroes the LINQ_* and BLUEBUBBLES_* settings in the constructor.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`) — 37 passed in \`tests/test_config_validation.py\` (4 new tests + 1 updated) against the new code
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`) — clean
- [x] New tests added for new functionality — 4 new tests in \`TestIMessageAddressWarning\` covering Linq and BlueBubbles paths, configured-but-empty vs configured-with-address vs nothing-configured
- [x] Bug fixes include regression tests — yes, the 4 tests above act as regression tests for the warning behavior

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Human flagged the symptom on a live Railway deploy (\"no clawbolt imessage address listed\" on GetStartedPage Step 3) and asked for a log-line fix. Planned and implemented by Claude Opus 4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)