### PR TITLE
fix: self-heal missing BOOTSTRAP.md and tighten onboarding detection

### DIFF
--- a/backend/app/agent/onboarding.py
+++ b/backend/app/agent/onboarding.py
@@ -70,15 +70,60 @@ def is_onboarding_complete_heuristic(user: User) -> bool:
 def is_onboarding_needed(user: User) -> bool:
     """Check if user needs onboarding.
 
-    Returns False once onboarding_complete is set, or if BOOTSTRAP.md
-    no longer exists in the user's directory, or if heuristic evidence
-    shows the user has already completed onboarding.
+    Returns False once onboarding_complete is set, or if heuristic evidence
+    shows the user has already completed onboarding (real name in user_text
+    or a custom soul_text).
+
+    Self-heal: if onboarding_complete is False and the heuristic shows no
+    evidence of a prior onboarding, a missing BOOTSTRAP.md is re-written
+    from the default template. This recovers from accidental deletions or
+    a re-signup after an admin purge where the on-disk file was wiped but
+    the user's onboarding flag remained False. Without this, a missing
+    BOOTSTRAP.md would silently skip onboarding forever.
     """
     if user.onboarding_complete:
+        logger.debug(
+            "is_onboarding_needed(user=%s)=False: onboarding_complete flag set",
+            user.id,
+        )
         return False
-    if not _bootstrap_path(user).exists():
+
+    if is_onboarding_complete_heuristic(user):
+        logger.debug(
+            "is_onboarding_needed(user=%s)=False: heuristic detected existing profile "
+            "(name_set=%s custom_soul=%s)",
+            user.id,
+            _has_real_user_profile(user),
+            _has_custom_soul(user),
+        )
         return False
-    return not is_onboarding_complete_heuristic(user)
+
+    bootstrap = _bootstrap_path(user)
+    if not bootstrap.exists():
+        try:
+            bootstrap.parent.mkdir(parents=True, exist_ok=True)
+            bootstrap.write_text(load_prompt("bootstrap") + "\n", encoding="utf-8")
+            logger.warning(
+                "is_onboarding_needed(user=%s): BOOTSTRAP.md was missing but user "
+                "has no onboarding evidence; re-created from template. This usually "
+                "means provision_user did not run (OAuth re-login after admin delete?) "
+                "or the file was wiped from disk. Onboarding will proceed.",
+                user.id,
+            )
+        except OSError:
+            logger.exception(
+                "is_onboarding_needed(user=%s): failed to re-create BOOTSTRAP.md; "
+                "skipping onboarding this turn",
+                user.id,
+            )
+            return False
+
+    logger.debug(
+        "is_onboarding_needed(user=%s)=True: onboarding_complete=False, "
+        "no heuristic evidence, BOOTSTRAP.md present",
+        user.id,
+    )
+    return True
 
 
 def _get_tool_capability_descriptions() -> list[str]:
@@ -226,11 +271,19 @@ class OnboardingSubscriber:
             self._user.onboarding_complete = True
             return
 
-        # Pre-populated user: BOOTSTRAP.md doesn't exist but flag was never set
-        if not is_onboarding_needed(self._user):
+        # Pre-populated user: not in onboarding this turn, and heuristic shows
+        # positive evidence of a prior profile (name set or custom soul). This
+        # catches migrated users whose onboarding_complete flag was never
+        # flipped. Requires heuristic evidence. A bare user with no profile
+        # data must go through onboarding via the self-heal in
+        # is_onboarding_needed.
+        if not self._was_onboarding and is_onboarding_complete_heuristic(self._user):
             logger.info(
-                "Onboarding complete for user %s: pre-populated user",
+                "Onboarding complete for user %s: pre-populated profile detected "
+                "(name_set=%s custom_soul=%s)",
                 self._user.id,
+                _has_real_user_profile(self._user),
+                _has_custom_soul(self._user),
             )
             db = SessionLocal()
             try:

