### PR TITLE
fix(compaction): record LLM usage with purpose="compaction"

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -26,6 +26,7 @@ from backend.app.services.llm_service import (
     prepare_system_with_caching,
     reasoning_effort_to_thinking,
 )
+from backend.app.services.llm_usage import log_llm_usage
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +198,8 @@ async def compact_session(
     except Exception:
         logger.exception("Compaction LLM call failed for user %s", user_id)
         return "", None
+
+    log_llm_usage(user_id, model, response, purpose="compaction")
 
     raw_content = get_response_text(response)
     result = _parse_compaction_response(raw_content)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -684,6 +684,85 @@ async def test_compact_session_falls_back_to_llm_model(test_user: UserData) -> N
     assert call_kwargs.kwargs.get("provider") == "test-provider"
 
 
+# --- compact_session llm_usage_logs tests ---
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_logs_llm_usage(test_user: UserData) -> None:
+    """Successful compaction should record a llm_usage_logs row with purpose='compaction'."""
+    mock_response = make_text_response(json.dumps({"memory_update": "", "summary": ""}))
+
+    messages: list[AgentMessage] = [UserMessage(content="hello")]
+
+    with (
+        patch("backend.app.agent.compaction.amessages", return_value=mock_response),
+        patch("backend.app.agent.compaction.log_llm_usage") as mock_log,
+        patch("backend.app.agent.compaction.settings") as mock_settings,
+    ):
+        mock_settings.compaction_enabled = True
+        mock_settings.compaction_model = "test-compact-model"
+        mock_settings.compaction_provider = "test-provider"
+        mock_settings.compaction_max_tokens = 300
+        mock_settings.llm_model = "test-model"
+        mock_settings.llm_provider = "test-provider"
+        mock_settings.llm_api_base = None
+        await compact_session(test_user.id, messages)
+
+    mock_log.assert_called_once()
+    args, kwargs = mock_log.call_args
+    assert args[0] == test_user.id
+    assert args[1] == "test-compact-model"
+    assert args[2] is mock_response
+    assert kwargs.get("purpose") == "compaction"
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_does_not_log_when_llm_fails(test_user: UserData) -> None:
+    """A failed amessages call should not emit a usage log row."""
+    messages: list[AgentMessage] = [UserMessage(content="hello")]
+
+    with (
+        patch(
+            "backend.app.agent.compaction.amessages",
+            side_effect=Exception("LLM unavailable"),
+        ),
+        patch("backend.app.agent.compaction.log_llm_usage") as mock_log,
+    ):
+        await compact_session(test_user.id, messages)
+
+    mock_log.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_does_not_log_when_disabled(test_user: UserData) -> None:
+    """When compaction is disabled, no usage log row should be written."""
+    messages: list[AgentMessage] = [UserMessage(content="hello")]
+
+    with (
+        patch("backend.app.agent.compaction.settings") as mock_settings,
+        patch("backend.app.agent.compaction.amessages") as mock_llm,
+        patch("backend.app.agent.compaction.log_llm_usage") as mock_log,
+    ):
+        mock_settings.compaction_enabled = False
+        await compact_session(test_user.id, messages)
+
+    mock_llm.assert_not_called()
+    mock_log.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_does_not_log_when_no_messages(test_user: UserData) -> None:
+    """An empty message list should short-circuit before any usage log is written."""
+    with (
+        patch("backend.app.agent.compaction.amessages") as mock_llm,
+        patch("backend.app.agent.compaction.log_llm_usage") as mock_log,
+    ):
+        await compact_session(test_user.id, [])
+
+    mock_llm.assert_not_called()
+    mock_log.assert_not_called()
+
+
 # --- Integration: load_conversation_history no longer triggers compaction ---
 # Compaction is now triggered from process_message() when trim_messages() drops
 # messages, not from load_conversation_history(). The tests below verify the new


### PR DESCRIPTION
## Description

`compact_session` in `backend/app/agent/compaction.py` was calling any-llm `amessages` directly without writing to `llm_usage_logs`. Only the agent main loop in `core.py:948` was logging usage (`agent_main` / `agent_followup`).

Consequence: every compaction round (trim-based and session-end consolidation) was invisible in the per-user usage breakdown surfaced by `/api/users/me/usage`. As we lean on the "infinite session" model, compaction will be a non-trivial fraction of spend per user, and undercounting it breaks the cost picture.

This PR adds a single `log_llm_usage(user_id, model, response, purpose="compaction")` call right after the successful `amessages` invocation. Placement is inside the post-`try/except` path so LLM failures stay no-ops, and the `model` passed is the resolved one (so `compaction_model` overrides are reflected).

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): Drafted with Claude Opus 4.7 (1M context) via Claude Code, including issue investigation, fix, regression tests, and full DoD verification (pytest, ruff, ty, frontend typecheck, knip).
- [ ] No AI used

Fixes #1076