### PR TITLE
fix: keep webchat agent status alive when user switches tabs

### DIFF
--- a/frontend/src/contexts/ChatActivityContext.tsx
+++ b/frontend/src/contexts/ChatActivityContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import api from '@/api';
+
+interface ChatActivityValue {
+  agentBusy: boolean;
+  activityTool: string | null;
+  // Monotonically-increasing counter, incremented once per 'done' event. Lets
+  // consumers fire an effect whenever the agent finishes without re-running on
+  // unrelated activity events.
+  doneTick: number;
+}
+
+const ChatActivityContext = createContext<ChatActivityValue | null>(null);
+
+export function ChatActivityProvider({ children }: { children: ReactNode }) {
+  const [agentBusy, setAgentBusy] = useState(false);
+  const [activityTool, setActivityTool] = useState<string | null>(null);
+  const [doneTick, setDoneTick] = useState(0);
+
+  useEffect(() => {
+    const controller = api.subscribeToActivity((event) => {
+      if (event.type === 'thinking') {
+        setAgentBusy(true);
+        setActivityTool(null);
+      } else if (event.type === 'tool_call') {
+        setAgentBusy(true);
+        setActivityTool(event.tool_name ?? null);
+      } else if (event.type === 'done') {
+        setAgentBusy(false);
+        setActivityTool(null);
+        setDoneTick((n) => n + 1);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <ChatActivityContext.Provider value={{ agentBusy, activityTool, doneTick }}>
+      {children}
+    </ChatActivityContext.Provider>
+  );
+}
+
+export function useChatActivity(): ChatActivityValue {
+  const ctx = useContext(ChatActivityContext);
+  if (!ctx) {
+    throw new Error('useChatActivity must be used within a ChatActivityProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -1,4 +1,6 @@
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Routes, Route } from 'react-router-dom';
 import { renderWithRouter } from '@/test/test-utils';
 import AppShell from '@/layouts/AppShell';
 
@@ -18,6 +20,7 @@ vi.mock('@/contexts/AuthContext', () => ({
 vi.mock('@/api', () => ({
   default: {
     getProfile: vi.fn(),
+    subscribeToActivity: vi.fn().mockReturnValue(new AbortController()),
   },
 }));
 
@@ -122,5 +125,94 @@ describe('AppShell', () => {
     });
     expect(screen.getByText('Report issue')).toBeInTheDocument();
     expect(screen.getByText('Feature request')).toBeInTheDocument();
+  });
+
+  // Regression: sending a chat message and then switching tabs used to abort the
+  // activity SSE subscription because it lived inside ChatPage. The subscription
+  // now lives in ChatActivityProvider at AppShell level, so navigation between
+  // app routes must not tear it down or spawn extra subscriptions.
+  it('keeps the activity subscription alive across route changes', async () => {
+    const controller = new AbortController();
+    const abortSpy = vi.spyOn(controller, 'abort');
+    mockApi.subscribeToActivity.mockClear();
+    mockApi.subscribeToActivity.mockReturnValue(controller);
+
+    renderWithRouter(
+      <Routes>
+        <Route path="/app" element={<AppShell />}>
+          <Route path="chat" element={<div>Chat route</div>} />
+          <Route path="permissions" element={<div>Permissions route</div>} />
+        </Route>
+      </Routes>,
+      { route: '/app/chat' },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Chat route')).toBeInTheDocument();
+    });
+    expect(mockApi.subscribeToActivity).toHaveBeenCalledTimes(1);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Permissions'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Permissions route')).toBeInTheDocument();
+    });
+
+    expect(mockApi.subscribeToActivity).toHaveBeenCalledTimes(1);
+    expect(abortSpy).not.toHaveBeenCalled();
+  });
+
+  it('exposes activity state to descendants and updates on events', async () => {
+    let capturedOnEvent:
+      | ((event: { type: string; tool_name?: string }) => void)
+      | null = null;
+    mockApi.subscribeToActivity.mockImplementation((onEvent) => {
+      capturedOnEvent = onEvent;
+      return new AbortController();
+    });
+
+    const { useChatActivity } = await import('@/contexts/ChatActivityContext');
+    function ActivityProbe() {
+      const { agentBusy, activityTool } = useChatActivity();
+      return (
+        <div>
+          <span data-testid="busy">{agentBusy ? 'yes' : 'no'}</span>
+          <span data-testid="tool">{activityTool ?? 'none'}</span>
+        </div>
+      );
+    }
+
+    renderWithRouter(
+      <Routes>
+        <Route path="/app" element={<AppShell />}>
+          <Route path="chat" element={<ActivityProbe />} />
+        </Route>
+      </Routes>,
+      { route: '/app/chat' },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('busy')).toHaveTextContent('no');
+    });
+
+    expect(capturedOnEvent).not.toBeNull();
+    act(() => {
+      capturedOnEvent!({ type: 'tool_call', tool_name: 'search_web' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('busy')).toHaveTextContent('yes');
+    });
+    expect(screen.getByTestId('tool')).toHaveTextContent('search_web');
+
+    act(() => {
+      capturedOnEvent!({ type: 'done' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('busy')).toHaveTextContent('no');
+    });
+    expect(screen.getByTestId('tool')).toHaveTextContent('none');
   });
 });

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/ui/button';
 import OfflineIndicator from '@/components/ui/OfflineIndicator';
 import { Spinner } from '@heroui/spinner';
 import { useAuth } from '@/contexts/AuthContext';
