### PR TITLE
fix: dedupe heartbeat items by window, not clock time

### DIFF
--- a/backend/app/agent/prompts/bootstrap.md
+++ b/backend/app/agent/prompts/bootstrap.md
@@ -35,7 +35,7 @@ Sometime during the conversation, mention that they can tap the microphone on th
 
 ## Capabilities
 
-Once you have names, personality, and some business context, mention what you can help with — estimates, clients, photos, calendar, reminders. Don't read the full list. Highlight what's relevant to their trade.
+Once you have names, personality, and some business context, mention what you can help with: estimates, clients, photos, calendar, reminders. Don't read the full list. Highlight what's relevant to their trade.
 
 If they ask for something you can't do, say so and move on.
 

--- a/backend/app/agent/prompts/heartbeat_rules.md
+++ b/backend/app/agent/prompts/heartbeat_rules.md
@@ -1,5 +1,5 @@
-- Only act on items that appear in the current "User's heartbeat" section above. If an item does not appear there, do not act on it, even if it appears in the recent heartbeat activity history. The history section shows past timing for reference only; it is not a list of tasks to re-run.
-- Do not infer patterns from heartbeat activity history. If past checks triggered check-ins for items that no longer appear in the current heartbeat section, do not continue those patterns. Removed items mean the user no longer wants those actions.
+- Only act on items in the current "User's heartbeat" section. The history section is reference only, not a list of tasks to re-run; do not continue patterns from items that have been removed.
+- Items with a time or day fire approximately, not on the dot. Before running one, check the heartbeat history: if the item already fired within its current window, skip. An early run still counts.
 - Choose 'run' when there is something genuinely actionable: a pending heartbeat item, a stale estimate, a follow-up that is due, data to check in an integration, or similar.
 - If nothing needs attention right now, choose 'skip'.
 - When choosing 'run', write a clear task description in the 'tasks' field. Be specific about what to check, query, or do. The executing agent will use this as its instructions.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -1,9 +1,9 @@
 - Reply directly with text. The system delivers whatever you write as the outbound message. Use `send_media_reply` only when you need to attach a file or image.
 - Be concise and practical. Users are busy.
-- You can ONLY communicate via this chat. You cannot send emails, make phone calls, or contact clients directly.
+- You can only communicate via this chat. You cannot send emails, make phone calls, or contact clients directly.
 - Always be helpful, friendly, and professional.
 - Keep replies concise. Users are on the job site.
-- If the user explicitly asks you not to respond (e.g. "don't say anything back"), return empty text. It is OK to not respond when the user asks for silence.
+- If the user explicitly asks you not to respond, return empty text. It is OK to not respond when the user asks for silence.
 
 ## Formatting
 Your replies are read on a phone. Format for mobile text messages:
@@ -26,7 +26,7 @@ Update these files proactively as you learn new things. Do not ask permission. J
 - **HEARTBEAT.md**: Recurring things to check on: unpaid invoices, pending estimates, follow-up reminders, active job deadlines. Suggest adding items when the user asks about ongoing monitoring.
 
 ## Proactive monitoring
-- When a user asks to be notified about changes or wants recurring visibility into data (e.g. unpaid invoices, overdue estimates, new payments), suggest adding a heartbeat item so it gets checked automatically.
+- When a user asks to be notified about changes or wants recurring visibility into data, suggest adding a heartbeat item so it gets checked automatically.
 - Do not wait for the user to mention the heartbeat. If the request is about ongoing monitoring, proactively offer to set it up.
 
 ## Permissions

--- a/backend/app/agent/prompts/proactive.md
+++ b/backend/app/agent/prompts/proactive.md
@@ -5,4 +5,4 @@ When to reach out proactively:
 - A follow-up reminder or deadline is approaching
 - You haven't heard from the user in a few days
 
-When a user asks to be reminded about something recurring (e.g. "send me a joke every week", "check on unpaid invoices daily"), you CAN do that. Add the item to HEARTBEAT.md and the heartbeat system will trigger you to follow through on schedule. Do not tell the user you cannot reach out on your own.
+When a user asks to be reminded about something recurring (e.g. "send me a joke every week", "check on unpaid invoices daily"), you CAN do that. Add the item to HEARTBEAT.md and the heartbeat system will trigger you to follow through on schedule. Heartbeat checks are approximate, so items fire within a window rather than at an exact clock time. Do not tell the user you cannot reach out on your own.

--- a/backend/app/agent/prompts/proactive.md
+++ b/backend/app/agent/prompts/proactive.md
@@ -5,4 +5,4 @@ When to reach out proactively:
 - A follow-up reminder or deadline is approaching
 - You haven't heard from the user in a few days
 
-When a user asks to be reminded about something recurring (e.g. "send me a joke every week", "check on unpaid invoices daily"), you CAN do that. Add the item to HEARTBEAT.md and the heartbeat system will trigger you to follow through on schedule. Heartbeat checks are approximate, so items fire within a window rather than at an exact clock time. Do not tell the user you cannot reach out on your own.
+When a user asks to be reminded about something recurring, you can do that. Add the item to HEARTBEAT.md and the heartbeat system will trigger you to follow through on schedule. Heartbeat checks are approximate, so items fire within a window rather than at an exact clock time. Do not tell the user you cannot reach out on your own.

--- a/backend/app/agent/skills/quickbooks/SKILL.md
+++ b/backend/app/agent/skills/quickbooks/SKILL.md
@@ -21,7 +21,7 @@ You now have access to QuickBooks Online tools. Here is how to use them effectiv
 - Payment: Id, CustomerRef, TotalAmt, TxnDate
 - Bill: Id, VendorRef, TotalAmt, DueDate, Balance
 
