### PR TITLE
feat(oauth): background scheduler proactively refreshes tokens before expiry

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -219,6 +219,13 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     await _verify_llm_settings()
     heartbeat_scheduler.start()
 
+    # Background OAuth token refresh: keep tokens fresh proactively so
+    # user-facing tool calls do not pay the inline ~150ms refresh cost
+    # during the 5 minute pre-expiry window.
+    from backend.app.services.oauth import oauth_refresh_scheduler
+
+    oauth_refresh_scheduler.start()
+
     if settings.telegram_bot_token:
         if settings.telegram_webhook_secret:
             logger.info("Webhook secret: using explicit TELEGRAM_WEBHOOK_SECRET")
@@ -273,6 +280,9 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             task.cancel()
     await manager.stop_all()
     heartbeat_scheduler.stop()
+    from backend.app.services.oauth import oauth_refresh_scheduler
+
+    oauth_refresh_scheduler.stop()
 
 
 app = FastAPI(title="Clawbolt", version="0.1.0", lifespan=lifespan)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,6 +40,7 @@ from backend.app.routers import (
     user_sessions,
     user_tools,
 )
+from backend.app.services.oauth import oauth_refresh_scheduler
 
 logging.basicConfig(
     level=logging.WARNING,
@@ -222,8 +223,6 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     # Background OAuth token refresh: keep tokens fresh proactively so
     # user-facing tool calls do not pay the inline ~150ms refresh cost
     # during the 5 minute pre-expiry window.
-    from backend.app.services.oauth import oauth_refresh_scheduler
-
     oauth_refresh_scheduler.start()
 
     if settings.telegram_bot_token:
@@ -280,8 +279,6 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             task.cancel()
     await manager.stop_all()
     heartbeat_scheduler.stop()
-    from backend.app.services.oauth import oauth_refresh_scheduler
-
     oauth_refresh_scheduler.stop()
 
 

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -7,6 +7,7 @@ table) with encrypted access/refresh token columns.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -921,6 +922,110 @@ class OAuthService:
 
 # Module-level singleton.
 oauth_service = OAuthService()
