### PR TITLE
fix: onboarding dismiss navigates to dashboard when messaging channel connected

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ const GetStartedPage = lazy(() => import('@/pages/GetStartedPage'));
 /** Redirect index to get-started if onboarding is incomplete, otherwise to dashboard.
  *
  * Once the user dismisses the Get Started card, we set a sessionStorage flag so
- * a refresh or tab reopen within the same session skips straight to chat
+ * a refresh or tab reopen within the same session skips straight to the dashboard
  * instead of bouncing back to the wizard while the LLM still works through
  * its BOOTSTRAP.md conversation.
  */
@@ -37,7 +37,7 @@ function DefaultRedirect() {
     let dismissed = false;
     try { dismissed = sessionStorage.getItem('getStartedDismissed') === '1'; } catch { /* ignore */ }
     if (dismissed) {
-      return <Navigate to="/app/chat" replace />;
+      return <Navigate to="/app/dashboard" replace />;
     }
     return <Navigate to="/app/get-started" replace />;
   }

--- a/frontend/src/pages/GetStartedPage.test.tsx
+++ b/frontend/src/pages/GetStartedPage.test.tsx
@@ -105,9 +105,21 @@ describe('GetStartedPage', () => {
     expect(screen.getByText('None')).toBeInTheDocument();
   });
 
-  it('renders the dismiss button', () => {
+  it('renders the dismiss button defaulting to chat when no channel selected', () => {
     renderWithRouter(<GetStartedPage />);
     expect(screen.getByText('Got it, take me to chat')).toBeInTheDocument();
+  });
+
+  it('shows dashboard dismiss button when a messaging channel is selected', async () => {
+    renderWithRouter(<GetStartedPage />);
+    const user = userEvent.setup();
+
+    const linqRadio = await screen.findByDisplayValue('linq');
+    await user.click(linqRadio);
+
+    await waitFor(() => {
+      expect(screen.getByText('Got it, take me to the dashboard')).toBeInTheDocument();
+    });
   });
 
   it('shows "Configure your channel" placeholder when no channel is selected', () => {
@@ -255,6 +267,8 @@ describe('GetStartedPage', () => {
       expect(screen.getByText('No setup needed')).toBeInTheDocument();
     });
     expect(screen.getByText('Use the chat in the sidebar to talk to your assistant.')).toBeInTheDocument();
+    // "None" keeps the chat-oriented dismiss button
+    expect(screen.getByText('Got it, take me to chat')).toBeInTheDocument();
   });
 
   it('pre-populates selection from active channel route', async () => {

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -122,7 +122,9 @@ export default function GetStartedPage() {
 
   const handleDismiss = () => {
     try { sessionStorage.setItem('getStartedDismissed', '1'); } catch { /* ignore */ }
-    navigate('/app/chat', { replace: true });
+    navigate(selectedChannel && selectedChannel !== 'none' ? '/app/dashboard' : '/app/chat', {
+      replace: true,
+    });
   };
 
   // Determine Step 2 heading based on selection
@@ -302,10 +304,19 @@ export default function GetStartedPage() {
                 <span className="text-xs font-medium text-muted-foreground">Step 4</span>
               </div>
               <h3 className="text-sm font-semibold font-display">You're off to the races</h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                That's it. Clawbolt learns about you and your business as you chat.
-                You can always fine-tune settings later from the sidebar.
-              </p>
+              {selectedChannel && selectedChannel !== 'none' ? (
+                <p className="text-sm text-muted-foreground mt-1">
+                  That's it. From here, just text your assistant directly.
+                  Clawbolt learns about you and your business as you chat,
+                  and you can set up integrations, approve tool access, and
+                  adjust settings all from the conversation.
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground mt-1">
+                  That's it. Clawbolt learns about you and your business as you chat.
+                  You can always fine-tune settings later from the sidebar.
+                </p>
+              )}
             </div>
           </div>
         </Card>
@@ -316,7 +327,9 @@ export default function GetStartedPage() {
           variant="primary"
           onClick={handleDismiss}
         >
-          Got it, take me to chat
+          {selectedChannel && selectedChannel !== 'none'
+            ? 'Got it, take me to the dashboard'
+            : 'Got it, take me to chat'}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Description

After connecting a messaging channel (iMessage, Telegram, etc.), the onboarding "Get Started" flow's dismiss button previously said "Got it, take me to chat" and navigated to the web chat. This was confusing because once a messaging channel is connected, users should be texting their assistant directly, not using the admin panel chat.

Changes:
- **Button text is contextual**: "Got it, take me to the dashboard" when a messaging channel is selected, "Got it, take me to chat" when "None"/web-chat-only is selected
- **Navigation is contextual**: dismiss goes to `/app/dashboard` with a channel, `/app/chat` without
- **Step 4 copy updated**: when a channel is connected, explains that integrations, tool approvals, and settings can all be managed from the conversation
- **DefaultRedirect**: dismissed-onboarding redirect now goes to dashboard (consistent with post-onboarding-complete behavior)

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the changes and tests)
- [ ] No AI used