### PR TITLE
fix: CompanyCam photo upload fallback, receipt formatting, and project URLs

### DIFF
--- a/.github/workflows/notify-premium.yml
+++ b/.github/workflows/notify-premium.yml
@@ -1,0 +1,18 @@
+name: Notify Premium on Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to clawbolt-premium
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PREMIUM_REPO_TOKEN }}
+          repository: mozilla-ai/clawbolt-premium
+          event-type: oss-release
+          client-payload: '{"tag": "${{ github.event.release.tag_name || ''manual'' }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/notify-premium.yml
+++ b/.github/workflows/notify-premium.yml
@@ -1,5 +1,12 @@
 name: Notify Premium on Release
 
+# Sends a repository_dispatch event to clawbolt-premium so it can
+# redeploy or bump OSS_REF when the OSS layer ships a new version.
+#
+# Prerequisite: configure a PREMIUM_REPO_TOKEN secret in this repo's
+# GitHub Settings > Secrets. The token must be a PAT with `repo` scope
+# that can dispatch to mozilla-ai/clawbolt-premium.
+
 on:
   release:
     types: [created]
@@ -15,4 +22,5 @@ jobs:
           token: ${{ secrets.PREMIUM_REPO_TOKEN }}
           repository: mozilla-ai/clawbolt-premium
           event-type: oss-release
-          client-payload: '{"tag": "${{ github.event.release.tag_name || ''manual'' }}", "sha": "${{ github.sha }}"}'
+          client-payload: >-
+            {"tag": "${{ github.event.release.tag_name || 'manual' }}", "sha": "${{ github.sha }}"}

--- a/backend/app/agent/tools/companycam_photos.py
+++ b/backend/app/agent/tools/companycam_photos.py
@@ -64,6 +64,15 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         if tags:
             tags = [t.strip()[:50] for t in tags[:10] if t.strip()]
 
+        # Sanitize LLM-supplied description: the LLM sometimes passes
+        # the raw vision analysis output (a dict repr or JSON object)
+        # instead of a plain-text sentence. Strip it so CompanyCam
+        # doesn't store garbage as the photo description.
+        if description:
+            description = description.strip()
+            if description.startswith(("{", "[")):
+                description = ""
+
         file_bytes: bytes = b""
         mime_type = "image/jpeg"
         photo_uri = ""
@@ -82,10 +91,13 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             all_staged = media_staging.get_all_for_user(ctx.user.id)
             if original_url and original_url in all_staged:
                 file_bytes = all_staged[original_url]
-            elif all_staged:
+            elif not original_url and all_staged:
+                # Only grab an arbitrary photo when the LLM did not
+                # specify which one. When original_url is set but not
+                # found, we must NOT silently substitute another photo.
                 first_url = next(iter(all_staged))
                 file_bytes = all_staged[first_url]
-                original_url = original_url or first_url
+                original_url = first_url
 
         # 3. Fall back to MediaFile records (already saved to storage)
         if not file_bytes:
@@ -93,7 +105,9 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             media_file = None
             if original_url:
                 media_file = await media_store.get_by_url(original_url)
-            if media_file is None:
+            if media_file is None and not original_url:
+                # Same guard as step 2: only grab the most recent media
+                # when the LLM did not specify a particular URL.
                 all_media = await media_store.list_all()
                 if all_media:
                     media_file = all_media[-1]

