### PR TITLE
fix: surface BlueBubbles typing indicator failures in logs

### DIFF
--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -482,7 +482,7 @@ class BlueBubblesChannel(BaseChannel):
                     "BlueBubbles typing indicator non-200: status=%s chatGuid=%s body=%s",
                     resp.status_code,
                     chat_guid,
-                    resp.text,
+                    resp.text[:500],
                 )
         except Exception:
             logger.exception("Failed to send BlueBubbles typing indicator to %s", to)

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -473,12 +473,19 @@ class BlueBubblesChannel(BaseChannel):
             return
         chat_guid = self._get_chat_guid(to)
         try:
-            await self._http.post(
+            resp = await self._http.post(
                 f"/api/v1/chat/{chat_guid}/typing",
                 params={"password": settings.bluebubbles_password},
             )
+            if resp.status_code >= 400:
+                logger.warning(
+                    "BlueBubbles typing indicator non-200: status=%s chatGuid=%s body=%s",
+                    resp.status_code,
+                    chat_guid,
+                    resp.text,
+                )
         except Exception:
-            logger.debug("Failed to send BlueBubbles typing indicator to %s", to)
+            logger.exception("Failed to send BlueBubbles typing indicator to %s", to)
 
     async def download_media(self, file_id: str) -> DownloadedMedia:
         """Download media by BlueBubbles attachment GUID."""


### PR DESCRIPTION
## Description

`send_typing_indicator` in `backend/app/channels/bluebubbles.py` silently swallowed both failure modes:

1. **Non-2xx responses were never checked.** The code ignored `resp.status_code`, so a 4xx or 5xx from BlueBubbles looked identical to a success. If the Private API helper bundle wasn't installed on the Mac, or the chat GUID was wrong (common for group chats, since the fallback constructs `iMessage;-;{to}` which only works for 1:1), there was no signal at all.
2. **Exceptions logged at DEBUG.** Unreachable host, timeout, TLS error, all invisible at the default INFO log level.

Result: operators report "typing indicators aren't showing" with nothing in the logs to debug from.

### Change

- Check `resp.status_code >= 400` and log at WARNING with status, chat_guid, and response body.
- Upgrade `logger.debug` to `logger.exception` on the except branch for full tracebacks.

Still best-effort: no raises, no retries. We just surface the failure instead of hiding it.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest tests/test_bluebubbles_channel.py -v` — 3 existing typing tests pass, status_code=200 mock doesn't trigger the new warning)
- [x] Lint passes (`ruff check` + `ruff format --check`)
- [x] Type check passes (`ty check`)
- [ ] New tests added for new functionality — none added; this is purely observability, no behavior change on success/exception paths. Happy to add a test for the non-2xx warning path if reviewer prefers.
- [x] Bug fixes include regression tests — N/A (logging-only change)

## AI Usage
- [x] AI-assisted (Claude investigated the "typing indicators not showing" report, traced the silent-failure path in `bluebubbles.py:466`, and proposed + applied this observability patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)