### PR TITLE
fix(channels): reply to unknown senders instead of silently dropping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,11 @@ STORAGE_PROVIDER=local
 # WEBHOOK_RATE_LIMIT_WINDOW_SECONDS=60
 # RATE_LIMIT_TRUST_PROXY=false
 
+# Unknown-sender reply (sent to numbers not in the allowlist; rate-limited
+# per (channel, sender) so we cannot be used as a spam relay).
+# UNKNOWN_SENDER_SIGNUP_URL=                 # link offered to unknown senders; empty = generic copy
+# UNKNOWN_SENDER_REPLY_COOLDOWN_SECONDS=86400  # seconds before we'll reply to the same number again
+
 # Media
 # MAX_MEDIA_SIZE_BYTES=20971520  # 20 MB
 # MEDIA_DOWNLOAD_MAX_SECONDS=60.0  # Hard wall-time deadline per media download

--- a/backend/app/channels/base.py
+++ b/backend/app/channels/base.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 
 from backend.app.agent.stores import get_idempotency_store
 from backend.app.bus import message_bus
+from backend.app.channels.unknown_sender import reply_to_unknown_sender
 from backend.app.media.download import DownloadedMedia
 
 if TYPE_CHECKING:
@@ -188,6 +189,7 @@ async def handle_webhook_inbound(
             "%s: sender not in allowlist, ignoring",
             channel.name,
         )
+        await reply_to_unknown_sender(channel, inbound.sender_id)
         return JSONResponse(content={"ok": True})
 
     if on_accepted is not None:

--- a/backend/app/channels/unknown_sender.py
+++ b/backend/app/channels/unknown_sender.py
@@ -13,6 +13,7 @@ import time
 from typing import TYPE_CHECKING
 
 from backend.app.config import settings
+from backend.app.logging_utils import mask_pii
 
 if TYPE_CHECKING:
     from backend.app.channels.base import BaseChannel
@@ -68,7 +69,7 @@ async def reply_to_unknown_sender(channel: BaseChannel, sender_id: str) -> bool:
         logger.debug(
             "%s: unknown sender %s already notified within cooldown, skipping",
             channel.name,
-            sender_id,
+            mask_pii(sender_id),
         )
         return False
 
@@ -79,13 +80,13 @@ async def reply_to_unknown_sender(channel: BaseChannel, sender_id: str) -> bool:
         logger.exception(
             "%s: failed to send unknown-sender reply to %s",
             channel.name,
-            sender_id,
+            mask_pii(sender_id),
         )
         return True
 
     logger.info(
         "%s: sent unknown-sender reply to %s",
         channel.name,
-        sender_id,
+        mask_pii(sender_id),
     )
     return True

