### PR TITLE
fix(quickbooks): add requestid for idempotent POSTs to QBO

### DIFF
--- a/backend/app/integrations/quickbooks/service.py
+++ b/backend/app/integrations/quickbooks/service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
@@ -150,7 +151,11 @@ class QuickBooksOnlineService(QuickBooksService):
 
     async def create_entity(self, entity_type: str, data: dict[str, Any]) -> dict[str, Any]:
         path = f"/{entity_type.lower()}"
-        result = await self._request("POST", path, json=data)
+        # Pass a stable requestid so any retry (401 refresh path or transport-level)
+        # is deduped by QBO instead of producing a second entity.
+        result = await self._request(
+            "POST", path, json=data, params={"requestid": uuid.uuid4().hex}
+        )
         # QBO wraps the created entity under the entity type key
         return result.get(entity_type, result)
 
@@ -158,7 +163,9 @@ class QuickBooksOnlineService(QuickBooksService):
         # QBO uses the same POST endpoint for create and update.
         # The presence of Id + SyncToken in the payload triggers an update.
         path = f"/{entity_type.lower()}"
-        result = await self._request("POST", path, json=data)
+        result = await self._request(
+            "POST", path, json=data, params={"requestid": uuid.uuid4().hex}
+        )
         return result.get(entity_type, result)
 
     async def send_entity_email(
@@ -175,5 +182,5 @@ class QuickBooksOnlineService(QuickBooksService):
         return await self._request(
             "POST",
             f"/{entity_type.lower()}/{entity_id.strip()}/send",
-            params={"sendTo": email},
+            params={"sendTo": email, "requestid": uuid.uuid4().hex},
         )

--- a/tests/test_quickbooks_service.py
+++ b/tests/test_quickbooks_service.py
@@ -1,0 +1,192 @@
+"""Tests for ``QuickBooksOnlineService`` HTTP behavior.
+
+Focus on idempotency: every POST that mutates state (create, update, send)
+must include a ``requestid`` query parameter so QBO collapses retries to a
+single entity. The 401-refresh retry path inside ``_request`` must reuse
+the same ``requestid``, otherwise a transient auth blip would create
+duplicates.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from backend.app.integrations.quickbooks import service as service_module
+from backend.app.integrations.quickbooks.service import QuickBooksOnlineService
+
+
+def _patch_transport(
+    monkeypatch: pytest.MonkeyPatch, handler: Callable[[httpx.Request], httpx.Response]
+) -> None:
+    """Route every ``httpx.AsyncClient`` constructed inside the service to
+    ``handler`` via ``MockTransport``."""
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(service_module.httpx, "AsyncClient", factory)
+
+
+def _service() -> QuickBooksOnlineService:
+    return QuickBooksOnlineService(
+        client_id="cid",
+        client_secret="csec",
+        realm_id="9999",
+        access_token="initial-access",
+        refresh_token="rfresh",
+        environment="production",
+        token_url="https://example.invalid/token",
+    )
+
+
+@pytest.mark.asyncio()
+async def test_create_entity_includes_requestid_in_query_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"Estimate": {"Id": "1", "TotalAmt": 10.0}})
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    await svc.create_entity("Estimate", {"CustomerRef": {"value": "1"}, "Line": []})
+
+    assert len(captured) == 1
+    rid = captured[0].url.params.get("requestid")
+    assert rid is not None
+    assert len(rid) >= 16
+
+
+@pytest.mark.asyncio()
+async def test_update_entity_includes_requestid(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"Estimate": {"Id": "1", "SyncToken": "1"}})
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    await svc.update_entity("Estimate", {"Id": "1", "SyncToken": "0"})
+
+    assert captured[0].url.params.get("requestid")
+
+
+@pytest.mark.asyncio()
+async def test_send_entity_email_includes_requestid_alongside_sendTo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"Estimate": {"Id": "1", "EmailStatus": "EmailSent"}})
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    await svc.send_entity_email("Estimate", "1", "to@example.com")
+
+    params = captured[0].url.params
+    assert params.get("requestid")
+    assert params.get("sendTo") == "to@example.com"
+
+
+@pytest.mark.asyncio()
+async def test_query_does_not_set_requestid(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"QueryResponse": {"Estimate": []}})
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    await svc.query("SELECT * FROM Estimate")
+
+    assert "requestid" not in captured[0].url.params
+
+
+@pytest.mark.asyncio()
+async def test_401_retry_reuses_same_requestid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """First POST returns 401, refresh succeeds, retry POST must carry the
+    same ``requestid`` so QBO collapses the pair to a single entity."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if request.url.path.endswith("/token"):
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "new-access",
+                    "refresh_token": "new-rfresh",
+                    "expires_in": 3600,
+                },
+            )
+        if request.method == "POST" and "/estimate" in request.url.path:
+            posts = [r for r in captured if r.method == "POST" and "/estimate" in r.url.path]
+            if len(posts) == 1:
+                return httpx.Response(401, json={"error": "expired"})
+            return httpx.Response(200, json={"Estimate": {"Id": "1", "TotalAmt": 10.0}})
+        return httpx.Response(404)
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    result = await svc.create_entity("Estimate", {"CustomerRef": {"value": "1"}, "Line": []})
+
+    posts = [r for r in captured if r.method == "POST" and "/estimate" in r.url.path]
+    assert len(posts) == 2, "expected initial POST + retry after token refresh"
+    rid_first = posts[0].url.params.get("requestid")
+    rid_retry = posts[1].url.params.get("requestid")
+    assert rid_first is not None
+    assert rid_first == rid_retry, "401 retry must reuse the requestid so QBO dedupes the pair"
+    assert result["Id"] == "1"
+
+
+@pytest.mark.asyncio()
+async def test_each_create_call_uses_a_fresh_requestid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two distinct logical creates must use distinct requestids; otherwise
+    QBO would dedupe the second one as a duplicate of the first."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"Estimate": {"Id": "1", "TotalAmt": 10.0}})
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    await svc.create_entity("Estimate", {"CustomerRef": {"value": "1"}, "Line": []})
+    await svc.create_entity("Estimate", {"CustomerRef": {"value": "2"}, "Line": []})
+
+    rid1 = captured[0].url.params.get("requestid")
+    rid2 = captured[1].url.params.get("requestid")
+    assert rid1 and rid2
+    assert rid1 != rid2
+
+
+@pytest.mark.asyncio()
+async def test_send_entity_email_validates_inputs_before_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bad inputs should raise without ever hitting the network."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(500)
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    with pytest.raises(ValueError):
+        await svc.send_entity_email("Estimate", "abc", "to@example.com")
+    with pytest.raises(ValueError):
+        await svc.send_entity_email("Estimate", "1", "not-an-email")
+    assert captured == []


