### PR TITLE
fix(calendar): stop double receipts and pre-activate connected specialists

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -578,13 +578,24 @@ async def execute_heartbeat_tasks(
 
     # Follow the same pattern as run_agent() in router.py:
     # 1. Core tools (always available, respects disabled groups/sub-tools)
-    # 2. list_capabilities meta-tool for on-demand specialist activation
-    #    (QuickBooks, Calendar, etc.)
+    # 2. Specialist tools the user is already authenticated for, pre-activated
+    #    so the heartbeat agent does not waste a turn calling list_capabilities
+    # 3. list_capabilities meta-tool for discovering unconnected integrations
     tools = await default_registry.create_core_tools(
         tool_context,
         excluded_factories=excluded,
         excluded_tool_names=disabled_sub_tools or None,
     )
+    (
+        ready_specialist_tools,
+        ready_specialist_names,
+    ) = await default_registry.create_ready_specialist_tools(
+        tool_context,
+        excluded_factories=excluded,
+        excluded_tool_names=disabled_sub_tools or None,
+    )
+    tools.extend(ready_specialist_tools)
+    activated_specialists |= ready_specialist_names
 
     # Auto-approve the media-delivery tool in heartbeat context (#932).
     # Phase 1 already decided to send this message; asking the user for

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -286,14 +286,28 @@ async def run_agent(
         activated_specialists=activated_specialists,
     )
 
-    # Start with core tools only; specialist tools are discovered on demand
-    # via the list_capabilities meta-tool. Exclude user-disabled groups and
-    # individual sub-tools.
+    # Core tools (always-on). Exclude user-disabled groups and sub-tools.
     tools = await default_registry.create_core_tools(
         tool_context,
         excluded_factories=disabled_groups or None,
         excluded_tool_names=disabled_sub_tools or None,
     )
+    # Pre-activate specialists the user is already authenticated for. Without
+    # this, the LLM had to call list_capabilities('calendar') / ('quickbooks')
+    # / ('companycam') on every inbound, which adds a round trip per turn for
+    # users who text about their calendar daily. Now those tools are on the
+    # schema from turn 1; list_capabilities still surfaces unconnected
+    # integrations for discovery.
+    (
+        ready_specialist_tools,
+        ready_specialist_names,
+    ) = await default_registry.create_ready_specialist_tools(
+        tool_context,
+        excluded_factories=disabled_groups or None,
+        excluded_tool_names=disabled_sub_tools or None,
+    )
+    tools.extend(ready_specialist_tools)
+    activated_specialists |= ready_specialist_names
     specialist_summaries = default_registry.get_available_specialist_summaries(
         tool_context, excluded_factories=disabled_groups or None
     )

--- a/backend/app/agent/tool_assembly.py
+++ b/backend/app/agent/tool_assembly.py
@@ -74,6 +74,18 @@ async def build_initial_turn_tools(
         excluded_factories=disabled_groups or None,
         excluded_tool_names=disabled_sub_tools or None,
     )
+    # Mirror router.py: specialist tools for connected integrations are
+    # pre-activated at agent boot, so the preview's tool list reflects what
+    # the LLM actually sees on a fresh turn.
+    (
+        ready_specialist_tools,
+        ready_specialist_names,
+    ) = await default_registry.create_ready_specialist_tools(
+        tool_context,
+        excluded_factories=disabled_groups or None,
+        excluded_tool_names=disabled_sub_tools or None,
+    )
+    tools.extend(ready_specialist_tools)
     specialist_summaries = default_registry.get_available_specialist_summaries(
         tool_context, excluded_factories=disabled_groups or None
     )
@@ -89,7 +101,7 @@ async def build_initial_turn_tools(
                 specialist_summaries,
                 unauthenticated=unauthenticated,
                 disabled_sub_tools=disabled_specialist_subs or None,
-                activated_specialists=set(),
+                activated_specialists=ready_specialist_names,
             )
         )
     return tools

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -248,10 +248,123 @@ def append_receipts(reply_text: str, tool_calls: list[StoredToolInteraction]) ->
     """Append a receipt block to ``reply_text`` if any write-side tool
     returned a receipt. Returns ``reply_text`` unchanged when there is
     nothing to confirm.
+
+    Before appending, scrub LLM-fabricated receipt bullets from
+    ``reply_text`` (see :func:`_strip_fabricated_receipts`). The LLM is
+    instructed not to restate tool confirmations but does so anyway,
+    pattern-matching the tool result content into a bullet of its own.
+    Without this scrub the user sees two receipts: the LLM's restatement
+    and the canonical block we append below.
     """
     block = format_receipts_block(tool_calls)
     if not block:
         return reply_text
