### PR TITLE
feat: CompanyCam receipts get clickable URLs + multi-action grouping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,9 @@ STORAGE_PROVIDER=local
 # Register your app at https://docs.companycam.com/docs/oauth
 # COMPANYCAM_CLIENT_ID=
 # COMPANYCAM_CLIENT_SECRET=
+# Web app base URL used to build clickable receipt URLs. Override only if
+# CompanyCam ever ships EU / sandbox hosts. Default: https://app.companycam.com
+# COMPANYCAM_WEB_BASE=
 
 # Supplier Pricing (SerpApi Home Depot engine)
 # Set SERPAPI_API_KEY to enable product price lookups at Home Depot.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,20 @@
+# TODOs
+
+## Receipt URL-off user preference (P2)
+
+Context: some contractors in iMessage / SMS find URL-laden receipts noisy.
+Requested 2026-04-19 while reviewing the CompanyCam-receipts PR. Deferred from that PR
+to keep the immediate bug fix small.
+
+Plan:
+1. Add `users.receipts_show_urls: Mapped[bool] = mapped_column(Boolean, default=True)`.
+2. Alembic migration.
+3. Expose via `UserProfileResponse`. Not writable through the public `UserProfileUpdate`
+   schema. Dedicated `set_preference(key, value)` tool for the LLM so it can honor a
+   "don't give me URLs" request from the user.
+4. In `backend/app/agent/tool_summary.py::render_receipt_line`, drop the URL line when
+   the current user's preference is off. Grouped receipts likewise skip the URL line.
+5. Tests: preference toggling, render output shape, LLM tool.
+
+Blast radius: `backend/app/models.py`, `alembic/`, `backend/app/agent/tool_summary.py`,
+new preferences tool, new tests. Estimate: one day CC.

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -8,11 +8,34 @@ trustworthy evidence that the claimed action actually happened.
 Read-side tools and tools that did not return a receipt contribute
 nothing to the block. A message with no receipts produces no footer at
 all.
+
+When a single turn produces multiple receipts that share the same URL
+(e.g. create project + upload photo + tag + archive all on the same
+project URL), the block collapses them into one entry with a joined
+verb list, so the iMessage footer stays compact on multi-action turns.
 """
 
 from __future__ import annotations
 
+import re
+
 from backend.app.agent.context import StoredToolInteraction
+
+# Last line of defence: any integration that builds a ToolReceipt must
+# not let newlines, tabs, or control chars reach the rendered output.
+# Integrations should sanitize earlier (see
+# ``backend/app/agent/tools/companycam_receipts._sanitize``), but the
+# renderer strips again so a new integration that forgets still ships
+# safe output.
+_CTRL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _scrub(text: str) -> str:
+    """Collapse control chars to a single space and trim the result."""
+    if not text:
+        return text
+    return re.sub(r"\s+", " ", _CTRL_RE.sub(" ", text)).strip()
+
 
 _SUMMARY_SEPARATOR = "\n\n"
 
@@ -29,26 +52,135 @@ def render_receipt_line(action: str, target: str, url: str | None) -> str:
 
     Used both when assembling the user-facing block and when echoing the
     rendered line back to the LLM inside the tool result (so the LLM knows
-    exactly what will be shown and does not restate it).
+    exactly what will be shown and does not restate it). Action and target
+    are scrubbed of control characters so a rogue newline cannot forge a
+    fake receipt line in the output.
     """
-    head = f"- {action} {target}".rstrip()
+    head = f"- {_scrub(action)} {_scrub(target)}".rstrip()
     if url:
-        return f"{head}\n  {url}"
+        return f"{head}\n  {_scrub(url)}"
     return head
+
+
+# Verb-reduction patterns used when grouping receipts that share a URL.
+# Drop the known noun suffixes so a list of actions reads as verbs:
+#   "Created CompanyCam project"          → "created"
+#   "Archived CompanyCam project"         → "archived"
+#   "Commented on CompanyCam project"     → "commented"
+#   "Uploaded photo to CompanyCam"        → "uploaded photo to"
+# Longest patterns first so we match the most specific form.
+_VERB_SUFFIXES: tuple[str, ...] = (
+    " on companycam project",
+    " on companycam photo",
+    " on companycam",
+    " companycam project",
+    " companycam photo",
+    " companycam checklist",
+    " companycam",
+)
+
+
+def _verb_phrase(action: str) -> str:
+    """Reduce an action string to the bare verb for a grouped receipt."""
+    lower = action.lower()
+    for suffix in _VERB_SUFFIXES:
+        if lower.endswith(suffix):
+            lower = lower[: -len(suffix)]
+            break
+    return lower.strip()
+
+
+def _render_group(
+    entries: list[tuple[str, str]],
+    target: str,
+    url: str,
+) -> str:
+    """Render a set of same-URL receipts as one three-line block.
+
+    ``entries`` is a list of (action, target) pairs, ordered by their
+    original appearance. The final target wins (most informative: it's
+    the entity's state after the last action). Each entry contributes a
+    verb phrase to the joined second line, with a parenthesised target
+    when the per-entry target differs from the final target.
+    """
+    verbs: list[str] = []
+    for action, entry_target in entries:
+        verb = _verb_phrase(action)
+        clean_entry_target = _scrub(entry_target)
+        if (
+            clean_entry_target
+            and clean_entry_target != target
+            and clean_entry_target not in ("photo", "project")
+        ):
+            verb = f"{verb} ({clean_entry_target})"
+        if verb:
+            verbs.append(verb)
+
+    head = f"- {_scrub(target)}".rstrip()
+    clean_url = _scrub(url)
+    if not verbs:
+        return f"{head}\n  {clean_url}"
+    return f"{head}\n  {' · '.join(verbs)}\n  {clean_url}"
+
+
+class _Bucket:
+    """One URL-keyed group of receipts. ``url=None`` means ungroupable."""
+
+    __slots__ = ("entries", "url")
+
+    def __init__(self, url: str | None, entries: list[tuple[str, str]]) -> None:
+        self.url = url
+        self.entries = entries
 
 
 def _collect_receipts(tool_calls: list[StoredToolInteraction]) -> list[str]:
     """Return rendered receipt lines for every successful tool call that
     populated a ``ToolReceipt``. Errors and read-side tools contribute
     nothing.
+
+    Receipts that share the same URL are grouped into a single block so
+    multi-action turns stay iMessage-compact. Receipts without a URL
+    each render as their own line (no grouping possible since the URL
+    is the grouping key).
     """
-    lines: list[str] = []
+    buckets: list[_Bucket] = []
+    by_url: dict[str, int] = {}
     for tc in tool_calls:
         if tc.is_error or tc.receipt is None:
             continue
         if not tc.receipt.action or not tc.receipt.target:
             continue
-        lines.append(render_receipt_line(tc.receipt.action, tc.receipt.target, tc.receipt.url))
+
+        url = tc.receipt.url
+        action = tc.receipt.action
+        target = tc.receipt.target
+
+        if not url:
+            # Non-groupable: ship as its own entry.
+            buckets.append(_Bucket(url=None, entries=[(action, target)]))
+            continue
+
+        if url in by_url:
+            buckets[by_url[url]].entries.append((action, target))
+        else:
+            by_url[url] = len(buckets)
+            buckets.append(_Bucket(url=url, entries=[(action, target)]))
+
+    lines: list[str] = []
+    for bucket in buckets:
+        entries = bucket.entries
+        url = bucket.url
+        if url is None:
+            action, target = entries[0]
+            lines.append(render_receipt_line(action, target, None))
+            continue
+        if len(entries) == 1:
+            action, target = entries[0]
+            lines.append(render_receipt_line(action, target, url))
+        else:
+            final_target = entries[-1][1]
+            lines.append(_render_group(entries, final_target, url))
+
     return lines
 
 

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -62,27 +62,28 @@ def render_receipt_line(action: str, target: str, url: str | None) -> str:
     return head
 
 
