### PR TITLE
feat: add calculator tool for reliable math

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,41 @@ Until this project has its first production release, you do not need to be conce
 - **Memory**: Freeform per-user MEMORY.md managed via workspace tools, backed by `memory_documents` table with automatic compaction
 - **Services**: External services abstracted behind service classes in `backend/app/services/`
 
+## Adding a New Agent Tool
+
+The agent's capabilities are extended by adding tools. Tools follow a factory/registry pattern with auto-discovery.
+
+### Core vs. Specialist
+
+- **Core tools** (`core=True`): Always available to the agent on every message. Use for universal capabilities (math, messaging, files, workspace). No activation step needed.
+- **Specialist tools** (`core=False`): Activated on demand via the `list_capabilities` meta-tool. Use for integrations and domain-specific features (calendar, QuickBooks, CompanyCam). Keeps the initial tool schema small.
+
+### Checklist for adding a tool
+
+1. **Create the tool module** at `backend/app/agent/tools/<name>_tools.py`. Follow the pattern in `heartbeat_tools.py` (simplest example): Pydantic params model, async tool function returning `ToolResult`, factory function, and `_register()` called at module level. The `_tools` suffix is required for auto-discovery.
+
+2. **Add tool name constants** to `backend/app/agent/tools/names.py` in the `ToolName` class. All tool name strings must be defined here to prevent silent breakage on renames.
+
+3. **Register in the dashboard** at `backend/app/routers/user_tools.py`:
+   - Add the factory name to `_CORE_FACTORIES` (if core) so it cannot be disabled
+   - Add a `_FACTORY_META` entry with a description (and `domain_group`/`domain_group_order` if specialist)
+
+4. **Add to the registry test** at `tests/test_tool_registry.py`: add `"backend.app.agent.tools.<name>_tools"` to `EXPECTED_TOOL_MODULES`.
+
+5. **Write tests** at `tests/test_<name>_tools.py`. Call the factory function directly (e.g., `_create_calculator_tools()`) and invoke the tool function. No database needed for stateless tools.
+
+6. **(Specialist only) Add a SKILL.md** at `backend/app/agent/skills/<name>/SKILL.md` if the tool has complex workflows the LLM needs guidance on. This markdown is injected into the conversation when the LLM activates the category via `list_capabilities`. Core tools do not need SKILL.md; their `description` and `usage_hint` fields in the Python code serve the same purpose.
+
+### Key files
+
+| File | Purpose |
+|---|---|
+| `backend/app/agent/tools/base.py` | `Tool`, `ToolResult`, `ToolErrorKind` definitions |
+| `backend/app/agent/tools/names.py` | All tool name constants (`ToolName` class) |
+| `backend/app/agent/tools/registry.py` | `ToolRegistry`, `ToolFactory`, `ToolContext`, auto-discovery |
+| `backend/app/agent/skills/loader.py` | SKILL.md loader (`get_skill_instructions`) |
+| `backend/app/routers/user_tools.py` | Dashboard wiring (`_CORE_FACTORIES`, `_FACTORY_META`) |
+
 ## Definition of Done
 
 Every change must pass all checks before it's considered complete:

