### PR TITLE
perf(oauth): cache load_token reads for 30s to dedupe per-turn DB hits

### DIFF
--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -33,6 +33,16 @@ def _refresh_lock_key(user_id: str, integration: str) -> str:
     return f"oauth_refresh:{user_id}:{integration}"
 
 
+# Per-process TTL on cached tokens. A single agent turn loads OAuth
+# credentials repeatedly (auth_check during registry build, factory
+# create() during tool instantiation, then again per actual tool call).
+# In production logs we saw 6+ load_token DB hits per inbound. This
+# cache deduplicates them. Kept short so a refresh in another worker
+# becomes visible quickly; even a stale read here is safe because the
+# returned access_token has its own expires_at that callers honor.
+_TOKEN_CACHE_TTL_SECONDS = 30.0
+
+
 # Token expiry buffer: refresh 5 minutes before actual expiry.
 _EXPIRY_BUFFER_SECONDS = 300
 
@@ -201,6 +211,9 @@ class OAuthService:
     def __init__(self) -> None:
         self._pending_states: dict[str, _PendingState] = {}
         self._http: httpx.AsyncClient | None = None
+        # In-memory TTL cache for load_token. Keyed by (user_id, integration);
+        # value is (token_data_or_none, monotonic_expires_at).
+        self._token_cache: dict[tuple[str, str], tuple[OAuthTokenData | None, float]] = {}
 
     def _get_http(self) -> httpx.AsyncClient:
         if self._http is None or self._http.is_closed:
@@ -364,13 +377,28 @@ class OAuthService:
         with db_session() as db:
             db.execute(stmt)
             db.commit()
+        # Drop any cached entry so the next load_token re-reads the
+        # freshly persisted row (e.g. after a refresh writes new tokens).
+        self._token_cache.pop((user_id, integration), None)
 
     def load_token(
         self,
         user_id: str,
         integration: str,
     ) -> OAuthTokenData | None:
-        """Load token data from the oauth_tokens table."""
+        """Load token data from the oauth_tokens table.
+
+        Results are cached in-memory for ``_TOKEN_CACHE_TTL_SECONDS`` so a
+        single agent turn (auth_check, factory create, tool invocation)
+        does not produce N duplicate DB roundtrips. Cache is invalidated
+        on ``save_token`` and ``delete_token`` within this process.
+        """
+        cache_key = (user_id, integration)
+        now = time.monotonic()
+        cached = self._token_cache.get(cache_key)
+        if cached is not None and cached[1] > now:
+            return cached[0]
+
         from backend.app.models import OAuthToken
 
         logger.info(
@@ -387,6 +415,7 @@ class OAuthService:
             ).scalar_one_or_none()
 
             if row is None:
+                self._token_cache[cache_key] = (None, now + _TOKEN_CACHE_TTL_SECONDS)
                 return None
 
             try:
@@ -399,7 +428,7 @@ class OAuthService:
             except json.JSONDecodeError:
                 extra = {}
 
