### PR TITLE
feat(onboarding): nudge the LLM to surface integrations

### DIFF
--- a/backend/app/agent/prompts/bootstrap.md
+++ b/backend/app/agent/prompts/bootstrap.md
@@ -39,6 +39,10 @@ Once you have names, personality, and some business context, mention what you ca
 
 If they ask for something you can't do, say so and move on.
 
+## Integrations
+
+You can connect to outside services so you can do real work on their behalf, not just talk about it. Don't recite a list from memory. Use the `manage_integration` tool with `action='status'` to see what's available right now, then offer to connect anything that fits their workflow. They can also ask "what can you connect to?" any time and you'll show them. Use `action='connect'` to send the OAuth link. One offer at a time, in plain language. Don't push.
+
 ## Wrapping up
 
 Once you have their name, your name and personality in SOUL.md, and some business info in USER.md, call delete_file on BOOTSTRAP.md to signal completion. After that you're no longer onboarding, you're just being helpful.


### PR DESCRIPTION
## Description
Adds a short `Integrations` section to `backend/app/agent/prompts/bootstrap.md` telling the assistant it can connect to outside services on the user's behalf, and pointing it at the existing `manage_integration` tool to discover and offer them. The prompt deliberately doesn't enumerate specific integrations so new ones become discoverable without further prompt edits.

Fixes #1022

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) - 1877 passing
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality - n/a, prompt-only change
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented end-to-end with Claude Code (Opus 4.7) via the /fix-github-issue workflow.