### PR TITLE
refactor: make resolve_heartbeat_route a pure lookup

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -877,9 +877,10 @@ def resolve_heartbeat_route(
     Returns ``(channel_name, route)`` on success, or ``None`` when no
     pushable route can be found.
 
-    Under single-channel enforcement each user has at most one enabled
-    non-webchat route. We query for it directly rather than guessing
-    from the preferred_channel field.
+    Pure lookup: never mutates the database. Under single-channel enforcement
+    each user has at most one enabled non-webchat route, and the write paths
+    that flip ``enabled`` are responsible for keeping ``User.preferred_channel``
+    in sync.
     """
     route = (
         db.query(ChannelRoute)
@@ -908,15 +909,6 @@ def resolve_heartbeat_route(
             route.channel,
         )
         return None
-
-    # Keep preferred_channel in sync if it drifted. ``user`` may be detached
-    # (the heartbeat scheduler expunges users from the loading session before
-    # handing them to a fresh one), so a column-scoped UPDATE is used instead
-    # of attribute mutation. This also avoids ``merge`` copying other columns
-    # from a possibly-stale detached instance back onto the persistent row.
-    if user.preferred_channel != route.channel:
-        db.query(User).filter(User.id == user.id).update({User.preferred_channel: route.channel})
-        db.commit()
 
     return route.channel, route
 

--- a/backend/app/channel_state.py
+++ b/backend/app/channel_state.py
@@ -1,0 +1,53 @@
+"""Helpers that preserve invariants on ``ChannelRoute`` + ``User`` state.
+
+Both OSS and the premium layer mutate ``ChannelRoute.enabled`` and create
+or delete route rows. The invariant that ``User.preferred_channel`` should
+point at an enabled non-webchat route (when any exists) is shared between
+those write paths, so the helper lives here for both to import.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from backend.app.models import ChannelRoute, User
+
+
+def realign_preferred_channel(db: Session, user: User) -> None:
+    """Point ``user.preferred_channel`` at an enabled non-webchat route.
+
+    No-op when ``preferred_channel`` already matches an enabled non-webchat
+    route, or when no enabled non-webchat route exists. Write paths that
+    disable or delete routes call this so downstream consumers (heartbeat
+    routing, reauth notifications) see a consistent view without a
+    read-time drift-sync.
+
+    Calls ``db.flush()`` so any just-mutated rows in the session are visible
+    to the lookups below. Our ``SessionLocal`` has ``autoflush=False``, so
+    without this a route that was disabled or deleted earlier in the same
+    transaction would still appear enabled here.
+    """
+    db.flush()
+    existing = (
+        db.query(ChannelRoute)
+        .filter(
+            ChannelRoute.user_id == user.id,
+            ChannelRoute.channel == user.preferred_channel,
+            ChannelRoute.enabled.is_(True),
+            ChannelRoute.channel != "webchat",
+        )
+        .first()
+    )
+    if existing is not None:
+        return
+    fallback = (
+        db.query(ChannelRoute)
+        .filter(
+            ChannelRoute.user_id == user.id,
+            ChannelRoute.enabled.is_(True),
+            ChannelRoute.channel != "webchat",
+        )
+        .first()
+    )
+    if fallback is not None:
+        user.preferred_channel = fallback.channel

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,6 +65,11 @@ def _enforce_single_channel() -> None:
     After the single-channel refactor, each user should have at most one
     enabled messaging channel.  This cleans up users who had multiple
     channels enabled before the refactor.
+
+    Also realigns ``preferred_channel`` if it points to a channel with no
+    enabled route while another enabled route exists. This keeps downstream
+    consumers (heartbeat, reauth notifications) consistent without needing
+    read-time drift-sync.
     """
     db = SessionLocal()
     try:
@@ -74,9 +79,20 @@ def _enforce_single_channel() -> None:
             routes = db.query(ChannelRoute).filter_by(user_id=user.id).all()
             enabled_messaging = [r for r in routes if r.enabled and r.channel != "webchat"]
             if len(enabled_messaging) > 1:
+                preferred_match = next(
+                    (r for r in enabled_messaging if r.channel == user.preferred_channel),
+                    None,
+                )
+                # If preferred_channel does not match any enabled route, pick
+                # the first enabled messaging route and make it preferred so
+                # we never end up with a user whose preferred points to a
+                # disabled channel while another is active.
+                keeper = preferred_match or enabled_messaging[0]
                 for r in enabled_messaging:
-                    if r.channel != user.preferred_channel:
+                    if r is not keeper:
                         r.enabled = False
+                if preferred_match is None:
+                    user.preferred_channel = keeper.channel
                 fixed += 1
         if fixed:
             db.commit()

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -231,6 +231,23 @@ async def update_channel_route(
 
     if body.enabled:
         user.preferred_channel = channel
+    elif user.preferred_channel == channel:
+        # Disabling the currently-preferred channel. Point preferred_channel
+        # at any other enabled non-webchat route so downstream consumers
+        # (heartbeat, etc.) see a consistent view without relying on a
+        # read-time drift-sync.
+        fallback = (
+            db.query(ChannelRoute)
+            .filter(
+                ChannelRoute.user_id == user.id,
+                ChannelRoute.enabled.is_(True),
+                ChannelRoute.channel != channel,
+                ChannelRoute.channel != "webchat",
+            )
+            .first()
+        )
+        if fallback is not None:
+            user.preferred_channel = fallback.channel
 
     db.commit()
     if route is not None:

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -7,6 +7,7 @@ from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
 from backend.app.auth.dependencies import get_current_user
+from backend.app.channel_state import realign_preferred_channel
 from backend.app.channels import is_bluebubbles_configured, reset_channel_clients
 from backend.app.config import (
     resolve_imessage_backend,
@@ -231,23 +232,8 @@ async def update_channel_route(
 
     if body.enabled:
         user.preferred_channel = channel
-    elif user.preferred_channel == channel:
-        # Disabling the currently-preferred channel. Point preferred_channel
-        # at any other enabled non-webchat route so downstream consumers
-        # (heartbeat, etc.) see a consistent view without relying on a
-        # read-time drift-sync.
-        fallback = (
-            db.query(ChannelRoute)
-            .filter(
-                ChannelRoute.user_id == user.id,
-                ChannelRoute.enabled.is_(True),
-                ChannelRoute.channel != channel,
-                ChannelRoute.channel != "webchat",
-            )
-            .first()
-        )
-        if fallback is not None:
-            user.preferred_channel = fallback.channel
+    else:
+        realign_preferred_channel(db, user)
 
     db.commit()
     if route is not None:

--- a/tests/test_channel_routes.py
+++ b/tests/test_channel_routes.py
@@ -249,13 +249,13 @@ def test_heartbeat_resolve_skips_disabled(test_user: User) -> None:
     assert result[0] == "linq"
 
 
-def test_heartbeat_resolve_persists_drift_sync(test_user: User) -> None:
-    """Drift-sync must persist even when the User passed in is detached.
+def test_heartbeat_resolve_is_pure_lookup(test_user: User) -> None:
+    """resolve_heartbeat_route must never mutate persisted state.
 
-    Regression for #1013: the heartbeat scheduler loads users, expunges them,
-    then processes each in a fresh session. ``resolve_heartbeat_route`` mutated
-    the detached ``User`` and called ``db.commit()``, but SQLAlchemy did not
-    track the change so the update never hit the database.
+    The write paths (PATCH, ingestion, startup migration, premium linking)
+    own ``preferred_channel``. The heartbeat scheduler runs in a hot path on
+    a detached User and should only read. If it drifts from an enabled route,
+    that is a bug at the write path, not something to paper over here.
     """
     _create_route(test_user.id, "telegram", "111", enabled=False)
     _create_route(test_user.id, "linq", "222", enabled=True)
@@ -281,11 +281,12 @@ def test_heartbeat_resolve_persists_drift_sync(test_user: User) -> None:
     assert result is not None
     assert result[0] == "linq"
 
+    # preferred_channel must be untouched by the lookup.
     db = _db_module.SessionLocal()
     try:
         refreshed = db.query(User).filter_by(id=test_user.id).first()
         assert refreshed is not None
-        assert refreshed.preferred_channel == "linq"
+        assert refreshed.preferred_channel == "telegram"
     finally:
         db.close()
 

--- a/tests/test_channel_state.py
+++ b/tests/test_channel_state.py
@@ -1,0 +1,116 @@
+"""Tests for realign_preferred_channel invariant helper."""
+
+import uuid
+
+import backend.app.database as _db_module
+from backend.app.channel_state import realign_preferred_channel
+from backend.app.models import ChannelRoute, User
+
+
+def _make_user(preferred_channel: str = "telegram") -> str:
+    db = _db_module.SessionLocal()
+    try:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id=f"test-{uuid.uuid4().hex[:8]}",
+            channel_identifier="",
+            preferred_channel=preferred_channel,
+            onboarding_complete=True,
+        )
+        db.add(user)
+        db.commit()
+        uid = user.id
+    finally:
+        db.close()
+    return uid
+
+
+def test_noop_when_preferred_matches_enabled() -> None:
+    uid = _make_user(preferred_channel="telegram")
+    db = _db_module.SessionLocal()
+    try:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=True)
+        )
+        db.commit()
+        user = db.query(User).filter_by(id=uid).first()
+        assert user is not None
+        realign_preferred_channel(db, user)
+        db.commit()
+        assert user.preferred_channel == "telegram"
+    finally:
+        db.close()
+
+
+def test_noop_when_no_enabled_route_exists() -> None:
+    """Nothing to repoint at: preferred_channel is left alone."""
+    uid = _make_user(preferred_channel="telegram")
+    db = _db_module.SessionLocal()
+    try:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=False)
+        )
+        db.commit()
+        user = db.query(User).filter_by(id=uid).first()
+        assert user is not None
+        realign_preferred_channel(db, user)
+        db.commit()
+        assert user.preferred_channel == "telegram"
+    finally:
+        db.close()
+
+
+def test_repoints_when_preferred_stale() -> None:
+    uid = _make_user(preferred_channel="telegram")
+    db = _db_module.SessionLocal()
+    try:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=False)
+        )
+        db.add(
+            ChannelRoute(
+                user_id=uid,
+                channel="linq",
+                channel_identifier="+15551234567",
+                enabled=True,
+            )
+        )
+        db.commit()
+        user = db.query(User).filter_by(id=uid).first()
+        assert user is not None
+        realign_preferred_channel(db, user)
+        db.commit()
+        assert user.preferred_channel == "linq"
+    finally:
+        db.close()
+
+
+def test_flushes_pending_disable() -> None:
+    """SessionLocal has autoflush=False. A route disabled in-session but not
+    yet committed must still be treated as disabled by the helper."""
+    uid = _make_user(preferred_channel="telegram")
+    db = _db_module.SessionLocal()
+    try:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=True)
+        )
+        db.add(
+            ChannelRoute(
+                user_id=uid,
+                channel="linq",
+                channel_identifier="+15551234567",
+                enabled=True,
+            )
+        )
+        db.commit()
+
+        telegram_route = db.query(ChannelRoute).filter_by(user_id=uid, channel="telegram").first()
+        assert telegram_route is not None
+        telegram_route.enabled = False
+        user = db.query(User).filter_by(id=uid).first()
+        assert user is not None
+        realign_preferred_channel(db, user)
+        db.commit()
+        assert user.preferred_channel == "linq"
+    finally:
+        db.close()

