### PR TITLE
fix(companycam): make agent aware of camera roll trade-off

### DIFF
--- a/backend/app/integrations/companycam/SKILL.md
+++ b/backend/app/integrations/companycam/SKILL.md
@@ -29,3 +29,9 @@ Derive tags from the conversation context:
 ## Connection
 
 Users connect via OAuth. Use `manage_integration(action='connect', target='companycam')` to start the authorization flow. The user will be redirected to CompanyCam to grant access.
+
+## Trade-off: Sending Photos via Messaging vs. the CompanyCam App
+
+When a user sends a photo through a messaging channel (iMessage, SMS, Telegram) for you to file into CompanyCam, the photo is also saved to their device camera roll by the messaging app. Photos taken directly inside the CompanyCam mobile app skip the camera roll entirely.
+
+Be aware of this trade-off. Don't lecture the user about it on every upload, but if you notice signs that camera roll clutter is bothering them (they mention it, ask how to keep their photos organized, or are filing many job photos at once), it is appropriate to mention once that snapping photos directly in the CompanyCam app avoids adding them to their camera roll.

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -66,6 +66,21 @@ def test_get_skill_instructions_returns_none_for_unknown() -> None:
     assert get_skill_instructions("nonexistent_skill") is None
 
 
+def test_companycam_skill_mentions_camera_roll_tradeoff() -> None:
+    """CompanyCam SKILL.md must brief the agent on the camera roll trade-off.
+
+    Photos sent via messaging channels (iMessage, SMS, Telegram) end up in
+    the user's camera roll. Photos taken directly in the CompanyCam app
+    do not. The agent needs to know this so it can mention the trade-off
+    when relevant. Regression test for issue #1023.
+    """
+    load_all_skills()
+    content = get_skill_instructions("companycam")
+    assert content is not None
+    lowered = content.lower()
+    assert "camera roll" in lowered
+
+
 # ---------------------------------------------------------------------------
 # list_capabilities integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
When a user sends a photo through a messaging channel (iMessage, SMS, Telegram) for filing into CompanyCam, the photo is also saved to their device camera roll by the messaging app. Photos taken directly inside the CompanyCam mobile app skip the camera roll entirely.

Adds a "Trade-off" section to the CompanyCam SKILL.md so the agent knows this is the case and can mention it once when there are signs the user is bothered by camera roll clutter (without lecturing on every upload). Per the issue: "maybe clawbolt understanding that this is the case is sufficient for the moment".

Fixes #1023

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Authored with Claude Code via the /fix-github-issue skill: explored the CompanyCam integration package, identified SKILL.md as the natural place to brief the agent, drafted the trade-off guidance, and added a regression test (verified to fail without the fix).