### PR TITLE
fix: CompanyCam photo receipts link to app instead of CDN image

### DIFF
--- a/backend/app/agent/tools/companycam_photos.py
+++ b/backend/app/agent/tools/companycam_photos.py
@@ -31,7 +31,7 @@ from backend.app.agent.tools.companycam_receipts import (
     tags_target,
 )
 from backend.app.agent.tools.names import ToolName
-from backend.app.services.companycam import CompanyCamService, get_photo_url
+from backend.app.services.companycam import CompanyCamService
 
 if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
@@ -158,13 +158,13 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                 except Exception:
                     break
 
-        url = get_photo_url(photo)
+        app_url = photo_url(photo.id)
         logger.info(
             "CompanyCam photo result: project=%s id=%s status=%s url=%s",
             project_id,
             photo.id,
             status,
-            url,
+            app_url,
         )
 
         if status == "processing_error":
@@ -185,7 +185,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                 receipt=ToolReceipt(
                     action="Photo already in CompanyCam",
                     target=photo_target(photo),
-                    url=url or photo_url(photo.id),
+                    url=app_url,
                 ),
             )
 
@@ -193,11 +193,11 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         if status == "pending":
             status_note = " (still processing, may take a moment to appear)"
         return ToolResult(
-            content=f"Photo uploaded to CompanyCam project {project_id}: {url}{status_note}",
+            content=f"Photo uploaded to CompanyCam project {project_id}: {app_url}{status_note}",
             receipt=ToolReceipt(
                 action="Uploaded photo to CompanyCam",
                 target=photo_target(photo),
-                url=url or photo_url(photo.id),
+                url=app_url,
             ),
         )
 
@@ -373,9 +373,9 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             return ToolResult(content="No photos found matching the criteria.")
         lines = [f"Found {len(photos)} photo(s):"]
         for p in photos[:20]:
-            url = get_photo_url(p)
+            p_url = photo_url(p.id) or f"photo {p.id}"
             desc = f" - {p.description}" if p.description else ""
-            lines.append(f"- ID: {p.id}{desc}: {url}")
+            lines.append(f"- ID: {p.id}{desc}: {p_url}")
         if len(photos) > 20:
             lines.append(f"(Showing 20 of {len(photos)})")
         if len(photos) >= 50:

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -1036,6 +1036,98 @@ async def test_receipt_create_checklist_is_clean() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_receipt_upload_photo_uses_app_url() -> None:
+    """Regression: upload receipt must link to the app, not the CDN image."""
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.media.download import DownloadedMedia
+    from backend.app.services.companycam_models import ImageURI, Photo
+
+    service = MagicMock(spec=CompanyCamService)
+    photo_obj = Photo(
+        id="39951388",
+        description="Clock repair job site",
+        processing_status="processed",
+        uris=[ImageURI(type="original", uri="https://img.companycam.com/long-cdn-hash.jpg")],
+    )
+    service.upload_photo = AsyncMock(return_value=photo_obj)
+
+    ctx = MagicMock()
+    ctx.user.id = "test-user"
+    ctx.downloaded_media = [
+        DownloadedMedia(
+            content=b"fake-jpg",
+            mime_type="image/jpeg",
+            original_url="https://example.com/photo.jpg",
+            filename="photo.jpg",
+        )
+    ]
+
+    with (
+        patch(
+            "backend.app.services.webhook.discover_tunnel_url",
+            new_callable=AsyncMock,
+            return_value="https://tunnel.example.com",
+        ),
+        patch(
+            "backend.app.routers.media_temp.create_temp_media_url",
+            return_value="https://tunnel.example.com/media/tmp/abc",
+        ),
+    ):
+        tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+        result = await tool.function(project_id="94772883")
+
+    _assert_receipt_clean(result.receipt, expect_url=True)
+    assert "photos/39951388" in result.receipt.url
+    # Content shown to the LLM should also use the app URL, not the CDN URL
+    assert "img.companycam.com" not in result.content
+
+
+@pytest.mark.asyncio()
+async def test_receipt_upload_duplicate_photo_uses_app_url() -> None:
+    """Regression: duplicate-photo receipt must link to the app, not the CDN."""
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.media.download import DownloadedMedia
+    from backend.app.services.companycam_models import ImageURI, Photo
+
+    service = MagicMock(spec=CompanyCamService)
+    photo_obj = Photo(
+        id="39951388",
+        description="Kitchen demo",
+        processing_status="duplicate",
+        uris=[ImageURI(type="original", uri="https://img.companycam.com/dup.jpg")],
+    )
+    service.upload_photo = AsyncMock(return_value=photo_obj)
+
+    ctx = MagicMock()
+    ctx.user.id = "test-user"
+    ctx.downloaded_media = [
+        DownloadedMedia(
+            content=b"fake-jpg",
+            mime_type="image/jpeg",
+            original_url="https://example.com/photo.jpg",
+            filename="photo.jpg",
+        )
+    ]
+
+    with (
+        patch(
+            "backend.app.services.webhook.discover_tunnel_url",
+            new_callable=AsyncMock,
+            return_value="https://tunnel.example.com",
+        ),
+        patch(
+            "backend.app.routers.media_temp.create_temp_media_url",
+            return_value="https://tunnel.example.com/media/tmp/abc",
+        ),
+    ):
+        tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+        result = await tool.function(project_id="94772883")
+
+    _assert_receipt_clean(result.receipt, expect_url=True)
+    assert "photos/39951388" in result.receipt.url
+
+
+@pytest.mark.asyncio()
 async def test_receipt_rendered_output_has_no_raw_ids() -> None:
     """End-to-end: a grouped footer of five actions on one project
     never surfaces a raw CompanyCam id in the rendered output."""


### PR DESCRIPTION
## Description
CompanyCam photo receipts (upload, duplicate, search) linked to CDN image URLs
(`img.companycam.com/...`) instead of the web app (`app.companycam.com/photos/{id}`).
Clicking a photo link in a receipt now opens CompanyCam's web app where the user can
see the photo in context, add comments, tags, etc.

The `photo_url()` helper in `companycam_receipts.py` already generated the correct app
URL, but `get_photo_url()` (CDN URL) always returned something truthy, so the
`url or photo_url(...)` fallback never triggered.

**Three places fixed in `companycam_photos.py`:**
- Upload photo receipt and content string
- Duplicate photo receipt
- Search photos result listing

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## Test Coverage
Two regression tests added:
- `test_receipt_upload_photo_uses_app_url`: verifies upload receipt points at `app.companycam.com` and content string has no CDN URLs
- `test_receipt_upload_duplicate_photo_uses_app_url`: same for the duplicate-photo path

All 112 related tests pass (34 receipt tests + 78 tool/service tests).

## AI Usage
- [x] AI-assisted (Claude Code authored the fix and regression tests)
- [ ] No AI used