### PR TITLE
feat(auth): refresh access token proactively before it expires

### DIFF
--- a/frontend/src/lib/api-client.test.ts
+++ b/frontend/src/lib/api-client.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  _decodeJwtExp,
+  _shouldProactivelyRefresh,
+  _getAccessTokenExp,
+  setAccessToken,
+  setRefreshToken,
+  tryRefresh,
+} from './api-client';
+
+// Build a fake JWT: header.payload.signature, where payload is { exp }.
+function makeJwt(exp: number): string {
+  const b64 = (s: string): string =>
+    btoa(s).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  return `${b64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))}.${b64(JSON.stringify({ exp, sub: 'test-user' }))}.signature`;
+}
+
+describe('_decodeJwtExp', () => {
+  it('extracts exp from a valid JWT', () => {
+    expect(_decodeJwtExp(makeJwt(1234567890))).toBe(1234567890);
+  });
+
+  it('returns null for tokens that are not JWT shaped', () => {
+    expect(_decodeJwtExp('opaque-token')).toBeNull();
+    expect(_decodeJwtExp('only.two')).toBeNull();
+  });
+
+  it('returns null when the payload has no exp claim', () => {
+    const noExp = `eyJhbGciOiJIUzI1NiJ9.${btoa(JSON.stringify({ sub: 'x' }))
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')}.sig`;
+    expect(_decodeJwtExp(noExp)).toBeNull();
+  });
+
+  it('returns null when the payload is unparseable', () => {
+    expect(_decodeJwtExp('header.@@@notbase64@@@.sig')).toBeNull();
+  });
+});
+
+describe('_shouldProactivelyRefresh', () => {
+  const now = 1_000_000;
+
+  it('refreshes when current time is within the leeway window', () => {
+    // 30 second leeway: anything from (exp - 30) to exp triggers refresh.
+    expect(_shouldProactivelyRefresh(now + 10, now)).toBe(true); // 10s left
+    expect(_shouldProactivelyRefresh(now, now)).toBe(true); // already expired
+    expect(_shouldProactivelyRefresh(now - 100, now)).toBe(true); // long expired
+  });
+
+  it('does not refresh when the token has plenty of time left', () => {
+    expect(_shouldProactivelyRefresh(now + 31, now)).toBe(false);
+    expect(_shouldProactivelyRefresh(now + 3600, now)).toBe(false);
+  });
+
+  it('does not refresh when exp is null (opaque token)', () => {
+    expect(_shouldProactivelyRefresh(null, now)).toBe(false);
+  });
+});
+
+describe('setAccessToken', () => {
+  afterEach(() => {
+    setAccessToken(null);
+    setRefreshToken(null);
+  });
+
+  it('records the JWT exp so the middleware can refresh proactively', () => {
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    setAccessToken(makeJwt(exp));
+    expect(_getAccessTokenExp()).toBe(exp);
+  });
+
+  it('clears the tracked exp when the token is cleared', () => {
+    setAccessToken(makeJwt(123));
+    setAccessToken(null);
+    expect(_getAccessTokenExp()).toBeNull();
+  });
+
+  it('records null exp for opaque (non-JWT) tokens', () => {
+    setAccessToken('opaque-token');
+    expect(_getAccessTokenExp()).toBeNull();
+  });
+});
+
+describe('tryRefresh', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.setItem('clawbolt_refresh_token', 'rt-test');
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    setAccessToken(null);
+    setRefreshToken(null);
+    vi.restoreAllMocks();
+  });
+
+  it('coalesces concurrent calls into a single /api/auth/refresh fetch', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: makeJwt(Math.floor(Date.now() / 1000) + 3600),
+          refresh_token: 'rt-new',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    const results = await Promise.all([tryRefresh(), tryRefresh(), tryRefresh()]);
+
+    expect(results).toEqual([true, true, true]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('/api/auth/refresh');
+  });
+
+  it('returns false and clears tokens when the refresh endpoint fails', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 401 }));
+
+    const ok = await tryRefresh();
+
+    expect(ok).toBe(false);
+    expect(localStorage.getItem('clawbolt_refresh_token')).toBeNull();
+  });
+
+  it('returns false when no refresh token is stored', async () => {
+    localStorage.removeItem('clawbolt_refresh_token');
+
+    const ok = await tryRefresh();
+
+    expect(ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -3,8 +3,55 @@ import type { paths } from '@/generated/api';
 
 // --- Token state (shared with api.ts via getters/setters) ---
 let _accessToken: string | null = null;
+// Decoded ``exp`` claim (seconds since epoch) for the current access token.
+// Tracked so we can refresh proactively before the next request goes out
+// rather than relying on the reactive 401-then-retry path. Null if the
+// token has no parseable JWT payload.
+let _accessTokenExp: number | null = null;
+
+// Refresh proactively when within this many seconds of expiry. Generous
+// enough to absorb modest client/server clock skew without firing too
+// often. The reactive 401 path remains as a safety net.
+const _PROACTIVE_REFRESH_LEEWAY_SECONDS = 30;
 
 const REFRESH_TOKEN_KEY = 'clawbolt_refresh_token';
+
+// Exported for unit tests; not part of the public auth surface.
+export function _decodeJwtExp(token: string): number | null {
+  // JWTs are header.payload.signature, base64url-encoded. We only need
+  // the payload's `exp` claim. Failures here are expected for non-JWT
+  // tokens; callers fall back to the reactive 401 path.
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const segment = parts[1];
+  if (!segment) return null;
+  try {
+    const payload = segment.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    const decoded = JSON.parse(atob(padded)) as { exp?: number };
+    return typeof decoded.exp === 'number' ? decoded.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+// Exported for unit tests. Returns true when the current access token's
+// `exp` claim is within ``_PROACTIVE_REFRESH_LEEWAY_SECONDS`` of now.
+// A null exp (opaque token / decode failed) returns false: callers fall
+// back to the reactive 401-then-retry path.
+export function _shouldProactivelyRefresh(
+  exp: number | null,
+  nowSeconds: number = Date.now() / 1000,
+): boolean {
+  if (exp === null) return false;
+  return nowSeconds >= exp - _PROACTIVE_REFRESH_LEEWAY_SECONDS;
+}
+
+// Exported for unit tests. Reflects the exp tracked at the most recent
+// setAccessToken call.
+export function _getAccessTokenExp(): number | null {
+  return _accessTokenExp;
+}
 
 // Consume refresh token from URL hash fragment (set by OAuth redirect).
 // This runs once at module load, before any auth checks.
@@ -34,6 +81,7 @@ export function getAccessToken(): string | null {
 
 export function setAccessToken(token: string | null): void {
   _accessToken = token;
+  _accessTokenExp = token ? _decodeJwtExp(token) : null;
 }
 
 export function setRefreshToken(token: string | null): void {
@@ -79,6 +127,13 @@ export async function tryRefresh(): Promise<boolean> {
 // --- Auth middleware for openapi-fetch ---
 const authMiddleware: Middleware = {
   async onRequest({ request }) {
+    // Proactive refresh: if the current access token is within
+    // _PROACTIVE_REFRESH_LEEWAY_SECONDS of its `exp`, refresh before
+    // sending. Eliminates the 401-then-retry chatter that shows up
+    // in the network panel on every page load near expiry.
+    if (_accessToken && _shouldProactivelyRefresh(_accessTokenExp)) {
+      await tryRefresh();
+    }
     if (_accessToken) {
       request.headers.set('Authorization', `Bearer ${_accessToken}`);
     }


### PR DESCRIPTION
## Description

Closes mozilla-ai/clawbolt-premium#333.

Production logs from a short user session showed 4-6 `GET /api/user/profile 401` responses paired with `POST /api/auth/refresh` on every page load. The existing reactive flow works (401 → refresh → retry) but produces noisy 401s in network panels and adds a round trip per page load near token expiry.

This PR decodes the access token's `exp` claim when it is set, and has the openapi-fetch middleware refresh proactively when the current time is within 30 seconds of expiry. The reactive 401 path remains as a safety net for tokens whose exp we could not decode (opaque tokens, JWT parsing failure) and for any race where the token expires between the proactive check and the request hitting the server.

## Implementation

- New helper `_decodeJwtExp(token)` extracts the `exp` claim (returns null on any decode failure).
- `setAccessToken` updates a tracked `_accessTokenExp` alongside the token itself.
- New helper `_shouldProactivelyRefresh(exp, now?)` is a pure function used by the middleware.
- The middleware `onRequest` calls `tryRefresh()` before sending if the helper returns true. Existing `_refreshPromise` dedup ensures concurrent requests do not stampede the refresh endpoint.

## Tests

13 new unit tests in `src/lib/api-client.test.ts`:
- `_decodeJwtExp`: valid JWT, non-JWT shape, missing exp claim, unparseable payload
- `_shouldProactivelyRefresh`: inside leeway window, outside, null exp
- `setAccessToken`: records/clears exp, handles opaque tokens
- `tryRefresh`: dedup of concurrent calls, 401 clears stored tokens, no-refresh-token early return

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`npx vitest run src/lib/api-client.test.ts`, 13 passed)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Knip clean (`npm run deadcode`)
- [x] New feature has tests

## AI Usage
- [x] AI-assisted: drafted by Claude via back-and-forth with @njbrake. Reasoning and decisions are mine; prose is Claude's.