-Note: SyncToken is returned in query results. You need it when updating an entity with `qb_update`.
+SyncToken is returned in query results; you need it when updating an entity with `qb_update`.
 
 ### Syntax
 SELECT <fields> FROM <Entity> [WHERE <conditions>] [ORDERBY <field> DESC] [MAXRESULTS <n>]

--- a/backend/app/agent/tools/calendar_tools.py
+++ b/backend/app/agent/tools/calendar_tools.py
@@ -733,7 +733,7 @@ def create_calendar_tools(
             name=ToolName.CALENDAR_CREATE_EVENT,
             description=(
                 "Create a new event on Google Calendar. "
-                "IMPORTANT: Some calendars are read-only. Check calendar_list_calendars "
+                "Some calendars are read-only; check calendar_list_calendars "
                 "first to verify the target calendar allows creation. "
                 "Use 'Job: {client} - {description}' format for job events. "
                 "Include the job location. "

--- a/backend/app/agent/tools/heartbeat_tools.py
+++ b/backend/app/agent/tools/heartbeat_tools.py
@@ -60,10 +60,12 @@ def create_heartbeat_tools(user_id: str) -> list[Tool]:
             name=ToolName.UPDATE_HEARTBEAT,
             description=(
                 "Update the user's heartbeat notes with new markdown text. "
-                "IMPORTANT: This overwrites the entire file. Only include items "
-                "that currently exist in the file plus whatever the user asked to "
-                "add or change. Never re-add items that are not in the current "
-                "file, even if you remember them from conversation history."
+                "Overwrites the entire file: include the current items plus "
+                "whatever the user asked to add or change, and never re-add "
+                "items not in the current file. Write timed items as windows "
+                "('every morning', 'Mondays') rather than exact clock times; "
+                "the heartbeat system checks periodically and fires each item "
+                "once per window."
             ),
             function=update_heartbeat,
             params_model=UpdateHeartbeatParams,

--- a/backend/app/agent/tools/media_tools.py
+++ b/backend/app/agent/tools/media_tools.py
@@ -153,10 +153,10 @@ def create_media_tools(
             name=ToolName.DISCARD_MEDIA,
             description=(
                 "Discard a staged photo the user asked you not to save. Use this "
-                "ONLY when the user's current message explicitly asks to drop the "
-                "photo (e.g. 'don't save that one', 'skip this photo'). Quote the "
-                "user's phrase in the reason argument; the user will be asked to "
-                "confirm. Idempotent: discarding an already-discarded handle is safe."
+                "only when the user's current message explicitly asks to drop the "
+                "photo. Quote the user's phrase in the reason argument; the user "
+                "will be asked to confirm. Idempotent: discarding an already-"
+                "discarded handle is safe."
             ),
             function=discard_media,
             params_model=DiscardMediaParams,

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -184,7 +184,7 @@ class TestSectionBuilders:
         """Should contain core behavioral rules."""
         result = build_instructions_section()
         assert "concise" in result
-        assert "ONLY communicate via this chat" in result
+        assert "only communicate via this chat" in result
 
     def test_build_instructions_section_no_trade_guidance(self) -> None:
         """Instructions section should not contain trade-specific guidance (removed from model)."""


### PR DESCRIPTION
## Description

Two related prompt-level changes on one branch.

### Heartbeat timing (commit 1)

Heartbeat ticks fire at irregular intervals, which caused the "every morning at 9am" item to sometimes fire at 8:17 AM (judged close enough) and then fire again at 9:18 AM (the earlier run dismissed as "before the 9am window"). Two sides needed to agree on a shared model: items describe a window, the evaluator dedupes by whether the item already fired in that window, and an early run still counts.

- **`heartbeat_rules.md`**: Merged two overlapping bullets about "current items only" into one, added a new bullet telling the Phase 1 evaluator to check history for a window-level dedupe before running a timed item. Net bullet count unchanged.
- **`proactive.md`**: Added one sentence noting heartbeat checks are approximate and fire within a window, not at an exact clock time.
- **`update_heartbeat` tool description**: Dropped the "IMPORTANT:" label, added guidance to write timed items as windows ("every morning", "Mondays") rather than exact clock times.

### Prompt style scrub (commit 2)

Removed "Important:" / "Note:" labels, ALL-CAPS emphasis words, gratuitous inline examples, and an em dash across prompt files and tool descriptions. Pure tone/bloat pass; content preserved.

- `calendar_tools.py`: drop `IMPORTANT:` from `calendar_create_event` description.
- `media_tools.py`: drop `ONLY` emphasis and example user phrases from `discard_media` description.
- `instructions.md`: de-emphasize `ONLY`, drop two inline `(e.g. ...)` lists that restated the surrounding sentence.
- `proactive.md`: drop `(e.g. "send me a joke every week", ...)` and `CAN` emphasis.
- `quickbooks/SKILL.md`: drop `Note:` prefix.
- `bootstrap.md`: replace em dash with a colon (per clawbolt CLAUDE.md style rule).

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [ ] Tests pass (`uv run pytest -v`)
- [ ] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

Existing `test_heartbeat.py` assertions on prompt substrings still hold. No new behavior, so no new tests; this is a prompt-level fix.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude (Opus 4.7) diagnosed the heartbeat double-fire from the user's reported log, drafted the prompt edits, and then ran a full scrub of the other prompt/tool-description files for the same style issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)