### PR TITLE
fix(channels): bluebubbles reliability, fire-and-forget typing + bounded retries (#1083, #1088)

### DIFF
--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -24,6 +24,31 @@ logger = logging.getLogger(__name__)
 
 STARTUP_DELAY_SECONDS = 3
 
+# Typing indicators run as fire-and-forget tasks (see ChannelManager).
+# Bound them tightly so even if the BlueBubbles server is wedged the task
+# clears quickly instead of consuming an HTTP slot for the full default
+# request timeout.
+_TYPING_TIMEOUT_SECONDS = 3.0
+
+# Outbound send retry policy. Self-hosted BlueBubbles servers running on
+# consumer hardware frequently hit transient failures (Mac wakes from
+# sleep, brief WiFi blip, BlueBubbles process restart). Without retry,
+# the dispatcher catches the exception and silently drops the reply.
+#
+# Per-attempt timeout is shorter than the default ``http_timeout_seconds``
+# (30s) so a hung server does not stretch the worst case past ~50s. With
+# 1 initial attempt + 3 retries and 1s/2s/4s backoff that totals
+# 10+1+10+2+10+4+10 = 47s before giving up.
+_SEND_TIMEOUT_SECONDS = 10.0
+_SEND_RETRY_BACKOFFS = (1.0, 2.0, 4.0)
+_TRANSIENT_HTTP_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
+    httpx.PoolTimeout,
+    httpx.RemoteProtocolError,
+)
+
 
 def _derive_webhook_token(password: str) -> str:
     """Derive a webhook authentication token from the BlueBubbles server password.
@@ -398,6 +423,48 @@ class BlueBubblesChannel(BaseChannel):
             return cached
         return f"iMessage;-;{to}"
 
+    async def _post_with_retry(self, url: str, **kwargs: object) -> httpx.Response:
+        """POST to BlueBubbles with bounded retries on transient failures.
+
+        Retries on connection errors, read/write/pool timeouts, remote
+        protocol errors, and 5xx responses. Does not retry on 4xx (those
+        indicate caller error: bad payload, missing chat, auth failure)
+        or non-network exceptions. Retries are safe because BlueBubbles
+        dedupes on ``tempGuid`` which the caller passes through unchanged.
+        """
+        delays: tuple[float, ...] = (0.0, *_SEND_RETRY_BACKOFFS)
+        last_exc: Exception | None = None
+        for attempt, delay in enumerate(delays):
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                resp = await self._http.post(url, timeout=_SEND_TIMEOUT_SECONDS, **kwargs)  # type: ignore[arg-type]
+            except _TRANSIENT_HTTP_EXCEPTIONS as exc:
+                last_exc = exc
+                logger.warning(
+                    "BlueBubbles %s transient failure (attempt %d/%d): %s",
+                    url,
+                    attempt + 1,
+                    len(delays),
+                    type(exc).__name__,
+                )
+                continue
+            if resp.status_code < 500:
+                return resp
+            # 5xx: server error, worth retrying
+            last_exc = httpx.HTTPStatusError(
+                f"{resp.status_code} from {url}", request=resp.request, response=resp
+            )
+            logger.warning(
+                "BlueBubbles %s 5xx (attempt %d/%d): status=%d",
+                url,
+                attempt + 1,
+                len(delays),
+                resp.status_code,
+            )
+        assert last_exc is not None
+        raise last_exc
+
     async def send_text(self, to: str, body: str) -> str:
         """Send a text message via BlueBubbles API."""
         chat_guid = self._get_chat_guid(to)
@@ -414,7 +481,7 @@ class BlueBubblesChannel(BaseChannel):
             settings.bluebubbles_send_method,
             len(body),
         )
-        resp = await self._http.post(
+        resp = await self._post_with_retry(
             "/api/v1/message/text",
             json=payload,
             params={"password": settings.bluebubbles_password},
@@ -450,7 +517,7 @@ class BlueBubblesChannel(BaseChannel):
         if body:
             data_fields["message"] = body
 
-        resp = await self._http.post(
+        resp = await self._post_with_retry(
             "/api/v1/message/attachment",
             data=data_fields,
             files=files,
@@ -475,6 +542,7 @@ class BlueBubblesChannel(BaseChannel):
             resp = await self._http.post(
                 f"/api/v1/chat/{chat_guid}/typing",
                 params={"password": settings.bluebubbles_password},
+                timeout=_TYPING_TIMEOUT_SECONDS,
             )
             if resp.status_code >= 400:
                 logger.warning(
@@ -501,6 +569,7 @@ class BlueBubblesChannel(BaseChannel):
             resp = await self._http.delete(
                 f"/api/v1/chat/{chat_guid}/typing",
                 params={"password": settings.bluebubbles_password},
+                timeout=_TYPING_TIMEOUT_SECONDS,
             )
             if resp.status_code >= 400:
                 logger.warning(

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -34,6 +34,11 @@ class ChannelManager:
     def __init__(self) -> None:
         self._channels: dict[str, BaseChannel] = {}
         self._bus_tasks: list[asyncio.Task[None]] = []
+        # Typing indicators run as fire-and-forget tasks so a slow upstream
+        # (e.g. an unreachable BlueBubbles server) does not block the
+        # outbound dispatcher and delay actual message delivery. We track
+        # them so shutdown can cancel any still in flight.
+        self._typing_tasks: set[asyncio.Task[None]] = set()
 
     # -- Registration ----------------------------------------------------------
 
@@ -158,9 +163,15 @@ class ChannelManager:
 
             try:
                 if outbound.is_typing_stop:
-                    await channel.stop_typing_indicator(to=outbound.chat_id)
+                    self._spawn_typing_task(
+                        channel.stop_typing_indicator(to=outbound.chat_id),
+                        outbound.channel,
+                    )
                 elif outbound.is_typing_indicator:
-                    await channel.send_typing_indicator(to=outbound.chat_id)
+                    self._spawn_typing_task(
+                        channel.send_typing_indicator(to=outbound.chat_id),
+                        outbound.channel,
+                    )
                 elif outbound.media:
                     await channel.send_message(
                         to=outbound.chat_id,
@@ -175,6 +186,28 @@ class ChannelManager:
                     outbound.channel,
                     outbound.chat_id,
                 )
+
+    def _spawn_typing_task(self, coro: Awaitable[None], channel_name: str) -> None:
+        """Run a typing-indicator coroutine as a background task.
+
+        Typing indicators are best-effort UX polish. Awaiting them inline
+        on the outbound dispatcher means a slow or unreachable upstream
+        (BlueBubbles in particular) blocks every reply behind it. By
+        spawning the call as a background task we keep the dispatcher
+        free to deliver real messages immediately. Errors are swallowed
+        with a debug log; the channel implementations already log their
+        own failures.
+        """
+
+        async def _runner() -> None:
+            try:
+                await coro
+            except Exception:
+                logger.debug("Typing indicator task on %s failed", channel_name, exc_info=True)
+
+        task = asyncio.create_task(_runner(), name=f"typing-{channel_name}")
+        self._typing_tasks.add(task)
+        task.add_done_callback(self._typing_tasks.discard)
 
     # -- Lifecycle -------------------------------------------------------------
 
@@ -211,6 +244,16 @@ class ChannelManager:
                 await task
         self._bus_tasks.clear()
         logger.info("Stopped message bus consumer and outbound dispatcher")
+
+        # Cancel any in-flight typing-indicator tasks so they do not extend
+        # shutdown waiting on an unreachable upstream.
+        for task in list(self._typing_tasks):
+            if not task.done():
+                task.cancel()
+        for task in list(self._typing_tasks):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        self._typing_tasks.clear()
 
         for channel in self._channels.values():
             try:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8,7 +8,27 @@
     "/api/health": {
       "get": {
         "summary": "Health Check",
+        "description": "Full health check: process is up AND can reach the database.\n\nUse for ops dashboards and richer monitoring. NOT recommended as the\ndeployment platform's healthcheck path: a sync DB call from an async\nhandler can block the event loop, and during an incident a healthcheck\nthat waits on the same DB can pile up alongside whatever already broke.\nUse ``/health/live`` for that.",
         "operationId": "health_check_api_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/health/live": {
+      "get": {
+        "summary": "Health Live",
+        "description": "Liveness probe: the process is up and the event loop is responsive.\n\nNo DB hit, no external calls. Returns instantly when the worker can\nprocess requests. Designed for the deployment platform's healthcheck\nso a stuck DB / external dep / slow query does not also block the\nhealthcheck and prevent traffic from rolling to a fresh container.\nUse ``/health`` for the deeper \"is the system actually working\" check.",
+        "operationId": "health_live_api_health_live_get",
         "responses": {
           "200": {
             "description": "Successful Response",

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -11,8 +11,43 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Health Check */
+        /**
+         * Health Check
+         * @description Full health check: process is up AND can reach the database.
+         *
+         *     Use for ops dashboards and richer monitoring. NOT recommended as the
+         *     deployment platform's healthcheck path: a sync DB call from an async
+         *     handler can block the event loop, and during an incident a healthcheck
+         *     that waits on the same DB can pile up alongside whatever already broke.
+         *     Use ``/health/live`` for that.
+         */
         get: operations["health_check_api_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/health/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health Live
+         * @description Liveness probe: the process is up and the event loop is responsive.
+         *
+         *     No DB hit, no external calls. Returns instantly when the worker can
+         *     process requests. Designed for the deployment platform's healthcheck
+         *     so a stuck DB / external dep / slow query does not also block the
+         *     healthcheck and prevent traffic from rolling to a fresh container.
+         *     Use ``/health`` for the deeper "is the system actually working" check.
+         */
+        get: operations["health_live_api_health_live_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1445,6 +1480,26 @@ export interface components {
 export type $defs = Record<string, never>;
 export interface operations {
     health_check_api_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
+    };
+    health_live_api_health_live_get: {
         parameters: {
             query?: never;
             header?: never;

--- a/tests/test_bluebubbles_channel.py
+++ b/tests/test_bluebubbles_channel.py
@@ -486,6 +486,160 @@ async def test_stop_typing_indicator_no_error_on_failure() -> None:
         await channel.stop_typing_indicator("+15551234567")
 
 
+# ---------------------------------------------------------------------------
+# Retry tests (regression for #1088)
+# ---------------------------------------------------------------------------
+
+
+async def test_send_text_retries_transient_connect_error_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First attempt raises httpx.ConnectError, retry succeeds.
+
+    Regression for #1088. Self-hosted BlueBubbles servers running on
+    consumer hardware drop occasional connections (Mac waking from sleep,
+    WiFi blip). Without retry these requests silently lost the user's
+    reply.
+    """
+    # Skip the actual sleeps to keep the test fast.
+    monkeypatch.setattr("backend.app.channels.bluebubbles._SEND_RETRY_BACKOFFS", (0.0, 0.0, 0.0))
+
+    attempts: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(len(attempts) + 1)
+        if len(attempts) == 1:
+            raise httpx.ConnectError("connection refused", request=request)
+        return httpx.Response(200, json={"guid": "msg-after-retry"})
+
+    channel = BlueBubblesChannel()
+    channel._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://bluebubbles.example"
+    )
+
+    result = await channel.send_text("+15551234567", "Hello")
+
+    assert result == "msg-after-retry"
+    assert len(attempts) == 2
+
+
+async def test_send_text_retries_5xx_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """First attempt returns 503, retry returns 200."""
+    monkeypatch.setattr("backend.app.channels.bluebubbles._SEND_RETRY_BACKOFFS", (0.0, 0.0, 0.0))
+
+    statuses: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if not statuses:
+            statuses.append(503)
+            return httpx.Response(503, text="bb backend unavailable")
+        statuses.append(200)
+        return httpx.Response(200, json={"guid": "msg-after-retry"})
+
+    channel = BlueBubblesChannel()
+    channel._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://bluebubbles.example"
+    )
+
+    result = await channel.send_text("+15551234567", "Hello")
+
+    assert result == "msg-after-retry"
+    assert statuses == [503, 200]
+
+
+async def test_send_text_does_not_retry_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    """4xx responses are caller errors and must not be retried.
+
+    A 401 means our credentials are wrong; retrying would just hammer the
+    server. Same for 400 (bad payload) and 404 (chat does not exist).
+    """
+    monkeypatch.setattr("backend.app.channels.bluebubbles._SEND_RETRY_BACKOFFS", (0.0, 0.0, 0.0))
+
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(401, text="unauthorized")
+
+    channel = BlueBubblesChannel()
+    channel._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://bluebubbles.example"
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await channel.send_text("+15551234567", "Hello")
+
+    assert call_count == 1
+
+
+async def test_send_text_gives_up_after_max_retries_and_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If every attempt fails transiently, the helper exhausts retries and raises.
+
+    The dispatcher catches the exception, logs it, and moves on, so the
+    caller observes a single raised exception (not a silent drop).
+    """
+    monkeypatch.setattr("backend.app.channels.bluebubbles._SEND_RETRY_BACKOFFS", (0.0, 0.0, 0.0))
+
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        raise httpx.ConnectError("connection refused", request=request)
+
+    channel = BlueBubblesChannel()
+    channel._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://bluebubbles.example"
+    )
+
+    with pytest.raises(httpx.ConnectError):
+        await channel.send_text("+15551234567", "Hello")
+
+    # 1 initial + 3 retries = 4 attempts
+    assert call_count == 4
+
+
+async def test_send_text_preserves_temp_guid_across_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retried POSTs must carry the same tempGuid so BlueBubbles dedupes.
+
+    Without this, a retry after a partial-success would create a duplicate
+    iMessage. BlueBubbles uses tempGuid as the client-side dedup key.
+    """
+    monkeypatch.setattr("backend.app.channels.bluebubbles._SEND_RETRY_BACKOFFS", (0.0, 0.0, 0.0))
+
+    seen_temp_guids: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.read()
+        import json as _json
+
+        payload = _json.loads(body)
+        seen_temp_guids.append(payload["tempGuid"])
+        if len(seen_temp_guids) == 1:
+            raise httpx.ConnectError("transient", request=request)
+        return httpx.Response(200, json={"guid": "ok"})
+
+    channel = BlueBubblesChannel()
+    channel._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://bluebubbles.example"
+    )
+
+    await channel.send_text("+15551234567", "Hello")
+
+    assert len(seen_temp_guids) == 2
+    assert seen_temp_guids[0] == seen_temp_guids[1]
+
+
+# ---------------------------------------------------------------------------
+# Send media tests
+# ---------------------------------------------------------------------------
+
+
 async def test_send_media_multipart_upload() -> None:
     """send_media should download media then upload as multipart form data."""
     channel = BlueBubblesChannel()

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -228,3 +228,79 @@ async def test_dispatcher_routes_typing_stop_to_channel() -> None:
 
     assert recipient == "+15551234567"
     assert ch.stopped_typing_for == ["+15551234567"]
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_does_not_block_on_slow_typing_indicator() -> None:
+    """Outbound dispatcher must keep delivering messages even when a
+    typing-indicator call hangs.
+
+    Regression for #1083. In production, an unreachable BlueBubbles server
+    caused ``send_typing_indicator`` to block for the full HTTP timeout
+    (~30s). Because the dispatcher was awaiting the typing call inline,
+    every queued reply behind it sat for the same duration. The fix runs
+    typing indicators as fire-and-forget tasks; this test pins that
+    behavior by queuing a slow typing call followed by a text message and
+    asserting the text message is delivered without waiting for typing to
+    resolve.
+    """
+    from backend.app.bus import OutboundMessage
+
+    mgr = ChannelManager()
+    ch = _StubChannel("bluebubbles")
+    mgr.register(ch)
+
+    typing_started = asyncio.get_running_loop().create_future()
+    typing_release = asyncio.get_running_loop().create_future()
+    text_sent = asyncio.get_running_loop().create_future()
+
+    async def slow_typing(to: str) -> None:
+        if not typing_started.done():
+            typing_started.set_result(to)
+        # Block until the test releases us, simulating an unreachable server.
+        await typing_release
+
+    async def fast_send_text(to: str, body: str) -> str:
+        if not text_sent.done():
+            text_sent.set_result((to, body))
+        return "stub-id"
+
+    ch.send_typing_indicator = slow_typing  # type: ignore[method-assign]
+    ch.send_text = fast_send_text  # type: ignore[method-assign]
+
+    # Drain anything already queued.
+    while not message_bus.outbound.empty():
+        message_bus.outbound.get_nowait()
+
+    await message_bus.publish_outbound(
+        OutboundMessage(
+            channel="bluebubbles",
+            chat_id="+15551234567",
+            content="",
+            is_typing_indicator=True,
+        )
+    )
+    await message_bus.publish_outbound(
+        OutboundMessage(
+            channel="bluebubbles",
+            chat_id="+15551234567",
+            content="hello world",
+        )
+    )
+
+    dispatcher = asyncio.create_task(mgr._run_outbound_dispatcher())
+    try:
+        # Typing call must enter, but the text reply must follow without
+        # waiting for typing to finish.
+        await asyncio.wait_for(typing_started, timeout=1.0)
+        recipient, body = await asyncio.wait_for(text_sent, timeout=1.0)
+        assert recipient == "+15551234567"
+        assert body == "hello world"
+    finally:
+        # Release the hung typing call so the background task can exit.
+        if not typing_release.done():
+            typing_release.set_result(None)
+        dispatcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await dispatcher
+        await mgr.stop_all()


