### PR TITLE
fix: stop leaking user UUID into iMessage onboarding form

### DIFF
--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -190,9 +190,12 @@ async def update_channel_route(
     non-webchat routes for this user are automatically disabled so
     exactly one messaging channel is active at a time.
 
-    If the user has no route for this channel yet (e.g. they configured
-    credentials but haven't messaged through the channel), a placeholder
-    route is created so the enabled flag can be persisted.
+    If the user has no route and no known identifier for this channel yet
+    (fresh onboarding), the selection is persisted via ``preferred_channel``
+    only. The route row is created later when the identifier arrives,
+    either via an inbound message (OSS) or via an explicit link call
+    (premium). This keeps placeholder rows out of the database and avoids
+    leaking the user's internal UUID into identifier-shaped UI fields.
     """
     from backend.app.channels import get_channel
 
@@ -215,28 +218,36 @@ async def update_channel_route(
         ).update({"enabled": False})
 
     route = db.query(ChannelRoute).filter_by(user_id=user.id, channel=channel).first()
-    if route is None:
+    if route is None and user.channel_identifier:
         route = ChannelRoute(
             user_id=user.id,
             channel=channel,
-            channel_identifier=user.channel_identifier or user.id,
+            channel_identifier=user.channel_identifier,
             enabled=body.enabled,
         )
         db.add(route)
-    else:
+    elif route is not None:
         route.enabled = body.enabled
 
     if body.enabled:
         user.preferred_channel = channel
 
     db.commit()
-    db.refresh(route)
+    if route is not None:
+        db.refresh(route)
+        return ChannelRouteResponse(
+            channel=route.channel,
+            channel_identifier=route.channel_identifier,
+            enabled=route.enabled,
+            created_at=route.created_at.isoformat() if route.created_at else "",
+            last_inbound_at=route.last_inbound_at.isoformat() if route.last_inbound_at else None,
+        )
     return ChannelRouteResponse(
-        channel=route.channel,
-        channel_identifier=route.channel_identifier,
-        enabled=route.enabled,
-        created_at=route.created_at.isoformat() if route.created_at else "",
-        last_inbound_at=route.last_inbound_at.isoformat() if route.last_inbound_at else None,
+        channel=channel,
+        channel_identifier="",
+        enabled=body.enabled,
+        created_at="",
+        last_inbound_at=None,
     )
 
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -550,7 +550,7 @@
     "/api/user/channels/routes/{channel}": {
       "patch": {
         "summary": "Update Channel Route",
-        "description": "Toggle enabled status for a channel route.\n\nSingle-channel enforcement: when enabling a channel, all other\nnon-webchat routes for this user are automatically disabled so\nexactly one messaging channel is active at a time.\n\nIf the user has no route for this channel yet (e.g. they configured\ncredentials but haven't messaged through the channel), a placeholder\nroute is created so the enabled flag can be persisted.",
+        "description": "Toggle enabled status for a channel route.\n\nSingle-channel enforcement: when enabling a channel, all other\nnon-webchat routes for this user are automatically disabled so\nexactly one messaging channel is active at a time.\n\nIf the user has no route and no known identifier for this channel yet\n(fresh onboarding), the selection is persisted via ``preferred_channel``\nonly. The route row is created later when the identifier arrives,\neither via an inbound message (OSS) or via an explicit link call\n(premium). This keeps placeholder rows out of the database and avoids\nleaking the user's internal UUID into identifier-shaped UI fields.",
         "operationId": "update_channel_route_api_user_channels_routes__channel__patch",
         "parameters": [
           {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -366,9 +366,12 @@ export interface paths {
          *     non-webchat routes for this user are automatically disabled so
          *     exactly one messaging channel is active at a time.
          *
-         *     If the user has no route for this channel yet (e.g. they configured
-         *     credentials but haven't messaged through the channel), a placeholder
-         *     route is created so the enabled flag can be persisted.
+         *     If the user has no route and no known identifier for this channel yet
+         *     (fresh onboarding), the selection is persisted via ``preferred_channel``
+         *     only. The route row is created later when the identifier arrives,
+         *     either via an inbound message (OSS) or via an explicit link call
+         *     (premium). This keeps placeholder rows out of the database and avoids
+         *     leaking the user's internal UUID into identifier-shaped UI fields.
          */
         patch: operations["update_channel_route_api_user_channels_routes__channel__patch"];
         trace?: never;

--- a/tests/test_channel_routes.py
+++ b/tests/test_channel_routes.py
@@ -83,14 +83,76 @@ def test_patch_toggle_to_true(client: TestClient, test_user: User) -> None:
 
 
 def test_patch_creates_route_when_missing(client: TestClient, test_user: User) -> None:
-    """PATCH on a channel with no route should create a placeholder route."""
+    """PATCH on a channel with no identifier should persist the selection via
+    preferred_channel without writing a placeholder ChannelRoute row.
+
+    The UUID of the user was previously leaked into the row as a stand-in
+    identifier and surfaced in the premium link UI. We now persist selection
+    via User.preferred_channel instead, and create the row lazily once a
+    real identifier (phone/email) is supplied.
+    """
+    # Simulate a fresh user who has never received an inbound message: no
+    # channel_identifier, no existing routes.
+    db = _db_module.SessionLocal()
+    try:
+        user = db.query(User).filter_by(id=test_user.id).first()
+        assert user is not None
+        user.channel_identifier = ""
+        db.commit()
+    finally:
+        db.close()
+
     resp = client.patch(
-        "/api/user/channels/routes/telegram",
-        json={"enabled": False},
+        "/api/user/channels/routes/linq",
+        json={"enabled": True},
     )
     assert resp.status_code == 200
-    assert resp.json()["channel"] == "telegram"
-    assert resp.json()["enabled"] is False
+    body = resp.json()
+    assert body["channel"] == "linq"
+    assert body["enabled"] is True
+    assert body["channel_identifier"] == ""
+
+    # No row should have been created.
+    db = _db_module.SessionLocal()
+    try:
+        rows = db.query(ChannelRoute).filter_by(user_id=test_user.id, channel="linq").all()
+        assert rows == []
+        user = db.query(User).filter_by(id=test_user.id).first()
+        assert user is not None
+        assert user.preferred_channel == "linq"
+    finally:
+        db.close()
+
+
+def test_patch_creates_route_when_user_has_identifier(client: TestClient, test_user: User) -> None:
+    """When the user has a real channel_identifier (e.g. from a prior inbound
+    message), PATCH creates a row so the enabled flag persists alongside it."""
+    db = _db_module.SessionLocal()
+    try:
+        user = db.query(User).filter_by(id=test_user.id).first()
+        assert user is not None
+        user.channel_identifier = "+15551234567"
+        db.commit()
+    finally:
+        db.close()
+
+    resp = client.patch(
+        "/api/user/channels/routes/linq",
+        json={"enabled": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["channel"] == "linq"
+    assert body["enabled"] is True
+    assert body["channel_identifier"] == "+15551234567"
+
+    db = _db_module.SessionLocal()
+    try:
+        row = db.query(ChannelRoute).filter_by(user_id=test_user.id, channel="linq").first()
+        assert row is not None
+        assert row.channel_identifier == "+15551234567"
+    finally:
+        db.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

On first-run onboarding, the "Your Phone Number" input on GetStartedPage was pre-filled with the user's UUID (e.g. `4f57bb33-821f-4359-8076-f6ae7768f201`) instead of being empty.

### Root cause

`update_channel_route` (OSS, `backend/app/routers/user_profile.py`) persisted a `ChannelRoute` row when the user toggled a channel, even if the user had no known identifier. To satisfy the `NOT NULL` + unique constraint on `channel_identifier`, it fell back to `user.id` as a stand-in:

```python
channel_identifier=user.channel_identifier or user.id,
```

The premium `/channels/linq` and `/channels/bluebubbles` endpoints read `channel_identifier` back as `phone_number`, so `PremiumChannelLinkForm` displayed the UUID as the pre-filled phone number. Telegram had the same shape via `/channels/telegram`.

### Fix

Stop creating placeholder rows. Selection is tracked via `User.preferred_channel` only; the row is created lazily when a real identifier arrives (inbound message on OSS, explicit link PUT on premium). The endpoint returns a synthetic `ChannelRouteResponse` with empty `channel_identifier` when no row exists yet.

No migration needed. No frontend change needed. Reverting is free.

## Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) - 1856 passing, 2 pre-existing env-dependent failures (`test_user_defaults`, `test_profile_defaults_from_settings`) unchanged and unrelated
- [x] Lint passes (`ruff check backend/ tests/ alembic/` and `ruff format --check`)
- [x] Type check (`uv run ty check --python .venv backend/ tests/ alembic/`)
- [x] Frontend typecheck + knip deadcode pass
- [x] Regression test added (`test_patch_creates_route_when_missing`)
- [x] Positive-path test added (`test_patch_creates_route_when_user_has_identifier`)

## Test Coverage

Updated `tests/test_channel_routes.py`:
- `test_patch_creates_route_when_missing` - asserts no row is created when the user has no identifier, `preferred_channel` is set, and the response has empty `channel_identifier`. Previously asserted the buggy placeholder-row behavior.
- `test_patch_creates_route_when_user_has_identifier` (new) - asserts a row IS created when the user already has a real identifier (e.g. from a prior inbound message), so enabled state persists alongside it.

## AI Usage
- [x] AI-assisted (Claude Opus 4.7, debugged via code read + reproduction trace)
- [ ] No AI used