-# Verb-reduction patterns used when grouping receipts that share a URL.
-# Drop the known noun suffixes so a list of actions reads as verbs:
+# Verb-reduction used when grouping receipts that share a URL. Strip
+# any "companycam [noun]" tail from the action so it reads as a verb:
 #   "Created CompanyCam project"          → "created"
 #   "Archived CompanyCam project"         → "archived"
 #   "Commented on CompanyCam project"     → "commented"
 #   "Uploaded photo to CompanyCam"        → "uploaded photo to"
-# Longest patterns first so we match the most specific form.
-_VERB_SUFFIXES: tuple[str, ...] = (
-    " on companycam project",
-    " on companycam photo",
-    " on companycam",
-    " companycam project",
-    " companycam photo",
-    " companycam checklist",
-    " companycam",
-)
+#   "Tagged CompanyCam photo"             → "tagged"
+# Case-insensitive. Also handles new CompanyCam action phrases we
+# haven't seen yet (e.g. "Created CompanyCam tag" → "created"),
+# which keeps verb lists short even if a future tool adds a novel
+# action string. A non-CompanyCam action passes through unchanged.
+_CC_TAIL_RE = re.compile(r"\s*(?:on\s+|to\s+)?companycam(?:\s+\w+)?\s*$", re.IGNORECASE)
 
-# Generic fallback words a tool may use for ``target`` when it doesn't
-# have a human name for the entity (archive_project, delete_photo, etc.).
+# Generic single-noun fallback words an integration may set as
+# ``target`` when it does not have a human name for the entity
+# (archive_project, delete_photo, delete_project, etc.). These are
+# universal English nouns, not CompanyCam-specific — any future
+# integration using the same fallback approach benefits for free.
 # When grouping, prefer any real name over these.
-_GENERIC_TARGETS: frozenset[str] = frozenset({"project", "photo", "checklist", "comment"})
+_GENERIC_TARGETS: frozenset[str] = frozenset(
+    {"project", "photo", "checklist", "comment", "event", "invoice", "customer", "estimate"}
+)
 
 
 def _pick_group_subject(entries: list[tuple[str, str]]) -> str:
@@ -106,12 +107,8 @@ def _pick_group_subject(entries: list[tuple[str, str]]) -> str:
 
 def _verb_phrase(action: str) -> str:
     """Reduce an action string to the bare verb for a grouped receipt."""
-    lower = action.lower()
-    for suffix in _VERB_SUFFIXES:
-        if lower.endswith(suffix):
-            lower = lower[: -len(suffix)]
-            break
-    return lower.strip()
+    stripped = _CC_TAIL_RE.sub("", action)
+    return stripped.strip().lower()
 
 
 def _render_group(

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -79,6 +79,30 @@ _VERB_SUFFIXES: tuple[str, ...] = (
     " companycam",
 )
 
+# Generic fallback words a tool may use for ``target`` when it doesn't
+# have a human name for the entity (archive_project, delete_photo, etc.).
+# When grouping, prefer any real name over these.
+_GENERIC_TARGETS: frozenset[str] = frozenset({"project", "photo", "checklist", "comment"})
+
+
+def _pick_group_subject(entries: list[tuple[str, str]]) -> str:
+    """Pick the most informative target across a bucket of receipts.
+
+    Real names (e.g. "Smith Residence", "kitchen demo") win over the
+    generic fallback words used by archive/delete/notepad tools. When
+    every entry is generic, keep the last entry's target so behaviour
+    is stable.
+
+    This is what lets `create Smith Residence + update_notepad + archive`
+    render with "Smith Residence" as the block subject instead of the
+    generic "project" from the archive receipt.
+    """
+    for _action, target in entries:
+        cleaned = _scrub(target)
+        if cleaned and cleaned not in _GENERIC_TARGETS:
+            return target
+    return entries[-1][1]
+
 
 def _verb_phrase(action: str) -> str:
     """Reduce an action string to the bare verb for a grouped receipt."""
@@ -98,19 +122,20 @@ def _render_group(
     """Render a set of same-URL receipts as one three-line block.
 
     ``entries`` is a list of (action, target) pairs, ordered by their
-    original appearance. The final target wins (most informative: it's
-    the entity's state after the last action). Each entry contributes a
-    verb phrase to the joined second line, with a parenthesised target
-    when the per-entry target differs from the final target.
+    original appearance. ``target`` is the chosen block subject (see
+    ``_pick_group_subject``). Each entry contributes a verb phrase to
+    the joined second line, with a parenthesised target when the
+    per-entry target differs from the subject.
     """
+    clean_subject = _scrub(target)
     verbs: list[str] = []
     for action, entry_target in entries:
         verb = _verb_phrase(action)
         clean_entry_target = _scrub(entry_target)
         if (
             clean_entry_target
-            and clean_entry_target != target
-            and clean_entry_target not in ("photo", "project")
+            and clean_entry_target != clean_subject
+            and clean_entry_target not in _GENERIC_TARGETS
         ):
             verb = f"{verb} ({clean_entry_target})"
         if verb:
@@ -178,8 +203,7 @@ def _collect_receipts(tool_calls: list[StoredToolInteraction]) -> list[str]:
             action, target = entries[0]
             lines.append(render_receipt_line(action, target, url))
         else:
-            final_target = entries[-1][1]
-            lines.append(_render_group(entries, final_target, url))
+            lines.append(_render_group(entries, _pick_group_subject(entries), url))
 
     return lines
 

--- a/backend/app/agent/tools/companycam_checklists.py
+++ b/backend/app/agent/tools/companycam_checklists.py
@@ -15,6 +15,7 @@ from backend.app.agent.tools.companycam_params import (
     CompanyCamGetChecklistParams,
     CompanyCamListChecklistsParams,
 )
+from backend.app.agent.tools.companycam_receipts import _sanitize, project_url
 from backend.app.agent.tools.names import ToolName
 from backend.app.services.companycam import CompanyCamService
 
@@ -100,7 +101,8 @@ def build_checklist_tools(service: CompanyCamService) -> list[Tool]:
             ),
             receipt=ToolReceipt(
                 action="Created CompanyCam checklist",
-                target=f"{cl.name or 'Untitled'} on project {project_id}",
+                target=_sanitize(cl.name or "", 40) or "checklist",
+                url=project_url(project_id),
             ),
         )
 

--- a/backend/app/agent/tools/companycam_photos.py
+++ b/backend/app/agent/tools/companycam_photos.py
@@ -23,6 +23,13 @@ from backend.app.agent.tools.companycam_params import (
     CompanyCamTagPhotoParams,
     CompanyCamUploadPhotoParams,
 )
+from backend.app.agent.tools.companycam_receipts import (
+    comment_target,
+    photo_target,
+    photo_url,
+    project_url,
+    tags_target,
+)
 from backend.app.agent.tools.names import ToolName
 from backend.app.services.companycam import CompanyCamService, get_photo_url
 
@@ -176,9 +183,9 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             return ToolResult(
                 content=f"CompanyCam detected this as a duplicate photo (ID: {photo.id}).",
                 receipt=ToolReceipt(
-                    action="Photo already in CompanyCam project",
-                    target=project_id,
-                    url=url or None,
+                    action="Photo already in CompanyCam",
+                    target=photo_target(photo),
+                    url=url or photo_url(photo.id),
                 ),
             )
 
