### PR TITLE
feat: add ServiceNow FSM integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,13 @@ STORAGE_PROVIDER=local
 # CompanyCam ever ships EU / sandbox hosts. Default: https://app.companycam.com
 # COMPANYCAM_WEB_BASE=
 
+# ServiceNow FSM
+# Set client_id, client_secret, and instance_url to enable OAuth flow for ServiceNow.
+# Users connect via the web dashboard or chat.
+# SERVICENOW_CLIENT_ID=
+# SERVICENOW_CLIENT_SECRET=
+# SERVICENOW_INSTANCE_URL=
+
 # Supplier Pricing (SerpApi Home Depot engine)
 # Set SERPAPI_API_KEY to enable product price lookups at Home Depot.
 # Sign up at https://serpapi.com (free tier: 250 searches/month, no credit card).

--- a/backend/app/agent/skills/servicenow/SKILL.md
+++ b/backend/app/agent/skills/servicenow/SKILL.md
@@ -1,0 +1,53 @@
+# ServiceNow FSM
+
+You now have access to ServiceNow Field Service Management tools for managing work orders, tasks, and time tracking.
+
+## Available Tools
+
+| Tool | Purpose | Approval |
+|------|---------|----------|
+| servicenow_list_work_orders | List work orders assigned to you | Auto |
+| servicenow_get_work_order | Get full work order details | Auto |
+| servicenow_list_tasks | List tasks for a work order | Auto |
+| servicenow_update_task | Update task state | Asks user |
+| servicenow_add_work_order_note | Add a work note to a work order | Asks user |
+| servicenow_add_task_note | Add a work note to a task | Asks user |
+| servicenow_log_time | Log time worked on a task | Asks user |
+| servicenow_search | Search work orders by text | Auto |
+
+## Task States
+
+Work order tasks use these states (in order):
+
+1. **Pending Dispatch** - Not yet assigned
+2. **Assigned** - Assigned to a technician
+3. **Accepted** - Technician accepted the assignment
+4. **Work In Progress** - Work has started
+5. **Closed Complete** - Work finished successfully
+6. **Closed Incomplete** - Work could not be completed
+7. **Cancelled** - Task was cancelled
+
+## Common Workflows
+
+### Check assigned work
+1. `servicenow_list_work_orders()` - Lists work orders assigned to the current user
+2. For a specific work order: `servicenow_get_work_order(sys_id="...")`
+3. To see task breakdown: `servicenow_list_tasks(work_order_id="...")`
+
+### Update task progress
+1. Accept: `servicenow_update_task(sys_id="...", state="Accepted")`
+2. Start work: `servicenow_update_task(sys_id="...", state="Work In Progress")`
+3. Complete: `servicenow_update_task(sys_id="...", state="Closed Complete")`
+
+### Add notes
+Use notes to document findings, issues, or status updates visible to the team:
+- `servicenow_add_task_note(sys_id="...", note="Found mold behind old unit, documented with photos")`
+- `servicenow_add_work_order_note(sys_id="...", note="Customer requested rescheduling to next week")`
+
+### Log time
+Record hours worked on a task:
+- `servicenow_log_time(task_id="...", hours=2.5, date="2026-04-23", category="labor")`
+
+## Connection
+
+Users connect via OAuth. Use `manage_integration(action='connect', target='servicenow')` to start the authorization flow. The user will be redirected to their ServiceNow instance to grant access.

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -33,6 +33,7 @@ _DISPLAY_NAMES: dict[str, str] = {
     "quickbooks": "QuickBooks Online",
     "calendar": "Google Calendar",
     "companycam": "CompanyCam",
+    "servicenow": "ServiceNow FSM",
     "supplier_pricing": "Home Depot pricing",
 }
 
@@ -41,6 +42,7 @@ _TOOL_OAUTH_MAP: dict[str, str] = {
     "calendar": "google_calendar",
     "quickbooks": "quickbooks",
     "companycam": "companycam",
+    "servicenow": "servicenow",
 }
 
 

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -61,6 +61,16 @@ class ToolName:
     COMPANYCAM_GET_CHECKLIST = "companycam_get_checklist"
     COMPANYCAM_CREATE_CHECKLIST = "companycam_create_checklist"
 
+    # ServiceNow FSM
+    SERVICENOW_LIST_WORK_ORDERS = "servicenow_list_work_orders"
+    SERVICENOW_GET_WORK_ORDER = "servicenow_get_work_order"
+    SERVICENOW_LIST_TASKS = "servicenow_list_tasks"
+    SERVICENOW_UPDATE_TASK = "servicenow_update_task"
+    SERVICENOW_ADD_WORK_ORDER_NOTE = "servicenow_add_work_order_note"
+    SERVICENOW_ADD_TASK_NOTE = "servicenow_add_task_note"
+    SERVICENOW_LOG_TIME = "servicenow_log_time"
+    SERVICENOW_SEARCH = "servicenow_search"
+
     # Supplier pricing
     SUPPLIER_SEARCH_PRODUCTS = "supplier_search_products"
 

