### PR TITLE
fix: resolve media handles in upload tools

### DIFF
--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -170,6 +170,39 @@ def touch(handle: str) -> bool:
     return True
 
 
+def resolve_media_ref(user_id: str, ref: str) -> tuple[str, bytes, str] | None:
+    """Resolve a media reference that may be a handle or an original URL.
+
+    The LLM sees media handles (``media_XXXXXX``) in the prompt and may
+    pass them to tools that expect original URLs. This function accepts
+    either form and returns ``(original_url, content, mime_type)`` when
+    the referenced media is still staged for the given user.
+
+    Returns ``None`` when the reference cannot be resolved (unknown handle,
+    wrong user, expired entry, or URL not in staging).
+    """
+    # Try handle resolution first (handles start with "media_" but so could
+    # a theoretical URL, so always check the handle index regardless).
+    entry = get_by_handle(ref)
+    if entry is not None:
+        stored_uid, original_url, content, mime = entry
+        if stored_uid == user_id:
+            return original_url, content, mime
+        return None
+
+    # Fall back to URL lookup in the user's staged entries.
+    _purge_expired()
+    now = time.monotonic()
+    user_items = _cache.get(user_id, {})
+    item = user_items.get(ref)
+    if item is not None:
+        content, mime, exp, _handle = item
+        if exp > now:
+            return ref, content, mime
+
+    return None
+
+
 def evict(user_id: str, original_url: str) -> None:
     """Remove a staged entry (call after successful upload or explicit deny)."""
     user_items = _cache.get(user_id)

--- a/backend/app/agent/tools/companycam_photos.py
+++ b/backend/app/agent/tools/companycam_photos.py
@@ -78,6 +78,15 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         mime_type = "image/jpeg"
         photo_uri = ""
 
+        # 0. Resolve media handles: the LLM may pass a handle
+        #    (e.g. "media_abZtYWFs") from analyze_photo instead of the
+        #    actual URL. Normalize to original_url + bytes before the
+        #    three-tier lookup below.
+        if original_url:
+            resolved = media_staging.resolve_media_ref(ctx.user.id, original_url)
+            if resolved is not None:
+                original_url, file_bytes, mime_type = resolved
+
         # 1. Try downloaded_media (current message, not yet evicted)
         for media in ctx.downloaded_media:
             if original_url and media.original_url != original_url:

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -178,6 +178,16 @@ def create_file_tools(
         mime_type: str = "image/jpeg",
     ) -> ToolResult:
         """Upload a file to the user's cloud storage."""
+        # Resolve media handles: the LLM may pass a handle from
+        # analyze_photo instead of the actual URL.
+        if original_url and original_url not in media_map:
+            resolved = media_staging.resolve_media_ref(user.id, original_url)
+            if resolved is not None:
+                resolved_url, resolved_bytes, resolved_mime = resolved
+                original_url = resolved_url
+                media_map.setdefault(resolved_url, resolved_bytes)
+                mime_type = resolved_mime
+
         # Determine file content
         file_bytes = b""
         if original_url and original_url in media_map:
@@ -254,6 +264,11 @@ def create_file_tools(
         description: str = "",
     ) -> ToolResult:
         """Move an auto-saved file from Unsorted into the correct client folder."""
+        # Resolve media handles to original URLs.
+        resolved = media_staging.resolve_media_ref(user.id, original_url)
+        if resolved is not None:
+            original_url = resolved[0]
+
         # Look up the media record
         media_store = MediaStore(user.id)
         media_file = await media_store.get_by_url(original_url)

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -656,3 +656,69 @@ async def test_permissions_write_normalizes_minified_json(test_user: User) -> No
     assert "\n" in result.content
     assert '  "tools"' in result.content
     assert '"qb_query": "always"' in result.content
+
+
+# ---------------------------------------------------------------------------
+# resolve_media_ref tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_media_ref_by_handle(test_user: User) -> None:
+    """resolve_media_ref resolves a handle to (original_url, bytes, mime)."""
+    handle = media_staging.stage(test_user.id, "bb_photo_1", b"photo", "image/jpeg")
+    assert handle is not None
+    result = media_staging.resolve_media_ref(test_user.id, handle)
+    assert result is not None
+    url, content, mime = result
+    assert url == "bb_photo_1"
+    assert content == b"photo"
+    assert mime == "image/jpeg"
+
+
+def test_resolve_media_ref_by_url(test_user: User) -> None:
+    """resolve_media_ref resolves a URL to (url, bytes, mime)."""
+    media_staging.stage(test_user.id, "bb_photo_2", b"photo2", "image/png")
+    result = media_staging.resolve_media_ref(test_user.id, "bb_photo_2")
+    assert result is not None
+    url, content, mime = result
+    assert url == "bb_photo_2"
+    assert content == b"photo2"
+    assert mime == "image/png"
+
+
+def test_resolve_media_ref_wrong_user(test_user: User) -> None:
+    """resolve_media_ref rejects handles owned by a different user."""
+    handle = media_staging.stage("other-user", "bb_foreign", b"data", "image/jpeg")
+    assert handle is not None
+    result = media_staging.resolve_media_ref(test_user.id, handle)
+    assert result is None
+    media_staging.clear_user("other-user")
+
+
+def test_resolve_media_ref_unknown_ref(test_user: User) -> None:
+    """resolve_media_ref returns None for unrecognized references."""
+    assert media_staging.resolve_media_ref(test_user.id, "media_UNKNOWN") is None
+    assert media_staging.resolve_media_ref(test_user.id, "https://no.such/url") is None
+
+
+@pytest.mark.asyncio()
+async def test_upload_to_storage_resolves_handle(test_user: User) -> None:
+    """Regression: upload_to_storage must accept media handles, not just URLs."""
+    handle = media_staging.stage(test_user.id, "bb_real_url", b"photo-bytes", "image/jpeg")
+    assert handle is not None
+
+    ctx = ToolContext(
+        user=test_user,
+        storage=MockStorageBackend(),
+        downloaded_media=[],
+    )
+    tools = _file_factory(ctx)
+    upload = tools[0].function
+
+    result = await upload(
+        file_category="job_photo",
+        original_url=handle,
+        client_name="Test Client",
+    )
+    assert result.is_error is False
+    assert "Uploaded" in result.content


### PR DESCRIPTION
## Description

The LLM sees media handles (`media_XXXXXX`) in the prompt from `analyze_photo` and naturally passes them to upload tools. But `companycam_upload_photo`, `upload_to_storage`, and `organize_file` only understood original URLs, not handles. When the LLM passed a handle as `original_url`, all three lookup tiers (downloaded_media, staging, MediaStore) missed, causing "No photo available to upload."

This happened in production today: a photo was downloaded and analyzed successfully, but the CompanyCam upload failed because the LLM passed the analyze_photo handle (`media_abZtYWFs`) instead of the original URL.

**Design fix:** Added `resolve_media_ref(user_id, ref)` to `media_staging` as a single utility that accepts either a handle or URL and returns `(original_url, content, mime_type)`. Three tools now call it before their existing lookup logic:

- `companycam_upload_photo` (companycam_photos.py)
- `upload_to_storage` (file_tools.py)
- `organize_file` (file_tools.py)

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code traced the production failure from server logs, implemented fix)
- [ ] No AI used