--- a/backend/app/agent/user_db.py
+++ b/backend/app/agent/user_db.py
@@ -30,11 +30,15 @@ def provision_user(user: User, db: object | None = None) -> None:
     populated when onboarding completes (see ``OnboardingSubscriber``).
     Creates the on-disk data directory for BOOTSTRAP.md and other files
     that still live on the filesystem.
+
+    Idempotent: safe to call on returning users. Only seeds fields that
+    are currently empty and only writes BOOTSTRAP.md if missing and the
+    user is not already onboarded.
     """
     from sqlalchemy.orm import Session as SASession
 
     # Seed DB text columns with default templates
-    needs_commit = False
+    seeded: list[str] = []
     own_session = db is None
     if own_session:
         db = SessionLocal()
@@ -45,11 +49,11 @@ def provision_user(user: User, db: object | None = None) -> None:
         if db_user is not None:
             if not db_user.soul_text:
                 db_user.soul_text = f"# Soul\n\n{load_prompt('default_soul')}\n"
-                needs_commit = True
+                seeded.append("soul_text")
             if not db_user.user_text:
                 db_user.user_text = f"# User\n\n{load_prompt('default_user')}\n"
-                needs_commit = True
-            if needs_commit:
+                seeded.append("user_text")
+            if seeded:
                 db.commit()
                 db.refresh(db_user)
                 # Update the in-memory user object so callers see the seeded values
@@ -64,8 +68,20 @@ def provision_user(user: User, db: object | None = None) -> None:
     user_dir.mkdir(parents=True, exist_ok=True)
 
     bootstrap_path = user_dir / "BOOTSTRAP.md"
+    bootstrap_written = False
     if not bootstrap_path.exists() and not user.onboarding_complete:
         bootstrap_path.write_text(load_prompt("bootstrap") + "\n", encoding="utf-8")
+        bootstrap_written = True
+
+    logger.info(
+        "provision_user(user=%s): seeded=%s bootstrap_written=%s "
+        "onboarding_complete=%s data_dir=%s",
+        user.id,
+        seeded or "none",
+        bootstrap_written,
+        user.onboarding_complete,
+        user_dir,
+    )
 
 
 def _user_to_dto(user: User) -> UserData:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -69,13 +69,38 @@ def test_is_onboarding_needed_new_user() -> None:
     assert is_onboarding_needed(user) is True
 
 
-def test_is_onboarding_needed_no_bootstrap() -> None:
-    """User without BOOTSTRAP.md should not need onboarding."""
+def test_is_onboarding_needed_self_heals_missing_bootstrap() -> None:
+    """Missing BOOTSTRAP.md is self-healed for a user with no profile evidence.
+
+    Regression: previously a missing BOOTSTRAP.md silently returned False,
+    so a user whose file was wiped (e.g. OAuth re-login after admin delete,
+    ephemeral disk loss) would never get onboarded.
+    """
     user = User(id="2", user_id="no-bootstrap-user", phone="+15550002222")
-    # Ensure user dir exists but no BOOTSTRAP.md
     cdir = Path(settings.data_dir) / str(user.id)
     cdir.mkdir(parents=True, exist_ok=True)
+    bootstrap = cdir / "BOOTSTRAP.md"
+    assert not bootstrap.exists()
+
+    assert is_onboarding_needed(user) is True
+    assert bootstrap.exists()
+
+
+def test_is_onboarding_needed_no_selfheal_when_heuristic_complete() -> None:
+    """Missing BOOTSTRAP.md is NOT re-created when heuristic says onboarded."""
+    user = User(
+        id="2b",
+        user_id="truly-prepopulated",
+        phone="+15550002223",
+        user_text="# User\n\n- Name: Nathan\n- Trade: GC\n",
+    )
+    cdir = Path(settings.data_dir) / str(user.id)
+    cdir.mkdir(parents=True, exist_ok=True)
+    bootstrap = cdir / "BOOTSTRAP.md"
+    assert not bootstrap.exists()
+
     assert is_onboarding_needed(user) is False
+    assert not bootstrap.exists()
 
 
 def test_is_onboarding_needed_complete_profile(test_user: User) -> None:
@@ -144,13 +169,15 @@ def test_provision_skips_bootstrap_when_onboarding_complete() -> None:
         db.close()
 
 
-def test_is_onboarding_needed_bootstrap_deleted() -> None:
-    """After BOOTSTRAP.md is deleted, onboarding is not needed."""
+def test_is_onboarding_needed_bootstrap_deleted_selfheals() -> None:
+    """Deleting BOOTSTRAP.md for an un-onboarded user re-creates it (self-heal)."""
     user = User(id="4", user_id="deleted-bootstrap-user", phone="+15550003333")
     _create_bootstrap(user)
     assert is_onboarding_needed(user) is True
     _remove_bootstrap(user)
-    assert is_onboarding_needed(user) is False
+    # Self-heal: no heuristic evidence, so BOOTSTRAP.md is re-written
+    assert is_onboarding_needed(user) is True
+    assert (Path(settings.data_dir) / str(user.id) / "BOOTSTRAP.md").exists()
 
 
 def test_build_onboarding_system_prompt_new_user() -> None:
@@ -411,11 +438,13 @@ async def test_complete_profile_uses_normal_prompt(
 async def test_prepopulated_user_gets_onboarding_complete(
     mock_amessages: object,
 ) -> None:
-    """User without BOOTSTRAP.md should get onboarding_complete=True.
+    """User with heuristic evidence of a prior profile gets onboarding_complete=True.
 
-    Regression test for #180: when BOOTSTRAP.md doesn't exist,
-    is_onboarding_needed() returns False but onboarding_complete was never set
-    because the 'if onboarding:' block was skipped entirely.
+    Covers migrated users whose onboarding_complete flag was never flipped
+    but whose user_text already has a real name. The OnboardingSubscriber
+    "pre-populated" branch requires heuristic evidence so that users with
+    a genuinely empty profile still go through onboarding (via the
+    is_onboarding_needed self-heal).
     """
     db = _db_module.SessionLocal()
     try:
@@ -425,6 +454,7 @@ async def test_prepopulated_user_gets_onboarding_complete(
                 user_id="prepopulated-user",
                 channel_identifier="888888888",
                 preferred_channel="telegram",
+                user_text="# User\n\n- Name: Nathan\n- Trade: GC\n",
             )
         )
         db.commit()
@@ -437,10 +467,9 @@ async def test_prepopulated_user_gets_onboarding_complete(
         channel_identifier="888888888",
         preferred_channel="telegram",
         onboarding_complete=False,
+        user_text="# User\n\n- Name: Nathan\n- Trade: GC\n",
     )
-    # No BOOTSTRAP.md created, so not onboarding
-
-    # Sanity: flag is not set but onboarding is not needed
+    # No BOOTSTRAP.md; heuristic should say not-needed
     assert not user.onboarding_complete
     assert not is_onboarding_needed(user)
 
@@ -487,6 +516,77 @@ async def test_prepopulated_user_gets_onboarding_complete(
 
 
 @pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_empty_user_without_bootstrap_self_heals_and_onboards(
+    mock_amessages: object,
+) -> None:
+    """An empty user with no BOOTSTRAP.md self-heals and enters onboarding.
+
+    Regression: previously such a user was auto-marked onboarding_complete=True
+    (the "pre-populated" branch fired on empty profiles too). This hid the
+    real bug where BOOTSTRAP.md had been wiped (e.g. OAuth re-login after
+    admin delete) and silently skipped onboarding forever.
+    """
+    db = _db_module.SessionLocal()
+    try:
+        db.add(
+            User(
+                id="30b",
+                user_id="empty-user",
+                channel_identifier="888888889",
+                preferred_channel="telegram",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    user = User(
+        id="30b",
+        user_id="empty-user",
+        channel_identifier="888888889",
+        preferred_channel="telegram",
+        onboarding_complete=False,
+    )
+    # No BOOTSTRAP.md yet, no user_text / soul_text
+
+    session = SessionState(
+        session_id="empty-user-session",
+        user_id=user.id,
+        is_active=True,
+        messages=[
+            StoredMessage(direction="inbound", body="hi", seq=1),
+        ],
+    )
+    _ensure_session_on_disk(user, session)
+    message = StoredMessage(direction="inbound", body="hi", seq=1)
+
+    mock_amessages.return_value = make_text_response("Hi there!")  # type: ignore[union-attr]
+
+    await handle_inbound_message(
+        user=user,
+        session=session,
+        message=message,
+        media_urls=[],
+        channel="telegram",
+    )
+
+    # BOOTSTRAP.md should have been re-created by the self-heal
+    assert (Path(settings.data_dir) / str(user.id) / "BOOTSTRAP.md").exists()
+
+    db = _db_module.SessionLocal()
+    try:
+        refreshed = db.query(User).filter_by(id=user.id).first()
+        if refreshed:
+            db.expunge(refreshed)
+    finally:
+        db.close()
+    assert refreshed is not None
+    # Still onboarding: flag was NOT auto-flipped
+    assert refreshed.onboarding_complete is False
+
+
+@pytest.mark.asyncio()
 @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
 @patch("backend.app.agent.core.amessages")
 async def test_prepopulated_user_included_in_heartbeat(
@@ -506,6 +606,7 @@ async def test_prepopulated_user_included_in_heartbeat(
                 channel_identifier="777777777",
                 preferred_channel="telegram",
                 heartbeat_text="- Check weather for outdoor jobs",
+                user_text="# User\n\n- Name: Jake\n- Trade: roofer\n",
             )
         )
         db.commit()
@@ -519,6 +620,7 @@ async def test_prepopulated_user_included_in_heartbeat(
         channel_identifier="777777777",
         preferred_channel="telegram",
         onboarding_complete=False,
+        user_text="# User\n\n- Name: Jake\n- Trade: roofer\n",
     )
 
     session = SessionState(


### PR DESCRIPTION
## Description

Onboarding was silently skipped for users whose BOOTSTRAP.md was missing on disk — most reproducibly after an OAuth re-login following an admin delete, or any disk loss. The gate `is_onboarding_needed()` returned False when the file was absent, and `OnboardingSubscriber` then auto-flipped `onboarding_complete=True`, locking the user out of onboarding forever.

Three fixes:

1. **Self-heal in `is_onboarding_needed`.** If the user isn't onboarded and the heuristic shows no evidence of a prior profile (no real name in `user_text`, no custom `soul_text`), re-write BOOTSTRAP.md from the template and proceed with onboarding. Logs a WARNING so the recovery is visible.

2. **Tighter "pre-populated user" branch in `OnboardingSubscriber`.** It no longer auto-completes onboarding whenever `is_onboarding_needed` returns False. It now requires positive heuristic evidence — the branch exists to catch migrated users, and should not fire on empty profiles.

3. **Observability.** `provision_user` logs `seeded=... bootstrap_written=... onboarding_complete=... data_dir=...`. `is_onboarding_needed` logs its decision and the reason at every branch. Next time this happens, `grep provision_user` and `grep is_onboarding_needed` answer it.

Companion PR in clawbolt-premium clears `user_text`/`heartbeat_text` on soft-delete and re-runs `provision_user` on OAuth re-login.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 1732 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

New/updated tests:
- `test_is_onboarding_needed_self_heals_missing_bootstrap` — missing BOOTSTRAP.md + no profile → re-created
- `test_is_onboarding_needed_no_selfheal_when_heuristic_complete` — missing BOOTSTRAP.md + filled name → no re-create
- `test_is_onboarding_needed_bootstrap_deleted_selfheals` — deletion is recovered
- `test_empty_user_without_bootstrap_self_heals_and_onboards` — empty user goes through onboarding instead of being silently marked complete
- `test_prepopulated_user_gets_onboarding_complete` updated to require heuristic evidence
- `test_prepopulated_user_included_in_heartbeat` updated likewise

## AI Usage
- [x] AI-assisted (describe how)

Claude Code used for investigation, implementation, and test updates. Human-reviewed.