### PR TITLE
feat: envelope-encrypt credential columns with pluggable KEK provider

### DIFF
--- a/alembic/versions/018_envelope_encrypt_oauth_tokens.py
+++ b/alembic/versions/018_envelope_encrypt_oauth_tokens.py
@@ -1,0 +1,129 @@
+"""Re-key oauth_tokens.access_token / refresh_token to envelope format.
+
+Each existing ciphertext was produced by a single HKDF-derived Fernet
+key (``info=b"oauth-token-encryption"``). Each row is decrypted with
+that key (or read as-is if the deployment had ``ENCRYPTION_KEY`` empty
+and stored plaintext) and re-encrypted under a per-row DEK whose wrap
+is delegated to ``LocalKEKProvider``. The new envelope is self-
+identifying via the ``clw1.`` prefix, so this migration is idempotent:
+already-envelope rows are skipped on re-run.
+
+Deployment ordering note: run this migration *before* the new
+application code rolls out. The new ``EncryptedString`` raises on
+non-envelope reads, so a code-rolled-out / migration-not-run gap will
+fail health checks. For premium (``clawbolt-premium``), this means
+``uv run alembic -c alembic.ini upgrade head`` against the production
+database during deploy, before swapping container images.
+
+Revision ID: 018
+Revises: 017
+Create Date: 2026-04-29
+"""
+
+from __future__ import annotations
+
+import base64
+
+import sqlalchemy as sa
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from alembic import op
+from backend.app.config import settings
+from backend.app.security.encryption import (
+    LocalKEKProvider,
+    is_envelope,
+)
+from backend.app.security.encryption import (
+    encrypt as envelope_encrypt,
+)
+
+revision: str = "018"
+down_revision: str = "017"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def _legacy_fernet() -> Fernet | None:
+    """Reproduce the pre-envelope HKDF/Fernet derivation.
+
+    Returns None when no ``ENCRYPTION_KEY`` is configured, meaning rows
+    were stored as plaintext.
+    """
+    key = settings.encryption_key.get_secret_value()
+    if not key:
+        return None
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b"oauth-token-encryption",
+    )
+    derived = hkdf.derive(key.encode())
+    return Fernet(base64.urlsafe_b64encode(derived))
+
+
+def _decrypt_legacy(value: str, fernet: Fernet | None) -> str:
+    """Decrypt a pre-envelope row.
+
+    If a legacy key is configured and decryption succeeds, returns the
+    plaintext. If decryption fails (or no key is set), the row was
+    stored as plaintext under the old "no-key" path; return it as-is.
+    """
+    if fernet is None:
+        return value
+    try:
+        return fernet.decrypt(value.encode()).decode()
+    except InvalidToken:
+        return value
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    legacy = _legacy_fernet()
+    provider = LocalKEKProvider()
+
+    rows = bind.execute(
+        sa.text("SELECT id, access_token, refresh_token FROM oauth_tokens")
+    ).fetchall()
+
+    for row_id, access_token, refresh_token in rows:
+        new_access = _rekey(access_token, legacy, provider, "access_token")
+        new_refresh = _rekey(refresh_token, legacy, provider, "refresh_token")
+        if new_access is access_token and new_refresh is refresh_token:
+            continue
+        bind.execute(
+            sa.text("UPDATE oauth_tokens SET access_token = :a, refresh_token = :r WHERE id = :id"),
+            {"a": new_access, "r": new_refresh, "id": row_id},
+        )
+
+
+def _rekey(
+    value: str | None,
+    legacy: Fernet | None,
+    provider: LocalKEKProvider,
+    column: str,
+) -> str | None:
+    if not value:
+        return value
+    if is_envelope(value):
+        # Already migrated (idempotent re-run).
+        return value
+    plaintext = _decrypt_legacy(value, legacy)
+    return envelope_encrypt(
+        plaintext,
+        provider,
+        {"table": "oauth_tokens", "column": column},
+    )
+
+
+def downgrade() -> None:
+    """No automatic downgrade.
+
+    Recovering pre-envelope ciphertext would require the legacy HKDF
+    key to be configured and would still re-encrypt under the old
+    single-key scheme, which we explicitly removed. Operators who need
+    to roll back must restore from backup.
+    """
+    raise NotImplementedError("Cannot downgrade revision 018; restore from backup if needed.")

--- a/backend/app/auth/loader.py
+++ b/backend/app/auth/loader.py
@@ -25,9 +25,12 @@ def get_kek_provider() -> KEKProvider:
     """Return the active KEK provider.
 
     Premium plugins override the OSS default by exposing
-    ``get_kek_provider()`` from their plugin module. The OSS default is
-    a process-singleton ``LocalKEKProvider`` derived from
-    ``settings.encryption_key``.
+    ``get_kek_provider()`` from their plugin module. A plugin may
+    return ``None`` from that hook to opt out of the override at
+    runtime (e.g. when KMS isn't configured yet); in that case we fall
+    back to the OSS default. This lets premium ship the KMS provider
+    code dormant and have it activate the moment the env vars are set,
+    without a code change.
     """
     global _kek_provider
     if _kek_provider is not None:
@@ -35,8 +38,10 @@ def get_kek_provider() -> KEKProvider:
     if settings.premium_plugin:
         module = importlib.import_module(settings.premium_plugin)
         if hasattr(module, "get_kek_provider"):
-            _kek_provider = module.get_kek_provider()
-            return _kek_provider
+            plugin_provider = module.get_kek_provider()
+            if plugin_provider is not None:
+                _kek_provider = plugin_provider
+                return _kek_provider
     _kek_provider = LocalKEKProvider()
     return _kek_provider
 

--- a/backend/app/auth/loader.py
+++ b/backend/app/auth/loader.py
@@ -2,9 +2,12 @@ import importlib
 
 from backend.app.auth.base import AuthBackend
 from backend.app.config import settings
+from backend.app.security.encryption import KEKProvider, LocalKEKProvider
 
 _backend: AuthBackend | None = None
 _loaded: bool = False
+
+_kek_provider: KEKProvider | None = None
 
 
 def get_auth_backend() -> AuthBackend | None:
@@ -16,3 +19,29 @@ def get_auth_backend() -> AuthBackend | None:
         _backend = module.get_auth_backend()
     _loaded = True
     return _backend
+
+
+def get_kek_provider() -> KEKProvider:
+    """Return the active KEK provider.
+
+    Premium plugins override the OSS default by exposing
+    ``get_kek_provider()`` from their plugin module. The OSS default is
+    a process-singleton ``LocalKEKProvider`` derived from
+    ``settings.encryption_key``.
+    """
+    global _kek_provider
+    if _kek_provider is not None:
+        return _kek_provider
+    if settings.premium_plugin:
+        module = importlib.import_module(settings.premium_plugin)
+        if hasattr(module, "get_kek_provider"):
+            _kek_provider = module.get_kek_provider()
+            return _kek_provider
+    _kek_provider = LocalKEKProvider()
+    return _kek_provider
+
+
+def reset_kek_provider() -> None:
+    """Reset the cached KEK provider. Test-only."""
+    global _kek_provider
+    _kek_provider = None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,5 @@
 """SQLAlchemy ORM models for clawbolt."""
 
-import base64
 import logging
 import uuid as _uuid
 from collections.abc import Callable
@@ -23,68 +22,73 @@ from sqlalchemy.types import TypeDecorator
 
 from .config import settings
 from .database import Base
+from .security import encryption as _encryption
 
 _logger = logging.getLogger(__name__)
 
 
 class EncryptedString(TypeDecorator):
-    """Transparently encrypts/decrypts string values using Fernet.
+    """Envelope-encrypts string values at rest.
 
-    When ``encryption_key`` is set in settings, values are encrypted before
-    storage and decrypted on retrieval. When the key is empty (local dev),
-    values pass through as plaintext with a logged warning on first use.
+    On write, generates a fresh per-row data-encryption key (DEK),
+    Fernet-encrypts the plaintext with it, and asks the configured
+    ``KEKProvider`` to wrap the DEK. The wrapped DEK and the ciphertext
+    are serialized into a single inline envelope (see
+    ``backend.app.security.encryption``).
+
+    On read, the envelope is parsed, the DEK is unwrapped via the
+    provider, and the plaintext is recovered.
+
+    The provider is selected through ``backend.app.auth.loader``: OSS
+    ships ``LocalKEKProvider`` (Fernet wrapping derived from
+    ``settings.encryption_key``); premium plugins override with a
+    KMS-backed provider for per-tenant DEK wrapping.
     """
 
     impl = Text
     cache_ok = True
 
-    _warned_no_key = False
+    def __init__(self, *, table: str = "", column: str = "") -> None:
+        super().__init__()
+        self._table = table
+        self._column = column
 
-    def _get_fernet(self):  # noqa: ANN202
-        key = settings.encryption_key.get_secret_value()
-        if not key:
-            if not EncryptedString._warned_no_key:
-                _logger.warning("encryption_key not set; OAuth tokens stored unencrypted")
-                EncryptedString._warned_no_key = True
-            return None
+    def _context(self) -> _encryption.EncryptionContext:
+        ctx: _encryption.EncryptionContext = {}
+        if self._table:
+            ctx["table"] = self._table
+        if self._column:
+            ctx["column"] = self._column
+        return ctx
 
-        from cryptography.fernet import Fernet
-        from cryptography.hazmat.primitives import hashes
-        from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+    def _get_provider(self) -> _encryption.KEKProvider:
+        # Imported lazily to avoid an import cycle: loader imports models
+        # transitively via the auth backend stack.
+        from backend.app.auth.loader import get_kek_provider
 
-        hkdf = HKDF(
-            algorithm=hashes.SHA256(),
-            length=32,
-            salt=None,
-            info=b"oauth-token-encryption",
-        )
-        derived = hkdf.derive(key.encode())
-        return Fernet(base64.urlsafe_b64encode(derived))
+        return get_kek_provider()
 
     def process_bind_param(self, value, dialect):  # noqa: ANN001, ANN201
-        if value is None:
+        if value is None or value == "":
             return value
-        fernet = self._get_fernet()
-        if fernet is None:
-            return value
-        return fernet.encrypt(value.encode()).decode()
+        provider = self._get_provider()
+        return _encryption.encrypt(value, provider, self._context())
 
     def process_result_value(self, value, dialect):  # noqa: ANN001, ANN201
-        if value is None:
+        if value is None or value == "":
             return value
-        fernet = self._get_fernet()
-        if fernet is None:
-            return value
-        try:
-            return fernet.decrypt(value.encode()).decode()
-        except Exception:
-            # Value may be plaintext (stored before encryption was enabled).
-            # Log so operators can distinguish misconfigured keys from migration.
-            _logger.warning(
-                "Fernet decryption failed; returning value as-is"
-                " (expected during migration from plaintext)"
+        if not _encryption.is_envelope(value):
+            # Migration 018 re-keys every existing row to the envelope
+            # format. A non-envelope value here means the migration
+            # didn't run (or a legacy code path bypassed the type
+            # decorator). Fail loudly rather than silently return
+            # ciphertext or plaintext that would corrupt downstream use.
+            raise RuntimeError(
+                "EncryptedString read found a non-envelope value. Run "
+                "`uv run alembic upgrade head` to re-key existing rows."
             )
-            return value
+        provider = self._get_provider()
+        return _encryption.decrypt(value, provider, self._context())
 
 
 class User(Base):
@@ -408,8 +412,10 @@ class ToolConfig(Base):
 class OAuthToken(Base):
     """Persisted OAuth token for a user-integration pair.
 