+import { ChatActivityProvider } from '@/contexts/ChatActivityContext';
 import { Tooltip } from '@heroui/tooltip';
 import { Link } from '@heroui/link';
 import { Divider } from '@heroui/divider';
@@ -107,6 +108,7 @@ export default function AppShell() {
   };
 
   return (
+    <ChatActivityProvider>
     <div className="flex h-dvh">
       {/* Mobile overlay */}
       {sidebarOpen && (
@@ -294,6 +296,7 @@ export default function AppShell() {
       <OfflineIndicator />
       <ToastProvider placement="bottom-right" />
     </div>
+    </ChatActivityProvider>
   );
 }
 

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '@/test/test-utils';
+import { ChatActivityProvider } from '@/contexts/ChatActivityContext';
 import ChatPage from './ChatPage';
 
 // Mock the api module
@@ -25,7 +26,7 @@ beforeEach(() => {
 
 describe('ChatPage auto-focus', () => {
   it('focuses the chat input on mount', async () => {
-    renderWithRouter(<ChatPage />);
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>);
 
     const textarea = screen.getByPlaceholderText('Type a message...');
     await waitFor(() => {
@@ -67,7 +68,7 @@ describe('ChatPage tool interactions', () => {
       ],
     });
 
-    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
 
     await waitFor(() => {
       expect(screen.getByText('I created the estimate for you.')).toBeInTheDocument();
@@ -107,7 +108,7 @@ describe('ChatPage tool interactions', () => {
       ],
     });
 
-    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
 
     await waitFor(() => {
       expect(screen.getByText('Hi there!')).toBeInTheDocument();
@@ -156,7 +157,7 @@ describe('ChatPage tool interaction expand/collapse', () => {
       { name: 'long_tool', args: {}, result: fullResult, is_error: false, tool_call_id: 'tc_123' },
     ]);
 
-    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
 
     const user = userEvent.setup();
 
@@ -183,7 +184,7 @@ describe('ChatPage tool interaction expand/collapse', () => {
       { name: 'toggle_tool', args: {}, result: 'some result', is_error: false, tool_call_id: 'tc_456' },
     ]);
 
-    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
 
     const user = userEvent.setup();
 
@@ -205,7 +206,7 @@ describe('ChatPage tool interaction expand/collapse', () => {
       { name: 'failing_tool', args: {}, result: 'Something went wrong', is_error: true },
     ]);
 
-    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
 
     await waitFor(() => {
       expect(screen.getByText('failing_tool')).toBeInTheDocument();
@@ -224,7 +225,7 @@ describe('ChatPage tool interaction expand/collapse', () => {
       },
     ]);
 
-    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
 
     const user = userEvent.setup();
 
@@ -248,7 +249,7 @@ describe('ChatPage tool interaction expand/collapse', () => {
       { name: 'no_args_tool', args: {}, result: 'Done', is_error: false },
     ]);
 
-    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
 
     const user = userEvent.setup();
 
@@ -270,7 +271,7 @@ describe('ChatPage tool interaction expand/collapse', () => {
       { name: 'empty_result_tool', args: { key: 'val' }, result: '', is_error: false },
     ]);
 
-    renderWithRouter(<ChatPage />, { route: `/app/chat?session=${sessionId}` });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
 
     const user = userEvent.setup();
 
@@ -329,7 +330,7 @@ describe('ChatPage session auto-discovery', () => {
     });
 
     // Render without ?session= param and with empty localStorage
-    renderWithRouter(<ChatPage />, { route: '/app/chat' });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: '/app/chat' });
 
     // Should discover the session and load its history
     await waitFor(() => {
@@ -345,7 +346,7 @@ describe('ChatPage session auto-discovery', () => {
   it('shows empty state when no active sessions exist', async () => {
     mockApi.listSessions.mockResolvedValue({ total: 0, items: [] });
 
-    renderWithRouter(<ChatPage />, { route: '/app/chat' });
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: '/app/chat' });
 
     await waitFor(() => {
       expect(mockApi.listSessions).toHaveBeenCalled();
@@ -361,7 +362,7 @@ describe('ChatPage concurrent messaging', () => {
     // sendChatMessage never resolves, simulating a pending response
     mockApi.sendChatMessage.mockReturnValue(new Promise(() => {}));
 
-    renderWithRouter(<ChatPage />);
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>);
 
     const textarea = screen.getByPlaceholderText('Type a message...');
     const user = userEvent.setup();

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -11,6 +11,7 @@ import api from '@/api';
 import { toast } from '@/lib/toast';
 import { useSession } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
+import { useChatActivity } from '@/contexts/ChatActivityContext';
 import type { ToolInteraction } from '@/types';
 
 interface FileAttachment {
@@ -54,8 +55,7 @@ export default function ChatPage() {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const [currentTool, setCurrentTool] = useState<string | null>(null);
-  const [activityTool, setActivityTool] = useState<string | null>(null);
-  const [agentBusy, setAgentBusy] = useState(false);
+  const { agentBusy, activityTool, doneTick } = useChatActivity();
   const [waitingForApproval, setWaitingForApproval] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deletingMsgId, setDeletingMsgId] = useState<number | null>(null);
@@ -83,32 +83,18 @@ export default function ChatPage() {
     return () => { mountedRef.current = false; };
   }, []);
 
-  // Subscribe to user-level activity stream for real-time agent status
-  // from any channel (Telegram, iMessage, etc.)
+  // Refresh session data when the agent finishes, so replies produced while
+  // we were mounted elsewhere (e.g. user switched tabs mid-send) show up on
+  // return. Skip when webchat is actively waiting for its own SSE reply:
+  // handleSubmit appends the reply and invalidates queries itself, and an
+  // early refetch here would race with the SSE handler and duplicate the
+  // assistant message. The activity subscription itself lives in
+  // ChatActivityProvider so it survives tab navigation.
   useEffect(() => {
-    const controller = api.subscribeToActivity((event) => {
-      if (!mountedRef.current) return;
-      if (event.type === 'thinking') {
-        setAgentBusy(true);
-        setActivityTool(null);
-      } else if (event.type === 'tool_call') {
-        setAgentBusy(true);
-        setActivityTool(event.tool_name ?? null);
-      } else if (event.type === 'done') {
-        setAgentBusy(false);
-        setActivityTool(null);
-        // Refresh session data to pick up the new message, but only when
-        // webchat isn't actively waiting for its own SSE reply. When sending,
-        // handleSubmit adds the reply and invalidates queries itself. Without
-        // this guard, the activity refresh can load the reply from the DB
-        // before the SSE resolves, and then the SSE handler appends a duplicate.
-        if (pendingRef.current === 0) {
-          void queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
-        }
-      }
-    });
-    return () => controller.abort();
-  }, [queryClient]);
+    if (doneTick === 0) return;
+    if (pendingRef.current > 0) return;
+    void queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
+  }, [doneTick, queryClient]);
 
   // Fetch session history via React Query.  The activity SSE stream
   // already invalidates queries on the "done" event, so periodic


### PR DESCRIPTION
## Description
Fixes #957.

Sending a message in web chat and then switching to another tab (e.g. Permissions) made the agent appear cancelled. The activity SSE subscription was owned by `ChatPage`, so its `useEffect` cleanup ran on unmount and called `controller.abort()`. The backend agent task kept running (it is detached via `asyncio.create_task`), but `thinking` / `done` events emitted during the gap between unmount and return to the chat tab were lost, and the UI showed no activity indicator.

Hoisted the subscription into a new `ChatActivityProvider` mounted at the AppShell level so it spans every in-app route. `ChatPage` now consumes `agentBusy`, `activityTool`, and a `doneTick` counter from the context. The per-page effect that invalidates session queries on a `done` event still guards against duplicate replies via `pendingRef`.

Verified end-to-end with Playwright: sent a message, navigated to Permissions while the agent was processing, and the backend logs showed the activity SSE stayed connected and delivered `thinking` + `done` events while the user was on the other tab. Returning to Chat showed the assistant reply as expected.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 1603 pass; 2 pre-existing failures on `main` (`test_user_defaults`, `test_profile_defaults_from_settings`) unrelated to this change
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests — two tests in `AppShell.test.tsx` cover (a) that the activity SSE is not aborted across route changes and (b) that activity state propagates to descendants via the context. Both fail without the fix.

## AI Usage
- [x] AI-assisted (Claude Code drafted the provider and tests under review)
- [ ] No AI used