### PR TITLE
refactor: extract shared brand-tokens.css from frontend and docs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+# Staged from frontend/ at build time by scripts/prepare-tokens.mjs.
+# frontend/src/styles/brand-tokens.css is the single source of truth.
+src/styles/brand-tokens.css

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
+    "prepare-tokens": "node scripts/prepare-tokens.mjs",
+    "predev": "npm run prepare-tokens",
+    "prestart": "npm run prepare-tokens",
+    "prebuild": "npm run prepare-tokens",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/docs/scripts/prepare-tokens.mjs
+++ b/docs/scripts/prepare-tokens.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/*
+ * Stage brand-tokens.css from frontend/src/styles/ into docs/src/styles/ so
+ * custom.css can @import "./brand-tokens.css" using a local path. The file
+ * is gitignored in docs/ -- frontend/ is the single source of truth.
+ *
+ * Runs automatically via the predev/prestart/prebuild hooks in
+ * docs/package.json. Mirrors the equivalent script in
+ * clawbolt-premium/docs/user-guide/scripts/prepare-tokens.mjs so the two
+ * docs sites follow the same staging pattern.
+ */
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = resolve(
+  here,
+  "..",
+  "..",
+  "frontend",
+  "src",
+  "styles",
+  "brand-tokens.css",
+);
+const dest = resolve(here, "..", "src", "styles", "brand-tokens.css");
+
+if (!existsSync(source)) {
+  console.error(
+    `[prepare-tokens] ERROR: ${source} not found.\n` +
+      `\n` +
+      `The docs site consumes brand-tokens.css from the sibling frontend/\n` +
+      `directory. If you cloned docs/ standalone, check out the full clawbolt\n` +
+      `repo so frontend/ sits next to docs/. If frontend/ exists but the file\n` +
+      `is missing, this branch predates the shared-tokens refactor; rebase on\n` +
+      `main or manually copy frontend/src/styles/brand-tokens.css into place.\n` +
+      `\n` +
+      `Note: the staged copy is not HMR-aware. If you edit brand-tokens.css\n` +
+      `while astro dev is running, restart dev to pick up the change.`,
+  );
+  process.exit(1);
+}
+
+// Guard: the staged copy is gitignored, but a force-add or a bad rebase can
+// still track it. If that happens, the .gitignore silently stops mattering
+// and the staged file becomes an inconsistent duplicate source of truth.
+// Fail loudly when git is available; skip silently when it is not (e.g.,
+// inside a Docker stage that copies in an already-staged tree).
+try {
+  const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  const relDest = relative(repoRoot, dest);
+  const tracked = execFileSync("git", ["ls-files", "--", relDest], {
+    encoding: "utf-8",
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  if (tracked) {
+    console.error(
+      `[prepare-tokens] ERROR: ${relDest} is tracked by git.\n` +
+        `\n` +
+        `The staged copy must stay untracked -- frontend/src/styles/\n` +
+        `brand-tokens.css is the single source of truth. Run:\n` +
+        `\n` +
+        `  git rm --cached ${relDest}\n` +
+        `\n` +
+        `then commit. The docs/.gitignore will keep it untracked going forward.`,
+    );
+    process.exit(1);
+  }
+} catch {
+  // git not available (e.g., Docker stage with no git binary) -- skip the
+  // guard. The Dockerfile uses COPY instead of this script anyway.
+}
+
+mkdirSync(dirname(dest), { recursive: true });
+copyFileSync(source, dest);
+console.log(`[prepare-tokens] copied ${source} -> ${dest}`);

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,54 +1,27 @@
 /*
- * Amber Workshop theme for Starlight docs.
- * Color values sourced from DESIGN.md -- see that file for rationale.
+ * Starlight overrides for the OSS docs site.
+ * Brand tokens (colors, fonts, radii) come from the shared brand-tokens file
+ * staged here by scripts/prepare-tokens.mjs (runs automatically on
+ * predev/prestart/prebuild). The staged copy is gitignored; frontend/ is
+ * the single source of truth.
+ *
+ * This file only carries Starlight-specific chrome tweaks on top of the
+ * shared tokens.
  */
 
-/* ---------- Design tokens (reused across both modes) ---------- */
-
-:root {
-  /* Fonts (same families loaded in astro.config.mjs head) */
-  --sl-font: 'DM Sans', system-ui, -apple-system, sans-serif;
-  --sl-font-mono: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
-
-  /* Dark mode colors (Starlight default) */
-  --sl-color-accent-low: #332810;
-  --sl-color-accent: #D4940F;
-  --sl-color-accent-high: #FDF3E3;
-  --sl-color-white: #E8E4DE;
-  --sl-color-gray-1: #C4BEB5;
-  --sl-color-gray-2: #9A948C;
-  --sl-color-gray-3: #6E6860;
-  --sl-color-gray-4: #524D46;
-  --sl-color-gray-5: #3A3630;
-  --sl-color-gray-6: #262320;
-  --sl-color-black: #1A1816;
-}
-
-:root[data-theme="light"] {
-  --sl-color-accent-low: #FDF3E3;
-  --sl-color-accent: #B8720E;
-  --sl-color-accent-high: #613C07;
-  --sl-color-white: #2D2A26;
-  --sl-color-gray-1: #3E3A35;
-  --sl-color-gray-2: #5A544D;
-  --sl-color-gray-3: #7A746C;
-  --sl-color-gray-4: #94908A;
-  --sl-color-gray-5: #C4BEB5;
-  --sl-color-gray-6: #EDEAE6;
-  --sl-color-black: #F6F5F3;
-}
+@import "./brand-tokens.css";
 
 /* ---------- Typography ---------- */
 
 /* Headings use the display font (Outfit) to match the app */
 :is(h1, h2, h3, h4, h5, h6),
 .sl-markdown-content :is(h1, h2, h3, h4, h5, h6) {
-  font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+  font-family: var(--brand-font-display);
 }
 
 /* Site title in the header */
 .site-title {
-  font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+  font-family: var(--brand-font-display);
   font-weight: 600;
 }
 
@@ -56,9 +29,9 @@
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: #C4BEB5 transparent;
+  scrollbar-color: var(--brand-color-neutral-400) transparent;
 }
 
 :root[data-theme="light"] * {
-  scrollbar-color: #E3DFD9 transparent;
+  scrollbar-color: var(--brand-color-border) transparent;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./styles/brand-tokens.css";
 
 @plugin "./hero.ts";
 @source "../node_modules/@heroui/theme/dist/**/*.{js,ts}";
@@ -6,125 +7,138 @@
 @custom-variant dark (&:where(.dark, .dark *));
 @custom-variant can-hover (@media (hover: hover));
 
+/*
+ * @theme declares Tailwind utility names and maps them to the --brand-*
+ * tokens in ./styles/brand-tokens.css via CSS var indirection. Tailwind
+ * generates utilities (.bg-primary, .text-foreground, etc.) while the
+ * actual values live exclusively in brand-tokens.css, so a palette change
+ * has one edit site. Dark-mode values cascade through automatically --
+ * brand-tokens.css's html:where(.dark, .dark *) block updates --brand-*,
+ * and every var() consumer below picks that up at runtime.
+ *
+ * text-* and animate-* tokens below are intentionally Tailwind-only
+ * (Starlight and other non-Tailwind consumers do not need them).
+ */
 @theme {
-  /* Amber Workshop palette - light mode */
-  --color-background: #F6F5F3;
-  --color-card: #FEFEFE;
-  --color-panel: #F0EEEB;
-  --color-foreground: #2D2A26;
-  --color-muted-foreground: #7A746C;
-  --color-primary: #B8720E;
-  --color-primary-hover: #9A5F0B;
-  --color-primary-light: #FDF3E3;
-  --color-border: #E3DFD9;
-  --color-danger: #C93B37;
-  --color-danger-light: #FCE8E8;
-  --color-danger-hover: #f5d0d0;
-  --color-warning-bg: #fdf4d6;
-  --color-warning-border: #e8c438;
-  --color-warning-text: #7a5a09;
-  --color-error-bg: #FCE8E8;
-  --color-error-border: #eba8a8;
-  --color-error-text: #872020;
-  --color-success: #1b8f46;
-  --color-success-bg: #E5F5EC;
-  --color-success-text: #0d5a33;
-  --color-info-bg: #E3EDF7;
-  --color-info-border: #88b6dc;
-  --color-info-text: #1f4a7e;
-  --color-header-bg-from: #FEFEFE;
-  --color-header-bg-to: #F6F5F3;
-  --color-header-text: #2D2A26;
-  --color-header-border: #E3DFD9;
-  --color-secondary-hover: #EDEAE6;
-  --color-selected-bg: #FDF3E3;
-  --color-focus-bg: #F6F5F3;
+  /* Colors -- light-mode values come from --brand-color-* at :root in
+   * brand-tokens.css; dark-mode values come from the dark block there. */
+  --color-background: var(--brand-color-background);
+  --color-card: var(--brand-color-card);
+  --color-panel: var(--brand-color-panel);
+  --color-foreground: var(--brand-color-foreground);
+  --color-muted-foreground: var(--brand-color-muted-foreground);
+  --color-primary: var(--brand-color-primary);
+  --color-primary-hover: var(--brand-color-primary-hover);
+  --color-primary-light: var(--brand-color-primary-light);
+  --color-border: var(--brand-color-border);
+  --color-danger: var(--brand-color-danger);
+  --color-danger-light: var(--brand-color-danger-light);
+  --color-danger-hover: var(--brand-color-danger-hover);
+  --color-warning-bg: var(--brand-color-warning-bg);
+  --color-warning-border: var(--brand-color-warning-border);
+  --color-warning-text: var(--brand-color-warning-text);
+  --color-error-bg: var(--brand-color-error-bg);
+  --color-error-border: var(--brand-color-error-border);
+  --color-error-text: var(--brand-color-error-text);
+  --color-success: var(--brand-color-success);
+  --color-success-bg: var(--brand-color-success-bg);
+  --color-success-text: var(--brand-color-success-text);
+  --color-info-bg: var(--brand-color-info-bg);
+  --color-info-border: var(--brand-color-info-border);
+  --color-info-text: var(--brand-color-info-text);
+  --color-header-bg-from: var(--brand-color-header-bg-from);
+  --color-header-bg-to: var(--brand-color-header-bg-to);
+  --color-header-text: var(--brand-color-header-text);
+  --color-header-border: var(--brand-color-header-border);
+  --color-secondary-hover: var(--brand-color-secondary-hover);
+  --color-selected-bg: var(--brand-color-selected-bg);
+  --color-focus-bg: var(--brand-color-focus-bg);
 
-  /* Extended primary scale (amber) */
-  --color-primary-50: #FDF8F0;
-  --color-primary-100: #FDF3E3;
-  --color-primary-200: #F5DDB4;
-  --color-primary-300: #E8C07A;
-  --color-primary-400: #D4A030;
-  --color-primary-500: #C4860E;
-  --color-primary-600: #B8720E;
-  --color-primary-700: #9A5F0B;
-  --color-primary-800: #7D4D09;
-  --color-primary-900: #613C07;
+  /* Extended primary scale */
+  --color-primary-50: var(--brand-color-primary-50);
+  --color-primary-100: var(--brand-color-primary-100);
+  --color-primary-200: var(--brand-color-primary-200);
+  --color-primary-300: var(--brand-color-primary-300);
+  --color-primary-400: var(--brand-color-primary-400);
+  --color-primary-500: var(--brand-color-primary-500);
+  --color-primary-600: var(--brand-color-primary-600);
+  --color-primary-700: var(--brand-color-primary-700);
+  --color-primary-800: var(--brand-color-primary-800);
+  --color-primary-900: var(--brand-color-primary-900);
 
-  /* Extended neutral scale (warm gray) */
-  --color-neutral-50: #FAF9F7;
-  --color-neutral-100: #F6F5F3;
-  --color-neutral-200: #EDEAE6;
-  --color-neutral-300: #E3DFD9;
-  --color-neutral-400: #C4BEB5;
-  --color-neutral-500: #94908A;
-  --color-neutral-600: #7A746C;
-  --color-neutral-700: #5A544D;
-  --color-neutral-800: #3E3A35;
-  --color-neutral-900: #2D2A26;
+  /* Extended neutral scale */
+  --color-neutral-50: var(--brand-color-neutral-50);
+  --color-neutral-100: var(--brand-color-neutral-100);
+  --color-neutral-200: var(--brand-color-neutral-200);
+  --color-neutral-300: var(--brand-color-neutral-300);
+  --color-neutral-400: var(--brand-color-neutral-400);
+  --color-neutral-500: var(--brand-color-neutral-500);
+  --color-neutral-600: var(--brand-color-neutral-600);
+  --color-neutral-700: var(--brand-color-neutral-700);
+  --color-neutral-800: var(--brand-color-neutral-800);
+  --color-neutral-900: var(--brand-color-neutral-900);
 
   /* Extended danger scale */
-  --color-danger-50: #fdf0f0;
-  --color-danger-100: #fce8e8;
-  --color-danger-200: #f5d0d0;
-  --color-danger-300: #eba8a8;
-  --color-danger-400: #e06464;
-  --color-danger-500: #C93B37;
-  --color-danger-600: #b82724;
-  --color-danger-700: #961f1d;
-  --color-danger-800: #7a1918;
-  --color-danger-900: #5e1413;
+  --color-danger-50: var(--brand-color-danger-50);
+  --color-danger-100: var(--brand-color-danger-100);
+  --color-danger-200: var(--brand-color-danger-200);
+  --color-danger-300: var(--brand-color-danger-300);
+  --color-danger-400: var(--brand-color-danger-400);
+  --color-danger-500: var(--brand-color-danger-500);
+  --color-danger-600: var(--brand-color-danger-600);
+  --color-danger-700: var(--brand-color-danger-700);
+  --color-danger-800: var(--brand-color-danger-800);
+  --color-danger-900: var(--brand-color-danger-900);
 
   /* Extended success scale */
-  --color-success-50: #edf8f1;
-  --color-success-100: #E5F5EC;
-  --color-success-200: #a8e4c0;
-  --color-success-300: #6bcf94;
-  --color-success-400: #36b468;
-  --color-success-500: #1b8f46;
-  --color-success-600: #17793c;
-  --color-success-700: #136332;
-  --color-success-800: #104d28;
-  --color-success-900: #0d3a1e;
+  --color-success-50: var(--brand-color-success-50);
+  --color-success-100: var(--brand-color-success-100);
+  --color-success-200: var(--brand-color-success-200);
+  --color-success-300: var(--brand-color-success-300);
+  --color-success-400: var(--brand-color-success-400);
+  --color-success-500: var(--brand-color-success-500);
+  --color-success-600: var(--brand-color-success-600);
+  --color-success-700: var(--brand-color-success-700);
+  --color-success-800: var(--brand-color-success-800);
+  --color-success-900: var(--brand-color-success-900);
 
   /* Extended warning scale */
-  --color-warning-50: #fefaf0;
-  --color-warning-100: #fdf4d6;
-  --color-warning-200: #fae6a2;
-  --color-warning-300: #f2d264;
-  --color-warning-400: #e8c438;
-  --color-warning-500: #d4a510;
-  --color-warning-600: #b08508;
-  --color-warning-700: #8c6a06;
-  --color-warning-800: #7a5a09;
-  --color-warning-900: #5c420a;
+  --color-warning-50: var(--brand-color-warning-50);
+  --color-warning-100: var(--brand-color-warning-100);
+  --color-warning-200: var(--brand-color-warning-200);
+  --color-warning-300: var(--brand-color-warning-300);
+  --color-warning-400: var(--brand-color-warning-400);
+  --color-warning-500: var(--brand-color-warning-500);
+  --color-warning-600: var(--brand-color-warning-600);
+  --color-warning-700: var(--brand-color-warning-700);
+  --color-warning-800: var(--brand-color-warning-800);
+  --color-warning-900: var(--brand-color-warning-900);
 
   /* Typography */
-  --font-display: 'Outfit', system-ui, -apple-system, sans-serif;
-  --font-ui: 'DM Sans', system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+  --font-display: var(--brand-font-display);
+  --font-ui: var(--brand-font-ui);
+  --font-mono: var(--brand-font-mono);
 
-  /* Override Tailwind text sizes: bump for field use */
+  /* Override Tailwind text sizes: bump for field use (Tailwind-only) */
   --text-sm: 0.9375rem; /* 15px (was 14px) */
   --text-xs: 0.8125rem; /* 13px (was 12px) */
 
-  /* Border radius - shape hierarchy */
-  --radius-sm: 8px;  /* buttons */
-  --radius-md: 10px; /* inputs */
-  --radius-lg: 14px; /* cards */
-  --radius-xl: 18px; /* containers/modals */
-  --radius-full: 9999px;
+  /* Border radius */
+  --radius-sm: var(--brand-radius-sm);
+  --radius-md: var(--brand-radius-md);
+  --radius-lg: var(--brand-radius-lg);
+  --radius-xl: var(--brand-radius-xl);
+  --radius-full: var(--brand-radius-full);
 
-  /* Shadows - warm tint */
-  --shadow-xs: 0 1px 2px rgba(45, 42, 38, 0.04);
-  --shadow-sm: 0 1px 3px rgba(45, 42, 38, 0.06), 0 1px 2px rgba(45, 42, 38, 0.04);
-  --shadow-md: 0 4px 6px -1px rgba(45, 42, 38, 0.07), 0 2px 4px -2px rgba(45, 42, 38, 0.05);
-  --shadow-lg: 0 10px 15px -3px rgba(45, 42, 38, 0.08), 0 4px 6px -4px rgba(45, 42, 38, 0.04);
-  --shadow-xl: 0 20px 25px -5px rgba(45, 42, 38, 0.08), 0 8px 10px -6px rgba(45, 42, 38, 0.04);
-  --shadow-inner: inset 0 2px 4px rgba(45, 42, 38, 0.04);
+  /* Shadows */
+  --shadow-xs: var(--brand-shadow-xs);
+  --shadow-sm: var(--brand-shadow-sm);
+  --shadow-md: var(--brand-shadow-md);
+  --shadow-lg: var(--brand-shadow-lg);
+  --shadow-xl: var(--brand-shadow-xl);
+  --shadow-inner: var(--brand-shadow-inner);
 
-  /* Animations (unchanged) */
+  /* Animations (Tailwind-only -- keyframes defined below) */
   --animate-spin: spin 0.8s linear infinite;
   --animate-overlay-in: overlay-in 150ms ease-out;
   --animate-dialog-in: dialog-in 150ms ease-out;
@@ -168,69 +182,9 @@
     overflow-x: hidden;
   }
 
-  html:where(.dark, .dark *) {
-    /* Dark mode: warm charcoal */
-    --color-background: #1A1816;
-    --color-card: #262320;
-    --color-panel: #1E1C19;
-    --color-foreground: #E8E4DE;
-    --color-muted-foreground: #9A948C;
-    --color-primary: #D4940F;
-    --color-primary-hover: #E5A82A;
-    --color-primary-light: #332810;
-    --color-border: #3A3630;
-    --color-danger: #e85450;
-    --color-danger-light: #351a1a;
-    --color-danger-hover: #422020;
-    --color-warning-bg: #362008;
-    --color-warning-border: #a67e14;
-    --color-warning-text: #f0d456;
-    --color-error-bg: #351a1a;
-    --color-error-border: #702020;
-    --color-error-text: #eba8a8;
-    --color-success: #3cc978;
-    --color-success-bg: #0c3626;
-    --color-success-text: #6ae0a0;
-    --color-info-bg: #1a2e48;
-    --color-info-border: #2e6bb5;
-    --color-info-text: #88b6dc;
-    --color-header-bg-from: #1A1816;
-    --color-header-bg-to: #262320;
-    --color-header-text: #E8E4DE;
-    --color-header-border: #3A3630;
-    --color-secondary-hover: #322F2B;
-    --color-selected-bg: #332810;
-    --color-focus-bg: #1E1C19;
-
-    /* Dark mode extended scales */
-    --color-primary-50: #1E1A10;
-    --color-primary-100: #332810;
-    --color-primary-200: #4A3A18;
-    --color-primary-300: #7D4D09;
-    --color-primary-400: #B8720E;
-    --color-primary-500: #D4940F;
-    --color-primary-600: #E5A82A;
-    --color-neutral-50: #1A1816;
-    --color-neutral-100: #262320;
-    --color-neutral-200: #3A3630;
-    --color-neutral-300: #524D46;
-    --color-neutral-400: #6E6860;
-    --color-neutral-500: #9A948C;
-    --color-neutral-600: #C4BEB5;
-    --color-danger-50: #351a1a;
-    --color-danger-100: #422020;
-    --color-success-50: #0c3626;
-    --color-success-100: #0d4630;
-    --color-warning-50: #362008;
-    --color-warning-100: #3e2406;
-
-    --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.2);
-    --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.25), 0 1px 2px rgba(0, 0, 0, 0.2);
-    --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.3), 0 2px 4px rgba(0, 0, 0, 0.2);
-    --shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.35), 0 4px 8px rgba(0, 0, 0, 0.25);
-    --shadow-xl: 0 20px 30px rgba(0, 0, 0, 0.4), 0 8px 12px rgba(0, 0, 0, 0.25);
-    --shadow-inner: inset 0 2px 4px rgba(0, 0, 0, 0.15);
-  }
+  /* Dark-mode color + shadow tokens are declared in brand-tokens.css; the
+   * @theme indirection above makes --color-* and --shadow-* cascade through
+   * automatically, so no dark overrides needed here. */
 
   body {
     font-family: var(--font-ui);

--- a/frontend/src/styles/brand-tokens.css
+++ b/frontend/src/styles/brand-tokens.css
@@ -1,0 +1,258 @@
+/*
+ * Clawbolt brand tokens. Single source of truth for design tokens across the
+ * frontend React app (consumed via Tailwind v4's @theme indirection in
+ * frontend/src/index.css), the OSS docs Starlight site, and the premium docs
+ * user guide in clawbolt-premium.
+ *
+ * Token names are prefixed --brand-* so there is exactly one source of truth
+ * per token. frontend/src/index.css's @theme block maps Tailwind utility
+ * names to these tokens via CSS var indirection, e.g.:
+ *
+ *   @theme { --color-primary: var(--brand-color-primary); }
+ *
+ * That generates the .bg-primary / .text-primary utilities while letting the
+ * value cascade from :root. A Tailwind palette change lives in one place.
+ *
+ * Source: DESIGN.md (canonical spec).
+ *
+ * Convention inversion -- read this before editing the Starlight alias
+ * block at the bottom of the file:
+ *
+ *   The frontend React app defaults to LIGHT mode and toggles TO dark via
+ *   an html.dark class. Starlight docs default to DARK mode and toggle TO
+ *   light via a [data-theme="light"] attribute. The two systems have
+ *   opposite defaults. This file therefore:
+ *
+ *     - Declares --brand-color-* tokens with LIGHT values at :root, and
+ *       DARK values under html:where(.dark, .dark *). Matches the frontend
+ *       convention.
+ *     - Declares --sl-color-* Starlight aliases with DARK values at :root,
+ *       and LIGHT values under :root[data-theme="light"]. Matches the
+ *       Starlight convention.
+ *
+ *   Both conventions coexist in :root. It looks inconsistent at a glance;
+ *   it is deliberate.
+ */
+
+/* ---------- Brand palette (light-mode default) ---------- */
+
+:root {
+  /* Core semantic tokens -- light mode */
+  --brand-color-background: #F6F5F3;
+  --brand-color-card: #FEFEFE;
+  --brand-color-panel: #F0EEEB;
+  --brand-color-foreground: #2D2A26;
+  --brand-color-muted-foreground: #7A746C;
+  --brand-color-primary: #B8720E;
+  --brand-color-primary-hover: #9A5F0B;
+  --brand-color-primary-light: #FDF3E3;
+  --brand-color-border: #E3DFD9;
+  --brand-color-danger: #C93B37;
+  --brand-color-danger-light: #FCE8E8;
+  --brand-color-danger-hover: #f5d0d0;
+  --brand-color-warning-bg: #fdf4d6;
+  --brand-color-warning-border: #e8c438;
+  --brand-color-warning-text: #7a5a09;
+  --brand-color-error-bg: #FCE8E8;
+  --brand-color-error-border: #eba8a8;
+  --brand-color-error-text: #872020;
+  --brand-color-success: #1b8f46;
+  --brand-color-success-bg: #E5F5EC;
+  --brand-color-success-text: #0d5a33;
+  --brand-color-info-bg: #E3EDF7;
+  --brand-color-info-border: #88b6dc;
+  --brand-color-info-text: #1f4a7e;
+  --brand-color-header-bg-from: #FEFEFE;
+  --brand-color-header-bg-to: #F6F5F3;
+  --brand-color-header-text: #2D2A26;
+  --brand-color-header-border: #E3DFD9;
+  --brand-color-secondary-hover: #EDEAE6;
+  --brand-color-selected-bg: #FDF3E3;
+  --brand-color-focus-bg: #F6F5F3;
+
+  /* Extended primary scale */
+  --brand-color-primary-50: #FDF8F0;
+  --brand-color-primary-100: #FDF3E3;
+  --brand-color-primary-200: #F5DDB4;
+  --brand-color-primary-300: #E8C07A;
+  --brand-color-primary-400: #D4A030;
+  --brand-color-primary-500: #C4860E;
+  --brand-color-primary-600: #B8720E;
+  --brand-color-primary-700: #9A5F0B;
+  --brand-color-primary-800: #7D4D09;
+  --brand-color-primary-900: #613C07;
+
+  /* Extended neutral scale */
+  --brand-color-neutral-50: #FAF9F7;
+  --brand-color-neutral-100: #F6F5F3;
+  --brand-color-neutral-200: #EDEAE6;
+  --brand-color-neutral-300: #E3DFD9;
+  --brand-color-neutral-400: #C4BEB5;
+  --brand-color-neutral-500: #94908A;
+  --brand-color-neutral-600: #7A746C;
+  --brand-color-neutral-700: #5A544D;
+  --brand-color-neutral-800: #3E3A35;
+  --brand-color-neutral-900: #2D2A26;
+
+  /* Extended danger scale */
+  --brand-color-danger-50: #fdf0f0;
+  --brand-color-danger-100: #fce8e8;
+  --brand-color-danger-200: #f5d0d0;
+  --brand-color-danger-300: #eba8a8;
+  --brand-color-danger-400: #e06464;
+  --brand-color-danger-500: #C93B37;
+  --brand-color-danger-600: #b82724;
+  --brand-color-danger-700: #961f1d;
+  --brand-color-danger-800: #7a1918;
+  --brand-color-danger-900: #5e1413;
+
+  /* Extended success scale */
+  --brand-color-success-50: #edf8f1;
+  --brand-color-success-100: #E5F5EC;
+  --brand-color-success-200: #a8e4c0;
+  --brand-color-success-300: #6bcf94;
+  --brand-color-success-400: #36b468;
+  --brand-color-success-500: #1b8f46;
+  --brand-color-success-600: #17793c;
+  --brand-color-success-700: #136332;
+  --brand-color-success-800: #104d28;
+  --brand-color-success-900: #0d3a1e;
+
+  /* Extended warning scale */
+  --brand-color-warning-50: #fefaf0;
+  --brand-color-warning-100: #fdf4d6;
+  --brand-color-warning-200: #fae6a2;
+  --brand-color-warning-300: #f2d264;
+  --brand-color-warning-400: #e8c438;
+  --brand-color-warning-500: #d4a510;
+  --brand-color-warning-600: #b08508;
+  --brand-color-warning-700: #8c6a06;
+  --brand-color-warning-800: #7a5a09;
+  --brand-color-warning-900: #5c420a;
+
+  /* Typography */
+  --brand-font-display: 'Outfit', system-ui, -apple-system, sans-serif;
+  --brand-font-ui: 'DM Sans', system-ui, -apple-system, sans-serif;
+  --brand-font-mono: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+
+  /* Border radius */
+  --brand-radius-sm: 8px;
+  --brand-radius-md: 10px;
+  --brand-radius-lg: 14px;
+  --brand-radius-xl: 18px;
+  --brand-radius-full: 9999px;
+
+  /* Shadows -- warm tint on light surfaces */
+  --brand-shadow-xs: 0 1px 2px rgba(45, 42, 38, 0.04);
+  --brand-shadow-sm: 0 1px 3px rgba(45, 42, 38, 0.06), 0 1px 2px rgba(45, 42, 38, 0.04);
+  --brand-shadow-md: 0 4px 6px -1px rgba(45, 42, 38, 0.07), 0 2px 4px -2px rgba(45, 42, 38, 0.05);
+  --brand-shadow-lg: 0 10px 15px -3px rgba(45, 42, 38, 0.08), 0 4px 6px -4px rgba(45, 42, 38, 0.04);
+  --brand-shadow-xl: 0 20px 25px -5px rgba(45, 42, 38, 0.08), 0 8px 10px -6px rgba(45, 42, 38, 0.04);
+  --brand-shadow-inner: inset 0 2px 4px rgba(45, 42, 38, 0.04);
+}
+
+/* Dark mode -- scoped to html.dark to match OSS frontend convention.
+ * Tokens not overridden here intentionally inherit their light-mode value. */
+html:where(.dark, .dark *) {
+  --brand-color-background: #1A1816;
+  --brand-color-card: #262320;
+  --brand-color-panel: #1E1C19;
+  --brand-color-foreground: #E8E4DE;
+  --brand-color-muted-foreground: #9A948C;
+  --brand-color-primary: #D4940F;
+  --brand-color-primary-hover: #E5A82A;
+  --brand-color-primary-light: #332810;
+  --brand-color-border: #3A3630;
+  --brand-color-danger: #e85450;
+  --brand-color-danger-light: #351a1a;
+  --brand-color-danger-hover: #422020;
+  --brand-color-warning-bg: #362008;
+  --brand-color-warning-border: #a67e14;
+  --brand-color-warning-text: #f0d456;
+  --brand-color-error-bg: #351a1a;
+  --brand-color-error-border: #702020;
+  --brand-color-error-text: #eba8a8;
+  --brand-color-success: #3cc978;
+  --brand-color-success-bg: #0c3626;
+  --brand-color-success-text: #6ae0a0;
+  --brand-color-info-bg: #1a2e48;
+  --brand-color-info-border: #2e6bb5;
+  --brand-color-info-text: #88b6dc;
+  --brand-color-header-bg-from: #1A1816;
+  --brand-color-header-bg-to: #262320;
+  --brand-color-header-text: #E8E4DE;
+  --brand-color-header-border: #3A3630;
+  --brand-color-secondary-hover: #322F2B;
+  --brand-color-selected-bg: #332810;
+  --brand-color-focus-bg: #1E1C19;
+
+  --brand-color-primary-50: #1E1A10;
+  --brand-color-primary-100: #332810;
+  --brand-color-primary-200: #4A3A18;
+  --brand-color-primary-300: #7D4D09;
+  --brand-color-primary-400: #B8720E;
+  --brand-color-primary-500: #D4940F;
+  --brand-color-primary-600: #E5A82A;
+  --brand-color-neutral-50: #1A1816;
+  --brand-color-neutral-100: #262320;
+  --brand-color-neutral-200: #3A3630;
+  --brand-color-neutral-300: #524D46;
+  --brand-color-neutral-400: #6E6860;
+  --brand-color-neutral-500: #9A948C;
+  --brand-color-neutral-600: #C4BEB5;
+  --brand-color-danger-50: #351a1a;
+  --brand-color-danger-100: #422020;
+  --brand-color-success-50: #0c3626;
+  --brand-color-success-100: #0d4630;
+  --brand-color-warning-50: #362008;
+  --brand-color-warning-100: #3e2406;
+
+  --brand-shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.2);
+  --brand-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.25), 0 1px 2px rgba(0, 0, 0, 0.2);
+  --brand-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.3), 0 2px 4px rgba(0, 0, 0, 0.2);
+  --brand-shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.35), 0 4px 8px rgba(0, 0, 0, 0.25);
+  --brand-shadow-xl: 0 20px 30px rgba(0, 0, 0, 0.4), 0 8px 12px rgba(0, 0, 0, 0.25);
+  --brand-shadow-inner: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+/* ---------- Starlight alias layer (dark-mode default) ---------- */
+
+/*
+ * Astro Starlight reads --sl-color-* and --sl-font. Its default convention
+ * is dark-at-root + [data-theme="light"] override. We mirror that convention
+ * here so a Starlight site can @import this file and inherit the Clawbolt
+ * palette without redeclaring values.
+ *
+ * See the "convention inversion" note at the top of this file.
+ */
+
+:root {
+  --sl-font: var(--brand-font-ui);
+  --sl-font-mono: var(--brand-font-mono);
+
+  --sl-color-accent-low: #332810;
+  --sl-color-accent: #D4940F;
+  --sl-color-accent-high: #FDF3E3;
+  --sl-color-white: #E8E4DE;
+  --sl-color-gray-1: #C4BEB5;
+  --sl-color-gray-2: #9A948C;
+  --sl-color-gray-3: #6E6860;
+  --sl-color-gray-4: #524D46;
+  --sl-color-gray-5: #3A3630;
+  --sl-color-gray-6: #262320;
+  --sl-color-black: #1A1816;
+}
+
+:root[data-theme="light"] {
+  --sl-color-accent-low: #FDF3E3;
+  --sl-color-accent: #B8720E;
+  --sl-color-accent-high: #613C07;
+  --sl-color-white: #2D2A26;
+  --sl-color-gray-1: #3E3A35;
+  --sl-color-gray-2: #5A544D;
+  --sl-color-gray-3: #7A746C;
+  --sl-color-gray-4: #94908A;
+  --sl-color-gray-5: #C4BEB5;
+  --sl-color-gray-6: #EDEAE6;
+  --sl-color-black: #F6F5F3;
+}