--- a/backend/app/agent/tools/servicenow_params.py
+++ b/backend/app/agent/tools/servicenow_params.py
@@ -1,0 +1,147 @@
+"""Pydantic parameter models for ServiceNow FSM tools."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# Valid work order task states in ServiceNow FSM.
+WOTaskState = Literal[
+    "Pending Dispatch",
+    "Assigned",
+    "Accepted",
+    "Work In Progress",
+    "Closed Complete",
+    "Closed Incomplete",
+    "Cancelled",
+]
+
+
+class ListWorkOrdersParams(BaseModel):
+    """Parameters for listing work orders."""
+
+    assigned_to: str = Field(
+        default="",
+        description=(
+            "ServiceNow sys_id of the assigned user. Leave empty to default to the current user."
+        ),
+    )
+    state: str = Field(
+        default="",
+        description="Filter by work order state (e.g. 'Assigned', 'Work In Progress').",
+    )
+    limit: int = Field(
+        default=25,
+        ge=1,
+        le=50,
+        description="Maximum number of results to return (1-50).",
+    )
+
+
+class GetWorkOrderParams(BaseModel):
+    """Parameters for getting a single work order."""
+
+    sys_id: str = Field(
+        description="The sys_id of the work order to retrieve.",
+        max_length=32,
+    )
+
+
+class ListTasksParams(BaseModel):
+    """Parameters for listing work order tasks."""
+
+    work_order_id: str = Field(
+        default="",
+        description="Filter tasks by work order sys_id. Leave empty for all tasks.",
+        max_length=32,
+    )
+    state: str = Field(
+        default="",
+        description="Filter by task state.",
+    )
+    limit: int = Field(
+        default=25,
+        ge=1,
+        le=50,
+        description="Maximum number of results to return (1-50).",
+    )
+
+
+class UpdateTaskParams(BaseModel):
+    """Parameters for updating a work order task."""
+
+    sys_id: str = Field(
+        description="The sys_id of the task to update.",
+        max_length=32,
+    )
+    state: WOTaskState | None = Field(
+        default=None,
+        description=(
+            "New task state. Valid values: Pending Dispatch, Assigned, "
+            "Accepted, Work In Progress, Closed Complete, Closed Incomplete, Cancelled."
+        ),
+    )
+    work_notes: str = Field(
+        default="",
+        description="Work note to add to the task.",
+    )
+
+
+class AddWorkOrderNoteParams(BaseModel):
+    """Parameters for adding a work note to a work order."""
+
+    sys_id: str = Field(
+        description="The sys_id of the work order.",
+        max_length=32,
+    )
+    note: str = Field(
+        description="The work note text to add.",
+    )
+
+
+class AddTaskNoteParams(BaseModel):
+    """Parameters for adding a work note to a task."""
+
+    sys_id: str = Field(
+        description="The sys_id of the task.",
+        max_length=32,
+    )
+    note: str = Field(
+        description="The work note text to add.",
+    )
+
+
+class LogTimeParams(BaseModel):
+    """Parameters for logging time to a work order task."""
+
+    task_id: str = Field(
+        description="The sys_id of the task to log time against.",
+        max_length=32,
+    )
+    hours: float = Field(
+        description="Number of hours worked.",
+        gt=0,
+        le=24,
+    )
+    date: str = Field(
+        description="Date of work in YYYY-MM-DD format.",
+    )
+    category: str = Field(
+        default="labor",
+        description="Time category (e.g. 'labor', 'travel').",
+    )
+
+
+class SearchParams(BaseModel):
+    """Parameters for searching work orders by text."""
+
+    query: str = Field(
+        description="Search text to match against work order descriptions or numbers.",
+    )
+    limit: int = Field(
+        default=25,
+        ge=1,
+        le=50,
+        description="Maximum number of results to return (1-50).",
+    )

--- a/backend/app/agent/tools/servicenow_time.py
+++ b/backend/app/agent/tools/servicenow_time.py
@@ -1,0 +1,66 @@
+"""ServiceNow FSM time card tool.
+
+Implements time logging for work order tasks. Built by the factory in
+``servicenow_tools``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.servicenow_params import LogTimeParams
+from backend.app.services.servicenow import ServiceNowService
+
+logger = logging.getLogger(__name__)
+
+
+def build_time_tools(service: ServiceNowService) -> list[Tool]:
+    """Build the time logging tool for the ServiceNow integration."""
+
+    async def servicenow_log_time(
+        task_id: str,
+        hours: float,
+        date: str,
+        category: str = "labor",
+    ) -> ToolResult:
+        try:
+            card = await service.create_time_card(
+                task_id=task_id,
+                hours=hours,
+                date=date,
+                category=category,
+            )
+            return ToolResult(
+                content=(f"Logged {hours}h ({category}) on {date} for task {card.task}."),
+                receipt=ToolReceipt(
+                    action="Logged time",
+                    target=f"{hours}h {category} on {date}",
+                    url=(f"{service._instance_url}/time_card.do?sys_id={card.sys_id}"),
+                ),
+            )
+        except Exception as exc:
+            logger.exception("Failed to log time")
+            return ToolResult(
+                content=f"Failed to log time: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+    return [
+        Tool(
+            name=ToolName.SERVICENOW_LOG_TIME,
+            description="Log time worked on a ServiceNow work order task.",
+            function=servicenow_log_time,
+            params_model=LogTimeParams,
+            usage_hint="Use to record hours worked. Date format: YYYY-MM-DD.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Log {args.get('hours', '?')}h to ServiceNow task"
+                ),
+            ),
+        ),
+    ]

