### PR TITLE
fix: persist preferred_channel drift sync in resolve_heartbeat_route

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -856,7 +856,11 @@ def resolve_heartbeat_route(
 
     # Keep preferred_channel in sync if it drifted.
     if user.preferred_channel != route.channel:
-        user.preferred_channel = route.channel
+        # ``user`` may be detached (e.g. the heartbeat scheduler expunges users
+        # from the loading session before handing them to a fresh session). Attach
+        # via ``merge`` so the mutation is tracked and persisted by ``commit``.
+        attached = db.merge(user)
+        attached.preferred_channel = route.channel
         db.commit()
 
     return route.channel, route

--- a/tests/test_channel_routes.py
+++ b/tests/test_channel_routes.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import backend.app.database as _db_module
+from backend.app.agent.heartbeat import resolve_heartbeat_route
 from backend.app.agent.ingestion import InboundMessage, process_inbound_from_bus
 from backend.app.bus import message_bus
 from backend.app.models import ChannelRoute, User
@@ -223,8 +224,6 @@ async def test_inbound_disabled_does_not_update_preferred(test_user: User) -> No
 
 def test_heartbeat_resolve_skips_disabled(test_user: User) -> None:
     """When preferred channel is disabled, fall back to next enabled."""
-    from backend.app.agent.heartbeat import resolve_heartbeat_route
-
     _create_route(test_user.id, "telegram", "111", enabled=False)
     _create_route(test_user.id, "linq", "222", enabled=True)
 
@@ -250,10 +249,49 @@ def test_heartbeat_resolve_skips_disabled(test_user: User) -> None:
     assert result[0] == "linq"
 
 
+def test_heartbeat_resolve_persists_drift_sync(test_user: User) -> None:
+    """Drift-sync must persist even when the User passed in is detached.
+
+    Regression for #1013: the heartbeat scheduler loads users, expunges them,
+    then processes each in a fresh session. ``resolve_heartbeat_route`` mutated
+    the detached ``User`` and called ``db.commit()``, but SQLAlchemy did not
+    track the change so the update never hit the database.
+    """
+    _create_route(test_user.id, "telegram", "111", enabled=False)
+    _create_route(test_user.id, "linq", "222", enabled=True)
+
+    db = _db_module.SessionLocal()
+    try:
+        user = db.query(User).filter_by(id=test_user.id).first()
+        assert user is not None
+        user.preferred_channel = "telegram"
+        db.commit()
+        db.refresh(user)
+        db.expunge(user)
+    finally:
+        db.close()
+
+    with patch("backend.app.agent.heartbeat.get_channel"):
+        db = _db_module.SessionLocal()
+        try:
+            result = resolve_heartbeat_route(user, db)
+        finally:
+            db.close()
+
+    assert result is not None
+    assert result[0] == "linq"
+
+    db = _db_module.SessionLocal()
+    try:
+        refreshed = db.query(User).filter_by(id=test_user.id).first()
+        assert refreshed is not None
+        assert refreshed.preferred_channel == "linq"
+    finally:
+        db.close()
+
+
 def test_heartbeat_resolve_none_when_all_disabled(test_user: User) -> None:
     """When all channels are disabled, return None."""
-    from backend.app.agent.heartbeat import resolve_heartbeat_route
-
     _create_route(test_user.id, "telegram", "111", enabled=False)
     _create_route(test_user.id, "linq", "222", enabled=False)
 


### PR DESCRIPTION
## Description

`resolve_heartbeat_route` mutates `user.preferred_channel` and calls `db.commit()`, but the `HeartbeatScheduler` loads users on one session, expunges them, then hands each to a fresh session for processing. SQLAlchemy does not track mutations on the detached `User`, so the commit is a silent no-op and the row stays stale. Any code that later reads `User.preferred_channel` from a fresh load sees the outdated value indefinitely.

This PR applies fix option **A** from the issue: attach the user via `db.merge` before mutating, so the commit actually persists. Includes a regression test that reproduces the scheduler's expunge-and-new-session pattern and asserts the row is updated.

Fixes #1013

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code via the `/fix-github-issue` skill. Verified the new regression test fails on unpatched code and passes with the fix.