-    if not reply_text:
+    cleaned = _strip_fabricated_receipts(reply_text, tool_calls)
+    if not cleaned:
         return block
-    return f"{reply_text}{_SUMMARY_SEPARATOR}{block}"
+    return f"{cleaned}{_SUMMARY_SEPARATOR}{block}"
+
+
+# Action verbs the LLM reaches for when it fabricates a receipt-shaped
+# bullet from a tool result. Past-tense, lowercase. Verbs cover create,
+# update, delete, and other write-side actions across our integrations.
+_FABRICATED_RECEIPT_VERBS: frozenset[str] = frozenset(
+    {
+        "added",
+        "archived",
+        "canceled",
+        "cancelled",
+        "created",
+        "deleted",
+        "modified",
+        "moved",
+        "named",
+        "organized",
+        "removed",
+        "saved",
+        "scheduled",
+        "set",
+        "tagged",
+        "updated",
+        "uploaded",
+    }
+)
+
+# Subject nouns the LLM uses when it fabricates a receipt-shaped bullet
+# for a calendar/photo/job/accounting action. The bullet must mention
+# at least one of these to qualify for stripping; this keeps the filter
+# conservative (an unrelated bullet like "- Saved progress for next
+# time" stays put because none of these nouns appear).
+_FABRICATED_RECEIPT_NOUNS: frozenset[str] = frozenset(
+    {
+        "appointment",
+        "bill",
+        "calendar",
+        "checklist",
+        "comment",
+        "customer",
+        "document",
+        "estimate",
+        "event",
+        "file",
+        "image",
+        "invoice",
+        "meeting",
+        "memo",
+        "note",
+        "photo",
+        "project",
+        "reminder",
+        "tag",
+    }
+)
+
+_BULLET_RE = re.compile(r"^\s*-\s+(\w+)(.*)$")
+_INDENT_RE = re.compile(r"^\s{2,}\S")
+
+
+def _strip_fabricated_receipts(
+    reply_text: str,
+    tool_calls: list[StoredToolInteraction],
+) -> str:
+    """Remove receipt-shaped bullets the LLM fabricated in ``reply_text``.
+
+    Triggers only when at least one tool call this turn produced a real
+    receipt, so on tool-less responses (or read-only tool turns) we never
+    touch the LLM's output. A bullet qualifies for stripping when it
+    starts with ``-`` followed by a known write-side action verb AND
+    mentions a known subject noun (``event``, ``photo``, ``project``,
+    etc.). Any indented continuation line immediately after a stripped
+    bullet (the LLM's "Thu Apr 30, 12:00 PM" date line) is also dropped.
+
+    Trailing blank lines created by the strip are collapsed so the
+    canonical receipt block joins cleanly afterward.
+    """
+    if not reply_text:
+        return reply_text
+    has_real_receipt = any(not tc.is_error and tc.receipt is not None for tc in tool_calls)
+    if not has_real_receipt:
+        return reply_text
+
+    lines = reply_text.split("\n")
+    kept: list[str] = []
+    drop_indented = False
+    for line in lines:
+        if drop_indented:
+            if _INDENT_RE.match(line):
+                continue
+            drop_indented = False
+        match = _BULLET_RE.match(line)
+        if match:
+            verb = match.group(1).lower()
+            rest = match.group(2).lower()
+            if verb in _FABRICATED_RECEIPT_VERBS and any(
+                noun in rest for noun in _FABRICATED_RECEIPT_NOUNS
+            ):
+                drop_indented = True
+                continue
+        kept.append(line)
+
+    while kept and not kept[-1].strip():
+        kept.pop()
+    return "\n".join(kept)

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -266,24 +266,23 @@ def append_receipts(reply_text: str, tool_calls: list[StoredToolInteraction]) ->
 
 
 # Action verbs the LLM reaches for when it fabricates a receipt-shaped