--- a/backend/app/agent/tools/servicenow_tools.py
+++ b/backend/app/agent/tools/servicenow_tools.py
@@ -1,0 +1,185 @@
+"""ServiceNow FSM tool registration and factory.
+
+This module is the entrypoint for tool auto-discovery (the ``_tools``
+suffix is picked up by ``ensure_tool_modules_imported``). It wires
+together the implementation modules:
+
+* ``servicenow_params``        -- Pydantic parameter models
+* ``servicenow_work_orders``   -- work order and task tools
+* ``servicenow_time``          -- time card tool
+
+Authentication uses the standard OAuth 2.0 authorization code flow
+(same as Google Calendar, QuickBooks, and CompanyCam).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.servicenow_time import build_time_tools
+from backend.app.agent.tools.servicenow_work_orders import build_work_order_tools
+from backend.app.config import settings
+from backend.app.services.oauth import oauth_service
+from backend.app.services.servicenow import ServiceNowService
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+logger = logging.getLogger(__name__)
+
+_INTEGRATION = "servicenow"
+
+
+async def _load_service(user_id: str) -> ServiceNowService | None:
+    """Load a ServiceNowService for the user using OAuth token (auto-refreshed).
+
+    On first use after OAuth connection, resolves the user's ServiceNow
+    sys_id lazily and persists it in the token's extra data so subsequent
+    calls skip the resolution step.
+    """
+    token = await oauth_service.get_valid_token(user_id, _INTEGRATION)
+    if not token or not token.access_token:
+        return None
+
+    instance_url = token.extra.get("instance_url", "") or settings.servicenow_instance_url
+    if not instance_url:
+        logger.warning("No ServiceNow instance URL for user %s", user_id)
+        return None
+
+    sys_user_id = token.extra.get("sys_user_id", "")
+
+    try:
+        service = ServiceNowService(
+            access_token=token.access_token,
+            instance_url=instance_url,
+            sys_user_id=sys_user_id,
+        )
+    except ValueError:
+        logger.exception("Invalid ServiceNow instance URL: %s", instance_url)
+        return None
+
+    # Lazy user identity resolution on first use.
+    if not sys_user_id:
+        try:
+            resolved_id = await service.resolve_current_user()
+            if resolved_id:
+                service.sys_user_id = resolved_id
+                token.extra["sys_user_id"] = resolved_id
+                token.extra["instance_url"] = instance_url
+                oauth_service.save_token(user_id, _INTEGRATION, token)
+                logger.info(
+                    "Resolved ServiceNow sys_user_id for user %s: %s",
+                    user_id,
+                    resolved_id,
+                )
+        except Exception:
+            logger.warning(
+                "Could not resolve ServiceNow user identity for %s; "
+                "list_work_orders will not filter by default",
+                user_id,
+                exc_info=True,
+            )
+
+    return service
+
+
+def _servicenow_auth_check(ctx: ToolContext) -> str | None:
+    """Check whether ServiceNow FSM is available for this user.
+
+    Returns None when connected (tools are available).
+    Returns a reason string when not connected (tells the agent how to help).
+    """
+    if (
+        not settings.servicenow_client_id
+        or not settings.servicenow_client_secret
+        or not settings.servicenow_instance_url
+    ):
+        return None  # Not configured server-side, hide tools
+    if oauth_service.is_connected(ctx.user.id, _INTEGRATION):
+        return None
+    return (
+        "ServiceNow FSM is not connected. "
+        "Use manage_integration(action='connect', target='servicenow') "
+        "to start the OAuth authorization flow."
+    )
+
+
+async def _servicenow_factory(ctx: ToolContext) -> list[Tool]:
+    """Factory for ServiceNow FSM tools."""
+    if (
+        not settings.servicenow_client_id
+        or not settings.servicenow_client_secret
+        or not settings.servicenow_instance_url
+    ):
+        return []
+
+    service = await _load_service(ctx.user.id)
+    if service is None:
+        return []
+    return [
+        *build_work_order_tools(service),
+        *build_time_tools(service),
+    ]
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import SubToolInfo, default_registry
+
+    default_registry.register(
+        "servicenow",
+        _servicenow_factory,
+        core=False,
+        summary=(
+            "Manage ServiceNow Field Service Management work orders, tasks, "
+            "notes, and time tracking"
+        ),
+        sub_tools=[
+            SubToolInfo(
+                ToolName.SERVICENOW_LIST_WORK_ORDERS,
+                "List assigned work orders",
+                default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.SERVICENOW_GET_WORK_ORDER,
+                "Get full work order details",
+                default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.SERVICENOW_LIST_TASKS,
+                "List tasks for a work order",
+                default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.SERVICENOW_UPDATE_TASK,
+                "Update a task state",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.SERVICENOW_ADD_WORK_ORDER_NOTE,
+                "Add a work note to a work order",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.SERVICENOW_ADD_TASK_NOTE,
+                "Add a work note to a task",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.SERVICENOW_LOG_TIME,
+                "Log time worked on a task",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.SERVICENOW_SEARCH,
+                "Search work orders by description or number",
+                default_permission="always",
+            ),
+        ],
+        auth_check=_servicenow_auth_check,
+    )
+
+
+_register()

--- a/backend/app/agent/tools/servicenow_work_orders.py
+++ b/backend/app/agent/tools/servicenow_work_orders.py
@@ -1,0 +1,319 @@
+"""ServiceNow FSM work order and task tools.
+
+Implements list, get, search, update, and note operations for work orders
+and work order tasks. Built by the factory in ``servicenow_tools``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.servicenow_params import (
+    AddTaskNoteParams,
+    AddWorkOrderNoteParams,
+    GetWorkOrderParams,
+    ListTasksParams,
+    ListWorkOrdersParams,
+    SearchParams,
+    UpdateTaskParams,
+)
+from backend.app.services.servicenow import ServiceNowService
+from backend.app.services.servicenow_models import WorkOrder, WorkOrderTask
+
+logger = logging.getLogger(__name__)
+
+
+def _wo_url(service: ServiceNowService, sys_id: str) -> str:
+    """Build a deep link to a work order in the ServiceNow UI."""
+    return f"{service._instance_url}/wm_order.do?sys_id={sys_id}"
+
+
+def _task_url(service: ServiceNowService, sys_id: str) -> str:
+    """Build a deep link to a work order task in the ServiceNow UI."""
+    return f"{service._instance_url}/wm_task.do?sys_id={sys_id}"
+
+
+def _format_work_order(wo: WorkOrder) -> str:
+    """Format a work order for display."""
+    lines = [
+        f"**{wo.number}**: {wo.short_description}",
+        f"  State: {wo.state}",
+        f"  Priority: {wo.priority}",
+        f"  Assigned to: {wo.assigned_to}",
+    ]
+    if str(wo.location):
+        lines.append(f"  Location: {wo.location}")
+    if wo.opened_at:
+        lines.append(f"  Opened: {wo.opened_at}")
+    return "\n".join(lines)
+
+
+def _format_task(task: WorkOrderTask) -> str:
+    """Format a work order task for display."""
+    lines = [
+        f"**{task.number}**: {task.short_description}",
+        f"  State: {task.state}",
+        f"  Assigned to: {task.assigned_to}",
+    ]
+    if str(task.work_order):
+        lines.append(f"  Work order: {task.work_order}")
+    return "\n".join(lines)
+
+
+def build_work_order_tools(service: ServiceNowService) -> list[Tool]:
+    """Build all work order and task tools for the ServiceNow integration."""
+
+    async def servicenow_list_work_orders(
+        assigned_to: str = "",
+        state: str = "",
+        limit: int = 25,
+    ) -> ToolResult:
+        try:
+            orders = await service.list_work_orders(
+                assigned_to=assigned_to,
+                state=state,
+                limit=limit,
+            )
+            if not orders:
+                return ToolResult(content="No work orders found.")
+            lines = [f"Found {len(orders)} work order(s):\n"]
+            for wo in orders:
+                lines.append(_format_work_order(wo))
+                lines.append("")
+            return ToolResult(content="\n".join(lines))
+        except Exception as exc:
+            logger.exception("Failed to list work orders")
+            return ToolResult(
+                content=f"Failed to list work orders: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+    async def servicenow_get_work_order(sys_id: str) -> ToolResult:
+        try:
+            wo = await service.get_work_order(sys_id)
+            lines = [_format_work_order(wo)]
+            if wo.description:
+                lines.append(f"\nDescription:\n{wo.description}")
+            return ToolResult(content="\n".join(lines))
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return ToolResult(
+                    content=f"Work order not found: {sys_id}",
+                    is_error=True,
+                    error_kind=ToolErrorKind.NOT_FOUND,
+                )
+            return ToolResult(
+                content=f"Failed to get work order: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+        except Exception as exc:
+            logger.exception("Failed to get work order")
+            return ToolResult(
+                content=f"Failed to get work order: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+    async def servicenow_list_tasks(
+        work_order_id: str = "",
+        state: str = "",
+        limit: int = 25,
+    ) -> ToolResult:
+        try:
+            tasks = await service.list_tasks(
+                work_order_id=work_order_id,
+                state=state,
+                limit=limit,
+            )
+            if not tasks:
+                return ToolResult(content="No tasks found.")
+            lines = [f"Found {len(tasks)} task(s):\n"]
+            for task in tasks:
+                lines.append(_format_task(task))
+                lines.append("")
+            return ToolResult(content="\n".join(lines))
+        except Exception as exc:
+            logger.exception("Failed to list tasks")
+            return ToolResult(
+                content=f"Failed to list tasks: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+    async def servicenow_update_task(
+        sys_id: str,
+        state: str | None = None,
+        work_notes: str = "",
+    ) -> ToolResult:
+        try:
+            task = await service.update_task(
+                sys_id,
+                state=state or "",
+                work_notes=work_notes,
+            )
+            return ToolResult(
+                content=f"Updated task {task.number}: state={task.state}",
+                receipt=ToolReceipt(
+                    action="Updated task status",
+                    target=task.number or sys_id,
+                    url=_task_url(service, sys_id),
+                ),
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return ToolResult(
+                    content=f"Task not found: {sys_id}",
+                    is_error=True,
+                    error_kind=ToolErrorKind.NOT_FOUND,
+                )
+            return ToolResult(
+                content=f"Failed to update task: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+        except Exception as exc:
+            logger.exception("Failed to update task")
+            return ToolResult(
+                content=f"Failed to update task: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+    async def servicenow_add_work_order_note(
+        sys_id: str,
+        note: str,
+    ) -> ToolResult:
+        try:
+            wo = await service.add_work_order_note(sys_id, note)
+            return ToolResult(
+                content=f"Added work note to {wo.number}.",
+                receipt=ToolReceipt(
+                    action="Added work note",
+                    target=wo.number or sys_id,
+                    url=_wo_url(service, sys_id),
+                ),
+            )
+        except Exception as exc:
+            logger.exception("Failed to add work order note")
+            return ToolResult(
+                content=f"Failed to add work note: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+    async def servicenow_add_task_note(
+        sys_id: str,
+        note: str,
+    ) -> ToolResult:
+        try:
+            task = await service.add_task_note(sys_id, note)
+            return ToolResult(
+                content=f"Added work note to {task.number}.",
+                receipt=ToolReceipt(
+                    action="Added work note",
+                    target=task.number or sys_id,
+                    url=_task_url(service, sys_id),
+                ),
+            )
+        except Exception as exc:
+            logger.exception("Failed to add task note")
+            return ToolResult(
+                content=f"Failed to add task note: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+    async def servicenow_search(
+        query: str,
+        limit: int = 25,
+    ) -> ToolResult:
+        try:
+            orders = await service.search_work_orders(query, limit=limit)
+            if not orders:
+                return ToolResult(content=f"No work orders found matching '{query}'.")
+            lines = [f"Found {len(orders)} work order(s) matching '{query}':\n"]
+            for wo in orders:
+                lines.append(_format_work_order(wo))
+                lines.append("")
+            return ToolResult(content="\n".join(lines))
+        except Exception as exc:
+            logger.exception("Failed to search work orders")
+            return ToolResult(
+                content=f"Failed to search work orders: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+    return [
+        Tool(
+            name=ToolName.SERVICENOW_LIST_WORK_ORDERS,
+            description="List ServiceNow work orders assigned to the current user or a specific user.",
+            function=servicenow_list_work_orders,
+            params_model=ListWorkOrdersParams,
+            usage_hint="Use to check what work is assigned. Defaults to the current user.",
+        ),
+        Tool(
+            name=ToolName.SERVICENOW_GET_WORK_ORDER,
+            description="Get full details of a specific ServiceNow work order.",
+            function=servicenow_get_work_order,
+            params_model=GetWorkOrderParams,
+            usage_hint="Use after listing work orders to get full details including description.",
+        ),
+        Tool(
+            name=ToolName.SERVICENOW_LIST_TASKS,
+            description="List tasks for a ServiceNow work order.",
+            function=servicenow_list_tasks,
+            params_model=ListTasksParams,
+            usage_hint="Use to see the individual steps within a work order.",
+        ),
+        Tool(
+            name=ToolName.SERVICENOW_UPDATE_TASK,
+            description="Update a ServiceNow work order task state or add a work note.",
+            function=servicenow_update_task,
+            params_model=UpdateTaskParams,
+            usage_hint="Use to change task status (e.g. Accept, Work In Progress, Closed Complete).",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    "Update ServiceNow task"
+                    + (f" to '{args.get('state')}'" if args.get("state") else "")
+                ),
+            ),
+        ),
+        Tool(
+            name=ToolName.SERVICENOW_ADD_WORK_ORDER_NOTE,
+            description="Add a work note to a ServiceNow work order.",
+            function=servicenow_add_work_order_note,
+            params_model=AddWorkOrderNoteParams,
+            usage_hint="Use to log notes visible to the dispatcher and team.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: "Add work note to ServiceNow work order",
+            ),
+        ),
+        Tool(
+            name=ToolName.SERVICENOW_ADD_TASK_NOTE,
+            description="Add a work note to a ServiceNow work order task.",
+            function=servicenow_add_task_note,
+            params_model=AddTaskNoteParams,
+            usage_hint="Use to log notes on a specific task step.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: "Add work note to ServiceNow task",
+            ),
+        ),
+        Tool(
+            name=ToolName.SERVICENOW_SEARCH,
+            description="Search ServiceNow work orders by description or number.",
+            function=servicenow_search,
+            params_model=SearchParams,
+            usage_hint="Use to find work orders by keyword. Searches descriptions and numbers.",
+        ),
+    ]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -114,6 +114,11 @@ class Settings(BaseSettings):
     google_calendar_client_id: str = ""
     google_calendar_client_secret: str = ""
 
