### PR TITLE
fix: enforce CompanyCam approval policies at runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,9 +129,11 @@ The agent's capabilities are extended by adding tools. Tools follow a factory/re
 
 4. **Add to the registry test** at `tests/test_tool_registry.py`: add `"backend.app.agent.tools.<name>_tools"` to `EXPECTED_TOOL_MODULES`.
 
-5. **Write tests** at `tests/test_<name>_tools.py`. Call the factory function directly (e.g., `_create_calculator_tools()`) and invoke the tool function. No database needed for stateless tools.
+5. **Wire up approval policies** for any mutating tool. If a `SubToolInfo` declares `default_permission="ask"`, the corresponding `Tool` object **must** have `approval_policy=ApprovalPolicy(default_level=PermissionLevel.ASK)`. Without this, the WebUI shows "ask" but the runtime auto-executes. See `quickbooks_tools.py` for the reference pattern. The global test `test_ask_sub_tools_have_approval_policy` in `test_tool_registry.py` enforces this.
 
-6. **(Specialist only) Add a SKILL.md** at `backend/app/agent/skills/<name>/SKILL.md` if the tool has complex workflows the LLM needs guidance on. This markdown is injected into the conversation when the LLM activates the category via `list_capabilities`. Core tools do not need SKILL.md; their `description` and `usage_hint` fields in the Python code serve the same purpose.
+6. **Write tests** at `tests/test_<name>_tools.py`. Call the factory function directly (e.g., `_create_calculator_tools()`) and invoke the tool function. No database needed for stateless tools.
+
+7. **(Specialist only) Add a SKILL.md** at `backend/app/agent/skills/<name>/SKILL.md` if the tool has complex workflows the LLM needs guidance on. This markdown is injected into the conversation when the LLM activates the category via `list_capabilities`. Core tools do not need SKILL.md; their `description` and `usage_hint` fields in the Python code serve the same purpose.
 
 ### Key files
 

--- a/backend/app/agent/tools/companycam_checklists.py
+++ b/backend/app/agent/tools/companycam_checklists.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.companycam_params import (
     CompanyCamCreateChecklistParams,
@@ -129,6 +130,10 @@ def build_checklist_tools(service: CompanyCamService) -> list[Tool]:
             usage_hint=(
                 "Create a new checklist from a template. "
                 "Use list_checklists or ask the user which template to use."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: "Create a checklist on a CompanyCam project",
             ),
         ),
     ]

