### PR TITLE
feat: migrate CompanyCam from API token auth to OAuth 2.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,10 +121,10 @@ STORAGE_PROVIDER=local
 # GOOGLE_CALENDAR_CLIENT_ID=
 # GOOGLE_CALENDAR_CLIENT_SECRET=
 
-# CompanyCam
-# Server-level API token. Per-user tokens (entered via UI or chat) take precedence.
-# Generate at https://app.companycam.com/access_tokens
-# COMPANYCAM_ACCESS_TOKEN=
+# CompanyCam OAuth 2.0
+# Register your app at https://docs.companycam.com/docs/oauth
+# COMPANYCAM_CLIENT_ID=
+# COMPANYCAM_CLIENT_SECRET=
 
 # Supplier Pricing (SerpApi Home Depot engine)
 # Set SERPAPI_API_KEY to enable product price lookups at Home Depot.

--- a/backend/app/agent/skills/companycam/SKILL.md
+++ b/backend/app/agent/skills/companycam/SKILL.md
@@ -6,7 +6,6 @@ You now have access to CompanyCam tools for managing job site photo documentatio
 
 | Tool | Purpose | Approval |
 |------|---------|----------|
-| companycam_connect | Connect with an API token | Asks user |
 | companycam_search_projects | Search projects by name or address | Auto |
 | companycam_upload_photo | Upload a photo to a project | Asks user |
 | companycam_create_project | Create a new project | Asks user |
@@ -29,4 +28,4 @@ Derive tags from the conversation context:
 
 ## Connection
 
-Users connect by providing their CompanyCam API token. They can generate one at app.companycam.com/access_tokens. Use `companycam_connect` to validate and store the token.
+Users connect via OAuth. Use `manage_integration(action='connect', target='companycam')` to start the authorization flow. The user will be redirected to CompanyCam to grant access.

--- a/backend/app/agent/tools/companycam_tools.py
+++ b/backend/app/agent/tools/companycam_tools.py
@@ -1,8 +1,8 @@
 """CompanyCam tools for the agent.
 
-Provides tools to connect to CompanyCam, search/create projects, and upload
-photos. The connection uses a per-user API token stored in the oauth_tokens
-table (OAuth 2.0 support is planned post-MVP).
+Provides tools to search/create projects, upload photos, and manage job
+documentation via CompanyCam. Authentication uses the standard OAuth 2.0
+authorization code flow (same as Google Calendar and QuickBooks).
 """
 
 from __future__ import annotations
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.services.companycam import CompanyCamService, get_photo_url
-from backend.app.services.oauth import OAuthTokenData, oauth_service
+from backend.app.services.oauth import oauth_service
 
 if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
@@ -32,10 +32,6 @@ _INTEGRATION = "companycam"
 # ---------------------------------------------------------------------------
 # Parameter models
 # ---------------------------------------------------------------------------
-
-
-class CompanyCamConnectParams(BaseModel):
-    api_token: str = Field(description="The user's CompanyCam API access token")
 
 
 class CompanyCamSearchParams(BaseModel):
