### PR TITLE
feat: use Intuit discovery document for QBO OAuth endpoints and capture intuit_tid

### DIFF
--- a/backend/app/agent/tools/quickbooks_tools.py
+++ b/backend/app/agent/tools/quickbooks_tools.py
@@ -14,6 +14,7 @@ from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolR
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
 from backend.app.services.oauth import (
+    _get_intuit_endpoints,
     oauth_service,
 )
 from backend.app.services.quickbooks_service import (
@@ -516,6 +517,7 @@ async def _get_quickbooks_service_for_user(user_id: str) -> QuickBooksService | 
     """Build a QuickBooks service using OAuth tokens for the given user."""
     token = await oauth_service.get_valid_token(user_id, "quickbooks")
     if token and token.access_token and token.realm_id:
+        _, token_url = _get_intuit_endpoints()
         return QuickBooksOnlineService(
             client_id=settings.quickbooks_client_id,
             client_secret=settings.quickbooks_client_secret,
@@ -524,6 +526,7 @@ async def _get_quickbooks_service_for_user(user_id: str) -> QuickBooksService | 
             refresh_token=token.refresh_token,
             environment=settings.quickbooks_environment,
             on_token_refresh=oauth_service.build_on_refresh_callback(user_id, "quickbooks"),
+            token_url=token_url,
         )
     return None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -191,6 +191,14 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     validate_imessage_backend()
     validate_personal_storage_backend()
     log_config_warnings()
+
+    # Warm the Intuit discovery document cache so QuickBooks OAuth
+    # endpoints are resolved from the discovery document rather than
+    # hardcoded URLs.
+    from backend.app.services.oauth import warm_intuit_discovery
+
+    await warm_intuit_discovery()
+
     await _verify_llm_settings()
     heartbeat_scheduler.start()
 

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -30,6 +30,12 @@ logger = logging.getLogger(__name__)
 # Token expiry buffer: refresh 5 minutes before actual expiry.
 _EXPIRY_BUFFER_SECONDS = 300
 
+# Intuit discovery document URL (OpenID Connect configuration).
+_INTUIT_DISCOVERY_URL = "https://developer.api.intuit.com/.well-known/openid_configuration"
+
+# Cache TTL for the discovery document (24 hours).
+_DISCOVERY_CACHE_TTL_SECONDS = 86400
+
 # OAuth state entries expire after 10 minutes.
 _STATE_TTL_SECONDS = 600
 
@@ -42,6 +48,61 @@ _PERMANENT_OAUTH_ERROR_CODES = frozenset(
         "unauthorized_client",
     }
 )
+
+
+# ---------------------------------------------------------------------------
+# Intuit discovery document cache
+# ---------------------------------------------------------------------------
+
+_intuit_discovery_cache: dict[str, Any] = {}
+_intuit_discovery_fetched_at: float = 0.0
+
+
+async def warm_intuit_discovery() -> None:
+    """Fetch and cache the Intuit OpenID Connect discovery document.
+
+    Called at app startup so that ``get_quickbooks_oauth_config()`` can
+    resolve endpoints from the discovery document instead of relying on
+    hardcoded URLs. Failures are logged and swallowed; the hardcoded
+    fallback URLs will be used until the next successful fetch.
+    """
+    global _intuit_discovery_cache, _intuit_discovery_fetched_at
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(_INTUIT_DISCOVERY_URL)
+            resp.raise_for_status()
+            _intuit_discovery_cache = resp.json()
+            _intuit_discovery_fetched_at = time.time()
+            logger.info(
+                "Intuit discovery document cached: authorization_endpoint=%s token_endpoint=%s",
+                _intuit_discovery_cache.get("authorization_endpoint"),
+                _intuit_discovery_cache.get("token_endpoint"),
+            )
+    except Exception:
+        logger.warning(
+            "Failed to fetch Intuit discovery document from %s, "
+            "falling back to hardcoded endpoints",
+            _INTUIT_DISCOVERY_URL,
+            exc_info=True,
+        )
+
+
+def _get_intuit_endpoints() -> tuple[str, str]:
+    """Return (authorize_url, token_url) from the discovery cache or fallbacks.
+
+    If the cache is stale (older than ``_DISCOVERY_CACHE_TTL_SECONDS``) or
+    missing, falls back to the hardcoded endpoint constants.
+    """
+    if (
+        _intuit_discovery_cache
+        and (time.time() - _intuit_discovery_fetched_at) < _DISCOVERY_CACHE_TTL_SECONDS
+    ):
+        authorize = _intuit_discovery_cache.get(
+            "authorization_endpoint", _QBO_AUTHORIZE_URL_FALLBACK
+        )
+        token = _intuit_discovery_cache.get("token_endpoint", _QBO_TOKEN_URL_FALLBACK)
+        return authorize, token
+    return _QBO_AUTHORIZE_URL_FALLBACK, _QBO_TOKEN_URL_FALLBACK
 
 
 @dataclass
