### PR TITLE
fix(quickbooks): use application/octet-stream for /send endpoint

### DIFF
--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -7,6 +7,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+import httpx
 from pydantic import BaseModel, Field
 
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
@@ -284,10 +285,10 @@ def create_quickbooks_tools(
         except Exception as exc:
             logger.exception("QuickBooks query failed")
             error_str = str(exc)
-            if hasattr(exc, "response"):
+            if isinstance(exc, httpx.HTTPStatusError):
                 try:
-                    body = exc.response.json()  # type: ignore[union-attr]
-                    error_str = json.dumps(body, indent=2)
+                    error_body = exc.response.json()
+                    error_str = json.dumps(error_body, indent=2)
                 except Exception:
                     pass
             return ToolResult(
@@ -313,9 +314,9 @@ def create_quickbooks_tools(
         except Exception as exc:
             logger.exception("QB create %s failed", entity_type)
             error_str = str(exc)
-            if hasattr(exc, "response"):
+            if isinstance(exc, httpx.HTTPStatusError):
                 try:
-                    error_body = exc.response.json()  # type: ignore[union-attr]
+                    error_body = exc.response.json()
                     error_str = json.dumps(error_body, indent=2)
                 except Exception:
                     pass
@@ -362,9 +363,9 @@ def create_quickbooks_tools(
         except Exception as exc:
             logger.exception("QB update %s failed", entity_type)
             error_str = str(exc)
-            if hasattr(exc, "response"):
+            if isinstance(exc, httpx.HTTPStatusError):
                 try:
-                    error_body = exc.response.json()  # type: ignore[union-attr]
+                    error_body = exc.response.json()
                     error_str = json.dumps(error_body, indent=2)
                 except Exception:
                     pass
@@ -411,9 +412,9 @@ def create_quickbooks_tools(
         except Exception as exc:
             logger.exception("QB send %s email failed", entity_type)
             error_str = str(exc)
-            if hasattr(exc, "response"):
+            if isinstance(exc, httpx.HTTPStatusError):
                 try:
-                    error_body = exc.response.json()  # type: ignore[union-attr]
+                    error_body = exc.response.json()
                     error_str = json.dumps(error_body, indent=2)
                 except Exception:
                     pass

--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -410,8 +410,15 @@ def create_quickbooks_tools(
             await qb_service.send_entity_email(entity_type, entity_id, email)
         except Exception as exc:
             logger.exception("QB send %s email failed", entity_type)
+            error_str = str(exc)
+            if hasattr(exc, "response"):
+                try:
+                    error_body = exc.response.json()  # type: ignore[union-attr]
+                    error_str = json.dumps(error_body, indent=2)
+                except Exception:
+                    pass
             return ToolResult(
-                content=f"Failed to send {entity_type.lower()}: {exc}",
+                content=f"Failed to send {entity_type.lower()}: {error_str}",
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
             )

--- a/backend/app/integrations/quickbooks/service.py
+++ b/backend/app/integrations/quickbooks/service.py
@@ -113,13 +113,19 @@ class QuickBooksOnlineService(QuickBooksService):
         *,
         json: dict[str, Any] | None = None,
         params: dict[str, str] | None = None,
+        content_type: str = "application/json",
     ) -> dict[str, Any]:
-        """Make an authenticated request to the QBO API with token refresh on 401."""
+        """Make an authenticated request to the QBO API with token refresh on 401.
+
+        ``content_type`` defaults to JSON because every entity CRUD endpoint
+        wants JSON. The ``/send`` endpoint is the lone exception: Intuit
+        requires ``application/octet-stream`` and 500s on JSON.
+        """
         url = f"{self._api_base}{path}"
         headers = {
             "Authorization": f"Bearer {self._access_token}",
             "Accept": "application/json",
-            "Content-Type": "application/json",
+            "Content-Type": content_type,
         }
 
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -183,4 +189,5 @@ class QuickBooksOnlineService(QuickBooksService):
             "POST",
             f"/{entity_type.lower()}/{entity_id.strip()}/send",
             params={"sendTo": email, "requestid": uuid.uuid4().hex},
+            content_type="application/octet-stream",
         )

--- a/tests/test_quickbooks_service.py
+++ b/tests/test_quickbooks_service.py
@@ -100,6 +100,57 @@ async def test_send_entity_email_includes_requestid_alongside_sendTo(
 
 
 @pytest.mark.asyncio()
+async def test_send_entity_email_uses_octet_stream_content_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Intuit's /send endpoint requires application/octet-stream and 500s
+    on application/json. Every other endpoint stays on application/json."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"Estimate": {"Id": "1", "EmailStatus": "EmailSent"}})
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    await svc.send_entity_email("Estimate", "1", "to@example.com")
+
+    assert captured[0].headers.get("content-type") == "application/octet-stream"
+    # /send takes its recipient via query param, not body.
+    assert captured[0].content == b""
+
+
+@pytest.mark.asyncio()
+async def test_create_entity_uses_json_content_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"Estimate": {"Id": "1", "TotalAmt": 10.0}})
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    await svc.create_entity("Estimate", {"CustomerRef": {"value": "1"}, "Line": []})
+
+    assert captured[0].headers.get("content-type") == "application/json"
+
+
+@pytest.mark.asyncio()
+async def test_query_uses_json_content_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"QueryResponse": {"Estimate": []}})
+
+    _patch_transport(monkeypatch, handler)
+    svc = _service()
+    await svc.query("SELECT * FROM Estimate")
+
+    assert captured[0].headers.get("content-type") == "application/json"
+
+
+@pytest.mark.asyncio()
 async def test_query_does_not_set_requestid(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: list[httpx.Request] = []
 

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
 from backend.app.integrations.quickbooks.factory import create_quickbooks_tools
@@ -399,6 +400,39 @@ async def test_qb_send_failure() -> None:
 
     assert result.is_error is True
     assert "Failed to send invoice" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_failure_surfaces_qbo_error_envelope() -> None:
+    """When QBO returns a Fault.Error[] envelope on a send failure, qb_send
+    must surface that body so users see Intuit's reason instead of just
+    'HTTPStatusError 500'."""
+    fault_body = {
+        "Fault": {
+            "Error": [
+                {
+                    "Message": "Invalid Email",
+                    "Detail": "The supplied email address is not valid.",
+                    "code": "2030",
+                }
+            ],
+            "type": "ValidationFault",
+        }
+    }
+    request = httpx.Request("POST", "https://example.invalid/estimate/1/send")
+    response = httpx.Response(400, json=fault_body, request=request)
+    err = httpx.HTTPStatusError("400 Bad Request", request=request, response=response)
+
+    svc = FakeQBService()
+    svc.send_entity_email = AsyncMock(side_effect=err)  # type: ignore[method-assign]
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_send")
+
+    result = await fn(entity_type="Estimate", entity_id="1", email="bad@example.com")
+
+    assert result.is_error is True
+    assert "Invalid Email" in result.content
+    assert "2030" in result.content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #1063.

QBO's `/send` endpoint requires `Content-Type: application/octet-stream`, not `application/json`. We hardcoded JSON for every QBO request in `QuickBooksOnlineService._request`, so sending an Estimate or Invoice via email reliably 500'd. Confirmed against Intuit's official PHP SDK (`DataService::SENDEMAIL` uses `CONTENTTYPE_OCTETSTREAM`).

The 500 surfaced with no error envelope because Intuit's email pipeline crashes parsing JSON content-type with an empty body. That's why our existing error handling couldn't recover anything useful.

Hit during real-user usage today: estimate creation succeeded, but every attempt to email it to the client returned 500 from QBO. Two retries, same error.

### Why CI never caught this

The `qb_send` tool tests (`tests/test_quickbooks_write.py`) use a `FakeQBService` that bypasses `_request` entirely, so the wire-level mismatch never appeared. New tests in this PR exercise the httpx layer via `MockTransport` so the real header is asserted.

### Changes

1. `service.py` — add a `content_type` kwarg to `_request` defaulting to `application/json`; every existing caller is unchanged. `send_entity_email` overrides to `application/octet-stream`. Body remains empty so the content type isn't a lie.
2. `factory.py` — `qb_send` adopts the same `exc.response.json()` envelope-extraction pattern that `qb_create` already uses, so future failures (which will carry valid JSON now that the content-type is right) surface Intuit's `Fault.Error[].Message` instead of the bare `HTTPStatusError` string.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 1929 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

### New tests

`tests/test_quickbooks_service.py` (httpx-layer, via `MockTransport`):
- `/send` request goes out with `Content-Type: application/octet-stream` and an empty body
- `create_entity` request still uses `application/json`
- `query` request still uses `application/json`

`tests/test_quickbooks_write.py`:
- When `qb_send` fails with a `Fault.Error[]` envelope, the user-facing content includes Intuit's `Message` and `code`, not just the bare exception string.

## AI Usage
- [x] AI-assisted (describe how)

Root cause located by reading Intuit's published PHP SDK source (the API docs themselves are JS-rendered and not crawlable). Code, tests, and PR written with Claude Opus 4.7. Diagnosis confirmed against Railway logs and production DB before writing the fix.

- [ ] No AI used