### PR TITLE
fix: make onboarding_complete backend-owned so BOOTSTRAP.md runs

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -51,6 +51,14 @@ class UserProfileResponse(BaseModel):
 
 
 class UserProfileUpdate(BaseModel):
+    """Fields the client is allowed to update on the current user.
+
+    ``onboarding_complete`` is deliberately not writable here. It is owned by
+    the backend (set by ``OnboardingSubscriber`` when the LLM deletes
+    BOOTSTRAP.md or heuristic evidence appears) so the conversational
+    onboarding can't be short-circuited by the UI.
+    """
+
     phone: str | None = None
     timezone: str | None = None
     soul_text: str | None = None
@@ -59,7 +67,6 @@ class UserProfileUpdate(BaseModel):
     heartbeat_opt_in: bool | None = None
     heartbeat_frequency: str | None = None
     heartbeat_max_daily: int | None = Field(default=None, ge=0)
-    onboarding_complete: bool | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
 
 /**
  * Wait for the OSS app to be fully loaded.
@@ -21,18 +22,33 @@ export async function navigateToChat(page: Page): Promise<void> {
 }
 
 /**
- * Complete onboarding by marking onboarding_complete=true via the API.
- * This avoids the get-started redirect so tests can go straight to /app/dashboard.
+ * Mark the OSS single-tenant user as onboarded so tests can skip the
+ * get-started redirect and exercise the dashboard experience.
+ *
+ * onboarding_complete is backend-owned (flipped by OnboardingSubscriber
+ * when the LLM deletes BOOTSTRAP.md or heuristic evidence appears), so
+ * there is no HTTP endpoint to flip it directly. For tests we write the
+ * flag to the database the server is already using.
+ *
+ * The baseUrl parameter is accepted for backward compatibility but unused.
  */
 export async function completeOnboarding(baseUrl: string): Promise<void> {
-  const res = await fetch(`${baseUrl}/api/user/profile`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ onboarding_complete: true }),
-  });
+  // Ensure the OSS single-tenant user exists before updating it. GET
+  // /api/user/profile triggers get_current_user, which lazily creates
+  // the local user on first access.
+  const res = await fetch(`${baseUrl}/api/user/profile`);
   if (!res.ok) {
-    throw new Error(`Failed to complete onboarding: ${res.status} ${await res.text()}`);
+    throw new Error(`Failed to ensure user exists: ${res.status} ${await res.text()}`);
   }
+
+  const dbUrl =
+    process.env.DATABASE_URL ??
+    'postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_e2e';
+  execFileSync(
+    'psql',
+    [dbUrl, '-v', 'ON_ERROR_STOP=1', '-c', 'UPDATE users SET onboarding_complete = true;'],
+    { stdio: 'pipe' },
+  );
 }
 
 /**

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2931,21 +2931,11 @@
               }
             ],
             "title": "Heartbeat Max Daily"
-          },
-          "onboarding_complete": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Onboarding Complete"
           }
         },
         "type": "object",
-        "title": "UserProfileUpdate"
+        "title": "UserProfileUpdate",
+        "description": "Fields the client is allowed to update on the current user.\n\n``onboarding_complete`` is deliberately not writable here. It is owned by\nthe backend (set by ``OnboardingSubscriber`` when the LLM deletes\nBOOTSTRAP.md or heuristic evidence appears) so the conversational\nonboarding can't be short-circuited by the UI."
       },
       "ValidationError": {
         "properties": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,7 +34,9 @@ const GetStartedPage = lazy(() => import('@/pages/GetStartedPage'));
 function DefaultRedirect() {
   const { profile } = useOutletContext<AppShellContext>();
   if (profile && !profile.onboarding_complete) {
-    if (sessionStorage.getItem('getStartedDismissed') === '1') {
+    let dismissed = false;
+    try { dismissed = sessionStorage.getItem('getStartedDismissed') === '1'; } catch { /* ignore */ }
+    if (dismissed) {
       return <Navigate to="/app/chat" replace />;
     }
     return <Navigate to="/app/get-started" replace />;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,10 +24,19 @@ const ToolsPage = lazy(() => import('@/pages/ToolsPage'));
 const OAuthCallbackPage = lazy(() => import('@/pages/OAuthCallbackPage'));
 const GetStartedPage = lazy(() => import('@/pages/GetStartedPage'));
 