@@ -146,18 +142,11 @@ class CompanyCamCreateChecklistParams(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _load_service(user_id: str) -> CompanyCamService | None:
-    """Load a CompanyCamService for the user.
-
-    Priority: per-user token (oauth_tokens) > server-level env var.
-    """
-    from backend.app.config import settings
-
-    token = oauth_service.load_token(user_id, _INTEGRATION)
+async def _load_service(user_id: str) -> CompanyCamService | None:
+    """Load a CompanyCamService for the user using OAuth token (auto-refreshed)."""
+    token = await oauth_service.get_valid_token(user_id, _INTEGRATION)
     if token and token.access_token:
         return CompanyCamService(access_token=token.access_token)
-    if settings.companycam_access_token:
-        return CompanyCamService(access_token=settings.companycam_access_token)
     return None
 
 
@@ -950,64 +939,6 @@ def _create_companycam_tools(
 
 
 # ---------------------------------------------------------------------------
-# Connect tool (separate, always available when integration is registered)
-# ---------------------------------------------------------------------------
-
-
-def _create_connect_tool(user_id: str) -> Tool:
-    """Create the companycam_connect tool for storing an API token."""
-
-    async def companycam_connect(api_token: str) -> ToolResult:
-        """Validate and store a CompanyCam API token for this user."""
-        service = CompanyCamService(access_token=api_token)
-        try:
-            user_info = await service.validate_token()
-        except Exception as exc:
-            logger.warning("CompanyCam token validation failed: %s", exc)
-            return ToolResult(
-                content=(
-                    "That token didn't work. CompanyCam returned an error. "
-                    "Double-check the token and try again."
-                ),
-                is_error=True,
-                error_kind=ToolErrorKind.AUTH,
-            )
-
-        token_data = OAuthTokenData(
-            access_token=api_token,
-            token_type="Bearer",
-        )
-        oauth_service.save_token(user_id, _INTEGRATION, token_data)
-
-        display_name = user_info.first_name or ""
-        if display_name:
-            display_name = f" ({display_name})"
-        logger.info("CompanyCam connected for user %s", user_id)
-        return ToolResult(
-            content=(
-                f"CompanyCam connected successfully{display_name}. "
-                "You can now search projects, upload photos, and create new projects. "
-                "The connection will be active starting with your next message."
-            ),
-        )
-
-    return Tool(
-        name=ToolName.COMPANYCAM_CONNECT,
-        description=(
-            "Connect to CompanyCam by providing an API access token. "
-            "The user can generate a token at app.companycam.com/access_tokens."
-        ),
-        function=companycam_connect,
-        params_model=CompanyCamConnectParams,
-        usage_hint=(
-            "When the user wants to connect CompanyCam, ask for their API token. "
-            "They can generate one at app.companycam.com/access_tokens. "
-            "Call this tool with the token to validate and store it."
-        ),
-    )
-
-
-# ---------------------------------------------------------------------------
 # Auth check, factory, and registration
 # ---------------------------------------------------------------------------
 
@@ -1017,35 +948,31 @@ def _companycam_auth_check(ctx: ToolContext) -> str | None:
 
     Returns None when connected (tools are available).
     Returns a reason string when not connected (tells the agent how to help).
-    Checks per-user token first, then server-level env var.
     """
     from backend.app.config import settings
 
-    token = oauth_service.load_token(ctx.user.id, _INTEGRATION)
-    if token and token.access_token:
-        return None
-    if settings.companycam_access_token:
+    if not settings.companycam_client_id or not settings.companycam_client_secret:
+        return None  # Not configured server-side, hide tools
+    if oauth_service.is_connected(ctx.user.id, _INTEGRATION):
         return None
     return (
         "CompanyCam is not connected. "
-        "Ask the user for their CompanyCam API token "
-        "(they can generate one at app.companycam.com/access_tokens), "
-        "then call companycam_connect with the token."
+        "Use manage_integration(action='connect', target='companycam') "
+        "to start the OAuth authorization flow."
     )
 
 
 async def _companycam_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for CompanyCam tools."""
-    tools: list[Tool] = []
+    from backend.app.config import settings
 
-    service = _load_service(ctx.user.id)
-    if service is not None:
-        tools.extend(_create_companycam_tools(service, ctx))
+    if not settings.companycam_client_id or not settings.companycam_client_secret:
+        return []
 
-    # The connect tool is always available so users can connect
-    tools.append(_create_connect_tool(ctx.user.id))
-
-    return tools
+    service = await _load_service(ctx.user.id)
+    if service is None:
+        return []
+    return _create_companycam_tools(service, ctx)
 
 
 def _register() -> None:
@@ -1060,11 +987,6 @@ def _register() -> None:
             "documents, comments, checklists, and tags"
         ),
         sub_tools=[
-            SubToolInfo(
-                ToolName.COMPANYCAM_CONNECT,
-                "Connect to CompanyCam with an API token",
-                default_permission="ask",
-            ),
             SubToolInfo(
                 ToolName.COMPANYCAM_SEARCH_PROJECTS,
                 "Search CompanyCam projects by name or address",

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -40,6 +40,7 @@ _DISPLAY_NAMES: dict[str, str] = {
 _TOOL_OAUTH_MAP: dict[str, str] = {
     "calendar": "google_calendar",
     "quickbooks": "quickbooks",
+    "companycam": "companycam",
 }
 
 

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -43,7 +43,6 @@ class ToolName:
     CALENDAR_CHECK_AVAILABILITY = "calendar_check_availability"
 
     # CompanyCam
-    COMPANYCAM_CONNECT = "companycam_connect"
     COMPANYCAM_SEARCH_PROJECTS = "companycam_search_projects"
     COMPANYCAM_CREATE_PROJECT = "companycam_create_project"
     COMPANYCAM_UPDATE_PROJECT = "companycam_update_project"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -111,8 +111,9 @@ class Settings(BaseSettings):
     google_calendar_client_id: str = ""
     google_calendar_client_secret: str = ""
 
-    # CompanyCam
-    companycam_access_token: str = ""  # Server-level API token (per-user tokens take precedence)
+    # CompanyCam OAuth 2.0
+    companycam_client_id: str = ""
+    companycam_client_secret: str = ""
 
     # Supplier pricing (SerpApi Home Depot engine)
     serpapi_api_key: str = ""  # https://serpapi.com — free tier: 250 searches/month

--- a/backend/app/routers/oauth.py
+++ b/backend/app/routers/oauth.py
@@ -14,11 +14,8 @@ from backend.app.schemas import (
     OAuthAuthorizeResponse,
     OAuthStatusEntry,
     OAuthStatusResponse,
-    TokenConnectRequest,
-    TokenConnectResponse,
 )
 from backend.app.services.oauth import (
-    OAuthTokenData,
     get_oauth_config,
     list_oauth_integrations,
     oauth_service,
@@ -29,16 +26,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-_TOKEN_BASED_INTEGRATIONS = ("companycam",)
-
-
 @router.get("/oauth/status", response_model=OAuthStatusResponse)
 async def get_oauth_status(
     current_user: User = Depends(get_current_user),
 ) -> OAuthStatusResponse:
-    """Return connection status for all OAuth and token-based integrations."""
-    from backend.app.config import settings
-
+    """Return connection status for all OAuth integrations."""
     entries: list[OAuthStatusEntry] = []
     for name in list_oauth_integrations():
         config = get_oauth_config(name)
@@ -47,16 +39,6 @@ async def get_oauth_status(
                 integration=name,
                 configured=config is not None and config.is_configured,
                 connected=oauth_service.is_connected(current_user.id, name),
-            )
-        )
-    for name in _TOKEN_BASED_INTEGRATIONS:
-        has_user_token = oauth_service.is_connected(current_user.id, name)
-        has_env_token = bool(getattr(settings, f"{name}_access_token", ""))
-        entries.append(
-            OAuthStatusEntry(
-                integration=name,
-                configured=True,
-                connected=has_user_token or has_env_token,
             )
         )
     return OAuthStatusResponse(integrations=entries)
@@ -234,49 +216,12 @@ def _chat_callback_page(
     return HTMLResponse(content=html)
 
 
-@router.post("/oauth/{integration}/token", response_model=TokenConnectResponse)
-async def connect_with_token(
-    integration: str,
-    body: TokenConnectRequest,
-    current_user: User = Depends(get_current_user),
-) -> TokenConnectResponse:
-    """Connect a token-based integration by validating and storing an API token."""
-    if integration not in _TOKEN_BASED_INTEGRATIONS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Integration '{integration}' does not support token-based auth",
-        )
-
-    if integration == "companycam":
-        from backend.app.services.companycam import CompanyCamService
-
-        service = CompanyCamService(access_token=body.token)
-        try:
-            user_info = await service.validate_token()
-        except Exception as exc:
-            logger.warning("CompanyCam token validation failed: %s", exc)
-            raise HTTPException(status_code=401, detail="Invalid CompanyCam API token") from exc
-
-        token_data = OAuthTokenData(access_token=body.token, token_type="Bearer")
-        oauth_service.save_token(current_user.id, integration, token_data)
-
-        display_name = user_info.first_name or ""
-        logger.info("User %s connected CompanyCam via API token", current_user.id)
-        return TokenConnectResponse(
-            status="connected",
-            integration=integration,
-            display_name=display_name,
-        )
-
-    raise HTTPException(status_code=400, detail=f"Unsupported integration: {integration}")
-
-
 @router.delete("/oauth/{integration}")
 async def disconnect_integration(
     integration: str,
     current_user: User = Depends(get_current_user),
 ) -> dict[str, str]:
-    """Disconnect an OAuth or token-based integration by removing stored tokens."""
+    """Disconnect an OAuth integration by removing stored tokens."""
     deleted = oauth_service.delete_token(current_user.id, integration)
     if not deleted:
         raise HTTPException(status_code=404, detail="No connection found for this integration")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -345,16 +345,6 @@ class OAuthAuthorizeResponse(BaseModel):
     integration: str
 
 
-class TokenConnectRequest(BaseModel):
-    token: str = Field(description="API access token for the integration")
-
-
-class TokenConnectResponse(BaseModel):
-    status: str
-    integration: str
-    display_name: str = ""
-
-
 # ---------------------------------------------------------------------------
 # Calendar config
 # ---------------------------------------------------------------------------

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -645,8 +645,13 @@ GOOGLE_CALENDAR_SCOPES = [
     "https://www.googleapis.com/auth/calendar.readonly",
 ]
 
+# CompanyCam OAuth 2.0 endpoints
+COMPANYCAM_AUTHORIZE_URL = "https://app.companycam.com/oauth/authorize"
+COMPANYCAM_TOKEN_URL = "https://app.companycam.com/oauth/token"
+COMPANYCAM_SCOPES = ["read", "write", "destroy"]
+
 # Registry of all supported OAuth integrations.
-_OAUTH_INTEGRATIONS = ("quickbooks", "google_calendar")
+_OAUTH_INTEGRATIONS = ("quickbooks", "google_calendar", "companycam")
 
 
 def get_quickbooks_oauth_config() -> OAuthConfig | None:
@@ -677,12 +682,28 @@ def get_google_calendar_oauth_config() -> OAuthConfig | None:
     return config if config.is_configured else None
 
 
+def get_companycam_oauth_config() -> OAuthConfig | None:
+    """Build the CompanyCam OAuth config from settings."""
+    config = OAuthConfig(
+        integration="companycam",
+        client_id=settings.companycam_client_id,
+        client_secret=settings.companycam_client_secret,
+        authorize_url=COMPANYCAM_AUTHORIZE_URL,
+        token_url=COMPANYCAM_TOKEN_URL,
+        scopes=COMPANYCAM_SCOPES,
+        use_pkce=False,
+    )
+    return config if config.is_configured else None
+
+
 def get_oauth_config(integration: str) -> OAuthConfig | None:
     """Return the OAuth config for the named integration, or None."""
     if integration == "quickbooks":
         return get_quickbooks_oauth_config()
     if integration == "google_calendar":
         return get_google_calendar_oauth_config()
+    if integration == "companycam":
+        return get_companycam_oauth_config()
     return None
 
 

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -184,9 +184,10 @@ When `GOOGLE_CALENDAR_CLIENT_ID` and `GOOGLE_CALENDAR_CLIENT_SECRET` are set, us
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `COMPANYCAM_ACCESS_TOKEN` | | Server-level CompanyCam API token. Per-user tokens (entered via the UI or chat) take precedence. Generate at [app.companycam.com/access_tokens](https://app.companycam.com/access_tokens) |
+| `COMPANYCAM_CLIENT_ID` | | CompanyCam OAuth 2.0 client ID. Register at [docs.companycam.com/docs/oauth](https://docs.companycam.com/docs/oauth) |
+| `COMPANYCAM_CLIENT_SECRET` | | CompanyCam OAuth 2.0 client secret |
 
-When set, all users get CompanyCam tools (`companycam_search_projects`, `companycam_upload_photo`, `companycam_create_project`). Users can also connect their own individual tokens via the Tools page or chat.
+When both are set, users can connect CompanyCam via OAuth on the Tools page or through chat. This enables tools like `companycam_search_projects`, `companycam_upload_photo`, and `companycam_create_project`.
 
 ## Supplier pricing
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -46,7 +46,7 @@
     "/api/oauth/status": {
       "get": {
         "summary": "Get Oauth Status",
-        "description": "Return connection status for all OAuth and token-based integrations.",
+        "description": "Return connection status for all OAuth integrations.",
         "operationId": "get_oauth_status_api_oauth_status_get",
         "responses": {
           "200": {
@@ -181,60 +181,10 @@
         }
       }
     },
-    "/api/oauth/{integration}/token": {
-      "post": {
-        "summary": "Connect With Token",
-        "description": "Connect a token-based integration by validating and storing an API token.",
-        "operationId": "connect_with_token_api_oauth__integration__token_post",
-        "parameters": [
-          {
-            "name": "integration",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Integration"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TokenConnectRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenConnectResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/oauth/{integration}": {
       "delete": {
         "summary": "Disconnect Integration",
-        "description": "Disconnect an OAuth or token-based integration by removing stored tokens.",
+        "description": "Disconnect an OAuth integration by removing stored tokens.",
         "operationId": "disconnect_integration_api_oauth__integration__delete",
         "parameters": [
           {
@@ -2683,43 +2633,6 @@
           "bot_link"
         ],
         "title": "TelegramBotInfoResponse"
-      },
-      "TokenConnectRequest": {
-        "properties": {
-          "token": {
-            "type": "string",
-            "title": "Token",
-            "description": "API access token for the integration"
-          }
-        },
-        "type": "object",
-        "required": [
-          "token"
-        ],
-        "title": "TokenConnectRequest"
-      },
-      "TokenConnectResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "integration": {
-            "type": "string",
-            "title": "Integration"
-          },
-          "display_name": {
-            "type": "string",
-            "title": "Display Name",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "integration"
-        ],
-        "title": "TokenConnectResponse"
       },
       "ToolConfigEntryResponse": {
         "properties": {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -258,15 +258,6 @@ const api = {
     });
     if (error) _throwApiError(error, 'Failed to disconnect OAuth');
   },
-  connectWithToken: async (integration: string, token: string) => {
-    const { data, error } = await client.POST('/api/oauth/{integration}/token', {
-      params: { path: { integration } },
-      body: { token },
-    });
-    if (error) _throwApiError(error, 'Failed to connect integration');
-    return data as { status: string; integration: string; display_name: string };
-  },
-
   // Calendar config
   getCalendarList: async () => {
     const { data, error } = await client.GET('/api/user/calendar/calendars');

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -47,7 +47,7 @@ export interface paths {
         };
         /**
          * Get Oauth Status
-         * @description Return connection status for all OAuth and token-based integrations.
+         * @description Return connection status for all OAuth integrations.
          */
         get: operations["get_oauth_status_api_oauth_status_get"];
         put?: never;
@@ -109,26 +109,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/oauth/{integration}/token": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Connect With Token
-         * @description Connect a token-based integration by validating and storing an API token.
-         */
-        post: operations["connect_with_token_api_oauth__integration__token_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/oauth/{integration}": {
         parameters: {
             query?: never;
@@ -141,7 +121,7 @@ export interface paths {
         post?: never;
         /**
          * Disconnect Integration
-         * @description Disconnect an OAuth or token-based integration by removing stored tokens.
+         * @description Disconnect an OAuth integration by removing stored tokens.
          */
         delete: operations["disconnect_integration_api_oauth__integration__delete"];
         options?: never;
@@ -1255,26 +1235,6 @@ export interface components {
             /** Bot Link */
             bot_link: string;
         };
-        /** TokenConnectRequest */
-        TokenConnectRequest: {
-            /**
-             * Token
-             * @description API access token for the integration
-             */
-            token: string;
-        };
-        /** TokenConnectResponse */
-        TokenConnectResponse: {
-            /** Status */
-            status: string;
-            /** Integration */
-            integration: string;
-            /**
-             * Display Name
-             * @default
-             */
-            display_name: string;
-        };
         /** ToolConfigEntryResponse */
         ToolConfigEntryResponse: {
             /** Name */
@@ -1530,41 +1490,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    connect_with_token_api_oauth__integration__token_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                integration: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TokenConnectRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TokenConnectResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -138,18 +138,6 @@ export function useOAuthDisconnect() {
   });
 }
 
-export function useTokenConnect() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ integration, token }: { integration: string; token: string }) =>
-      api.connectWithToken(integration, token),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: queryKeys.oauth });
-      void queryClient.invalidateQueries({ queryKey: queryKeys.tools });
-    },
-  });
-}
-
 // --- Calendar config ---
 
 export function useCalendarList() {

--- a/frontend/src/lib/tool-utils.ts
+++ b/frontend/src/lib/tool-utils.ts
@@ -6,10 +6,9 @@
  *
  * 1. Add an entry to DISPLAY_NAMES.
  * 2. Add sub-tool entries to SUB_TOOL_NAMES.
- * 3. If the tool requires OAuth or token auth, add it to TOOL_OAUTH_MAP.
+ * 3. If the tool requires OAuth, add it to TOOL_OAUTH_MAP.
  *    If it does NOT require auth (like supplier_pricing), leave it out
  *    and it will be treated as "always available."
- * 4. If the tool uses API tokens (not OAuth), add it to TOKEN_BASED_INTEGRATIONS.
  */
 
 /** Map tool factory names to integration identifiers. Tools NOT in this
@@ -19,10 +18,6 @@ export const TOOL_OAUTH_MAP: Record<string, string> = {
   calendar: 'google_calendar',
   companycam: 'companycam',
 };
-
-/** Integrations that use API tokens instead of OAuth.
- *  These show a token input field instead of an OAuth redirect. */
-export const TOKEN_BASED_INTEGRATIONS = new Set(['companycam']);
 
 /** Human-readable display names for tool factories. */
 const DISPLAY_NAMES: Record<string, string> = {
@@ -62,7 +57,6 @@ const SUB_TOOL_NAMES: Record<string, string> = {
   send_reply: 'Send replies',
   send_media_reply: 'Send media',
   update_permission: 'Change permissions',
-  companycam_connect: 'Connect to CompanyCam',
   companycam_search_projects: 'Search projects',
   companycam_create_project: 'Create project',
   companycam_update_project: 'Update project',

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -4,9 +4,9 @@ import Button from '@/components/ui/button';
 import { Switch } from '@heroui/switch';
 import { Tooltip } from '@heroui/tooltip';
 import { toast } from '@/lib/toast';
-import { displayName, subToolDisplayName, TOOL_OAUTH_MAP, TOKEN_BASED_INTEGRATIONS, getToolOAuthStatus } from '@/lib/tool-utils';
+import { displayName, subToolDisplayName, TOOL_OAUTH_MAP, getToolOAuthStatus } from '@/lib/tool-utils';
 import { IntegrationIcon } from '@/components/integration-icons';
-import { useToolConfig, useUpdateToolConfig, useOAuthStatus, useOAuthDisconnect, useTokenConnect, useCalendarList, useCalendarConfig, useUpdateCalendarConfig } from '@/hooks/queries';
+import { useToolConfig, useUpdateToolConfig, useOAuthStatus, useOAuthDisconnect, useCalendarList, useCalendarConfig, useUpdateCalendarConfig } from '@/hooks/queries';
 import api from '@/api';
 import type { ToolConfigEntryResponse, OAuthStatusEntry, SubToolEntryResponse } from '@/types';
 
@@ -44,10 +44,8 @@ export default function ToolsPage() {
   const updateMutation = useUpdateToolConfig();
   const { data: oauthData } = useOAuthStatus();
   const disconnectMutation = useOAuthDisconnect();
-  const tokenConnectMutation = useTokenConnect();
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const [connectingIntegration, setConnectingIntegration] = useState<string | null>(null);
-  const [tokenInputs, setTokenInputs] = useState<Record<string, string>>({});
 
   const tools = data?.tools ?? [];
   const oauthMap: Record<string, OAuthStatusEntry> = {};
@@ -140,8 +138,6 @@ export default function ToolsPage() {
               const oauthIntegration = TOOL_OAUTH_MAP[tool.name];
               const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(tool.name, oauthMap, tool.configured);
 
-              const isTokenBased = TOKEN_BASED_INTEGRATIONS.has(tool.name);
-
               return (
                 <Card key={tool.name}>
                   <div className="flex items-start justify-between gap-4">
@@ -180,7 +176,7 @@ export default function ToolsPage() {
                           Disconnect
                         </Button>
                       )}
-                      {needsOAuth && !isConnected && !isTokenBased && (
+                      {needsOAuth && !isConnected && (
                         <Button
                           size="sm"
                           onClick={() => void handleConnect(oauthIntegration!)}
@@ -192,48 +188,6 @@ export default function ToolsPage() {
                       )}
                     </div>
                   </div>
-
-                  {/* Token-based connection input */}
-                  {isTokenBased && !isConnected && (
-                    <div className="mt-3 pt-3 border-t border-border">
-                      <label className="block text-xs text-muted-foreground mb-1.5">
-                        API token
-                        {tool.name === 'companycam' && (
-                          <span> (generate at <a href="https://app.companycam.com/access_tokens" target="_blank" rel="noreferrer" className="text-primary hover:underline">app.companycam.com</a>)</span>
-                        )}
-                      </label>
-                      <div className="flex gap-2">
-                        <input
-                          type="password"
-                          placeholder="Paste your API token"
-                          value={tokenInputs[tool.name] ?? ''}
-                          onChange={(e) => setTokenInputs((prev) => ({ ...prev, [tool.name]: e.target.value }))}
-                          className="flex-1 text-sm px-2.5 py-1.5 rounded-md border border-border bg-background"
-                        />
-                        <Button
-                          size="sm"
-                          disabled={!tokenInputs[tool.name]?.trim() || tokenConnectMutation.isPending}
-                          isLoading={tokenConnectMutation.isPending}
-                          onClick={() => {
-                            const token = tokenInputs[tool.name]?.trim();
-                            if (!token) return;
-                            tokenConnectMutation.mutate(
-                              { integration: oauthIntegration!, token },
-                              {
-                                onSuccess: () => {
-                                  toast.success(`${displayName(tool.name)} connected`);
-                                  setTokenInputs((prev) => ({ ...prev, [tool.name]: '' }));
-                                },
-                                onError: (e) => toast.error(e.message),
-                              },
-                            );
-                          }}
-                        >
-                          Connect
-                        </Button>
-                      </div>
-                    </div>
-                  )}
 
                   {/* Enable/disable toggle: show when connected (OAuth) or always (non-OAuth) */}
                   {isConnected && (

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -169,8 +169,8 @@ def test_companycam_tools_registered() -> None:
     assert "companycam" in default_registry.factory_names
 
 
-def test_companycam_auth_check_no_token() -> None:
-    """Auth check should return a reason when no token is stored and no env var."""
+def test_companycam_auth_check_not_connected() -> None:
+    """Auth check should return a reason when OAuth is not connected."""
     from backend.app.agent.tools.companycam_tools import _companycam_auth_check
     from backend.app.config import settings
 
@@ -179,32 +179,54 @@ def test_companycam_auth_check_no_token() -> None:
     ctx = MagicMock()
     ctx.user = user
 
-    original = settings.companycam_access_token
-    try:
-        settings.companycam_access_token = ""
-        with patch("backend.app.agent.tools.companycam_tools.oauth_service") as mock_oauth:
-            mock_oauth.load_token.return_value = None
-            result = _companycam_auth_check(ctx)
-    finally:
-        settings.companycam_access_token = original
+    with (
+        patch.object(settings, "companycam_client_id", "cid"),
+        patch.object(settings, "companycam_client_secret", "csec"),
+        patch("backend.app.agent.tools.companycam_tools.oauth_service") as mock_oauth,
+    ):
+        mock_oauth.is_connected.return_value = False
+        result = _companycam_auth_check(ctx)
 
     assert result is not None
     assert "not connected" in result.lower()
+    assert "manage_integration" in result
 
 
-def test_companycam_auth_check_with_token() -> None:
-    """Auth check should return None when a token is stored."""
+def test_companycam_auth_check_connected() -> None:
+    """Auth check should return None when OAuth is connected."""
     from backend.app.agent.tools.companycam_tools import _companycam_auth_check
+    from backend.app.config import settings
 
     user = MagicMock()
-    user.id = "test-user-with-token"
+    user.id = "test-user-connected"
     ctx = MagicMock()
     ctx.user = user
 
-    with patch("backend.app.agent.tools.companycam_tools.oauth_service") as mock_oauth:
-        token = MagicMock()
-        token.access_token = "valid-token"
-        mock_oauth.load_token.return_value = token
+    with (
+        patch.object(settings, "companycam_client_id", "cid"),
+        patch.object(settings, "companycam_client_secret", "csec"),
+        patch("backend.app.agent.tools.companycam_tools.oauth_service") as mock_oauth,
+    ):
+        mock_oauth.is_connected.return_value = True
+        result = _companycam_auth_check(ctx)
+
+    assert result is None
+
+
+def test_companycam_auth_check_not_configured() -> None:
+    """Auth check should return None (hide tools) when OAuth creds are not configured."""
+    from backend.app.agent.tools.companycam_tools import _companycam_auth_check
+    from backend.app.config import settings
+
+    user = MagicMock()
+    user.id = "test-user"
+    ctx = MagicMock()
+    ctx.user = user
+
+    with (
+        patch.object(settings, "companycam_client_id", ""),
+        patch.object(settings, "companycam_client_secret", ""),
+    ):
         result = _companycam_auth_check(ctx)
 
     assert result is None
@@ -708,7 +730,6 @@ def test_new_companycam_tools_registered() -> None:
     tool_names = {st.name for st in info.sub_tools}
 
     expected = {
-        ToolName.COMPANYCAM_CONNECT,
         ToolName.COMPANYCAM_SEARCH_PROJECTS,
         ToolName.COMPANYCAM_CREATE_PROJECT,
         ToolName.COMPANYCAM_UPDATE_PROJECT,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -21,6 +21,7 @@ from backend.app.services.oauth import (
     OAuthService,
     OAuthTokenData,
     _generate_pkce_pair,
+    get_companycam_oauth_config,
     get_google_calendar_oauth_config,
     get_oauth_config,
     get_quickbooks_oauth_config,
@@ -482,6 +483,41 @@ def test_google_calendar_auth_url_includes_access_type_offline(
     assert "prompt=consent" in url
 
 
+def test_companycam_oauth_config_not_configured() -> None:
+    """When companycam client_id/secret are empty, config should be None."""
+    with (
+        patch.object(settings, "companycam_client_id", ""),
+        patch.object(settings, "companycam_client_secret", ""),
+    ):
+        config = get_companycam_oauth_config()
+    assert config is None
+
+
+def test_companycam_oauth_config_configured() -> None:
+    """When companycam client_id/secret are set, config should be returned."""
+    with (
+        patch.object(settings, "companycam_client_id", "cc-cid"),
+        patch.object(settings, "companycam_client_secret", "cc-csec"),
+    ):
+        config = get_companycam_oauth_config()
+    assert config is not None
+    assert config.client_id == "cc-cid"
+    assert config.integration == "companycam"
+    assert config.use_pkce is False
+    assert config.scopes == ["read", "write", "destroy"]
+
+
+def test_get_oauth_config_dispatches_companycam() -> None:
+    """get_oauth_config('companycam') should return CompanyCam config."""
+    with (
+        patch.object(settings, "companycam_client_id", "cc-cid"),
+        patch.object(settings, "companycam_client_secret", "cc-csec"),
+    ):
+        config = get_oauth_config("companycam")
+    assert config is not None
+    assert config.integration == "companycam"
+
+
 def test_get_oauth_config_dispatches_google_calendar() -> None:
     """get_oauth_config('google_calendar') should return Google Calendar config."""
     with (
@@ -594,6 +630,7 @@ def test_oauth_status_endpoint(client: TestClient) -> None:
     assert "integrations" in data
     names = [e["integration"] for e in data["integrations"]]
     assert "quickbooks" in names
+    assert "companycam" in names
 
 
 def test_oauth_authorize_endpoint(client: TestClient) -> None:


### PR DESCRIPTION
## Description

Replaces the manual API token paste flow for CompanyCam with the standard OAuth 2.0 authorization code grant, matching how Google Calendar and QuickBooks already work. Users now click "Connect" and authorize via CompanyCam's OAuth screen instead of generating and pasting API tokens.

Key changes:
- Register CompanyCam as an OAuth integration (authorize URL, token URL, scopes: read/write/destroy, PKCE disabled)
- Remove all token-based auth infrastructure (`_TOKEN_BASED_INTEGRATIONS`, `POST /token` endpoint, `TokenConnect` schemas, token input UI)
- Switch `companycam_tools` to use `get_valid_token()` for automatic token refresh
- Remove `companycam_connect` tool (connection now goes through `manage_integration`)
- Add CompanyCam to the `_TOOL_OAUTH_MAP` so connect/disconnect works via chat

New env vars: `COMPANYCAM_CLIENT_ID`, `COMPANYCAM_CLIENT_SECRET` (replaces `COMPANYCAM_ACCESS_TOKEN`)

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 1730 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Frontend types regenerated (`openapi.json` + `api.d.ts`)
- [x] Frontend typecheck and deadcode pass
- [x] Docs updated (`.env.example`, `configuration.mdx`)

## AI Usage
- [x] AI-assisted (Claude Code planned and implemented the migration)