### PR TITLE
fix(dashboard): hide LLM Settings card from non-admin tenants in premium

### DIFF
--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -186,10 +186,11 @@ export function useUpdateStorageConfig() {
 
 // --- Model config ---
 
-export function useModelConfig() {
+export function useModelConfig(opts: { enabled?: boolean } = {}) {
   return useQuery({
     queryKey: queryKeys.modelConfig,
     queryFn: () => api.getModelConfig(),
+    enabled: opts.enabled ?? true,
   });
 }
 

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -50,15 +50,19 @@ const mockProfile = {
   updated_at: '2024-01-01T00:00:00Z',
 };
 
-vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({
+const authMock = vi.hoisted(() => ({
+  state: {
     authState: 'ready',
-    currentAuthUser: { id: 1, name: 'Test User' },
+    currentAuthUser: { id: 1, name: 'Test User', role: undefined as string | undefined },
     authConfig: { required: true, method: 'oidc' },
     isPremium: false,
     handleLogin: vi.fn(),
     handleLogout: vi.fn(),
-  }),
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authMock.state,
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -151,6 +155,10 @@ beforeEach(() => {
   mockProfile.soul_text = 'You are a helpful contractor assistant.';
   mockProfile.user_text = 'John is a plumber in Portland.';
   mockProfile.timezone = 'America/Los_Angeles';
+  // Reset auth state to OSS defaults; tests that need premium/admin override
+  // mutate authMock.state directly.
+  authMock.state.isPremium = false;
+  authMock.state.currentAuthUser = { id: 1, name: 'Test User', role: undefined };
 });
 
 describe('DashboardPage', () => {
@@ -539,5 +547,34 @@ describe('DashboardPage', () => {
     });
     // Other cards still render
     expect(screen.getByText('some memory content here')).toBeInTheDocument();
+  });
+
+  it('hides the Settings card for non-admin users in premium', async () => {
+    authMock.state.isPremium = true;
+    authMock.state.currentAuthUser = { id: 1, name: 'Tenant', role: 'user' };
+    setupMocks();
+    renderWithRouter(<DashboardPage />);
+
+    // Wait for dashboard to settle (some other card has loaded)
+    await waitFor(() => {
+      expect(screen.getByText('Channels')).toBeInTheDocument();
+    });
+    // Settings card and its content must not render for non-admin tenants
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('AI model and provider configuration.')).not.toBeInTheDocument();
+    // The model config endpoint must not be called either
+    expect(mockGetModelConfig).not.toHaveBeenCalled();
+  });
+
+  it('shows the Settings card for admin users in premium', async () => {
+    authMock.state.isPremium = true;
+    authMock.state.currentAuthUser = { id: 1, name: 'Admin', role: 'admin' };
+    setupMocks();
+    renderWithRouter(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+    expect(mockGetModelConfig).toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@heroui/spinner';
 import { toast } from '@/lib/toast';
 import { useToolConfig, useUpdateToolConfig, useOAuthStatus, useCalendarConfig, useMemory, useModelConfig, useUpdateProfile } from '@/hooks/queries';
 import { useChannelStates } from '@/hooks/useChannelStates';
+import { useAuth } from '@/contexts/AuthContext';
 import { getVisibleChannels, getChannelStatusDisplay } from '@/lib/channel-utils';
 import { displayName as toolDisplayName, getToolOAuthStatus } from '@/lib/tool-utils';
 import type { AppShellContext } from '@/layouts/AppShell';
@@ -101,7 +102,11 @@ export default function DashboardPage() {
   const oauth = useOAuthStatus();
   const calendarConfig = useCalendarConfig();
   const memory = useMemory();
-  const modelConfig = useModelConfig();
+  const { currentAuthUser, isPremium } = useAuth();
+  // In premium, the LLM model/provider is an admin-only operational detail.
+  // OSS single-tenant deployments have no role concept, so the card always shows.
+  const canSeeModelConfig = !isPremium || currentAuthUser?.role === 'admin';
+  const modelConfig = useModelConfig({ enabled: canSeeModelConfig });
   const updateProfile = useUpdateProfile();
 
   // --- Channels ---
@@ -292,37 +297,39 @@ export default function DashboardPage() {
           )}
         </DashboardCard>
 
-        {/* Settings */}
-        <DashboardCard
-          title="Settings"
-          description="AI model and provider configuration."
-          configured={settingsConfigured}
-          icon={<SettingsIcon />}
-          onClick={() => navigate('/app/settings')}
-          isLoading={modelConfig.isPending && !modelConfig.data}
-          isError={modelConfig.isError && !modelConfig.data}
-        >
-          {settingsConfigured ? (
-            <div className="space-y-1">
-              <div className="flex items-center gap-2 text-xs">
-                <span className="text-muted-foreground">Model</span>
-                <span className="text-foreground font-medium">{model}</span>
-              </div>
-              <div className="flex items-center gap-2 text-xs">
-                <span className="text-muted-foreground">Provider</span>
-                <span className="text-foreground font-medium">{provider}</span>
-              </div>
-              {visionModel && visionModel !== model && (
+        {/* Settings (admin-only in premium; LLM provider/model is platform config) */}
+        {canSeeModelConfig && (
+          <DashboardCard
+            title="Settings"
+            description="AI model and provider configuration."
+            configured={settingsConfigured}
+            icon={<SettingsIcon />}
+            onClick={() => navigate('/app/settings')}
+            isLoading={modelConfig.isPending && !modelConfig.data}
+            isError={modelConfig.isError && !modelConfig.data}
+          >
+            {settingsConfigured ? (
+              <div className="space-y-1">
                 <div className="flex items-center gap-2 text-xs">
-                  <span className="text-muted-foreground">Vision</span>
-                  <span className="text-foreground font-medium">{visionModel}</span>
+                  <span className="text-muted-foreground">Model</span>
+                  <span className="text-foreground font-medium">{model}</span>
                 </div>
-              )}
-            </div>
-          ) : (
-            <p className="text-xs text-muted-foreground">Configure which AI model and provider your assistant uses.</p>
-          )}
-        </DashboardCard>
+                <div className="flex items-center gap-2 text-xs">
+                  <span className="text-muted-foreground">Provider</span>
+                  <span className="text-foreground font-medium">{provider}</span>
+                </div>
+                {visionModel && visionModel !== model && (
+                  <div className="flex items-center gap-2 text-xs">
+                    <span className="text-muted-foreground">Vision</span>
+                    <span className="text-foreground font-medium">{visionModel}</span>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">Configure which AI model and provider your assistant uses.</p>
+            )}
+          </DashboardCard>
+        )}
 
       </div>
 


### PR DESCRIPTION
## Description

In multi-tenant premium deployments, the LLM provider/model is an admin-only operational detail. The Dashboard's Settings card was rendering it (and triggering \`GET /api/user/model/config\`) for every authenticated user, leaking the platform's model stack to all tenants.

This PR is the OSS-side half of the fix:
- Thread \`useAuth\` into \`DashboardPage\` to read \`currentAuthUser.role\` and \`isPremium\`.
- Compute \`canSeeModelConfig = !isPremium || role === 'admin'\`.
- Wrap the Settings card render in \`{canSeeModelConfig && (...)}\`.
- Extend \`useModelConfig\` with an \`enabled\` option (mirroring \`useProfile\`) so non-admin tenants don't fire a fetch that's about to 403.

OSS single-tenant mode: \`isPremium === false\`, so the card always renders exactly as before. No OSS regression.

The companion premium PR (mozilla-ai/clawbolt-premium#312) extends \`AdminConfigGuardMiddleware\` to also block non-admin GETs at the API layer — the security source of truth.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (\`npx vitest run src/pages/DashboardPage.test.tsx\` -- 27 passed; +2 new visibility tests)
- [x] Lint passes
- [x] New tests added: \`hides the Settings card for non-admin users in premium\`, \`shows the Settings card for admin users in premium\`
- [x] Bug fix includes regression test: the new \"non-admin in premium\" test asserts the Settings card text is absent and \`getModelConfig\` is not called.

## AI Usage
- [x] AI-assisted (Claude Code identified the leak, wrote the targeted hide + the enabled-flag for the hook, and authored this PR description)

## Operator notes
- After this and clawbolt-premium#312 merge: non-admin tenants on premium see no Settings card on the Dashboard, and the underlying GET endpoint returns 403 for them.
- Admins see the card and the data unchanged.
- OSS single-tenant deployments are unaffected.