--- a/tests/test_single_channel.py
+++ b/tests/test_single_channel.py
@@ -366,6 +366,11 @@ class TestHeartbeatRouting:
             db.close()
 
     def test_fallback_when_preferred_disabled(self) -> None:
+        """Resolve returns an enabled route even if preferred_channel drifted.
+
+        The lookup is pure: it does not rewrite preferred_channel. Write
+        paths are responsible for keeping preferred_channel aligned.
+        """
         uid = _create_user_with_routes(
             [
                 ("telegram", "hb-222", False),
@@ -384,7 +389,7 @@ class TestHeartbeatRouting:
             assert channel_name == "linq"
 
             db.refresh(user)
-            assert user.preferred_channel == "linq"
+            assert user.preferred_channel == "telegram"
         finally:
             db.close()
 
@@ -485,5 +490,132 @@ class TestStartupMigration:
             route = db.query(ChannelRoute).filter_by(user_id=uid, channel="telegram").first()
             assert route is not None
             assert route.enabled is True
+        finally:
+            db.close()
+
+    def test_realigns_preferred_when_stale(self) -> None:
+        """preferred_channel is repointed to an enabled route when stale.
+
+        Multi-channel users whose ``preferred_channel`` points at a channel
+        that is not in the enabled set would otherwise be left with every
+        messaging route disabled and a dangling preferred_channel.
+        """
+        from backend.app.main import _enforce_single_channel
+
+        uid = _create_user_with_routes(
+            [
+                ("linq", "+15551111111", True),
+                ("bluebubbles", "+15552222222", True),
+            ],
+            preferred_channel="telegram",
+        )
+
+        _enforce_single_channel()
+
+        db = _db_module.SessionLocal()
+        try:
+            user = db.query(User).filter_by(id=uid).first()
+            assert user is not None
+            assert user.preferred_channel in {"linq", "bluebubbles"}
+            enabled = (
+                db.query(ChannelRoute)
+                .filter(
+                    ChannelRoute.user_id == uid,
+                    ChannelRoute.enabled.is_(True),
+                    ChannelRoute.channel != "webchat",
+                )
+                .all()
+            )
+            assert len(enabled) == 1
+            assert enabled[0].channel == user.preferred_channel
+        finally:
+            db.close()
+
+
+class TestPatchDisableSyncsPreferred:
+    """Disabling the currently-preferred channel via PATCH updates preferred_channel."""
+
+    def test_disable_preferred_no_other(self, client) -> None:  # noqa: ANN001
+        """Disabling the only messaging channel is a no-op for preferred_channel.
+
+        There is no other enabled route to repoint to, and resolve now
+        returns None instead of relying on drift-sync.
+        """
+        db = _db_module.SessionLocal()
+        try:
+            user = db.query(User).first()
+            assert user is not None
+            user_id = user.id
+            user.preferred_channel = "telegram"
+            db.add(
+                ChannelRoute(
+                    user_id=user_id,
+                    channel="telegram",
+                    channel_identifier="111",
+                    enabled=True,
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        resp = client.patch(
+            "/api/user/channels/routes/telegram",
+            json={"enabled": False},
+        )
+        assert resp.status_code == 200
+
+        db = _db_module.SessionLocal()
+        try:
+            user = db.query(User).filter_by(id=user_id).first()
+            assert user is not None
+            assert user.preferred_channel == "telegram"
+        finally:
+            db.close()
+
+    def test_disable_preferred_repoints_to_other_enabled(self, client) -> None:  # noqa: ANN001
+        """If another enabled route exists, disabling preferred repoints to it.
+
+        This state is unusual under single-channel enforcement, but it can
+        arise from legacy data. Fix at the write path so the heartbeat lookup
+        never needs to paper over drift.
+        """
+        db = _db_module.SessionLocal()
+        try:
+            user = db.query(User).first()
+            assert user is not None
+            user_id = user.id
+            user.preferred_channel = "telegram"
+            db.add(
+                ChannelRoute(
+                    user_id=user_id,
+                    channel="telegram",
+                    channel_identifier="111",
+                    enabled=True,
+                )
+            )
+            db.add(
+                ChannelRoute(
+                    user_id=user_id,
+                    channel="linq",
+                    channel_identifier="+15551234567",
+                    enabled=True,
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        resp = client.patch(
+            "/api/user/channels/routes/telegram",
+            json={"enabled": False},
+        )
+        assert resp.status_code == 200
+
+        db = _db_module.SessionLocal()
+        try:
+            user = db.query(User).filter_by(id=user_id).first()
+            assert user is not None
+            assert user.preferred_channel == "linq"
         finally:
             db.close()


### PR DESCRIPTION
## Description

Fixes #1019.

Drops the ``preferred_channel`` drift-sync side effect from ``resolve_heartbeat_route`` so the function is a pure lookup. Responsibility for keeping ``preferred_channel`` aligned moves to the write paths that actually change ``ChannelRoute.enabled``.

Follow-up to #1013 (fixed in #1016, refactored in #1018). A function named ``resolve`` should not mutate, and the recent fixes were patching the same symptom twice. The root cause was the design, not the persistence mechanism.

### Write-path gaps closed

1. **PATCH ``/api/user/channels/routes/{channel}`` with ``enabled=False``** now repoints ``preferred_channel`` to another enabled non-webchat route when the disabled route was the user's currently-preferred channel.
2. **``_enforce_single_channel`` startup migration** realigns ``preferred_channel`` when it points at a channel that has no enabled route but another enabled messaging route exists. This closes the legacy multi-channel data gap where every messaging route would get disabled and ``preferred_channel`` would dangle.

Ingestion (``_get_or_create_user``) and premium channel linking (``_set_channel_link``) already update ``preferred_channel`` correctly; no changes needed there.

### Tests

- ``test_heartbeat_resolve_persists_drift_sync`` is flipped into ``test_heartbeat_resolve_is_pure_lookup`` and asserts ``preferred_channel`` is **untouched** by the lookup.
- ``test_fallback_when_preferred_disabled`` similarly asserts the lookup does not mutate ``preferred_channel``.
- New coverage for the ``_enforce_single_channel`` realignment edge case and the PATCH-disable sync behaviour.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (``uv run pytest -v``) -- 1873 pass
- [x] Lint passes (``ruff check backend/ && ruff format --check backend/``)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code). Audited all write paths that flip ``ChannelRoute.enabled`` or create a route, drafted the pure-lookup and write-path patches, flipped the drift-sync tests to the new contract, and ran the full Definition of Done locally (pytest, ruff check, ruff format, ty, frontend tsc, frontend knip).
- [ ] No AI used