--- a/backend/app/channels/unknown_sender.py
+++ b/backend/app/channels/unknown_sender.py
@@ -1,0 +1,91 @@
+"""Reply helper for messages from senders not in the allowlist.
+
+When an inbound message arrives from a phone or chat ID that isn't connected
+to a Clawbolt account, we send a one-time templated reply explaining the
+situation and pointing them at sign-up. Rate-limited per (channel, sender_id)
+so we can't be turned into a spam relay.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from backend.app.config import settings
+
+if TYPE_CHECKING:
+    from backend.app.channels.base import BaseChannel
+
+logger = logging.getLogger(__name__)
+
+
+_recent_replies: dict[tuple[str, str], float] = {}
+
+
+def _build_reply_body() -> str:
+    url = settings.unknown_sender_signup_url.strip()
+    if url:
+        return f"Hi! This number isn't connected to a Clawbolt account. Sign up at {url}."
+    return (
+        "Hi! This number isn't connected to a Clawbolt account. "
+        "Visit clawbolt.ai to sign up, or ask the person who invited you to add you."
+    )
+
+
+def _claim_reply_slot(channel_name: str, sender_id: str, *, now: float | None = None) -> bool:
+    """Reserve a reply slot for (channel, sender_id) if cooldown has elapsed.
+
+    Updates the timestamp eagerly: a transient send failure won't trigger another
+    reply attempt until the cooldown elapses. This is the conservative choice for
+    a spam-relay guard.
+    """
+    if now is None:
+        now = time.monotonic()
+    cooldown = settings.unknown_sender_reply_cooldown_seconds
+    key = (channel_name, sender_id)
+    last = _recent_replies.get(key)
+    if last is not None and now - last < cooldown:
+        return False
+    _recent_replies[key] = now
+    return True
+
+
+def reset_unknown_sender_cache() -> None:
+    """Test helper: clear the in-memory rate-limit cache."""
+    _recent_replies.clear()
+
+
+async def reply_to_unknown_sender(channel: BaseChannel, sender_id: str) -> bool:
+    """Send a one-shot 'not connected' reply to *sender_id* via *channel*.
+
+    Returns True if a reply was attempted (sent or raised), False if it was
+    suppressed by the rate limiter or by an empty sender_id.
+    """
+    if not sender_id:
+        return False
+    if not _claim_reply_slot(channel.name, sender_id):
+        logger.debug(
+            "%s: unknown sender %s already notified within cooldown, skipping",
+            channel.name,
+            sender_id,
+        )
+        return False
+
+    body = _build_reply_body()
+    try:
+        await channel.send_text(sender_id, body)
+    except Exception:
+        logger.exception(
+            "%s: failed to send unknown-sender reply to %s",
+            channel.name,
+            sender_id,
+        )
+        return True
+
+    logger.info(
+        "%s: sent unknown-sender reply to %s",
+        channel.name,
+        sender_id,
+    )
+    return True

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -85,6 +85,11 @@ class Settings(BaseSettings):
     webhook_rate_limit_window_seconds: int = Field(default=60, ge=1)
     rate_limit_trust_proxy: bool = False
 
+    # Unknown-sender reply (sent when a non-allowlisted number messages us;
+    # rate-limited per sender so we can't be used as a spam relay).
+    unknown_sender_signup_url: str = ""
+    unknown_sender_reply_cooldown_seconds: int = Field(default=86_400, ge=0)
+
     # Media
     max_media_size_bytes: int = Field(default=20_971_520, ge=1)  # 20 MB
     # Hard wall-time ceiling for any single media download. Guards against

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -127,6 +127,8 @@ See [Storage Providers](./storage.md) for setup instructions.
 | `WEBHOOK_RATE_LIMIT_MAX_REQUESTS` | `30` | Max webhook requests per window |
 | `WEBHOOK_RATE_LIMIT_WINDOW_SECONDS` | `60` | Rate limit window in seconds |
 | `RATE_LIMIT_TRUST_PROXY` | `false` | Trust `X-Forwarded-For` for client IP (set `true` behind a reverse proxy) |
+| `UNKNOWN_SENDER_SIGNUP_URL` | (empty) | Sign-up link included in the reply we send to numbers not in the allowlist. Empty = generic copy pointing at clawbolt.ai |
+| `UNKNOWN_SENDER_REPLY_COOLDOWN_SECONDS` | `86400` | Minimum seconds between unknown-sender replies to the same `(channel, sender)`. Prevents the bot from being used as a spam relay |
 
 ## Heartbeat (proactive check-ins)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from backend.app.agent.memory_db import reset_memory_stores
 from backend.app.agent.session_db import reset_session_stores
 from backend.app.auth.dependencies import get_current_user
 from backend.app.bus import message_bus
+from backend.app.channels import unknown_sender as unknown_sender_module
 from backend.app.config import settings
 from backend.app.database import Base
 from backend.app.main import app
@@ -193,14 +194,12 @@ def _stub_unknown_sender_reply() -> Generator[AsyncMock]:
     timeout. Tests that exercise the unknown-sender behavior import
     ``reply_to_unknown_sender`` directly from its module, bypassing this patch.
     """