-    Sensitive fields (access_token, refresh_token) are encrypted at rest
-    via the ``EncryptedString`` type when ``ENCRYPTION_KEY`` is configured.
+    Sensitive fields (access_token, refresh_token) are envelope-encrypted
+    at rest via ``EncryptedString``: per-row DEK wrapped by the configured
+    ``KEKProvider`` (OSS: ``LocalKEKProvider`` keyed by ``ENCRYPTION_KEY``;
+    premium: KMS-backed, per-tenant).
     """
 
     __tablename__ = "oauth_tokens"
@@ -422,8 +428,12 @@ class OAuthToken(Base):
         String, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
     )
     integration: Mapped[str] = mapped_column(String, nullable=False)
-    access_token: Mapped[str] = mapped_column(EncryptedString(), default="")
-    refresh_token: Mapped[str] = mapped_column(EncryptedString(), default="")
+    access_token: Mapped[str] = mapped_column(
+        EncryptedString(table="oauth_tokens", column="access_token"), default=""
+    )
+    refresh_token: Mapped[str] = mapped_column(
+        EncryptedString(table="oauth_tokens", column="refresh_token"), default=""
+    )
     token_type: Mapped[str] = mapped_column(String, default="Bearer")
     expires_at: Mapped[float] = mapped_column(Float, default=0.0)
     scopes_json: Mapped[str] = mapped_column(Text, default="[]")

--- a/backend/app/security/encryption.py
+++ b/backend/app/security/encryption.py
@@ -1,0 +1,194 @@
+"""Envelope encryption for credential columns.
+
+Each encrypted value carries its own random data-encryption key (DEK).
+The DEK is wrapped by a key-encryption key (KEK) supplied by a
+``KEKProvider``. Both the wrapped DEK and the ciphertext are stored
+inline in a single column so any ``EncryptedString`` column gets
+envelope encryption without schema changes.
+
+Envelope format (text):
+
+    clw1.<kek_id>.<base64-urlsafe(wrapped_dek)>.<fernet_token>
+
+The ``kek_id`` lets a provider route to the correct key version on
+unwrap; ``LocalKEKProvider`` uses the constant id ``local``. Premium
+deployments swap in a KMS-backed provider whose ``kek_id`` is a
+tenant-scoped key alias.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import secrets
+from typing import Protocol, TypedDict
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from backend.app.config import settings
+
+_logger = logging.getLogger(__name__)
+
+ENVELOPE_PREFIX = "clw1"
+ENVELOPE_VERSION = 1
+
+
+class EncryptionContext(TypedDict, total=False):
+    """Per-row context passed to wrap/unwrap.
+
+    OSS uses only ``table`` and ``column``. Premium plugins extend with
+    ``tenant_id``, ``user_id``, etc. to scope the KEK selection.
+    """
+
+    table: str
+    column: str
+    user_id: str
+    tenant_id: str
+
+
+class KEKProvider(Protocol):
+    """Wraps and unwraps per-row DEKs.
+
+    Implementations decide where the master key lives (env var, AWS KMS,
+    GCP KMS, Vault Transit) and how it is selected per request. The OSS
+    default is ``LocalKEKProvider``; premium plugins override via the
+    auth loader.
+    """
+
+    def wrap(self, dek: bytes, *, context: EncryptionContext) -> tuple[str, bytes]:
+        """Wrap *dek* with the provider's current KEK.
+
+        Returns ``(kek_id, wrapped_dek)``. The ``kek_id`` is stored
+        alongside the ciphertext so ``unwrap`` can route to the right
+        key version (e.g. after a KMS key rotation).
+        """
+        ...
+
+    def unwrap(self, kek_id: str, wrapped: bytes, *, context: EncryptionContext) -> bytes:
+        """Unwrap a previously wrapped DEK using the key identified by *kek_id*."""
+        ...
+
+
+class LocalKEKProvider:
+    """KEK provider backed by ``settings.encryption_key``.
+
+    Derives a Fernet wrapping key via HKDF-SHA256. If no key is
+    configured, generates an ephemeral process-local key and logs a
+    warning. Ephemeral keys mean stored credentials become unreadable
+    after a process restart, which is the loudest acceptable signal
+    that the operator forgot to set ``ENCRYPTION_KEY``.
+    """
+
+    KEK_ID = "local"
+
+    def __init__(self, key_material: bytes | None = None) -> None:
+        if key_material is None:
+            configured = settings.encryption_key.get_secret_value().encode()
+            if configured:
+                key_material = configured
+            else:
+                key_material = secrets.token_bytes(32)
+                _logger.warning(
+                    "ENCRYPTION_KEY not set; using ephemeral process-local KEK. "
+                    "Stored credentials will become unreadable after restart."
+                )
+        self._fernet = Fernet(_derive_wrapping_key(key_material))
+
+    def wrap(self, dek: bytes, *, context: EncryptionContext) -> tuple[str, bytes]:
+        del context  # unused in OSS provider
+        return self.KEK_ID, self._fernet.encrypt(dek)
+
+    def unwrap(self, kek_id: str, wrapped: bytes, *, context: EncryptionContext) -> bytes:
+        del context  # unused in OSS provider
+        if kek_id != self.KEK_ID:
+            raise ValueError(
+                f"LocalKEKProvider cannot unwrap kek_id={kek_id!r}; expected {self.KEK_ID!r}"
+            )
+        return self._fernet.decrypt(wrapped)
+
+
+def _derive_wrapping_key(key_material: bytes) -> bytes:
+    """Derive a 32-byte Fernet key from raw key material via HKDF-SHA256.
+
+    The ``info`` parameter namespaces this derivation away from the
+    pre-envelope ``oauth-token-encryption`` derivation so a single
+    ``ENCRYPTION_KEY`` value can't be used to read both old and new
+    ciphertexts by mistake.
+    """
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b"clawbolt-kek-wrap-v1",
+    )
+    return base64.urlsafe_b64encode(hkdf.derive(key_material))
+
+
+def encrypt(plaintext: str, provider: KEKProvider, context: EncryptionContext) -> str:
+    """Envelope-encrypt *plaintext* and return the serialized envelope."""
+    dek = Fernet.generate_key()
+    kek_id, wrapped = provider.wrap(dek, context=context)
+    ciphertext = Fernet(dek).encrypt(plaintext.encode()).decode()
+    return _serialize(kek_id, wrapped, ciphertext)
+
+
+def decrypt(envelope: str, provider: KEKProvider, context: EncryptionContext) -> str:
+    """Decrypt a serialized envelope back to plaintext.
+
+    Raises ``ValueError`` for malformed envelopes and propagates
+    ``InvalidToken`` if the underlying Fernet operations fail.
+    """
+    kek_id, wrapped, ciphertext = _parse(envelope)
+    dek = provider.unwrap(kek_id, wrapped, context=context)
+    return Fernet(dek).decrypt(ciphertext.encode()).decode()
+
+
+def is_envelope(value: str) -> bool:
+    """Return True if *value* looks like a serialized envelope.
+
+    Used by the migration to skip rows that have already been re-keyed
+    (idempotent re-runs) and by tests.
+    """
+    return value.startswith(ENVELOPE_PREFIX + ".")
+
+
+def _serialize(kek_id: str, wrapped: bytes, ciphertext: str) -> str:
+    if "." in kek_id:
+        raise ValueError(f"kek_id must not contain '.': {kek_id!r}")
+    return ".".join(
+        (
+            ENVELOPE_PREFIX,
+            kek_id,
+            base64.urlsafe_b64encode(wrapped).decode(),
+            ciphertext,
+        )
+    )
+
+
+def _parse(envelope: str) -> tuple[str, bytes, str]:
+    parts = envelope.split(".", 3)
+    if len(parts) != 4 or parts[0] != ENVELOPE_PREFIX:
+        raise ValueError(f"Malformed envelope (prefix/parts): {envelope[:32]!r}")
+    _, kek_id, wrapped_b64, ciphertext = parts
+    try:
+        wrapped = base64.urlsafe_b64decode(wrapped_b64.encode())
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError(f"Malformed envelope (wrapped DEK): {exc}") from exc
+    return kek_id, wrapped, ciphertext
+
+
+# Re-export for convenience in tests/scripts.
+__all__ = [
+    "ENVELOPE_PREFIX",
+    "ENVELOPE_VERSION",
+    "EncryptionContext",
+    "InvalidToken",
+    "KEKProvider",
+    "LocalKEKProvider",
+    "decrypt",
+    "encrypt",
+    "is_envelope",
+]

