### PR TITLE
chore(gitignore): ignore PLAN_*.md and drop stale plan doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ clawbolt-premium/
 clawbolt-infra/
 data/
 
+# Agent planning docs (output of /autoplan and similar). Intended to be
+# ephemeral working state, not committed to the repo.
+/PLAN_*.md
+
 # Frontend
 frontend/node_modules/
 frontend/dist/


### PR DESCRIPTION
## Description

The `/autoplan` skill writes `PLAN_<topic>.md` files at repo root as ephemeral working state. `PLAN_onboarding_fixup.md` from a previous session was sitting untracked at the root. Add the pattern so future planning docs do not surface in git status, and remove the stale one.

## Type
- [x] CI/CD

## Checklist
- [x] No code changes; gitignore-only
- [x] `git check-ignore -v PLAN_anything.md` confirms the new pattern matches

## AI Usage
- [x] AI-assisted: drafted by Claude via back-and-forth with @njbrake. Reasoning and decisions are mine; prose is Claude's.