### PR TITLE
fix: cancel orphaned heartbeat typing indicators

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -191,6 +191,36 @@ def is_within_business_hours(
     return not in_quiet
 
 
+async def _publish_heartbeat_typing(channel: str, chat_id: str, *, stop: bool) -> None:
+    """Publish a typing indicator (or stop) via the bus, swallowing errors.
+
+    The heartbeat fires a typing indicator early (before Phase 1) so the user
+    sees instant feedback. If the heartbeat then exits without sending a reply,
+    we must explicitly cancel the indicator so the user does not see a phantom
+    "typing..." that never resolves into a message.
+    """
+    if not channel or not chat_id:
+        return
+    try:
+        from backend.app.bus import OutboundMessage, message_bus
+
+        await message_bus.publish_outbound(
+            OutboundMessage(
+                channel=channel,
+                chat_id=chat_id,
+                content="",
+                is_typing_indicator=not stop,
+                is_typing_stop=stop,
+            )
+        )
+    except Exception:
+        logger.debug(
+            "Failed to publish heartbeat typing %s for chat %s",
+            "stop" if stop else "start",
+            chat_id,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Phase 1: Decision LLM call
 # ---------------------------------------------------------------------------
@@ -198,6 +228,18 @@ def is_within_business_hours(
 
 def _parse_decision_response(response: MessageResponse) -> HeartbeatDecision:
     """Extract a HeartbeatDecision from the Phase 1 LLM response."""
+    stop_reason = getattr(response, "stop_reason", None)
+    if stop_reason == "max_tokens":
+        logger.warning(
+            "Heartbeat decision truncated by max_tokens; treating as skip. "
+            "Increase llm_max_tokens_heartbeat if this recurs."
+        )
+        return HeartbeatDecision(
+            action="skip",
+            tasks="",
+            reasoning="Decision truncated by max_tokens",
+        )
+
     parsed = parse_tool_calls(response)
 
     if not parsed:
@@ -420,20 +462,7 @@ async def evaluate_heartbeat_need(
     )
 
     # Send typing indicator before LLM call via the bus
-    if channel and chat_id:
-        try:
-            from backend.app.bus import OutboundMessage, message_bus
-
-            await message_bus.publish_outbound(
-                OutboundMessage(
-                    channel=channel,
-                    chat_id=chat_id,
-                    content="",
-                    is_typing_indicator=True,
-                )
-            )
-        except Exception:
-            logger.debug("Failed to send heartbeat typing indicator to %s", chat_id)
+    await _publish_heartbeat_typing(channel, chat_id, stop=False)
 
     model = settings.heartbeat_model or settings.llm_model
     provider = settings.heartbeat_provider or settings.llm_provider
@@ -857,6 +886,12 @@ async def run_heartbeat_for_user(
     finally:
         if total_input_tokens or total_output_tokens:
             _dispatch_heartbeat_usage(user.id, total_input_tokens, total_output_tokens, sent_reply)
+        # The heartbeat fires a typing indicator before Phase 1. If we exit
+        # without delivering a reply (skip, empty tasks, no Phase 2 output,
+        # or exception), the indicator is orphaned. Cancel it explicitly so
+        # the user does not see a phantom "typing..." with no follow-up.
+        if not sent_reply:
+            await _publish_heartbeat_typing(channel, chat_id, stop=True)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -39,10 +39,12 @@ from backend.app.agent.system_prompt import (
 )
 from backend.app.agent.tools.base import ToolTags
 from backend.app.agent.tools.names import ToolName
+from backend.app.bus import OutboundMessage, message_bus
 from backend.app.channels import get_channel
 from backend.app.config import settings
 from backend.app.database import SessionLocal
 from backend.app.enums import MessageDirection
+from backend.app.logging_utils import mask_pii
 from backend.app.models import ChannelRoute, User
 from backend.app.services.llm_service import (
     prepare_system_with_caching,
@@ -201,23 +203,19 @@ async def _publish_heartbeat_typing(channel: str, chat_id: str, *, stop: bool) -
     """
     if not channel or not chat_id:
         return
-    try:
-        from backend.app.bus import OutboundMessage, message_bus
-
-        await message_bus.publish_outbound(
-            OutboundMessage(
-                channel=channel,
-                chat_id=chat_id,
-                content="",
-                is_typing_indicator=not stop,
-                is_typing_stop=stop,
-            )
+    if stop:
+        msg = OutboundMessage(channel=channel, chat_id=chat_id, content="", is_typing_stop=True)
+    else:
+        msg = OutboundMessage(
+            channel=channel, chat_id=chat_id, content="", is_typing_indicator=True
         )
+    try:
+        await message_bus.publish_outbound(msg)
     except Exception:
         logger.debug(
             "Failed to publish heartbeat typing %s for chat %s",
             "stop" if stop else "start",
-            chat_id,
+            mask_pii(chat_id),
         )
 
 
@@ -547,7 +545,6 @@ async def execute_heartbeat_tasks(
         default_registry,
         ensure_tool_modules_imported,
     )
-    from backend.app.bus import message_bus
 
     ensure_tool_modules_imported()
 
@@ -839,8 +836,6 @@ async def run_heartbeat_for_user(
                 reply_text,
             )
             try:
-                from backend.app.bus import OutboundMessage, message_bus
-
                 await message_bus.publish_outbound(
                     OutboundMessage(
                         channel=channel,

--- a/backend/app/bus.py
+++ b/backend/app/bus.py
@@ -34,6 +34,7 @@ class OutboundMessage:
     media: list[str] = field(default_factory=list)
     request_id: str = ""
     is_typing_indicator: bool = False
+    is_typing_stop: bool = False
 
 
 class MessageBus:

--- a/backend/app/channels/base.py
+++ b/backend/app/channels/base.py
@@ -135,6 +135,16 @@ class BaseChannel(ABC):
     async def send_typing_indicator(self, to: str) -> None:
         """Send a typing indicator to show the bot is processing."""
 
+    async def stop_typing_indicator(self, to: str) -> None:
+        """Clear an active typing indicator.
+
+        Default implementation is a no-op. Channels whose typing indicators
+        do not auto-expire promptly (e.g. BlueBubbles iMessage) should
+        override this to actively cancel the indicator when the agent stops
+        without sending a reply.
+        """
+        return None
+
     @abstractmethod
     async def download_media(self, file_id: str) -> DownloadedMedia:
         """Download media by channel-specific file identifier."""

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -488,6 +488,32 @@ class BlueBubblesChannel(BaseChannel):
         except Exception:
             logger.exception("Failed to send BlueBubbles typing indicator to %s", mask_pii(to))
 
+    async def stop_typing_indicator(self, to: str) -> None:
+        """Clear an active typing indicator via BlueBubbles API (best-effort).
+
+        iMessage typing indicators do not expire promptly on their own, so
+        when the agent decides not to reply we explicitly cancel the
+        indicator to avoid a phantom "typing..." with no follow-up message.
+        Skipped in apple-script mode where typing indicators are never sent.
+        """
+        if settings.bluebubbles_send_method != "private-api":
+            return
+        chat_guid = self._get_chat_guid(to)
+        try:
+            resp = await self._http.delete(
+                f"/api/v1/chat/{chat_guid}/typing",
+                params={"password": settings.bluebubbles_password},
+            )
+            if resp.status_code >= 400:
+                logger.warning(
+                    "BlueBubbles stop typing non-200: status=%s chatGuid=%s body=%s",
+                    resp.status_code,
+                    mask_pii(chat_guid),
+                    resp.text[:500],
+                )
+        except Exception:
+            logger.exception("Failed to stop BlueBubbles typing indicator for %s", mask_pii(to))
+
     async def download_media(self, file_id: str) -> DownloadedMedia:
         """Download media by BlueBubbles attachment GUID.
 

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -157,7 +157,9 @@ class ChannelManager:
                 continue
 
             try:
-                if outbound.is_typing_indicator:
+                if outbound.is_typing_stop:
+                    await channel.stop_typing_indicator(to=outbound.chat_id)
+                elif outbound.is_typing_indicator:
                     await channel.send_typing_indicator(to=outbound.chat_id)
                 elif outbound.media:
                     await channel.send_message(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -54,7 +54,7 @@ class Settings(BaseSettings):
     vision_provider: str = ""  # empty = fall back to llm_provider
     reasoning_effort: str = "auto"  # none, minimal, low, medium, high, xhigh, auto
     llm_max_tokens_agent: int = Field(default=1024, ge=1)
-    llm_max_tokens_heartbeat: int = Field(default=300, ge=1)
+    llm_max_tokens_heartbeat: int = Field(default=12000, ge=1)
     llm_max_tokens_vision: int = Field(default=1000, ge=1)
 
     # Storage

--- a/tests/test_bluebubbles_channel.py
+++ b/tests/test_bluebubbles_channel.py
@@ -440,6 +440,52 @@ async def test_send_typing_indicator_no_error_on_failure() -> None:
         await channel.send_typing_indicator("+15551234567")
 
 
+async def test_stop_typing_indicator_private_api_issues_delete() -> None:
+    """stop_typing_indicator should DELETE the typing endpoint when in private-api mode.
+
+    iMessage typing indicators don't expire promptly on their own, so when
+    the agent decides not to reply we explicitly cancel the indicator.
+    """
+    channel = BlueBubblesChannel()
+    channel._chat_cache["+15551234567"] = "iMessage;-;+15551234567"
+
+    mock_http = _make_mock_http({})
+    channel._client = mock_http
+
+    with patch("backend.app.channels.bluebubbles.settings.bluebubbles_send_method", "private-api"):
+        await channel.stop_typing_indicator("+15551234567")
+
+    mock_http.delete.assert_called_once()
+    call_args = mock_http.delete.call_args
+    assert call_args[0][0] == "/api/v1/chat/iMessage;-;+15551234567/typing"
+
+
+async def test_stop_typing_indicator_skipped_for_apple_script() -> None:
+    """stop_typing_indicator should be a no-op for apple-script (no typing was ever sent)."""
+    channel = BlueBubblesChannel()
+
+    mock_http = _make_mock_http({})
+    channel._client = mock_http
+
+    with patch("backend.app.channels.bluebubbles.settings.bluebubbles_send_method", "apple-script"):
+        await channel.stop_typing_indicator("+15551234567")
+
+    mock_http.delete.assert_not_called()
+
+
+async def test_stop_typing_indicator_no_error_on_failure() -> None:
+    """stop_typing_indicator should not raise if the BB server is unreachable."""
+    channel = BlueBubblesChannel()
+
+    mock_http = AsyncMock()
+    mock_http.delete.side_effect = Exception("Connection refused")
+    channel._client = mock_http
+
+    with patch("backend.app.channels.bluebubbles.settings.bluebubbles_send_method", "private-api"):
+        # Should not raise
+        await channel.stop_typing_indicator("+15551234567")
+
+
 async def test_send_media_multipart_upload() -> None:
     """send_media should download media then upload as multipart form data."""
     channel = BlueBubblesChannel()

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -22,6 +22,7 @@ class _StubChannel(BaseChannel):
         self._name = channel_name
         self.started = False
         self.stopped = False
+        self.stopped_typing_for: list[str] = []
 
     @property
     def name(self) -> str:
@@ -52,7 +53,6 @@ class _StubChannel(BaseChannel):
         pass
 
     async def stop_typing_indicator(self, to: str) -> None:
-        self.stopped_typing_for: list[str] = getattr(self, "stopped_typing_for", [])
         self.stopped_typing_for.append(to)
 
     async def download_media(self, file_id: str) -> DownloadedMedia:
@@ -193,6 +193,18 @@ async def test_dispatcher_routes_typing_stop_to_channel() -> None:
     ch = _StubChannel("bluebubbles")
     mgr.register(ch)
 
+    # Resolve a future on first stop_typing_indicator call so the test can
+    # await dispatcher work directly instead of polling.
+    called = asyncio.get_running_loop().create_future()
+    original_stop = ch.stop_typing_indicator
+
+    async def signaling_stop(to: str) -> None:
+        await original_stop(to)
+        if not called.done():
+            called.set_result(to)
+
+    ch.stop_typing_indicator = signaling_stop  # type: ignore[method-assign]
+
     # Drain anything already queued.
     while not message_bus.outbound.empty():
         message_bus.outbound.get_nowait()
@@ -206,17 +218,13 @@ async def test_dispatcher_routes_typing_stop_to_channel() -> None:
         )
     )
 
-    # Run one iteration of the dispatcher loop manually.
     task = asyncio.create_task(mgr._run_outbound_dispatcher())
     try:
-        # Wait for the dispatcher to consume our message.
-        for _ in range(50):
-            if getattr(ch, "stopped_typing_for", None):
-                break
-            await asyncio.sleep(0.01)
+        recipient = await asyncio.wait_for(called, timeout=1.0)
     finally:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
 
+    assert recipient == "+15551234567"
     assert ch.stopped_typing_for == ["+15551234567"]

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,6 +1,7 @@
 """Tests for channel base class, ChannelManager, and protocol conformance."""
 
 import asyncio
+import contextlib
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -49,6 +50,10 @@ class _StubChannel(BaseChannel):
 
     async def send_typing_indicator(self, to: str) -> None:
         pass
+
+    async def stop_typing_indicator(self, to: str) -> None:
+        self.stopped_typing_for: list[str] = getattr(self, "stopped_typing_for", [])
+        self.stopped_typing_for.append(to)
 
     async def download_media(self, file_id: str) -> DownloadedMedia:
         return DownloadedMedia(
@@ -176,3 +181,42 @@ async def test_handle_inbound_sends_error_fallback_on_crash() -> None:
             found = True
             break
     assert found, "Expected an error fallback message on the outbound bus"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_routes_typing_stop_to_channel() -> None:
+    """An outbound with is_typing_stop=True must call channel.stop_typing_indicator,
+    not send_text or send_typing_indicator."""
+    from backend.app.bus import OutboundMessage
+
+    mgr = ChannelManager()
+    ch = _StubChannel("bluebubbles")
+    mgr.register(ch)
+
+    # Drain anything already queued.
+    while not message_bus.outbound.empty():
+        message_bus.outbound.get_nowait()
+
+    await message_bus.publish_outbound(
+        OutboundMessage(
+            channel="bluebubbles",
+            chat_id="+15551234567",
+            content="",
+            is_typing_stop=True,
+        )
+    )
+
+    # Run one iteration of the dispatcher loop manually.
+    task = asyncio.create_task(mgr._run_outbound_dispatcher())
+    try:
+        # Wait for the dispatcher to consume our message.
+        for _ in range(50):
+            if getattr(ch, "stopped_typing_for", None):
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert ch.stopped_typing_for == ["+15551234567"]

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -36,7 +36,11 @@ from backend.app.agent.heartbeat import (
 )
 from backend.app.agent.system_prompt import to_local_time
 from backend.app.models import ChannelRoute, User
-from tests.mocks.llm import make_text_response, make_tool_call_response
+from tests.mocks.llm import (
+    make_text_response,
+    make_tool_call_response,
+    make_truncated_tool_call_response,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -512,6 +516,29 @@ class TestParseDecisionResponse:
         decision = _parse_decision_response(resp)
         assert decision.action == "skip"
         assert "Malformed" in decision.reasoning
+
+    def test_max_tokens_truncation_forces_skip(self) -> None:
+        """A truncated tool call (stop_reason=max_tokens) must not be parsed as run.
+
+        Without this guard, a partial JSON that happened to include a valid
+        action+reasoning but a truncated tasks list would surface as
+        action=run, tasks="" and skip Phase 2 while leaving a typing
+        indicator orphaned in iMessage.
+        """
+        resp = make_truncated_tool_call_response(
+            [
+                {
+                    "name": "heartbeat_decision",
+                    "arguments": json.dumps(
+                        {"action": "run", "tasks": "do stuff", "reasoning": "valid"}
+                    ),
+                    "id": "call_trunc",
+                }
+            ]
+        )
+        decision = _parse_decision_response(resp)
+        assert decision.action == "skip"
+        assert "max_tokens" in decision.reasoning
 
 
 # ---------------------------------------------------------------------------
@@ -1005,6 +1032,159 @@ class TestRunHeartbeatForUser:
         # Should still return the action, just not record a message
         assert result is not None
         assert result.action_type == "send_message"
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_phase1_skip_emits_typing_stop(
+        self,
+        mock_count: AsyncMock,
+        mock_eval: AsyncMock,
+        mock_heartbeat_store_cls: MagicMock,
+        user: User,
+    ) -> None:
+        """Phase 1 skip must emit a typing-stop so iMessage doesn't show
+        a phantom 'typing...' that never resolves into a reply."""
+        mock_count.return_value = 0
+        mock_eval.return_value = HeartbeatDecision(
+            action="skip", tasks="", reasoning="nothing to do"
+        )
+        mock_hb_store = MagicMock()
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        from backend.app.bus import message_bus
+
+        message_bus.reset()
+        await run_heartbeat_for_user(user, "bluebubbles", "+15559990000", 5)
+
+        # Drain the outbound queue and find the typing-stop message
+        published: list = []
+        while message_bus.outbound_size > 0:
+            published.append(await message_bus.consume_outbound())
+        stops = [m for m in published if m.is_typing_stop]
+        assert len(stops) == 1
+        assert stops[0].channel == "bluebubbles"
+        assert stops[0].chat_id == "+15559990000"
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_phase1_run_with_empty_tasks_emits_typing_stop(
+        self,
+        mock_count: AsyncMock,
+        mock_eval: AsyncMock,
+        mock_heartbeat_store_cls: MagicMock,
+        user: User,
+    ) -> None:
+        """Phase 1 run-with-empty-tasks (e.g., partial parse) must emit typing-stop."""
+        mock_count.return_value = 0
+        mock_eval.return_value = HeartbeatDecision(
+            action="run", tasks="", reasoning="empty tasks for some reason"
+        )
+        mock_hb_store = MagicMock()
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        from backend.app.bus import message_bus
+
+        message_bus.reset()
+        await run_heartbeat_for_user(user, "bluebubbles", "+15559990000", 5)
+
+        published: list = []
+        while message_bus.outbound_size > 0:
+            published.append(await message_bus.consume_outbound())
+        stops = [m for m in published if m.is_typing_stop]
+        assert len(stops) == 1
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.execute_heartbeat_tasks")
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_phase2_no_output_emits_typing_stop(
+        self,
+        mock_count: AsyncMock,
+        mock_eval: AsyncMock,
+        mock_execute: AsyncMock,
+        mock_heartbeat_store_cls: MagicMock,
+        user: User,
+    ) -> None:
+        """Phase 2 returning None must still cancel the typing indicator."""
+        mock_count.return_value = 0
+        mock_eval.return_value = HeartbeatDecision(action="run", tasks="something", reasoning="run")
+        mock_execute.return_value = None
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- something"
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        from backend.app.bus import message_bus
+
+        message_bus.reset()
+        await run_heartbeat_for_user(user, "bluebubbles", "+15559990000", 5)
+
+        published: list = []
+        while message_bus.outbound_size > 0:
+            published.append(await message_bus.consume_outbound())
+        stops = [m for m in published if m.is_typing_stop]
+        assert len(stops) == 1
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.get_session_store")
+    @patch("backend.app.agent.heartbeat.get_or_create_conversation")
+    @patch("backend.app.agent.heartbeat.execute_heartbeat_tasks")
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_successful_reply_does_not_emit_typing_stop(
+        self,
+        mock_count: AsyncMock,
+        mock_eval: AsyncMock,
+        mock_execute: AsyncMock,
+        mock_get_conv: MagicMock,
+        mock_get_session_store: MagicMock,
+        mock_heartbeat_store_cls: MagicMock,
+        user: User,
+    ) -> None:
+        """When a reply was actually sent, no redundant typing-stop should be emitted.
+
+        The reply itself implicitly clears the typing indicator on iMessage,
+        so emitting an additional stop would be wasted work.
+        """
+        from backend.app.agent.core import AgentResponse
+
+        mock_count.return_value = 0
+        mock_eval.return_value = HeartbeatDecision(
+            action="run", tasks="check stuff", reasoning="run"
+        )
+        mock_execute.return_value = AgentResponse(reply_text="Here is the answer.")
+        mock_session = MagicMock()
+        mock_get_conv.return_value = (mock_session, True)
+        mock_session_store = MagicMock()
+        mock_session_store.add_message = AsyncMock()
+        mock_get_session_store.return_value = mock_session_store
+        mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- check stuff"
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_heartbeat_store_cls.return_value = mock_hb_store
+
+        from backend.app.bus import message_bus
+
+        message_bus.reset()
+        await run_heartbeat_for_user(user, "bluebubbles", "+15559990000", 5)
+
+        published: list = []
+        while message_bus.outbound_size > 0:
+            published.append(await message_bus.consume_outbound())
+        stops = [m for m in published if m.is_typing_stop]
+        assert stops == []
+        # The reply itself was published.
+        replies = [m for m in published if not m.is_typing_indicator and not m.is_typing_stop]
+        assert len(replies) == 1
+        assert replies[0].content == "Here is the answer."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -904,8 +904,8 @@ class TestRunHeartbeatForUser:
     @patch("backend.app.agent.heartbeat.HeartbeatStore")
     @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.get_or_create_conversation")
-    @patch("backend.app.bus.OutboundMessage")
-    @patch("backend.app.bus.message_bus")
+    @patch("backend.app.agent.heartbeat.OutboundMessage")
+    @patch("backend.app.agent.heartbeat.message_bus")
     @patch("backend.app.agent.heartbeat.execute_heartbeat_tasks")
     @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
     @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
@@ -1002,8 +1002,8 @@ class TestRunHeartbeatForUser:
 
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.HeartbeatStore")
-    @patch("backend.app.bus.OutboundMessage")
-    @patch("backend.app.bus.message_bus")
+    @patch("backend.app.agent.heartbeat.OutboundMessage")
+    @patch("backend.app.agent.heartbeat.message_bus")
     @patch("backend.app.agent.heartbeat.execute_heartbeat_tasks")
     @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
     @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
@@ -1245,8 +1245,8 @@ class TestHeartbeatUsageHooks:
     @patch("backend.app.agent.heartbeat.HeartbeatStore")
     @patch("backend.app.agent.heartbeat.get_session_store")
     @patch("backend.app.agent.heartbeat.get_or_create_conversation")
-    @patch("backend.app.bus.OutboundMessage")
-    @patch("backend.app.bus.message_bus")
+    @patch("backend.app.agent.heartbeat.OutboundMessage")
+    @patch("backend.app.agent.heartbeat.message_bus")
     @patch("backend.app.agent.heartbeat.execute_heartbeat_tasks")
     @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
     @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
@@ -1438,7 +1438,7 @@ class TestExecuteHeartbeatTasks:
         with (
             patch("backend.app.agent.core.ClawboltAgent") as MockAgent,
             patch("backend.app.agent.tools.registry.default_registry") as mock_registry,
-            patch("backend.app.bus.message_bus") as mock_bus,
+            patch("backend.app.agent.heartbeat.message_bus") as mock_bus,
             patch("backend.app.agent.router.init_storage", return_value=None),
             patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
             patch("backend.app.agent.stores.ToolConfigStore") as MockToolConfig,
@@ -1469,7 +1469,7 @@ class TestExecuteHeartbeatTasks:
         with (
             patch("backend.app.agent.core.ClawboltAgent") as MockAgent,
             patch("backend.app.agent.tools.registry.default_registry") as mock_registry,
-            patch("backend.app.bus.message_bus") as mock_bus,
+            patch("backend.app.agent.heartbeat.message_bus") as mock_bus,
             patch("backend.app.agent.router.init_storage", return_value=None),
             patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
             patch("backend.app.agent.stores.ToolConfigStore") as MockToolConfig,
@@ -1502,7 +1502,7 @@ class TestExecuteHeartbeatTasks:
         with (
             patch("backend.app.agent.core.ClawboltAgent") as MockAgent,
             patch("backend.app.agent.tools.registry.default_registry") as mock_registry,
-            patch("backend.app.bus.message_bus") as mock_bus,
+            patch("backend.app.agent.heartbeat.message_bus") as mock_bus,
             patch("backend.app.agent.router.init_storage", return_value=None),
             patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
             patch("backend.app.agent.stores.ToolConfigStore") as MockToolConfig,
@@ -1535,7 +1535,7 @@ class TestExecuteHeartbeatTasks:
         with (
             patch("backend.app.agent.core.ClawboltAgent") as MockAgent,
             patch("backend.app.agent.tools.registry.default_registry") as mock_registry,
-            patch("backend.app.bus.message_bus") as mock_bus,
+            patch("backend.app.agent.heartbeat.message_bus") as mock_bus,
             patch("backend.app.agent.router.init_storage", return_value=None),
             patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
             patch("backend.app.agent.stores.ToolConfigStore") as MockToolConfig,
@@ -3034,7 +3034,7 @@ async def test_execute_heartbeat_uses_core_tools_and_list_capabilities(user: Use
             return_value=MagicMock(name="list_capabilities"),
         ) as mock_list_cap,
         patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
-        patch("backend.app.bus.message_bus"),
+        patch("backend.app.agent.heartbeat.message_bus"),
     ):
         from backend.app.agent.heartbeat import execute_heartbeat_tasks
 
@@ -3085,7 +3085,7 @@ async def test_execute_heartbeat_respects_disabled_tools(user: User) -> None:
         ),
         patch("backend.app.agent.tools.registry.create_list_capabilities_tool"),
         patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
-        patch("backend.app.bus.message_bus"),
+        patch("backend.app.agent.heartbeat.message_bus"),
     ):
         from backend.app.agent.heartbeat import execute_heartbeat_tasks
 
@@ -3137,7 +3137,7 @@ async def test_heartbeat_skips_manual_delivery_when_agent_sent_reply(user: User)
         patch("backend.app.agent.heartbeat.HeartbeatStore") as mock_hb_cls,
         patch("backend.app.agent.heartbeat.get_or_create_conversation") as mock_get_conv,
         patch("backend.app.agent.heartbeat.get_session_store") as mock_get_ss,
-        patch("backend.app.bus.message_bus") as mock_bus,
+        patch("backend.app.agent.heartbeat.message_bus") as mock_bus,
     ):
         mock_count.return_value = 0
         mock_eval.return_value = HeartbeatDecision(
@@ -3197,7 +3197,7 @@ async def test_heartbeat_logs_when_sent_reply_but_empty_reply_text(user: User) -
         patch("backend.app.agent.heartbeat.HeartbeatStore") as mock_hb_cls,
         patch("backend.app.agent.heartbeat.get_or_create_conversation") as mock_get_conv,
         patch("backend.app.agent.heartbeat.get_session_store") as mock_get_ss,
-        patch("backend.app.bus.message_bus") as mock_bus,
+        patch("backend.app.agent.heartbeat.message_bus") as mock_bus,
     ):
         mock_count.return_value = 0
         mock_eval.return_value = HeartbeatDecision(
@@ -3285,7 +3285,7 @@ async def test_heartbeat_auto_approves_send_media_reply(user: User) -> None:
         patch("backend.app.agent.stores.ToolConfigStore", return_value=mock_tool_config),
         patch("backend.app.agent.tools.registry.create_list_capabilities_tool"),
         patch("backend.app.agent.tools.registry.ensure_tool_modules_imported"),
-        patch("backend.app.bus.message_bus"),
+        patch("backend.app.agent.heartbeat.message_bus"),
     ):
         from backend.app.agent.heartbeat import execute_heartbeat_tasks
 

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -356,7 +356,7 @@ async def test_activity_forwarder_agent_end() -> None:
 @patch("backend.app.agent.heartbeat.get_session_store")
 @patch("backend.app.agent.heartbeat.settings")
 @patch("backend.app.agent.heartbeat.amessages")
-@patch("backend.app.bus.message_bus")
+@patch("backend.app.agent.heartbeat.message_bus")
 async def test_heartbeat_sends_typing_indicator_before_llm_call(
     mock_bus: MagicMock,
     mock_llm: AsyncMock,


### PR DESCRIPTION
## Description

Fixes the issue where iMessage typing indicators showed up with no follow-up message when the heartbeat decided not to reply.

The heartbeat fires a typing indicator before Phase 1 so the user gets instant feedback. But if Phase 1 returned `skip`, `run` with empty tasks, or hit `max_tokens` (truncating the tool call JSON to `tasks=[]`), Phase 2 was skipped and no reply was ever sent. The typing indicator just hung in iMessage until passive expiry.

The 13:50:00 heartbeat in prod logs is the smoking gun: typing fired at `13:50:01`, decision came back `stop_reason=max_tokens` at `13:50:07` parsed as `action=run, tasks_empty=True`, Phase 2 skipped, no message ever sent.

### What changed

- `config.py`: `llm_max_tokens_heartbeat` default `300 → 12000`. The reasoning string alone in the prod log was ~80 tokens, leaving no room for the tasks list.
- `heartbeat.py:_parse_decision_response`: treat `stop_reason=max_tokens` as a defensive `skip` so a partial decision cannot be parsed as a real `run`.
- `bus.py`: add `OutboundMessage.is_typing_stop: bool = False`.
- `channels/base.py`: add `stop_typing_indicator(to)` with a default no-op body.
- `channels/bluebubbles.py`: override `stop_typing_indicator` to issue `DELETE /api/v1/chat/{guid}/typing` (private-api only; apple-script no-op).
- `channels/manager.py`: dispatcher routes `is_typing_stop` outbounds to `channel.stop_typing_indicator(...)`.
- `agent/heartbeat.py`: emit a typing-stop in every `run_heartbeat_for_user` exit path that does not deliver a reply, via a `finally` block so future no-reply paths are covered automatically.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v` -- 1886 passed)
- [x] Lint passes (`ruff check`, `ruff format --check`)
- [x] Type checks pass (`ty check`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

### Test coverage

- `_parse_decision_response` skips on `max_tokens` truncation
- `run_heartbeat_for_user`: typing-stop emitted on Phase 1 skip, run-with-empty-tasks, Phase 2 no-output
- `run_heartbeat_for_user`: typing-stop NOT emitted when a reply was sent
- `BlueBubblesChannel.stop_typing_indicator`: DELETE in private-api, no-op in apple-script, swallows errors
- `ChannelManager` dispatcher routes `is_typing_stop` to `stop_typing_indicator`

## AI Usage
- [x] AI-assisted -- Claude Code (investigate skill) traced root cause from prod logs, proposed the two-bug fix (eager typing + max_tokens truncation), implemented changes and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)