### PR TITLE
fix(channels): skip /bot-info call when telegram_bot_token_set is false

### DIFF
--- a/frontend/src/hooks/useChannelStates.ts
+++ b/frontend/src/hooks/useChannelStates.ts
@@ -54,14 +54,20 @@ export function useChannelStates(): ChannelStatesResult {
   const routesQuery = useChannelRoutes();
   const configQuery = useChannelConfig();
 
-  // Premium link queries (only fire when isPremium)
-  const telegramLinkQuery = useTelegramLink(isPremium);
-  const telegramBotInfoQuery = useTelegramBotInfo(isPremium);
-  const linqLinkQuery = useLinqLink(isPremium);
-  const blueBubblesLinkQuery = useBlueBubblesLink(isPremium);
-
   const routes = routesQuery.data?.routes ?? [];
   const channelConfig = configQuery.data;
+
+  // Premium link queries (only fire when isPremium).
+  // Bot info is additionally gated on telegram_bot_token_set: in premium
+  // prod, tenants are routed via tenant-specific bots and the global
+  // TELEGRAM_BOT_TOKEN env var is empty, so the OSS /bot-info endpoint
+  // returns 404 (issue #332). Skipping the call when no bot token is
+  // configured eliminates the noise without touching backend behavior.
+  const telegramBotTokenSet = channelConfig?.telegram_bot_token_set ?? false;
+  const telegramLinkQuery = useTelegramLink(isPremium);
+  const telegramBotInfoQuery = useTelegramBotInfo(isPremium && telegramBotTokenSet);
+  const linqLinkQuery = useLinqLink(isPremium);
+  const blueBubblesLinkQuery = useBlueBubblesLink(isPremium);
 
   // Build premium data from React Query results
   const linkDataMap = useMemo<Partial<Record<ChannelKey, PremiumLinkData | null>>>(() => {

--- a/frontend/src/pages/ChannelsPage.test.tsx
+++ b/frontend/src/pages/ChannelsPage.test.tsx
@@ -392,6 +392,32 @@ describe('ChannelsPage - Unavailable channels are hidden', () => {
     expect(screen.queryByText(/Contact your administrator to enable Telegram/)).not.toBeInTheDocument();
     expect(screen.queryByText(/TELEGRAM_BOT_TOKEN/)).not.toBeInTheDocument();
   });
+
+  it('does not call /bot-info when telegram_bot_token_set is false (regression #332)', async () => {
+    // In premium prod, tenants are routed via tenant-specific bots and the
+    // global TELEGRAM_BOT_TOKEN env var is empty, so the OSS /bot-info
+    // endpoint returns 404. The frontend must not call it in that state.
+    mockGetChannelConfig.mockResolvedValue({
+      telegram_bot_token_set: false,
+      telegram_allowed_chat_id: '',
+      linq_api_token_set: true,
+      linq_from_number: '+15551234567',
+      linq_allowed_numbers: '',
+      linq_preferred_service: 'iMessage',
+      bluebubbles_configured: false,
+      bluebubbles_allowed_numbers: '',
+      imessage_backend: 'linq',
+    });
+    mockGetTelegramLink.mockResolvedValue({ telegram_user_id: null, connected: false });
+    mockGetLinqLink.mockResolvedValue({ phone_number: null, connected: false });
+
+    renderWithRouter(<ChannelsPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('iMessage')).toBeInTheDocument();
+    });
+    expect(mockGetTelegramBotInfo).not.toHaveBeenCalled();
+  });
 });
 
 describe('ChannelsPage - Empty state', () => {


### PR DESCRIPTION
## Description

Closes mozilla-ai/clawbolt-premium#332.

In premium prod, tenants are routed via tenant-specific bots and the global `TELEGRAM_BOT_TOKEN` env var is empty, so the OSS `/api/channels/telegram/bot-info` endpoint returns 404 by design. The mobile get-started page and admin Channels page still called it on every load, producing four 404s per session.

`useChannelStates` was firing `useTelegramBotInfo(isPremium)` without checking whether a bot token was configured. This PR gates the query on `channelConfig.telegram_bot_token_set` so the call only fires when the endpoint can actually return useful data.

## Tests

`tests/ChannelsPage.test.tsx`: new regression test that mocks `telegram_bot_token_set=false` and asserts `api.getTelegramBotInfo` is not called.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`npx vitest run src/pages/ChannelsPage.test.tsx`, 19 passed)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Knip clean (`npm run deadcode`)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: drafted by Claude via back-and-forth with @njbrake. Reasoning and decisions are mine; prose is Claude's.