--- a/backend/app/agent/tools/calculator_tools.py
+++ b/backend/app/agent/tools/calculator_tools.py
@@ -1,0 +1,163 @@
+"""Calculator tool for the agent.
+
+Uses simpleeval for safe mathematical expression evaluation.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+from simpleeval import (
+    FeatureNotAvailable,
+    FunctionNotDefined,
+    NameNotDefined,
+    NumberTooHigh,
+    simple_eval,
+)
+
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.names import ToolName
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+
+CALC_FUNCTIONS: dict[str, object] = {
+    "sqrt": math.sqrt,
+    "abs": abs,
+    "round": round,
+    "ceil": math.ceil,
+    "floor": math.floor,
+    "min": min,
+    "max": max,
+}
+
+CALC_NAMES: dict[str, float] = {
+    "pi": math.pi,
+    "e": math.e,
+}
+
+
+class CalculateParams(BaseModel):
+    """Parameters for the calculate tool."""
+
+    expression: str = Field(
+        max_length=1000,
+        description="A mathematical expression to evaluate, e.g. '(12 * 15) + (8 * 10)'",
+    )
+
+
+def _create_calculator_tools() -> list[Tool]:
+    """Create the calculator tool for the agent."""
+
+    async def calculate(expression: str) -> ToolResult:
+        """Evaluate a mathematical expression and return the result."""
+        if not expression.strip():
+            return ToolResult(
+                content="Error: empty expression",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint="Provide a mathematical expression to evaluate.",
+            )
+
+        try:
+            result = simple_eval(expression, functions=CALC_FUNCTIONS, names=CALC_NAMES)
+        except ZeroDivisionError:
+            return ToolResult(
+                content="Error: division by zero",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint="Check the expression for division by zero.",
+            )
+        except SyntaxError:
+            return ToolResult(
+                content=f"Error: invalid syntax in expression: {expression}",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint="Check the expression for syntax errors.",
+            )
+        except (NameNotDefined, FunctionNotDefined, FeatureNotAvailable) as exc:
+            return ToolResult(
+                content=f"Error: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint=(
+                    "Only basic arithmetic, parentheses, and these functions are supported: "
+                    "sqrt, abs, round, ceil, floor, min, max. "
+                    "Constants: pi, e."
+                ),
+            )
+        except NumberTooHigh as exc:
+            return ToolResult(
+                content=f"Error: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint="Use smaller exponents. The power operator is capped for safety.",
+            )
+        except (TypeError, ValueError, OverflowError) as exc:
+            return ToolResult(
+                content=f"Error: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint="Check the expression for type or value errors.",
+            )
+
+        if isinstance(result, float):
+            if math.isinf(result) or math.isnan(result):
+                return ToolResult(
+                    content="Error: result is not a finite number",
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                    hint="The expression produced infinity or NaN. Check for overflow.",
+                )
+            formatted = f"{result:.10g}"
+        else:
+            formatted = str(result)
+
+        return ToolResult(content=formatted)
+
+    return [
+        Tool(
+            name=ToolName.CALCULATE,
+            description=(
+                "Evaluate a mathematical expression and return the exact result. "
+                "Use this tool for ALL arithmetic instead of computing in your head. "
+                "Examples: '12.5 * 47 * 1.15' for material cost with markup, "
+                "'(24 * 36) / 144' for square footage to square yards, "
+                "'round(2450 * 1.25, 2)' for 25% markup, "
+                "'ceil(sqrt(400))' for square root rounded up."
+            ),
+            function=calculate,
+            params_model=CalculateParams,
+            usage_hint=(
+                "Use this tool whenever the user asks you to do math, calculate costs, "
+                "estimate quantities, compute areas, or any arithmetic. Always prefer "
+                "this tool over doing math in your head. Supported functions: "
+                "sqrt, abs, round, ceil, floor, min, max. Constants: pi, e."
+            ),
+        ),
+    ]
+
+
+def _calculator_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for calculator tools, used by the registry."""
+    return _create_calculator_tools()
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import SubToolInfo, default_registry
+
+    default_registry.register(
+        "calculator",
+        _calculator_factory,
+        core=True,
+        summary="Evaluate mathematical expressions",
+        sub_tools=[
+            SubToolInfo(ToolName.CALCULATE, "Evaluate a math expression"),
+        ],
+    )
+
+
+_register()

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -62,6 +62,9 @@ class ToolName:
     # Supplier pricing
     SUPPLIER_SEARCH_PRODUCTS = "supplier_search_products"
 
+    # Calculator
+    CALCULATE = "calculate"
+
     # Meta-tools
     LIST_CAPABILITIES = "list_capabilities"
     MANAGE_INTEGRATION = "manage_integration"

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -30,7 +30,16 @@ ensure_tool_modules_imported()
 
 # Factories whose tools are always available and cannot be disabled.
 _CORE_FACTORIES: frozenset[str] = frozenset(
-    {"workspace", "profile", "memory", "messaging", "file", "heartbeat", "integration"}
+    {
+        "calculator",
+        "workspace",
+        "profile",
+        "memory",
+        "messaging",
+        "file",
+        "heartbeat",
+        "integration",
+    }
 )
 
 # Consolidated metadata for each factory group: description, display group,
