### PR TITLE
feat: expose heartbeat usage hook for post-run token tracking

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -18,6 +18,7 @@ import datetime
 import logging
 import random
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -132,6 +133,8 @@ class HeartbeatDecision:
     action: str  # "skip" or "run"
     tasks: str
     reasoning: str
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 # Legacy data structure kept for backwards compatibility with existing code
@@ -483,7 +486,11 @@ async def evaluate_heartbeat_need(
         getattr(response, "stop_reason", "unknown"),
         len(response.content),
     )
-    return _parse_decision_response(response)
+    decision = _parse_decision_response(response)
+    if response.usage:
+        decision.input_tokens = response.usage.input_tokens or 0
+        decision.output_tokens = response.usage.output_tokens or 0
+    return decision
 
 
 # ---------------------------------------------------------------------------
@@ -650,6 +657,39 @@ async def get_daily_heartbeat_count(user_id: str) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Post-heartbeat usage hooks
+# ---------------------------------------------------------------------------
+
+HeartbeatUsageHook = Callable[[str, int, int, bool], None]
+
+_heartbeat_usage_hooks: list[HeartbeatUsageHook] = []
+
+
+def register_heartbeat_usage_hook(hook: HeartbeatUsageHook) -> None:
+    """Register a callback invoked after each heartbeat LLM run.
+
+    Called with ``(user_id, input_tokens, output_tokens, sent_reply)`` once
+    Phase 1 (plus any Phase 2) has completed. Premium layers subscribe to
+    this hook to reflect heartbeat LLM spend in per-tenant usage counters.
+    """
+    _heartbeat_usage_hooks.append(hook)
+
+
+def _dispatch_heartbeat_usage(
+    user_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    sent_reply: bool,
+) -> None:
+    """Fire all registered usage hooks, isolating failures per hook."""
+    for hook in _heartbeat_usage_hooks:
+        try:
+            hook(user_id, input_tokens, output_tokens, sent_reply)
+        except Exception:
+            logger.exception("heartbeat usage hook failed for user %s", user_id)
+
+
+# ---------------------------------------------------------------------------
 # Per-user runner (orchestrates Phase 1 + Phase 2)
 # ---------------------------------------------------------------------------
 
