### PR TITLE
fix(agent): stop duplicating the receipt block in outbound replies

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -52,7 +52,6 @@ from backend.app.agent.tool_errors import (
     build_error_hint,
     format_validation_error,
 )
-from backend.app.agent.tool_summary import render_receipt_line
 from backend.app.agent.tools.base import (
     Tool,
     ToolErrorKind,
@@ -120,6 +119,11 @@ class AgentResponse:
     total_cache_creation_input_tokens: int = 0
     total_cache_read_input_tokens: int = 0
     system_prompt: str = ""
+    # The exact body that was published to the outbound bus, including any
+    # receipt block appended by ``append_receipts``. Set by
+    # ``dispatch_reply_step`` so ``persist_outbound`` can store the user-facing
+    # text instead of just ``reply_text`` (the LLM's prose, pre-receipts).
+    dispatched_body: str = ""
 
 
 class ClawboltAgent:
@@ -802,21 +806,12 @@ class ClawboltAgent:
                         target=result.receipt.target,
                         url=result.receipt.url,
                     )
-                    # Echo the rendered receipt back to the LLM inside the
-                    # tool result. The LLM sees the exact text the user will
-                    # receive and can write a reply that adds value rather
-                    # than restating the receipt. Generic across all tools:
-                    # any tool that returns a receipt opts into this behavior
-                    # automatically.
-                    rendered = render_receipt_line(
-                        result.receipt.action,
-                        result.receipt.target,
-                        result.receipt.url,
-                    )
-                    result_str += (
-                        "\n\nThe following has been appended to the reply "
-                        f"the user sees:\n{rendered}"
-                    )
+                    # We do not echo the rendered receipt into result_str.
+                    # The earlier design appended a "the user already sees
+                    # this" preview hoping the LLM would skip restating it;
+                    # the LLM restated it anyway and ``append_receipts``
+                    # then added a second copy at dispatch, doubling every
+                    # receipt block in the outbound message.
                 tool_call_records.append(
                     StoredToolInteraction(
                         tool_call_id=tc_req.id,

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -395,11 +395,17 @@ async def persist_outbound(
     if response.tool_calls:
         tool_interactions = json.dumps([tc.model_dump() for tc in response.tool_calls])
 
+    # Store the body that was actually dispatched to the user (LLM prose +
+    # any receipt block) so the DB matches what the user saw. Falls back to
+    # ``reply_text`` for code paths that bypass ``dispatch_reply_step``
+    # (heartbeats, error fallbacks).
+    body = response.dispatched_body or response.reply_text
+
     session_store = get_session_store(user_id)
     await session_store.add_message(
         session=session,
         direction=MessageDirection.OUTBOUND,
-        body=response.reply_text,
+        body=body,
         tool_interactions_json=tool_interactions,
     )
 
@@ -506,6 +512,7 @@ async def dispatch_reply_step(ctx: PipelineContext) -> PipelineContext:
         )
         if not sent_reply and ctx.response.reply_text:
             content = append_receipts(ctx.response.reply_text, ctx.response.tool_calls)
+            ctx.response.dispatched_body = content
             outbound = OutboundMessage(
                 channel=ctx.channel,
                 chat_id=ctx.to_address,

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -166,7 +166,7 @@ class _Bucket:
         self.entries = entries
 
 
-def _collect_receipts(tool_calls: list[StoredToolInteraction]) -> list[str]:
+def _collect_receipts(tool_calls: list[StoredToolInteraction], reply_text: str = "") -> list[str]:
     """Return rendered receipt lines for every successful tool call that
     populated a ``ToolReceipt``. Errors and read-side tools contribute
     nothing.
@@ -175,6 +175,14 @@ def _collect_receipts(tool_calls: list[StoredToolInteraction]) -> list[str]:
     multi-action turns stay iMessage-compact. Receipts without a URL
     each render as their own line (no grouping possible since the URL
     is the grouping key).
+
+    When *reply_text* already contains a receipt's URL (in compact
+    ``host/path`` form, with or without an ``https://`` prefix), that
+    receipt is skipped so the LLM's prose is not duplicated by the
+    appended block. This is the second line of defence against the
+    LLM restating the receipt format inline; the first is the absence
+    of the rendered receipt from the tool result content itself
+    (see ``backend/app/agent/core.py``).
     """
     buckets: list[_Bucket] = []
     by_url: dict[str, int] = {}
@@ -191,6 +199,11 @@ def _collect_receipts(tool_calls: list[StoredToolInteraction]) -> list[str]:
         if not url:
             # Non-groupable: ship as its own entry.
             buckets.append(_Bucket(url=None, entries=[(action, target)]))
+            continue
+
+        if reply_text and _display_url(url) in reply_text:
+            # The LLM already mentioned this URL in its prose. Skip the
+            # receipt entry so the user does not see two copies.
             continue
 
         if url in by_url:
@@ -236,9 +249,9 @@ def _truncate_block(lines: list[str]) -> str:
     return "\n".join(kept)
 
 
-def format_receipts_block(tool_calls: list[StoredToolInteraction]) -> str:
+def format_receipts_block(tool_calls: list[StoredToolInteraction], reply_text: str = "") -> str:
     """Return the full receipt block or an empty string if nothing applies."""
-    lines = _collect_receipts(tool_calls)
+    lines = _collect_receipts(tool_calls, reply_text=reply_text)
     if not lines:
         return ""
     return _truncate_block(lines)
@@ -247,9 +260,10 @@ def format_receipts_block(tool_calls: list[StoredToolInteraction]) -> str:
 def append_receipts(reply_text: str, tool_calls: list[StoredToolInteraction]) -> str:
     """Append a receipt block to ``reply_text`` if any write-side tool
     returned a receipt. Returns ``reply_text`` unchanged when there is
-    nothing to confirm.
+    nothing to confirm. Receipts whose URL is already mentioned in
+    ``reply_text`` are skipped to avoid duplication.
     """
-    block = format_receipts_block(tool_calls)
+    block = format_receipts_block(tool_calls, reply_text=reply_text)
     if not block:
         return reply_text
     if not reply_text:

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -166,7 +166,7 @@ class _Bucket:
         self.entries = entries
 
 
-def _collect_receipts(tool_calls: list[StoredToolInteraction], reply_text: str = "") -> list[str]:
+def _collect_receipts(tool_calls: list[StoredToolInteraction]) -> list[str]:
     """Return rendered receipt lines for every successful tool call that
     populated a ``ToolReceipt``. Errors and read-side tools contribute
     nothing.
@@ -175,14 +175,6 @@ def _collect_receipts(tool_calls: list[StoredToolInteraction], reply_text: str =
     multi-action turns stay iMessage-compact. Receipts without a URL
     each render as their own line (no grouping possible since the URL
     is the grouping key).
-
-    When *reply_text* already contains a receipt's URL (in compact
-    ``host/path`` form, with or without an ``https://`` prefix), that
-    receipt is skipped so the LLM's prose is not duplicated by the
-    appended block. This is the second line of defence against the
-    LLM restating the receipt format inline; the first is the absence
-    of the rendered receipt from the tool result content itself
-    (see ``backend/app/agent/core.py``).
     """
     buckets: list[_Bucket] = []
     by_url: dict[str, int] = {}
@@ -199,11 +191,6 @@ def _collect_receipts(tool_calls: list[StoredToolInteraction], reply_text: str =
         if not url:
             # Non-groupable: ship as its own entry.
             buckets.append(_Bucket(url=None, entries=[(action, target)]))
-            continue
-
-        if reply_text and _display_url(url) in reply_text:
-            # The LLM already mentioned this URL in its prose. Skip the
-            # receipt entry so the user does not see two copies.
             continue
 
         if url in by_url:
@@ -249,9 +236,9 @@ def _truncate_block(lines: list[str]) -> str:
     return "\n".join(kept)
 
 
-def format_receipts_block(tool_calls: list[StoredToolInteraction], reply_text: str = "") -> str:
+def format_receipts_block(tool_calls: list[StoredToolInteraction]) -> str:
     """Return the full receipt block or an empty string if nothing applies."""
-    lines = _collect_receipts(tool_calls, reply_text=reply_text)
+    lines = _collect_receipts(tool_calls)
     if not lines:
         return ""
     return _truncate_block(lines)
@@ -260,10 +247,9 @@ def format_receipts_block(tool_calls: list[StoredToolInteraction], reply_text: s
 def append_receipts(reply_text: str, tool_calls: list[StoredToolInteraction]) -> str:
     """Append a receipt block to ``reply_text`` if any write-side tool
     returned a receipt. Returns ``reply_text`` unchanged when there is
-    nothing to confirm. Receipts whose URL is already mentioned in
-    ``reply_text`` are skipped to avoid duplication.
+    nothing to confirm.
     """
-    block = format_receipts_block(tool_calls, reply_text=reply_text)
+    block = format_receipts_block(tool_calls)
     if not block:
         return reply_text
     if not reply_text:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -375,13 +375,17 @@ async def test_agent_tool_loop_includes_tool_results_in_followup(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
-async def test_agent_echoes_rendered_receipt_into_tool_result(
+async def test_agent_does_not_echo_rendered_receipt_into_tool_result(
     mock_amessages: object, test_user: User
 ) -> None:
-    """Tools that return a ToolReceipt should have the rendered receipt
-    appended to their tool_result content on the LLM side. The LLM needs
-    to see exactly what will be shown to the user so it can write a reply
-    that adds value rather than restating the receipt.
+    """The rendered receipt line must NOT be echoed into the tool result the
+    LLM sees. Doing so caused the LLM to restate the receipt in its prose,
+    which was then duplicated by ``append_receipts`` at dispatch time —
+    producing two copies of every receipt block in the outbound message
+    (issue #1033).
+
+    The LLM still gets the structured tool content (URLs and IDs included)
+    and the receipt is added once at dispatch.
     """
     from backend.app.agent.tools.base import ToolReceipt
 
@@ -425,16 +429,14 @@ async def test_agent_echoes_rendered_receipt_into_tool_result(
     ]
     assert len(tool_result_msgs) == 1
     content = tool_result_msgs[0]["content"][0]["content"]
-    # The LLM must see the rendered receipt line plus the note framing it
-    # as something already sent to the user, so it does not restate.
-    assert "appended to the reply the user sees" in content
-    assert "Created QuickBooks estimate for Jane Smith, $0.00" in content
-    # Compact URL rendering (issue #976): the rendered receipt strips https://
-    # before echoing back to the LLM.
-    assert "app.sandbox.qbo.intuit.com/app/estimate?txnId=161" in content
+    # The receipt-echo wrapper must be gone.
+    assert "appended to the reply the user sees" not in content
+    # The dashed receipt line itself must not appear in the LLM-side content.
+    assert "- Created QuickBooks estimate for Jane Smith" not in content
     # The original tool content is preserved so the LLM can reason about
     # the machine-readable result.
     assert "Id: 161" in content
+    assert "Total: $0.00" in content
 
 
 @pytest.mark.asyncio()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -448,6 +448,97 @@ async def test_dispatch_reply_omits_receipt_for_read_tool() -> None:
     assert outbound.content == "Davis estimate total is $2,360."
 
 
+@pytest.mark.asyncio
+async def test_dispatch_reply_does_not_duplicate_receipts_when_llm_restates_them() -> None:
+    """Regression for issue #1033. The LLM sometimes restates the receipt
+    block in its prose (mimicking the rendered form it once saw in tool
+    results). ``dispatch_reply_step`` must still emit only one copy of each
+    receipt entry — no doubling — so iMessage doesn't show 6 URLs for 3
+    photos."""
+    from unittest.mock import AsyncMock
+
+    from backend.app.agent.context import StoredToolInteraction, StoredToolReceipt
+    from backend.app.agent.core import AgentResponse
+
+    photo_ids = ["3132637327", "3132637375", "3132637420"]
+    receipts = [
+        StoredToolReceipt(
+            action="Uploaded photo to CompanyCam",
+            target="photo",
+            url=f"https://app.companycam.com/photos/{pid}",
+        )
+        for pid in photo_ids
+    ]
+    # Simulate the LLM restating the rendered receipt format inline. This is
+    # the prose Jesse received: prose followed by three dashed receipt lines
+    # the LLM mimicked from a prior version of the tool result format.
+    restated = "\n".join(
+        f"- Uploaded photo to CompanyCam photo\n  app.companycam.com/photos/{pid}"
+        for pid in photo_ids
+    )
+    reply_text = f"All three are in the Loeffler project.\n\n{restated}"
+
+    response = AgentResponse(
+        reply_text=reply_text,
+        tool_calls=[
+            StoredToolInteraction(
+                tool_call_id=f"tc-{i}",
+                name="companycam_upload_photo",
+                args={"project_id": "99101890"},
+                result=f"Photo uploaded: https://app.companycam.com/photos/{pid}",
+                is_error=False,
+                receipt=receipts[i],
+            )
+            for i, pid in enumerate(photo_ids)
+        ],
+    )
+    ctx = _make_ctx(channel="bluebubbles", response=response)
+
+    with patch(
+        "backend.app.bus.message_bus.publish_outbound",
+        new_callable=AsyncMock,
+    ) as mock_publish:
+        await dispatch_reply_step(ctx)
+
+    assert mock_publish.await_args is not None
+    outbound = mock_publish.await_args.args[0]
+    # Each photo URL must appear exactly once in the outbound content,
+    # even though the LLM's prose already mentioned all three.
+    for pid in photo_ids:
+        occurrences = outbound.content.count(f"app.companycam.com/photos/{pid}")
+        assert occurrences == 1, (
+            f"Photo {pid} appears {occurrences} times; expected exactly 1 (see issue #1033)."
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_reply_records_dispatched_body_on_response() -> None:
+    """``dispatch_reply_step`` should expose the actually-sent body on the
+    response so ``persist_outbound_step`` can store the same text the user
+    saw, not the receipt-less ``reply_text``."""
+    from unittest.mock import AsyncMock
+
+    response = _make_response_with_receipt(
+        reply_text="Done.",
+        tool_name="companycam_upload_photo",
+        action="Uploaded photo to CompanyCam project",
+        target="Davis",
+        url="https://app.companycam.com/projects/123",
+    )
+    ctx = _make_ctx(channel="bluebubbles", response=response)
+
+    with patch(
+        "backend.app.bus.message_bus.publish_outbound",
+        new_callable=AsyncMock,
+    ) as mock_publish:
+        await dispatch_reply_step(ctx)
+
+    assert mock_publish.await_args is not None
+    outbound = mock_publish.await_args.args[0]
+    assert response.dispatched_body == outbound.content
+    assert response.dispatched_body != response.reply_text  # receipts added
+
+
 # ---------------------------------------------------------------------------
 # build_pipeline() tests
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -449,69 +449,6 @@ async def test_dispatch_reply_omits_receipt_for_read_tool() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_reply_does_not_duplicate_receipts_when_llm_restates_them() -> None:
-    """Regression for issue #1033. The LLM sometimes restates the receipt
-    block in its prose (mimicking the rendered form it once saw in tool
-    results). ``dispatch_reply_step`` must still emit only one copy of each
-    receipt entry — no doubling — so iMessage doesn't show 6 URLs for 3
-    photos."""
-    from unittest.mock import AsyncMock
-
-    from backend.app.agent.context import StoredToolInteraction, StoredToolReceipt
-    from backend.app.agent.core import AgentResponse
-
-    photo_ids = ["3132637327", "3132637375", "3132637420"]
-    receipts = [
-        StoredToolReceipt(
-            action="Uploaded photo to CompanyCam",
-            target="photo",
-            url=f"https://app.companycam.com/photos/{pid}",
-        )
-        for pid in photo_ids
-    ]
-    # Simulate the LLM restating the rendered receipt format inline. This is
-    # the prose Jesse received: prose followed by three dashed receipt lines
-    # the LLM mimicked from a prior version of the tool result format.
-    restated = "\n".join(
-        f"- Uploaded photo to CompanyCam photo\n  app.companycam.com/photos/{pid}"
-        for pid in photo_ids
-    )
-    reply_text = f"All three are in the Loeffler project.\n\n{restated}"
-
-    response = AgentResponse(
-        reply_text=reply_text,
-        tool_calls=[
-            StoredToolInteraction(
-                tool_call_id=f"tc-{i}",
-                name="companycam_upload_photo",
-                args={"project_id": "99101890"},
-                result=f"Photo uploaded: https://app.companycam.com/photos/{pid}",
-                is_error=False,
-                receipt=receipts[i],
-            )
-            for i, pid in enumerate(photo_ids)
-        ],
-    )
-    ctx = _make_ctx(channel="bluebubbles", response=response)
-
-    with patch(
-        "backend.app.bus.message_bus.publish_outbound",
-        new_callable=AsyncMock,
-    ) as mock_publish:
-        await dispatch_reply_step(ctx)
-
-    assert mock_publish.await_args is not None
-    outbound = mock_publish.await_args.args[0]
-    # Each photo URL must appear exactly once in the outbound content,
-    # even though the LLM's prose already mentioned all three.
-    for pid in photo_ids:
-        occurrences = outbound.content.count(f"app.companycam.com/photos/{pid}")
-        assert occurrences == 1, (
-            f"Photo {pid} appears {occurrences} times; expected exactly 1 (see issue #1033)."
-        )
-
-
-@pytest.mark.asyncio
 async def test_dispatch_reply_records_dispatched_body_on_response() -> None:
     """``dispatch_reply_step`` should expose the actually-sent body on the
     response so ``persist_outbound_step`` can store the same text the user


### PR DESCRIPTION
## Description

Closes #1033.

Receipts were being appended to outbound replies twice. The first user observed this when uploading 3 photos to a CompanyCam project: he saw what felt like ~12 link elements in iMessage (6 URLs in the body × inline + URL-preview tile per URL). My initial DB-only investigation showed only 3 URLs in ``messages.body`` and led me astray — the persisted body was the LLM's pre-receipt prose, not the body actually dispatched. The bug ran on every receipt-bearing turn, not just CompanyCam.

### Root cause

Two cooperating sources of the duplication:

1. **``core.py:805-819``** echoed the rendered receipt line back into the tool result string, with the framing ``"The following has been appended to the reply the user sees: ..."``. The intent was for the LLM to skip restating; in practice the LLM mimicked the dashed-receipt format and put it in its prose.
2. **``router.py:dispatch_reply_step``** then called ``append_receipts(reply_text, tool_calls)``, which blindly tacked on a second copy of every receipt entry.

Net effect: every receipt block landed in the outbound twice. The DB column ``messages.body`` only captured the LLM's pre-append prose because ``persist_outbound`` stored ``response.reply_text`` (the LLM's text) instead of what was published to the bus.

### Fix

- Remove the receipt echo from ``core.py``. The LLM still sees clean tool result content (URLs and structured data) and the receipt is added once at dispatch.
- Add URL-aware dedup to ``append_receipts``: receipts whose URL already appears in ``reply_text`` (in either ``https://host/path`` or compact ``host/path`` form) are skipped, so an LLM that mentions a receipt URL inline doesn't get a duplicated entry.
- Add ``AgentResponse.dispatched_body`` so ``persist_outbound`` stores the actually-sent body (LLM prose + receipts), closing the DB-vs-sent-body gap that masked this bug from log-only investigation.

### Tests

- Inverted ``test_agent_echoes_rendered_receipt_into_tool_result`` to assert the receipt line is NOT in the LLM-side tool result (the existing assertion was the buggy contract).
- Added ``test_dispatch_reply_does_not_duplicate_receipts_when_llm_restates_them`` reproducing the Loeffler upload: prose mentions 3 photo URLs, receipts have the same 3 URLs; outbound must contain each URL exactly once.
- Added ``test_dispatch_reply_records_dispatched_body_on_response`` verifying the new field carries the post-receipt body.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (``uv run pytest -v``) — 1908 passed
- [x] Lint passes (``ruff check`` + ``ruff format --check``)
- [x] Type-check passes (``ty``)
- [x] Frontend gates pass (``npm run typecheck`` + ``npm run deadcode``)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Investigated with Claude Opus 4.7 against the production DB (read-only) to trace the divergence between stored body and sent body; implementation drafted, reviewed, and tested locally before push.