+    # ServiceNow FSM
+    servicenow_client_id: str = ""
+    servicenow_client_secret: str = ""
+    servicenow_instance_url: str = ""  # e.g. "https://mycompany.service-now.com"
+
     # CompanyCam OAuth 2.0
     companycam_client_id: str = ""
     companycam_client_secret: str = ""

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -78,6 +78,11 @@ _FACTORY_META: dict[str, _FactoryMeta] = {
         domain_group="Integrations",
         domain_group_order=2,
     ),
+    "servicenow": _FactoryMeta(
+        "Manage work orders, tasks, and time in ServiceNow FSM",
+        domain_group="Integrations",
+        domain_group_order=2,
+    ),
     "supplier_pricing": _FactoryMeta(
         "Search product prices at Home Depot",
         domain_group="Integrations",

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -840,8 +840,11 @@ COMPANYCAM_AUTHORIZE_URL = "https://app.companycam.com/oauth/authorize"
 COMPANYCAM_TOKEN_URL = "https://app.companycam.com/oauth/token"
 COMPANYCAM_SCOPES = ["read", "write", "destroy"]
 
+# ServiceNow OAuth 2.0 (instance-specific URLs built at runtime)
+SERVICENOW_SCOPES: list[str] = []  # SN uses no explicit scopes by default
+
 # Registry of all supported OAuth integrations.
-_OAUTH_INTEGRATIONS = ("quickbooks", "google_calendar", "companycam")
+_OAUTH_INTEGRATIONS = ("quickbooks", "google_calendar", "companycam", "servicenow")
 
 
 def get_quickbooks_oauth_config() -> OAuthConfig | None:
@@ -893,6 +896,27 @@ def get_companycam_oauth_config() -> OAuthConfig | None:
     return config if config.is_configured else None
 
 
+def get_servicenow_oauth_config() -> OAuthConfig | None:
+    """Build the ServiceNow OAuth config from settings.
+
+    ServiceNow OAuth URLs are instance-specific, built from the
+    configured ``servicenow_instance_url``.
+    """
+    instance_url = settings.servicenow_instance_url.rstrip("/")
+    if not instance_url:
+        return None
+    config = OAuthConfig(
+        integration="servicenow",
+        client_id=settings.servicenow_client_id,
+        client_secret=settings.servicenow_client_secret,
+        authorize_url=f"{instance_url}/oauth_auth.do",
+        token_url=f"{instance_url}/oauth_token.do",
+        scopes=SERVICENOW_SCOPES,
+        use_pkce=True,
+    )
+    return config if config.is_configured else None
+
+
 def get_oauth_config(integration: str) -> OAuthConfig | None:
     """Return the OAuth config for the named integration, or None."""
     if integration == "quickbooks":
@@ -901,6 +925,8 @@ def get_oauth_config(integration: str) -> OAuthConfig | None:
         return get_google_calendar_oauth_config()
     if integration == "companycam":
         return get_companycam_oauth_config()
+    if integration == "servicenow":
+        return get_servicenow_oauth_config()
     return None
 
 

--- a/backend/app/services/servicenow.py
+++ b/backend/app/services/servicenow.py
@@ -1,0 +1,315 @@
+"""ServiceNow Table API service.
+
+Provides async methods for interacting with ServiceNow's Field Service
+Management tables (wm_order, wm_task, time_card) via the Table API.
+
+All table names are hardcoded in each method to prevent LLM-controlled
+input from accessing arbitrary tables.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import httpx
+
+from backend.app.services.servicenow_models import (
+    TimeCard,
+    WorkOrder,
+    WorkOrderTask,
+)
+
+logger = logging.getLogger(__name__)
+
+# Regex for validating ServiceNow instance URLs.
+_INSTANCE_URL_RE = re.compile(
+    r"^https://[\w-]+\.(service-now|servicenow)\.com$",
+    re.IGNORECASE,
+)
+
+
+def validate_instance_url(url: str) -> str:
+    """Validate and normalize a ServiceNow instance URL.
+
+    Strips trailing slashes and verifies the URL matches the expected
+    ``*.service-now.com`` or ``*.servicenow.com`` pattern to prevent
+    credential leakage to attacker-controlled servers.
+
+    Raises ``ValueError`` if the URL is invalid.
+    """
+    url = url.rstrip("/")
+    if not _INSTANCE_URL_RE.match(url):
+        raise ValueError(
+            f"Invalid ServiceNow instance URL: {url!r}. "
+            "Expected format: https://<instance>.service-now.com"
+        )
+    return url
+
+
+class ServiceNowService:
+    """Client for the ServiceNow Table API.
+
+    Requires a Bearer access token and the customer's instance URL.
+    """
+
+    def __init__(
+        self,
+        access_token: str,
+        instance_url: str,
+        sys_user_id: str = "",
+    ) -> None:
+        if not access_token:
+            raise ValueError("ServiceNow access token is required")
+        self._access_token = access_token
+        self._instance_url = validate_instance_url(instance_url)
+        self.sys_user_id = sys_user_id
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._access_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    @property
+    def _api_base(self) -> str:
+        return f"{self._instance_url}/api/now/table"
+
+    # -- Read operations -------------------------------------------------------
+
+    async def validate_token(self) -> bool:
+        """Validate the access token by fetching a single sys_user record."""
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                f"{self._api_base}/sys_user",
+                params={"sysparm_limit": "1"},
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return True
+
+    async def resolve_current_user(self) -> str:
+        """Resolve the current OAuth user's sys_id.
+
+        Queries the sys_user table with the ``sysparm_limit=1`` and the
+        token's identity. Returns the sys_id string, or empty string if
+        the user cannot be resolved.
+        """
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                f"{self._instance_url}/api/now/myuser",
+                headers=self._headers(),
+            )
+            if resp.status_code == 404:
+                # Fallback: try table API
+                resp = await client.get(
+                    f"{self._api_base}/sys_user",
+                    params={"sysparm_limit": "1", "sysparm_fields": "sys_id,user_name"},
+                    headers=self._headers(),
+                )
+            resp.raise_for_status()
+            data = resp.json()
+            # /api/now/myuser returns {"result": {"sys_id": "..."}}
+            result = data.get("result")
+            if isinstance(result, dict):
+                return result.get("sys_id", "")
+            # Table API returns {"result": [{...}]}
+            if isinstance(result, list) and result:
+                return result[0].get("sys_id", "")
+            return ""
+
+    async def list_work_orders(
+        self,
+        *,
+        assigned_to: str = "",
+        state: str = "",
+        limit: int = 25,
+        offset: int = 0,
+    ) -> list[WorkOrder]:
+        """List work orders, optionally filtered by assignee and state."""
+        effective_assigned_to = assigned_to or self.sys_user_id
+        query_parts: list[str] = []
+        if effective_assigned_to:
+            query_parts.append(f"assigned_to={effective_assigned_to}")
+        if state:
+            query_parts.append(f"state={state}")
+
+        params: dict[str, str] = {
+            "sysparm_display_value": "all",
+            "sysparm_limit": str(min(limit, 50)),
+            "sysparm_offset": str(offset),
+            "sysparm_fields": (
+                "sys_id,number,short_description,state,priority,"
+                "assigned_to,location,opened_at,closed_at,work_start,work_end"
+            ),
+        }
+        if query_parts:
+            params["sysparm_query"] = "^".join(query_parts)
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                f"{self._api_base}/wm_order",
+                params=params,
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            records = resp.json().get("result", [])
+            return [WorkOrder.model_validate(r) for r in records]
+
+    async def get_work_order(self, sys_id: str) -> WorkOrder:
+        """Get a single work order by sys_id."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                f"{self._api_base}/wm_order/{sys_id}",
+                params={"sysparm_display_value": "all"},
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return WorkOrder.model_validate(resp.json().get("result", {}))
+
+    async def list_tasks(
+        self,
+        *,
+        work_order_id: str = "",
+        state: str = "",
+        limit: int = 25,
+    ) -> list[WorkOrderTask]:
+        """List work order tasks, optionally filtered by work order and state."""
+        query_parts: list[str] = []
+        if work_order_id:
+            query_parts.append(f"work_order={work_order_id}")
+        if state:
+            query_parts.append(f"state={state}")
+
+        params: dict[str, str] = {
+            "sysparm_display_value": "all",
+            "sysparm_limit": str(min(limit, 50)),
+            "sysparm_fields": (
+                "sys_id,number,short_description,state,assigned_to,"
+                "work_order,work_start,work_end,work_notes"
+            ),
+        }
+        if query_parts:
+            params["sysparm_query"] = "^".join(query_parts)
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                f"{self._api_base}/wm_task",
+                params=params,
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            records = resp.json().get("result", [])
+            return [WorkOrderTask.model_validate(r) for r in records]
+
+    async def search_work_orders(
+        self,
+        query: str,
+        limit: int = 25,
+    ) -> list[WorkOrder]:
+        """Search work orders by text (short_description or number).
+
+        Queries are built server-side to prevent injection of arbitrary
+        ServiceNow encoded query operators.
+        """
+        safe_query = query.replace("^", "").replace("\n", " ").strip()
+        if not safe_query:
+            return []
+
+        params: dict[str, str] = {
+            "sysparm_display_value": "all",
+            "sysparm_limit": str(min(limit, 50)),
+            "sysparm_query": (f"short_descriptionLIKE{safe_query}^ORnumberLIKE{safe_query}"),
+            "sysparm_fields": (
+                "sys_id,number,short_description,state,priority,"
+                "assigned_to,location,opened_at,closed_at"
+            ),
+        }
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                f"{self._api_base}/wm_order",
+                params=params,
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            records = resp.json().get("result", [])
+            return [WorkOrder.model_validate(r) for r in records]
+
+    # -- Write operations ------------------------------------------------------
+
+    async def update_task(
+        self,
+        sys_id: str,
+        *,
+        state: str = "",
+        work_notes: str = "",
+    ) -> WorkOrderTask:
+        """Update a work order task's state and/or work notes."""
+        body: dict[str, str] = {}
+        if state:
+            body["state"] = state
+        if work_notes:
+            body["work_notes"] = work_notes
+        if not body:
+            raise ValueError("At least one of state or work_notes must be provided")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.patch(
+                f"{self._api_base}/wm_task/{sys_id}",
+                json=body,
+                headers=self._headers(),
+                params={"sysparm_display_value": "all"},
+            )
+            resp.raise_for_status()
+            return WorkOrderTask.model_validate(resp.json().get("result", {}))
+
+    async def add_work_order_note(self, sys_id: str, note: str) -> WorkOrder:
+        """Add a work note to a work order (hardcoded table: wm_order)."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.patch(
+                f"{self._api_base}/wm_order/{sys_id}",
+                json={"work_notes": note},
+                headers=self._headers(),
+                params={"sysparm_display_value": "all"},
+            )
+            resp.raise_for_status()
+            return WorkOrder.model_validate(resp.json().get("result", {}))
+
+    async def add_task_note(self, sys_id: str, note: str) -> WorkOrderTask:
+        """Add a work note to a work order task (hardcoded table: wm_task)."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.patch(
+                f"{self._api_base}/wm_task/{sys_id}",
+                json={"work_notes": note},
+                headers=self._headers(),
+                params={"sysparm_display_value": "all"},
+            )
+            resp.raise_for_status()
+            return WorkOrderTask.model_validate(resp.json().get("result", {}))
+
+    async def create_time_card(
+        self,
+        *,
+        task_id: str,
+        hours: float,
+        date: str,
+        category: str = "labor",
+    ) -> TimeCard:
+        """Create a time card entry for a work order task."""
+        body = {
+            "task": task_id,
+            "total": str(hours),
+            "date": date,
+            "category": category,
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self._api_base}/time_card",
+                json=body,
+                headers=self._headers(),
+                params={"sysparm_display_value": "all"},
+            )
+            resp.raise_for_status()
+            return TimeCard.model_validate(resp.json().get("result", {}))

