### PR TITLE
feat: harden Anthropic prompt caching across specialist activation

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -249,7 +249,7 @@ class ClawboltAgent:
 
         The tool list is meant to grow append-only as specialists activate.
         Any reorder, removal, or mid-list insert would reset the cache for
-        the tools block. Emits an INFO line on normal growth and a WARNING
+        the tools block. Emits a DEBUG line on normal growth and a WARNING
         when the prefix diverges.
         """
         current = [t.name for t in self.tools]

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -95,6 +95,8 @@ class AgentResponse:
     is_error_fallback: bool = False
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    total_cache_creation_input_tokens: int = 0
+    total_cache_read_input_tokens: int = 0
     system_prompt: str = ""
 
 
@@ -130,6 +132,11 @@ class ClawboltAgent:
         self._session_id = session_id
         self._excluded_tool_names = excluded_tool_names
         self._request_id = request_id
+        # Previous round's tool-name sequence, used to detect when a newly
+        # built tool list fails to preserve the prefix (which busts the
+        # Anthropic tools prompt cache). The list is append-only by design;
+        # a non-monotonic change is logged as a warning.
+        self._prev_tool_names: list[str] = []
         self._reactive_trim_dropped: list[AgentMessage] = []
         # Remembers ASK decisions within a single agent run so the user is not
         # re-prompted for the same (tool, resource) if the LLM retries or
@@ -235,6 +242,36 @@ class ClawboltAgent:
             self.user.id if self.user else "N/A",
             ", ".join(sorted(self._tools_by_name.keys())),
         )
+
+    def _log_tool_prefix_stability(self, round_number: int) -> None:
+        """Warn if the current tool-name sequence fails to preserve the prior
+        prefix, which would bust the Anthropic tools prompt cache.
+
+        The tool list is meant to grow append-only as specialists activate.
+        Any reorder, removal, or mid-list insert would reset the cache for
+        the tools block. Emits an INFO line on normal growth and a WARNING
+        when the prefix diverges.
+        """
+        current = [t.name for t in self.tools]
+        prev = self._prev_tool_names
+        if prev and current[: len(prev)] != prev:
+            logger.warning(
+                "Tool prefix changed non-monotonically at round %d, "
+                "prompt cache for tools is likely invalidated. "
+                "prev=%s current=%s",
+                round_number,
+                prev,
+                current,
+            )
+        elif len(current) > len(prev):
+            added = current[len(prev) :]
+            logger.debug(
+                "Tool list grew at round %d: added=%s (total=%d)",
+                round_number,
+                added,
+                len(current),
+            )
+        self._prev_tool_names = current
 
     async def _activate_specialist(self, factory_name: str) -> None:
         """Activate a specialist tool factory, injecting its tools for the next round.
@@ -808,6 +845,8 @@ class ClawboltAgent:
         _empty_reply_retried = False
         _total_input_tokens = 0
         _total_output_tokens = 0
+        _total_cache_creation_tokens = 0
+        _total_cache_read_tokens = 0
 
         for _round in range(MAX_TOOL_ROUNDS):
             logger.debug(
@@ -819,6 +858,7 @@ class ClawboltAgent:
             # Rebuild tool schemas each round so dynamically activated
             # specialist tools are visible to the LLM.
             tool_schemas = [tool_to_function_schema(t) for t in self.tools] if self.tools else None
+            self._log_tool_prefix_stability(_round)
             await self._emit(TurnStartEvent(round_number=_round, message_count=len(messages)))
             response = await self._call_llm_with_retry(
                 messages, tool_schemas, llm_kwargs, max_tokens=max_tokens
@@ -829,10 +869,16 @@ class ClawboltAgent:
                 self._last_input_tokens = response.usage.input_tokens
                 _total_input_tokens += response.usage.input_tokens
                 _total_output_tokens += response.usage.output_tokens or 0
+                cache_create = response.usage.cache_creation_input_tokens or 0
+                cache_read = response.usage.cache_read_input_tokens or 0
+                _total_cache_creation_tokens += cache_create
+                _total_cache_read_tokens += cache_read
                 logger.debug(
-                    "LLM usage: input_tokens=%d output_tokens=%d",
+                    "LLM usage: input_tokens=%d output_tokens=%d cache_create=%d cache_read=%d",
                     response.usage.input_tokens,
                     response.usage.output_tokens or 0,
+                    cache_create,
+                    cache_read,
                 )
 
             # Guard: skip error responses to prevent context poisoning.
@@ -869,6 +915,8 @@ class ClawboltAgent:
                     is_error_fallback=True,
                     total_input_tokens=_total_input_tokens,
                     total_output_tokens=_total_output_tokens,
+                    total_cache_creation_input_tokens=_total_cache_creation_tokens,
+                    total_cache_read_input_tokens=_total_cache_read_tokens,
                     system_prompt=system_prompt,
                 )
 
@@ -1001,6 +1049,18 @@ class ClawboltAgent:
             actions_taken or "(none)",
             len(reply_text),
         )
