### PR TITLE
fix(pricing): strip apionline subdomain from Home Depot URLs

### DIFF
--- a/backend/app/integrations/supplier_pricing/homedepot.py
+++ b/backend/app/integrations/supplier_pricing/homedepot.py
@@ -13,6 +13,17 @@ logger = logging.getLogger(__name__)
 _SERPAPI_BASE = "https://serpapi.com/search"
 
 
+def _normalize_product_url(url: str) -> str:
+    """Strip SerpApi's apionline. subdomain from Home Depot product URLs.
+
+    SerpApi returns links like https://apionline.homedepot.com/p/... which 404
+    in a browser. The path resolves correctly on www.homedepot.com.
+    """
+    if not url:
+        return url
+    return url.replace("//apionline.homedepot.com", "//www.homedepot.com", 1)
+
+
 class HomeDepotSupplier:
     """Home Depot product search via SerpApi's dedicated HD engine.
 
@@ -96,7 +107,7 @@ class HomeDepotSupplier:
                     was_price_dollars=was_dollars,
                     in_stock=in_stock,
                     aisle="",
-                    product_url=product.get("link", ""),
+                    product_url=_normalize_product_url(product.get("link", "")),
                     image_url=product.get("thumbnail", ""),
                     rating=product.get("rating"),
                 )

--- a/tests/test_pricing_tools.py
+++ b/tests/test_pricing_tools.py
@@ -237,6 +237,40 @@ class TestHomeDepotSupplier:
         assert results[0].in_stock is None
 
     @pytest.mark.asyncio
+    async def test_search_strips_apionline_subdomain(self) -> None:
+        """SerpApi returns links on apionline.homedepot.com which 404 in browsers."""
+        supplier = HomeDepotSupplier(api_key="test-key")
+        products = [
+            {
+                "product_id": "312528815",
+                "title": "2 in. x 4 in. x 12 ft. SPF Lumber",
+                "link": (
+                    "https://apionline.homedepot.com/p/"
+                    "2-in-x-4-in-x-12-ft-2-Premium-Grade-SPF-Dimensional-Lumber-058440/312528815"
+                ),
+            }
+        ]
+        mock_resp = _make_httpx_response(200, {"products": products})
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "backend.app.integrations.supplier_pricing.homedepot.httpx.AsyncClient",
+            return_value=mock_client,
+        ):
+            results = await supplier.search_products("lumber", Location(zip_code="15213"))
+
+        assert len(results) == 1
+        assert "apionline" not in results[0].product_url
+        assert results[0].product_url == (
+            "https://www.homedepot.com/p/"
+            "2-in-x-4-in-x-12-ft-2-Premium-Grade-SPF-Dimensional-Lumber-058440/312528815"
+        )
+
+    @pytest.mark.asyncio
     async def test_search_max_results_truncation(self) -> None:
         supplier = HomeDepotSupplier(api_key="test-key")
         products = [{"product_id": str(i), "title": f"Item {i}"} for i in range(10)]


### PR DESCRIPTION
## Description
SerpApi's Home Depot engine returns product links on `apionline.homedepot.com` (e.g. `https://apionline.homedepot.com/p/2-in-x-4-in-x-12-ft-2-Premium-Grade-SPF-Dimensional-Lumber-058440/312528815`). That host serves a 404 page in browsers; the same path resolves correctly on `www.homedepot.com`. This PR normalizes the host before assigning it to `ProductResult.product_url`, so the agent surfaces working links to users.

Implementation: a small `_normalize_product_url()` helper in `backend/app/integrations/supplier_pricing/homedepot.py` that swaps `//apionline.homedepot.com` for `//www.homedepot.com`. Applied at the single call site where the SerpApi `link` field is read.

Fixes #1026

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Regression test `test_search_strips_apionline_subdomain` in `tests/test_pricing_tools.py` uses the exact URL from the issue and asserts the normalized output. Verified the test fails without the fix and passes with it.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented with Claude Code: read the issue, located the URL pass-through in `homedepot.py`, added the normalizer + regression test, and ran the full Definition of Done suite (pytest, ruff, ty, frontend typecheck, knip).