### PR TITLE
feat(health): add /api/health/live liveness probe

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -12,6 +12,14 @@ router = APIRouter()
 
 @router.get("/health", response_model=HealthResponse)
 async def health_check() -> HealthResponse:
+    """Full health check: process is up AND can reach the database.
+
+    Use for ops dashboards and richer monitoring. NOT recommended as the
+    deployment platform's healthcheck path: a sync DB call from an async
+    handler can block the event loop, and during an incident a healthcheck
+    that waits on the same DB can pile up alongside whatever already broke.
+    Use ``/health/live`` for that.
+    """
     db_status = "ok"
     try:
         db = SessionLocal()
@@ -25,3 +33,16 @@ async def health_check() -> HealthResponse:
 
     status = "ok" if db_status == "ok" else "degraded"
     return HealthResponse(status=status, database=db_status)
+
+
+@router.get("/health/live", response_model=HealthResponse)
+async def health_live() -> HealthResponse:
+    """Liveness probe: the process is up and the event loop is responsive.
+
+    No DB hit, no external calls. Returns instantly when the worker can
+    process requests. Designed for the deployment platform's healthcheck
+    so a stuck DB / external dep / slow query does not also block the
+    healthcheck and prevent traffic from rolling to a fresh container.
+    Use ``/health`` for the deeper "is the system actually working" check.
+    """
+    return HealthResponse(status="ok", database="not_checked")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -6,3 +6,16 @@ def test_health_endpoint(client: TestClient) -> None:
     assert response.status_code == 200
     data = response.json()
     assert data == {"status": "ok", "database": "ok"}
+
+
+def test_health_live_endpoint(client: TestClient) -> None:
+    """The liveness probe must respond instantly without touching the DB.
+
+    Used as the deployment platform's healthcheck path so a stuck DB or
+    a blocked event loop on another worker does not also pile up on the
+    healthcheck and prevent traffic from rolling to a fresh container.
+    """
+    response = client.get("/api/health/live")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"status": "ok", "database": "not_checked"}


### PR DESCRIPTION
## Description

Add a no-DB-touching ``/api/health/live`` endpoint as a safer target for Railway's healthcheck path.

## Why

Today's ``/api/health`` opens a sync DB session and runs ``SELECT 1`` from an async handler. When the event loop is blocked (sync DB call backed up, slow third-party HTTP call), the healthcheck piles up on the same blocked worker and starts returning 502 to Railway's edge. We saw this live this afternoon: ``/api/user/chat/activity`` SSE streams + a slow upstream froze the single uvicorn worker, and the external ``/api/health`` probe hit a 30s timeout → Railway 502 → site looked down.

``/api/health/live`` returns ``{"status":"ok","database":"not_checked"}`` instantly with no DB connection. Premium will switch its ``railway.toml`` healthcheckPath to this in a follow-up. ``/api/health`` stays for ops dashboards and richer monitoring.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (1979/1979)
- [x] Lint passes
- [x] Type checking passes
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code diagnosed the prod hang from logs and proposed the split-endpoint fix)
- [ ] No AI used