--- a/backend/app/agent/tools/companycam_photos.py
+++ b/backend/app/agent/tools/companycam_photos.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.companycam_params import (
     CompanyCamAddCommentParams,
@@ -410,6 +411,10 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                 "search for the CompanyCam project, then upload the photo with "
                 "relevant tags (e.g. 'kitchen', 'demo', 'before')."
             ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: "Upload a photo to CompanyCam",
+            ),
         ),
         Tool(
             name=ToolName.COMPANYCAM_ADD_COMMENT,
@@ -419,6 +424,12 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             usage_hint=(
                 "Add a note or comment to a project (target_type='project') "
                 "or a specific photo (target_type='photo')."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Add comment to CompanyCam {args.get('target_type', 'project')}"
+                ),
             ),
         ),
         Tool(
@@ -437,6 +448,10 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             function=companycam_tag_photo,
             params_model=CompanyCamTagPhotoParams,
             usage_hint="Tag photos with descriptive labels like 'before', 'kitchen', 'damage'.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: "Add tags to a CompanyCam photo",
+            ),
         ),
         Tool(
             name=ToolName.COMPANYCAM_DELETE_PHOTO,
@@ -444,6 +459,12 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             function=companycam_delete_photo,
             params_model=CompanyCamDeletePhotoParams,
             usage_hint="Only delete a photo if the user explicitly asks.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    "Permanently delete a CompanyCam photo (cannot be undone)"
+                ),
+            ),
         ),
         Tool(
             name=ToolName.COMPANYCAM_SEARCH_PHOTOS,

--- a/backend/app/agent/tools/companycam_projects.py
+++ b/backend/app/agent/tools/companycam_projects.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.companycam_params import (
     CompanyCamArchiveProjectParams,
@@ -256,6 +257,12 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
                 "Create a new project when no matching project exists. "
                 "Use the client name and address as the project name."
             ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Create CompanyCam project '{args.get('name', 'new project')}'"
+                ),
+            ),
         ),
         Tool(
             name=ToolName.COMPANYCAM_UPDATE_PROJECT,
@@ -265,6 +272,10 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             usage_hint=(
                 "Use to rename a project or update its address. "
                 "For example, adding a client name to a project."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: "Update CompanyCam project details",
             ),
         ),
         Tool(
@@ -283,6 +294,10 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             function=companycam_archive_project,
             params_model=CompanyCamArchiveProjectParams,
             usage_hint="Archive a project when a job is completed.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: "Archive a CompanyCam project",
+            ),
         ),
         Tool(
             name=ToolName.COMPANYCAM_DELETE_PROJECT,
@@ -295,6 +310,12 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             usage_hint=(
                 "Only delete a project if the user explicitly asks. Suggest archiving first."
             ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    "Permanently delete a CompanyCam project (cannot be undone)"
+                ),
+            ),
         ),
         Tool(
             name=ToolName.COMPANYCAM_UPDATE_NOTEPAD,
@@ -302,6 +323,10 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             function=companycam_update_notepad,
             params_model=CompanyCamUpdateNotepadParams,
             usage_hint="Add or update notes on a project.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: "Update notes on a CompanyCam project",
+            ),
         ),
         Tool(
             name=ToolName.COMPANYCAM_LIST_DOCUMENTS,

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -320,6 +320,19 @@ class ToolRegistry:
             created: list[Tool] = await result if inspect.isawaitable(result) else result  # type: ignore[assignment]
             if excluded_tool_names:
                 created = [t for t in created if t.name not in excluded_tool_names]
+            # Warn when SubToolInfo declares "ask" but the Tool has no
+            # approval_policy. This means the UI shows "ask" but the
+            # runtime will auto-execute without prompting.
+            if factory.sub_tools:
+                ask_names = {st.name for st in factory.sub_tools if st.default_permission == "ask"}
+                for tool in created:
+                    if tool.name in ask_names and tool.approval_policy is None:
+                        logger.warning(
+                            "Tool %s has default_permission='ask' in SubToolInfo "
+                            "but no approval_policy on the Tool object. "
+                            "The runtime will auto-execute without asking the user.",
+                            tool.name,
+                        )
             tools.extend(created)
         return tools
 

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -728,6 +728,58 @@ async def test_list_project_photos_pagination() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Regression: approval policies must match SubToolInfo defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_companycam_ask_tools_have_approval_policy() -> None:
+    """Regression: every CompanyCam tool with default_permission='ask' must have
+    an ApprovalPolicy on the Tool object so the runtime actually enforces it.
+
+    Without this, the WebUI shows 'ask' but the execution pipeline treats the
+    tool as 'always' (auto-execute without prompting the user).
+    """
+    from backend.app.agent.tools.companycam_checklists import build_checklist_tools
+    from backend.app.agent.tools.companycam_photos import build_photo_tools
+    from backend.app.agent.tools.companycam_projects import build_project_tools
+    from backend.app.agent.tools.registry import default_registry, ensure_tool_modules_imported
+
+    ensure_tool_modules_imported()
+
+    # Get the SubToolInfo entries that declare default_permission="ask"
+    factory_entry = default_registry._factories["companycam"]
+    ask_tool_names = {st.name for st in factory_entry.sub_tools if st.default_permission == "ask"}
+    assert ask_tool_names, "Expected at least one CompanyCam tool with default_permission='ask'"
+
+    # Build the actual Tool objects (with a mock service + context)
+    service = CompanyCamService(access_token="test-token")
+    ctx = MagicMock()
+    ctx.user = MagicMock()
+    ctx.user.id = "test-user"
+
+    all_tools = [
+        *build_project_tools(service),
+        *build_photo_tools(service, ctx),
+        *build_checklist_tools(service),
+    ]
+    tool_map = {t.name: t for t in all_tools}
+
+    missing = []
+    for name in sorted(ask_tool_names):
+        tool = tool_map.get(name)
+        if tool is None:
+            missing.append(f"{name}: not found in built tools")
+        elif tool.approval_policy is None:
+            missing.append(f"{name}: has default_permission='ask' but no approval_policy")
+
+    assert not missing, (
+        "CompanyCam tools with default_permission='ask' must have an ApprovalPolicy "
+        "on the Tool object so the runtime enforces permissions:\n" + "\n".join(missing)
+    )
+
+
+# ---------------------------------------------------------------------------
 # New service method tests: error handling
 # ---------------------------------------------------------------------------
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1193,7 +1193,7 @@ class TestExecuteHeartbeatTasks:
             # Should use create_core_tools without messaging excluded (#921)
             mock_registry.create_core_tools.assert_called_once()
             call_kwargs = mock_registry.create_core_tools.call_args
-            excluded: set[str] = call_kwargs.kwargs.get("excluded_factories") or set()  # type: ignore[assignment]
+            excluded: set[str] = call_kwargs.kwargs.get("excluded_factories") or set()
             assert "messaging" not in excluded
 
             # Should create list_capabilities since specialists are available

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -108,8 +108,10 @@ async def test_ask_sub_tools_have_approval_policy() -> None:
         try:
             import inspect
 
+            from backend.app.agent.tools.base import Tool
+
             result = factory.create(ctx)
-            tools = await result if inspect.isawaitable(result) else result
+            tools: list[Tool] = await result if inspect.isawaitable(result) else result  # type: ignore[assignment]
         except Exception:
             continue
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import importlib
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import backend.app.agent.tools.registry as _reg
-from backend.app.agent.tools.registry import ensure_tool_modules_imported
+from backend.app.agent.tools.registry import (
+    ToolContext,
+    default_registry,
+    ensure_tool_modules_imported,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -65,3 +69,59 @@ def test_auto_discovery_ignores_non_tool_modules() -> None:
         m for m in imported if m.startswith("backend.app.agent.tools.") and not m.endswith("_tools")
     }
     assert non_tool == set(), f"Non-tool modules were imported: {non_tool}"
+
+
+@pytest.mark.asyncio()
+async def test_ask_sub_tools_have_approval_policy() -> None:
+    """Every tool with default_permission='ask' must have an ApprovalPolicy.
+
+    Without this, the WebUI shows 'ask' but the execution pipeline in
+    core.py treats the tool as 'always' (auto-execute without prompting).
+    This test covers ALL registered factories, not just one integration.
+    """
+    ensure_tool_modules_imported()
+
+    ctx = MagicMock(spec=ToolContext)
+    ctx.user = MagicMock()
+    ctx.user.id = "test-user"
+    ctx.storage = MagicMock()
+    ctx.publish_outbound = AsyncMock()
+    ctx.channel = "test"
+    ctx.to_address = ""
+    ctx.downloaded_media = []
+    ctx.turn_text = ""
+
+    missing: list[str] = []
+
+    for factory_name, factory in default_registry._factories.items():
+        if not factory.sub_tools:
+            continue
+
+        ask_names = {st.name for st in factory.sub_tools if st.default_permission == "ask"}
+        if not ask_names:
+            continue
+
+        # Build the tools. Some factories need auth (OAuth tokens etc.),
+        # so we patch the service loading to avoid real network calls.
+        # If the factory raises, skip it (auth-gated integrations that
+        # can't build tools without credentials).
+        try:
+            import inspect
+
+            result = factory.create(ctx)
+            tools = await result if inspect.isawaitable(result) else result
+        except Exception:
+            continue
+
+        tool_map = {t.name: t for t in tools}
+        for name in sorted(ask_names):
+            tool = tool_map.get(name)
+            if tool is not None and tool.approval_policy is None:
+                missing.append(
+                    f"{factory_name}/{name}: default_permission='ask' but no approval_policy"
+                )
+
+    assert not missing, (
+        "Tools with default_permission='ask' must have an ApprovalPolicy "
+        "on the Tool object so the runtime enforces permissions:\n" + "\n".join(missing)
+    )


### PR DESCRIPTION
## Description

CompanyCam tools declared `default_permission="ask"` in their `SubToolInfo` registration (displayed correctly in the WebUI permissions page), but the actual `Tool` objects had no `approval_policy` set. The execution pipeline in `core.py:219` treats `approval_policy=None` as `PermissionLevel.ALWAYS`, meaning mutating CompanyCam actions (create project, upload photo, delete, archive, etc.) executed without prompting the user for permission.

This fixes the bug and adds three layers of defense to prevent it from happening again with future integrations:

1. **The fix**: Added `ApprovalPolicy(default_level=PermissionLevel.ASK)` to all 10 CompanyCam `Tool` objects that should require approval
2. **Runtime warning**: `registry.py:create_tools()` now logs a warning when a tool's `SubToolInfo.default_permission` says "ask" but the `Tool` object has no `approval_policy`
3. **Global test**: `test_ask_sub_tools_have_approval_policy` in `test_tool_registry.py` checks ALL registered factories, not just CompanyCam, so any future integration that makes the same mistake will fail CI
4. **Documentation**: Updated the "Adding a New Agent Tool" checklist in CLAUDE.md with a new step about wiring approval policies

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code investigated root cause, implemented fix, wrote regression tests)
- [ ] No AI used