### PR DESCRIPTION
## Description

Fixes #1083 and #1088. Two BlueBubbles reliability fixes that combine to turn "BlueBubbles flakiness drops user replies" into "BlueBubbles flakiness adds a few seconds of delay".

### #1083: typing indicators block reply delivery

Production observation: an agent reply was generated but sat ~27 seconds before being delivered. The only event in that window was a 30s typing-indicator timeout. Root cause: the outbound dispatcher in `ChannelManager._run_outbound_dispatcher` was awaiting typing calls inline; because the dispatcher is a single asyncio task, every queued reply waited behind the typing call.

Fix: typing/stop_typing are now spawned as background tasks via a new `_spawn_typing_task()` helper. Tasks are tracked on `self._typing_tasks` and cancelled in `stop_all()`. BlueBubbles typing calls also get an explicit 3s timeout so orphan tasks self-terminate quickly.

### #1088: zero retry on transient send failures

The dispatcher catches `Exception` from `send_text`/`send_media` and silently drops the reply. Self-hosted BlueBubbles servers running on consumer hardware (the maintainer's basement Mac) hit transient failures regularly: Mac waking from sleep, brief WiFi blip, BlueBubbles process restart. Without retry the user never sees the reply.

Fix: new `_post_with_retry` helper in `bluebubbles.py`. 4 attempts (1 initial + 3 retries), 1s/2s/4s backoff, 10s per-attempt timeout. Retries on `httpx.ConnectError`, `ReadTimeout`, `WriteTimeout`, `PoolTimeout`, `RemoteProtocolError` and 5xx responses. Never retries 4xx (caller error). `tempGuid` is generated once before the retry loop so BlueBubbles client-side dedupe stops a partial-success retry from creating a duplicate iMessage.

Typing indicators are intentionally **not** retried; #1083 makes them fire-and-forget and retrying would defeat that fix.

### Worst-case timing

If BlueBubbles is fully unreachable, `send_text` spends up to ~47s exhausting retries before giving up (10+1+10+2+10+4+10). Acceptable because most basement-Mac flakes are sub-10s and clear on the first retry. Multi-minute outages still drop replies; a persistent outbound queue is the next reliability layer if needed.

## Tests

- `tests/test_channels.py`: regression test for #1083, queues a hung typing call followed by a text reply and asserts the text is delivered without waiting for typing.
- `tests/test_bluebubbles_channel.py`: 5 regression tests for #1088, transient ConnectError then retry then success, 5xx then retry then 200, 4xx not retried, exhaust retries then raise, tempGuid stable across retries.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: drafted by Claude via back-and-forth with @njbrake. Reasoning and decisions are mine; prose is Claude's.