### PR TITLE
docs(config): document LLM_CACHE_EXTENDED_TTL setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,7 @@ STORAGE_PROVIDER=local
 # MAX_INPUT_TOKENS=120000
 # CONTEXT_TRIM_TARGET_TOKENS=80000
 # LLM_MAX_RETRIES=3
+# LLM_CACHE_EXTENDED_TTL=true  # Use Anthropic's 1h cache TTL (vs default 5min); set false on providers that reject the ttl field
 
 # Conversation & memory
 # CONVERSATION_HISTORY_LIMIT=20

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -108,6 +108,7 @@ See [Storage Providers](./storage.md) for setup instructions.
 | `MAX_INPUT_TOKENS` | `120000` | Max input token budget before context trimming |
 | `CONTEXT_TRIM_TARGET_TOKENS` | `80000` | Target token count after trimming |
 | `LLM_MAX_RETRIES` | `3` | Maximum number of retry attempts on rate limit errors |
+| `LLM_CACHE_EXTENDED_TTL` | `true` | Use Anthropic's 1-hour extended cache TTL instead of the default 5 minutes. Reduces cold-start cache misses for users with multi-hour gaps between messages. Set to `false` on non-Anthropic providers that reject the `ttl` field |
 
 ## Conversation and memory
 


### PR DESCRIPTION
## Description

Follow-up to #1095 which added the new setting but missed the env example and configuration docs. The doc-guard tests are failing on main:

```
AssertionError: Settings fields missing from .env.example: ['LLM_CACHE_EXTENDED_TTL']
AssertionError: Settings fields missing from docs/self-host/configuration.md: ['LLM_CACHE_EXTENDED_TTL']
```

Adds both entries.

## Type
- [x] Documentation
- [x] Bug fix (CI is red on main)

## Checklist
- [x] Tests pass (`uv run pytest tests/test_env_example.py`, 2 passed)

## AI Usage
- [x] AI-assisted: drafted by Claude via back-and-forth with @njbrake.