--- a/backend/app/agent/tools/companycam_receipts.py
+++ b/backend/app/agent/tools/companycam_receipts.py
@@ -51,10 +51,14 @@ def _web_base() -> str:
 
 def project_url(project_id: str) -> str | None:
     """Return the web URL for a CompanyCam project, or None when the id
-    is missing or not a numeric string."""
+    is missing or not a numeric string.
+
+    Links to the ``/photos`` tab because that is the primary view
+    contractors use after tapping a project link in iMessage or SMS.
+    """
     if not project_id or not _ID_RE.match(project_id):
         return None
-    return f"{_web_base()}/projects/{project_id}"
+    return f"{_web_base()}/projects/{project_id}/photos"
 
 
 def photo_url(photo_id: str) -> str | None:
@@ -75,9 +79,18 @@ def project_target(project: Project | None) -> str:
 
 
 def photo_target(photo: Photo | None) -> str:
-    """Human-readable target for a photo receipt. Never a raw id."""
+    """Human-readable target for a photo receipt. Never a raw id.
+
+    Guards against structured data (dict repr, JSON) that the LLM may
+    have passed as the description parameter. A description that starts
+    with ``{`` or ``[`` is almost certainly not prose, so we fall back
+    to the generic word rather than surfacing raw braces in the footer.
+    """
     if photo and photo.description:
-        desc = _sanitize(photo.description, 60)
+        stripped = photo.description.strip()
+        if stripped.startswith(("{", "[")):
+            return "photo"
+        desc = _sanitize(stripped, 60)
         if desc:
             return desc
     return "photo"

--- a/tests/test_companycam_receipts.py
+++ b/tests/test_companycam_receipts.py
@@ -27,7 +27,7 @@ from backend.app.services.companycam_models import Photo, Project
 
 
 def test_project_url_numeric_id() -> None:
-    assert project_url("94772883") == "https://app.companycam.com/projects/94772883"
+    assert project_url("94772883") == "https://app.companycam.com/projects/94772883/photos"
 
 
 def test_project_url_empty_id_returns_none() -> None:
@@ -107,6 +107,19 @@ def test_photo_target_truncates_description() -> None:
     out = photo_target(ph)
     assert len(out) == 60
     assert out.endswith("\u2026")
+
+
+def test_photo_target_rejects_dict_like_description() -> None:
+    """Regression: LLM may pass a dict repr as the photo description.
+    The receipt target must fall back to 'photo', not surface raw braces."""
+    ph = Photo(id="x", description="{'id': '39959882', 'html_content': 'Basement staircase'}")
+    assert photo_target(ph) == "photo"
+
+
+def test_photo_target_rejects_json_array_description() -> None:
+    """JSON array descriptions also fall back to generic."""
+    ph = Photo(id="x", description='[{"key": "value"}]')
+    assert photo_target(ph) == "photo"
 
 
 def test_photo_target_strips_newlines() -> None:
@@ -205,11 +218,11 @@ def test_project_url_honors_settings_web_base(monkeypatch: Any) -> None:
     from backend.app.config import settings
 
     monkeypatch.setattr(settings, "companycam_web_base", "https://eu.app.companycam.com")
-    assert project_url("94772883") == "https://eu.app.companycam.com/projects/94772883"
+    assert project_url("94772883") == "https://eu.app.companycam.com/projects/94772883/photos"
 
 
 def test_project_url_strips_trailing_slash_on_web_base(monkeypatch: Any) -> None:
     from backend.app.config import settings
 
     monkeypatch.setattr(settings, "companycam_web_base", "https://app.companycam.com/")
-    assert project_url("94772883") == "https://app.companycam.com/projects/94772883"
+    assert project_url("94772883") == "https://app.companycam.com/projects/94772883/photos"

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -1128,6 +1128,55 @@ async def test_receipt_upload_duplicate_photo_uses_app_url() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_upload_photo_strips_dict_description() -> None:
+    """Regression: LLM may pass a dict repr as the photo description.
+    The tool must strip it before sending to CompanyCam so the project
+    doesn't store garbage."""
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.media.download import DownloadedMedia
+    from backend.app.services.companycam_models import ImageURI, Photo
+
+    service = MagicMock(spec=CompanyCamService)
+    photo_obj = Photo(
+        id="39951388",
+        description="",
+        processing_status="processed",
+        uris=[ImageURI(type="original", uri="https://img.companycam.com/abc.jpg")],
+    )
+    service.upload_photo = AsyncMock(return_value=photo_obj)
+
+    ctx = MagicMock()
+    ctx.user.id = "test-user"
+    ctx.downloaded_media = [
+        DownloadedMedia(
+            content=b"fake-jpg",
+            mime_type="image/jpeg",
+            original_url="https://example.com/photo.jpg",
+            filename="photo.jpg",
+        )
+    ]
+
+    dict_description = "{'id': '39959882', 'html_content': 'Basement staircase'}"
+    with (
+        patch(
+            "backend.app.services.webhook.discover_tunnel_url",
+            new_callable=AsyncMock,
+            return_value="https://tunnel.example.com",
+        ),
+        patch(
+            "backend.app.routers.media_temp.create_temp_media_url",
+            return_value="https://tunnel.example.com/media/tmp/abc",
+        ),
+    ):
+        tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+        await tool.function(project_id="94772883", description=dict_description)
+
+    # The description sent to CompanyCam must be empty, not the dict repr
+    call_kwargs = service.upload_photo.call_args
+    assert call_kwargs.kwargs.get("description", "") == ""
+
+
+@pytest.mark.asyncio()
 async def test_receipt_rendered_output_has_no_raw_ids() -> None:
     """End-to-end: a grouped footer of five actions on one project
     never surfaces a raw CompanyCam id in the rendered output."""
@@ -1151,19 +1200,19 @@ async def test_receipt_rendered_output_has_no_raw_ids() -> None:
                     "companycam_create_project",
                     "Created CompanyCam project",
                     "Smith Residence",
-                    "https://app.companycam.com/projects/94772883",
+                    "https://app.companycam.com/projects/94772883/photos",
                 ),
                 (
                     "companycam_update_notepad",
                     "Updated notepad on CompanyCam project",
                     "project",
-                    "https://app.companycam.com/projects/94772883",
+                    "https://app.companycam.com/projects/94772883/photos",
                 ),
                 (
                     "companycam_add_comment",
                     "Commented on CompanyCam project",
                     "All demo done",
-                    "https://app.companycam.com/projects/94772883",
+                    "https://app.companycam.com/projects/94772883/photos",
                 ),
                 (
                     "companycam_tag_photo",
@@ -1175,7 +1224,7 @@ async def test_receipt_rendered_output_has_no_raw_ids() -> None:
                     "companycam_archive_project",
                     "Archived CompanyCam project",
                     "project",
-                    "https://app.companycam.com/projects/94772883",
+                    "https://app.companycam.com/projects/94772883/photos",
                 ),
             ]
         )