-            return OAuthTokenData(
+            token = OAuthTokenData(
                 access_token=row.access_token,
                 refresh_token=row.refresh_token,
                 token_type=row.token_type,
@@ -408,6 +437,8 @@ class OAuthService:
                 realm_id=row.realm_id,
                 extra=extra,
             )
+            self._token_cache[cache_key] = (token, now + _TOKEN_CACHE_TTL_SECONDS)
+            return token
 
     def delete_token(
         self,
@@ -431,10 +462,12 @@ class OAuthService:
             ).scalar_one_or_none()
 
             if row is None:
+                self._token_cache.pop((user_id, integration), None)
                 return False
 
             db.delete(row)
             db.commit()
+            self._token_cache.pop((user_id, integration), None)
             return True
 
     def is_connected(self, user_id: str, integration: str) -> bool:
@@ -592,6 +625,11 @@ class OAuthService:
             # session-scoped and survives the commit.
             db.commit()
             try:
+                # Drop any cached entry: the whole point of the post-lock
+                # reload is to detect that a peer worker just refreshed
+                # this token and persisted a new value. A stale in-memory
+                # cache would mask that and cause a redundant HTTP refresh.
+                self._token_cache.pop((user_id, integration), None)
                 token = self.load_token(user_id, integration)
                 if not token or not token.refresh_token:
                     logger.debug(

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -42,6 +42,16 @@ def _refresh_lock_key(user_id: str, integration: str) -> str:
 # returned access_token has its own expires_at that callers honor.
 _TOKEN_CACHE_TTL_SECONDS = 30.0
 
+# Shorter TTL for negative results (no token row exists). Cross-worker
+# OAuth completion race: worker B handles the OAuth callback and
+# save_token invalidates B's local cache, but worker A's cache still
+# has a "not connected" entry from a recent is_connected() check. Until
+# A's entry expires, A reports the user as unconnected even though
+# they just finished connecting. Keep negative TTL short enough that
+# the post-OAuth blackout is barely noticeable, but long enough to
+# still dedupe the multiple auth_check reads within a single agent turn.
+_NEGATIVE_TOKEN_CACHE_TTL_SECONDS = 5.0
+
 
 # Token expiry buffer: refresh 5 minutes before actual expiry.
 _EXPIRY_BUFFER_SECONDS = 300
@@ -204,8 +214,25 @@ def _generate_pkce_pair() -> tuple[str, str]:
 class OAuthService:
     """Manages OAuth flows and token lifecycle.
 
-    State is held in memory (pending authorization flows) and in PostgreSQL
-    (persisted tokens via the oauth_tokens table).
+    State is held in memory (pending authorization flows, a small TTL
+    cache of recent token reads) and in PostgreSQL (persisted tokens via
+    the oauth_tokens table).
+
+    Token cache semantics:
+
+    - Per-process: each uvicorn worker has its own cache, no shared memory.
+    - Positive entries live ``_TOKEN_CACHE_TTL_SECONDS``; negative entries
+      live ``_NEGATIVE_TOKEN_CACHE_TTL_SECONDS`` (shorter, to keep the
+      post-OAuth-completion blackout small).
+    - ``save_token`` and ``delete_token`` invalidate the local cache.
+    - Inside an advisory-lock critical section, callers MUST use
+      ``_load_token_uncached`` to defeat the cache: the whole point of
+      the post-lock reload is to observe a peer worker's just-persisted
+      refresh, and a stale cache would mask it.
+    - Cross-worker staleness is bounded by the TTL. Within that window a
+      worker may return a token whose access_token was rotated by a peer,
+      but the cached access_token's own expires_at is honored by callers,
+      so behavior is correct.
     """
 
     def __init__(self) -> None:
@@ -388,10 +415,15 @@ class OAuthService:
     ) -> OAuthTokenData | None:
         """Load token data from the oauth_tokens table.
 
-        Results are cached in-memory for ``_TOKEN_CACHE_TTL_SECONDS`` so a
-        single agent turn (auth_check, factory create, tool invocation)
-        does not produce N duplicate DB roundtrips. Cache is invalidated
-        on ``save_token`` and ``delete_token`` within this process.
+        Results are cached in-memory so a single agent turn (auth_check,
+        factory create, tool invocation) does not produce N duplicate DB
+        roundtrips. Positive entries cache for ``_TOKEN_CACHE_TTL_SECONDS``;
+        negative entries (no row) cache for the shorter
+        ``_NEGATIVE_TOKEN_CACHE_TTL_SECONDS`` so a freshly-completed
+        OAuth flow on a peer worker becomes visible quickly. The cache
+        is invalidated on ``save_token`` and ``delete_token`` within this
+        process. Callers inside an advisory-lock critical section must
+        use ``_load_token_uncached`` instead.
         """
         cache_key = (user_id, integration)
         now = time.monotonic()
@@ -415,7 +447,10 @@ class OAuthService:
             ).scalar_one_or_none()
 
             if row is None:
-                self._token_cache[cache_key] = (None, now + _TOKEN_CACHE_TTL_SECONDS)
+                self._token_cache[cache_key] = (
+                    None,
+                    now + _NEGATIVE_TOKEN_CACHE_TTL_SECONDS,
+                )
                 return None
 
             try:
@@ -439,6 +474,23 @@ class OAuthService:
             )
             self._token_cache[cache_key] = (token, now + _TOKEN_CACHE_TTL_SECONDS)
             return token
