### PR TITLE
fix: stop rendering the assistant address card inside Step 2's form

### DIFF
--- a/frontend/src/components/ChannelConfigForm.tsx
+++ b/frontend/src/components/ChannelConfigForm.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import TextAssistantCard from '@/components/TextAssistantCard';
 import Input from '@/components/ui/input';
 import Button from '@/components/ui/button';
 import Field from '@/components/ui/field';
@@ -56,9 +55,6 @@ interface PremiumLinkConfig {
   placeholder: string;
   helpText: string;
   inputMode?: 'tel' | 'text';
-  /** Return the display address for the TextAssistantCard, or empty to hide it. */
-  getAssistantAddress: (config: ChannelConfigResponse | undefined) => string;
-  assistantSubtitle?: string;
   setLink: (identifier: string) => Promise<unknown>;
 }
 
@@ -70,8 +66,6 @@ const PREMIUM_LINK_CONFIGS: Partial<Record<ChannelKey, PremiumLinkConfig>> = {
     placeholder: 'e.g. +15551234567',
     helpText: "E.164 format phone number. This is the number you'll send messages from.",
     inputMode: 'tel',
-    getAssistantAddress: (config) => config?.linq_from_number ?? '',
-    assistantSubtitle: 'Send an iMessage to this address to reach your assistant.',
     setLink: (id) => api.setLinqLink(id),
   },
   bluebubbles: {
@@ -80,8 +74,6 @@ const PREMIUM_LINK_CONFIGS: Partial<Record<ChannelKey, PremiumLinkConfig>> = {
     label: 'Your Phone Number or iCloud Email',
     placeholder: 'e.g. +15551234567 or user@icloud.com',
     helpText: 'The phone number or iCloud email you send iMessages from.',
-    getAssistantAddress: (config) => config?.bluebubbles_imessage_address ?? '',
-    assistantSubtitle: 'Send an iMessage to this address to reach your assistant.',
     setLink: (id) => api.setBlueBubblesLink(id),
   },
 };
@@ -89,14 +81,12 @@ const PREMIUM_LINK_CONFIGS: Partial<Record<ChannelKey, PremiumLinkConfig>> = {
 function PremiumChannelLinkForm({
   config,
   premiumLinkData,
-  channelConfig,
   onSaved,
 }: { config: PremiumLinkConfig } & Omit<ChannelConfigFormProps, 'channelKey' | 'isPremium'>) {
   const [identifier, setIdentifier] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   const displayedValue = identifier ?? premiumLinkData?.identifier ?? '';
-  const assistantAddress = config.getAssistantAddress(channelConfig);
 
   const handleSave = async () => {
     if (premiumLinkData && displayedValue === (premiumLinkData.identifier ?? '')) {
@@ -118,12 +108,6 @@ function PremiumChannelLinkForm({
 
   return (
     <div className="grid gap-4">
-      {assistantAddress && (
-        <TextAssistantCard
-          fromNumber={assistantAddress}
-          subtitle={config.assistantSubtitle}
-        />
-      )}
       <Field label={config.label}>
         <Input
           value={displayedValue}
@@ -236,7 +220,6 @@ function OssLinqForm({ channelConfig, onSaved }: SubFormProps) {
 
   const displayedNumber = allowedNumber ?? channelConfig?.linq_allowed_numbers ?? '';
   const displayedService = preferredService ?? channelConfig?.linq_preferred_service ?? 'iMessage';
-  const fromNumber = channelConfig?.linq_from_number ?? '';
 
   const handleSave = () => {
     const updates: Record<string, string> = {};
@@ -263,7 +246,6 @@ function OssLinqForm({ channelConfig, onSaved }: SubFormProps) {
 
   return (
     <div className="grid gap-4">
-      {fromNumber && <TextAssistantCard fromNumber={fromNumber} />}
       <Field label="Allowed Phone Number">
         <Input
           value={displayedNumber}


### PR DESCRIPTION
## Description
Step 2 of the Get Started flow showed a \"Text your assistant\" card with the iMessage address at the top of its config form, and Step 3 showed the same card again. The address ended up rendered twice on one page (and a third time on ChannelsPage alongside the banner added in mozilla-ai/clawbolt#959).

Drop the \`TextAssistantCard\` from \`OssLinqForm\` and \`PremiumChannelLinkForm\` so Step 2 is just the user's input field (\"Your Phone Number\" / \"Your Phone Number or iCloud Email\"). The address still appears in the two canonical places:

- **GetStartedPage Step 3** — the dedicated \"Send a message\" step during onboarding.
- **ChannelsPage banner** — in steady state, on the iMessage card itself.

The \`getAssistantAddress\` and \`assistantSubtitle\` fields on \`PremiumLinkConfig\` are also removed since nothing else consumes them.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`) — N/A (frontend-only change); \`npx vitest run\` → 132 passed
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`) — N/A (no backend change); \`npm run typecheck\` clean
- [x] New tests added for new functionality — N/A (removal of duplicate UI; existing tests cover the non-duplicated behavior)
- [x] Bug fixes include regression tests — N/A (visual duplication caught on live deploy, not a behavior regression; existing ChannelsPage banner tests + GetStartedPage Step 3 tests cover the canonical render points)

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Human reported the duplication on a live premium Railway deploy after mozilla-ai/clawbolt#959 added the channel-picker banner. Claude Opus 4.6 identified that both the premium link form and the OSS Linq form rendered their own TextAssistantCard at the top, overlapping with the Step 3 card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)