### PR TITLE
feat: compaction writes USER.md and SOUL.md when profile or personality info is detected

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -61,6 +61,11 @@ class CompactionResult:
         self.user_profile_update = user_profile_update
         self.soul_update = soul_update
 
+    def __setattr__(self, name: str, value: str) -> None:
+        if hasattr(self, name):
+            raise AttributeError(f"CompactionResult is immutable: cannot reassign '{name}'")
+        object.__setattr__(self, name, value)
+
 
 _EMPTY_RESULT = CompactionResult()
 

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -44,14 +44,36 @@ def _format_messages_for_compaction(messages: list[AgentMessage]) -> str:
     return "\n".join(lines)
 
 
-def _parse_compaction_response(raw: str) -> tuple[str, str]:
-    """Parse the LLM compaction response into a memory update and summary.
+class CompactionResult:
+    """Parsed result from the compaction LLM response."""
+
+    __slots__ = ("memory_update", "soul_update", "summary", "user_profile_update")
+
+    def __init__(
+        self,
+        memory_update: str = "",
+        summary: str = "",
+        user_profile_update: str = "",
+        soul_update: str = "",
+    ) -> None:
+        self.memory_update = memory_update
+        self.summary = summary
+        self.user_profile_update = user_profile_update
+        self.soul_update = soul_update
+
+
+_EMPTY_RESULT = CompactionResult()
+
+
+def _parse_compaction_response(raw: str) -> CompactionResult:
+    """Parse the LLM compaction response into structured updates.
 
     The assistant prefill starts the response with ``{``, so the raw text from
     the LLM may be missing the leading brace.  We try the text as-is first,
     then retry with a prepended ``{`` before giving up.
 
-    Returns a tuple of (memory_update, summary_string).
+    Returns a ``CompactionResult`` with memory, summary, user profile, and
+    soul updates. Empty strings indicate no change for that field.
     """
     text = raw.strip()
     # Strip markdown code fences if present
@@ -73,15 +95,18 @@ def _parse_compaction_response(raw: str) -> tuple[str, str]:
 
     if parsed is None:
         logger.warning("Failed to parse compaction response as JSON: %s", text[:200])
-        return "", ""
+        return _EMPTY_RESULT
 
     if not isinstance(parsed, dict):
         logger.warning("Compaction response is not a JSON object")
-        return "", ""
+        return _EMPTY_RESULT
 
-    memory_update = str(parsed.get("memory_update", "")).strip()
-    summary = str(parsed.get("summary", "")).strip()
-    return memory_update, summary
+    return CompactionResult(
+        memory_update=str(parsed.get("memory_update", "")).strip(),
+        summary=str(parsed.get("summary", "")).strip(),
+        user_profile_update=str(parsed.get("user_profile_update", "")).strip(),
+        soul_update=str(parsed.get("soul_update", "")).strip(),
+    )
 
 
 async def compact_session(
@@ -170,21 +195,31 @@ async def compact_session(
         return "", None
 
     raw_content = get_response_text(response)
-    memory_update, summary = _parse_compaction_response(raw_content)
+    result = _parse_compaction_response(raw_content)
 
     # Write updated MEMORY.md if the LLM produced content
-    if memory_update:
-        memory_store.write_memory(memory_update)
+    if result.memory_update:
+        memory_store.write_memory(result.memory_update)
         logger.info("Compaction rewrote MEMORY.md for user %s", user_id)
 
     # Append summary to HISTORY.md if the LLM produced one
-    if summary:
+    if result.summary:
         timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M")
-        entry = summary.replace("[TIMESTAMP]", f"[{timestamp}]")
+        entry = result.summary.replace("[TIMESTAMP]", f"[{timestamp}]")
         try:
             await memory_store.append_history(entry)
             logger.info("Compaction appended history entry for user %s", user_id)
         except Exception:
             logger.exception("Failed to append history for user %s", user_id)
 
-    return memory_update, max_message_seq
+    # Write updated USER.md if the LLM detected new profile info
+    if result.user_profile_update:
+        memory_store.write_user(result.user_profile_update)
+        logger.info("Compaction updated USER.md for user %s", user_id)
+
+    # Write updated SOUL.md if the LLM detected personality changes
+    if result.soul_update:
+        memory_store.write_soul(result.soul_update)
+        logger.info("Compaction updated SOUL.md for user %s", user_id)
+
+    return result.memory_update, max_message_seq

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -1,9 +1,8 @@
-"""Session compaction: consolidate aging messages into MEMORY.md.
+"""Session compaction: consolidate aging messages into persistent files.
 
 When conversation history reaches the configured limit, messages about to be
-trimmed are passed through a lightweight LLM call that rewrites MEMORY.md
-with any new durable facts from the conversation.  This replaces the old
-fact-extraction approach with a full-rewrite model (like nanobot).
+trimmed are passed through a lightweight LLM call that updates MEMORY.md,
+USER.md, and SOUL.md with any new durable facts from the conversation.
 
 A timestamped summary is also appended to HISTORY.md so the conversation
 remains searchable after the raw messages are gone.

--- a/backend/app/agent/prompts/compaction.md
+++ b/backend/app/agent/prompts/compaction.md
@@ -9,7 +9,7 @@ Each file has a distinct purpose. Route facts to the correct file:
 - Geographic area, service radius, zip code
 - Preferred tools, equipment, material brands (general preferences)
 - Working hours, availability, timezone
-- Communication preferences
+- Preferred contact method, response time expectations
 
 **memory (MEMORY.md)**: durable business facts that are not about the user themselves.
 - Client names, contact info, project history

--- a/backend/app/agent/prompts/compaction.md
+++ b/backend/app/agent/prompts/compaction.md
@@ -1,18 +1,40 @@
-You are a memory consolidation agent. You will receive five XML-tagged sections: `<current_memory>`, `<user_profile>`, `<soul>`, `<heartbeat>`, and `<conversation>`. Your job is to produce an updated version of <current_memory> that incorporates any new durable facts from the conversation.
+You are a memory consolidation agent. You will receive five XML-tagged sections: `<current_memory>`, `<user_profile>`, `<soul>`, `<heartbeat>`, and `<conversation>`. Your job is to update the user's persistent files with any new durable facts from the conversation.
 
-Durable facts worth remembering:
-- Client names
-- Pricing decisions or quoted rates
-- Material preferences or supplier names
-- Job details, measurements, or scheduling commitments
-- Business preferences or policies
+Each file has a distinct purpose. Route facts to the correct file:
 
-The `<user_profile>`, `<soul>`, and `<heartbeat>` sections are provided as read-only context so you can avoid duplicating information that is already tracked there. The soul contains the assistant's personality and behavioral instructions. The heartbeat contains reminder items and recurring tasks.
+**user_profile (USER.md)**: the user's personal and business profile.
+- Name, preferred name, pronouns
+- Trade/profession, business name, crew size
+- Pricing: day rate, hourly rate, per-unit rates, markup policies
+- Geographic area, service radius, zip code
+- Preferred tools, equipment, material brands (general preferences)
+- Working hours, availability, timezone
+- Communication preferences
 
-Your response must be a JSON object with two fields:
+**memory (MEMORY.md)**: durable business facts that are not about the user themselves.
+- Client names, contact info, project history
+- Specific job quotes, pricing history per project
+- Supplier details, material costs for particular jobs
+- Job details, measurements, scheduling commitments
+- Business policies, terms, recurring arrangements
+
+**soul (SOUL.md)**: the assistant's personality and communication style.
+- How the user wants the assistant to talk (tone, formality, humor)
+- Communication preferences ("be more blunt", "stop using emojis")
+- Working relationship norms
+
+The `<heartbeat>` section is read-only context (reminder items and recurring tasks).
+
+Your response must be a JSON object with these fields:
 
 1. "memory_update": the full updated long-term memory as markdown. Base this only on the content from `<current_memory>` plus new durable facts from `<conversation>`. Remove facts that are clearly outdated or contradicted. If nothing new was learned, return the existing memory unchanged.
 
 2. "summary": a 1-3 sentence summary of the conversation. Start with a timestamp placeholder [TIMESTAMP]. Include enough detail to be useful when searching later (names, topics, decisions). If the conversation is trivial small talk, use an empty string.
+
+3. "user_profile_update": the full updated user profile as markdown. Base this only on the content from `<user_profile>` plus new profile-level facts from `<conversation>`. Preserve ALL existing content unless explicitly contradicted. If nothing profile-relevant was discussed, use an empty string.
+
+4. "soul_update": the full updated soul/personality as markdown. Base this only on the content from `<soul>` plus new personality/style instructions from `<conversation>`. If no personality changes were discussed, use an empty string.
+
+Do not duplicate facts across files. A day rate goes in user_profile_update, not memory_update. A client's phone number goes in memory_update, not user_profile_update.
 
 Return only the JSON object, no other text.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -78,7 +78,7 @@ class Settings(BaseSettings):
     compaction_enabled: bool = True
     compaction_model: str = ""  # empty = fall back to llm_model
     compaction_provider: str = ""  # empty = fall back to llm_provider
-    compaction_max_tokens: int = Field(default=2000, ge=1)
+    compaction_max_tokens: int = Field(default=16_000, ge=1)
 
     # Rate limiting
     webhook_rate_limit_max_requests: int = Field(default=30, ge=1)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -78,7 +78,7 @@ class Settings(BaseSettings):
     compaction_enabled: bool = True
     compaction_model: str = ""  # empty = fall back to llm_model
     compaction_provider: str = ""  # empty = fall back to llm_provider
-    compaction_max_tokens: int = Field(default=1500, ge=1)
+    compaction_max_tokens: int = Field(default=2000, ge=1)
 
     # Rate limiting
     webhook_rate_limit_max_requests: int = Field(default=30, ge=1)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -96,17 +96,17 @@ def test_parse_valid_response() -> None:
             "summary": "[TIMESTAMP] Discussed pricing.",
         }
     )
-    memory_update, summary = _parse_compaction_response(raw)
-    assert "Deck: $45/sqft" in memory_update
-    assert summary == "[TIMESTAMP] Discussed pricing."
+    result = _parse_compaction_response(raw)
+    assert "Deck: $45/sqft" in result.memory_update
+    assert result.summary == "[TIMESTAMP] Discussed pricing."
 
 
 def test_parse_empty_fields() -> None:
     """Should handle empty memory_update and summary."""
     raw = json.dumps({"memory_update": "", "summary": ""})
-    memory_update, summary = _parse_compaction_response(raw)
-    assert memory_update == ""
-    assert summary == ""
+    result = _parse_compaction_response(raw)
+    assert result.memory_update == ""
+    assert result.summary == ""
 
 
 def test_parse_markdown_fenced_json() -> None:
@@ -118,9 +118,9 @@ def test_parse_markdown_fenced_json() -> None:
         }
     )
     raw = f"```json\n{inner}\n```"
-    memory_update, summary = _parse_compaction_response(raw)
-    assert "Rate: $50/hr" in memory_update
-    assert summary == "A summary."
+    result = _parse_compaction_response(raw)
+    assert "Rate: $50/hr" in result.memory_update
+    assert result.summary == "A summary."
 
 
 def test_parse_prefilled_response() -> None:
@@ -134,23 +134,66 @@ def test_parse_prefilled_response() -> None:
     )
     # Strip the leading "{" to simulate what the LLM returns after prefill
     raw_without_brace = inner.lstrip("{")
-    memory_update, summary = _parse_compaction_response(raw_without_brace)
-    assert "8am starts" in memory_update
-    assert summary == "[TIMESTAMP] Scheduling preferences."
+    result = _parse_compaction_response(raw_without_brace)
+    assert "8am starts" in result.memory_update
+    assert result.summary == "[TIMESTAMP] Scheduling preferences."
 
 
 def test_parse_invalid_json() -> None:
     """Invalid JSON should return empty strings without raising."""
-    memory_update, summary = _parse_compaction_response("not json at all")
-    assert memory_update == ""
-    assert summary == ""
+    result = _parse_compaction_response("not json at all")
+    assert result.memory_update == ""
+    assert result.summary == ""
 
 
 def test_parse_non_object_json() -> None:
     """Non-object JSON should return empty strings."""
-    memory_update, summary = _parse_compaction_response("[1, 2, 3]")
-    assert memory_update == ""
-    assert summary == ""
+    result = _parse_compaction_response("[1, 2, 3]")
+    assert result.memory_update == ""
+    assert result.summary == ""
+
+
+def test_parse_user_profile_update() -> None:
+    """Should parse user_profile_update field from compaction response."""
+    raw = json.dumps(
+        {
+            "memory_update": "",
+            "summary": "",
+            "user_profile_update": "- Name: Nathan\n- Day rate: $500",
+            "soul_update": "",
+        }
+    )
+    result = _parse_compaction_response(raw)
+    assert result.memory_update == ""
+    assert "Day rate: $500" in result.user_profile_update
+    assert result.soul_update == ""
+
+
+def test_parse_soul_update() -> None:
+    """Should parse soul_update field from compaction response."""
+    raw = json.dumps(
+        {
+            "memory_update": "",
+            "summary": "",
+            "user_profile_update": "",
+            "soul_update": "Be more concise. Skip the pleasantries.",
+        }
+    )
+    result = _parse_compaction_response(raw)
+    assert "Be more concise" in result.soul_update
+
+
+def test_parse_missing_new_fields_defaults_empty() -> None:
+    """Responses without user_profile_update/soul_update should default to empty."""
+    raw = json.dumps(
+        {
+            "memory_update": "## Facts\n- something",
+            "summary": "A summary.",
+        }
+    )
+    result = _parse_compaction_response(raw)
+    assert result.user_profile_update == ""
+    assert result.soul_update == ""
 
 
 # --- compact_session tests ---
@@ -424,6 +467,97 @@ async def test_compact_session_returns_max_message_seq(test_user: UserData) -> N
 
     assert memory_update != ""
     assert max_seq == 42
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_writes_user_profile(test_user: UserData) -> None:
+    """compact_session should write USER.md when LLM returns user_profile_update."""
+    store = get_memory_store(test_user.id)
+    store.write_user("- Name: Nathan\n- Trade: General contractor")
+
+    llm_response_content = json.dumps(
+        {
+            "memory_update": "",
+            "summary": "[TIMESTAMP] User shared their day rate.",
+            "user_profile_update": "- Name: Nathan\n- Trade: General contractor\n- Day rate: $500",
+            "soul_update": "",
+        }
+    )
+    mock_response = make_text_response(llm_response_content)
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="My day rate is $500"),
+        AssistantMessage(content="Got it, updated the estimate."),
+    ]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, messages)
+
+    updated_profile = store.read_user()
+    assert "Day rate: $500" in updated_profile
+    assert "Nathan" in updated_profile
+    assert "General contractor" in updated_profile
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_writes_soul(test_user: UserData) -> None:
+    """compact_session should write SOUL.md when LLM returns soul_update."""
+    store = get_memory_store(test_user.id)
+    store.write_soul("You are a friendly assistant.")
+
+    llm_response_content = json.dumps(
+        {
+            "memory_update": "",
+            "summary": "[TIMESTAMP] User asked for more direct communication.",
+            "user_profile_update": "",
+            "soul_update": "You are a direct, no-nonsense assistant. Skip the pleasantries.",
+        }
+    )
+    mock_response = make_text_response(llm_response_content)
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="Be more blunt with me, skip the niceties"),
+        AssistantMessage(content="Done. I'll keep it direct from now on."),
+    ]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, messages)
+
+    updated_soul = store.read_soul()
+    assert "direct, no-nonsense" in updated_soul
+    assert "Skip the pleasantries" in updated_soul
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_skips_empty_profile_and_soul(test_user: UserData) -> None:
+    """compact_session should not write USER.md or SOUL.md when updates are empty."""
+    store = get_memory_store(test_user.id)
+    store.write_user("- Name: Nathan")
+    store.write_soul("You are helpful.")
+
+    llm_response_content = json.dumps(
+        {
+            "memory_update": "## Clients\n- Bob: 555-0100",
+            "summary": "[TIMESTAMP] Discussed client info.",
+            "user_profile_update": "",
+            "soul_update": "",
+        }
+    )
+    mock_response = make_text_response(llm_response_content)
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="Bob's number is 555-0100"),
+        AssistantMessage(content="Saved Bob's number."),
+    ]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, messages)
+
+    # Profile and soul should be unchanged
+    assert store.read_user() == "- Name: Nathan"
+    assert store.read_soul() == "You are helpful."
+    # Memory should be updated
+    assert "Bob: 555-0100" in store.read_memory()
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description

When the LLM agent is busy with multi-tool workflows (e.g. updating a QuickBooks estimate), it often completes the primary task but skips the housekeeping step of persisting user profile info to USER.md. Details like "my day rate is $500" get lost.

The compaction system already receives USER.md and SOUL.md as read-only context. This change promotes them to writable: the compaction LLM can now return `user_profile_update` and `soul_update` fields alongside the existing `memory_update` and `summary`. The prompt explicitly routes facts to the correct file to prevent duplication:
- Day rate, location, timezone -> USER.md
- Client names, job quotes -> MEMORY.md  
- Communication style preferences -> SOUL.md

No new modules, config settings, or pipeline steps. Just extends what's already there.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code authored the implementation)
- [ ] No AI used