### PR TITLE
fix(agent): stop persisting approval prompts so the LLM doesn't mimic them

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -8,6 +8,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
+from backend.app.agent.approval import _parse_approval_response
 from backend.app.agent.compaction import compact_session
 from backend.app.agent.dto import SessionState
 from backend.app.agent.messages import (
@@ -23,6 +24,12 @@ from backend.app.database import SessionLocal
 from backend.app.enums import MessageDirection
 
 logger = logging.getLogger(__name__)
+
+# Canonical trailer that ``format_approval_message`` appends to every
+# system-issued approval prompt. Used to identify approval-prompt rows
+# in stored history so they can be filtered out before the LLM sees
+# them. See the comment in ``load_history`` for why.
+_APPROVAL_PROMPT_TRAILER = "Reply yes or no (always/never to remember your choice)"
 
 DEFAULT_HISTORY_LIMIT = settings.conversation_history_limit
 
@@ -297,10 +304,21 @@ async def load_conversation_history(
 
     history: list[AgentMessage] = []
     tool_interaction_count = 0
+    last_was_approval_prompt = False
     for msg in messages:
         # Prefer processed context (includes media descriptions) over raw body
         content = msg.processed_context if msg.processed_context else msg.body
         if msg.direction == MessageDirection.INBOUND:
+            # Drop the user's approval reply ("Yes", "Always", ...) when it
+            # immediately follows a (now-filtered) approval prompt. Without
+            # this, the orphan reply floats in history with no antecedent
+            # and risks confusing the LLM. We only filter the strict
+            # fast-path keyword set so a stray "Yes" in normal conversation
+            # is preserved.
+            if last_was_approval_prompt and _parse_approval_response(content) is not None:
+                last_was_approval_prompt = False
+                continue
+            last_was_approval_prompt = False
             history.append(UserMessage(content=content))
         else:
             # Check for stored tool interactions
@@ -308,8 +326,18 @@ async def load_conversation_history(
             if tool_interactions:
                 tool_interaction_count += len(tool_interactions)
                 history.extend(_expand_outbound_with_tools(tool_interactions, content))
+                last_was_approval_prompt = False
+            elif content.rstrip().endswith(_APPROVAL_PROMPT_TRAILER):
+                # Skip approval prompts (real ones persisted by older code,
+                # plus any LLM-generated fake prompts that mimic the format).
+                # Persisted prompts in past turns trained the LLM to produce
+                # them as prose instead of calling tools, creating an
+                # infinite-loop UX bug. Filtering at load time heals
+                # already-poisoned sessions without a DB migration.
+                last_was_approval_prompt = True
             else:
                 history.append(AssistantMessage(content=content))
+                last_was_approval_prompt = False
     logger.debug(
         "Loaded %d history messages (%d with tool interactions) for session %s",
         len(history),

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -208,26 +208,6 @@ class ClawboltAgent:
             except Exception:
                 logger.debug("Failed to send typing indicator to %s", mask_pii(self._chat_id))
 
-    async def _persist_approval_prompt(self, prompt: str) -> None:
-        """Store the approval prompt as an outbound message in the session.
-
-        This ensures the prompt is visible in the web UI when viewing
-        session history, even if the conversation originated on a
-        different channel (e.g. iMessage or Telegram).
-        """
-        try:
-            from backend.app.agent.session_db import get_session_store
-            from backend.app.enums import MessageDirection
-
-            session_store = get_session_store(self.user.id)
-            await session_store.add_message_by_session_id(
-                session_id=self._session_id,
-                direction=MessageDirection.OUTBOUND,
-                body=prompt,
-            )
-        except Exception:
-            logger.warning("Failed to persist approval prompt for user %s", self.user.id)
-
     def _get_tool_permission(
         self,
         tool_obj: Tool,
@@ -682,8 +662,14 @@ class ClawboltAgent:
                 elif self._publish_outbound is not None and self._chat_id is not None:
                     prompt = format_approval_message(tool_obj.name, description)
 
-                    if self._session_id:
-                        await self._persist_approval_prompt(prompt)
+                    # We deliberately do not persist the approval prompt to the
+                    # session here. Past attempts persisted it as an OUTBOUND
+                    # message which then loaded back as an ``AssistantMessage``
+                    # in the next turn's history. The LLM mimicked the format
+                    # in subsequent prose replies, generating fake permission
+                    # prompts without calling the actual tool. The user sees
+                    # the prompt via the channel; the agent does not need it
+                    # in conversation history.
 
                     if self._request_id:
                         from backend.app.bus import message_bus

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -616,19 +616,15 @@ async def process_inbound_from_bus(
                 inbound.text[:100],
             )
             gate.resolve(user.id, decision)
-            # Persist the reply to the session so it appears in conversation history
-            session, _is_new = await get_or_create_conversation(
-                user.id, external_session_id=inbound.session_id
-            )
-            session_store = get_session_store(user.id)
-            await session_store.add_message(
-                session=session,
-                direction=MessageDirection.INBOUND,
-                body=inbound.text,
-                external_message_id=inbound.external_message_id or "",
-                media_urls_json=json.dumps([file_id for file_id, _mime in inbound.media_refs]),
-                channel=inbound.channel,
-            )
+            # We do not persist the user's approval reply ("Yes", "Always", ...)
+            # to the session. The reply is a UX artifact of the approval flow;
+            # the underlying action is captured semantically when the resumed
+            # agent run records its tool_interactions. Persisting it as a
+            # standalone INBOUND message leaves it floating in history without
+            # the (also-unpersisted) approval prompt that motivated it, which
+            # gives the LLM no useful context and risks the same kind of
+            # template-mimicry that caused the fake-prompt loop.
+
             # For webchat: resolve the response future so the SSE stream for
             # this approval message closes cleanly with an empty reply.
             if inbound.request_id:

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -365,3 +365,139 @@ async def test_load_history_malformed_tool_json_falls_back_to_flat(
     assert isinstance(history[1], AssistantMessage)
     assert history[1].content == "Reply text"
     assert history[1].tool_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #1049: poisoned approval prompts in history
+# trained the LLM to mimic the format and produce fake permission asks.
+# ---------------------------------------------------------------------------
+
+
+_APPROVAL_PROMPT = (
+    "I'd like to: Create Estimate in QuickBooks\n\n"
+    "Reply yes or no (always/never to remember your choice)"
+)
+
+
+@pytest.mark.asyncio()
+async def test_load_history_filters_persisted_approval_prompts(
+    conversation: SessionState,
+) -> None:
+    """Outbound messages that are clearly approval prompts (canonical
+    trailer, no tool_interactions) must not appear in the LLM-side
+    history. Persisted prompts in past turns trained the LLM to mimic
+    the format as plain prose, breaking the approval gate."""
+    conversation.messages.append(
+        StoredMessage(direction="inbound", body="Create that estimate", seq=1)
+    )
+    conversation.messages.append(StoredMessage(direction="outbound", body=_APPROVAL_PROMPT, seq=2))
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=3))
+
+    history = await load_conversation_history(conversation)
+    assert len(history) == 1
+    assert isinstance(history[0], UserMessage)
+    assert history[0].content == "Create that estimate"
+    assert all(
+        "Reply yes or no" not in (m.content or "")
+        for m in history
+        if isinstance(m, AssistantMessage)
+    )
+
+
+@pytest.mark.asyncio()
+async def test_load_history_filters_orphan_approval_reply_following_prompt(
+    conversation: SessionState,
+) -> None:
+    """An inbound that parses as a fast-path approval response and
+    immediately follows a (just-filtered) approval prompt is also
+    dropped. Otherwise the orphan "Yes" floats in history with no
+    antecedent and risks similar pattern-matching by the LLM."""
+    conversation.messages.append(
+        StoredMessage(direction="inbound", body="Create that estimate", seq=1)
+    )
+    conversation.messages.append(StoredMessage(direction="outbound", body=_APPROVAL_PROMPT, seq=2))
+    conversation.messages.append(StoredMessage(direction="inbound", body="Always", seq=3))
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=4))
+
+    history = await load_conversation_history(conversation)
+    # Only the original "Create that estimate" inbound survives.
+    assert len(history) == 1
+    assert isinstance(history[0], UserMessage)
+    assert history[0].content == "Create that estimate"
+
+
+@pytest.mark.asyncio()
+async def test_load_history_keeps_yes_unrelated_to_approval_prompt(
+    conversation: SessionState,
+) -> None:
+    """A user "Yes" that does NOT immediately follow a stripped
+    approval prompt is preserved. Filtering it would silently drop
+    legitimate one-word replies in normal conversation."""
+    conversation.messages.append(StoredMessage(direction="inbound", body="Should I do X?", seq=1))
+    conversation.messages.append(StoredMessage(direction="outbound", body="Want me to?", seq=2))
+    conversation.messages.append(StoredMessage(direction="inbound", body="Yes", seq=3))
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=4))
+
+    history = await load_conversation_history(conversation)
+    assert len(history) == 3
+    assert isinstance(history[2], UserMessage)
+    assert history[2].content == "Yes"
+
+
+@pytest.mark.asyncio()
+async def test_load_history_keeps_assistant_reply_that_happens_to_mention_yes_no(
+    conversation: SessionState,
+) -> None:
+    """An ordinary assistant reply that happens to mention "yes or no"
+    in prose but doesn't end with the canonical trailer is preserved."""
+    conversation.messages.append(
+        StoredMessage(direction="inbound", body="What's your policy?", seq=1)
+    )
+    conversation.messages.append(
+        StoredMessage(
+            direction="outbound",
+            body=(
+                "Some questions are yes-or-no, others need more context. "
+                "Tell me which kind you have."
+            ),
+            seq=2,
+        )
+    )
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=3))
+
+    history = await load_conversation_history(conversation)
+    assert len(history) == 2
+    assert isinstance(history[1], AssistantMessage)
+    assert "yes-or-no" in (history[1].content or "")
+
+
+@pytest.mark.asyncio()
+async def test_load_history_filters_llm_generated_fake_approval_prompt(
+    conversation: SessionState,
+) -> None:
+    """When the LLM produces a fake approval prompt as plain prose
+    (the bug from #1049), it gets persisted as outbound with no
+    tool_interactions. The load-time filter must catch these too so
+    the cycle stops on subsequent turns."""
+    fake_prompt = (
+        "I'd like to: Create Estimate in QuickBooks\n\n"
+        "Reply yes or no (always/never to remember your choice)"
+    )
+    conversation.messages.append(StoredMessage(direction="inbound", body="estimate?", seq=1))
+    conversation.messages.append(
+        StoredMessage(
+            direction="outbound",
+            body=fake_prompt,
+            tool_interactions_json="",
+            seq=2,
+        )
+    )
+    conversation.messages.append(StoredMessage(direction="inbound", body="Yes", seq=3))
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=4))
+
+    history = await load_conversation_history(conversation)
+    # Only the original user prompt survives; fake "I'd like to:" and the
+    # orphan "Yes" reply are both stripped.
+    assert len(history) == 1
+    assert isinstance(history[0], UserMessage)
+    assert history[0].content == "estimate?"

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -670,14 +670,16 @@ class TestBatchApproval:
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
-    async def test_approval_prompt_persisted_to_session(
+    async def test_approval_prompt_not_persisted_to_session(
         self, mock_amessages: object, test_user: User
     ) -> None:
-        """Approval prompt is stored in session history so it appears in the web UI.
+        """Approval prompt must NOT be stored in session history.
 
-        Regression test for #840: tool approval sent to iMessage channel
-        did not show up in the web UI because the prompt was never
-        persisted to the session message history.
+        Reverses the original behavior from #840. Persisting the prompt
+        gave the LLM a template that subsequent turns mimicked as plain
+        prose, generating fake permission prompts and breaking the
+        approval flow (issue #1049). The user still sees the prompt
+        through their channel; the agent does not need it in history.
         """
         mock_publish = AsyncMock()
         session_id = "test-approval-persist"
@@ -713,11 +715,12 @@ class TestBatchApproval:
         await agent.process_message("read then write")
         await task
 
-        # The approval prompt should be stored in session history
+        # The approval prompt must NOT appear in session history.
         store = get_session_store(test_user.id)
         session = store.load_session(session_id)
         assert session is not None
         outbound_msgs = [m for m in session.messages if m.direction == "outbound"]
-        assert any("reply yes or no" in m.body.lower() for m in outbound_msgs), (
-            "Approval prompt not found in session history"
+        assert not any("reply yes or no" in m.body.lower() for m in outbound_msgs), (
+            "Approval prompt was persisted to session history; this trains the "
+            "LLM to mimic the format. See issue #1049."
         )


### PR DESCRIPTION
## Description

Closes #1049.

The first user said "Always" seven times trying to create one QuickBooks estimate, and the system kept asking again. He said "I'll speak to your maker about this" and gave up after seven minutes.

### Root cause (confirmed against the production DB and Railway logs)

The approval gate is fine. The bug is that the LLM was generating fake approval prompts as its plain-prose reply, never calling the real tool, so the gate never fired.

How it happened:
1. Real approval prompts sent by ``ApprovalGate.request_approval`` were persisted to ``messages`` as plain ``OUTBOUND`` rows by ``core.py:_persist_approval_prompt`` (originally added for #840 web-UI visibility).
2. ``context.load_history`` reads them back as ordinary ``AssistantMessage`` history, indistinguishable from the model's own past replies.
3. After a few real prompts in the same session, Claude pattern-matches on the format and starts producing ``"I'd like to: X — Reply yes or no..."`` as its prose for subsequent turns -- with ``actions=(none)``, no tool call.
4. The user replies "Always" to a fake prompt. There's no pending approval, so the inbound is dispatched as a fresh agent run, which produces another fake prompt. Loop until 120s gate timeout fires for the one real attempt.

Railway logs (filtered for ``Approval``) show this clearly: zero ``Approval resolved`` lines during the seven-minute QB flow. The DB shows ``user_permissions.updated_at`` last changed at 11:41:07 (the morning's CompanyCam upload), with no writes during 16:11-16:18 despite him saying "Always" repeatedly -- because the gate was never invoked.

### Fix (three coordinated changes)

1. **``core.py``** -- remove ``_persist_approval_prompt`` and its call site. The user still sees the prompt via their channel; we just don't put it in the agent's conversation history.
2. **``ingestion.py``** -- after ``gate.resolve``, stop persisting the user's "Yes" / "Always" reply as a separate INBOUND message. Without the matching prompt it has no useful context and is itself an orphan template.
3. **``context.load_history``** -- filter at read time: outbound rows with no ``tool_interactions`` whose body ends in ``"Reply yes or no (always/never to remember your choice)"`` are dropped, and an inbound immediately following one that parses as a fast-path approval response (``yes``, ``always``, ``no``, ``never``) is dropped with it. This **heals already-poisoned sessions like Jesse's without a DB migration** -- past rows stay intact, they just stop being shown to the LLM.

### What this means for Jesse's session

No DB migration needed. The next agent run loading his session will skip the seven persisted fake prompts and the orphan "Always" replies; the LLM will see a clean conversation; the next real ``qb_create`` invocation will hit the real approval gate.

### Why not also fix the "yes always" slow-path classification

Tangential observation: the morning's CompanyCam upload required the slow LLM-classification path because ``"yes always"`` isn't in the fast-path keyword map. Adding it would shave ~20s of latency. Not bundling because it's orthogonal to this bug -- worth its own one-liner PR.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (``uv run pytest -v``) -- 1912 passed
- [x] Lint passes (``ruff check`` + ``ruff format --check``)
- [x] Type-check passes (``ty``)
- [x] Frontend gates pass (``npm run typecheck`` + ``npm run deadcode``)
- [x] New tests added for new functionality (5 in ``tests/test_conversation_continuity.py``)
- [x] Bug fixes include regression tests (one inverted test in ``test_plan_approval.py``, four new in ``test_conversation_continuity.py``)

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used