-    from backend.app.channels import unknown_sender as _unknown_sender_module
-
-    _unknown_sender_module.reset_unknown_sender_cache()
+    unknown_sender_module.reset_unknown_sender_cache()
     with patch(
         "backend.app.channels.base.reply_to_unknown_sender", new_callable=AsyncMock
     ) as mock_reply:
         yield mock_reply
-    _unknown_sender_module.reset_unknown_sender_cache()
+    unknown_sender_module.reset_unknown_sender_cache()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,6 +184,25 @@ def _reset_bus_queues() -> Generator[None]:
     message_bus.reset()
 
 
+@pytest.fixture(autouse=True)
+def _stub_unknown_sender_reply() -> Generator[AsyncMock]:
+    """Patch the unknown-sender reply at the import site in ``base.py``.
+
+    Without this, every existing allowlist-rejection test would trigger a real
+    outbound HTTP call (Linq/BlueBubbles/Telegram) and hang on the configured
+    timeout. Tests that exercise the unknown-sender behavior import
+    ``reply_to_unknown_sender`` directly from its module, bypassing this patch.
+    """
+    from backend.app.channels import unknown_sender as _unknown_sender_module
+
+    _unknown_sender_module.reset_unknown_sender_cache()
+    with patch(
+        "backend.app.channels.base.reply_to_unknown_sender", new_callable=AsyncMock
+    ) as mock_reply:
+        yield mock_reply
+    _unknown_sender_module.reset_unknown_sender_cache()
+
+
 @pytest.fixture()
 def linq_client(test_user: User) -> Generator[TestClient]:
     """FastAPI test client with Linq channel available.

--- a/tests/test_unknown_sender.py
+++ b/tests/test_unknown_sender.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import APIRouter
 
+from backend.app.agent.ingestion import InboundMessage
 from backend.app.channels.base import BaseChannel, handle_webhook_inbound
 from backend.app.channels.unknown_sender import (
     _build_reply_body,
@@ -168,11 +169,11 @@ def test_claim_reply_slot_is_monotonic_per_now() -> None:
 
 
 @pytest.mark.asyncio
-async def test_handle_webhook_inbound_replies_when_allowlist_rejects() -> None:
+async def test_handle_webhook_inbound_replies_when_allowlist_rejects(
+    _stub_unknown_sender_reply: AsyncMock,
+) -> None:
     """When ``is_allowed`` returns False, ``handle_webhook_inbound`` must still
     return 200 and trigger a reply attempt to the unknown sender."""
-    from backend.app.agent.ingestion import InboundMessage
-
     channel = _RecordingChannel("sms")
     inbound = InboundMessage(
         channel="sms",
@@ -183,10 +184,7 @@ async def test_handle_webhook_inbound_replies_when_allowlist_rejects() -> None:
         external_message_id="ext-1",
     )
 
-    with patch(
-        "backend.app.channels.base.reply_to_unknown_sender", new_callable=AsyncMock
-    ) as mock_reply:
-        resp = await handle_webhook_inbound(channel, inbound)
+    resp = await handle_webhook_inbound(channel, inbound)
 
     assert resp.status_code == 200
-    mock_reply.assert_awaited_once_with(channel, "+15551234567")
+    _stub_unknown_sender_reply.assert_awaited_once_with(channel, "+15551234567")

--- a/tests/test_unknown_sender.py
+++ b/tests/test_unknown_sender.py
@@ -1,0 +1,192 @@
+"""Tests for the unknown-sender reply helper and its integration with
+``handle_webhook_inbound``."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import APIRouter
+
+from backend.app.channels.base import BaseChannel, handle_webhook_inbound
+from backend.app.channels.unknown_sender import (
+    _build_reply_body,
+    _claim_reply_slot,
+    reply_to_unknown_sender,
+    reset_unknown_sender_cache,
+)
+from backend.app.media.download import DownloadedMedia
+
+
+class _RecordingChannel(BaseChannel):
+    """Minimal channel that records send_text calls for assertions."""
+
+    def __init__(self, name: str = "test", *, raise_on_send: bool = False) -> None:
+        self._name = name
+        self.sent: list[tuple[str, str]] = []
+        self._raise_on_send = raise_on_send
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get_router(self) -> APIRouter:
+        return APIRouter()
+
+    def is_allowed(self, sender_id: str, username: str) -> bool:
+        return False
+
+    async def send_text(self, to: str, body: str) -> str:
+        if self._raise_on_send:
+            raise RuntimeError("simulated provider failure")
+        self.sent.append((to, body))
+        return "msg-id"
+
+    async def send_media(self, to: str, body: str, media_url: str) -> str:
+        return "msg-id"
+
+    async def send_typing_indicator(self, to: str) -> None:
+        return None
+
+    async def download_media(self, file_id: str) -> DownloadedMedia:
+        return DownloadedMedia(
+            content=b"", mime_type="application/octet-stream", original_url="", filename=""
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    reset_unknown_sender_cache()
+
+
+# -- reply_to_unknown_sender direct tests ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replies_to_unknown_sender() -> None:
+    channel = _RecordingChannel()
+    sent = await reply_to_unknown_sender(channel, "+15551234567")
+    assert sent is True
+    assert len(channel.sent) == 1
+    to, body = channel.sent[0]
+    assert to == "+15551234567"
+    assert "Clawbolt" in body
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_within_cooldown() -> None:
+    channel = _RecordingChannel()
+    with patch(
+        "backend.app.channels.unknown_sender.settings.unknown_sender_reply_cooldown_seconds",
+        86_400,
+    ):
+        first = await reply_to_unknown_sender(channel, "+15551234567")
+        second = await reply_to_unknown_sender(channel, "+15551234567")
+    assert first is True
+    assert second is False
+    assert len(channel.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_zero_cooldown_lets_every_message_reply() -> None:
+    channel = _RecordingChannel()
+    with patch(
+        "backend.app.channels.unknown_sender.settings.unknown_sender_reply_cooldown_seconds", 0
+    ):
+        await reply_to_unknown_sender(channel, "+15551234567")
+        await reply_to_unknown_sender(channel, "+15551234567")
+    assert len(channel.sent) == 2
+
+
+@pytest.mark.asyncio
+async def test_per_sender_isolation() -> None:
+    channel = _RecordingChannel()
+    await reply_to_unknown_sender(channel, "+15551111111")
+    await reply_to_unknown_sender(channel, "+15552222222")
+    assert {to for to, _ in channel.sent} == {"+15551111111", "+15552222222"}
+
+
+@pytest.mark.asyncio
+async def test_per_channel_isolation() -> None:
+    """The cooldown is keyed by (channel, sender), so the same number on a
+    different channel still gets a reply."""
+    sms = _RecordingChannel("sms")
+    imessage = _RecordingChannel("imessage")
+    await reply_to_unknown_sender(sms, "+15551234567")
+    await reply_to_unknown_sender(imessage, "+15551234567")
+    assert len(sms.sent) == 1
+    assert len(imessage.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_failure_is_swallowed_but_consumes_slot() -> None:
+    """A failed send still updates the cooldown so a flood of inbound from one
+    spoofed sender can't trigger repeated outbound attempts."""
+    channel = _RecordingChannel(raise_on_send=True)
+    first = await reply_to_unknown_sender(channel, "+15551234567")
+    second = await reply_to_unknown_sender(channel, "+15551234567")
+    assert first is True
+    assert second is False
+
+
+@pytest.mark.asyncio
+async def test_empty_sender_id_is_skipped() -> None:
+    channel = _RecordingChannel()
+    sent = await reply_to_unknown_sender(channel, "")
+    assert sent is False
+    assert channel.sent == []
+
+
+def test_reply_body_includes_signup_url_when_set() -> None:
+    with patch(
+        "backend.app.channels.unknown_sender.settings.unknown_sender_signup_url",
+        "https://app.clawbolt.ai/signup",
+    ):
+        body = _build_reply_body()
+    assert "https://app.clawbolt.ai/signup" in body
+
+
+def test_reply_body_falls_back_when_url_unset() -> None:
+    with patch("backend.app.channels.unknown_sender.settings.unknown_sender_signup_url", ""):
+        body = _build_reply_body()
+    assert "clawbolt.ai" in body
+
+
+def test_claim_reply_slot_is_monotonic_per_now() -> None:
+    """``_claim_reply_slot`` accepts an explicit *now* so we can assert
+    cooldown boundaries deterministically without sleeping."""
+    with patch(
+        "backend.app.channels.unknown_sender.settings.unknown_sender_reply_cooldown_seconds",
+        60,
+    ):
+        assert _claim_reply_slot("ch", "s", now=100.0) is True
+        assert _claim_reply_slot("ch", "s", now=159.0) is False
+        assert _claim_reply_slot("ch", "s", now=160.5) is True
+
+
+# -- handle_webhook_inbound integration tests -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_inbound_replies_when_allowlist_rejects() -> None:
+    """When ``is_allowed`` returns False, ``handle_webhook_inbound`` must still
+    return 200 and trigger a reply attempt to the unknown sender."""
+    from backend.app.agent.ingestion import InboundMessage
+
+    channel = _RecordingChannel("sms")
+    inbound = InboundMessage(
+        channel="sms",
+        sender_id="+15551234567",
+        sender_username=None,
+        text="Hello",
+        media_refs=[],
+        external_message_id="ext-1",
+    )
+
+    with patch(
+        "backend.app.channels.base.reply_to_unknown_sender", new_callable=AsyncMock
+    ) as mock_reply:
+        resp = await handle_webhook_inbound(channel, inbound)
+
+    assert resp.status_code == 200
+    mock_reply.assert_awaited_once_with(channel, "+15551234567")


### PR DESCRIPTION
## Description

Closes #1032.

Inbound messages from numbers not in the allowlist were dropped without any reply, leaving senders confused about whether the system was working. (Our first user hit this when his phone had two numbers configured and he texted from the wrong one — silence, no signal he wasn't connected.)

Now ``handle_webhook_inbound`` sends a templated "this number isn't connected to a Clawbolt account" reply via the rejecting channel, then continues to drop the inbound message as before. Reply is rate-limited per ``(channel, sender_id)`` with a configurable cooldown (default 24h) so the bot can't be turned into an SMS spam relay. Failed sends still consume the cooldown slot, so a flood from one spoofed sender cannot trigger repeated outbound attempts.

Two new settings:
- ``UNKNOWN_SENDER_SIGNUP_URL`` — sign-up link to include in the reply (empty falls back to generic copy pointing at clawbolt.ai).
- ``UNKNOWN_SENDER_REPLY_COOLDOWN_SECONDS`` — minimum seconds between replies to the same ``(channel, sender)``. Default 86400.

Webchat is unaffected (its ``is_allowed`` always returns True; auth happens via ``get_current_user``). Telegram, Linq, and BlueBubbles all flow through ``handle_webhook_inbound``, so the fix lands once and applies to all three.

A new autouse conftest fixture stubs ``reply_to_unknown_sender`` so the existing allowlist-rejection tests don't trigger real outbound HTTP. Tests that exercise the helper import it directly to bypass the stub.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (``uv run pytest -v``) — 1906 passed
- [x] Lint passes (``ruff check backend/ && ruff format --check backend/``)
- [x] New tests added for new functionality (11 in ``tests/test_unknown_sender.py``)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation drafted with Claude Opus 4.7 from observed-onboarding notes; reviewed and edited locally before push.