### PR TITLE
ci: notify premium repo on OSS release

### DIFF
--- a/.github/workflows/notify-premium.yml
+++ b/.github/workflows/notify-premium.yml
@@ -1,0 +1,18 @@
+name: Notify Premium on Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to clawbolt-premium
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PREMIUM_REPO_TOKEN }}
+          repository: mozilla-ai/clawbolt-premium
+          event-type: oss-release
+          client-payload: '{"tag": "${{ github.event.release.tag_name || ''manual'' }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/notify-premium.yml
+++ b/.github/workflows/notify-premium.yml
@@ -1,5 +1,12 @@
 name: Notify Premium on Release
 
+# Sends a repository_dispatch event to clawbolt-premium so it can
+# redeploy or bump OSS_REF when the OSS layer ships a new version.
+#
+# Prerequisite: configure a PREMIUM_REPO_TOKEN secret in this repo's
+# GitHub Settings > Secrets. The token must be a PAT with `repo` scope
+# that can dispatch to mozilla-ai/clawbolt-premium.
+
 on:
   release:
     types: [created]
@@ -15,4 +22,5 @@ jobs:
           token: ${{ secrets.PREMIUM_REPO_TOKEN }}
           repository: mozilla-ai/clawbolt-premium
           event-type: oss-release
-          client-payload: '{"tag": "${{ github.event.release.tag_name || ''manual'' }}", "sha": "${{ github.sha }}"}'
+          client-payload: >-
+            {"tag": "${{ github.event.release.tag_name || 'manual' }}", "sha": "${{ github.sha }}"}


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow that sends a `repository_dispatch` event to `clawbolt-premium` when a new OSS release is created. This enables the premium repo to automatically redeploy or bump its `OSS_REF` when the OSS layer ships a new version, instead of requiring a manual redeploy from the Railway dashboard.

Requires a `PREMIUM_REPO_TOKEN` secret (PAT with `repo` scope) to be configured in this repo's GitHub settings.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

N/A -- CI workflow only, no application code changes.

## AI Usage
- [x] AI-assisted (Claude Code -- planned and implemented based on octonous patterns)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)