### PR DESCRIPTION
## Description

Closes the latent idempotency gap on QBO POSTs that surfaced while investigating issue #1035 (estimate duplication on first real-user onboarding).

`QuickBooksOnlineService._request` re-POSTs the same body on a 401 after refreshing the access token. If QBO ever partial-commits before returning 401 (or if any future transport-level retry fires), the user gets a duplicate entity. Intuit's docs explicitly recommend the `requestid` query parameter for this case: same `requestid` + same body = QBO returns the original response instead of creating a second record.

This change passes a UUID4 `requestid` on every mutating POST (`create_entity`, `update_entity`, `send_entity_email`). The param dict is built once per logical call and threaded through `_request` unchanged, so the 401-refresh retry inside `_request` reuses the same id by construction.

### What the investigation found for #1035

Pulled Railway logs from the deployment running at the time of incident (12:04 UTC):

```
12:04:30,494 INFO  [httpx] HTTP Request: POST .../v3/company/.../estimate "HTTP/1.1 200 OK"
12:04:30,494 DEBUG [quickbooks.service] QBO response: status=200 intuit_tid=1-69f0a24d-...
12:04:34,979 DEBUG [agent.core] Agent finished ... actions=['Called write_file','Called list_capabilities','Called qb_create']
```

One POST. One 200. No 401 retry. The DB tool_interactions also show one `qb_create` for that turn. So the duplicate the user reported was the receipt-rendering bug already fixed in #1055 (LLM echoed a receipt block, `append_receipts` appended another, iMessage showed two receipts for the same `Id`). Visual dup, not a real QBO dup.

This PR is the defensive fix so a future retry can never turn into a real duplicate entity.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

### New tests (`tests/test_quickbooks_service.py`)

- `requestid` is present on every mutating POST and absent on `GET /query`
- **The 401 retry reuses the same `requestid`** (load-bearing — this is what makes the retry safe)
- Distinct logical calls get distinct requestids
- `send_entity_email` input validation short-circuits before any network attempt

## AI Usage
- [x] AI-assisted (describe how)

Investigation, code, and tests written with Claude Opus 4.7. Root cause confirmed against Railway logs + production DB before writing the fix.

- [ ] No AI used