+
+
+# ---------------------------------------------------------------------------
+# Background refresh scheduler
+# ---------------------------------------------------------------------------
+
+# How often the background sweep runs.
+_REFRESH_SWEEP_INTERVAL_SECONDS = 120.0
+
+# How far ahead the sweep looks for tokens to refresh. Slightly larger
+# than ``_EXPIRY_BUFFER_SECONDS`` (300s) so the sweep catches tokens
+# before ``OAuthTokenData.is_expired()`` flips True and the inline
+# refresh in ``get_valid_token`` would fire on the user-facing path.
+_REFRESH_LOOKAHEAD_SECONDS = 360.0
+
+
+class OAuthRefreshScheduler:
+    """Periodically refresh OAuth tokens before they expire.
+
+    Without this, every user message that arrives during the 5 minute
+    pre-expiry window pays the cost of an inline HTTP refresh
+    (~150ms). Sweeping in the background pulls that cost off the
+    critical path: by the time the user texts, the token is already
+    fresh and ``get_valid_token`` returns immediately.
+
+    Failures are logged and swallowed; a single bad token never stops
+    the sweep from processing the rest. Inline refresh in
+    ``get_valid_token`` remains the safety net for tokens the sweep
+    missed (e.g. process just started, sweep hasn't run yet).
+    """
+
+    def __init__(self, service: OAuthService) -> None:
+        self._service = service
+        self._task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        """Start the sweep loop (idempotent)."""
+        if self._task is not None and not self._task.done():
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No event loop (sync test harness, etc.): skip silently.
+            return
+        self._task = loop.create_task(self._run())
+        logger.info(
+            "OAuth refresh sweep started (interval=%.0fs lookahead=%.0fs)",
+            _REFRESH_SWEEP_INTERVAL_SECONDS,
+            _REFRESH_LOOKAHEAD_SECONDS,
+        )
+
+    def stop(self) -> None:
+        """Cancel the sweep loop."""
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+            logger.info("OAuth refresh sweep stopped")
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                await self.sweep()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("OAuth refresh sweep failed")
+            await asyncio.sleep(_REFRESH_SWEEP_INTERVAL_SECONDS)
+
+    async def sweep(self) -> int:
+        """Run one sweep. Returns the number of tokens that were refreshed.
+
+        Exposed publicly so tests can drive a single tick without
+        spinning up the background task.
+        """
+        from backend.app.models import OAuthToken
+
+        cutoff = time.time() + _REFRESH_LOOKAHEAD_SECONDS
+        with db_session() as db:
+            rows = db.execute(
+                select(OAuthToken.user_id, OAuthToken.integration)
+                .where(OAuthToken.expires_at > 0)
+                .where(OAuthToken.expires_at < cutoff)
+                .where(OAuthToken.refresh_token != "")
+            ).all()
+        if not rows:
+            return 0
+        logger.info("OAuth refresh sweep: %d token(s) due for refresh", len(rows))
+        refreshed = 0
+        for user_id, integration in rows:
+            try:
+                result = await self._service.refresh_token(user_id, integration)
+            except Exception:
+                logger.exception(
+                    "Background OAuth refresh failed: user=%s integration=%s",
+                    user_id,
+                    integration,
+                )
+                continue
+            if result is not None:
+                refreshed += 1
+        return refreshed
+
+
+oauth_refresh_scheduler = OAuthRefreshScheduler(oauth_service)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -944,6 +944,17 @@ _REFRESH_SWEEP_JITTER_SECONDS = 15.0
 # refresh in ``get_valid_token`` would fire on the user-facing path.
 _REFRESH_LOOKAHEAD_SECONDS = 360.0
 
+# Only refresh in the background for users who have been active in the
+# last N days. Why: refresh tokens for some providers (notably
+# QuickBooks, 100 day inactivity expiry) are designed to expire when
+# a user stops using the integration, forcing reconnection and a fresh
+# user-consent confirmation. Background refresh would silently bypass
+# that signal for dormant accounts. Activity is "received an inbound
+# message via any channel route" -- this captures iMessage, Telegram,
+# webchat, etc. Inactive users still get the inline refresh path on
+# their next interaction.
+_REFRESH_ACTIVITY_WINDOW_DAYS = 14
+
 
 class OAuthRefreshScheduler:
     """Periodically refresh OAuth tokens before they expire.
@@ -1001,18 +1012,35 @@ class OAuthRefreshScheduler:
     async def sweep(self) -> int:
         """Run one sweep. Returns the number of tokens that were refreshed.
 
