### PR TITLE
fix: shorten receipt URLs by stripping https:// prefix (#976)

### DIFF
--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -37,6 +37,17 @@ def _scrub(text: str) -> str:
     return re.sub(r"\s+", " ", _CTRL_RE.sub(" ", text)).strip()
 
 
+def _display_url(url: str) -> str:
+    """Render a deep link in compact form for plain-text channels.
+
+    Strips the ``https://`` scheme so auto-linking channels (iMessage,
+    Telegram, webchat) still render a tappable link while the visible text
+    is eight characters shorter. Bare or non-https URLs pass through so
+    an unusual scheme stays visible as a signal.
+    """
+    return url.removeprefix("https://")
+
+
 _SUMMARY_SEPARATOR = "\n\n"
 
 # Upper bound on the receipt block length. Past this, the tail collapses
@@ -58,7 +69,7 @@ def render_receipt_line(action: str, target: str, url: str | None) -> str:
     """
     head = f"- {_scrub(action)} {_scrub(target)}".rstrip()
     if url:
-        return f"{head}\n  {_scrub(url)}"
+        return f"{head}\n  {_scrub(_display_url(url))}"
     return head
 
 
@@ -139,7 +150,7 @@ def _render_group(
             verbs.append(verb)
 
     head = f"- {_scrub(target)}".rstrip()
-    clean_url = _scrub(url)
+    clean_url = _scrub(_display_url(url))
     if not verbs:
         return f"{head}\n  {clean_url}"
     return f"{head}\n  {' · '.join(verbs)}\n  {clean_url}"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -429,7 +429,9 @@ async def test_agent_echoes_rendered_receipt_into_tool_result(
     # as something already sent to the user, so it does not restate.
     assert "appended to the reply the user sees" in content
     assert "Created QuickBooks estimate for Jane Smith, $0.00" in content
-    assert "https://app.sandbox.qbo.intuit.com/app/estimate?txnId=161" in content
+    # Compact URL rendering (issue #976): the rendered receipt strips https://
+    # before echoing back to the LLM.
+    assert "app.sandbox.qbo.intuit.com/app/estimate?txnId=161" in content
     # The original tool content is preserved so the LLM can reason about
     # the machine-readable result.
     assert "Id: 161" in content

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -1284,13 +1284,15 @@ async def test_receipt_rendered_output_has_no_raw_ids() -> None:
     block = format_receipts_block(fake_calls)
 
     # The rendered footer has two URL-keyed blocks (project + photo).
-    assert block.count("https://app.companycam.com/projects/94772883/photos") == 1
-    assert block.count("https://app.companycam.com/photos/8675309") == 1
+    # URLs are rendered in compact form (https:// stripped) per issue #976.
+    assert block.count("app.companycam.com/projects/94772883/photos") == 1
+    assert block.count("app.companycam.com/photos/8675309") == 1
+    assert "https://" not in block
 
     # Scan every visible token for a 6+ digit run: only the two URLs
     # are allowed to contain ids. Strip URLs then assert no digit runs.
     def _strip_urls(text: str) -> str:
-        return re.sub(r"https://\S+", "", text)
+        return re.sub(r"app\.companycam\.com/\S+", "", text)
 
     visible = _strip_urls(block)
     assert _RAW_ID_RE.search(visible) is None, (

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -357,7 +357,9 @@ async def test_dispatch_reply_appends_receipt_for_imessage_write_tool() -> None:
     outbound = mock_publish.await_args.args[0]
     assert "Kitchen demo looks good." in outbound.content
     assert "- Uploaded photo to CompanyCam project Davis" in outbound.content
-    assert "https://companycam.com/p/abc123" in outbound.content
+    # Issue #976: URLs render in compact form (https:// stripped).
+    assert "companycam.com/p/abc123" in outbound.content
+    assert "https://" not in outbound.content
 
 
 @pytest.mark.asyncio
@@ -388,7 +390,9 @@ async def test_dispatch_reply_also_appends_receipt_for_webchat() -> None:
     outbound = mock_publish.await_args.args[0]
     assert outbound.content.startswith("Done.")
     assert "- Uploaded photo to CompanyCam project Davis" in outbound.content
-    assert "https://companycam.com/p/abc123" in outbound.content
+    # Issue #976: URLs render in compact form (https:// stripped).
+    assert "companycam.com/p/abc123" in outbound.content
+    assert "https://" not in outbound.content
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -124,7 +124,9 @@ def test_get_session_detail_appends_receipts_to_outbound(
     body = resp.json()["messages"][1]["body"]
     assert body.startswith("Done!")
     assert "Created CompanyCam project Smith Residence" in body
-    assert "https://app.companycam.com/projects/12345" in body
+    # Compact URL rendering (issue #976) strips the https:// prefix.
+    assert "app.companycam.com/projects/12345" in body
+    assert "https://" not in body
 
 
 def test_get_session_detail_inbound_body_unchanged(client: TestClient, test_user: User) -> None:

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -67,9 +67,7 @@ def test_single_receipt_renders_action_target_url() -> None:
             )
         ]
     )
-    assert block == (
-        "- Uploaded photo to CompanyCam project Davis\n  https://companycam.com/p/abc123"
-    )
+    assert block == ("- Uploaded photo to CompanyCam project Davis\n  companycam.com/p/abc123")
 
 
 def test_receipt_without_url_omits_link_line() -> None:
@@ -104,8 +102,9 @@ def test_multiple_receipts_one_per_line() -> None:
     )
     assert "Uploaded photo to CompanyCam project Davis" in block
     assert "Created QuickBooks invoice for Johnson, $2,560.00" in block
-    assert "https://companycam.com/p/1" in block
-    assert "https://app.qbo.intuit.com/app/invoice?txnId=4782" in block
+    assert "companycam.com/p/1" in block
+    assert "app.qbo.intuit.com/app/invoice?txnId=4782" in block
+    assert "https://" not in block
 
 
 def test_failed_tool_receipt_is_suppressed() -> None:
@@ -152,7 +151,8 @@ def test_append_preserves_reply_and_separates_block() -> None:
     )
     assert body.startswith("Kitchen demo looks good.")
     assert "- Uploaded photo to CompanyCam project Davis" in body
-    assert "https://companycam.com/p/1" in body
+    assert "companycam.com/p/1" in body
+    assert "https://" not in body
 
 
 def test_append_returns_reply_unchanged_when_no_receipts() -> None:
@@ -174,9 +174,7 @@ def test_append_handles_empty_reply_text() -> None:
             )
         ],
     )
-    assert body == (
-        "- Created CompanyCam project Davis bathroom remodel\n  https://companycam.com/p/new"
-    )
+    assert body == ("- Created CompanyCam project Davis bathroom remodel\n  companycam.com/p/new")
 
 
 def test_block_caps_long_receipt_lists_with_more_suffix() -> None:
@@ -236,7 +234,7 @@ def test_same_url_receipts_are_grouped() -> None:
     assert len(lines) == 3
     # Subject is the real name from the create receipt.
     assert lines[0] == "- Smith Residence"
-    assert lines[2] == "  https://app.companycam.com/projects/94772883"
+    assert lines[2] == "  app.companycam.com/projects/94772883"
     # Verb list contains all three verbs joined with ' · '.
     assert "created" in lines[1]
     assert "updated notepad" in lines[1]
@@ -311,7 +309,8 @@ def test_distinct_urls_stay_separate() -> None:
             ),
         ]
     )
-    assert block.count("https://app.companycam.com/projects/") == 2
+    assert block.count("app.companycam.com/projects/") == 2
+    assert "https://" not in block
     assert "Smith" in block
     assert "Jones" in block
 
@@ -375,7 +374,7 @@ def test_receipt_injection_via_newline_is_defused_at_render() -> None:
     # Exactly one bullet line in the output (single receipt).
     assert sum(1 for line in block.split("\n") if line.startswith("- ")) == 1
     # The real URL is on its own line (the clickable one).
-    assert block.endswith("  https://app.companycam.com/projects/1")
+    assert block.endswith("  app.companycam.com/projects/1")
 
 
 def test_verb_phrase_strips_unseen_companycam_suffixes() -> None:
@@ -421,7 +420,8 @@ def test_grouping_works_across_integrations() -> None:
     lines = block.split("\n")
     # One grouped 3-line block.
     assert len(lines) == 3
-    assert qbo_url in lines[2]
+    assert "app.qbo.intuit.com/app/invoice?txnId=4782" in lines[2]
+    assert "https://" not in block
     # Subject is the first informative target (the invoice with amount).
     assert lines[0] == "- Johnson, $2,560.00"
     # Email recipient survives as a parenthesised qualifier on the email verb.
@@ -474,3 +474,78 @@ def test_render_receipt_line_scrubs_control_chars_directly() -> None:
     assert "\n" not in head
     assert "\n" not in body
     assert "\t" not in line
+
+
+# ---------------------------------------------------------------------------
+# Compact URL rendering (issue #976) -- strip https:// prefix
+# ---------------------------------------------------------------------------
+
+
+def test_display_url_strips_https_prefix() -> None:
+    """The helper is the one place that decides the compact form."""
+    from backend.app.agent.tool_summary import _display_url
+
+    assert (
+        _display_url("https://app.companycam.com/projects/42/photos")
+        == "app.companycam.com/projects/42/photos"
+    )
+
+
+def test_display_url_passes_through_bare_url() -> None:
+    """A URL without a scheme is left alone so auto-linking channels
+    still see a bare domain (already compact)."""
+    from backend.app.agent.tool_summary import _display_url
+
+    assert _display_url("app.companycam.com/projects/42") == "app.companycam.com/projects/42"
+
+
+def test_display_url_preserves_http_prefix() -> None:
+    """A plain http:// URL is visually suspicious; keeping it visible
+    lets the user notice that the link is not over TLS."""
+    from backend.app.agent.tool_summary import _display_url
+
+    assert _display_url("http://example.com/x") == "http://example.com/x"
+
+
+def test_display_url_is_case_sensitive() -> None:
+    """removeprefix is case-sensitive by design. No production integration
+    emits an uppercase scheme today, so we document rather than mitigate."""
+    from backend.app.agent.tool_summary import _display_url
+
+    assert _display_url("HTTPS://app.companycam.com/x") == "HTTPS://app.companycam.com/x"
+
+
+def test_render_receipt_strips_https_prefix() -> None:
+    """End-to-end: a single receipt renders the URL in compact form."""
+    from backend.app.agent.tool_summary import render_receipt_line
+
+    rendered = render_receipt_line(
+        "Created CompanyCam project",
+        "Astro Home Management",
+        "https://app.companycam.com/projects/103320586/photos",
+    )
+    assert "\n  app.companycam.com/projects/103320586/photos" in rendered
+    assert "https://" not in rendered
+
+
+def test_grouped_receipt_strips_https_prefix() -> None:
+    """Grouped-receipt path (shared URL) also runs through _display_url."""
+    shared = "https://app.companycam.com/projects/42/photos"
+    block = format_receipts_block(
+        [
+            _tc_with_receipt(
+                "companycam_create_project",
+                action="Created CompanyCam project",
+                target="Demo",
+                url=shared,
+            ),
+            _tc_with_receipt(
+                "companycam_upload_photo",
+                action="Uploaded photo to CompanyCam",
+                target="photo",
+                url=shared,
+            ),
+        ]
+    )
+    assert "app.companycam.com/projects/42/photos" in block
+    assert "https://" not in block


### PR DESCRIPTION
## Description

Closes #976. PR #975 shipped structured receipts on plain-text channels, but the deep links visually dominated the block:

```
- Created CompanyCam project Astro Home Management
  https://app.companycam.com/projects/103320586/photos
```

iMessage, Telegram, and webchat all auto-link bare domains, so the `https://` prefix is noise. This PR strips it:

```
- Created CompanyCam project Astro Home Management
  app.companycam.com/projects/103320586/photos
```

Eight fewer characters per URL. The link still taps. Hostname is still visible (verifiability preserved). No infra, no migration, no flag.

### Implementation

One helper in `backend/app/agent/tool_summary.py`:

```python
def _display_url(url: str) -> str:
    return url.removeprefix("https://")
```

Wired into `render_receipt_line` and `_render_group`. Case-sensitive by design — `http://` and non-TLS schemes pass through unchanged, keeping them visible as a "this looks weird" signal.

The raw `url` persisted in `messages.tool_interactions_json` is unchanged. `user_sessions.py:103` recomputes the block at read time, so historical session views also render the compact form. Reverting the change requires zero data migration.

### What this is NOT

- **Not a self-hosted shortener.** Option B (`clawbolt.ai/l/{code}`) was considered and deferred. Trading verifiability for brevity isn't worth the infra debt (unbounded table, open-redirect risk, trust-laundering) without CTR data showing URLs are tapped.
- **Not per-channel rendering.** Option D would need a new `BaseChannel` capability flag (`shows_tool_calls_in_ui` doesn't actually exist yet, despite the PR #975 description). Defer until MVNO carriers start dropping bare domains.
- **Not a CompanyCam short-path swap.** Verified at review time: `companycam.com/p/{id}` returns 404. The shape was a hypothetical example in the #975 description, not a live redirect. Dead option.

## Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 1855 passing. Two pre-existing env-dependent failures on main (`test_user_defaults`, `test_profile_defaults_from_settings`) are unrelated, same ones noted in PR #975.
- [x] Lint passes (`ruff check backend/ tests/ alembic/` and `ruff format --check`)
- [x] Type check (`uv run ty check --python .venv backend/ tests/ alembic/`)
- [x] Frontend typecheck + knip deadcode pass
- [x] New tests added for the helper and its integration into both render paths
- [x] Existing snapshot-style assertions updated across 4 test files (`test_tool_summary.py`, `test_pipeline.py`, `test_companycam_tools.py`, `test_session_endpoints.py`, `test_agent.py`)

## Test Coverage

Six new tests in `tests/test_tool_summary.py`:
- `test_display_url_strips_https_prefix` — helper unit test, happy path
- `test_display_url_passes_through_bare_url` — URL without scheme is left alone
- `test_display_url_preserves_http_prefix` — plain HTTP kept visible as a signal
- `test_display_url_is_case_sensitive` — `HTTPS://` pass-through (documented behavior)
- `test_render_receipt_strips_https_prefix` — end-to-end single receipt
- `test_grouped_receipt_strips_https_prefix` — end-to-end grouped receipts

Existing integration tests updated:
- `test_pipeline.py::test_dispatch_reply_appends_receipt` (bluebubbles path)
- `test_pipeline.py::test_dispatch_reply_also_appends_receipt_for_webchat`
- `test_companycam_tools.py::test_receipt_rendered_output_has_no_raw_ids`
- `test_session_endpoints.py::test_get_session_detail_renders_receipt` (historical view)
- `test_agent.py::test_agent_echoes_rendered_receipt_into_tool_result` (LLM-echo path)

## AI Usage
- [x] AI-assisted (Claude Opus 4.7, design via `/autoplan` with CEO + Eng review phases)
- [ ] No AI used