### PR TITLE
feat(compaction): emit structured summary log per compaction run

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -11,6 +11,7 @@ remains searchable after the raw messages are gone.
 import datetime
 import json
 import logging
+import time
 from typing import Any, cast
 
 from any_llm import amessages
@@ -146,6 +147,14 @@ async def compact_session(
     if not conversation_text.strip():
         return "", None
 
+    # Telemetry: compaction is a routine operation for active users (every
+    # ~27 days at 15k tokens/day, more often for power users). Capturing
+    # per-run shape so we can audit frequency, cost, and whether the LLM
+    # is actually picking up new facts vs producing empty rewrites.
+    _start_monotonic = time.monotonic()
+    _trimmed_count = len(trimmed_messages)
+    _input_chars = sum(len(m.content or "") for m in trimmed_messages if hasattr(m, "content"))
+
     memory_store = get_memory_store(user_id)
     current_memory = memory_store.read_memory()
     current_user_profile = memory_store.read_user()
@@ -228,5 +237,30 @@ async def compact_session(
     if result.soul_update:
         memory_store.write_soul(result.soul_update)
         logger.info("Compaction updated SOUL.md for user %s", user_id)
+
+    # Single structured summary line. Fields are space-separated key=value
+    # so log aggregators (Railway, Loki) can group / filter without
+    # needing JSON. ``input_tokens`` reflects the tokens Anthropic
+    # billed; the ``trimmed_chars`` field gives a provider-agnostic
+    # input-size proxy. ``*_updated`` flags reveal whether the LLM
+    # actually produced content for each file vs returning empty.
+    _input_tokens = response.usage.input_tokens or 0 if response.usage else 0
+    _output_tokens = response.usage.output_tokens or 0 if response.usage else 0
+    _duration_ms = int((time.monotonic() - _start_monotonic) * 1000)
+    logger.info(
+        "compaction.summary user=%s trimmed_count=%d trimmed_chars=%d "
+        "input_tokens=%d output_tokens=%d duration_ms=%d "
+        "memory_updated=%s user_updated=%s soul_updated=%s summary_len=%d",
+        user_id,
+        _trimmed_count,
+        _input_chars,
+        _input_tokens,
+        _output_tokens,
+        _duration_ms,
+        bool(result.memory_update),
+        bool(result.user_profile_update),
+        bool(result.soul_update),
+        len(result.summary or ""),
+    )
 
     return result.memory_update, max_message_seq

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -635,6 +635,102 @@ async def test_compact_session_no_new_info(test_user: UserData) -> None:
 
 
 @pytest.mark.asyncio()
+async def test_compact_session_emits_structured_summary_log(
+    test_user: UserData, caplog: pytest.LogCaptureFixture
+) -> None:
+    """compact_session must emit a single ``compaction.summary`` line with the
+    fields downstream telemetry will aggregate.
+
+    Ties down the field set so changes here are intentional. Compaction is
+    a routine operation for active users (every ~27 days at 15k tokens/day),
+    so the summary line is the primary signal we have for tracking
+    frequency, cost, and whether the LLM is producing meaningful updates.
+    """
+    import logging
+
+    llm_response_content = json.dumps(
+        {
+            "memory_update": "## Pricing\n- Day rate: $500",
+            "summary": "[TIMESTAMP] Discussed pricing.",
+            "user_profile_update": "- Day rate: $500",
+            "soul_update": "",
+        }
+    )
+    mock_response = make_text_response(
+        llm_response_content,
+        input_tokens=1234,
+        output_tokens=42,
+    )
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="My day rate is $500"),
+        AssistantMessage(content="Got it."),
+    ]
+
+    with (
+        caplog.at_level(logging.INFO, logger="backend.app.agent.compaction"),
+        patch("backend.app.agent.compaction.amessages", return_value=mock_response),
+    ):
+        await compact_session(test_user.id, messages)
+
+    summary_lines = [r for r in caplog.records if "compaction.summary" in r.getMessage()]
+    assert len(summary_lines) == 1, (
+        f"expected exactly one compaction.summary line, got {len(summary_lines)}"
+    )
+    msg = summary_lines[0].getMessage()
+    assert f"user={test_user.id}" in msg
+    assert "trimmed_count=2" in msg
+    assert "input_tokens=1234" in msg
+    assert "output_tokens=42" in msg
+    assert "memory_updated=True" in msg
+    assert "user_updated=True" in msg
+    assert "soul_updated=False" in msg
+    # summary_len is the byte length of the parsed summary field, which
+    # has the [TIMESTAMP] placeholder still in it (the run replaces it
+    # before appending to HISTORY.md, but the log captures the parsed
+    # value, not the substituted one).
+    assert "summary_len=" in msg
+    assert "duration_ms=" in msg
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_summary_log_marks_all_updates_false_when_llm_returns_empty(
+    test_user: UserData, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When the LLM returns empty fields, the summary line still fires but
+    all ``*_updated`` flags must be False.
+
+    This is the signal we use to detect "compaction ran but found nothing
+    to persist" -- which is fine occasionally but persistent emptiness
+    points to an upstream issue (agent isn't surfacing facts in the
+    conversation, or the prompt isn't extracting them).
+    """
+    import logging
+
+    mock_response = make_text_response(
+        json.dumps(
+            {"memory_update": "", "summary": "", "user_profile_update": "", "soul_update": ""}
+        )
+    )
+
+    messages: list[AgentMessage] = [UserMessage(content="just a chat")]
+
+    with (
+        caplog.at_level(logging.INFO, logger="backend.app.agent.compaction"),
+        patch("backend.app.agent.compaction.amessages", return_value=mock_response),
+    ):
+        await compact_session(test_user.id, messages)
+
+    summary_lines = [r for r in caplog.records if "compaction.summary" in r.getMessage()]
+    assert len(summary_lines) == 1
+    msg = summary_lines[0].getMessage()
+    assert "memory_updated=False" in msg
+    assert "user_updated=False" in msg
+    assert "soul_updated=False" in msg
+    assert "summary_len=0" in msg
+
+
+@pytest.mark.asyncio()
 async def test_compact_session_uses_configured_model(test_user: UserData) -> None:
     """compact_session should use compaction_model/provider when configured."""
     mock_response = make_text_response(json.dumps({"memory_update": "", "summary": ""}))


### PR DESCRIPTION
## Description

Closes #1086 (the investigation portion). The original framing of "long context biases toward terse replies" turned out to be inconclusive on a single data point. The more useful angle, surfaced during the investigation, is that **compaction is a routine operation we have almost no visibility into**.

For an active user at ~15k tokens/day (Jesse's observed rate), the 400k token trim threshold lands every ~27 days. For a power user at 5x that rate, every 5-6 days. Across a multi-tenant deployment, compactions fire frequently enough that their cost and quality matter.

This PR adds a single structured log line per compaction run so we can audit frequency, cost, and quality from prod logs without code changes.

## Log format

Single space-delimited key=value line so log aggregators (Railway, Loki) can group / filter without JSON parsing:

```
compaction.summary user=<id> trimmed_count=N trimmed_chars=N
  input_tokens=N output_tokens=N duration_ms=N
  memory_updated=bool user_updated=bool soul_updated=bool
  summary_len=N
```

Fields support three audit angles:
- **Frequency:** count occurrences per user per week
- **Cost:** sum `input_tokens` / `output_tokens`, multiply by current model price
- **Quality:** rate of all-False `*_updated` flags. Persistent emptiness signals an upstream issue (agent isn't surfacing facts in conversation, or the prompt isn't extracting them)

## Tests

Two regression tests pin the field set:
- `test_compact_session_emits_structured_summary_log`: happy path with non-empty updates, asserts every field is present
- `test_compact_session_summary_log_marks_all_updates_false_when_llm_returns_empty`: asserts the all-False case fires the line and the `*_updated` flags reflect what the LLM produced

## Type
- [x] Feature (telemetry only, no behavior change)

## Checklist
- [x] Tests pass (`uv run pytest tests/test_compaction.py`, 51 passed)
- [x] Lint passes
- [x] Type checking passes
- [x] New behavior has tests

## AI Usage
- [x] AI-assisted: drafted by Claude via back-and-forth with @njbrake. Reasoning and decisions are mine; prose is Claude's.