--- a/backend/app/security/encryption.py
+++ b/backend/app/security/encryption.py
@@ -33,7 +33,6 @@ from backend.app.config import settings
 _logger = logging.getLogger(__name__)
 
 ENVELOPE_PREFIX = "clw1"
-ENVELOPE_VERSION = 1
 
 
 class EncryptionContext(TypedDict, total=False):
@@ -183,7 +182,6 @@ def _parse(envelope: str) -> tuple[str, bytes, str]:
 # Re-export for convenience in tests/scripts.
 __all__ = [
     "ENVELOPE_PREFIX",
-    "ENVELOPE_VERSION",
     "EncryptionContext",
     "InvalidToken",
     "KEKProvider",

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -373,6 +373,11 @@ class OAuthService:
         """Load token data from the oauth_tokens table."""
         from backend.app.models import OAuthToken
 
+        logger.info(
+            "credential.read action=load user=%s integration=%s",
+            user_id,
+            integration,
+        )
         with db_session() as db:
             row = db.execute(
                 select(OAuthToken).where(
@@ -412,6 +417,11 @@ class OAuthService:
         """Remove a stored token row."""
         from backend.app.models import OAuthToken
 
+        logger.info(
+            "credential.read action=revoke user=%s integration=%s",
+            user_id,
+            integration,
+        )
         with db_session() as db:
             row = db.execute(
                 select(OAuthToken).where(
@@ -565,6 +575,11 @@ class OAuthService:
         acquiring the lock we re-load the token and skip the HTTP call
         entirely if another worker already refreshed it.
         """
+        logger.info(
+            "credential.read action=refresh user=%s integration=%s",
+            user_id,
+            integration,
+        )
         db = SessionLocal()
         lock_key = _refresh_lock_key(user_id, integration)
         try:

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,248 @@
+"""Tests for envelope encryption (KEK provider, EncryptedString, migration helper).
+
+Covers:
+- LocalKEKProvider round-trip
+- A fake provider that records ``EncryptionContext`` so premium-style
+  routing (per-tenant, per-user) is exercised end to end
+- Malformed envelope rejection
+- ``EncryptedString`` integration with the OAuthToken model
+- Read of a non-envelope value raises (catches missed migrations)
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+
+import backend.app.auth.loader as auth_loader
+import backend.app.database as _db_module
+from backend.app.models import OAuthToken, User
+from backend.app.security.encryption import (
+    ENVELOPE_PREFIX,
+    EncryptionContext,
+    KEKProvider,
+    LocalKEKProvider,
+    decrypt,
+    encrypt,
+    is_envelope,
+)
+
+
+@pytest.fixture()
+def local_provider() -> LocalKEKProvider:
+    return LocalKEKProvider(key_material=secrets.token_bytes(32))
+
+
+class _RecordingProvider:
+    """KEK provider that records every wrap/unwrap context.
+
+    Wraps DEKs with an in-memory dict keyed by an opaque token, so the
+    tests can assert the context was threaded through end to end
+    without depending on any specific cryptographic backend.
+    """
+
+    KEK_ID = "recording"
+
+    def __init__(self) -> None:
+        self.wrap_calls: list[EncryptionContext] = []
+        self.unwrap_calls: list[EncryptionContext] = []
+        self._store: dict[bytes, bytes] = {}
+
+    def wrap(self, dek: bytes, *, context: EncryptionContext) -> tuple[str, bytes]:
+        self.wrap_calls.append(dict(context))  # type: ignore[arg-type]
+        token = secrets.token_bytes(16)
+        self._store[token] = dek
+        return self.KEK_ID, token
+
+    def unwrap(self, kek_id: str, wrapped: bytes, *, context: EncryptionContext) -> bytes:
+        assert kek_id == self.KEK_ID
+        self.unwrap_calls.append(dict(context))  # type: ignore[arg-type]
+        return self._store[wrapped]
+
+
+def test_local_provider_round_trip(local_provider: LocalKEKProvider) -> None:
+    envelope = encrypt("hello", local_provider, {"table": "t", "column": "c"})
+    assert is_envelope(envelope)
+    assert envelope.startswith(ENVELOPE_PREFIX + ".")
+    assert decrypt(envelope, local_provider, {"table": "t", "column": "c"}) == "hello"
+
+
+def test_local_provider_rejects_unknown_kek_id(
+    local_provider: LocalKEKProvider,
+) -> None:
+    with pytest.raises(ValueError, match="LocalKEKProvider cannot unwrap"):
+        local_provider.unwrap("not-local", b"\x00" * 16, context={})
+
+
+def test_recording_provider_threads_context_end_to_end() -> None:
+    provider = _RecordingProvider()
+    ctx: EncryptionContext = {
+        "table": "oauth_tokens",
+        "column": "access_token",
+        "user_id": "u-1",
+        "tenant_id": "tenant-abc",
+    }
+    envelope = encrypt("secret", cast(KEKProvider, provider), ctx)
+    assert provider.wrap_calls == [ctx]
+    decrypted = decrypt(envelope, cast(KEKProvider, provider), ctx)
+    assert decrypted == "secret"
+    assert provider.unwrap_calls == [ctx]
+
+
+def test_malformed_envelope_raises(local_provider: LocalKEKProvider) -> None:
+    with pytest.raises(ValueError, match="Malformed envelope"):
+        decrypt("not-an-envelope", local_provider, {})
+    with pytest.raises(ValueError, match="Malformed envelope"):
+        decrypt("clw1.local.only-three-parts", local_provider, {})
+
+
+def test_kek_id_with_dot_is_rejected(local_provider: LocalKEKProvider) -> None:
+    """Serialization uses '.' as a delimiter; kek_ids must not embed it."""
+
+    class BadProvider:
+        def wrap(self, dek: bytes, *, context: EncryptionContext) -> tuple[str, bytes]:
+            return "has.dot", b"x"
+
+        def unwrap(self, kek_id: str, wrapped: bytes, *, context: EncryptionContext) -> bytes:
+            return b""
+
+    with pytest.raises(ValueError, match=r"must not contain '\.'"):
+        encrypt("hello", cast(KEKProvider, BadProvider()), {})
+
+
+@pytest.fixture()
+def install_recording_provider() -> Generator[_RecordingProvider]:
+    """Install a recording KEK provider for the duration of the test."""
+    auth_loader.reset_kek_provider()
+    provider = _RecordingProvider()
+    auth_loader._kek_provider = cast(KEKProvider, provider)
+    yield provider
+    auth_loader.reset_kek_provider()
+
+
+def test_encrypted_string_round_trip_through_orm(
+    install_recording_provider: _RecordingProvider,
+) -> None:
+    """An OAuthToken row's encrypted columns round-trip through PostgreSQL."""
+    db = _db_module.SessionLocal()
+    try:
+        user = User(id=str(uuid.uuid4()), user_id="enc-test", onboarding_complete=True)
+        db.add(user)
+        db.flush()
+
+        row = OAuthToken(
+            user_id=user.id,
+            integration="test",
+            access_token="access-plaintext",
+            refresh_token="refresh-plaintext",
+        )
+        db.add(row)
+        db.commit()
+        token_id = row.id
+    finally:
+        db.close()
+
+    db = _db_module.SessionLocal()
+    try:
+        loaded = db.get(OAuthToken, token_id)
+        assert loaded is not None
+        assert loaded.access_token == "access-plaintext"
+        assert loaded.refresh_token == "refresh-plaintext"
+    finally:
+        db.close()
+
+    contexts = install_recording_provider.wrap_calls
+    columns_wrapped = sorted(c.get("column", "") for c in contexts)
+    assert columns_wrapped == ["access_token", "refresh_token"]
+    assert all(c.get("table") == "oauth_tokens" for c in contexts)
+
+
+def test_encrypted_string_read_of_non_envelope_raises(
+    install_recording_provider: _RecordingProvider,
+) -> None:
+    """Reading a row whose ciphertext was not migrated to envelope format
+    fails fast rather than returning silently corrupted data."""
+    db = _db_module.SessionLocal()
+    try:
+        user = User(id=str(uuid.uuid4()), user_id="enc-pre", onboarding_complete=True)
+        db.add(user)
+        db.flush()
+        # Bypass the type decorator with a raw INSERT to simulate a row
+        # left over from before migration 018.
+        from sqlalchemy import text
+
+        db.execute(
+            text(
+                "INSERT INTO oauth_tokens (user_id, integration, access_token, "
+                "refresh_token, token_type, expires_at, scopes_json, realm_id, "
+                "extra_json, created_at, updated_at) VALUES (:u, 'test', "
+                "'legacy-cipher', '', 'Bearer', 0, '[]', '', '{}', NOW(), NOW())"
+            ),
+            {"u": user.id},
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    db = _db_module.SessionLocal()
+    try:
+        # SQLAlchemy materializes column values eagerly during ORM
+        # loading, so the EncryptedString check fires on .one() rather
+        # than on attribute access.
+        with pytest.raises(RuntimeError, match="non-envelope value"):
+            db.query(OAuthToken).filter(OAuthToken.integration == "test").one()
+    finally:
+        db.close()
+
+
+def test_get_kek_provider_defaults_to_local() -> None:
+    auth_loader.reset_kek_provider()
+    try:
+        provider = auth_loader.get_kek_provider()
+        assert isinstance(provider, LocalKEKProvider)
+    finally:
+        auth_loader.reset_kek_provider()
+
+
+def test_migration_018_rekey_helper_round_trip() -> None:
+    """The migration's ``_rekey`` helper turns a pre-envelope value into
+    an envelope that decrypts back to the original plaintext.
+
+    Imports the migration via importlib because module names starting
+    with a digit aren't valid Python identifiers.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.spec_from_file_location(
+        "migration_018",
+        Path(__file__).parent.parent
+        / "alembic"
+        / "versions"
+        / "018_envelope_encrypt_oauth_tokens.py",
+    )
+    assert spec and spec.loader
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    provider = LocalKEKProvider()
+    # Pre-envelope plaintext (the path taken when ENCRYPTION_KEY was unset
+    # in the prior deployment). legacy=None signals "row is plaintext."
+    rekeyed = migration._rekey("plain-access", None, provider, "access_token")
+    assert isinstance(rekeyed, str)
+    assert rekeyed.startswith(ENVELOPE_PREFIX + ".")
+    assert (
+        decrypt(rekeyed, provider, {"table": "oauth_tokens", "column": "access_token"})
+        == "plain-access"
+    )
+
+    # Idempotent: re-running the migration leaves an envelope untouched.
+    assert migration._rekey(rekeyed, None, provider, "access_token") is rekeyed
+
+    # Empty / None rows are skipped.
+    assert migration._rekey("", None, provider, "access_token") == ""
+    assert migration._rekey(None, None, provider, "access_token") is None

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import base64
 import importlib.util
 import secrets
+import sys
+import types
 import uuid
 from collections.abc import Generator
 from pathlib import Path
@@ -236,6 +238,59 @@ def test_get_kek_provider_defaults_to_local() -> None:
     try:
         provider = auth_loader.get_kek_provider()
         assert isinstance(provider, LocalKEKProvider)
+    finally:
+        auth_loader.reset_kek_provider()
+
+
+def _install_fake_plugin(
+    monkeypatch: pytest.MonkeyPatch, name: str, get_kek_provider: object
+) -> None:
+    """Install a fake premium plugin module that exposes ``get_kek_provider``.
+
+    Cleans up automatically when the test's monkeypatch fixture tears
+    down: the sys.modules entry and the settings override both revert.
+    """
+    fake_module = types.ModuleType(name)
+    fake_module.get_kek_provider = get_kek_provider  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, name, fake_module)
+    monkeypatch.setattr(auth_loader.settings, "premium_plugin", name)
+
+
+def test_get_kek_provider_falls_back_to_local_when_plugin_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A premium plugin can opt out of the KEK override at runtime by
+    returning ``None`` from ``get_kek_provider()``. The loader then
+    falls back to ``LocalKEKProvider`` instead of caching ``None`` and
+    breaking subsequent reads.
+
+    Lets premium ship the KMS provider dormant: when the env vars
+    aren't set yet, the plugin returns ``None`` and OSS encryption
+    keeps working unchanged.
+    """
+    _install_fake_plugin(monkeypatch, "fake_premium_plugin_dormant", lambda: None)
+
+    auth_loader.reset_kek_provider()
+    try:
+        provider = auth_loader.get_kek_provider()
+        assert isinstance(provider, LocalKEKProvider)
+    finally:
+        auth_loader.reset_kek_provider()
+
+
+def test_get_kek_provider_uses_plugin_provider_when_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the plugin returns a real provider, the loader uses it
+    instead of the OSS default. Mirror of the dormant-fallback test
+    above, on the active branch."""
+    sentinel_provider = _RecordingProvider()
+    _install_fake_plugin(monkeypatch, "fake_premium_plugin_active", lambda: sentinel_provider)
+
+    auth_loader.reset_kek_provider()
+    try:
+        provider = auth_loader.get_kek_provider()
+        assert provider is sentinel_provider
     finally:
         auth_loader.reset_kek_provider()
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -11,12 +11,18 @@ Covers:
 
 from __future__ import annotations
 
+import base64
+import importlib.util
 import secrets
 import uuid
 from collections.abc import Generator
+from pathlib import Path
 from typing import cast
 
 import pytest
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 import backend.app.auth.loader as auth_loader
 import backend.app.database as _db_module
@@ -30,6 +36,32 @@ from backend.app.security.encryption import (
     encrypt,
     is_envelope,
 )
+
+
+def _load_migration_018():  # noqa: ANN202
+    """Load migration 018 by file path because module names cannot start with a digit."""
+    spec = importlib.util.spec_from_file_location(
+        "migration_018",
+        Path(__file__).parent.parent
+        / "alembic"
+        / "versions"
+        / "018_envelope_encrypt_oauth_tokens.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _legacy_fernet_for(key_material: bytes) -> Fernet:
+    """Reproduce the pre-envelope HKDF/Fernet derivation for tests."""
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b"oauth-token-encryption",
+    )
+    return Fernet(base64.urlsafe_b64encode(hkdf.derive(key_material)))
 
 
 @pytest.fixture()
@@ -208,30 +240,14 @@ def test_get_kek_provider_defaults_to_local() -> None:
         auth_loader.reset_kek_provider()
 
 
-def test_migration_018_rekey_helper_round_trip() -> None:
-    """The migration's ``_rekey`` helper turns a pre-envelope value into
-    an envelope that decrypts back to the original plaintext.
-
-    Imports the migration via importlib because module names starting
-    with a digit aren't valid Python identifiers.
+def test_migration_018_rekey_helper_plaintext_path() -> None:
+    """When the pre-envelope deployment had ``ENCRYPTION_KEY`` unset,
+    rows were stored as plaintext. ``_rekey`` should pass them through
+    to envelope encryption with no decryption attempt.
     """
-    import importlib.util
-    from pathlib import Path
-
-    spec = importlib.util.spec_from_file_location(
-        "migration_018",
-        Path(__file__).parent.parent
-        / "alembic"
-        / "versions"
-        / "018_envelope_encrypt_oauth_tokens.py",
-    )
-    assert spec and spec.loader
-    migration = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(migration)
-
+    migration = _load_migration_018()
     provider = LocalKEKProvider()
-    # Pre-envelope plaintext (the path taken when ENCRYPTION_KEY was unset
-    # in the prior deployment). legacy=None signals "row is plaintext."
+
     rekeyed = migration._rekey("plain-access", None, provider, "access_token")
     assert isinstance(rekeyed, str)
     assert rekeyed.startswith(ENVELOPE_PREFIX + ".")
@@ -246,3 +262,66 @@ def test_migration_018_rekey_helper_round_trip() -> None:
     # Empty / None rows are skipped.
     assert migration._rekey("", None, provider, "access_token") == ""
     assert migration._rekey(None, None, provider, "access_token") is None
+
+
+def test_migration_018_decrypts_legacy_fernet_then_rekeys() -> None:
+    """The branch that takes a pre-envelope Fernet ciphertext, decrypts
+    it with the legacy HKDF derivation, and re-encrypts under the new
+    envelope. This is the path most rows take in a real deployment that
+    had ``ENCRYPTION_KEY`` set; the plaintext fallback only fires when
+    the prior deployment ran without a key.
+
+    Round-trip assertion: a row encrypted by the old code path decrypts
+    via ``_rekey`` to the original plaintext, with the new envelope as
+    the surface form.
+    """
+    migration = _load_migration_018()
+
+    # Build a legacy Fernet matching the pre-envelope derivation, encrypt
+    # a token under it, and confirm the ciphertext is not envelope-shaped.
+    key_material = secrets.token_bytes(32)
+    legacy = _legacy_fernet_for(key_material)
+    legacy_ciphertext = legacy.encrypt(b"legacy-access-token").decode()
+    assert not is_envelope(legacy_ciphertext)
+
+    # The new KEK provider must use the same key material so its derived
+    # KEK can wrap DEKs that downstream reads will unwrap. (The legacy
+    # and new HKDF info parameters differ, so the keys themselves are
+    # distinct even when the input material is shared.)
+    provider = LocalKEKProvider(key_material=key_material)
+    rekeyed = migration._rekey(legacy_ciphertext, legacy, provider, "access_token")
+
+    assert is_envelope(rekeyed)
+    assert (
+        decrypt(rekeyed, provider, {"table": "oauth_tokens", "column": "access_token"})
+        == "legacy-access-token"
+    )
+
+
+def test_migration_018_falls_back_to_plaintext_on_invalid_legacy_token() -> None:
+    """If a row's ciphertext fails to decrypt under the configured
+    legacy key (``InvalidToken``), the migration treats it as plaintext.
+
+    Documents the behavior so a future change can't silently regress to
+    raising. The realistic path here is "row was stored as plaintext
+    before the operator set ENCRYPTION_KEY"; the dangerous path is
+    "ENCRYPTION_KEY was rotated since the row was written," which would
+    re-encrypt unrecoverable ciphertext as if it were plaintext. The
+    migration's no-downgrade docstring calls out backup-restore as the
+    recovery path for that case.
+    """
+    migration = _load_migration_018()
+
+    legacy = _legacy_fernet_for(secrets.token_bytes(32))
+    provider = LocalKEKProvider(key_material=secrets.token_bytes(32))
+
+    # Pass a value that isn't valid Fernet ciphertext. Legacy decryption
+    # will raise InvalidToken; _decrypt_legacy returns the value as-is;
+    # _rekey envelope-encrypts that string verbatim.
+    rekeyed = migration._rekey("not-a-fernet-token", legacy, provider, "access_token")
+
+    assert is_envelope(rekeyed)
+    assert (
+        decrypt(rekeyed, provider, {"table": "oauth_tokens", "column": "access_token"})
+        == "not-a-fernet-token"
+    )


### PR DESCRIPTION
## Description

Replaces the single-Fernet-key `EncryptedString` with envelope encryption: each row gets a fresh DEK that's wrapped by a configurable `KEKProvider` and stored inline alongside the ciphertext. OSS ships `LocalKEKProvider` backed by `ENCRYPTION_KEY`; premium plugins override via the auth loader to plug in KMS-backed per-tenant wrapping.

The driver isn't urgent live-prod compliance: it's that the migration is trivial today (one user, a handful of rows) and gets exponentially harder once the premium deployment onboards more tenants. Same reasoning applies to the structured `credential.read` log line added at the OAuth read sites: a small forensic down-payment that's cheap now and useful later.

### Key design decisions

- **Inline envelope** format `clw1.<kek_id>.<b64-wrapped-dek>.<fernet-token>` — any `EncryptedString` column gets envelope encryption with zero schema change. Issue #1065's "wrapped_dek + dek_id columns" acceptance is satisfied semantically (the same data lives inline) rather than literally.
- **Migration 018** re-keys existing rows from old single-key Fernet (or plaintext, if the old "no-key" path was ever used) to envelope. Idempotent on re-run; no automatic downgrade (restore from backup if rollback is needed).
- **Fail-loud** on non-envelope reads after migration. `RuntimeError` with "run alembic upgrade head" guidance, instead of silently returning ciphertext-as-plaintext.
- **No "no-key" plaintext fallback.** If `ENCRYPTION_KEY` isn't configured, `LocalKEKProvider` generates an ephemeral process-local key and warns loudly — credentials become unreadable after restart, which surfaces operator misconfig instead of writing tokens in the clear.
- **Premium deploy doc** — couldn't update `clawbolt-premium/deployment.md` from this PR; the migration's docstring carries the deploy-ordering note as a follow-up handoff.

## Type
- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 1938 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (`tests/test_encryption.py`, 9 tests)
- [x] Bug fixes include regression tests (n/a — feature)

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 drafted the design, implementation, migration, and tests; human reviewed scope decisions, pushed back on backwards-compat shims, and approved the final scope.)
- [ ] No AI used

Fixes #1065