@@ -1183,7 +1232,7 @@ async def test_receipt_rendered_output_has_no_raw_ids() -> None:
     block = format_receipts_block(fake_calls)
 
     # The rendered footer has two URL-keyed blocks (project + photo).
-    assert block.count("https://app.companycam.com/projects/94772883") == 1
+    assert block.count("https://app.companycam.com/projects/94772883/photos") == 1
     assert block.count("https://app.companycam.com/photos/8675309") == 1
 
     # Scan every visible token for a 6+ digit run: only the two URLs


### PR DESCRIPTION
## Description

Three CompanyCam bugs fixed from production observation:

1. **Wrong photo uploaded**: The fallback cascade in `companycam_upload_photo` was too aggressive. When the LLM passed an `original_url` that didn't match in any media tier (downloaded_media, staging, MediaStore), the code silently grabbed whatever photo was available instead of returning an error. Now the "grab any" fallback only applies when no `original_url` was specified.

2. **Ugly receipt target**: `photo_target()` was passing dict-repr descriptions straight through to the iMessage footer (e.g. `{'id': '39959882', 'html_content': 'Basement staircase - in...`). Now detects structured data and falls back to generic "photo". The upload tool also strips dict/JSON descriptions before sending to CompanyCam so the project itself doesn't store garbage.

3. **Project URL missing /photos**: `project_url()` now returns `/projects/{id}/photos` so links land on the photos tab, which is the primary view contractors use.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code investigated production logs, identified root causes, implemented fixes and regression tests)
- [ ] No AI used