@@ -188,9 +195,9 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         return ToolResult(
             content=f"Photo uploaded to CompanyCam project {project_id}: {url}{status_note}",
             receipt=ToolReceipt(
-                action="Uploaded photo to CompanyCam project",
-                target=project_id,
-                url=url or None,
+                action="Uploaded photo to CompanyCam",
+                target=photo_target(photo),
+                url=url or photo_url(photo.id),
             ),
         )
 
@@ -218,11 +225,13 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
             )
+        parent_url = project_url(target_id) if target_type == "project" else photo_url(target_id)
         return ToolResult(
             content=f"Comment added to {target_type} {target_id} (ID: {comment.id}).",
             receipt=ToolReceipt(
                 action=f"Commented on CompanyCam {target_type}",
-                target=target_id,
+                target=comment_target(content),
+                url=parent_url,
             ),
         )
 
@@ -292,7 +301,8 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             content=f"Tagged photo {photo_id} with: {', '.join(tag_names)}",
             receipt=ToolReceipt(
                 action="Tagged CompanyCam photo",
-                target=f"{photo_id} ({', '.join(tag_names)})",
+                target=tags_target(tag_names),
+                url=photo_url(photo_id),
             ),
         )
 
@@ -311,7 +321,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             content=f"Photo {photo_id} permanently deleted.",
             receipt=ToolReceipt(
                 action="Deleted CompanyCam photo",
-                target=photo_id,
+                target=photo_target(None),
             ),
         )
 

--- a/backend/app/agent/tools/companycam_projects.py
+++ b/backend/app/agent/tools/companycam_projects.py
@@ -20,6 +20,10 @@ from backend.app.agent.tools.companycam_params import (
     CompanyCamUpdateNotepadParams,
     CompanyCamUpdateProjectParams,
 )
+from backend.app.agent.tools.companycam_receipts import (
+    project_target,
+    project_url,
+)
 from backend.app.agent.tools.names import ToolName
 from backend.app.services.companycam import CompanyCamService
 
@@ -72,8 +76,8 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             content=(f"Created CompanyCam project: {project.name or name} (ID: {project.id})"),
             receipt=ToolReceipt(
                 action="Created CompanyCam project",
-                target=project.name or name,
-                url=project.project_url or None,
+                target=project_target(project),
+                url=project.project_url or project_url(project.id),
             ),
         )
 
@@ -107,8 +111,8 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             content=f"Updated CompanyCam project: {project.name or ''} (ID: {project_id})",
             receipt=ToolReceipt(
                 action="Updated CompanyCam project",
-                target=project.name or project_id,
-                url=project.project_url or None,
+                target=project_target(project),
+                url=project.project_url or project_url(project_id),
             ),
         )
 
@@ -161,7 +165,8 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             content=f"Project {project_id} archived successfully.",
             receipt=ToolReceipt(
                 action="Archived CompanyCam project",
-                target=project_id,
+                target=project_target(None),
+                url=project_url(project_id),
             ),
         )
 
@@ -180,7 +185,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             content=f"Project {project_id} permanently deleted.",
             receipt=ToolReceipt(
                 action="Deleted CompanyCam project",
-                target=project_id,
+                target=project_target(None),
             ),
         )
 
@@ -202,7 +207,8 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             content=f"Notepad updated on project {project_id}.",
             receipt=ToolReceipt(
                 action="Updated notepad on CompanyCam project",
-                target=project_id,
+                target=project_target(None),
+                url=project_url(project_id),
             ),
         )
 

--- a/backend/app/agent/tools/companycam_receipts.py
+++ b/backend/app/agent/tools/companycam_receipts.py
@@ -13,10 +13,8 @@ from __future__ import annotations
 
 import re
 
+from backend.app.config import settings
 from backend.app.services.companycam_models import Photo, Project
-
-_WEB_BASE = "https://app.companycam.com"
-# TODO: pull from settings if CompanyCam ever ships EU or sandbox hosts.
 
 # CompanyCam entity ids are numeric strings. Gate URL construction on this
 # so a garbled id from the API or a confused LLM cannot poison the URL
@@ -46,12 +44,17 @@ def _sanitize(text: str, max_chars: int) -> str:
     return flat[: max_chars - 1].rstrip() + "\u2026"
 
 
+def _web_base() -> str:
+    """Return the CompanyCam web base URL from settings, without a trailing slash."""
+    return settings.companycam_web_base.rstrip("/")
+
+
 def project_url(project_id: str) -> str | None:
     """Return the web URL for a CompanyCam project, or None when the id
     is missing or not a numeric string."""
     if not project_id or not _ID_RE.match(project_id):
         return None
-    return f"{_WEB_BASE}/projects/{project_id}"
+    return f"{_web_base()}/projects/{project_id}"
 
 
 def photo_url(photo_id: str) -> str | None:
@@ -59,7 +62,7 @@ def photo_url(photo_id: str) -> str | None:
     missing or not a numeric string."""
     if not photo_id or not _ID_RE.match(photo_id):
         return None
-    return f"{_WEB_BASE}/photos/{photo_id}"
+    return f"{_web_base()}/photos/{photo_id}"
 
 
 def project_target(project: Project | None) -> str:
@@ -88,11 +91,15 @@ def comment_target(content: str) -> str:
 def tags_target(tag_names: list[str]) -> str:
     """Human-readable target for a tag-photo receipt.
 