-# bullet from a tool result. Past-tense, lowercase. Verbs cover create,
-# update, delete, and other write-side actions across our integrations.
+# bullet from a tool result. Past-tense, lowercase. Restricted to verbs
+# that read as receipt confirmations rather than generic English (no
+# "saved", "added", "set", "moved", "named", "organized") to avoid
+# stripping legitimate user-facing prose like "Saved $5k by switching
+# estimate templates" or "Added 3 hours to the labor estimate".
+# In prod we only saw the LLM fabricate with "Created", "Scheduled",
+# "Deleted"; the rest are receipt-flavored siblings of those.
 _FABRICATED_RECEIPT_VERBS: frozenset[str] = frozenset(
     {
-        "added",
         "archived",
         "canceled",
         "cancelled",
         "created",
         "deleted",
         "modified",
-        "moved",
-        "named",
-        "organized",
         "removed",
-        "saved",
         "scheduled",
-        "set",
         "tagged",
         "updated",
         "uploaded",

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -391,6 +391,48 @@ class ToolRegistry:
             summaries[name] = factory.summary
         return summaries
 
+    async def create_ready_specialist_tools(
+        self,
+        context: ToolContext,
+        *,
+        excluded_factories: set[str] | None = None,
+        excluded_tool_names: set[str] | None = None,
+    ) -> tuple[list[Tool], set[str]]:
+        """Materialize specialist tools for categories the user is ready to use.
+
+        A specialist is "ready" when:
+        - it is not excluded,
+        - its infrastructure deps (storage, outbound) are met,
+        - its ``auth_check`` is None OR returns None (user authenticated).
+
+        Returns ``(tools, factory_names)`` so callers can both register the
+        tools with the agent AND pre-populate the shared
+        ``activated_specialists`` set. Pre-activation skips the otherwise-mandatory
+        round trip through ``list_capabilities`` for users with connected
+        integrations: the calendar tools are simply on the schema from turn 1.
+        """
+        ready: set[str] = set()
+        for name, factory in self._factories.items():
+            if factory.core:
+                continue
+            if excluded_factories and name in excluded_factories:
+                continue
+            if factory.requires_storage and context.storage is None:
+                continue
+            if factory.requires_outbound and context.publish_outbound is None:
+                continue
+            if factory.auth_check is not None and factory.auth_check(context) is not None:
+                continue
+            ready.add(name)
+        if not ready:
+            return [], set()
+        tools = await self.create_tools(
+            context,
+            selected_factories=ready,
+            excluded_tool_names=excluded_tool_names,
+        )
+        return tools, ready
+
     def get_unauthenticated_specialists(
         self,
         context: ToolContext,

--- a/backend/app/integrations/calendar/factory.py
+++ b/backend/app/integrations/calendar/factory.py
@@ -501,13 +501,15 @@ def create_calendar_tools(
                 error_kind=ToolErrorKind.SERVICE,
             )
 
+        # Minimal content. The rich record (title, start, end) lives only in
+        # the ToolReceipt below, which is rendered server-side and shown to
+        # the user. Don't echo title/dates back to the LLM here: when we did,
+        # the model pattern-matched the formatted "field | field | field"
+        # layout into a fabricated bullet ("- Created Google Calendar event:
+        # Lunch with Tam\n  Thu Apr 30, 12:00 PM") that doubled the receipt
+        # block in the outbound. Matches the CompanyCam convention.
         return ToolResult(
-            content=(
-                f"Event created: {event.title} | "
-                f"{event.start.strftime('%Y-%m-%d %H:%M')} - "
-                f"{event.end.strftime('%H:%M')} | "
-                f"id: {event.id}"
-            ),
+            content=f"Event created (id={event.id}).",
             receipt=ToolReceipt(
                 action="Scheduled calendar event",
                 target=(f"{event.title} on {event.start.strftime('%Y-%m-%d %H:%M')}"),
@@ -578,13 +580,10 @@ def create_calendar_tools(
                 error_kind=ToolErrorKind.SERVICE,
             )
 
+        # Minimal content. See calendar_create_event above for why the rich
+        # record stays in the receipt and not in content.
         return ToolResult(
-            content=(
-                f"Event updated: {event.title} | "
-                f"{event.start.strftime('%Y-%m-%d %H:%M')} - "
-                f"{event.end.strftime('%H:%M')} | "
-                f"id: {event.id}"
-            ),
+            content=f"Event updated (id={event.id}).",
             receipt=ToolReceipt(
                 action="Updated calendar event",
                 target=(f"{event.title} on {event.start.strftime('%Y-%m-%d %H:%M')}"),

--- a/tests/test_calendar_tools.py
+++ b/tests/test_calendar_tools.py
@@ -461,7 +461,59 @@ async def test_create_event_happy_path(cal_tools: list[Tool]) -> None:
     )
     assert result.is_error is False
     assert "Event created" in result.content
-    assert "Test - Plumbing" in result.content
+    # Title and times are intentionally NOT in content -- they live in the
+    # ToolReceipt below to stop the LLM from pattern-matching the structured
+    # content into a fabricated bullet that doubles the receipt block.
+    assert "Test - Plumbing" not in result.content
+    assert result.receipt is not None
+    assert result.receipt.target.startswith("Job: Test - Plumbing on 2026-03-28")
+
+
+@pytest.mark.asyncio()
+async def test_create_event_content_is_minimal(cal_tools: list[Tool]) -> None:
+    """The LLM-visible content for create_event must omit title and dates.
+
+    Regression for the prod calendar bug observed 2026-04-29: when create_event
+    returned content like "Event created: Lunch with Tam | 2026-04-30 12:00 -
+    13:00 | id: abc", the LLM pattern-matched the formatted layout into a
+    fabricated "- Created Google Calendar event: Lunch with Tam\\n  Thu Apr
+    30, 12:00 PM" bullet that doubled the receipt block. Match the CompanyCam
+    convention: title and dates only in the ToolReceipt, never in content.
+    """
+    tool = _get_tool(cal_tools, ToolName.CALENDAR_CREATE_EVENT)
+    result = await tool.function(
+        title="Lunch with Tam",
+        start="2026-04-30T12:00:00",
+        end="2026-04-30T13:00:00",
+        calendar_id="primary",
+    )
+    assert result.is_error is False
+    # Content must not contain anything the LLM could mirror as a fake receipt.
+    assert "Lunch with Tam" not in result.content
+    assert "2026-04-30" not in result.content
+    assert "12:00" not in result.content
+    assert "|" not in result.content
+    # But the receipt has the full record so the user sees it.
+    assert result.receipt is not None
+    assert "Lunch with Tam" in result.receipt.target
+    assert "2026-04-30" in result.receipt.target
+
+
+@pytest.mark.asyncio()
+async def test_update_event_content_is_minimal() -> None:
+    """update_event content must also exclude title/dates (same reason as create)."""
+    service = MockGoogleCalendarService()
+    tools = create_calendar_tools(service, enabled_calendars=[("primary", "Personal", [], "owner")])
+    tool = _get_tool(tools, ToolName.CALENDAR_UPDATE_EVENT)
+    result = await tool.function(
+        event_id="evt-001",
+        title="Lunch with Tam (revised)",
+    )
+    assert result.is_error is False
+    assert "Lunch with Tam" not in result.content
+    assert "|" not in result.content
+    assert result.receipt is not None
+    assert "Lunch with Tam (revised)" in result.receipt.target
 
 
 @pytest.mark.asyncio()
@@ -590,7 +642,10 @@ async def test_update_event_happy_path() -> None:
     )
     assert result.is_error is False
     assert "Event updated" in result.content
-    assert "Revised" in result.content
+    # Title is intentionally NOT in content; it lives in the receipt only.
+    assert "Revised" not in result.content
+    assert result.receipt is not None
+    assert "Revised" in result.receipt.target
 
 
 @pytest.mark.asyncio()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1453,6 +1453,7 @@ class TestExecuteHeartbeatTasks:
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
             mock_registry.create_core_tools = AsyncMock(return_value=[])
+            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
             mock_registry.get_available_specialist_summaries.return_value = {}
             mock_registry.get_unauthenticated_specialists.return_value = {}
             mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -1484,6 +1485,7 @@ class TestExecuteHeartbeatTasks:
             mock_agent_instance.process_message = AsyncMock(side_effect=Exception("LLM down"))
             MockAgent.return_value = mock_agent_instance
             mock_registry.create_core_tools = AsyncMock(return_value=[])
+            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
             mock_registry.get_available_specialist_summaries.return_value = {}
             mock_registry.get_unauthenticated_specialists.return_value = {}
             mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -1517,6 +1519,7 @@ class TestExecuteHeartbeatTasks:
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
             mock_registry.create_core_tools = AsyncMock(return_value=[])
+            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
             mock_registry.get_available_specialist_summaries.return_value = {}
             mock_registry.get_unauthenticated_specialists.return_value = {}
             mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -1552,6 +1555,7 @@ class TestExecuteHeartbeatTasks:
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
             mock_registry.create_core_tools = AsyncMock(return_value=[])
+            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
             mock_registry.get_available_specialist_summaries.return_value = {
                 "quickbooks": "QB tools"
             }
@@ -3011,6 +3015,7 @@ async def test_execute_heartbeat_uses_core_tools_and_list_capabilities(user: Use
 
     mock_registry = MagicMock()
     mock_registry.create_core_tools = AsyncMock(return_value=[MagicMock(name="core_tool")])
+    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
     mock_registry.get_available_specialist_summaries.return_value = {"quickbooks": "QB tools"}
     mock_registry.get_unauthenticated_specialists.return_value = {}
     mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -3068,6 +3073,7 @@ async def test_execute_heartbeat_respects_disabled_tools(user: User) -> None:
 
     mock_registry = MagicMock()
     mock_registry.create_core_tools = AsyncMock(return_value=[])
+    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
     mock_registry.get_available_specialist_summaries.return_value = {}
     mock_registry.get_unauthenticated_specialists.return_value = {}
     mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -3271,6 +3277,7 @@ async def test_heartbeat_auto_approves_send_media_reply(user: User) -> None:
 
     mock_registry = MagicMock()
     mock_registry.create_core_tools = AsyncMock(return_value=core_tools)
+    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
     mock_registry.get_available_specialist_summaries.return_value = {}
     mock_registry.get_unauthenticated_specialists.return_value = {}
     mock_registry.get_disabled_specialist_sub_tools.return_value = {}

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import importlib
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import backend.app.agent.tools.registry as _reg
+from backend.app.agent.tools.base import Tool
 from backend.app.agent.tools.registry import (
     ToolContext,
     default_registry,
@@ -78,6 +80,111 @@ def test_auto_discovery_ignores_non_tool_modules() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_create_ready_specialist_tools_skips_unauthenticated() -> None:
+    """A specialist whose ``auth_check`` returns a reason string (user has
+    not connected the integration yet) must NOT appear in the ready list.
+
+    Regression for the prod calendar bug observed 2026-04-29: the LLM was
+    forced to call ``list_capabilities('calendar')`` on every turn because
+    specialist tools were never pre-activated. Pre-activation now happens
+    at agent boot for ready specialists, but only those passing auth.
+    """
+    from backend.app.agent.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+
+    async def _build_calendar(_ctx: ToolContext) -> list[Tool]:
+        return [cast(Tool, MagicMock(name="calendar_create_event"))]
+
+    async def _build_qb(_ctx: ToolContext) -> list[Tool]:
+        return [cast(Tool, MagicMock(name="qb_query"))]
+
+    reg.register(
+        "calendar",
+        _build_calendar,
+        core=False,
+        summary="Calendar tools",
+        auth_check=lambda _ctx: None,  # connected
+    )
+    reg.register(
+        "quickbooks",
+        _build_qb,
+        core=False,
+        summary="QuickBooks tools",
+        auth_check=lambda _ctx: "Not connected",  # NOT connected
+    )
+
+    ctx = MagicMock(spec=ToolContext)
+    ctx.user = MagicMock()
+    ctx.storage = MagicMock()
+    ctx.publish_outbound = AsyncMock()
+
+    tools, names = await reg.create_ready_specialist_tools(ctx)
+    assert names == {"calendar"}
+    assert len(tools) == 1
+
+
+@pytest.mark.asyncio()
+async def test_create_ready_specialist_tools_returns_empty_when_none_ready() -> None:
+    """No connected specialists -> empty tool list and empty name set.
+
+    Important: the caller uses the returned name set to seed
+    ``activated_specialists``. An empty set must not pre-activate anything.
+    """
+    from backend.app.agent.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+
+    async def _build(_ctx: ToolContext) -> list[Tool]:
+        return [cast(Tool, MagicMock())]
+
+    reg.register(
+        "qb",
+        _build,
+        core=False,
+        summary="QB",
+        auth_check=lambda _ctx: "Not connected",
+    )
+
+    ctx = MagicMock(spec=ToolContext)
+    ctx.user = MagicMock()
+    ctx.storage = MagicMock()
+    ctx.publish_outbound = AsyncMock()
+
+    tools, names = await reg.create_ready_specialist_tools(ctx)
+    assert tools == []
+    assert names == set()
+
+
+@pytest.mark.asyncio()
+async def test_create_ready_specialist_tools_respects_excluded_factories() -> None:
+    """User-disabled tool groups must not be pre-activated even when connected."""
+    from backend.app.agent.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+
+    async def _build(_ctx: ToolContext) -> list[Tool]:
+        return [cast(Tool, MagicMock())]
+
+    reg.register(
+        "calendar",
+        _build,
+        core=False,
+        summary="Calendar",
+        auth_check=lambda _ctx: None,
+    )
+
+    ctx = MagicMock(spec=ToolContext)
+    ctx.user = MagicMock()
+    ctx.storage = MagicMock()
+    ctx.publish_outbound = AsyncMock()
+
+    tools, names = await reg.create_ready_specialist_tools(ctx, excluded_factories={"calendar"})
+    assert tools == []
+    assert names == set()
+
+
+@pytest.mark.asyncio()
 async def test_ask_sub_tools_have_approval_policy() -> None:
     """Every tool with default_permission='ask' must have an ApprovalPolicy.
 
@@ -113,8 +220,6 @@ async def test_ask_sub_tools_have_approval_policy() -> None:
         # can't build tools without credentials).
         try:
             import inspect
-
-            from backend.app.agent.tools.base import Tool
 
             result = factory.create(ctx)
             tools: list[Tool] = await result if inspect.isawaitable(result) else result  # type: ignore[assignment]

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -260,6 +260,37 @@ def test_append_keeps_unrelated_bullets_when_receipt_present() -> None:
     assert "- Smith: paid in full" in body
 
 
+def test_append_does_not_strip_generic_english_verb_bullets() -> None:
+    """Bullets starting with generic English verbs ("Saved", "Added", "Set",
+    "Moved", "Named", "Organized") must survive the scrub even when the turn
+    has a real receipt.
+
+    The receipt-flavored noun set is broad enough that a sentence like
+    "Saved $5k by switching estimate templates" or "Added 3 hours to the
+    labor estimate" would be a false positive if the verb set included
+    these generic verbs. Restricting verbs to receipt-flavored ones
+    (Created, Scheduled, Updated, Deleted, etc.) keeps the filter safe.
+    """
+    body = append_receipts(
+        (
+            "Here's the summary:\n"
+            "- Saved $5k by switching estimate templates\n"
+            "- Added 3 hours to the labor estimate\n"
+            "- Set up a reminder for next Tuesday's invoice"
+        ),
+        [
+            _tc_with_receipt(
+                "memory_save",
+                action="Saved memory",
+                target="estimate-templates note",
+            )
+        ],
+    )
+    assert "Saved $5k" in body
+    assert "Added 3 hours" in body
+    assert "Set up a reminder" in body
+
+
 def test_append_does_not_strip_when_no_real_receipt() -> None:
     """Without a real receipt this turn, leave the LLM's text alone.
 

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -160,6 +160,121 @@ def test_append_returns_reply_unchanged_when_no_receipts() -> None:
     assert body == "Here's what I found."
 
 
+def test_append_strips_llm_fabricated_calendar_bullet() -> None:
+    """When the LLM restates a calendar receipt as its own bullet, scrub it.
+
+    Regression for the prod calendar bug observed 2026-04-29: the LLM was
+    emitting a "- Created Google Calendar event: Lunch with Tam\\n  Thu Apr
+    30, 12:00 PM..." bullet inside reply_text and ``append_receipts``
+    appended the canonical "- Scheduled calendar event Lunch with Tam on
+    2026-04-30 12:00" below it, so the user saw two receipts per event.
+    """
+    body = append_receipts(
+        (
+            "Done! Lunch with Tam is on your calendar for tomorrow at noon.\n\n"
+            "- Created Google Calendar event: Lunch with Tam\n"
+            "  Thu Apr 30, 12:00 PM – 1:00 PM"  # noqa: RUF001
+        ),
+        [
+            _tc_with_receipt(
+                "calendar_create_event",
+                action="Scheduled calendar event",
+                target="Lunch with Tam on 2026-04-30 12:00",
+            )
+        ],
+    )
+    # Fabricated bullet and its indented date line are gone.
+    assert "Created Google Calendar event" not in body
+    assert "Thu Apr 30" not in body
+    # Real receipt is appended.
+    assert "- Scheduled calendar event Lunch with Tam on 2026-04-30 12:00" in body
+    # Reply preface is preserved.
+    assert body.startswith("Done! Lunch with Tam is on your calendar")
+
+
+def test_append_strips_multiple_fabricated_bullets() -> None:
+    """Two events created in one turn produce two fabricated bullets;
+    both should be stripped so only the canonical receipts remain.
+    """
+    body = append_receipts(
+        (
+            "Both reminders are set.\n\n"
+            "- Scheduled calendar event: Call PNC Bank about a vehicle loan\n"
+            "  Thu Apr 30, 11:00 AM\n\n"
+            "- Scheduled calendar event: Call Maryann and Mark about jobs\n"
+            "  Thu Apr 30, 9:00 AM"
+        ),
+        [
+            _tc_with_receipt(
+                "calendar_create_event",
+                action="Scheduled calendar event",
+                target="Call PNC Bank about a vehicle loan on 2026-04-30 11:00",
+            ),
+            _tc_with_receipt(
+                "calendar_create_event",
+                action="Scheduled calendar event",
+                target="Call Maryann and Mark about jobs on 2026-04-30 09:00",
+            ),
+        ],
+    )
+    # Only the canonical receipts should appear, once each.
+    assert body.count("- Scheduled calendar event") == 2
+    assert "Thu Apr 30, 11:00 AM" not in body
+    assert "Thu Apr 30, 9:00 AM" not in body
+    assert body.startswith("Both reminders are set.")
+
+
+def test_append_strips_delete_fabricated_bullet() -> None:
+    """The LLM also fabricates "Deleted Google Calendar event:" lines for
+    cancellations. Same scrub should catch them."""
+    body = append_receipts(
+        ("Done, that's off your calendar.\n\n- Deleted Google Calendar event: Lunch with Tam"),
+        [
+            _tc_with_receipt(
+                "calendar_delete_event",
+                action="Canceled calendar event",
+                target="abc123",
+            )
+        ],
+    )
+    assert "Deleted Google Calendar event" not in body
+    assert "- Canceled calendar event abc123" in body
+
+
+def test_append_keeps_unrelated_bullets_when_receipt_present() -> None:
+    """A non-receipt bullet ("- Acme: $5k owed") in the LLM's reply must
+    survive the scrub. The filter only fires on lines that look like
+    fabricated tool receipts (action verb + receipt-flavored noun)."""
+    body = append_receipts(
+        ("Here's what I found:\n- Acme: $5k owed\n- Smith: paid in full"),
+        [
+            _tc_with_receipt(
+                "qb_create",
+                action="Created QuickBooks invoice for",
+                target="Davis",
+                url="https://app.qbo.intuit.com/app/invoice?txnId=1",
+            )
+        ],
+    )
+    assert "- Acme: $5k owed" in body
+    assert "- Smith: paid in full" in body
+
+
+def test_append_does_not_strip_when_no_real_receipt() -> None:
+    """Without a real receipt this turn, leave the LLM's text alone.
+
+    The scrub only fires when a canonical receipt block will be appended
+    below. If the agent had no write-side tool calls, an LLM bullet that
+    happens to start with a receipt-like verb is just user-relevant
+    text and must pass through untouched.
+    """
+    body = append_receipts(
+        "- Created a draft of the proposal in your notes.",
+        [_tc_no_receipt("read_file")],
+    )
+    assert body == "- Created a draft of the proposal in your notes."
+
+
 def test_append_handles_empty_reply_text() -> None:
     """If the LLM returned no text but a mutation ran, the receipt block
     still ships so the user sees the confirmation."""


### PR DESCRIPTION
## Description

Two prod bugs from the 2026-04-29 user observation, fixed in one PR.

**Bug 1: every Google Calendar event produces a duplicated confirmation.**

```
Done! Lunch with Tam is on your calendar for tomorrow at noon.

- Created Google Calendar event: Lunch with Tam
  Thu Apr 30, 12:00 PM – 1:00 PM

- Scheduled calendar event Lunch with Tam on 2026-04-30 12:00
```

The first bullet is fabricated by the LLM. The second is the canonical
`ToolReceipt` block. Root cause: `calendar_create_event` returned `content`
formatted like `"Event created: Lunch with Tam | 2026-04-30 12:00 - 13:00 | id: abc"`,
and the LLM dutifully pattern-matched it into a receipt-shaped bullet of its
own. (See `core.py:798` — a previous engineer hit this exact class of bug.)

**Bug 2: `list_capabilities` fires every turn for users with connected integrations.**

`activated_specialists` was created fresh per-message, so every inbound from
a calendar-connected user spent a tool round on `list_capabilities('calendar')`
before the agent could even call `calendar_create_event`.

## Fix (defense in depth)

1. **Minimal calendar content**, matching CompanyCam's pattern: `Event created (id=abc)` instead of `Event created: Lunch with Tam | 2026-04-30 12:00 - 13:00 | id: abc`. The rich record lives only in the `ToolReceipt`. LLM has nothing to mirror.

2. **Defensive scrub** in `tool_summary.append_receipts`: `_strip_fabricated_receipts()` removes bullet lines that look like fabricated receipts (action verb + receipt-flavored noun) plus their indented continuation lines, only triggered when the turn produced a real receipt. Catches future tools that ship rich content + any LLM that mirrors the format anyway.

3. **Pre-activate ready specialists** at agent boot via `ToolRegistry.create_ready_specialist_tools`. Calendar tools are on the schema from turn 1 for connected users; `list_capabilities` round-trip is no longer needed. `list_capabilities` still surfaces unconnected integrations for discovery.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v` — 1973 passing, +9 net)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] Type checking passes (`uv run ty check --python .venv backend/ tests/ alembic/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## Regression tests added
- `tests/test_calendar_tools.py::test_create_event_content_is_minimal` and `::test_update_event_content_is_minimal` — calendar content invariant.
- `tests/test_tool_summary.py::test_append_strips_llm_fabricated_calendar_bullet` — exact transcript shape from prod (Lunch with Tam).
- `tests/test_tool_summary.py::test_append_strips_multiple_fabricated_bullets` — two events one turn (PNC, Maryann/Mark).
- `tests/test_tool_summary.py::test_append_strips_delete_fabricated_bullet` — delete variant.
- `tests/test_tool_summary.py::test_append_keeps_unrelated_bullets_when_receipt_present` — false-positive guard.
- `tests/test_tool_summary.py::test_append_does_not_strip_when_no_real_receipt` — no-trigger guard.
- `tests/test_tool_registry.py::test_create_ready_specialist_tools_skips_unauthenticated`
- `tests/test_tool_registry.py::test_create_ready_specialist_tools_returns_empty_when_none_ready`
- `tests/test_tool_registry.py::test_create_ready_specialist_tools_respects_excluded_factories`

## AI Usage
- [x] AI-assisted (Claude Code drove root-cause investigation, the two-layer fix design, and implementation; user reviewed and approved both layers including the CompanyCam-pattern alignment)
- [ ] No AI used