+
+    def _load_token_uncached(
+        self,
+        user_id: str,
+        integration: str,
+    ) -> OAuthTokenData | None:
+        """Force a DB read by dropping any cached entry first.
+
+        Use only inside an advisory-lock critical section where the
+        whole point of the read is to observe a peer worker's just-
+        persisted token. A stale cache would mask the peer's write and
+        cause this worker to repeat work (e.g. duplicate HTTP refresh
+        that overwrites the rotated refresh_token). All other callers
+        should use ``load_token``.
+        """
+        self._token_cache.pop((user_id, integration), None)
+        return self.load_token(user_id, integration)
 
     def delete_token(
         self,
@@ -519,7 +571,10 @@ class OAuthService:
                 # session-scoped and survives the commit.
                 db.commit()
                 try:
-                    current = self.load_token(user_id, integration)
+                    # Bypass the cache: this load is the peer-write detection
+                    # point for the on_refresh callback path. Same race as
+                    # in refresh_token's post-lock reload.
+                    current = self._load_token_uncached(user_id, integration)
                     if current is None:
                         logger.warning(
                             "on_refresh callback fired for missing token: user=%s integration=%s",
@@ -625,12 +680,10 @@ class OAuthService:
             # session-scoped and survives the commit.
             db.commit()
             try:
-                # Drop any cached entry: the whole point of the post-lock
-                # reload is to detect that a peer worker just refreshed
-                # this token and persisted a new value. A stale in-memory
-                # cache would mask that and cause a redundant HTTP refresh.
-                self._token_cache.pop((user_id, integration), None)
-                token = self.load_token(user_id, integration)
+                # Bypass the cache: the post-lock reload exists to detect
+                # a peer worker's just-persisted refresh, which an in-memory
+                # cache from before the lock would mask.
+                token = self._load_token_uncached(user_id, integration)
                 if not token or not token.refresh_token:
                     logger.debug(
                         "Cannot refresh token (missing): user=%s integration=%s "

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -305,6 +305,64 @@ def test_build_on_refresh_callback_preserves_refresh_token_when_empty(
     assert reloaded.refresh_token == "rt-original"
 
 
+def test_build_on_refresh_callback_bypasses_cache_for_post_lock_reload(
+    oauth_svc: OAuthService, test_user: User
+) -> None:
+    """The on_refresh callback must observe a peer worker's just-persisted
+    rotated refresh_token rather than reading a stale cached value.
+
+    Regression for #1085 review feedback. The callback acquires the same
+    advisory lock as refresh_token to avoid losing the rotated
+    refresh_token. Inside that critical section it reloads the current
+    token to merge the new access/refresh values onto fields it doesn't
+    know about (realm_id, scopes). If a stale cache hides a peer worker's
+    recent save here, the callback writes back stale realm_id/scopes
+    on top of the peer's update.
+    """
+    original = OAuthTokenData(
+        access_token="at-old",
+        refresh_token="rt-old",
+        realm_id="realm-stale",
+        scopes=["scope.stale"],
+        expires_at=time.time() - 100,
+    )
+    oauth_svc.save_token(test_user.id, "quickbooks", original)
+    # Prime the cache via load_token.
+    primed = oauth_svc.load_token(test_user.id, "quickbooks")
+    assert primed is not None and primed.realm_id == "realm-stale"
+
+    # Simulate a peer worker writing fresh realm_id and scopes_json to
+    # the DB while our cache still has the stale values.
+    from sqlalchemy import update
+
+    from backend.app.database import db_session
+    from backend.app.models import OAuthToken
+
+    with db_session() as db:
+        db.execute(
+            update(OAuthToken)
+            .where(
+                OAuthToken.user_id == test_user.id,
+                OAuthToken.integration == "quickbooks",
+            )
+            .values(realm_id="realm-peer-fresh", scopes_json='["scope.peer"]')
+        )
+        db.commit()
+
+    # Run the callback as the provider client would.
+    callback = oauth_svc.build_on_refresh_callback(test_user.id, "quickbooks")
+    callback("at-new", "rt-new", time.time() + 7200)
+
+    # The merged write must have started from the peer's fresh values,
+    # not the cached stale ones.
+    reloaded = oauth_svc.load_token(test_user.id, "quickbooks")
+    assert reloaded is not None
+    assert reloaded.access_token == "at-new"
+    assert reloaded.refresh_token == "rt-new"
+    assert reloaded.realm_id == "realm-peer-fresh"
+    assert reloaded.scopes == ["scope.peer"]
+
+
 def test_save_token_upsert(oauth_svc: OAuthService, test_user: User) -> None:
     """Saving a token twice should update the existing row, not create a duplicate."""
     token1 = OAuthTokenData(access_token="first")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -230,6 +230,60 @@ async def test_refresh_token_returns_early_when_peer_worker_already_refreshed(
     mock_client.post.assert_not_called()
 
 
+async def test_refresh_token_bypasses_cache_for_post_lock_reload(
+    oauth_svc: OAuthService, test_user: User
+) -> None:
+    """The post-advisory-lock reload inside refresh_token must bypass the cache.
+
+    Regression for #1085. Without the bypass, the in-memory token cache
+    can hide a peer worker's recently-persisted refresh from this worker:
+    we'd return the stale (still-expired) cached token, fall through to
+    an unnecessary HTTP refresh, and risk overwriting the rotated
+    refresh_token. Simulate the race by priming the cache with an
+    expired token, then writing a fresh one straight to the DB to mimic
+    a peer worker, and asserting refresh_token observes the fresh value
+    without a network call.
+    """
+    expired = OAuthTokenData(
+        access_token="at-stale",
+        refresh_token="rt-stale",
+        expires_at=time.time() - 100,
+    )
+    oauth_svc.save_token(test_user.id, "quickbooks", expired)
+    # Prime the cache.
+    cached = oauth_svc.load_token(test_user.id, "quickbooks")
+    assert cached is not None and cached.access_token == "at-stale"
+
+    # Simulate a peer worker writing a freshly-refreshed token directly
+    # to the DB (bypassing this OAuthService instance, so our cache stays
+    # populated with the expired version).
+    fresh_expires = time.time() + 7200
+    from sqlalchemy import update
+
+    from backend.app.database import db_session
+    from backend.app.models import OAuthToken
+
+    with db_session() as db:
+        db.execute(
+            update(OAuthToken)
+            .where(
+                OAuthToken.user_id == test_user.id,
+                OAuthToken.integration == "quickbooks",
+            )
+            .values(access_token="at-peer-fresh", expires_at=fresh_expires)
+        )
+        db.commit()
+
+    with patch.object(oauth_svc, "_get_http") as mock_http_fn:
+        mock_client = AsyncMock()
+        mock_http_fn.return_value = mock_client
+        result = await oauth_svc.refresh_token(test_user.id, "quickbooks")
+
+    assert result is not None
+    assert result.access_token == "at-peer-fresh"
+    mock_client.post.assert_not_called()
+
+
 def test_build_on_refresh_callback_preserves_refresh_token_when_empty(
     oauth_svc: OAuthService, test_user: User
 ) -> None:
@@ -326,6 +380,108 @@ def test_delete_token(oauth_svc: OAuthService, test_user: User) -> None:
 def test_delete_nonexistent_token(oauth_svc: OAuthService) -> None:
     """Deleting a non-existent token should return False."""
     assert oauth_svc.delete_token("999", "quickbooks") is False
+
+
+def test_load_token_cached_within_ttl(oauth_svc: OAuthService, test_user: User) -> None:
+    """A second load_token within the TTL window should not hit the database.
+
+    Regression for #1085. A single agent turn loads OAuth credentials
+    multiple times (auth_check, factory create, tool invocation). Without
+    a cache, that produced 6+ duplicate DB roundtrips per inbound message
+    in production logs.
+    """
+    token = OAuthTokenData(access_token="at-cached", expires_at=time.time() + 3600)
+    oauth_svc.save_token(test_user.id, "quickbooks", token)
+
+    # Prime the cache.
+    first = oauth_svc.load_token(test_user.id, "quickbooks")
+    assert first is not None and first.access_token == "at-cached"
+
+    # Out-of-band delete the row so a fresh DB read would return None.
+    # If the cache works, the second load_token should still return
+    # the cached value.
+    from sqlalchemy import delete
+
+    from backend.app.database import db_session
+    from backend.app.models import OAuthToken
+
+    with db_session() as db:
+        db.execute(
+            delete(OAuthToken).where(
+                OAuthToken.user_id == test_user.id,
+                OAuthToken.integration == "quickbooks",
+            )
+        )
+        db.commit()
+
+    second = oauth_svc.load_token(test_user.id, "quickbooks")
+    assert second is not None
+    assert second.access_token == "at-cached"
+
+
+def test_save_token_invalidates_cache(oauth_svc: OAuthService, test_user: User) -> None:
+    """save_token must drop the cache entry so the next load sees the new value."""
+    initial = OAuthTokenData(access_token="at-initial", expires_at=time.time() + 3600)
+    oauth_svc.save_token(test_user.id, "quickbooks", initial)
+    primed = oauth_svc.load_token(test_user.id, "quickbooks")
+    assert primed is not None and primed.access_token == "at-initial"
+
+    rotated = OAuthTokenData(access_token="at-rotated", expires_at=time.time() + 3600)
+    oauth_svc.save_token(test_user.id, "quickbooks", rotated)
+
+    reloaded = oauth_svc.load_token(test_user.id, "quickbooks")
+    assert reloaded is not None
+    assert reloaded.access_token == "at-rotated"
+
+
+def test_delete_token_invalidates_cache(oauth_svc: OAuthService, test_user: User) -> None:
+    """delete_token must drop the cache entry so the next load returns None."""
+    token = OAuthTokenData(access_token="at", expires_at=time.time() + 3600)
+    oauth_svc.save_token(test_user.id, "quickbooks", token)
+    primed = oauth_svc.load_token(test_user.id, "quickbooks")
+    assert primed is not None
+
+    oauth_svc.delete_token(test_user.id, "quickbooks")
+    assert oauth_svc.load_token(test_user.id, "quickbooks") is None
+
+
+def test_load_token_caches_negative_lookup(oauth_svc: OAuthService, test_user: User) -> None:
+    """A None result is also cached so repeated 'not connected' checks
+    do not flood the DB.
+
+    Real-world trigger: the agent runs auth_check on every specialist
+    factory at registry build time. For users who have not connected
+    QuickBooks, that is N negative DB reads per inbound. Cache both
+    positive and negative results.
+    """
+    # First load: row does not exist, returns None.
+    assert oauth_svc.load_token(test_user.id, "quickbooks") is None
+
+    # Out-of-band insert a row.
+    token = OAuthTokenData(access_token="at-now-exists", expires_at=time.time() + 3600)
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from backend.app.database import db_session
+    from backend.app.models import OAuthToken
+
+    with db_session() as db:
+        db.execute(
+            pg_insert(OAuthToken).values(
+                user_id=test_user.id,
+                integration="quickbooks",
+                access_token=token.access_token,
+                refresh_token="",
+                token_type="Bearer",
+                expires_at=token.expires_at,
+                scopes_json="[]",
+                realm_id="",
+                extra_json="{}",
+            )
+        )
+        db.commit()
+
+    # Within the TTL the cached None should still be returned.
+    assert oauth_svc.load_token(test_user.id, "quickbooks") is None
 
 
 def test_is_connected(oauth_svc: OAuthService, test_user: User) -> None:


### PR DESCRIPTION
## Description

Closes #1085 (partial: the OAuth-credentials half of the issue).

Production logs showed 6+ `credential.read action=load` entries per inbound message. A single agent turn reads each integration's token multiple times: once during specialist `auth_check` at registry build, again inside `factory.create()` when the OAuth client is constructed, and again per actual tool invocation. Each read was a fresh DB roundtrip.

This PR adds a per-process TTL cache (30s) keyed on `(user_id, integration)`. Both positive and negative results are cached so unconnected integrations also stop spamming the DB.

## Cache invalidation

- `save_token` drops the entry so a refresh's new value is observed.
- `delete_token` drops the entry so the next load returns None.
- `refresh_token` explicitly drops the entry before its post-advisory-lock reload. The whole point of that reload is to detect a peer worker's just-persisted refresh; a stale cache would mask it and cause a redundant HTTP refresh that may overwrite the rotated `refresh_token`.

## Cross-worker behavior

Bounded by the 30s TTL. Within that window a worker may return a token whose `access_token` was rotated by a peer, but the cached `access_token` is still valid until its own `expires_at`, so callers behave correctly. The refresh path is the one place stale data would matter and we explicitly bypass the cache there.

## Out of scope

The original issue #1085 also called for caching the per-user `ToolRegistry`. That's a larger refactor (tool factories close over `ToolContext` which mutates per turn) and is left for a follow-up. The OAuth credential caching addresses the dominant cost surfaced in prod logs.

## Tests

5 new regression tests in `tests/test_oauth.py`:
- `test_load_token_cached_within_ttl`
- `test_save_token_invalidates_cache`
- `test_delete_token_invalidates_cache`
- `test_load_token_caches_negative_lookup`
- `test_refresh_token_bypasses_cache_for_post_lock_reload` (cross-worker race)

## Type
- [x] Performance / refactor

## Checklist
- [x] Tests pass (`uv run pytest tests/test_oauth.py tests/test_oauth_refresh.py`, 82 passed)
- [x] Lint passes
- [x] Type checking passes
- [x] Bug fixes / behavior changes include regression tests

## AI Usage
- [x] AI-assisted: drafted by Claude via back-and-forth with @njbrake. Reasoning and decisions are mine; prose is Claude's.