### PR TITLE
fix: stop infinite SSE reconnect on 401 and add exponential backoff

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -340,11 +340,22 @@ const api = {
   // Activity stream: real-time agent status from any channel.
   // Auto-reconnects on disconnect so transient drops (proxy timeout,
   // network glitch) don't permanently kill the spinner updates.
+  // Stops retrying on auth errors (401/403) since reconnecting won't help.
+  // Uses exponential backoff for transient errors to avoid server spam.
   subscribeToActivity: (
     onEvent: (event: { type: string; tool_name?: string; channel?: string }) => void,
   ): AbortController => {
     const controller = new AbortController();
-    const RECONNECT_MS = 2_000;
+    const BASE_MS = 2_000;
+    const MAX_MS = 30_000;
+    let failures = 0;
+
+    const backoff = (): number => Math.min(BASE_MS * 2 ** failures, MAX_MS);
+
+    const reconnect = (): void => {
+      failures++;
+      if (!controller.signal.aborted) setTimeout(connect, backoff());
+    };
 
     const connect = (): void => {
       if (controller.signal.aborted) return;
@@ -356,10 +367,15 @@ const api = {
       })
         .then((res) => {
           if (!res.ok || !res.body) {
-            // Non-OK response (e.g. 401): retry after delay
-            if (!controller.signal.aborted) setTimeout(connect, RECONNECT_MS);
+            if (res.status === 401 || res.status === 403) {
+              // Auth error: stop retrying, reconnecting won't fix this
+              return;
+            }
+            reconnect();
             return;
           }
+          // Connected successfully, reset backoff
+          failures = 0;
           const reader = res.body.getReader();
           const decoder = new TextDecoder();
           let buffer = '';
@@ -370,7 +386,7 @@ const api = {
               .then(({ done, value }) => {
                 if (done) {
                   // Server closed the stream: reconnect
-                  if (!controller.signal.aborted) setTimeout(connect, RECONNECT_MS);
+                  reconnect();
                   return;
                 }
                 buffer += decoder.decode(value, { stream: true });
@@ -394,14 +410,14 @@ const api = {
               })
               .catch(() => {
                 // Stream error: reconnect unless intentionally aborted
-                if (!controller.signal.aborted) setTimeout(connect, RECONNECT_MS);
+                reconnect();
               });
           };
           read();
         })
         .catch(() => {
           // Connection failed: reconnect unless intentionally aborted
-          if (!controller.signal.aborted) setTimeout(connect, RECONNECT_MS);
+          reconnect();
         });
     };
 


### PR DESCRIPTION
## Description

The activity SSE stream (`subscribeToActivity` in `api.ts`) retried every 2 seconds on any failure, including 401 Unauthorized. When a token expired or a stale browser tab lost its session, this created an infinite loop of 401 requests that spammed server logs and wasted resources.

Two changes:
- **Stop retrying on 401/403**: Auth errors are terminal. Reconnecting won't fix an expired token, so the SSE stops instead of looping forever.
- **Exponential backoff for transient errors**: Starts at 2s, doubles each failure (2s, 4s, 8s, 16s), capped at 30s. Resets on successful connection. Prevents server spam from network glitches or 500s while still recovering quickly.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code identified the root cause from production logs and implemented the fix)
- [ ] No AI used