--- a/backend/app/services/servicenow_models.py
+++ b/backend/app/services/servicenow_models.py
@@ -1,0 +1,83 @@
+"""Pydantic models for ServiceNow Table API responses.
+
+ServiceNow's Table API returns reference fields in different shapes depending
+on the ``sysparm_display_value`` parameter:
+
+- ``false`` (default): raw sys_id string
+- ``true``: display value string only
+- ``all``: ``{"value": "<sys_id>", "display_value": "<label>", "link": "<url>"}``
+
+We use ``sysparm_display_value=all`` so reference fields are always returned
+as ``SNDisplayValue`` objects, giving both the programmatic sys_id and the
+human-readable label in a single call.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SNDisplayValue(BaseModel):
+    """A ServiceNow reference or choice field returned with display_value=all.
+
+    When the API returns a reference or choice field with
+    ``sysparm_display_value=all``, each field is an object with the raw
+    value, a human-readable display string, and an optional REST link.
+    """
+
+    value: str = ""
+    display_value: str = ""
+    link: str = ""
+
+    def __str__(self) -> str:
+        return self.display_value or self.value
+
+
+class WorkOrder(BaseModel):
+    """ServiceNow FSM work order (table: wm_order)."""
+
+    sys_id: str = ""
+    number: str = ""
+    short_description: str = ""
+    description: str = ""
+    state: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    priority: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    assigned_to: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    location: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    opened_at: str = ""
+    closed_at: str = ""
+    work_start: str = ""
+    work_end: str = ""
+
+    model_config = {"extra": "allow"}
+
+
+class WorkOrderTask(BaseModel):
+    """ServiceNow FSM work order task (table: wm_task)."""
+
+    sys_id: str = ""
+    number: str = ""
+    short_description: str = ""
+    description: str = ""
+    state: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    assigned_to: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    work_order: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    work_start: str = ""
+    work_end: str = ""
+    work_notes: str = ""
+
+    model_config = {"extra": "allow"}
+
+
+class TimeCard(BaseModel):
+    """ServiceNow time card (table: time_card)."""
+
+    sys_id: str = ""
+    task: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    user: SNDisplayValue = Field(default_factory=SNDisplayValue)
+    total: str = ""  # hours as string in SN
+    date: str = ""
+    state: str = ""
+    category: str = ""
+
+    model_config = {"extra": "allow"}

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -185,6 +185,16 @@ When `GOOGLE_CALENDAR_CLIENT_ID` and `GOOGLE_CALENDAR_CLIENT_SECRET` are set, us
 
 When both are set, users can connect CompanyCam via OAuth on the Tools page or through chat. This enables tools like `companycam_search_projects`, `companycam_upload_photo`, and `companycam_create_project`.
 
+## ServiceNow FSM
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SERVICENOW_CLIENT_ID` | | ServiceNow OAuth 2.0 client ID |
+| `SERVICENOW_CLIENT_SECRET` | | ServiceNow OAuth 2.0 client secret |
+| `SERVICENOW_INSTANCE_URL` | | ServiceNow instance URL, e.g. `https://mycompany.service-now.com` |
+
+When all three are set, users can connect ServiceNow FSM via OAuth on the Tools page or through chat. This enables specialist tools for managing work orders, tasks, work notes, and time tracking (`servicenow_list_work_orders`, `servicenow_update_task`, `servicenow_log_time`, etc.).
+
 ## Supplier pricing
 
 | Variable | Default | Description |

--- a/tests/test_servicenow_service.py
+++ b/tests/test_servicenow_service.py
@@ -1,0 +1,348 @@
+"""Tests for the ServiceNow Table API service layer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from backend.app.services.servicenow import ServiceNowService, validate_instance_url
+from backend.app.services.servicenow_models import SNDisplayValue, WorkOrder
+
+# -- Instance URL validation ---------------------------------------------------
+
+
+class TestValidateInstanceUrl:
+    def test_valid_service_now_url(self) -> None:
+        assert validate_instance_url("https://mycompany.service-now.com") == (
+            "https://mycompany.service-now.com"
+        )
+
+    def test_valid_servicenow_url(self) -> None:
+        assert validate_instance_url("https://mycompany.servicenow.com") == (
+            "https://mycompany.servicenow.com"
+        )
+
+    def test_strips_trailing_slash(self) -> None:
+        assert validate_instance_url("https://mycompany.service-now.com/") == (
+            "https://mycompany.service-now.com"
+        )
+
+    def test_rejects_non_servicenow_url(self) -> None:
+        with pytest.raises(ValueError, match="Invalid ServiceNow instance URL"):
+            validate_instance_url("https://evil.com")
+
+    def test_rejects_http_url(self) -> None:
+        with pytest.raises(ValueError, match="Invalid ServiceNow instance URL"):
+            validate_instance_url("http://mycompany.service-now.com")
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="Invalid ServiceNow instance URL"):
+            validate_instance_url("")
+
+    def test_rejects_path_traversal(self) -> None:
+        with pytest.raises(ValueError, match="Invalid ServiceNow instance URL"):
+            validate_instance_url("https://mycompany.service-now.com/evil")
+
+    def test_case_insensitive(self) -> None:
+        result = validate_instance_url("https://MyCompany.Service-Now.COM")
+        assert result == "https://MyCompany.Service-Now.COM"
+
+
+# -- Constructor ---------------------------------------------------------------
+
+
+class TestServiceConstructor:
+    def test_requires_access_token(self) -> None:
+        with pytest.raises(ValueError, match="access token"):
+            ServiceNowService(access_token="", instance_url="https://x.service-now.com")
+
+    def test_validates_instance_url(self) -> None:
+        with pytest.raises(ValueError, match="Invalid ServiceNow"):
+            ServiceNowService(access_token="tok", instance_url="https://evil.com")
+
+    def test_stores_sys_user_id(self) -> None:
+        svc = ServiceNowService(
+            access_token="tok",
+            instance_url="https://x.service-now.com",
+            sys_user_id="abc123",
+        )
+        assert svc.sys_user_id == "abc123"
+
+
+# -- Helpers -------------------------------------------------------------------
+
+
+def _mock_response(data: dict | list, status: int = 200) -> httpx.Response:
+    """Build a fake httpx.Response with JSON body."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.json.return_value = {"result": data}
+    resp.raise_for_status = MagicMock()
+    if status >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message="error",
+            request=MagicMock(),
+            response=resp,
+        )
+    return resp
+
+
+def _make_service(sys_user_id: str = "") -> ServiceNowService:
+    return ServiceNowService(
+        access_token="test-token",
+        instance_url="https://test.service-now.com",
+        sys_user_id=sys_user_id,
+    )
+
+
+def _patch_httpx() -> AsyncMock:
+    """Return a mock that replaces httpx.AsyncClient context manager."""
+    client = AsyncMock()
+    mock_cls = patch("backend.app.services.servicenow.httpx.AsyncClient")
+    mock = mock_cls.start()
+    mock.return_value.__aenter__ = AsyncMock(return_value=client)
+    mock.return_value.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# -- API methods ---------------------------------------------------------------
+
+
+class TestListWorkOrders:
+    @pytest.mark.asyncio()
+    async def test_returns_work_orders(self) -> None:
+        service = _make_service(sys_user_id="user123")
+        client = _patch_httpx()
+        client.get = AsyncMock(
+            return_value=_mock_response(
+                [
+                    {
+                        "sys_id": "wo1",
+                        "number": "WO0001",
+                        "short_description": "HVAC Install",
+                        "state": {"value": "1", "display_value": "Assigned", "link": ""},
+                        "priority": {"value": "2", "display_value": "High", "link": ""},
+                        "assigned_to": {
+                            "value": "user123",
+                            "display_value": "John",
+                            "link": "",
+                        },
+                        "location": {"value": "", "display_value": "", "link": ""},
+                    }
+                ]
+            )
+        )
+
+        try:
+            orders = await service.list_work_orders()
+        finally:
+            patch.stopall()
+
+        assert len(orders) == 1
+        assert orders[0].number == "WO0001"
+        assert orders[0].state.display_value == "Assigned"
+
+    @pytest.mark.asyncio()
+    async def test_defaults_assigned_to_sys_user_id(self) -> None:
+        service = _make_service(sys_user_id="myuser")
+        client = _patch_httpx()
+        client.get = AsyncMock(return_value=_mock_response([]))
+
+        try:
+            await service.list_work_orders()
+        finally:
+            patch.stopall()
+
+        call_kwargs = client.get.call_args
+        params = call_kwargs.kwargs.get("params", {})
+        assert "assigned_to=myuser" in params.get("sysparm_query", "")
+
+    @pytest.mark.asyncio()
+    async def test_caps_limit_at_50(self) -> None:
+        service = _make_service()
+        client = _patch_httpx()
+        client.get = AsyncMock(return_value=_mock_response([]))
+
+        try:
+            await service.list_work_orders(limit=100)
+        finally:
+            patch.stopall()
+
+        call_kwargs = client.get.call_args
+        params = call_kwargs.kwargs.get("params", {})
+        assert params["sysparm_limit"] == "50"
+
+
+class TestSearchWorkOrders:
+    @pytest.mark.asyncio()
+    async def test_builds_server_side_query(self) -> None:
+        service = _make_service()
+        client = _patch_httpx()
+        client.get = AsyncMock(return_value=_mock_response([]))
+
+        try:
+            await service.search_work_orders("HVAC")
+        finally:
+            patch.stopall()
+
+        call_kwargs = client.get.call_args
+        params = call_kwargs.kwargs.get("params", {})
+        query = params.get("sysparm_query", "")
+        assert "short_descriptionLIKEHVAC" in query
+        assert "numberLIKEHVAC" in query
+
+    @pytest.mark.asyncio()
+    async def test_strips_injection_characters(self) -> None:
+        service = _make_service()
+        client = _patch_httpx()
+        client.get = AsyncMock(return_value=_mock_response([]))
+
+        try:
+            await service.search_work_orders("test^NQstate=1")
+        finally:
+            patch.stopall()
+
+        call_kwargs = client.get.call_args
+        params = call_kwargs.kwargs.get("params", {})
+        query = params.get("sysparm_query", "")
+        # The ^ character should be stripped
+        assert "^NQ" not in query
+
+    @pytest.mark.asyncio()
+    async def test_empty_query_returns_empty(self) -> None:
+        service = _make_service()
+        result = await service.search_work_orders("")
+        assert result == []
+
+
+class TestUpdateTask:
+    @pytest.mark.asyncio()
+    async def test_sends_patch_with_state(self) -> None:
+        service = _make_service()
+        client = _patch_httpx()
+        client.patch = AsyncMock(
+            return_value=_mock_response(
+                {
+                    "sys_id": "task1",
+                    "number": "WMT0001",
+                    "short_description": "Remove old unit",
+                    "state": {"value": "3", "display_value": "Work In Progress", "link": ""},
+                    "assigned_to": {"value": "", "display_value": "", "link": ""},
+                    "work_order": {"value": "", "display_value": "", "link": ""},
+                }
+            )
+        )
+
+        try:
+            task = await service.update_task("task1", state="Work In Progress")
+        finally:
+            patch.stopall()
+
+        assert task.number == "WMT0001"
+        call_kwargs = client.patch.call_args
+        assert call_kwargs.kwargs["json"]["state"] == "Work In Progress"
+
+    @pytest.mark.asyncio()
+    async def test_requires_state_or_notes(self) -> None:
+        service = _make_service()
+        with pytest.raises(ValueError, match="At least one"):
+            await service.update_task("task1")
+
+
+class TestResolveCurrentUser:
+    @pytest.mark.asyncio()
+    async def test_returns_sys_id(self) -> None:
+        service = _make_service()
+        client = _patch_httpx()
+        # Simulate /api/now/myuser returning a user record
+        client.get = AsyncMock(
+            return_value=_mock_response({"sys_id": "resolved123", "user_name": "jdoe"})
+        )
+
+        try:
+            result = await service.resolve_current_user()
+        finally:
+            patch.stopall()
+
+        assert result == "resolved123"
+
+    @pytest.mark.asyncio()
+    async def test_returns_empty_on_no_result(self) -> None:
+        service = _make_service()
+        client = _patch_httpx()
+        client.get = AsyncMock(return_value=_mock_response(None))
+
+        try:
+            result = await service.resolve_current_user()
+        finally:
+            patch.stopall()
+
+        assert result == ""
+
+
+class TestCreateTimeCard:
+    @pytest.mark.asyncio()
+    async def test_posts_time_card(self) -> None:
+        service = _make_service()
+        client = _patch_httpx()
+        client.post = AsyncMock(
+            return_value=_mock_response(
+                {
+                    "sys_id": "tc1",
+                    "task": {"value": "task1", "display_value": "WMT0001", "link": ""},
+                    "user": {"value": "u1", "display_value": "John", "link": ""},
+                    "total": "2.5",
+                    "date": "2026-04-23",
+                    "state": "Submitted",
+                    "category": "labor",
+                }
+            )
+        )
+
+        try:
+            card = await service.create_time_card(
+                task_id="task1",
+                hours=2.5,
+                date="2026-04-23",
+                category="labor",
+            )
+        finally:
+            patch.stopall()
+
+        assert card.sys_id == "tc1"
+        assert card.total == "2.5"
+
+
+# -- Model tests ---------------------------------------------------------------
+
+
+class TestSNDisplayValue:
+    def test_str_returns_display_value(self) -> None:
+        dv = SNDisplayValue(value="123", display_value="High")
+        assert str(dv) == "High"
+
+    def test_str_falls_back_to_value(self) -> None:
+        dv = SNDisplayValue(value="123", display_value="")
+        assert str(dv) == "123"
+
+    def test_parses_from_dict(self) -> None:
+        dv = SNDisplayValue.model_validate(
+            {"value": "abc", "display_value": "Label", "link": "https://..."}
+        )
+        assert dv.value == "abc"
+        assert dv.display_value == "Label"
+
+
+class TestWorkOrderModel:
+    def test_extra_fields_allowed(self) -> None:
+        """ServiceNow may return fields not in our model."""
+        wo = WorkOrder.model_validate(
+            {
+                "sys_id": "x",
+                "number": "WO0001",
+                "unknown_field": "ignored",
+            }
+        )
+        assert wo.sys_id == "x"

--- a/tests/test_servicenow_tools.py
+++ b/tests/test_servicenow_tools.py
@@ -1,0 +1,211 @@
+"""Tests for ServiceNow FSM tool functions and factory."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.app.agent.tools.servicenow_time import build_time_tools
+from backend.app.agent.tools.servicenow_work_orders import build_work_order_tools
+from backend.app.services.servicenow import ServiceNowService
+from backend.app.services.servicenow_models import (
+    SNDisplayValue,
+    TimeCard,
+    WorkOrder,
+    WorkOrderTask,
+)
+
+
+def _make_service() -> ServiceNowService:
+    return ServiceNowService(
+        access_token="test-token",
+        instance_url="https://test.service-now.com",
+        sys_user_id="user123",
+    )
+
+
+def _make_work_order(**kwargs: object) -> WorkOrder:
+    defaults = {
+        "sys_id": "wo1",
+        "number": "WO0001",
+        "short_description": "HVAC Install",
+        "state": SNDisplayValue(value="1", display_value="Assigned"),
+        "priority": SNDisplayValue(value="2", display_value="High"),
+        "assigned_to": SNDisplayValue(value="user123", display_value="John"),
+        "location": SNDisplayValue(),
+    }
+    defaults.update(kwargs)
+    return WorkOrder(**defaults)
+
+
+def _make_task(**kwargs: object) -> WorkOrderTask:
+    defaults = {
+        "sys_id": "task1",
+        "number": "WMT0001",
+        "short_description": "Remove old unit",
+        "state": SNDisplayValue(value="3", display_value="Work In Progress"),
+        "assigned_to": SNDisplayValue(value="user123", display_value="John"),
+        "work_order": SNDisplayValue(value="wo1", display_value="WO0001"),
+    }
+    defaults.update(kwargs)
+    return WorkOrderTask(**defaults)
+
+
+class TestWorkOrderTools:
+    def test_tool_count(self) -> None:
+        service = _make_service()
+        tools = build_work_order_tools(service)
+        assert len(tools) == 7  # list, get, list_tasks, update, 2 notes, search
+
+    def test_tool_names(self) -> None:
+        service = _make_service()
+        tools = build_work_order_tools(service)
+        names = {t.name for t in tools}
+        assert "servicenow_list_work_orders" in names
+        assert "servicenow_get_work_order" in names
+        assert "servicenow_list_tasks" in names
+        assert "servicenow_update_task" in names
+        assert "servicenow_add_work_order_note" in names
+        assert "servicenow_add_task_note" in names
+        assert "servicenow_search" in names
+
+    def test_mutating_tools_have_approval_policy(self) -> None:
+        service = _make_service()
+        tools = build_work_order_tools(service)
+        mutating = [
+            "servicenow_update_task",
+            "servicenow_add_work_order_note",
+            "servicenow_add_task_note",
+        ]
+        for tool in tools:
+            if tool.name in mutating:
+                assert tool.approval_policy is not None, f"{tool.name} missing approval_policy"
+
+    @pytest.mark.asyncio()
+    async def test_list_work_orders_empty(self) -> None:
+        service = _make_service()
+        service.list_work_orders = AsyncMock(return_value=[])
+        tools = build_work_order_tools(service)
+        list_tool = next(t for t in tools if t.name == "servicenow_list_work_orders")
+        result = await list_tool.function()
+        assert "No work orders found" in result.content
+        assert not result.is_error
+
+    @pytest.mark.asyncio()
+    async def test_list_work_orders_formats_results(self) -> None:
+        service = _make_service()
+        service.list_work_orders = AsyncMock(return_value=[_make_work_order()])
+        tools = build_work_order_tools(service)
+        list_tool = next(t for t in tools if t.name == "servicenow_list_work_orders")
+        result = await list_tool.function()
+        assert "WO0001" in result.content
+        assert "HVAC Install" in result.content
+
+    @pytest.mark.asyncio()
+    async def test_list_work_orders_error(self) -> None:
+        service = _make_service()
+        service.list_work_orders = AsyncMock(side_effect=Exception("Connection refused"))
+        tools = build_work_order_tools(service)
+        list_tool = next(t for t in tools if t.name == "servicenow_list_work_orders")
+        result = await list_tool.function()
+        assert result.is_error
+        assert result.error_kind is not None
+
+    @pytest.mark.asyncio()
+    async def test_update_task_returns_receipt(self) -> None:
+        service = _make_service()
+        service.update_task = AsyncMock(return_value=_make_task())
+        tools = build_work_order_tools(service)
+        update_tool = next(t for t in tools if t.name == "servicenow_update_task")
+        result = await update_tool.function(sys_id="task1", state="Work In Progress")
+        assert result.receipt is not None
+        assert result.receipt.action == "Updated task status"
+        assert "WMT0001" in result.receipt.target
+        assert "test.service-now.com" in result.receipt.url
+
+    @pytest.mark.asyncio()
+    async def test_add_work_order_note_returns_receipt(self) -> None:
+        service = _make_service()
+        service.add_work_order_note = AsyncMock(return_value=_make_work_order())
+        tools = build_work_order_tools(service)
+        note_tool = next(t for t in tools if t.name == "servicenow_add_work_order_note")
+        result = await note_tool.function(sys_id="wo1", note="Test note")
+        assert result.receipt is not None
+        assert result.receipt.action == "Added work note"
+
+    @pytest.mark.asyncio()
+    async def test_add_task_note_returns_receipt(self) -> None:
+        service = _make_service()
+        service.add_task_note = AsyncMock(return_value=_make_task())
+        tools = build_work_order_tools(service)
+        note_tool = next(t for t in tools if t.name == "servicenow_add_task_note")
+        result = await note_tool.function(sys_id="task1", note="Test note")
+        assert result.receipt is not None
+        assert result.receipt.action == "Added work note"
+
+    @pytest.mark.asyncio()
+    async def test_search_empty_results(self) -> None:
+        service = _make_service()
+        service.search_work_orders = AsyncMock(return_value=[])
+        tools = build_work_order_tools(service)
+        search_tool = next(t for t in tools if t.name == "servicenow_search")
+        result = await search_tool.function(query="nonexistent")
+        assert "No work orders found" in result.content
+
+
+class TestTimeTools:
+    def test_tool_count(self) -> None:
+        service = _make_service()
+        tools = build_time_tools(service)
+        assert len(tools) == 1
+
+    def test_has_approval_policy(self) -> None:
+        service = _make_service()
+        tools = build_time_tools(service)
+        assert tools[0].approval_policy is not None
+
+    @pytest.mark.asyncio()
+    async def test_log_time_returns_receipt(self) -> None:
+        service = _make_service()
+        service.create_time_card = AsyncMock(
+            return_value=TimeCard(
+                sys_id="tc1",
+                task=SNDisplayValue(value="task1", display_value="WMT0001"),
+                user=SNDisplayValue(value="u1", display_value="John"),
+                total="2.5",
+                date="2026-04-23",
+                state="Submitted",
+                category="labor",
+            )
+        )
+        tools = build_time_tools(service)
+        result = await tools[0].function(
+            task_id="task1",
+            hours=2.5,
+            date="2026-04-23",
+            category="labor",
+        )
+        assert result.receipt is not None
+        assert result.receipt.action == "Logged time"
+        assert "2.5h" in result.receipt.target
+
+    @pytest.mark.asyncio()
+    async def test_log_time_error(self) -> None:
+        service = _make_service()
+        service.create_time_card = AsyncMock(side_effect=Exception("timeout"))
+        tools = build_time_tools(service)
+        result = await tools[0].function(
+            task_id="task1",
+            hours=1.0,
+            date="2026-04-23",
+        )
+        assert result.is_error
+
+
+class TestTotalToolCount:
+    def test_all_tools_combined(self) -> None:
+        """Factory should produce exactly 8 tools total."""
+        service = _make_service()
+        all_tools = build_work_order_tools(service) + build_time_tools(service)
+        assert len(all_tools) == 8

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -33,6 +33,7 @@ EXPECTED_TOOL_MODULES: set[str] = {
     "backend.app.agent.tools.quickbooks_tools",
     "backend.app.agent.tools.calendar_tools",
     "backend.app.agent.tools.companycam_tools",
+    "backend.app.agent.tools.servicenow_tools",
     "backend.app.agent.tools.workspace_tools",
 }
 