@@ -671,9 +732,10 @@ oauth_service = OAuthService()
 # Integration-specific config builders
 # ---------------------------------------------------------------------------
 
-# QuickBooks OAuth 2.0 endpoints
-QBO_AUTHORIZE_URL = "https://appcenter.intuit.com/connect/oauth2"
-QBO_TOKEN_URL = "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
+# QuickBooks OAuth 2.0 endpoint fallbacks (used when the Intuit discovery
+# document is unavailable or stale).
+_QBO_AUTHORIZE_URL_FALLBACK = "https://appcenter.intuit.com/connect/oauth2"
+_QBO_TOKEN_URL_FALLBACK = "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
 QBO_SCOPES = ["com.intuit.quickbooks.accounting"]
 
 # Google Calendar OAuth 2.0 endpoints
@@ -694,13 +756,20 @@ _OAUTH_INTEGRATIONS = ("quickbooks", "google_calendar", "companycam")
 
 
 def get_quickbooks_oauth_config() -> OAuthConfig | None:
-    """Build the QuickBooks OAuth config from settings."""
+    """Build the QuickBooks OAuth config from settings.
+
+    Endpoint URLs are resolved from the Intuit OpenID Connect discovery
+    document when available (populated by ``warm_intuit_discovery()`` at
+    startup). Falls back to hardcoded URLs if the discovery document has
+    not been fetched or is stale.
+    """
+    authorize_url, token_url = _get_intuit_endpoints()
     config = OAuthConfig(
         integration="quickbooks",
         client_id=settings.quickbooks_client_id,
         client_secret=settings.quickbooks_client_secret,
-        authorize_url=QBO_AUTHORIZE_URL,
-        token_url=QBO_TOKEN_URL,
+        authorize_url=authorize_url,
+        token_url=token_url,
         scopes=QBO_SCOPES,
     )
     return config if config.is_configured else None

--- a/backend/app/services/quickbooks_service.py
+++ b/backend/app/services/quickbooks_service.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 
 QBO_SANDBOX_BASE = "https://sandbox-quickbooks.api.intuit.com"
 QBO_PRODUCTION_BASE = "https://quickbooks.api.intuit.com"
-QBO_TOKEN_URL = "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
 
 
 class QuickBooksService(ABC):
@@ -55,6 +54,7 @@ class QuickBooksOnlineService(QuickBooksService):
         refresh_token: str,
         environment: str = "sandbox",
         on_token_refresh: Callable[[str, str, float], None] | None = None,
+        token_url: str = "",
     ) -> None:
         self._client_id = client_id
         self._client_secret = client_secret
@@ -62,6 +62,7 @@ class QuickBooksOnlineService(QuickBooksService):
         self._access_token = access_token
         self._refresh_token = refresh_token
         self._on_token_refresh = on_token_refresh
+        self._token_url = token_url or "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
         self._token_expires_at = 0.0
         base = QBO_PRODUCTION_BASE if environment == "production" else QBO_SANDBOX_BASE
         self._api_base = f"{base}/v3/company/{realm_id}"