### PR DESCRIPTION
## Description

Extract `frontend/src/styles/brand-tokens.css` as a single source of truth for design tokens (colors, fonts, radii) consumed by non-Tailwind build pipelines: the OSS docs Starlight site, and the premium docs user guide in `clawbolt-premium`.

Today the same amber palette is hand-copied across four places:
- `DESIGN.md` (spec)
- `frontend/src/index.css` `@theme` block (Tailwind utilities)
- `docs/src/styles/custom.css` (Starlight tokens for OSS docs)
- `clawbolt-premium/docs/user-guide/src/styles/custom.css` (Starlight tokens for premium docs, 560 lines)

This PR collapses the last three consumers onto one file. The Tailwind `@theme` block in `index.css` stays in place as a parallel declaration because Tailwind v4 requires tokens declared inside `@theme` to generate utilities (`bg-primary`, `text-foreground`, etc.). Both files are cross-referenced with comments flagging the sync requirement.

Visual output is unchanged: same hex values, same dark/light switching, same font stacks. Downstream of this PR, premium will import `brand-tokens.css` at Docker build time and delete its 560-line token copy.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (not applicable for CSS-only refactor; no backend changes)
- [x] Lint passes (no backend changes)
- [x] New tests added for new functionality (visual-output-only refactor, no new functionality)
- [x] Bug fixes include regression tests (not a bug fix)

Additional verification:
- [x] `npm run typecheck` in `frontend/` passes
- [x] `npm run build` in `frontend/` passes
- [x] `astro build` in `docs/` passes (29 pages)
- [x] Compiled docs CSS contains the full brand-tokens palette and Starlight aliases

## AI Usage
- [x] AI-assisted (Claude Code, Opus 4.7): plan review across CEO/Design/Eng lenses in `clawbolt-premium/PLAN_docs_unification.md`, then implementation on this branch. User reviewed and approved the plan premises before any code was written.
- [ ] No AI used