+        Only refreshes tokens for users who have been active in the last
+        ``_REFRESH_ACTIVITY_WINDOW_DAYS`` days, so dormant users still
+        hit the natural provider-side inactivity expiry on their refresh
+        tokens (e.g. QuickBooks 100 day rule). Inactive users fall back
+        to the inline refresh path the next time they interact.
+
         Exposed publicly so tests can drive a single tick without
         spinning up the background task.
         """
-        from backend.app.models import OAuthToken
+        import datetime as _dt
+
+        from backend.app.models import ChannelRoute, OAuthToken
 
         cutoff = time.time() + _REFRESH_LOOKAHEAD_SECONDS
+        activity_cutoff = _dt.datetime.now(_dt.UTC) - _dt.timedelta(
+            days=_REFRESH_ACTIVITY_WINDOW_DAYS
+        )
+        active_user_ids = (
+            select(ChannelRoute.user_id)
+            .where(ChannelRoute.last_inbound_at.is_not(None))
+            .where(ChannelRoute.last_inbound_at > activity_cutoff)
+        )
         with db_session() as db:
             rows = db.execute(
                 select(OAuthToken.user_id, OAuthToken.integration)
                 .where(OAuthToken.expires_at > 0)
                 .where(OAuthToken.expires_at < cutoff)
                 .where(OAuthToken.refresh_token != "")
+                .where(OAuthToken.user_id.in_(active_user_ids))
             ).all()
         if not rows:
             return 0

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -12,6 +12,7 @@ import base64
 import hashlib
 import json
 import logging
+import random
 import secrets
 import time
 from collections.abc import Callable
@@ -931,6 +932,12 @@ oauth_service = OAuthService()
 # How often the background sweep runs.
 _REFRESH_SWEEP_INTERVAL_SECONDS = 120.0
 
+# Random jitter applied to each inter-sweep sleep so that schedulers
+# running in N uvicorn workers do not synchronize and stampede the DB
+# / advisory locks at the same instant. Bounded so the effective
+# interval stays in the [105s, 135s] range.
+_REFRESH_SWEEP_JITTER_SECONDS = 15.0
+
 # How far ahead the sweep looks for tokens to refresh. Slightly larger
 # than ``_EXPIRY_BUFFER_SECONDS`` (300s) so the sweep catches tokens
 # before ``OAuthTokenData.is_expired()`` flips True and the inline
@@ -988,7 +995,8 @@ class OAuthRefreshScheduler:
                 raise
             except Exception:
                 logger.exception("OAuth refresh sweep failed")
-            await asyncio.sleep(_REFRESH_SWEEP_INTERVAL_SECONDS)
+            jitter = random.uniform(-_REFRESH_SWEEP_JITTER_SECONDS, _REFRESH_SWEEP_JITTER_SECONDS)
+            await asyncio.sleep(_REFRESH_SWEEP_INTERVAL_SECONDS + jitter)
 
     async def sweep(self) -> int:
         """Run one sweep. Returns the number of tokens that were refreshed.

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -20,6 +20,7 @@ from backend.app.models import User
 from backend.app.services.oauth import (
     _DISCOVERY_CACHE_TTL_SECONDS,
     OAuthConfig,
+    OAuthRefreshScheduler,
     OAuthService,
     OAuthTokenData,
     _generate_pkce_pair,
@@ -1222,3 +1223,134 @@ def test_quickbooks_config_uses_discovery_endpoints(_reset_discovery_cache: None
     assert config is not None
     assert config.authorize_url == "https://discovered.intuit.com/oauth2/authorize"
     assert config.token_url == "https://discovered.intuit.com/oauth2/token"
+
+
+# ---------------------------------------------------------------------------
+# OAuthRefreshScheduler tests (#1087)
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_sweep_refreshes_tokens_within_lookahead(
+    oauth_svc: OAuthService, test_user: User
+) -> None:
+    """A token expiring within the lookahead window must be refreshed."""
+    # 4 minutes from now: well inside the 6 minute lookahead.
+    near_expiry = OAuthTokenData(
+        access_token="at-near",
+        refresh_token="rt-near",
+        expires_at=time.time() + 240,
+    )
+    oauth_svc.save_token(test_user.id, "quickbooks", near_expiry)
+
+    refresh_calls: list[tuple[str, str]] = []
+
+    async def fake_refresh(user_id: str, integration: str) -> OAuthTokenData | None:
+        refresh_calls.append((user_id, integration))
+        return OAuthTokenData(access_token="at-refreshed", expires_at=time.time() + 3600)
+
+    scheduler = OAuthRefreshScheduler(oauth_svc)
+    with patch.object(oauth_svc, "refresh_token", side_effect=fake_refresh):
+        count = await scheduler.sweep()
+
+    assert count == 1
+    assert refresh_calls == [(test_user.id, "quickbooks")]
+
+
+async def test_refresh_sweep_skips_tokens_outside_lookahead(
+    oauth_svc: OAuthService, test_user: User
+) -> None:
+    """A token with plenty of time left must not be refreshed."""
+    # 30 minutes out: outside the 6 minute lookahead.
+    far_expiry = OAuthTokenData(
+        access_token="at",
+        refresh_token="rt",
+        expires_at=time.time() + 1800,
+    )
+    oauth_svc.save_token(test_user.id, "quickbooks", far_expiry)
+
+    scheduler = OAuthRefreshScheduler(oauth_svc)
+    with patch.object(oauth_svc, "refresh_token", new_callable=AsyncMock) as mock_refresh:
+        count = await scheduler.sweep()
+
+    assert count == 0
+    mock_refresh.assert_not_called()
+
+
+async def test_refresh_sweep_skips_tokens_without_refresh_token(
+    oauth_svc: OAuthService, test_user: User
+) -> None:
+    """Tokens without a refresh_token cannot be refreshed and must be skipped.
+
+    Without this guard the sweep would call refresh_token, which then
+    immediately returns None after a wasted DB read and log line.
+    """
+    no_refresh = OAuthTokenData(
+        access_token="at",
+        refresh_token="",
+        expires_at=time.time() + 60,  # would otherwise be in lookahead
+    )
+    oauth_svc.save_token(test_user.id, "quickbooks", no_refresh)
+
+    scheduler = OAuthRefreshScheduler(oauth_svc)
+    with patch.object(oauth_svc, "refresh_token", new_callable=AsyncMock) as mock_refresh:
+        count = await scheduler.sweep()
+
+    assert count == 0
+    mock_refresh.assert_not_called()
+
+
+async def test_refresh_sweep_skips_non_expiring_tokens(
+    oauth_svc: OAuthService, test_user: User
+) -> None:
+    """Tokens with expires_at <= 0 never expire and need no refresh."""
+    non_expiring = OAuthTokenData(
+        access_token="at",
+        refresh_token="rt",
+        expires_at=0.0,
+    )
+    oauth_svc.save_token(test_user.id, "quickbooks", non_expiring)
+
+    scheduler = OAuthRefreshScheduler(oauth_svc)
+    with patch.object(oauth_svc, "refresh_token", new_callable=AsyncMock) as mock_refresh:
+        count = await scheduler.sweep()
+
+    assert count == 0
+    mock_refresh.assert_not_called()
+
+
+async def test_refresh_sweep_continues_after_individual_failure(
+    oauth_svc: OAuthService, test_user: User
+) -> None:
+    """One failing refresh must not prevent the rest of the sweep.
+
+    Otherwise a single user with a revoked grant would block all other
+    users' background refreshes.
+    """
+    # Two due tokens, one for each integration.
+    for integration in ("quickbooks", "google_calendar"):
+        oauth_svc.save_token(
+            test_user.id,
+            integration,
+            OAuthTokenData(
+                access_token=f"at-{integration}",
+                refresh_token=f"rt-{integration}",
+                expires_at=time.time() + 60,
+            ),
+        )
+
+    seen: list[str] = []
+
+    async def fake_refresh(user_id: str, integration: str) -> OAuthTokenData | None:
+        seen.append(integration)
+        if integration == "quickbooks":
+            raise RuntimeError("boom")
+        return OAuthTokenData(access_token="at-new", expires_at=time.time() + 3600)
+
+    scheduler = OAuthRefreshScheduler(oauth_svc)
+    with patch.object(oauth_svc, "refresh_token", side_effect=fake_refresh):
+        count = await scheduler.sweep()
+
+    # Both integrations were attempted; the QB one failed and the
+    # google_calendar one succeeded.
+    assert sorted(seen) == ["google_calendar", "quickbooks"]
+    assert count == 1

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1230,10 +1230,38 @@ def test_quickbooks_config_uses_discovery_endpoints(_reset_discovery_cache: None
 # ---------------------------------------------------------------------------
 
 
+def _mark_user_active(user_id: str, days_ago: int = 0) -> None:
+    """Insert a channel_route row with last_inbound_at = now - days_ago.
+
+    The sweep gates on recent activity so dormant users do not get their
+    refresh tokens silently kept alive past the provider's natural
+    inactivity expiry. Tests that expect a token to be refreshed must
+    register the user as recently active first.
+    """
+    import datetime as _dt
+
+    from backend.app.database import db_session
+    from backend.app.models import ChannelRoute
+
+    last = _dt.datetime.now(_dt.UTC) - _dt.timedelta(days=days_ago)
+    with db_session() as db:
+        db.add(
+            ChannelRoute(
+                user_id=user_id,
+                channel="webchat",
+                channel_identifier=f"test-{user_id}",
+                enabled=True,
+                last_inbound_at=last,
+            )
+        )
+        db.commit()
+
+
 async def test_refresh_sweep_refreshes_tokens_within_lookahead(
     oauth_svc: OAuthService, test_user: User
 ) -> None:
     """A token expiring within the lookahead window must be refreshed."""
+    _mark_user_active(test_user.id)
     # 4 minutes from now: well inside the 6 minute lookahead.
     near_expiry = OAuthTokenData(
         access_token="at-near",
@@ -1256,10 +1284,57 @@ async def test_refresh_sweep_refreshes_tokens_within_lookahead(
     assert refresh_calls == [(test_user.id, "quickbooks")]
 
 
+async def test_refresh_sweep_skips_inactive_users(oauth_svc: OAuthService, test_user: User) -> None:
+    """Tokens for users dormant past the activity window must not be refreshed.
+
+    Regression for security review of #1087. Refresh tokens for some
+    providers (notably QuickBooks, 100 day inactivity expiry) are
+    designed to expire when the user stops using the integration so
+    re-consent is required on return. Background refresh would silently
+    keep them alive forever; we gate it on recent activity.
+    """
+    _mark_user_active(test_user.id, days_ago=30)  # past the 14 day window
+    near_expiry = OAuthTokenData(
+        access_token="at",
+        refresh_token="rt",
+        expires_at=time.time() + 240,
+    )
+    oauth_svc.save_token(test_user.id, "quickbooks", near_expiry)
+
+    scheduler = OAuthRefreshScheduler(oauth_svc)
+    with patch.object(oauth_svc, "refresh_token", new_callable=AsyncMock) as mock_refresh:
+        count = await scheduler.sweep()
+
+    assert count == 0
+    mock_refresh.assert_not_called()
+
+
+async def test_refresh_sweep_skips_users_with_no_channel_route(
+    oauth_svc: OAuthService, test_user: User
+) -> None:
+    """A user with no channel_route at all has no activity signal and
+    must not be background-refreshed."""
+    near_expiry = OAuthTokenData(
+        access_token="at",
+        refresh_token="rt",
+        expires_at=time.time() + 240,
+    )
+    oauth_svc.save_token(test_user.id, "quickbooks", near_expiry)
+    # Note: deliberately no _mark_user_active call here.
+
+    scheduler = OAuthRefreshScheduler(oauth_svc)
+    with patch.object(oauth_svc, "refresh_token", new_callable=AsyncMock) as mock_refresh:
+        count = await scheduler.sweep()
+
+    assert count == 0
+    mock_refresh.assert_not_called()
+
+
 async def test_refresh_sweep_skips_tokens_outside_lookahead(
     oauth_svc: OAuthService, test_user: User
 ) -> None:
     """A token with plenty of time left must not be refreshed."""
+    _mark_user_active(test_user.id)
     # 30 minutes out: outside the 6 minute lookahead.
     far_expiry = OAuthTokenData(
         access_token="at",
@@ -1284,6 +1359,7 @@ async def test_refresh_sweep_skips_tokens_without_refresh_token(
     Without this guard the sweep would call refresh_token, which then
     immediately returns None after a wasted DB read and log line.
     """
+    _mark_user_active(test_user.id)
     no_refresh = OAuthTokenData(
         access_token="at",
         refresh_token="",
@@ -1303,6 +1379,7 @@ async def test_refresh_sweep_skips_non_expiring_tokens(
     oauth_svc: OAuthService, test_user: User
 ) -> None:
     """Tokens with expires_at <= 0 never expire and need no refresh."""
+    _mark_user_active(test_user.id)
     non_expiring = OAuthTokenData(
         access_token="at",
         refresh_token="rt",
@@ -1344,6 +1421,7 @@ async def test_refresh_sweep_continues_after_individual_failure(
     Otherwise a single user with a revoked grant would block all other
     users' background refreshes.
     """
+    _mark_user_active(test_user.id)
     # Two due tokens, one for each integration.
     for integration in ("quickbooks", "google_calendar"):
         oauth_svc.save_token(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1318,6 +1318,24 @@ async def test_refresh_sweep_skips_non_expiring_tokens(
     mock_refresh.assert_not_called()
 
 
+async def test_scheduler_start_is_idempotent(oauth_svc: OAuthService) -> None:
+    """Calling start() twice in a row must not spawn a second sweep task.
+
+    The lifespan reload code path (or any caller that re-invokes start()
+    by mistake) should be a no-op the second time.
+    """
+    scheduler = OAuthRefreshScheduler(oauth_svc)
+    try:
+        scheduler.start()
+        first_task = scheduler._task
+        assert first_task is not None
+        scheduler.start()
+        # Same task object: the second call returned early.
+        assert scheduler._task is first_task
+    finally:
+        scheduler.stop()
+
+
 async def test_refresh_sweep_continues_after_individual_failure(
     oauth_svc: OAuthService, test_user: User
 ) -> None:


### PR DESCRIPTION
## Description

Closes #1087.

When a user message arrived during the 5 minute pre-expiry window, `get_valid_token` would refresh inline on the user-facing path, adding ~150ms to the reply latency. With three integrations per user (CompanyCam, QuickBooks, Google Calendar) and tokens that typically last an hour, every active user hit this path several times an hour.

This PR adds an `OAuthRefreshScheduler` that sweeps every 2 minutes, finds tokens expiring within the next 6 minutes (one minute past the 5 minute inline threshold so the sweep always wins the race), and refreshes them in the background. Inline refresh in `get_valid_token` remains as a safety net for tokens the sweep missed (cold start, sweep paused, etc.).

## Behavior

The sweep:
- skips tokens with `expires_at <= 0` (non-expiring tokens never need refresh)
- skips tokens without a `refresh_token` (cannot be refreshed)
- continues past individual failures so one user's revoked grant does not block all other users' background refreshes
- reuses the existing `refresh_token()` advisory-lock path so a concurrent inline refresh in another worker does not double-refresh

## Lifespan wiring

Wired into the OSS lifespan in `backend/app/main.py` next to the existing `heartbeat_scheduler.start/stop` calls. Premium will pick up the same scheduler in a follow-up PR once `OSS_REF` is bumped to a release containing this commit.

## Tests

5 new tests in `tests/test_oauth.py`:
- `test_refresh_sweep_refreshes_tokens_within_lookahead`
- `test_refresh_sweep_skips_tokens_outside_lookahead`
- `test_refresh_sweep_skips_tokens_without_refresh_token`
- `test_refresh_sweep_skips_non_expiring_tokens`
- `test_refresh_sweep_continues_after_individual_failure`

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`, 1996 OSS tests passed)
- [x] Lint passes (`ruff check backend/ tests/ alembic/`)
- [x] Type checking passes (`uv run ty check`)
- [x] New feature has tests

## AI Usage
- [x] AI-assisted: drafted by Claude via back-and-forth with @njbrake. Reasoning and decisions are mine; prose is Claude's.