-    Caps each tag at 25 chars and the list at 3 tags + '+N more' so a
-    tag run cannot blow up the footer.
+    Caps each tag at 25 chars, dedupes while preserving insertion order,
+    and truncates the list at 3 tags + '+N more' so a tag run cannot
+    blow up the footer.
     """
     cleaned = [_sanitize(name, 25) for name in tag_names if name]
     cleaned = [name for name in cleaned if name]
+    # Order-preserving dedupe so ["kitchen", "kitchen", "demo"] collapses
+    # to ["kitchen", "demo"] without re-sorting.
+    cleaned = list(dict.fromkeys(cleaned))
     if not cleaned:
         return "photo"
     if len(cleaned) <= 3:

--- a/backend/app/agent/tools/companycam_receipts.py
+++ b/backend/app/agent/tools/companycam_receipts.py
@@ -1,0 +1,100 @@
+"""Shared helpers for building human-readable CompanyCam tool receipts.
+
+CompanyCam entity URLs are deterministic (``app.companycam.com/{kind}/{id}``)
+so receipts can link to the web app without any extra HTTP round trip.
+Every helper here is pure: no I/O, no DB, no network.
+
+The tools pass LLM-authored or API-authored text through these helpers so
+the receipt footer in iMessage, SMS, and Telegram stays compact and can
+never be used to forge fake receipt lines by injecting newlines.
+"""
+
+from __future__ import annotations
+
+import re
+
+from backend.app.services.companycam_models import Photo, Project
+
+_WEB_BASE = "https://app.companycam.com"
+# TODO: pull from settings if CompanyCam ever ships EU or sandbox hosts.
+
+# CompanyCam entity ids are numeric strings. Gate URL construction on this
+# so a garbled id from the API or a confused LLM cannot poison the URL
+# (e.g. "94772883?foo=bar" or "../admin" never reach the output).
+_ID_RE = re.compile(r"^\d+$")
+
+# Collapse newlines, tabs, and other control chars so LLM/user-authored
+# text cannot break out of the "- {action} {target}\n  {url}" shape.
+_CTRL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _sanitize(text: str, max_chars: int) -> str:
+    """Scrub control chars, collapse whitespace, cap length.
+
+    Used for any string that started as LLM output, user comment, or
+    CompanyCam API text that may contain stray newlines. Truncation adds
+    a trailing ellipsis when the original did not fit.
+    """
+    if not text:
+        return ""
+    flat = _CTRL_RE.sub(" ", text)
+    flat = re.sub(r"\s+", " ", flat).strip()
+    if not flat:
+        return ""
+    if len(flat) <= max_chars:
+        return flat
+    return flat[: max_chars - 1].rstrip() + "\u2026"
+
+
+def project_url(project_id: str) -> str | None:
+    """Return the web URL for a CompanyCam project, or None when the id
+    is missing or not a numeric string."""
+    if not project_id or not _ID_RE.match(project_id):
+        return None
+    return f"{_WEB_BASE}/projects/{project_id}"
+
+
+def photo_url(photo_id: str) -> str | None:
+    """Return the web URL for a CompanyCam photo, or None when the id is
+    missing or not a numeric string."""
+    if not photo_id or not _ID_RE.match(photo_id):
+        return None
+    return f"{_WEB_BASE}/photos/{photo_id}"
+
+
+def project_target(project: Project | None) -> str:
+    """Human-readable target for a project receipt. Never a raw id."""
+    if project and project.name:
+        sanitized = _sanitize(project.name, 60)
+        if sanitized:
+            return sanitized
+    return "project"
+
+
+def photo_target(photo: Photo | None) -> str:
+    """Human-readable target for a photo receipt. Never a raw id."""
+    if photo and photo.description:
+        desc = _sanitize(photo.description, 60)
+        if desc:
+            return desc
+    return "photo"
+
+
+def comment_target(content: str) -> str:
+    """Human-readable target for an add-comment receipt."""
+    return _sanitize(content, 40) or "comment"
+
+
+def tags_target(tag_names: list[str]) -> str:
+    """Human-readable target for a tag-photo receipt.
+
+    Caps each tag at 25 chars and the list at 3 tags + '+N more' so a
+    tag run cannot blow up the footer.
+    """
+    cleaned = [_sanitize(name, 25) for name in tag_names if name]
+    cleaned = [name for name in cleaned if name]
+    if not cleaned:
+        return "photo"
+    if len(cleaned) <= 3:
+        return ", ".join(cleaned)
+    return ", ".join(cleaned[:3]) + f" +{len(cleaned) - 3} more"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -114,6 +114,9 @@ class Settings(BaseSettings):
     # CompanyCam OAuth 2.0
     companycam_client_id: str = ""
     companycam_client_secret: str = ""
+    # Web app base URL for receipt deep links. Override if CompanyCam ever
+    # ships EU / sandbox hosts (the US prod URL is stable today).
+    companycam_web_base: str = "https://app.companycam.com"
 
     # Supplier pricing (SerpApi Home Depot engine)
     serpapi_api_key: str = ""  # https://serpapi.com — free tier: 250 searches/month

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -186,6 +186,7 @@ When `GOOGLE_CALENDAR_CLIENT_ID` and `GOOGLE_CALENDAR_CLIENT_SECRET` are set, us
 |----------|---------|-------------|
 | `COMPANYCAM_CLIENT_ID` | | CompanyCam OAuth 2.0 client ID. Register at [docs.companycam.com/docs/oauth](https://docs.companycam.com/docs/oauth) |
 | `COMPANYCAM_CLIENT_SECRET` | | CompanyCam OAuth 2.0 client secret |
+| `COMPANYCAM_WEB_BASE` | `https://app.companycam.com` | Web app base URL used to build clickable receipt deep links. Override only if CompanyCam ships a non-US host. |
 
 When both are set, users can connect CompanyCam via OAuth on the Tools page or through chat. This enables tools like `companycam_search_projects`, `companycam_upload_photo`, and `companycam_create_project`.
 

--- a/tests/test_companycam_receipts.py
+++ b/tests/test_companycam_receipts.py
@@ -8,6 +8,8 @@ that could forge a fake receipt line.
 
 from __future__ import annotations
 
+from typing import Any
+
 from backend.app.agent.tools.companycam_receipts import (
     _sanitize,
     comment_target,
@@ -153,6 +155,20 @@ def test_tags_target_empty_falls_back_to_word() -> None:
     assert tags_target([""]) == "photo"
 
 
+def test_tags_target_dedupes_preserving_order() -> None:
+    """Duplicate tags collapse to one entry, first-seen wins."""
+    assert tags_target(["kitchen", "demo", "kitchen"]) == "kitchen, demo"
+    # Dedup happens after sanitization and length capping.
+    assert tags_target(["kitchen", "Kitchen"]) == "kitchen, Kitchen"  # case-sensitive dedup
+
+
+def test_tags_target_dedupes_then_caps_at_three() -> None:
+    """Dedup runs before the 3-tag cap so 'kitchen, kitchen, a, b, c, d'
+    collapses to 'kitchen, a, b +2 more' rather than losing real tags."""
+    out = tags_target(["kitchen", "kitchen", "a", "b", "c", "d"])
+    assert out == "kitchen, a, b +2 more"
+
+
 # ---------------------------------------------------------------------------
 # _sanitize internals
 # ---------------------------------------------------------------------------
@@ -176,3 +192,24 @@ def test_sanitize_returns_empty_for_blank_input() -> None:
     assert _sanitize("", 10) == ""
     assert _sanitize("   ", 10) == ""
     assert _sanitize("\n\n\n", 10) == ""
+
+
+# ---------------------------------------------------------------------------
+# Settings-driven web base (EU / sandbox readiness)
+# ---------------------------------------------------------------------------
+
+
+def test_project_url_honors_settings_web_base(monkeypatch: Any) -> None:
+    """The web base is pulled from settings so future EU / sandbox
+    deployments can override without code changes."""
+    from backend.app.config import settings
+
+    monkeypatch.setattr(settings, "companycam_web_base", "https://eu.app.companycam.com")
+    assert project_url("94772883") == "https://eu.app.companycam.com/projects/94772883"
+
+
+def test_project_url_strips_trailing_slash_on_web_base(monkeypatch: Any) -> None:
+    from backend.app.config import settings
+
+    monkeypatch.setattr(settings, "companycam_web_base", "https://app.companycam.com/")
+    assert project_url("94772883") == "https://app.companycam.com/projects/94772883"

--- a/tests/test_companycam_receipts.py
+++ b/tests/test_companycam_receipts.py
@@ -1,0 +1,178 @@
+"""Unit tests for the CompanyCam receipt helpers.
+
+These helpers produce the `target` and `url` fields of a ToolReceipt for
+every CompanyCam write-side tool. They must never leak a raw CompanyCam
+id into the contractor's iMessage footer, and must never embed newlines
+that could forge a fake receipt line.
+"""
+
+from __future__ import annotations
+
+from backend.app.agent.tools.companycam_receipts import (
+    _sanitize,
+    comment_target,
+    photo_target,
+    photo_url,
+    project_target,
+    project_url,
+    tags_target,
+)
+from backend.app.services.companycam_models import Photo, Project
+
+# ---------------------------------------------------------------------------
+# URL builders
+# ---------------------------------------------------------------------------
+
+
+def test_project_url_numeric_id() -> None:
+    assert project_url("94772883") == "https://app.companycam.com/projects/94772883"
+
+
+def test_project_url_empty_id_returns_none() -> None:
+    assert project_url("") is None
+
+
+def test_project_url_blocks_query_injection() -> None:
+    assert project_url("94772883?foo=bar") is None
+
+
+def test_project_url_blocks_path_traversal() -> None:
+    assert project_url("../admin") is None
+
+
+def test_project_url_blocks_non_numeric() -> None:
+    assert project_url("abc123") is None
+
+
+def test_photo_url_numeric_id() -> None:
+    assert photo_url("8675309") == "https://app.companycam.com/photos/8675309"
+
+
+def test_photo_url_empty_id_returns_none() -> None:
+    assert photo_url("") is None
+
+
+def test_photo_url_blocks_non_numeric() -> None:
+    assert photo_url("not-an-id") is None
+
+
+# ---------------------------------------------------------------------------
+# Target formatters
+# ---------------------------------------------------------------------------
+
+
+def test_project_target_uses_name() -> None:
+    p = Project(id="94772883", name="Smith Residence")
+    assert project_target(p) == "Smith Residence"
+
+
+def test_project_target_falls_back_to_word_when_no_project() -> None:
+    assert project_target(None) == "project"
+
+
+def test_project_target_falls_back_to_word_when_name_empty() -> None:
+    p = Project(id="94772883", name="")
+    assert project_target(p) == "project"
+
+
+def test_project_target_strips_newlines_from_name() -> None:
+    """A malicious project name cannot forge a fake receipt line."""
+    p = Project(id="94772883", name="Foo\nBar\nBaz")
+    assert "\n" not in project_target(p)
+    assert project_target(p) == "Foo Bar Baz"
+
+
+def test_project_target_truncates_long_name() -> None:
+    p = Project(id="x", name="A" * 200)
+    out = project_target(p)
+    assert len(out) == 60
+    assert out.endswith("\u2026")
+
+
+def test_photo_target_uses_description() -> None:
+    ph = Photo(id="8675309", description="kitchen demo")
+    assert photo_target(ph) == "kitchen demo"
+
+
+def test_photo_target_falls_back_to_word() -> None:
+    assert photo_target(None) == "photo"
+    ph = Photo(id="8675309", description="")
+    assert photo_target(ph) == "photo"
+
+
+def test_photo_target_truncates_description() -> None:
+    ph = Photo(id="x", description="A" * 200)
+    out = photo_target(ph)
+    assert len(out) == 60
+    assert out.endswith("\u2026")
+
+
+def test_photo_target_strips_newlines() -> None:
+    ph = Photo(id="x", description="line1\nline2")
+    assert "\n" not in photo_target(ph)
+
+
+def test_comment_target_short() -> None:
+    assert comment_target("All demo done") == "All demo done"
+
+
+def test_comment_target_long_is_truncated_with_ellipsis() -> None:
+    out = comment_target("A" * 100)
+    assert len(out) == 40
+    assert out.endswith("\u2026")
+
+
+def test_comment_target_strips_newlines() -> None:
+    """Receipt-injection defence: newline in content cannot forge a line."""
+    assert "\n" not in comment_target("Hi\nFake - Receipt")
+    assert comment_target("Hi\nFake receipt") == "Hi Fake receipt"
+
+
+def test_comment_target_empty_falls_back_to_word() -> None:
+    assert comment_target("") == "comment"
+    assert comment_target("   \n\t   ") == "comment"
+
+
+def test_tags_target_short_list() -> None:
+    assert tags_target(["kitchen", "demo"]) == "kitchen, demo"
+
+
+def test_tags_target_truncates_long_lists() -> None:
+    assert tags_target(["a", "b", "c", "d", "e"]) == "a, b, c +2 more"
+
+
+def test_tags_target_caps_single_tag_length() -> None:
+    out = tags_target(["x" * 100])
+    # One tag truncated to 25 chars with ellipsis.
+    assert out.endswith("\u2026")
+    assert len(out) == 25
+
+
+def test_tags_target_empty_falls_back_to_word() -> None:
+    assert tags_target([]) == "photo"
+    assert tags_target([""]) == "photo"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize internals
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_collapses_whitespace() -> None:
+    assert _sanitize("foo \t  bar", 40) == "foo bar"
+
+
+def test_sanitize_removes_control_chars() -> None:
+    assert _sanitize("foo\x00bar\x07baz", 40) == "foo bar baz"
+
+
+def test_sanitize_respects_length_cap() -> None:
+    out = _sanitize("A" * 100, 10)
+    assert len(out) == 10
+    assert out.endswith("\u2026")
+
+
+def test_sanitize_returns_empty_for_blank_input() -> None:
+    assert _sanitize("", 10) == ""
+    assert _sanitize("   ", 10) == ""
+    assert _sanitize("\n\n\n", 10) == ""

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -828,3 +828,281 @@ def test_new_tool_permissions() -> None:
         ToolName.COMPANYCAM_CREATE_CHECKLIST,
     ]:
         assert perms[name] == "ask", f"{name} should be 'ask'"
+
+
+# ---------------------------------------------------------------------------
+# Receipt shape (contractor-facing iMessage footer)
+# ---------------------------------------------------------------------------
+#
+# Every write-side CompanyCam tool populates a ToolReceipt(action,
+# target, url). The footer rendered to iMessage/SMS must never surface
+# raw CompanyCam ids (8-digit numeric strings) because a contractor
+# cannot recognize or click them. These tests assert the invariant
+# per-tool: no digit-only id substring in the target, and a clickable
+# URL for every non-destructive action.
+
+import re  # noqa: E402 — placed with the receipt-shape block for locality
+from typing import Any  # noqa: E402
+
+from backend.app.agent.tools.base import ToolReceipt  # noqa: E402
+from backend.app.agent.tools.companycam_checklists import build_checklist_tools  # noqa: E402
+from backend.app.agent.tools.companycam_photos import build_photo_tools  # noqa: E402
+from backend.app.agent.tools.companycam_projects import build_project_tools  # noqa: E402
+
+# Matches any 6+ digit run with word boundaries — catches both a bare
+# id ("94772883") and an id embedded in a longer string
+# ("kitchen 94772883 done"). Using \b ensures a short numeric token
+# like "2026" inside a date does not false-flag, but 6+ digits is
+# unambiguously a CompanyCam id.
+_RAW_ID_RE = re.compile(r"\b\d{6,}\b")
+
+
+def _assert_receipt_clean(receipt: ToolReceipt | None, *, expect_url: bool) -> None:
+    assert receipt is not None, "write-side tool must populate a receipt"
+    assert receipt.action, "receipt action must be non-empty"
+    assert receipt.target, "receipt target must be non-empty"
+    # No raw CompanyCam id in the visible text.
+    assert _RAW_ID_RE.search(receipt.target) is None, (
+        f"receipt target contains raw id: {receipt.target!r}"
+    )
+    # No control chars that could forge a receipt line.
+    assert "\n" not in receipt.target, "receipt target contains newline"
+    assert "\r" not in receipt.target, "receipt target contains carriage return"
+    assert "\t" not in receipt.target, "receipt target contains tab"
+    # Non-destructive actions must have a clickable URL.
+    if expect_url:
+        assert receipt.url, "non-destructive action must supply a URL"
+        assert receipt.url.startswith("https://app.companycam.com/"), (
+            f"URL must point at CompanyCam web app: {receipt.url!r}"
+        )
+    else:
+        assert receipt.url is None, f"destructive action should not have a URL: {receipt.url!r}"
+
+
+def _get_tool(tools: list, name: str) -> Any:
+    for t in tools:
+        if t.name == name:
+            return t
+    raise AssertionError(f"tool {name} not found")
+
+
+@pytest.mark.asyncio()
+async def test_receipt_create_project_is_clean() -> None:
+    """Receipt for create_project: human name, full URL, no raw id."""
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    project_data = {
+        "id": "94772883",
+        "name": "Smith Residence",
+        "project_url": "https://app.companycam.com/projects/94772883",
+    }
+    from backend.app.services.companycam_models import Project
+
+    service.create_project = AsyncMock(return_value=Project.model_validate(project_data))
+    tool = _get_tool(build_project_tools(service), ToolName.COMPANYCAM_CREATE_PROJECT)
+    result = await tool.function(name="Smith Residence", address="")
+    _assert_receipt_clean(result.receipt, expect_url=True)
+    assert result.receipt.target == "Smith Residence"
+
+
+@pytest.mark.asyncio()
+async def test_receipt_archive_project_is_clean() -> None:
+    """Receipt for archive_project (void return) uses generic target + URL from id."""
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    service.archive_project = AsyncMock(return_value=None)
+    tool = _get_tool(build_project_tools(service), ToolName.COMPANYCAM_ARCHIVE_PROJECT)
+    result = await tool.function(project_id="94772883")
+    _assert_receipt_clean(result.receipt, expect_url=True)
+    assert result.receipt.target == "project"
+
+
+@pytest.mark.asyncio()
+async def test_receipt_delete_project_is_clean_no_url() -> None:
+    """Delete receipt: generic target, no URL (entity is gone)."""
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    service.delete_project = AsyncMock(return_value=None)
+    tool = _get_tool(build_project_tools(service), ToolName.COMPANYCAM_DELETE_PROJECT)
+    result = await tool.function(project_id="94772883")
+    _assert_receipt_clean(result.receipt, expect_url=False)
+    assert result.receipt.target == "project"
+
+
+@pytest.mark.asyncio()
+async def test_receipt_update_notepad_is_clean() -> None:
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    service.update_notepad = AsyncMock(return_value=None)
+    tool = _get_tool(build_project_tools(service), ToolName.COMPANYCAM_UPDATE_NOTEPAD)
+    result = await tool.function(project_id="94772883", notepad="On track")
+    _assert_receipt_clean(result.receipt, expect_url=True)
+
+
+@pytest.mark.asyncio()
+async def test_receipt_add_comment_uses_parent_url() -> None:
+    """Comments have no own URL. The receipt links to the parent entity."""
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    from backend.app.services.companycam_models import Comment
+
+    service.add_project_comment = AsyncMock(
+        return_value=Comment.model_validate({"id": "555", "content": "All demo done"})
+    )
+    ctx = MagicMock()
+    tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_ADD_COMMENT)
+    result = await tool.function(
+        target_type="project", target_id="388472672", content="All demo done"
+    )
+    _assert_receipt_clean(result.receipt, expect_url=True)
+    assert result.receipt.target == "All demo done"
+    assert "projects/388472672" in result.receipt.url
+
+
+@pytest.mark.asyncio()
+async def test_receipt_add_comment_truncates_long_content() -> None:
+    """A 500-char comment never reaches the iMessage footer intact."""
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    from backend.app.services.companycam_models import Comment
+
+    service.add_photo_comment = AsyncMock(
+        return_value=Comment.model_validate({"id": "555", "content": "X"})
+    )
+    ctx = MagicMock()
+    tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_ADD_COMMENT)
+    long_content = "A" * 500
+    result = await tool.function(target_type="photo", target_id="8675309", content=long_content)
+    _assert_receipt_clean(result.receipt, expect_url=True)
+    assert len(result.receipt.target) <= 40
+    assert result.receipt.target.endswith("\u2026")
+
+
+@pytest.mark.asyncio()
+async def test_receipt_tag_photo_is_clean() -> None:
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    from backend.app.services.companycam_models import Tag
+
+    service.add_photo_tags = AsyncMock(
+        return_value=[
+            Tag.model_validate({"id": "1", "display_value": "kitchen", "value": "kitchen"}),
+            Tag.model_validate({"id": "2", "display_value": "demo", "value": "demo"}),
+        ]
+    )
+    ctx = MagicMock()
+    tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_TAG_PHOTO)
+    result = await tool.function(photo_id="8675309", tags=["kitchen", "demo"])
+    _assert_receipt_clean(result.receipt, expect_url=True)
+    assert result.receipt.target == "kitchen, demo"
+
+
+@pytest.mark.asyncio()
+async def test_receipt_delete_photo_is_clean_no_url() -> None:
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    service.delete_photo = AsyncMock(return_value=None)
+    ctx = MagicMock()
+    tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_DELETE_PHOTO)
+    result = await tool.function(photo_id="8675309")
+    _assert_receipt_clean(result.receipt, expect_url=False)
+    assert result.receipt.target == "photo"
+
+
+@pytest.mark.asyncio()
+async def test_receipt_create_checklist_is_clean() -> None:
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    from backend.app.services.companycam_models import Checklist
+
+    service.create_project_checklist = AsyncMock(
+        return_value=Checklist.model_validate(
+            {"id": "777", "name": "Rough-in inspection", "completed_at": None}
+        )
+    )
+    tool = _get_tool(build_checklist_tools(service), ToolName.COMPANYCAM_CREATE_CHECKLIST)
+    result = await tool.function(project_id="94772883", template_id="abc")
+    _assert_receipt_clean(result.receipt, expect_url=True)
+    assert result.receipt.target == "Rough-in inspection"
+
+
+@pytest.mark.asyncio()
+async def test_receipt_rendered_output_has_no_raw_ids() -> None:
+    """End-to-end: a grouped footer of five actions on one project
+    never surfaces a raw CompanyCam id in the rendered output."""
+    from backend.app.agent.context import StoredToolInteraction, StoredToolReceipt
+    from backend.app.agent.tool_summary import format_receipts_block
+
+    # Simulate the receipt fingerprints that each CompanyCam tool would
+    # leave after a successful call (matches the tool-layer rewrite).
+    fake_calls = [
+        StoredToolInteraction(
+            tool_call_id=f"cc-{i}",
+            name=name,
+            args={},
+            result="",
+            is_error=False,
+            receipt=StoredToolReceipt(action=action, target=target, url=url),
+        )
+        for i, (name, action, target, url) in enumerate(
+            [
+                (
+                    "companycam_create_project",
+                    "Created CompanyCam project",
+                    "Smith Residence",
+                    "https://app.companycam.com/projects/94772883",
+                ),
+                (
+                    "companycam_update_notepad",
+                    "Updated notepad on CompanyCam project",
+                    "project",
+                    "https://app.companycam.com/projects/94772883",
+                ),
+                (
+                    "companycam_add_comment",
+                    "Commented on CompanyCam project",
+                    "All demo done",
+                    "https://app.companycam.com/projects/94772883",
+                ),
+                (
+                    "companycam_tag_photo",
+                    "Tagged CompanyCam photo",
+                    "kitchen, demo",
+                    "https://app.companycam.com/photos/8675309",
+                ),
+                (
+                    "companycam_archive_project",
+                    "Archived CompanyCam project",
+                    "project",
+                    "https://app.companycam.com/projects/94772883",
+                ),
+            ]
+        )
+    ]
+    block = format_receipts_block(fake_calls)
+
+    # The rendered footer has two URL-keyed blocks (project + photo).
+    assert block.count("https://app.companycam.com/projects/94772883") == 1
+    assert block.count("https://app.companycam.com/photos/8675309") == 1
+
+    # Scan every visible token for a 6+ digit run: only the two URLs
+    # are allowed to contain ids. Strip URLs then assert no digit runs.
+    def _strip_urls(text: str) -> str:
+        return re.sub(r"https://\S+", "", text)
+
+    visible = _strip_urls(block)
+    assert _RAW_ID_RE.search(visible) is None, (
+        f"rendered footer leaked a raw CompanyCam id into user-visible text:\n{visible!r}"
+    )
+
+    # Block stays compact (grouping saves lines).
+    assert len(block) < 500

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -202,7 +202,13 @@ def test_block_caps_long_receipt_lists_with_more_suffix() -> None:
 
 
 def test_same_url_receipts_are_grouped() -> None:
-    """Multiple actions on the same entity collapse into one block."""
+    """Multiple actions on the same entity collapse into one block.
+
+    The block subject is the most informative target: a real name wins
+    over the generic 'project' / 'photo' / 'checklist' fallbacks used
+    by archive/delete/notepad tools. Users see 'Smith Residence', not
+    'project', even when the last action was archive.
+    """
     block = format_receipts_block(
         [
             _tc_with_receipt(
@@ -225,21 +231,40 @@ def test_same_url_receipts_are_grouped() -> None:
             ),
         ]
     )
-    # Subject is the final entry's target, which carried the real name.
-    # Wait — last entry's target is "project", a fallback. The current
-    # design uses the final entry's target verbatim. The test should
-    # reflect that actual behavior (see the CompanyCam tool rewrites:
-    # archive/notepad use "project" as a generic fallback). Users still
-    # get the URL to click, which is the real goal.
     lines = block.split("\n")
     # Three lines: subject, verb list, url.
     assert len(lines) == 3
+    # Subject is the real name from the create receipt.
+    assert lines[0] == "- Smith Residence"
     assert lines[2] == "  https://app.companycam.com/projects/94772883"
     # Verb list contains all three verbs joined with ' · '.
     assert "created" in lines[1]
     assert "updated notepad" in lines[1]
     assert "archived" in lines[1]
     assert lines[1].count(" · ") == 2
+
+
+def test_grouped_subject_falls_back_to_last_when_all_generic() -> None:
+    """If every entry has a generic fallback target, keep the last one
+    so behaviour is stable (no picking semantics to debate)."""
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "companycam_update_notepad",
+                action="Updated notepad on CompanyCam project",
+                target="project",
+                url="https://app.companycam.com/projects/1",
+            ),
+            _tc_with_receipt(
+                "companycam_archive_project",
+                action="Archived CompanyCam project",
+                target="project",
+                url="https://app.companycam.com/projects/1",
+            ),
+        ]
+    )
+    lines = block.split("\n")
+    assert lines[0] == "- project"
 
 
 def test_grouped_block_preserves_distinct_targets() -> None:

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -378,6 +378,86 @@ def test_receipt_injection_via_newline_is_defused_at_render() -> None:
     assert block.endswith("  https://app.companycam.com/projects/1")
 
 
+def test_verb_phrase_strips_unseen_companycam_suffixes() -> None:
+    """New CompanyCam tools with novel action phrases still get the
+    'companycam [noun]' tail stripped so verb lists stay tight."""
+    from backend.app.agent.tool_summary import _verb_phrase
+
+    # Known phrases from the plan.
+    assert _verb_phrase("Created CompanyCam project") == "created"
+    assert _verb_phrase("Archived CompanyCam project") == "archived"
+    assert _verb_phrase("Commented on CompanyCam project") == "commented"
+    assert _verb_phrase("Uploaded photo to CompanyCam") == "uploaded photo"
+    assert _verb_phrase("Tagged CompanyCam photo") == "tagged"
+    # Novel action phrases (not enumerated at authorship time).
+    assert _verb_phrase("Created CompanyCam tag") == "created"
+    assert _verb_phrase("Created CompanyCam label") == "created"
+    # Non-CompanyCam action passes through.
+    assert _verb_phrase("Scheduled calendar event") == "scheduled calendar event"
+
+
+def test_grouping_works_across_integrations() -> None:
+    """Same-URL grouping is integration-agnostic. QBO and Calendar get
+    the same treatment as CompanyCam for free."""
+    # QuickBooks: create invoice + email invoice to client, both share the
+    # same QBO deep link.
+    qbo_url = "https://app.qbo.intuit.com/app/invoice?txnId=4782"
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "qb_create",
+                action="Created QuickBooks invoice for",
+                target="Johnson, $2,560.00",
+                url=qbo_url,
+            ),
+            _tc_with_receipt(
+                "qb_send",
+                action="Emailed QuickBooks invoice to",
+                target="johnson@example.com",
+                url=qbo_url,
+            ),
+        ]
+    )
+    lines = block.split("\n")
+    # One grouped 3-line block.
+    assert len(lines) == 3
+    assert qbo_url in lines[2]
+    # Subject is the first informative target (the invoice with amount).
+    assert lines[0] == "- Johnson, $2,560.00"
+    # Email recipient survives as a parenthesised qualifier on the email verb.
+    assert "johnson@example.com" in lines[1]
+
+
+def test_calendar_event_delete_is_standalone() -> None:
+    """Calendar delete produces a single-line receipt (no URL) alongside
+    a grouped project block. The two must not interfere."""
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "calendar_delete_event",
+                action="Canceled calendar event",
+                target="Kitchen walkthrough",
+            ),
+            _tc_with_receipt(
+                "companycam_create_project",
+                action="Created CompanyCam project",
+                target="Smith Residence",
+                url="https://app.companycam.com/projects/94772883",
+            ),
+            _tc_with_receipt(
+                "companycam_archive_project",
+                action="Archived CompanyCam project",
+                target="project",
+                url="https://app.companycam.com/projects/94772883",
+            ),
+        ]
+    )
+    # Calendar line is standalone (no URL). CompanyCam pair is one grouped block.
+    assert "- Canceled calendar event Kitchen walkthrough\n" in block + "\n"
+    assert "- Smith Residence" in block
+    assert "created · archived" in block
+
+
 def test_render_receipt_line_scrubs_control_chars_directly() -> None:
     """Unit-level guarantee for render_receipt_line: newlines in any
     field are scrubbed before they hit output."""

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -194,3 +194,178 @@ def test_block_caps_long_receipt_lists_with_more_suffix() -> None:
     block = format_receipts_block(many)
     assert "(+" in block and "more)" in block
     assert len(block) <= _MAX_RECEIPTS_CHARS
+
+
+# ---------------------------------------------------------------------------
+# Same-URL grouping
+# ---------------------------------------------------------------------------
+
+
+def test_same_url_receipts_are_grouped() -> None:
+    """Multiple actions on the same entity collapse into one block."""
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "companycam_create_project",
+                action="Created CompanyCam project",
+                target="Smith Residence",
+                url="https://app.companycam.com/projects/94772883",
+            ),
+            _tc_with_receipt(
+                "companycam_update_notepad",
+                action="Updated notepad on CompanyCam project",
+                target="project",
+                url="https://app.companycam.com/projects/94772883",
+            ),
+            _tc_with_receipt(
+                "companycam_archive_project",
+                action="Archived CompanyCam project",
+                target="project",
+                url="https://app.companycam.com/projects/94772883",
+            ),
+        ]
+    )
+    # Subject is the final entry's target, which carried the real name.
+    # Wait — last entry's target is "project", a fallback. The current
+    # design uses the final entry's target verbatim. The test should
+    # reflect that actual behavior (see the CompanyCam tool rewrites:
+    # archive/notepad use "project" as a generic fallback). Users still
+    # get the URL to click, which is the real goal.
+    lines = block.split("\n")
+    # Three lines: subject, verb list, url.
+    assert len(lines) == 3
+    assert lines[2] == "  https://app.companycam.com/projects/94772883"
+    # Verb list contains all three verbs joined with ' · '.
+    assert "created" in lines[1]
+    assert "updated notepad" in lines[1]
+    assert "archived" in lines[1]
+    assert lines[1].count(" · ") == 2
+
+
+def test_grouped_block_preserves_distinct_targets() -> None:
+    """When a grouped entry has a distinct target, it is surfaced in the
+    verb list parenthetically so the information is not lost."""
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "companycam_tag_photo",
+                action="Tagged CompanyCam photo",
+                target="kitchen, demo",
+                url="https://app.companycam.com/photos/8675309",
+            ),
+            _tc_with_receipt(
+                "companycam_add_comment",
+                action="Commented on CompanyCam photo",
+                target="great work",
+                url="https://app.companycam.com/photos/8675309",
+            ),
+        ]
+    )
+    lines = block.split("\n")
+    assert len(lines) == 3
+    # Both targets appear (either as subject or in parenthesised verb).
+    assert "great work" in block
+    assert "kitchen, demo" in block
+
+
+def test_distinct_urls_stay_separate() -> None:
+    """Different URLs never collapse. Two projects stay two blocks."""
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "companycam_create_project",
+                action="Created CompanyCam project",
+                target="Smith",
+                url="https://app.companycam.com/projects/1",
+            ),
+            _tc_with_receipt(
+                "companycam_create_project",
+                action="Created CompanyCam project",
+                target="Jones",
+                url="https://app.companycam.com/projects/2",
+            ),
+        ]
+    )
+    assert block.count("https://app.companycam.com/projects/") == 2
+    assert "Smith" in block
+    assert "Jones" in block
+
+
+def test_receipts_without_url_never_group() -> None:
+    """Delete operations have no URL; they always render as their own line."""
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "companycam_delete_project",
+                action="Deleted CompanyCam project",
+                target="project",
+            ),
+            _tc_with_receipt(
+                "companycam_delete_photo",
+                action="Deleted CompanyCam photo",
+                target="photo",
+            ),
+        ]
+    )
+    assert block == "- Deleted CompanyCam project project\n- Deleted CompanyCam photo photo"
+
+
+def test_grouped_block_length_is_bounded() -> None:
+    """Five same-URL receipts still fit within _MAX_RECEIPTS_CHARS."""
+    many = [
+        _tc_with_receipt(
+            f"action_{i}",
+            action=f"Action {i} CompanyCam project",
+            target=f"target {i}",
+            url="https://app.companycam.com/projects/1",
+        )
+        for i in range(5)
+    ]
+    block = format_receipts_block(many)
+    assert len(block) <= _MAX_RECEIPTS_CHARS
+    # Single three-line block (since they all share a URL).
+    assert block.count("\n") == 2
+
+
+def test_receipt_injection_via_newline_is_defused_at_render() -> None:
+    """Defense in depth: if any integration bypasses per-tool sanitization
+    and hands a target with an embedded newline to the renderer, the
+    renderer must scrub control chars so no fake receipt BULLET starts
+    a new line in the output."""
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "companycam_add_comment",
+                action="Commented on CompanyCam project",
+                target="legit\n- Fake receipt\n  https://evil.example",
+                url="https://app.companycam.com/projects/1",
+            )
+        ]
+    )
+    # The attack is a forged receipt bullet at the start of a line.
+    # After sanitization the hostile text is absorbed into the single
+    # action/target line, so no line in the block starts with "- Fake".
+    for line in block.split("\n"):
+        assert not line.startswith("- Fake")
+    # Exactly one bullet line in the output (single receipt).
+    assert sum(1 for line in block.split("\n") if line.startswith("- ")) == 1
+    # The real URL is on its own line (the clickable one).
+    assert block.endswith("  https://app.companycam.com/projects/1")
+
+
+def test_render_receipt_line_scrubs_control_chars_directly() -> None:
+    """Unit-level guarantee for render_receipt_line: newlines in any
+    field are scrubbed before they hit output."""
+    from backend.app.agent.tool_summary import render_receipt_line
+
+    line = render_receipt_line(
+        "Commented\non CompanyCam project",
+        "malicious\ttarget",
+        "https://example.com/path\nfoo",
+    )
+    assert "\n" in line  # the action/url separator is a real newline
+    # But no stray newlines inside the fields themselves:
+    head, _, body = line.partition("\n")
+    assert "\n" not in head
+    assert "\n" not in body
+    assert "\t" not in line


### PR DESCRIPTION
## Description

Contractors on iMessage were seeing raw CompanyCam ids in receipt footers ("- Commented on CompanyCam project 388472672") which meant nothing and couldn't be clicked. Several receipts also had no URL at all.

Two layers:

**1. Helper module `backend/app/agent/tools/companycam_receipts.py`** — builds human-readable targets and deterministic web URLs from ids. CompanyCam URL conventions are fixed (`app.companycam.com/projects/{id}` and `/photos/{id}`), so we can link archive/delete/notepad tools that return void without an extra HTTP round trip. Helpers sanitize all LLM- and user-authored text (comment content, photo descriptions, tag names) so a newline or control char cannot forge a fake receipt line. ID validation gates URL construction on `^\d+$` so a garbled id returns None instead of a broken or attacker-controlled URL. Every CompanyCam write-side tool uses these helpers; raw ids never reach the receipt target.

**2. Receipt grouping in `tool_summary.py`** — receipts sharing the same URL collapse into one three-line block. A multi-action turn on the same project renders as one block instead of many. When grouping, `_pick_group_subject` walks the entries and picks the first real name it finds (e.g. "Smith Residence"), falling back to the generic word ("project") only when every receipt uses a fallback. Calendar and QuickBooks get grouping for free since they share the renderer. The renderer also scrubs control chars on every field as a last line of defence for any future integration that forgets to sanitize.

### Before / after

Scenario: user says "create a project for Smith Residence, upload this photo (tagged kitchen, demo), comment 'all demo done', then archive it".

Before (5 receipts, 8 lines, raw ids everywhere, half the actions with no URL):
\`\`\`
- Created CompanyCam project Smith Residence
  https://app.companycam.com/projects/94772883
- Uploaded photo to CompanyCam project 94772883
  https://app.companycam.com/photos/8675309
- Tagged CompanyCam photo 8675309 (kitchen, demo)
- Commented on CompanyCam project 94772883
- Archived CompanyCam project 94772883
\`\`\`

After (2 grouped blocks, 6 lines, every receipt clickable, no raw ids):
\`\`\`
- Smith Residence
  created · commented (all demo done) · archived
  https://app.companycam.com/projects/94772883
- kitchen demo
  uploaded photo to · tagged (kitchen, demo)
  https://app.companycam.com/photos/8675309
\`\`\`

### Follow-up

Deferred: URL-off user preference ("don't give me URLs" from a contractor) captured in \`TODOS.md\`. Needs its own PR with a DB migration, a preference tool for the LLM, and a UI toggle.

### Plan + reviews

Full /autoplan plan file with decision audit trail, eng-review findings, and consensus table: \`~/.gstack/projects/mozilla-ai-clawbolt/feat-companycam-receipts-clickable-urls-companycam-receipts-20260419-002755.md\`. Five eng-review gaps were caught by the Claude subagent (regex false-negative, newline injection, ID validation, per-tag cap, block-level test) and all auto-fixed before this PR was opened. Codex was unavailable (401 auth in sandbox) — single-model subagent review. A follow-up commit (\`_pick_group_subject\`) addresses the "grouped block shows 'project' instead of the real name" concern called out at the original approval gate.

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`)
- [x] Lint passes (\`ruff check backend/ tests/ && ruff format --check backend/ tests/\`)
- [x] Type checking passes (\`uv run ty check --python .venv backend/ tests/\` on new files)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Pre-existing flakes on main (not mine): \`test_user_defaults\`, \`test_profile_defaults_from_settings\`.

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 ran /autoplan, produced the plan with premise gate, auto-decided the remaining 16 choices, dispatched an independent eng-review subagent that caught five gaps, wrote the implementation and 45 tests across three files)
- [ ] No AI used