+        _cacheable_total = _total_cache_creation_tokens + _total_cache_read_tokens
+        _cache_hit_ratio = _total_cache_read_tokens / _cacheable_total if _cacheable_total else 0.0
+        logger.info(
+            "Agent turn cache summary: user=%s input=%d output=%d "
+            "cache_create=%d cache_read=%d hit_ratio=%.2f",
+            self.user.id,
+            _total_input_tokens,
+            _total_output_tokens,
+            _total_cache_creation_tokens,
+            _total_cache_read_tokens,
+            _cache_hit_ratio,
+        )
         await self._emit(
             AgentEndEvent(
                 reply_text=reply_text,
@@ -1016,6 +1076,8 @@ class ClawboltAgent:
             tool_calls=tool_call_records,
             total_input_tokens=_total_input_tokens,
             total_output_tokens=_total_output_tokens,
+            total_cache_creation_input_tokens=_total_cache_creation_tokens,
+            total_cache_read_input_tokens=_total_cache_read_tokens,
             system_prompt=system_prompt,
         )
 

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -242,20 +242,20 @@ async def build_agent_system_prompt(
 
     builder.add_section("About Your User", build_user_section(user))
 
-    tool_guidelines = build_tool_guidelines_section(tools)
-    if tool_guidelines:
-        instructions = (
-            build_instructions_section() + "\n" + "\n## Tool Guidelines\n" + tool_guidelines
-        )
-    else:
-        instructions = build_instructions_section()
-    builder.add_section("Instructions", instructions)
+    builder.add_section("Instructions", build_instructions_section())
 
     builder.add_section("Proactive Messaging", build_proactive_section())
     builder.add_section("Recall Behavior", build_recall_section())
 
     # Dynamic sections: content changes between turns, placed after the
-    # stable prefix so prompt caching can reuse the stable portion.
+    # stable prefix so prompt caching can reuse the stable portion. Tool
+    # guidelines are dynamic because newly activated specialists append
+    # their usage hints mid-conversation. Keeping them out of Instructions
+    # prevents that activation from busting the stable system-prompt cache.
+    tool_guidelines = build_tool_guidelines_section(tools)
+    if tool_guidelines:
+        builder.add_section("Tool Guidelines", tool_guidelines, dynamic=True)
+
     memory = await build_memory_section(user.id, query=message_context)
     builder.add_section("Your Memory", memory, dynamic=True)
 

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -286,10 +286,16 @@ class ToolRegistry:
         When *excluded_tool_names* is provided, individual tools whose names
         appear in the set are filtered out after creation.
 
+        Factories are iterated in sorted factory-name order so the resulting
+        tool schema sequence is deterministic across process restarts. The
+        Anthropic tools cache key is order-sensitive, so a stable prefix
+        depends on stable ordering regardless of module import order.
+
         Factories may be sync or async callables.
         """
         tools: list[Tool] = []
-        for name, factory in self._factories.items():
+        for name in sorted(self._factories):
+            factory = self._factories[name]
             if selected_factories is not None and name not in selected_factories:
                 logger.debug("Skipping %s: not selected for this message", name)
                 continue

--- a/tests/mocks/llm.py
+++ b/tests/mocks/llm.py
@@ -25,9 +25,27 @@ def make_vision_response(
     return _make_text_message_response(description)
 
 
-def make_text_response(content: str = "I'll help you with that.") -> MessageResponse:
-    """Build a mock any-llm MessageResponse for text calls."""
-    return _make_text_message_response(content)
+def make_text_response(
+    content: str = "I'll help you with that.",
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_creation_input_tokens: int | None = None,
+    cache_read_input_tokens: int | None = None,
+) -> MessageResponse:
+    """Build a mock any-llm MessageResponse for text calls.
+
+    Optional token fields let cache-aware tests assert rollup behavior.
+    """
+    resp = _make_text_message_response(content)
+    if input_tokens or output_tokens:
+        resp.usage.input_tokens = input_tokens
+        resp.usage.output_tokens = output_tokens
+    if cache_creation_input_tokens is not None:
+        resp.usage.cache_creation_input_tokens = cache_creation_input_tokens
+    if cache_read_input_tokens is not None:
+        resp.usage.cache_read_input_tokens = cache_read_input_tokens
+    return resp
 
 
 def make_tool_call_response(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2112,3 +2112,88 @@ async def test_truncated_response_increases_max_tokens(
     first_max = first_call.kwargs["max_tokens"]
     second_max = second_call.kwargs["max_tokens"]
     assert second_max > first_max
+
+
+def _tool_stub(name: str) -> Tool:
+    async def _noop(**_: object) -> ToolResult:
+        return ToolResult(content="")
+
+    return Tool(name=name, description="", function=_noop, params_model=_EmptyParams)
+
+
+def test_tool_prefix_logs_debug_on_append(
+    caplog: pytest.LogCaptureFixture, test_user: User
+) -> None:
+    """Appending a specialist tool to the end should log a growth debug line,
+    never the cache-bust warning."""
+    agent = ClawboltAgent(user=test_user)
+    agent.tools = [_tool_stub("core_a"), _tool_stub("core_b")]
+    with caplog.at_level(logging.DEBUG, logger="backend.app.agent.core"):
+        agent._log_tool_prefix_stability(round_number=0)
+        agent.tools = [_tool_stub("core_a"), _tool_stub("core_b"), _tool_stub("calendar_list")]
+        agent._log_tool_prefix_stability(round_number=1)
+    assert not any("non-monotonically" in rec.message for rec in caplog.records)
+    assert any("added=['calendar_list']" in rec.message for rec in caplog.records)
+
+
+def test_tool_prefix_warns_on_reorder(caplog: pytest.LogCaptureFixture, test_user: User) -> None:
+    """Reordering the tool list between rounds should surface a warning so
+    a prompt-cache regression can be spotted in logs."""
+    agent = ClawboltAgent(user=test_user)
+    agent.tools = [_tool_stub("core_a"), _tool_stub("core_b")]
+    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
+        agent._log_tool_prefix_stability(round_number=0)
+        # Re-ordered on round 1 (core_b moved before core_a).
+        agent.tools = [_tool_stub("core_b"), _tool_stub("core_a")]
+        agent._log_tool_prefix_stability(round_number=1)
+    assert any(
+        "non-monotonically" in rec.message and rec.levelname == "WARNING" for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_response_rolls_up_cache_tokens_across_rounds(
+    mock_amessages: object, test_user: User
+) -> None:
+    """AgentResponse should sum cache_creation/cache_read tokens across multi-round
+    LLM calls so callers can verify prompt caching end-to-end."""
+
+    async def remember_preference(**_: object) -> ToolResult:
+        return ToolResult(content="saved")
+
+    tool = Tool(
+        name="remember_preference",
+        description="Save a user preference",
+        function=remember_preference,
+        params_model=_KeyValueParams,
+    )
+
+    # Round 1: tool call, first-turn cache creation only (cache miss).
+    tool_response = make_tool_call_response(
+        [{"name": "remember_preference", "arguments": {"key": "rate", "value": "75"}}]
+    )
+    tool_response.usage.input_tokens = 1000
+    tool_response.usage.output_tokens = 50
+    tool_response.usage.cache_creation_input_tokens = 800
+    tool_response.usage.cache_read_input_tokens = 0
+
+    # Round 2: follow-up text, cache hit on stable prefix.
+    followup = make_text_response(
+        "Got it!",
+        input_tokens=1200,
+        output_tokens=20,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=800,
+    )
+
+    mock_amessages.side_effect = [tool_response, followup]  # type: ignore[union-attr]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    response = await agent.process_message("remember my rate is $75", system_prompt_override="sys")
+
+    assert response.total_input_tokens == 2200
+    assert response.total_output_tokens == 70
+    assert response.total_cache_creation_input_tokens == 800
+    assert response.total_cache_read_input_tokens == 800

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -260,6 +260,44 @@ class TestBuildAgentSystemPrompt:
         assert "Recall Behavior" in result
 
     @pytest.mark.asyncio
+    async def test_tool_guidelines_live_after_cache_boundary(self) -> None:
+        """Tool guidelines must sit in the dynamic suffix so that specialist
+        activation mid-conversation does not bust the stable system-prompt
+        cache. They should appear after CACHE_BOUNDARY, never inside
+        Instructions."""
+        user = MagicMock()
+        user.soul_text = "I'm Bolt."
+        user.user_text = ""
+        user.id = 1
+        user.timezone = ""
+
+        tool = MagicMock()
+        tool.usage_hint = "Use save_fact for memories"
+
+        with patch(
+            "backend.app.agent.system_prompt.build_memory_context",
+            new_callable=AsyncMock,
+            return_value="",
+        ):
+            result = await build_agent_system_prompt(
+                user=user,
+                tools=[tool],
+                message_context="hello",
+            )
+
+        marker = SystemPromptBuilder.CACHE_BOUNDARY.strip()
+        assert marker in result
+        boundary_idx = result.index(marker)
+        guidelines_idx = result.index("Tool Guidelines")
+        assert guidelines_idx > boundary_idx
+        # The stable Instructions block (everything before the boundary)
+        # must not leak the tool hints, or activating a new specialist
+        # would invalidate the cached prefix.
+        stable_prefix = result[:boundary_idx]
+        assert "Tool Guidelines" not in stable_prefix
+        assert "save_fact" not in stable_prefix
+
+    @pytest.mark.asyncio
     async def test_preamble_is_generic(self) -> None:
         """Agent prompt preamble should be generic (no assistant_name)."""
         user = MagicMock()


### PR DESCRIPTION
## Description

Three targeted fixes to make the Anthropic prompt cache for tools and system prompt actually hold up across a multi-round agent loop with specialist activation. Context is the cache review that found `list_capabilities` activation was busting both the tools cache and the system prompt cache, silently, and with no metric to prove either way.

### 1. Cache observability at the turn level

Cache tokens were already plumbed per-LLM-call in `llm_service.log_llm_usage`. What was missing: a rollup at the agent-turn level so a turn with 4 LLM rounds shows the overall hit rate, not 4 disjoint log lines.

- Accumulate `cache_creation_input_tokens` and `cache_read_input_tokens` in the round loop.
- Surface totals on `AgentResponse` so tests / dashboard / premium quota plugins can assert caching end-to-end.
- Emit one summary line at agent finish with `input`, `output`, `cache_create`, `cache_read`, and `hit_ratio`.

### 2. Stable tool ordering across specialist activations

The Anthropic tools cache is order-sensitive. Two fragility points:

- Registry iterated factories in dict-insertion order, which depends on `pkgutil.iter_modules` filesystem order. Now sorted by factory name — deterministic across process restarts.
- Specialist activation appends tools to `self.tools`; if anything ever broke the append-only invariant (reorder, remove, mid-list insert), the cache would silently bust. Added a per-round check that compares the current tool-name sequence to the previous round's. Prefix preserved  →  DEBUG line. Prefix broken  →  WARNING. Until now the regression was invisible.

### 3. Tool guidelines moved into the dynamic cache section

`build_tool_guidelines_section()` was being concatenated into the stable `Instructions` section. Every specialist activation added new `usage_hint` bullets to that section  →  stable prefix changed byte-for-byte  →  system prompt cache invalidated on the very turn the cache was most valuable.

Now `Tool Guidelines` is its own `dynamic=True` section placed after `CACHE_BOUNDARY`. The stable prefix (identity, user profile, instructions, proactive rules, recall rules) is now truly independent of which tools happen to be registered this turn.

### Deferred

CompanyCam sub-grouping (splitting its 15 sub-tools into photo / project / checklist sub-categories) was flagged as part of the same review. It's a multi-day registry refactor affecting `registry.py`, every specialist factory, the skill loader, and the Permissions UI. Left for a follow-up PR once the metrics from this one tell us whether CompanyCam is actually the hot path.

## Type
- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- 1636 passed; 2 pre-existing failures (`test_user_defaults`, `test_profile_defaults_from_settings`) also fail on origin/main, unrelated to this PR
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] Type check passes (`ty check --python .venv backend/ tests/ alembic/`) -- 1 pre-existing warning about an unused `type: ignore` in `test_heartbeat.py`, also present on main
- [x] New tests added for new functionality (cache rollup on `AgentResponse`, tool-prefix stability logging, tool guidelines placed after `CACHE_BOUNDARY`)

## AI Usage
- [x] AI-assisted. Claude Code drafted the diffs and tests; a subagent reviewed the caching plumbing before implementation to confirm where the cache was actually busting.
- [ ] No AI used

## Test plan
- [ ] Check logs after a real Telegram message that activates a specialist (e.g. "check my calendar") and confirm `Agent turn cache summary: ... hit_ratio=` appears and is non-zero on the second message
- [ ] Verify the `Tool prefix changed non-monotonically` WARNING does NOT fire during normal specialist activation
- [ ] Verify `cache_read_input_tokens` column in `llm_usage_logs` grows after the second turn of a conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)