@@ -700,108 +740,123 @@ async def run_heartbeat_for_user(
 
     logger.debug("Heartbeat evaluating user %s via LLM (channel=%s)", user.id, channel)
 
-    # -- Phase 1: decide whether tasks need attention --
-    decision = await evaluate_heartbeat_need(user, channel=channel, chat_id=chat_id)
+    total_input_tokens = 0
+    total_output_tokens = 0
+    sent_reply = False
+    try:
+        # -- Phase 1: decide whether tasks need attention --
+        decision = await evaluate_heartbeat_need(user, channel=channel, chat_id=chat_id)
+        total_input_tokens += decision.input_tokens
+        total_output_tokens += decision.output_tokens
 
-    logger.debug(
-        "Heartbeat Phase 1 decision for user %s: action=%s, reasoning=%s",
-        user.id,
-        decision.action,
-        decision.reasoning,
-    )
-
-    if decision.action != "run" or not decision.tasks:
         logger.debug(
-            "Heartbeat skip Phase 2 for user %s: action=%s, tasks_empty=%s",
+            "Heartbeat Phase 1 decision for user %s: action=%s, reasoning=%s",
             user.id,
             decision.action,
-            not decision.tasks,
+            decision.reasoning,
         )
-        # Log the skip so the admin page shows decision history
+
+        if decision.action != "run" or not decision.tasks:
+            logger.debug(
+                "Heartbeat skip Phase 2 for user %s: action=%s, tasks_empty=%s",
+                user.id,
+                decision.action,
+                not decision.tasks,
+            )
+            # Log the skip so the admin page shows decision history
+            heartbeat_store = HeartbeatStore(user.id)
+            await heartbeat_store.log_heartbeat(
+                action_type="skip",
+                channel=channel,
+                reasoning=decision.reasoning,
+            )
+            return HeartbeatAction(
+                action_type="no_action",
+                message="",
+                reasoning=decision.reasoning,
+                priority=0,
+            )
+
+        # -- Phase 2: execute tasks via full agent loop --
+        response = await execute_heartbeat_tasks(
+            user, decision.tasks, channel=channel, chat_id=chat_id
+        )
+        if response is not None:
+            total_input_tokens += response.total_input_tokens
+            total_output_tokens += response.total_output_tokens
+
+        # Check whether a SENDS_REPLY-tagged tool (currently send_media_reply)
+        # already delivered the message before relying on reply_text. Tool-based
+        # sends are logged even when the LLM produces no trailing text.
+        sent_reply = response is not None and any(
+            ToolTags.SENDS_REPLY in tc.tags and not tc.is_error for tc in response.tool_calls
+        )
+
+        if not response or (not response.reply_text and not sent_reply):
+            logger.debug("Heartbeat Phase 2 produced no output for user %s", user.id)
+            return HeartbeatAction(
+                action_type="no_action",
+                message="",
+                reasoning="Phase 2 agent produced no output",
+                priority=0,
+            )
+
+        reply_text = response.reply_text
+
+        if not sent_reply:
+            logger.info(
+                "Heartbeat sending message to user %s: %.100s",
+                user.id,
+                reply_text,
+            )
+            try:
+                from backend.app.bus import OutboundMessage, message_bus
+
+                await message_bus.publish_outbound(
+                    OutboundMessage(
+                        channel=channel,
+                        chat_id=chat_id,
+                        content=reply_text,
+                    )
+                )
+                sent_reply = True
+            except Exception:
+                logger.exception("Heartbeat message failed for user %s", user.id)
+                return HeartbeatAction(
+                    action_type="send_message",
+                    message=reply_text,
+                    reasoning=decision.reasoning,
+                    priority=3,
+                )
+
+        # Record outbound message in session history
+        session, _ = await get_or_create_conversation(user.id)
+        session_store = get_session_store(user.id)
+        await session_store.add_message(
+            session=session,
+            direction=MessageDirection.OUTBOUND,
+            body=reply_text,
+        )
+
+        # Record heartbeat log for persistent rate limiting
         heartbeat_store = HeartbeatStore(user.id)
         await heartbeat_store.log_heartbeat(
-            action_type="skip",
+            action_type="send",
+            message_text=reply_text,
             channel=channel,
             reasoning=decision.reasoning,
+            tasks=decision.tasks,
         )
+
         return HeartbeatAction(
-            action_type="no_action",
-            message="",
+            action_type="send_message",
+            message=reply_text,
             reasoning=decision.reasoning,
-            priority=0,
+            priority=3,
         )
-
-    # -- Phase 2: execute tasks via full agent loop --
-    response = await execute_heartbeat_tasks(user, decision.tasks, channel=channel, chat_id=chat_id)
-
-    # Check whether a SENDS_REPLY-tagged tool (currently send_media_reply)
-    # already delivered the message before relying on reply_text. Tool-based
-    # sends are logged even when the LLM produces no trailing text.
-    sent_reply = response is not None and any(
-        ToolTags.SENDS_REPLY in tc.tags and not tc.is_error for tc in response.tool_calls
-    )
-
-    if not response or (not response.reply_text and not sent_reply):
-        logger.debug("Heartbeat Phase 2 produced no output for user %s", user.id)
-        return HeartbeatAction(
-            action_type="no_action",
-            message="",
-            reasoning="Phase 2 agent produced no output",
-            priority=0,
-        )
-
-    reply_text = response.reply_text
-
-    if not sent_reply:
-        logger.info(
-            "Heartbeat sending message to user %s: %.100s",
-            user.id,
-            reply_text,
-        )
-        try:
-            from backend.app.bus import OutboundMessage, message_bus
-
-            await message_bus.publish_outbound(
-                OutboundMessage(
-                    channel=channel,
-                    chat_id=chat_id,
-                    content=reply_text,
-                )
-            )
-        except Exception:
-            logger.exception("Heartbeat message failed for user %s", user.id)
-            return HeartbeatAction(
-                action_type="send_message",
-                message=reply_text,
-                reasoning=decision.reasoning,
-                priority=3,
-            )
-
-    # Record outbound message in session history
-    session, _ = await get_or_create_conversation(user.id)
-    session_store = get_session_store(user.id)
-    await session_store.add_message(
-        session=session,
-        direction=MessageDirection.OUTBOUND,
-        body=reply_text,
-    )
-
-    # Record heartbeat log for persistent rate limiting
-    heartbeat_store = HeartbeatStore(user.id)
-    await heartbeat_store.log_heartbeat(
-        action_type="send",
-        message_text=reply_text,
-        channel=channel,
-        reasoning=decision.reasoning,
-        tasks=decision.tasks,
-    )
-
-    return HeartbeatAction(
-        action_type="send_message",
-        message=reply_text,
-        reasoning=decision.reasoning,
-        priority=3,
-    )
+    finally:
+        if total_input_tokens or total_output_tokens:
+            _dispatch_heartbeat_usage(user.id, total_input_tokens, total_output_tokens, sent_reply)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -22,6 +22,7 @@ from backend.app.agent.heartbeat import (
     HeartbeatDecisionParams,
     HeartbeatScheduler,
     _format_heartbeat_history,
+    _heartbeat_usage_hooks,
     _parse_decision_response,
     _parse_tool_call_response,
     evaluate_heartbeat_need,
@@ -29,6 +30,7 @@ from backend.app.agent.heartbeat import (
     get_daily_heartbeat_count,
     is_within_business_hours,
     parse_frequency_to_minutes,
+    register_heartbeat_usage_hook,
     run_heartbeat_for_user,
 )
 from backend.app.agent.system_prompt import to_local_time
@@ -584,6 +586,40 @@ class TestEvaluateHeartbeatNeed:
     @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.settings")
     @patch("backend.app.agent.heartbeat.amessages")
+    async def test_populates_tokens_from_response(
+        self,
+        mock_llm: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        mock_build_prompt: AsyncMock,
+        mock_log_usage: MagicMock,
+        user: User,
+    ) -> None:
+        """Phase 1 decision carries back the LLM's token usage."""
+        self._setup_mocks(
+            mock_llm,
+            mock_settings,
+            mock_get_session_store,
+            mock_heartbeat_store_cls,
+            mock_build_prompt,
+        )
+        response = _make_decision_tool_call(action="skip", tasks="", reasoning="nope")
+        response.usage.input_tokens = 42
+        response.usage.output_tokens = 7
+        mock_llm.return_value = response
+
+        decision = await evaluate_heartbeat_need(user)
+        assert decision.input_tokens == 42
+        assert decision.output_tokens == 7
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.log_llm_usage")
+    @patch("backend.app.agent.heartbeat.build_heartbeat_system_prompt", new_callable=AsyncMock)
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
+    @patch("backend.app.agent.heartbeat.settings")
+    @patch("backend.app.agent.heartbeat.amessages")
     async def test_llm_says_run(
         self,
         mock_llm: AsyncMock,
@@ -968,6 +1004,160 @@ class TestRunHeartbeatForUser:
         # Should still return the action, just not record a message
         assert result is not None
         assert result.action_type == "send_message"
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat usage hooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def clear_heartbeat_hooks() -> object:
+    """Snapshot and restore the module-level usage-hook list around a test."""
+    snapshot = list(_heartbeat_usage_hooks)
+    _heartbeat_usage_hooks.clear()
+    yield
+    _heartbeat_usage_hooks.clear()
+    _heartbeat_usage_hooks.extend(snapshot)
+
+
+class TestHeartbeatUsageHooks:
+    """Tests for register_heartbeat_usage_hook and post-run dispatch."""
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_hook_fires_with_phase1_tokens_on_skip(
+        self,
+        mock_count: AsyncMock,
+        mock_eval: AsyncMock,
+        mock_heartbeat_store_cls: MagicMock,
+        user: User,
+        clear_heartbeat_hooks: object,
+    ) -> None:
+        """Phase 1 skip still reports Phase 1 tokens via the hook."""
+        mock_count.return_value = 0
+        mock_eval.return_value = HeartbeatDecision(
+            action="skip",
+            tasks="",
+            reasoning="nothing to do",
+            input_tokens=120,
+            output_tokens=30,
+        )
+        mock_hb_store = MagicMock()
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        calls: list[tuple[str, int, int, bool]] = []
+
+        def _hook(user_id: str, in_tok: int, out_tok: int, sent: bool) -> None:
+            calls.append((user_id, in_tok, out_tok, sent))
+
+        register_heartbeat_usage_hook(_hook)
+
+        await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
+
+        assert calls == [(user.id, 120, 30, False)]
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
+    @patch("backend.app.agent.heartbeat.get_or_create_conversation")
+    @patch("backend.app.bus.OutboundMessage")
+    @patch("backend.app.bus.message_bus")
+    @patch("backend.app.agent.heartbeat.execute_heartbeat_tasks")
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_hook_sums_phase1_and_phase2_tokens(
+        self,
+        mock_count: AsyncMock,
+        mock_eval: AsyncMock,
+        mock_execute: AsyncMock,
+        mock_bus: MagicMock,
+        mock_outbound_msg: MagicMock,
+        mock_get_conv: AsyncMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        user: User,
+        clear_heartbeat_hooks: object,
+    ) -> None:
+        """When Phase 2 runs and delivers, hook sees Phase 1+2 tokens and sent_reply=True."""
+        mock_count.return_value = 0
+        mock_eval.return_value = HeartbeatDecision(
+            action="run",
+            tasks="Check inbox",
+            reasoning="due",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        from backend.app.agent.core import AgentResponse
+
+        mock_execute.return_value = AgentResponse(
+            reply_text="All clear.",
+            total_input_tokens=800,
+            total_output_tokens=200,
+        )
+        mock_bus.publish_outbound = AsyncMock()
+        mock_get_conv.return_value = (MagicMock(), True)
+        mock_session_store = MagicMock()
+        mock_session_store.add_message = AsyncMock()
+        mock_get_session_store.return_value = mock_session_store
+        mock_hb_store = MagicMock()
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        calls: list[tuple[str, int, int, bool]] = []
+        register_heartbeat_usage_hook(lambda uid, i, o, s: calls.append((uid, i, o, s)))
+
+        await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
+
+        assert calls == [(user.id, 900, 250, True)]
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_hook_failure_does_not_break_heartbeat(
+        self,
+        mock_count: AsyncMock,
+        mock_eval: AsyncMock,
+        mock_heartbeat_store_cls: MagicMock,
+        user: User,
+        clear_heartbeat_hooks: object,
+    ) -> None:
+        """A raising hook must not bubble up and break the heartbeat run."""
+        mock_count.return_value = 0
+        mock_eval.return_value = HeartbeatDecision(
+            action="skip",
+            tasks="",
+            reasoning="nothing",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        mock_hb_store = MagicMock()
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        def _boom(*_args: object) -> None:
+            raise RuntimeError("hook exploded")
+
+        register_heartbeat_usage_hook(_boom)
+
+        # Should not raise
+        result = await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_hook_not_called_when_no_llm_ran(self, clear_heartbeat_hooks: object) -> None:
+        """Early-return paths (not onboarded, rate-limited, etc.) skip the hook."""
+        calls: list[tuple[str, int, int, bool]] = []
+        register_heartbeat_usage_hook(lambda uid, i, o, s: calls.append((uid, i, o, s)))
+
+        u = User(id="99", user_id="hb-early", phone="+15550000099", onboarding_complete=False)
+        await run_heartbeat_for_user(u, "telegram", u.phone, 5)
+
+        assert calls == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Adds a post-run hook so layers above OSS (like clawbolt-premium) can react to each heartbeat evaluation with the aggregated LLM token usage and whether a reply was actually delivered. The hook is the seam premium needs to fix [clawbolt-premium#305](https://github.com/mozilla-ai/clawbolt-premium/issues/305), where Phase 1 + Phase 2 heartbeat LLM calls bypassed per-tenant UsageQuota tracking.

Changes:
- `HeartbeatDecision` now carries `input_tokens` / `output_tokens`, populated from the Phase 1 LLM response.
- New `register_heartbeat_usage_hook(callback)` registers a callback invoked once per `run_heartbeat_for_user`. Signature: `(user_id, input_tokens, output_tokens, sent_reply) -> None`. Phase 1 tokens are always summed; Phase 2 tokens are added when Phase 2 runs. `sent_reply` flips to `True` only after a message actually went out (via tool-tagged delivery or bus publish).
- Dispatch sits in a `finally` so hooks fire exactly once per run, even on exception. Individual hook failures are logged and swallowed so one broken subscriber cannot break heartbeats.
- No behavior change when no hooks are registered.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code drafted the hook, test scaffolding, and phase-1 token propagation; human reviewed design and flow)
- [ ] No AI used