### PR TITLE
feat: render web chat messages with iMessage parity

### DIFF
--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -8,7 +8,9 @@ from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
 from backend.app.agent.concurrency import user_locks
+from backend.app.agent.context import StoredToolInteraction
 from backend.app.agent.session_db import get_session_store
+from backend.app.agent.tool_summary import append_receipts
 from backend.app.auth.dependencies import get_current_user
 from backend.app.database import get_db
 from backend.app.models import ChatSession, Message, User
@@ -85,11 +87,26 @@ async def get_session(
         if msg.tool_interactions_json and msg.tool_interactions_json not in ("", "[]"):
             with contextlib.suppress(json.JSONDecodeError, TypeError):
                 tool_interactions = json.loads(msg.tool_interactions_json)
+
+        # Mirror the channel-side transform: outbound replies render with the
+        # deterministic receipt block appended, matching what iMessage/Telegram
+        # users receive. Messages in the DB store the raw LLM reply so the
+        # agent's own history stays clean; the receipt block is recomputed
+        # here for the display surface.
+        body = msg.body
+        if msg.direction == "outbound" and tool_interactions:
+            stored: list[StoredToolInteraction] = []
+            for entry in tool_interactions:
+                with contextlib.suppress(Exception):
+                    stored.append(StoredToolInteraction.model_validate(entry))
+            if stored:
+                body = append_receipts(body, stored)
+
         messages.append(
             SessionMessage(
                 seq=msg.seq,
                 direction=msg.direction,
-                body=msg.body,
+                body=body,
                 timestamp=msg.timestamp,
                 tool_interactions=tool_interactions,
             )

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect, useCallback, type FormEvent } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
-import Markdown from 'react-markdown';
 import Button from '@/components/ui/button';
 import ConfirmModal from '@/components/ui/confirm-modal';
 import { Checkbox } from '@heroui/checkbox';
@@ -566,13 +565,7 @@ export default function ChatPage() {
                     </div>
                   )}
                   {msg.body && (
-                    msg.role === 'assistant' ? (
-                      <div className="prose-chat">
-                        <Markdown>{msg.body}</Markdown>
-                      </div>
-                    ) : (
-                      <p className="text-sm whitespace-pre-wrap">{msg.body}</p>
-                    )
+                    <p className="text-sm whitespace-pre-wrap">{msg.body}</p>
                   )}
 
                   {msg.toolInteractions && msg.toolInteractions.length > 0 && (

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -78,6 +78,91 @@ def test_get_session_detail(client: TestClient, test_user: User) -> None:
     assert data["messages"][1]["tool_interactions"][0]["tool"] == "save_fact"
 
 
+def test_get_session_detail_appends_receipts_to_outbound(
+    client: TestClient, test_user: User
+) -> None:
+    """Outbound messages with tool receipts should include the rendered
+    receipt block in the returned body, matching what iMessage/Telegram
+    users see."""
+    tool_json = json.dumps(
+        [
+            {
+                "tool_call_id": "call_1",
+                "name": "create_companycam_project",
+                "args": {},
+                "result": "ok",
+                "is_error": False,
+                "receipt": {
+                    "action": "Created CompanyCam project",
+                    "target": "Smith Residence",
+                    "url": "https://app.companycam.com/projects/12345",
+                },
+            },
+        ]
+    )
+    _create_session(
+        test_user,
+        "1_250",
+        [
+            {
+                "direction": "inbound",
+                "body": "Create a project for Smith",
+                "timestamp": "2025-01-15T10:01:00",
+                "seq": 1,
+            },
+            {
+                "direction": "outbound",
+                "body": "Done!",
+                "timestamp": "2025-01-15T10:02:00",
+                "seq": 2,
+                "tool_interactions_json": tool_json,
+            },
+        ],
+    )
+    resp = client.get("/api/user/sessions/1_250")
+    assert resp.status_code == 200
+    body = resp.json()["messages"][1]["body"]
+    assert body.startswith("Done!")
+    assert "Created CompanyCam project Smith Residence" in body
+    assert "https://app.companycam.com/projects/12345" in body
+
+
+def test_get_session_detail_inbound_body_unchanged(client: TestClient, test_user: User) -> None:
+    """Receipt append must only apply to outbound messages, never inbound."""
+    tool_json = json.dumps(
+        [
+            {
+                "tool_call_id": "call_1",
+                "name": "create_companycam_project",
+                "args": {},
+                "result": "ok",
+                "is_error": False,
+                "receipt": {
+                    "action": "Created CompanyCam project",
+                    "target": "Smith Residence",
+                    "url": "https://app.companycam.com/projects/12345",
+                },
+            },
+        ]
+    )
+    _create_session(
+        test_user,
+        "1_260",
+        [
+            {
+                "direction": "inbound",
+                "body": "Hello",
+                "timestamp": "2025-01-15T10:01:00",
+                "seq": 1,
+                "tool_interactions_json": tool_json,
+            },
+        ],
+    )
+    resp = client.get("/api/user/sessions/1_260")
+    assert resp.status_code == 200
+    assert resp.json()["messages"][0]["body"] == "Hello"
+
+
 def test_session_direction_values(client: TestClient, test_user: User) -> None:
     """API response direction values must be 'inbound'/'outbound' (not 'incoming'/'outgoing')."""
     _create_session(


### PR DESCRIPTION
## Description

Makes the web chat render assistant messages the same way an iMessage/Telegram user sees them:

1. **Strip markdown rendering from assistant bubbles.** Web chat was running `react-markdown` over the reply text, so `**Done!**` became bold. iMessage shows literal asterisks. The chat bubble now uses the same `whitespace-pre-wrap` paragraph as user messages, so the rendered text matches byte-for-byte what a phone user sees.

2. **Show tool receipts in session history.** The SSE live path already piped outbound content through `append_receipts()` at the channel boundary (`router.py:497`), so receipts appeared right when the agent replied. The `get_session` endpoint pulled straight from `messages.body` (raw `reply_text`), so a page refresh dropped the receipt block from past assistant replies. `get_session` now mirrors the channel-side transform: for outbound messages with tool interactions, it parses the stored `StoredToolInteraction` JSON and applies `append_receipts` before returning. The DB still stores raw `reply_text` so the agent's own history reconstruction stays clean -- only the display API composes the receipt block.

Regression tests cover both directions (receipts appear on outbound; untouched on inbound). All existing `test_session_endpoints.py` tests pass unchanged since their fixtures don't include `receipt` fields on tool interactions.

Before/after screenshots against a seeded session with `**Done!**` + two grouped receipts:

- Before: `**Done!**` rendered bold, receipts missing on reload
- After: `**Done!**` rendered verbatim, receipt block visible (`- Smith Residence / created · uploaded photo / https://...`)

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 1815 pass, 2 pre-existing failures on main unrelated to this change (`test_user_defaults`, `test_profile_defaults_from_settings` — telegram/bluebubbles default drift)
- [x] Lint passes (`ruff check` + `ruff format --check` clean on changed files)
- [x] Type check passes (`ty check` clean on changed files; `tsc --noEmit` clean; `knip` clean)
- [x] New tests added for new functionality (`test_get_session_detail_appends_receipts_to_outbound`, `test_get_session_detail_inbound_body_unchanged`)
- [x] Bug fixes include regression tests — N/A, but new behavior has regression tests
- [x] Visual verification via Playwright against a seeded session -- confirmed `**Done!**` renders literal, receipt block renders in bubble

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code. Human directed the scope (strip markdown, skip iMessage coloring, ensure receipts appear), Claude traced the data flow across `router.py`/`webchat.py`/`tool_summary.py`/`user_sessions.py`, identified the SSE vs history-load divergence, implemented the server-side mirror, removed the markdown renderer from `ChatPage.tsx`, added regression tests, and ran visual verification via Playwright against a seeded session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)