### PR TITLE
feat: early typing indicator on message receipt for BlueBubbles

### DIFF
--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -76,6 +76,28 @@ def _check_channel_route_enabled(user_id: str, channel: str) -> bool | None:
         db.close()
 
 
+async def _send_early_typing_indicator(channel: str, chat_id: str) -> None:
+    """Fire a typing indicator immediately on message receipt (best-effort).
+
+    Called before pipeline dispatch so the user sees instant feedback that
+    the agent received their message. Intentionally omits ``request_id``
+    so the typing indicator cannot resolve a webchat SSE response future.
+    """
+    try:
+        from backend.app.bus import OutboundMessage, message_bus
+
+        await message_bus.publish_outbound(
+            OutboundMessage(
+                channel=channel,
+                chat_id=chat_id,
+                content="",
+                is_typing_indicator=True,
+            )
+        )
+    except Exception:
+        logger.debug("Failed to send early typing indicator to %s/%s", channel, chat_id)
+
+
 async def _send_error_fallback(
     channel: str,
     user: User,
@@ -651,6 +673,9 @@ async def process_inbound_from_bus(
         media_urls_json=json.dumps([file_id for file_id, _mime in inbound.media_refs]),
         channel=inbound.channel,
     )
+
+    # Immediate typing indicator so the user knows the agent saw their message.
+    await _send_early_typing_indicator(inbound.channel, inbound.sender_id)
 
     if settings.message_batch_window_ms > 0:
         await message_batcher.enqueue(

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -108,6 +108,27 @@ class ChannelManager:
                 inbound.channel,
                 inbound.sender_id,
             )
+            # Send an error reply so the user isn't left with a dangling
+            # typing indicator and no response.
+            try:
+                from backend.app.bus import OutboundMessage, message_bus
+
+                await message_bus.publish_outbound(
+                    OutboundMessage(
+                        channel=inbound.channel,
+                        chat_id=inbound.sender_id,
+                        content=(
+                            "Sorry, something went wrong processing your message. Please try again."
+                        ),
+                        request_id=inbound.request_id,
+                    )
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to send error fallback for %s/%s",
+                    inbound.channel,
+                    inbound.sender_id,
+                )
 
     async def _run_outbound_dispatcher(self) -> None:
         """Loop: consume outbound messages and route to channels."""

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,10 +1,12 @@
 """Tests for channel base class, ChannelManager, and protocol conformance."""
 
 import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import APIRouter
 
+from backend.app.bus import message_bus
 from backend.app.channels.base import BaseChannel
 from backend.app.channels.manager import ChannelManager
 from backend.app.media.download import DownloadedMedia
@@ -141,3 +143,36 @@ async def test_manager_stop_all() -> None:
     await mgr.stop_all()
     assert ch1.stopped
     assert ch2.stopped
+
+
+@pytest.mark.asyncio
+async def test_handle_inbound_sends_error_fallback_on_crash() -> None:
+    """When process_inbound_from_bus crashes, an error reply should be sent."""
+    from backend.app.agent.ingestion import InboundMessage
+
+    mgr = ChannelManager()
+    ch = _StubChannel("bluebubbles")
+    mgr.register(ch)
+
+    inbound = InboundMessage(
+        channel="bluebubbles",
+        sender_id="+15551234567",
+        text="hello",
+    )
+
+    with patch(
+        "backend.app.agent.ingestion.process_inbound_from_bus",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("total crash"),
+    ):
+        await mgr._handle_inbound(inbound)
+
+    # An error fallback message should have been published to the bus
+    found = False
+    while not message_bus.outbound.empty():
+        outbound = message_bus.outbound.get_nowait()
+        if not outbound.is_typing_indicator and outbound.chat_id == "+15551234567":
+            assert "something went wrong" in outbound.content.lower()
+            found = True
+            break
+    assert found, "Expected an error fallback message on the outbound bus"

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -1,4 +1,4 @@
-"""Tests for typing indicator integration with the agent loop and heartbeat."""
+"""Tests for typing indicator integration with the agent loop, heartbeat, and ingestion."""
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,10 +8,12 @@ from pydantic import BaseModel
 
 from backend.app.agent.core import ClawboltAgent
 from backend.app.agent.events import AgentEndEvent, ToolExecutionStartEvent, TurnStartEvent
+from backend.app.agent.file_store import SessionState, StoredMessage
 from backend.app.agent.heartbeat import evaluate_heartbeat_need
+from backend.app.agent.ingestion import InboundMessage, process_inbound_from_bus
 from backend.app.agent.router import _create_activity_forwarder
 from backend.app.agent.tools.base import Tool, ToolResult
-from backend.app.bus import MessageBus, OutboundMessage
+from backend.app.bus import MessageBus, OutboundMessage, message_bus
 from backend.app.models import User
 from tests.mocks.llm import make_text_response, make_tool_call_response
 
@@ -474,3 +476,81 @@ async def test_heartbeat_works_without_channel(
     # Should not raise when no channel is provided
     decision = await evaluate_heartbeat_need(test_user)
     assert decision.action == "skip"
+
+
+# ---------------------------------------------------------------------------
+# Early typing indicator (ingestion) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_early_typing_indicator_published_on_inbound() -> None:
+    """process_inbound_from_bus should publish a typing indicator before dispatch."""
+    inbound = InboundMessage(
+        channel="bluebubbles",
+        sender_id="+15551234567",
+        text="hello",
+    )
+
+    mock_user = User(id="1", channel_identifier="+15551234567", phone="")
+    mock_session = SessionState(session_id="sess-1", user_id="1")
+    mock_message = StoredMessage(direction="inbound", body="hello")
+
+    with (
+        patch(
+            "backend.app.agent.ingestion._get_or_create_user",
+            new_callable=AsyncMock,
+            return_value=mock_user,
+        ),
+        patch(
+            "backend.app.agent.ingestion.get_approval_gate",
+        ) as mock_gate,
+        patch(
+            "backend.app.agent.ingestion.get_or_create_conversation",
+            new_callable=AsyncMock,
+            return_value=(mock_session, True),
+        ),
+        patch(
+            "backend.app.agent.ingestion.get_session_store",
+        ) as mock_store_fn,
+        patch(
+            "backend.app.agent.ingestion.settings",
+        ) as mock_settings,
+        patch(
+            "backend.app.agent.ingestion._dispatch_to_pipeline",
+            new_callable=AsyncMock,
+        ) as mock_dispatch,
+    ):
+        mock_gate.return_value.has_pending.return_value = False
+        mock_session_store = AsyncMock()
+        mock_session_store.add_message.return_value = mock_message
+        mock_store_fn.return_value = mock_session_store
+        mock_settings.message_batch_window_ms = 0
+
+        await process_inbound_from_bus(inbound)
+
+        # A typing indicator should have been published to the bus
+        typing_found = False
+        while not message_bus.outbound.empty():
+            outbound = message_bus.outbound.get_nowait()
+            if outbound.is_typing_indicator:
+                assert outbound.channel == "bluebubbles"
+                assert outbound.chat_id == "+15551234567"
+                typing_found = True
+                break
+        assert typing_found, "Expected an early typing indicator on the outbound bus"
+
+        # Pipeline dispatch should still have been called
+        mock_dispatch.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_early_typing_indicator_swallows_bus_errors() -> None:
+    """_send_early_typing_indicator should not raise even when the bus fails."""
+    from backend.app.agent.ingestion import _send_early_typing_indicator
+
+    with patch("backend.app.bus.message_bus") as mock_bus:
+        mock_bus.publish_outbound = AsyncMock(side_effect=RuntimeError("bus exploded"))
+
+        # Should not raise
+        await _send_early_typing_indicator("bluebubbles", "+15551234567")


### PR DESCRIPTION
## Description
Send a typing indicator immediately when an inbound message is accepted, before the heavy pipeline processing (user lookup, session management, media processing, context building). This gives the user instant feedback that the agent saw their message within ~200ms instead of waiting 2-5 seconds for the first LLM call.

Also adds an error fallback in the ChannelManager so if `process_inbound_from_bus` crashes after the typing indicator fires, the user always gets an error reply instead of a dangling typing bubble.

**Note:** Typing indicators require `BLUEBUBBLES_SEND_METHOD=private-api` (the BlueBubbles Private API must be enabled on the server). The default `apple-script` method silently skips typing indicators at the channel level.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Changes
- `backend/app/agent/ingestion.py`: Added `_send_early_typing_indicator()` helper and call after message persistence, before pipeline dispatch
- `backend/app/channels/manager.py`: Added error fallback in `_handle_inbound()` when `process_inbound_from_bus` crashes
- `tests/test_typing_indicator.py`: Two new tests (happy path + error resilience)
- `tests/test_channels.py`: One new test for the error fallback path

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code, plan + implementation + review)
- [ ] No AI used