@@ -70,7 +71,7 @@ class QuickBooksOnlineService(QuickBooksService):
         """Refresh the OAuth2 access token using the refresh token."""
         logger.info("Refreshing QuickBooks access token")
         resp = await client.post(
-            QBO_TOKEN_URL,
+            self._token_url,
             data={
                 "grant_type": "refresh_token",
                 "refresh_token": self._refresh_token,
@@ -86,6 +87,23 @@ class QuickBooksOnlineService(QuickBooksService):
             self._token_expires_at = time.time() + data["expires_in"]
         if self._on_token_refresh:
             self._on_token_refresh(self._access_token, self._refresh_token, self._token_expires_at)
+
+    @staticmethod
+    def _log_intuit_tid(resp: httpx.Response, *, level: int = logging.DEBUG) -> str:
+        """Extract and log the intuit_tid header for request tracing.
+
+        Returns the tid value (empty string when absent) so callers can
+        include it in error messages forwarded to the user.
+        """
+        tid = resp.headers.get("intuit_tid", "")
+        if tid:
+            logger.log(
+                level,
+                "QBO response: status=%s intuit_tid=%s",
+                resp.status_code,
+                tid,
+            )
+        return tid
 
     async def _request(
         self,
@@ -105,13 +123,20 @@ class QuickBooksOnlineService(QuickBooksService):
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.request(method, url, headers=headers, json=json, params=params)
+            self._log_intuit_tid(resp)
 
             if resp.status_code == 401:
                 await self._refresh_access_token(client)
                 headers["Authorization"] = f"Bearer {self._access_token}"
                 resp = await client.request(method, url, headers=headers, json=json, params=params)
+                self._log_intuit_tid(resp)
 
-            resp.raise_for_status()
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPStatusError:
+                self._log_intuit_tid(resp, level=logging.WARNING)
+                raise
+
             return resp.json()
 
     async def query(self, query_str: str) -> list[dict[str, Any]]:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -12,20 +12,24 @@ from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
 import backend.app.database as _db_module
+import backend.app.services.oauth as _oauth_module
 from backend.app.auth.dependencies import get_current_user
 from backend.app.config import settings
 from backend.app.main import app
 from backend.app.models import User
 from backend.app.services.oauth import (
+    _DISCOVERY_CACHE_TTL_SECONDS,
     OAuthConfig,
     OAuthService,
     OAuthTokenData,
     _generate_pkce_pair,
+    _get_intuit_endpoints,
     get_companycam_oauth_config,
     get_google_calendar_oauth_config,
     get_oauth_config,
     get_quickbooks_oauth_config,
     oauth_service,
+    warm_intuit_discovery,
 )
 
 # ---------------------------------------------------------------------------
@@ -877,3 +881,104 @@ def test_web_callback_still_redirects(
 
     assert resp.status_code == 302
     assert "/app/oauth/callback?status=success" in resp.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# Intuit discovery document tests
+# ---------------------------------------------------------------------------
+
+_FAKE_DISCOVERY = {
+    "authorization_endpoint": "https://discovered.intuit.com/oauth2/authorize",
+    "token_endpoint": "https://discovered.intuit.com/oauth2/token",
+    "userinfo_endpoint": "https://discovered.intuit.com/userinfo",
+    "issuer": "https://oauth.platform.intuit.com/op/v1",
+}
+
+
+@pytest.fixture(autouse=False)
+def _reset_discovery_cache() -> Generator[None]:
+    """Reset the module-level discovery cache before and after each test."""
+    _oauth_module._intuit_discovery_cache.clear()
+    _oauth_module._intuit_discovery_fetched_at = 0.0
+    yield
+    _oauth_module._intuit_discovery_cache.clear()
+    _oauth_module._intuit_discovery_fetched_at = 0.0
+
+
+@pytest.mark.asyncio()
+async def test_warm_intuit_discovery_success(_reset_discovery_cache: None) -> None:
+    """Successful discovery fetch should cache endpoints."""
+    mock_resp = httpx.Response(200, json=_FAKE_DISCOVERY, request=httpx.Request("GET", "https://x"))
+    with patch("backend.app.services.oauth.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_cls.return_value = mock_client
+
+        await warm_intuit_discovery()
+
+    assert _oauth_module._intuit_discovery_cache["authorization_endpoint"] == (
+        "https://discovered.intuit.com/oauth2/authorize"
+    )
+    assert _oauth_module._intuit_discovery_cache["token_endpoint"] == (
+        "https://discovered.intuit.com/oauth2/token"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_warm_intuit_discovery_failure_swallowed(_reset_discovery_cache: None) -> None:
+    """Failed discovery fetch should not raise; cache stays empty."""
+    with patch("backend.app.services.oauth.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.ConnectError("network error")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_cls.return_value = mock_client
+
+        await warm_intuit_discovery()
+
+    assert _oauth_module._intuit_discovery_cache == {}
+
+
+def test_get_intuit_endpoints_from_cache(_reset_discovery_cache: None) -> None:
+    """When the discovery cache is warm, endpoints come from it."""
+    _oauth_module._intuit_discovery_cache.update(_FAKE_DISCOVERY)
+    _oauth_module._intuit_discovery_fetched_at = time.time()
+
+    authorize, token = _get_intuit_endpoints()
+    assert authorize == "https://discovered.intuit.com/oauth2/authorize"
+    assert token == "https://discovered.intuit.com/oauth2/token"
+
+
+def test_get_intuit_endpoints_fallback_when_empty(_reset_discovery_cache: None) -> None:
+    """When the discovery cache is empty, hardcoded fallbacks are returned."""
+    authorize, token = _get_intuit_endpoints()
+    assert authorize == "https://appcenter.intuit.com/connect/oauth2"
+    assert token == "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
+
+
+def test_get_intuit_endpoints_fallback_when_stale(_reset_discovery_cache: None) -> None:
+    """When the cache is older than the TTL, fallbacks are returned."""
+    _oauth_module._intuit_discovery_cache.update(_FAKE_DISCOVERY)
+    _oauth_module._intuit_discovery_fetched_at = time.time() - _DISCOVERY_CACHE_TTL_SECONDS - 1
+
+    authorize, token = _get_intuit_endpoints()
+    assert authorize == "https://appcenter.intuit.com/connect/oauth2"
+    assert token == "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
+
+
+def test_quickbooks_config_uses_discovery_endpoints(_reset_discovery_cache: None) -> None:
+    """get_quickbooks_oauth_config should use discovery endpoints when cached."""
+    _oauth_module._intuit_discovery_cache.update(_FAKE_DISCOVERY)
+    _oauth_module._intuit_discovery_fetched_at = time.time()
+
+    with (
+        patch.object(settings, "quickbooks_client_id", "cid"),
+        patch.object(settings, "quickbooks_client_secret", "csec"),
+    ):
+        config = get_quickbooks_oauth_config()
+
+    assert config is not None
+    assert config.authorize_url == "https://discovered.intuit.com/oauth2/authorize"
+    assert config.token_url == "https://discovered.intuit.com/oauth2/token"


### PR DESCRIPTION
## Description

Two changes required for the QBO production API app assessment questionnaire:

1. **Intuit discovery document**: Resolve QuickBooks OAuth endpoints (`authorization_endpoint`, `token_endpoint`) from the [Intuit OpenID Connect discovery document](https://developer.api.intuit.com/.well-known/openid_configuration) instead of hardcoding them. The document is fetched and cached at app startup with a 24-hour TTL. If the fetch fails, hardcoded fallback URLs are used. The discovered token URL is also passed through to `QuickBooksOnlineService` for mid-call token refresh.

2. **`intuit_tid` capture**: Log the `intuit_tid` response header from every QBO API response. Logged at DEBUG on success and WARNING on errors, so support can reference it when troubleshooting with Intuit.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented both features, wrote tests, and verified lint/test pass)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)