### PR TITLE
refactor: use column-scoped UPDATE for preferred_channel drift sync

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -854,13 +854,13 @@ def resolve_heartbeat_route(
         )
         return None
 
-    # Keep preferred_channel in sync if it drifted.
+    # Keep preferred_channel in sync if it drifted. ``user`` may be detached
+    # (the heartbeat scheduler expunges users from the loading session before
+    # handing them to a fresh one), so a column-scoped UPDATE is used instead
+    # of attribute mutation. This also avoids ``merge`` copying other columns
+    # from a possibly-stale detached instance back onto the persistent row.
     if user.preferred_channel != route.channel:
-        # ``user`` may be detached (e.g. the heartbeat scheduler expunges users
-        # from the loading session before handing them to a fresh session). Attach
-        # via ``merge`` so the mutation is tracked and persisted by ``commit``.
-        attached = db.merge(user)
-        attached.preferred_channel = route.channel
+        db.query(User).filter(User.id == user.id).update({User.preferred_channel: route.channel})
         db.commit()
 
     return route.channel, route


### PR DESCRIPTION
## Description

Follow-up to #1016. The merged fix used `db.merge(user)` to attach the detached ``User`` before mutating ``preferred_channel``. That works, but ``merge`` copies *every* column from the detached instance onto the persistent row, so if a future caller mutated other fields between the scheduler load and ``resolve_heartbeat_route``, merge could silently overwrite fresh DB state.

This PR swaps to a targeted ``db.query(User).filter(User.id == user.id).update({User.preferred_channel: route.channel})`` so the side effect stays contained to the one column being synced. The existing regression test (#1013) still passes.

See also the long-term cleanup tracked in the follow-up issue: removing the drift-sync side effect from ``resolve_heartbeat_route`` entirely and handling ``preferred_channel`` on write paths.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code as a follow-up after PR review surfaced the merge footgun.