### PR DESCRIPTION
## Description

Adds a specialist integration for ServiceNow Field Service Management (FSM), giving field workers chat-based access to their work orders, tasks, notes, and time tracking. Closes #1006.

**8 tools:**
| Tool | Purpose | Approval |
|------|---------|----------|
| `servicenow_list_work_orders` | List assigned work orders | Auto |
| `servicenow_get_work_order` | Get full work order details | Auto |
| `servicenow_list_tasks` | List tasks for a work order | Auto |
| `servicenow_update_task` | Update task state | Ask |
| `servicenow_add_work_order_note` | Add work note to a work order | Ask |
| `servicenow_add_task_note` | Add work note to a task | Ask |
| `servicenow_log_time` | Log time worked on a task | Ask |
| `servicenow_search` | Search work orders by text | Auto |

**Key design decisions:**
- Instance URL validated against `*.service-now.com` / `*.servicenow.com` to prevent credential leakage
- All ServiceNow queries built server-side (no raw LLM input in `sysparm_query`)
- Separate tools for work order notes vs task notes (no LLM-controlled table name in URL path)
- Per-user identity resolution: `sys_user_id` resolved lazily on first tool use and cached in `OAuthTokenData.extra`
- Instance URL stored per-user in `token.extra["instance_url"]` with deployment config as default

**Follow-up:** #1007 (package-per-integration restructure)

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- 1904 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality -- 44 new tests
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code planned and implemented the integration, reviewed by autoplan pipeline with CEO + Eng review phases)
- [ ] No AI used