### PR TITLE
chore(logging): tone down high-frequency DEBUG noise

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -450,15 +450,6 @@ async def evaluate_heartbeat_need(
         user, recent_text, heartbeat_md=heartbeat_md, heartbeat_history=heartbeat_history
     )
 
-    logger.debug(
-        "Heartbeat Phase 1 context for user %s: recent_messages=%d, "
-        "heartbeat_length=%d, system_prompt_length=%d",
-        user.id,
-        len(recent),
-        len(heartbeat_md),
-        len(prompt),
-    )
-
     # Send typing indicator before LLM call via the bus
     await _publish_heartbeat_typing(channel, chat_id, stop=False)
 
@@ -507,12 +498,6 @@ async def evaluate_heartbeat_need(
         raise RuntimeError("Heartbeat LLM retry loop exited without response")
 
     log_llm_usage(user.id, model, response, "heartbeat_decision")
-    logger.debug(
-        "Heartbeat Phase 1 response for user %s: stop_reason=%s, blocks=%d",
-        user.id,
-        getattr(response, "stop_reason", "unknown"),
-        len(response.content),
-    )
     decision = _parse_decision_response(response)
     if response.usage:
         decision.input_tokens = response.usage.input_tokens or 0
@@ -783,12 +768,6 @@ async def run_heartbeat_for_user(
         )
 
         if decision.action != "run" or not decision.tasks:
-            logger.debug(
-                "Heartbeat skip Phase 2 for user %s: action=%s, tasks_empty=%s",
-                user.id,
-                decision.action,
-                not decision.tasks,
-            )
             # Log the skip so the admin page shows decision history
             heartbeat_store = HeartbeatStore(user.id)
             await heartbeat_store.log_heartbeat(
@@ -1035,7 +1014,6 @@ class HeartbeatScheduler:
 
     async def tick(self) -> None:
         """Single heartbeat pass: evaluate due users concurrently."""
-        logger.debug("Heartbeat tick starting")
         db = SessionLocal()
         try:
             users = (
@@ -1049,17 +1027,12 @@ class HeartbeatScheduler:
             db.close()
 
         if not users:
-            logger.debug("Heartbeat tick: no onboarded users found")
             return
 
         now = datetime.datetime.now(datetime.UTC)
         due_users = [u for u in users if self._is_user_due(u, now)]
 
         if not due_users:
-            logger.debug(
-                "Heartbeat tick: %d onboarded user(s) but none due yet",
-                len(users),
-            )
             return
 
         logger.info(

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -541,10 +541,7 @@ async def persist_outbound_step(ctx: PipelineContext) -> PipelineContext:
 async def run_pipeline(ctx: PipelineContext, steps: list[PipelineStep]) -> PipelineContext:
     """Execute pipeline steps in sequence."""
     for step in steps:
-        step_name = getattr(step, "__name__", type(step).__name__)
-        logger.debug("Pipeline step starting: %s", step_name)
         ctx = await step(ctx)
-        logger.debug("Pipeline step completed: %s", step_name)
     return ctx
 
 

--- a/backend/app/bus.py
+++ b/backend/app/bus.py
@@ -154,22 +154,9 @@ class MessageBus:
         """
         queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self._activity_queues.setdefault(user_id, set()).add(queue)
-        subscriber_count = len(self._activity_queues[user_id])
         last = self._last_activity.get(user_id)
         if last is not None:
             queue.put_nowait(last)
-            logger.debug(
-                "Activity queue registered for user %s (subscribers=%d), replayed last event: %s",
-                user_id,
-                subscriber_count,
-                last.get("type", "unknown"),
-            )
-        else:
-            logger.debug(
-                "Activity queue registered for user %s (subscribers=%d), no prior state",
-                user_id,
-                subscriber_count,
-            )
         return queue
 
     def remove_activity_queue(self, user_id: str, queue: asyncio.Queue[dict[str, Any]]) -> None:
@@ -179,28 +166,11 @@ class MessageBus:
             queues.discard(queue)
             if not queues:
                 del self._activity_queues[user_id]
-                logger.debug(
-                    "Last activity queue removed for user %s (no subscribers left)",
-                    user_id,
-                )
-            else:
-                logger.debug(
-                    "Activity queue removed for user %s (subscribers=%d remaining)",
-                    user_id,
-                    len(queues),
-                )
 
     async def publish_activity(self, user_id: str, event: dict[str, Any]) -> None:
         """Push an activity event to all connected dashboard clients for *user_id*."""
         self._last_activity[user_id] = event
         queues = self._activity_queues.get(user_id)
-        subscriber_count = len(queues) if queues else 0
-        logger.debug(
-            "Activity event for user %s: type=%s, subscribers=%d",
-            user_id,
-            event.get("type", "unknown"),
-            subscriber_count,
-        )
         if queues:
             # Snapshot to avoid RuntimeError if a queue is removed during iteration
             for queue in list(queues):

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -360,8 +360,6 @@ class BlueBubblesChannel(BaseChannel):
                 logger.warning("BlueBubbles webhook received invalid JSON")
                 return JSONResponse(content={"ok": True})
 
-            logger.debug("BlueBubbles webhook received: type=%s", raw.get("type", "?"))
-
             try:
                 payload = BBWebhookPayload.model_validate(raw)
             except Exception:

--- a/backend/app/channels/webchat.py
+++ b/backend/app/channels/webchat.py
@@ -191,7 +191,6 @@ class WebChatChannel(BaseChannel):
             browser tabs can subscribe concurrently.
             """
             user_id = str(user.id)
-            logger.debug("Activity SSE connected for user %s", user_id)
             queue = message_bus.register_activity_queue(user_id)
 
             async def event_stream() -> collections.abc.AsyncIterator[str]:
@@ -199,17 +198,11 @@ class WebChatChannel(BaseChannel):
                     while True:
                         try:
                             event = await asyncio.wait_for(queue.get(), timeout=15.0)
-                            logger.debug(
-                                "Activity SSE sending event to user %s: %s",
-                                user_id,
-                                event.get("type", "unknown"),
-                            )
                             yield f"data: {json.dumps(event)}\n\n"
                         except TimeoutError:
                             # Send keepalive comment to detect disconnected clients
                             yield ": keepalive\n\n"
                 finally:
-                    logger.debug("Activity SSE disconnected for user %s", user_id)
                     message_bus.remove_activity_queue(user_id, queue)
 
             return StreamingResponse(

--- a/backend/app/channels/webchat.py
+++ b/backend/app/channels/webchat.py
@@ -14,7 +14,6 @@ download step) and processed through the same vision/audio pipeline.
 import asyncio
 import collections.abc
 import json
-import logging
 import re
 import uuid
 
@@ -30,8 +29,6 @@ from backend.app.channels.base import BaseChannel
 from backend.app.config import settings
 from backend.app.media.download import DEFAULT_MIME_TYPE, DownloadedMedia, generate_filename
 from backend.app.models import User
-
-logger = logging.getLogger(__name__)
 
 _SESSION_ID_RE = re.compile(r"^[\w-]+_\d+(_[\w]+)?$")
 


### PR DESCRIPTION
## Description
Trims out the DEBUG log lines that dominated production deploy logs without carrying useful signal. Identified by reading a real deployment log dump.

What's gone:
- **Heartbeat scheduler ticks** (`agent/heartbeat.py`): \"tick starting\", \"none due yet\", \"no onboarded users found\" — fire every minute forever; the existing INFO line \"evaluating N/M user(s)\" still fires when something interesting happens.
- **Pipeline step start/complete pairs** (`agent/router.py`): two DEBUG lines per step per message; just step name, no timing.
- **BlueBubbles webhook received** (`channels/bluebubbles.py`): immediately followed by the \"parsed\" line which carries the actual fields (type, isFromMe, handle, attachments). Kept the parsed line.
- **Heartbeat Phase 1 context/response/skip Phase 2** (`agent/heartbeat.py`): redundant with the kept \"Phase 1 decision\" DEBUG, which already includes action + reasoning.
- **Activity SSE / bus lifecycle** (`channels/webchat.py`, `bus.py`): connect/disconnect/sending event/queue registered/queue removed/event published.

## Type
- [x] Refactor

## Checklist
- [x] Tests pass (no test asserts on the removed log strings; pytest not run locally — no PostgreSQL in the sandbox)
- [x] Lint passes (\`ruff check\` + \`ruff format --check\`)
- [x] Type check passes (\`ty check\`)
- [ ] New tests added for new functionality (n/a — log-line removals only)
- [ ] Bug fixes include regression tests (n/a)

## AI Usage
- [x] AI-assisted (Claude Code reviewed the deployment log sample, identified the highest-volume DEBUG offenders, and removed only the lines that were either purely periodic or fully redundant with another nearby log line)