### PR TITLE
feat: allow premium plugin's get_kek_provider() to return None

### DIFF
--- a/backend/app/auth/loader.py
+++ b/backend/app/auth/loader.py
@@ -25,9 +25,12 @@ def get_kek_provider() -> KEKProvider:
     """Return the active KEK provider.
 
     Premium plugins override the OSS default by exposing
-    ``get_kek_provider()`` from their plugin module. The OSS default is
-    a process-singleton ``LocalKEKProvider`` derived from
-    ``settings.encryption_key``.
+    ``get_kek_provider()`` from their plugin module. A plugin may
+    return ``None`` from that hook to opt out of the override at
+    runtime (e.g. when KMS isn't configured yet); in that case we fall
+    back to the OSS default. This lets premium ship the KMS provider
+    code dormant and have it activate the moment the env vars are set,
+    without a code change.
     """
     global _kek_provider
     if _kek_provider is not None:
@@ -35,8 +38,10 @@ def get_kek_provider() -> KEKProvider:
     if settings.premium_plugin:
         module = importlib.import_module(settings.premium_plugin)
         if hasattr(module, "get_kek_provider"):
-            _kek_provider = module.get_kek_provider()
-            return _kek_provider
+            plugin_provider = module.get_kek_provider()
+            if plugin_provider is not None:
+                _kek_provider = plugin_provider
+                return _kek_provider
     _kek_provider = LocalKEKProvider()
     return _kek_provider
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -240,6 +240,57 @@ def test_get_kek_provider_defaults_to_local() -> None:
         auth_loader.reset_kek_provider()
 
 
+def test_get_kek_provider_falls_back_to_local_when_plugin_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A premium plugin can opt out of the KEK override at runtime by
+    returning ``None`` from ``get_kek_provider()``. The loader then
+    falls back to ``LocalKEKProvider`` instead of caching ``None`` and
+    breaking subsequent reads.
+
+    Lets premium ship the KMS provider dormant: when the env vars
+    aren't set yet, the plugin returns ``None`` and OSS encryption
+    keeps working unchanged.
+    """
+    import sys
+    import types
+
+    fake_module = types.ModuleType("fake_premium_plugin")
+    fake_module.get_kek_provider = lambda: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fake_premium_plugin", fake_module)
+    monkeypatch.setattr(auth_loader.settings, "premium_plugin", "fake_premium_plugin")
+
+    auth_loader.reset_kek_provider()
+    try:
+        provider = auth_loader.get_kek_provider()
+        assert isinstance(provider, LocalKEKProvider)
+    finally:
+        auth_loader.reset_kek_provider()
+
+
+def test_get_kek_provider_uses_plugin_provider_when_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the plugin returns a real provider, the loader uses it
+    instead of the OSS default. Mirror of the dormant-fallback test
+    above, on the active branch."""
+    import sys
+    import types
+
+    sentinel_provider = _RecordingProvider()
+    fake_module = types.ModuleType("fake_premium_plugin_active")
+    fake_module.get_kek_provider = lambda: sentinel_provider  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fake_premium_plugin_active", fake_module)
+    monkeypatch.setattr(auth_loader.settings, "premium_plugin", "fake_premium_plugin_active")
+
+    auth_loader.reset_kek_provider()
+    try:
+        provider = auth_loader.get_kek_provider()
+        assert provider is sentinel_provider
+    finally:
+        auth_loader.reset_kek_provider()
+
+
 def test_migration_018_rekey_helper_plaintext_path() -> None:
     """When the pre-envelope deployment had ``ENCRYPTION_KEY`` unset,
     rows were stored as plaintext. ``_rekey`` should pass them through

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import base64
 import importlib.util
 import secrets
+import sys
+import types
 import uuid
 from collections.abc import Generator
 from pathlib import Path
@@ -240,6 +242,20 @@ def test_get_kek_provider_defaults_to_local() -> None:
         auth_loader.reset_kek_provider()
 
 
+def _install_fake_plugin(
+    monkeypatch: pytest.MonkeyPatch, name: str, get_kek_provider: object
+) -> None:
+    """Install a fake premium plugin module that exposes ``get_kek_provider``.
+
+    Cleans up automatically when the test's monkeypatch fixture tears
+    down: the sys.modules entry and the settings override both revert.
+    """
+    fake_module = types.ModuleType(name)
+    fake_module.get_kek_provider = get_kek_provider  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, name, fake_module)
+    monkeypatch.setattr(auth_loader.settings, "premium_plugin", name)
+
+
 def test_get_kek_provider_falls_back_to_local_when_plugin_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -252,13 +268,7 @@ def test_get_kek_provider_falls_back_to_local_when_plugin_returns_none(
     aren't set yet, the plugin returns ``None`` and OSS encryption
     keeps working unchanged.
     """
-    import sys
-    import types
-
-    fake_module = types.ModuleType("fake_premium_plugin")
-    fake_module.get_kek_provider = lambda: None  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "fake_premium_plugin", fake_module)
-    monkeypatch.setattr(auth_loader.settings, "premium_plugin", "fake_premium_plugin")
+    _install_fake_plugin(monkeypatch, "fake_premium_plugin_dormant", lambda: None)
 
     auth_loader.reset_kek_provider()
     try:
@@ -274,14 +284,8 @@ def test_get_kek_provider_uses_plugin_provider_when_returned(
     """When the plugin returns a real provider, the loader uses it
     instead of the OSS default. Mirror of the dormant-fallback test
     above, on the active branch."""
-    import sys
-    import types
-
     sentinel_provider = _RecordingProvider()
-    fake_module = types.ModuleType("fake_premium_plugin_active")
-    fake_module.get_kek_provider = lambda: sentinel_provider  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "fake_premium_plugin_active", fake_module)
-    monkeypatch.setattr(auth_loader.settings, "premium_plugin", "fake_premium_plugin_active")
+    _install_fake_plugin(monkeypatch, "fake_premium_plugin_active", lambda: sentinel_provider)
 
     auth_loader.reset_kek_provider()
     try:


### PR DESCRIPTION
## Description

The KEK provider loader currently treats the plugin's hook as authoritative: if the plugin module exposes `get_kek_provider()`, its return value is cached and used unconditionally. That couples the plugin code merge to the infra rollout — shipping a premium KMS provider class would mean the env vars (KMS ARN, AWS creds) have to be wired the same day or the plugin crashes on first credential read.

This PR lets the plugin signal "not configured yet" by returning `None`. The loader falls back to `LocalKEKProvider` as it would without a plugin at all. Premium can ship the KMS provider dormant; platform engineering activates it by setting env vars and restarting — no code change required.

3-line behavior change in `backend/app/auth/loader.py`, plus two tests covering the fallback and the active-plugin paths.

**Stacks on #1071** (which introduces `get_kek_provider`). Merge after #1071 lands; the diff against `main` after that will show only this PR's changes.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 13 encryption tests pass; full suite untouched
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (`test_get_kek_provider_falls_back_to_local_when_plugin_returns_none`, `test_get_kek_provider_uses_plugin_provider_when_returned`)
- [x] Bug fixes include regression tests (n/a — feature)

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 drafted; human directed scope and approved.)
- [ ] No AI used