@@ -44,6 +53,7 @@ class _FactoryMeta(NamedTuple):
 
 
 _FACTORY_META: dict[str, _FactoryMeta] = {
+    "calculator": _FactoryMeta("Evaluate mathematical expressions"),
     "workspace": _FactoryMeta("Read, write, and edit markdown files in the workspace"),
     "profile": _FactoryMeta("View and update user profile information"),
     "memory": _FactoryMeta("Save, recall, and forget long-term facts"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "cryptography>=42.0",
     "cachetools>=5.3",
     "Pillow>=10.0",
+    "simpleeval>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_calculator_tools.py
+++ b/tests/test_calculator_tools.py
@@ -1,0 +1,351 @@
+"""Tests for the calculator tool."""
+
+import math
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from backend.app.agent.tools.base import ToolResult
+from backend.app.agent.tools.calculator_tools import _create_calculator_tools
+
+
+def _get_calculate() -> Callable[..., Awaitable[ToolResult]]:
+    """Get the calculate tool function."""
+    tools = _create_calculator_tools()
+    return tools[0].function
+
+
+# --- Basic arithmetic ---
+
+
+@pytest.mark.asyncio()
+async def test_addition() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="2 + 3")
+    assert result.content == "5"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_subtraction() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="10 - 4")
+    assert result.content == "6"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_multiplication() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="6 * 7")
+    assert result.content == "42"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_division() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="15 / 3")
+    assert result.content == "5"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_floor_division() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="7 // 2")
+    assert result.content == "3"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_modulo() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="7 % 2")
+    assert result.content == "1"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_exponentiation() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="2 ** 10")
+    assert result.content == "1024"
+    assert result.is_error is False
+
+
+# --- Order of operations and parentheses ---
+
+
+@pytest.mark.asyncio()
+async def test_order_of_operations() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="2 + 3 * 4")
+    assert result.content == "14"
+
+
+@pytest.mark.asyncio()
+async def test_parentheses() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="(2 + 3) * 4")
+    assert result.content == "20"
+
+
+@pytest.mark.asyncio()
+async def test_nested_parentheses() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="((2 + 3) * (4 - 1))")
+    assert result.content == "15"
+
+
+# --- Floating point ---
+
+
+@pytest.mark.asyncio()
+async def test_floating_point() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="3.14 * 2")
+    assert result.content == "6.28"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_float_formatting_no_noise() -> None:
+    """0.1 + 0.2 should not show 0.30000000000000004."""
+    calc = _get_calculate()
+    result = await calc(expression="0.1 + 0.2")
+    assert result.content == "0.3"
+
+
+# --- Unary operators ---
+
+
+@pytest.mark.asyncio()
+async def test_unary_negation() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="-5 + 3")
+    assert result.content == "-2"
+
+
+# --- Math functions ---
+
+
+@pytest.mark.asyncio()
+async def test_sqrt() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="sqrt(16)")
+    assert result.content == "4"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_abs() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="abs(-5)")
+    assert result.content == "5"
+
+
+@pytest.mark.asyncio()
+async def test_round() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="round(3.14159, 2)")
+    assert result.content == "3.14"
+
+
+@pytest.mark.asyncio()
+async def test_ceil() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="ceil(3.2)")
+    assert result.content == "4"
+
+
+@pytest.mark.asyncio()
+async def test_floor() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="floor(3.8)")
+    assert result.content == "3"
+
+
+@pytest.mark.asyncio()
+async def test_min() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="min(3, 5, 1)")
+    assert result.content == "1"
+
+
+@pytest.mark.asyncio()
+async def test_max() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="max(3, 5, 1)")
+    assert result.content == "5"
+
+
+# --- Constants ---
+
+
+@pytest.mark.asyncio()
+async def test_pi() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="pi")
+    assert float(result.content) == pytest.approx(math.pi)
+
+
+@pytest.mark.asyncio()
+async def test_e() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="e")
+    assert float(result.content) == pytest.approx(math.e)
+
+
+@pytest.mark.asyncio()
+async def test_pi_in_expression() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="pi * 2")
+    assert float(result.content) == pytest.approx(math.pi * 2)
+
+
+# --- Contractor math examples ---
+
+
+@pytest.mark.asyncio()
+async def test_square_footage() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="12 * 15")
+    assert result.content == "180"
+
+
+@pytest.mark.asyncio()
+async def test_markup() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="round(2450 * 1.25, 2)")
+    assert result.content == "3062.5"
+
+
+@pytest.mark.asyncio()
+async def test_material_cost_with_waste() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="round(150 * 1.10 * 3.50, 2)")
+    assert result.content == "577.5"
+
+
+# --- Error cases ---
+
+
+@pytest.mark.asyncio()
+async def test_division_by_zero() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="1 / 0")
+    assert result.is_error is True
+    assert "division by zero" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_invalid_syntax() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="2 +")
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_empty_expression() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="")
+    assert result.is_error is True
+    assert "empty" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_whitespace_only() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="   ")
+    assert result.is_error is True
+    assert "empty" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_unknown_variable() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="foo + 1")
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_unknown_function() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="sin(1)")
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_huge_exponent_rejected() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="2 ** 5000000")
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_infinity_result() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="1e308 * 2")
+    assert result.is_error is True
+    assert "not a finite number" in result.content
+
+
+# --- Security ---
+
+
+@pytest.mark.asyncio()
+async def test_import_rejected() -> None:
+    calc = _get_calculate()
+    result = await calc(expression='__import__("os")')
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_attribute_access_rejected() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="().__class__")
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_eval_rejected() -> None:
+    calc = _get_calculate()
+    result = await calc(expression='eval("1+1")')
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_open_rejected() -> None:
+    calc = _get_calculate()
+    result = await calc(expression='open("/etc/passwd")')
+    assert result.is_error is True
+
+
+# --- Large numbers ---
+
+
+@pytest.mark.asyncio()
+async def test_large_multiplication() -> None:
+    calc = _get_calculate()
+    result = await calc(expression="999999999 * 999999999")
+    assert result.content == "999999998000000001"
+    assert result.is_error is False
+
+
+# --- Tool metadata ---
+
+
+def test_tool_name() -> None:
+    tools = _create_calculator_tools()
+    assert tools[0].name == "calculate"
+
+
+def test_tool_has_description() -> None:
+    tools = _create_calculator_tools()
+    assert "arithmetic" in tools[0].description.lower() or "math" in tools[0].description.lower()
+
+
+def test_tool_has_usage_hint() -> None:
+    tools = _create_calculator_tools()
+    assert tools[0].usage_hint

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -18,6 +18,7 @@ def _reset_import_guard() -> None:
 
 
 EXPECTED_TOOL_MODULES: set[str] = {
+    "backend.app.agent.tools.calculator_tools",
     "backend.app.agent.tools.memory_tools",
     "backend.app.agent.tools.messaging_tools",
     "backend.app.agent.tools.heartbeat_tools",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-09T13:43:39.309231926Z"
+exclude-newer = "2026-04-10T09:48:17.101325087Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -598,6 +598,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "python-telegram-bot" },
+    { name = "simpleeval" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -640,6 +641,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "python-telegram-bot", specifier = ">=22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
+    { name = "simpleeval", specifier = ">=1.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a0" },
@@ -3082,6 +3084,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "simpleeval"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9d/e7c9309940794dd3073cba2e5101df5874d84243595ce63b1e1c8f9b9c76/simpleeval-1.0.7.tar.gz", hash = "sha256:1e10e5f9fec597814444e20c0892ed15162fa214c8a88f434b5b077cf2fef85b", size = 30250, upload-time = "2026-03-16T10:53:03.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl", hash = "sha256:97ac271bfd8f2af9e7b9a36ceea67617f26fa873f9d5ae1922f64d4c1442534b", size = 18792, upload-time = "2026-03-16T10:53:02.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds a `calculate` core tool that gives the agent precise arithmetic instead of relying on LLM reasoning (which regularly fails on multi-step math). When a contractor asks "what's the square footage of a 12x15 room with 25% markup", the agent now calls `calculate("round(12 * 15 * 1.25, 2)")` and gets the exact answer.

Uses [simpleeval](https://github.com/danthedeckie/simpleeval), a battle-tested single-file library that safely evaluates expressions via Python's `ast` module. Same approach as LangChain's calculator but with a safer library (no underlying `eval()` call).

**Supports:** basic arithmetic (+, -, *, /, //, %, **), parentheses, math functions (sqrt, round, abs, ceil, floor, min, max), constants (pi, e).

**Rejects:** imports, attribute access, arbitrary function calls, oversized exponents.

### Files changed
- `backend/app/agent/tools/calculator_tools.py` — New tool implementation using simpleeval
- `backend/app/agent/tools/names.py` — Added `CALCULATE` constant
- `backend/app/routers/user_tools.py` — Registered calculator as core tool in dashboard
- `pyproject.toml` — Added `simpleeval>=1.0` dependency
- `tests/test_calculator_tools.py` — 42 tests (arithmetic, functions, errors, security)
- `tests/test_tool_registry.py` — Updated expected module set

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Test Coverage

42 new tests covering:
- Basic arithmetic, order of operations, parentheses
- Math functions (sqrt, abs, round, ceil, floor, min, max)
- Constants (pi, e)
- Contractor math examples (square footage, markup, material cost with waste)
- Error paths (division by zero, invalid syntax, empty input, overflow, infinity)
- Security (import rejection, attribute access, eval injection, open rejection)
- Float formatting (0.1 + 0.2 = 0.3, not 0.30000000000000004)

```
All 1688 tests pass (42 new + 1646 existing)
```

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Plan reviewed via /autoplan (CEO + Eng review phases). Implementation and tests generated with Claude Code.

Closes #968