-/** Redirect index to get-started if onboarding is incomplete, otherwise to dashboard. */
+/** Redirect index to get-started if onboarding is incomplete, otherwise to dashboard.
+ *
+ * Once the user dismisses the Get Started card, we set a sessionStorage flag so
+ * a refresh or tab reopen within the same session skips straight to chat
+ * instead of bouncing back to the wizard while the LLM still works through
+ * its BOOTSTRAP.md conversation.
+ */
 function DefaultRedirect() {
   const { profile } = useOutletContext<AppShellContext>();
   if (profile && !profile.onboarding_complete) {
+    if (sessionStorage.getItem('getStartedDismissed') === '1') {
+      return <Navigate to="/app/chat" replace />;
+    }
     return <Navigate to="/app/get-started" replace />;
   }
   return <Navigate to="/app/dashboard" replace />;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1325,7 +1325,15 @@ export interface components {
             /** Updated At */
             updated_at: string;
         };
-        /** UserProfileUpdate */
+        /**
+         * UserProfileUpdate
+         * @description Fields the client is allowed to update on the current user.
+         *
+         *     ``onboarding_complete`` is deliberately not writable here. It is owned by
+         *     the backend (set by ``OnboardingSubscriber`` when the LLM deletes
+         *     BOOTSTRAP.md or heuristic evidence appears) so the conversational
+         *     onboarding can't be short-circuited by the UI.
+         */
         UserProfileUpdate: {
             /** Phone */
             phone?: string | null;
@@ -1343,8 +1351,6 @@ export interface components {
             heartbeat_frequency?: string | null;
             /** Heartbeat Max Daily */
             heartbeat_max_daily?: number | null;
-            /** Onboarding Complete */
-            onboarding_complete?: boolean | null;
         };
         /** ValidationError */
         ValidationError: {

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -1,23 +1,20 @@
 import { useState, useEffect, useRef } from 'react';
-import { useNavigate, useOutletContext } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Card from '@/components/ui/card';
 import Button from '@/components/ui/button';
 import TextAssistantCard from '@/components/TextAssistantCard';
 import { toast } from '@/lib/toast';
-import { useUpdateProfile, useChannelConfig, useToggleChannelRoute, useChannelRoutes } from '@/hooks/queries';
+import { useChannelConfig, useToggleChannelRoute, useChannelRoutes } from '@/hooks/queries';
 import { useAuth } from '@/contexts/AuthContext';
 import { getVisibleChannels, isServerAvailable, type ChannelKey } from '@/lib/channel-utils';
 import { ChannelConfigForm, type TelegramLinkData, type PremiumLinkData } from '@/components/ChannelConfigForm';
 import api from '@/api';
-import type { AppShellContext } from '@/layouts/AppShell';
 
 type Selection = ChannelKey | 'none';
 
 export default function GetStartedPage() {
-  const { reloadProfile } = useOutletContext<AppShellContext>();
   const navigate = useNavigate();
   const { isPremium } = useAuth();
-  const updateProfile = useUpdateProfile();
   const { data: channelConfig } = useChannelConfig();
   const { data: routesData } = useChannelRoutes();
   const visibleChannels = getVisibleChannels(channelConfig);
@@ -124,16 +121,8 @@ export default function GetStartedPage() {
   };
 
   const handleDismiss = () => {
-    updateProfile.mutate(
-      { onboarding_complete: true },
-      {
-        onSuccess: () => {
-          reloadProfile();
-          navigate('/app/chat', { replace: true });
-        },
-        onError: (e) => toast.error(e.message),
-      },
-    );
+    sessionStorage.setItem('getStartedDismissed', '1');
+    navigate('/app/chat', { replace: true });
   };
 
   // Determine Step 2 heading based on selection
@@ -326,8 +315,6 @@ export default function GetStartedPage() {
         <Button
           variant="primary"
           onClick={handleDismiss}
-          disabled={updateProfile.isPending}
-          isLoading={updateProfile.isPending}
         >
           Got it, take me to chat
         </Button>

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -121,7 +121,7 @@ export default function GetStartedPage() {
   };
 
   const handleDismiss = () => {
-    sessionStorage.setItem('getStartedDismissed', '1');
+    try { sessionStorage.setItem('getStartedDismissed', '1'); } catch { /* ignore */ }
     navigate('/app/chat', { replace: true });
   };
 

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -53,14 +53,29 @@ def test_update_profile_soul_text(client: TestClient) -> None:
     assert data["soul_text"] == "Be friendly."
 
 
-def test_update_profile_onboarding_complete(client: TestClient) -> None:
-    """PUT /api/user/profile can set onboarding_complete flag."""
+def test_update_profile_ignores_onboarding_complete(client: TestClient) -> None:
+    """PUT /api/user/profile cannot set onboarding_complete.
+
+    The flag is backend-owned (flipped by OnboardingSubscriber when the
+    LLM deletes BOOTSTRAP.md) so the UI can't short-circuit the
+    conversational onboarding by toggling it directly.
+    """
+    # Sending only onboarding_complete = empty body after field stripping.
     resp = client.put(
         "/api/user/profile",
-        json={"onboarding_complete": True},
+        json={"onboarding_complete": False},
+    )
+    assert resp.status_code == 400
+
+    # The flag stays at its fixture default (True) even when bundled with
+    # a legitimate field: onboarding_complete is silently dropped.
+    resp = client.put(
+        "/api/user/profile",
+        json={"onboarding_complete": False, "phone": "+15551111111"},
     )
     assert resp.status_code == 200
     data = resp.json()
+    assert data["phone"] == "+15551111111"
     assert data["onboarding_complete"] is True
 
 


### PR DESCRIPTION
## Description
The frontend Get Started wizard was flipping `onboarding_complete=true` via `PUT /api/user/profile` as soon as the user clicked "Got it, take me to chat". That happened before the LLM ever saw a message, so `is_onboarding_needed()` returned False on the first turn and BOOTSTRAP.md sat unused. Repro from production logs: `provision_user` writes BOOTSTRAP.md at OAuth time, the next PUT flips the flag, and the first `POST /api/user/chat` shows `onboarding_complete=True, is_onboarding_needed=False` with a 30-char generic reply from the LLM.

Fix (option 1 from the design discussion):
- Drop `onboarding_complete` from `UserProfileUpdate` in `backend/app/schemas.py` so Pydantic silently ignores any attempt to set it. The flag is now exclusively backend-owned (flipped by `OnboardingSubscriber` when the LLM deletes BOOTSTRAP.md or the heuristic in `is_onboarding_complete_heuristic` matches).
- `GetStartedPage.handleDismiss` is now pure navigation. Removed the `useUpdateProfile` call, `reloadProfile`, and the button's `isPending` state.
- To avoid bouncing the user back to Get Started on refresh while the LLM is still working through its multi-turn BOOTSTRAP.md conversation, `handleDismiss` writes `sessionStorage.getStartedDismissed = '1'` and `DefaultRedirect` reads it and routes to `/app/chat` instead.
- Regenerated `frontend/openapi.json` and `frontend/src/generated/api.d.ts`.
- Updated `test_profile_endpoints.py::test_update_profile_ignores_onboarding_complete` to assert the flag is not writable: a body containing only `onboarding_complete` returns 400 (empty after field stripping), and bundling `onboarding_complete` with `phone` updates `phone` while leaving `onboarding_complete` untouched.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Verified:
- `tests/test_profile_endpoints.py`, `tests/test_onboarding.py`, `tests/test_oauth.py`, `tests/test_auth.py`, `tests/test_message_router.py`, `tests/test_heartbeat.py` all pass.
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` all pass.
- `frontend: npm run typecheck`, `npm run deadcode`, and `GetStartedPage.test.tsx` all pass.
- Pre-existing failure in `test_profile_defaults_from_settings` exists on `main` too (unrelated: asserts `preferred_channel` default).

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 diagnosed the root cause from Railway logs, proposed three options, implemented option 1 plus the sessionStorage fallback)
- [ ] No AI used