### PR TITLE
feat: /report inline channel command for user-initiated conversation flagging

### DIFF
--- a/alembic/versions/021_add_reported_conversations.py
+++ b/alembic/versions/021_add_reported_conversations.py
@@ -1,0 +1,72 @@
+"""Add reported_conversations table for the /report channel command.
+
+Item 5 of the clawbolt-premium privacy redesign (issue #325). Users on
+iMessage/Telegram/SMS-only deployments need a way to flag a
+conversation for admin review without ever opening the web app, so we
+intercept the literal text ``/report [reason]`` in the inbound pipeline
+and write a row here. The premium ``/admin/reported-conversations``
+router consumes these rows.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-05-01
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "021"
+down_revision: str = "020"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reported_conversations",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.String(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "session_id",
+            sa.Integer(),
+            sa.ForeignKey("sessions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("anchor_seq", sa.Integer(), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("dismissed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "reviewed_admin_user_id",
+            sa.String(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_reported_conversations_user_id", "reported_conversations", ["user_id"])
+    op.create_index(
+        "ix_reported_conversations_session_id", "reported_conversations", ["session_id"]
+    )
+    op.create_index(
+        "ix_reported_conversations_created_at", "reported_conversations", ["created_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reported_conversations_created_at", "reported_conversations")
+    op.drop_index("ix_reported_conversations_session_id", "reported_conversations")
+    op.drop_index("ix_reported_conversations_user_id", "reported_conversations")
+    op.drop_table("reported_conversations")

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -36,7 +36,7 @@ from backend.app.database import SessionLocal
 from backend.app.enums import MessageDirection
 from backend.app.logging_utils import mask_pii
 from backend.app.media.download import DownloadedMedia
-from backend.app.models import ChannelRoute, User
+from backend.app.models import ChannelRoute, ReportedConversation, User
 
 logger = logging.getLogger(__name__)
 
@@ -547,6 +547,154 @@ message_batcher = MessageBatcher(window_ms=settings.message_batch_window_ms)
 
 
 # ---------------------------------------------------------------------------
+# /report inline command
+# ---------------------------------------------------------------------------
+#
+# Users on iMessage / Telegram / SMS can flag a conversation for admin
+# review by texting ``/report`` (optionally followed by a free-text
+# reason). The literal text is intercepted before it reaches the LLM
+# and never persisted as a normal user message; instead a row goes
+# into ``reported_conversations`` and the user gets a fixed
+# acknowledgement reply. The premium ``/admin/reported-conversations``
+# router consumes the rows.
+
+_REPORT_PREFIX = "/report"
+_REPORT_ACK = (
+    "Got it. I've flagged this conversation for our team to review. "
+    "They'll only look at messages you've already sent through this chat."
+)
+
+
+def _parse_report_command(text: str) -> str | None:
+    """Return the optional reason if *text* is a ``/report`` invocation.
+
+    Recognized shapes (case-insensitive on the command word):
+
+    - ``/report`` → returns ``""`` (empty reason)
+    - ``/report bot was rude`` → returns ``"bot was rude"``
+    - ``/reportbot ...`` → returns ``None`` (not a command, just a
+      message that happens to start with the same letters)
+    - ``please /report this`` → returns ``None`` (command must be at
+      the start so users typing ``/report`` mid-sentence aren't
+      surprised by a flag)
+
+    Leading/trailing whitespace is allowed and stripped.
+    """
+    if not text:
+        return None
+    stripped = text.strip()
+    lowered = stripped.lower()
+    if not lowered.startswith(_REPORT_PREFIX):
+        return None
+    # Must be ``/report`` exactly or ``/report `` followed by content.
+    rest = stripped[len(_REPORT_PREFIX) :]
+    if rest and not rest[0].isspace():
+        return None
+    return rest.strip()
+
+
+async def _handle_report_command(
+    inbound: "InboundMessage",
+    user: User,
+    reason: str,
+) -> None:
+    """Persist the report and send an acknowledgement to the user.
+
+    Resolves (or creates) the user's session so the report row has a
+    stable ``session_id`` FK. Best-effort about ``anchor_seq``: looks
+    up the latest message in the session at report time, but if
+    something fails we still write the row with ``anchor_seq=NULL``
+    rather than fail the user-visible ack.
+    """
+    from backend.app.bus import OutboundMessage, message_bus
+
+    try:
+        session, _is_new = await get_or_create_conversation(
+            user.id, external_session_id=inbound.session_id
+        )
+    except Exception:
+        logger.exception(
+            "/report: failed to resolve session for user %s; skipping persistence",
+            user.id,
+        )
+        # Send the ack anyway. The user shouldn't see a 500 because we
+        # couldn't resolve their session; better to drop the row than
+        # to drop the ack.
+        await message_bus.publish_outbound(
+            OutboundMessage(
+                channel=inbound.channel,
+                chat_id=inbound.sender_id,
+                content=_REPORT_ACK,
+                request_id=inbound.request_id,
+            )
+        )
+        return
+
+    # Look up the most recent message seq in this session as the anchor.
+    # Best-effort: NULL is acceptable if the session is empty or the
+    # query fails. The DTO carries ``session.session_id`` (the UUID
+    # string); we resolve to the integer ``ChatSession.id`` here for
+    # the FK on ``reported_conversations``.
+    anchor_seq: int | None = None
+    db = SessionLocal()
+    try:
+        from backend.app.models import ChatSession as _ChatSession
+        from backend.app.models import Message
+
+        cs_row = (
+            db.query(_ChatSession).filter(_ChatSession.session_id == session.session_id).first()
+        )
+        if cs_row is None:
+            logger.error(
+                "/report: session %s not in DB; skipping persistence",
+                session.session_id,
+            )
+        else:
+            latest_seq = (
+                db.query(Message.seq)
+                .filter(Message.session_id == cs_row.id)
+                .order_by(Message.seq.desc())
+                .limit(1)
+                .scalar()
+            )
+            if latest_seq is not None:
+                anchor_seq = int(latest_seq)
+            row = ReportedConversation(
+                user_id=user.id,
+                session_id=cs_row.id,
+                anchor_seq=anchor_seq,
+                reason=reason,
+            )
+            db.add(row)
+            db.commit()
+            logger.info(
+                "/report filed by user %s for session %s (anchor_seq=%s, reason_len=%d)",
+                user.id,
+                session.session_id,
+                anchor_seq,
+                len(reason),
+            )
+    except Exception:
+        logger.exception(
+            "/report: failed to persist row for user %s session %s",
+            user.id,
+            session.session_id,
+        )
+        db.rollback()
+    finally:
+        db.close()
+
+    await message_bus.publish_outbound(
+        OutboundMessage(
+            channel=inbound.channel,
+            chat_id=inbound.sender_id,
+            content=_REPORT_ACK,
+            request_id=inbound.request_id,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
 # Bus consumer entry point
 # ---------------------------------------------------------------------------
 
@@ -589,6 +737,17 @@ async def process_inbound_from_bus(
             inbound.channel,
             inbound.sender_id,
         )
+        return
+
+    # -- Intercept /report command before approval / agent dispatch --
+    # Runs ahead of the approval check on purpose: a user mid-approval
+    # who decides to file a report should still be able to. We send the
+    # ack and bail without resolving the approval, which leaves any
+    # blocked agent loop pending. The user can subsequently reply to
+    # the approval prompt as usual.
+    report_reason = _parse_report_command(inbound.text)
+    if report_reason is not None:
+        await _handle_report_command(inbound, user, report_reason)
         return
 
     # -- Intercept approval responses before normal processing --

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -36,7 +36,7 @@ from backend.app.database import SessionLocal
 from backend.app.enums import MessageDirection
 from backend.app.logging_utils import mask_pii
 from backend.app.media.download import DownloadedMedia
-from backend.app.models import ChannelRoute, ReportedConversation, User
+from backend.app.models import ChannelRoute, ChatSession, Message, ReportedConversation, User
 
 logger = logging.getLogger(__name__)
 
@@ -563,6 +563,12 @@ _REPORT_ACK = (
     "Got it. I've flagged this conversation for our team to review. "
     "They'll only look at messages you've already sent through this chat."
 )
+# Cap on the reason text persisted into ``reported_conversations.reason``.
+# Defends against accidentally storing a 100KB message in the row when a
+# user pastes a long transcript or rant after ``/report``. 4KB is more
+# than enough for "the bot said X and I disagreed because Y," and it
+# bounds row size for the admin UI's list view.
+_REPORT_REASON_MAX_LEN = 4096
 
 
 def _parse_report_command(text: str) -> str | None:
@@ -578,7 +584,9 @@ def _parse_report_command(text: str) -> str | None:
       the start so users typing ``/report`` mid-sentence aren't
       surprised by a flag)
 
-    Leading/trailing whitespace is allowed and stripped.
+    Leading/trailing whitespace is allowed and stripped. The returned
+    reason is also capped at ``_REPORT_REASON_MAX_LEN`` chars; longer
+    text is truncated rather than rejected so the report still files.
     """
     if not text:
         return None
@@ -590,7 +598,7 @@ def _parse_report_command(text: str) -> str | None:
     rest = stripped[len(_REPORT_PREFIX) :]
     if rest and not rest[0].isspace():
         return None
-    return rest.strip()
+    return rest.strip()[:_REPORT_REASON_MAX_LEN]
 
 
 async def _handle_report_command(
@@ -605,21 +613,79 @@ async def _handle_report_command(
     up the latest message in the session at report time, but if
     something fails we still write the row with ``anchor_seq=NULL``
     rather than fail the user-visible ack.
+
+    The ack is sent in a ``try/finally`` so there is exactly one call
+    site regardless of which failure path the persistence takes. The
+    user should never see silence for ``/report``.
     """
+    # ``backend.app.bus`` is imported lazily here because the bus
+    # module imports ingestion (via the channel manager) and the two
+    # would form a circular dependency at module-load time. The other
+    # functions in this file do the same.
     from backend.app.bus import OutboundMessage, message_bus
 
     try:
-        session, _is_new = await get_or_create_conversation(
-            user.id, external_session_id=inbound.session_id
-        )
-    except Exception:
-        logger.exception(
-            "/report: failed to resolve session for user %s; skipping persistence",
-            user.id,
-        )
-        # Send the ack anyway. The user shouldn't see a 500 because we
-        # couldn't resolve their session; better to drop the row than
-        # to drop the ack.
+        try:
+            session, _is_new = await get_or_create_conversation(
+                user.id, external_session_id=inbound.session_id
+            )
+        except Exception:
+            logger.exception(
+                "/report: failed to resolve session for user %s; skipping persistence",
+                user.id,
+            )
+            return
+
+        # Look up the most recent message seq in this session as the
+        # anchor. Best-effort: NULL is acceptable if the session is
+        # empty or the query fails. The DTO carries
+        # ``session.session_id`` (the UUID string); we resolve to the
+        # integer ``ChatSession.id`` here for the FK on
+        # ``reported_conversations``.
+        db = SessionLocal()
+        try:
+            cs_row = (
+                db.query(ChatSession).filter(ChatSession.session_id == session.session_id).first()
+            )
+            if cs_row is None:
+                logger.error(
+                    "/report: session %s not in DB; skipping persistence",
+                    session.session_id,
+                )
+            else:
+                latest_seq = (
+                    db.query(Message.seq)
+                    .filter(Message.session_id == cs_row.id)
+                    .order_by(Message.seq.desc())
+                    .limit(1)
+                    .scalar()
+                )
+                anchor_seq = int(latest_seq) if latest_seq is not None else None
+                row = ReportedConversation(
+                    user_id=user.id,
+                    session_id=cs_row.id,
+                    anchor_seq=anchor_seq,
+                    reason=reason,
+                )
+                db.add(row)
+                db.commit()
+                logger.info(
+                    "/report filed by user %s for session %s (anchor_seq=%s, reason_len=%d)",
+                    user.id,
+                    session.session_id,
+                    anchor_seq,
+                    len(reason),
+                )
+        except Exception:
+            logger.exception(
+                "/report: failed to persist row for user %s session %s",
+                user.id,
+                session.session_id,
+            )
+            db.rollback()
+        finally:
+            db.close()
+    finally:
         await message_bus.publish_outbound(
             OutboundMessage(
                 channel=inbound.channel,
@@ -628,70 +694,6 @@ async def _handle_report_command(
                 request_id=inbound.request_id,
             )
         )
-        return
-
-    # Look up the most recent message seq in this session as the anchor.
-    # Best-effort: NULL is acceptable if the session is empty or the
-    # query fails. The DTO carries ``session.session_id`` (the UUID
-    # string); we resolve to the integer ``ChatSession.id`` here for
-    # the FK on ``reported_conversations``.
-    anchor_seq: int | None = None
-    db = SessionLocal()
-    try:
-        from backend.app.models import ChatSession as _ChatSession
-        from backend.app.models import Message
-
-        cs_row = (
-            db.query(_ChatSession).filter(_ChatSession.session_id == session.session_id).first()
-        )
-        if cs_row is None:
-            logger.error(
-                "/report: session %s not in DB; skipping persistence",
-                session.session_id,
-            )
-        else:
-            latest_seq = (
-                db.query(Message.seq)
-                .filter(Message.session_id == cs_row.id)
-                .order_by(Message.seq.desc())
-                .limit(1)
-                .scalar()
-            )
-            if latest_seq is not None:
-                anchor_seq = int(latest_seq)
-            row = ReportedConversation(
-                user_id=user.id,
-                session_id=cs_row.id,
-                anchor_seq=anchor_seq,
-                reason=reason,
-            )
-            db.add(row)
-            db.commit()
-            logger.info(
-                "/report filed by user %s for session %s (anchor_seq=%s, reason_len=%d)",
-                user.id,
-                session.session_id,
-                anchor_seq,
-                len(reason),
-            )
-    except Exception:
-        logger.exception(
-            "/report: failed to persist row for user %s session %s",
-            user.id,
-            session.session_id,
-        )
-        db.rollback()
-    finally:
-        db.close()
-
-    await message_bus.publish_outbound(
-        OutboundMessage(
-            channel=inbound.channel,
-            chat_id=inbound.sender_id,
-            content=_REPORT_ACK,
-            request_id=inbound.request_id,
-        )
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -204,6 +204,19 @@ class User(Base):
     oauth_tokens: Mapped[list["OAuthToken"]] = relationship(
         "OAuthToken", back_populates="user", cascade="all, delete-orphan"
     )
+    # Reports this user filed via ``/report``. ``ReportedConversation``
+    # has two FKs to ``users.id`` (``user_id`` for the reporter,
+    # ``reviewed_admin_user_id`` for the admin who closed it); the
+    # explicit ``foreign_keys=`` disambiguates that this relationship
+    # is the reporter side. We don't expose the admin-side relationship
+    # because the audit log already lets ops query "what did this admin
+    # do" without an ORM round-trip.
+    reported_conversations: Mapped[list["ReportedConversation"]] = relationship(
+        "ReportedConversation",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        foreign_keys="ReportedConversation.user_id",
+    )
 
 
 class ChannelRoute(Base):
@@ -403,6 +416,14 @@ class ReportedConversation(Base):
     dismissed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     reviewed_admin_user_id: Mapped[str | None] = mapped_column(
         String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+
+    # Reverse side of ``User.reported_conversations``. Disambiguated by
+    # ``foreign_keys`` because this table has two FKs to ``users.id``.
+    user: Mapped["User"] = relationship(
+        "User",
+        back_populates="reported_conversations",
+        foreign_keys=[user_id],
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -361,6 +361,51 @@ class HeartbeatLog(Base):
     user: Mapped["User"] = relationship("User", back_populates="heartbeat_logs")
 
 
+class ReportedConversation(Base):
+    """A user-initiated report flagging a conversation for admin review.
+
+    Created when a user texts ``/report [reason]`` to the bot through any
+    channel. The user is signaling that something happened in this
+    conversation they want a human to look at: the bot misbehaved, gave
+    wrong information, said something distressing, etc.
+
+    The premium ``/admin/reported-conversations`` router consumes these
+    rows. ``anchor_seq`` records which inbound message triggered the
+    report so the admin UI can highlight the surrounding conversation
+    window. ``dismissed_at`` + ``reviewed_admin_user_id`` are set when an
+    admin closes out the report. ``reason`` is the optional free-text
+    that followed ``/report`` (empty string if the user just sent
+    ``/report`` alone).
+    """
+
+    __tablename__ = "reported_conversations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(
+        String, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    session_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("sessions.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    # The seq of the inbound message whose ``/report`` text created this
+    # row. Nullable because future programmatic reports (e.g. an admin
+    # tool that flags a conversation without an originating message)
+    # might not have one.
+    anchor_seq: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    reason: Mapped[str] = mapped_column(Text, default="")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), index=True
+    )
+    # Admin review state. ``dismissed_at`` is the time the report was
+    # closed; ``reviewed_admin_user_id`` is the admin who closed it.
+    # Both NULL until a review happens. ``ondelete=SET NULL`` on the
+    # admin FK so deleting an admin doesn't cascade-delete reports.
+    dismissed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    reviewed_admin_user_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+
+
 class IdempotencyKey(Base):
     __tablename__ = "idempotency_keys"
 

--- a/tests/test_report_command.py
+++ b/tests/test_report_command.py
@@ -67,6 +67,18 @@ class TestParseReportCommand:
         assert _parse_report_command("hello there") is None
         assert _parse_report_command("/help") is None
 
+    def test_reason_is_truncated_at_4kb(self) -> None:
+        """A pasted-transcript-sized reason is silently truncated rather
+        than rejected, so the report still files. Bounds row size for
+        the admin UI's list view and the JSON envelope."""
+        from backend.app.agent.ingestion import _REPORT_REASON_MAX_LEN
+
+        huge = "a" * (_REPORT_REASON_MAX_LEN * 4)
+        result = _parse_report_command(f"/report {huge}")
+        assert result is not None
+        assert len(result) == _REPORT_REASON_MAX_LEN
+        assert result == "a" * _REPORT_REASON_MAX_LEN
+
 
 class TestReportInterception:
     """End-to-end behavior: /report short-circuits the agent pipeline."""

--- a/tests/test_report_command.py
+++ b/tests/test_report_command.py
@@ -1,0 +1,272 @@
+"""Tests for the inline ``/report`` channel command (issue #325 item 5).
+
+Covers:
+- Parsing (``_parse_report_command``): exact match, with reason, false
+  positives like ``/reportbot`` and ``please /report`` are not commands.
+- End-to-end intercept inside ``process_inbound_from_bus``: a /report
+  message persists a row, sends an ack, and does NOT continue to the
+  agent pipeline.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import backend.app.database as _db_module
+from backend.app.agent.ingestion import (
+    InboundMessage,
+    _parse_report_command,
+    process_inbound_from_bus,
+)
+from backend.app.bus import message_bus
+from backend.app.models import ChatSession, Message, ReportedConversation, User
+
+
+class TestParseReportCommand:
+    def test_bare_report_returns_empty_reason(self) -> None:
+        assert _parse_report_command("/report") == ""
+
+    def test_report_with_reason(self) -> None:
+        assert _parse_report_command("/report bot was rude") == "bot was rude"
+
+    def test_case_insensitive_command_word(self) -> None:
+        """Recognize ``/Report``, ``/REPORT``, etc. as the same command.
+
+        Mobile keyboards autocapitalize the first letter, so we should
+        accept ``/Report`` from a user who didn't override the
+        autocap.
+        """
+        assert _parse_report_command("/Report something happened") == "something happened"
+        assert _parse_report_command("/REPORT") == ""
+
+    def test_leading_and_trailing_whitespace_is_stripped(self) -> None:
+        assert _parse_report_command("  /report   the bot lied   ") == "the bot lied"
+
+    def test_reportbot_is_not_a_command(self) -> None:
+        """``/reportbot`` (no space after the prefix) is a different word."""
+        assert _parse_report_command("/reportbot is a tool") is None
+
+    def test_mid_sentence_report_is_not_a_command(self) -> None:
+        """The command must be at the start of the message.
+
+        Otherwise a user typing "please /report this" mid-sentence in
+        normal conversation would silently flag the conversation, which
+        violates the principle of least surprise.
+        """
+        assert _parse_report_command("please /report this") is None
+        assert _parse_report_command("about to /report something") is None
+
+    def test_empty_input_is_not_a_command(self) -> None:
+        assert _parse_report_command("") is None
+        assert _parse_report_command("   ") is None
+
+    def test_non_command_message_returns_none(self) -> None:
+        assert _parse_report_command("hello there") is None
+        assert _parse_report_command("/help") is None
+
+
+class TestReportInterception:
+    """End-to-end behavior: /report short-circuits the agent pipeline."""
+
+    @pytest.fixture()
+    def report_user(self) -> User:
+        """Create a User that exists in the test database."""
+        db = _db_module.SessionLocal()
+        try:
+            user = User(
+                id=str(uuid.uuid4()),
+                user_id=f"google_{uuid.uuid4().hex[:8]}",
+                phone="",
+                onboarding_complete=True,
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+            db.expunge(user)
+            return user
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_report_persists_row_and_sends_ack(self, report_user: User) -> None:
+        """A ``/report`` message: writes one ReportedConversation row,
+        sends one ack to the bus, never calls the agent pipeline."""
+        # Drain the bus so we only see this test's outbound.
+        while not message_bus.outbound.empty():
+            message_bus.outbound.get_nowait()
+
+        inbound = InboundMessage(
+            channel="telegram",
+            sender_id=report_user.user_id,
+            text="/report the bot said something rude",
+        )
+
+        with (
+            patch(
+                "backend.app.agent.ingestion._get_or_create_user",
+                new_callable=AsyncMock,
+                return_value=report_user,
+            ),
+            patch(
+                "backend.app.agent.ingestion._check_channel_route_enabled",
+                return_value=True,
+            ),
+            patch(
+                "backend.app.agent.ingestion.handle_inbound_message",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+        ):
+            await process_inbound_from_bus(inbound)
+
+        # Pipeline must NOT have been called for a /report.
+        mock_handle.assert_not_called()
+
+        # Exactly one ReportedConversation row exists for this user.
+        db = _db_module.SessionLocal()
+        try:
+            rows = (
+                db.query(ReportedConversation)
+                .filter(ReportedConversation.user_id == report_user.id)
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].reason == "the bot said something rude"
+            assert rows[0].dismissed_at is None
+            assert rows[0].reviewed_admin_user_id is None
+        finally:
+            db.close()
+
+        # One ack on the bus, with the canonical body.
+        assert not message_bus.outbound.empty()
+        ack = message_bus.outbound.get_nowait()
+        assert ack.chat_id == report_user.user_id
+        assert "flagged" in ack.content.lower()
+        # Drain anything else (typing indicators) but the only real
+        # outbound should be the ack.
+        while not message_bus.outbound.empty():
+            extra = message_bus.outbound.get_nowait()
+            assert extra.is_typing_indicator, (
+                f"Unexpected non-typing outbound after /report ack: {extra.content!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_report_anchor_seq_points_at_latest_message(self, report_user: User) -> None:
+        """The ``anchor_seq`` column captures the seq of the last
+        message in the session at report time so admins can highlight
+        the surrounding window."""
+        # Pre-seed a session with two prior messages so seq=2 is the
+        # latest before /report fires.
+        db = _db_module.SessionLocal()
+        try:
+            cs = ChatSession(
+                session_id=f"sess-{uuid.uuid4().hex[:8]}",
+                user_id=report_user.id,
+                channel="telegram",
+            )
+            db.add(cs)
+            db.flush()
+            db.add_all(
+                [
+                    Message(session_id=cs.id, seq=1, direction="inbound", body="hi"),
+                    Message(session_id=cs.id, seq=2, direction="outbound", body="hello!"),
+                ]
+            )
+            db.commit()
+            session_db_id = cs.id
+            session_external_id = cs.session_id
+        finally:
+            db.close()
+
+        # Drain the bus.
+        while not message_bus.outbound.empty():
+            message_bus.outbound.get_nowait()
+
+        inbound = InboundMessage(
+            channel="telegram",
+            sender_id=report_user.user_id,
+            text="/report",
+            session_id=session_external_id,
+        )
+
+        with (
+            patch(
+                "backend.app.agent.ingestion._get_or_create_user",
+                new_callable=AsyncMock,
+                return_value=report_user,
+            ),
+            patch(
+                "backend.app.agent.ingestion._check_channel_route_enabled",
+                return_value=True,
+            ),
+        ):
+            await process_inbound_from_bus(inbound)
+
+        db = _db_module.SessionLocal()
+        try:
+            row = (
+                db.query(ReportedConversation)
+                .filter(ReportedConversation.user_id == report_user.id)
+                .filter(ReportedConversation.session_id == session_db_id)
+                .one()
+            )
+            assert row.anchor_seq == 2
+            assert row.reason == ""
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_non_report_message_is_not_intercepted(self, report_user: User) -> None:
+        """A normal inbound text must reach the agent pipeline (no
+        ReportedConversation row, no canned ack, no short-circuit)."""
+        while not message_bus.outbound.empty():
+            message_bus.outbound.get_nowait()
+
+        inbound = InboundMessage(
+            channel="telegram",
+            sender_id=report_user.user_id,
+            text="hi there, how's it going",
+        )
+
+        with (
+            patch(
+                "backend.app.agent.ingestion._get_or_create_user",
+                new_callable=AsyncMock,
+                return_value=report_user,
+            ),
+            patch(
+                "backend.app.agent.ingestion._check_channel_route_enabled",
+                return_value=True,
+            ),
+            patch(
+                "backend.app.agent.ingestion.get_approval_gate",
+            ) as mock_gate,
+            patch(
+                "backend.app.agent.ingestion.handle_inbound_message",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+            patch(
+                "backend.app.agent.ingestion.settings",
+            ) as mock_settings,
+        ):
+            mock_gate.return_value.has_pending.return_value = False
+            mock_settings.message_batch_window_ms = 0
+            mock_settings.agent_processing_timeout_seconds = 60.0
+            await process_inbound_from_bus(inbound)
+
+        # Pipeline IS called for normal traffic.
+        mock_handle.assert_called_once()
+
+        # No ReportedConversation row was written.
+        db = _db_module.SessionLocal()
+        try:
+            count = (
+                db.query(ReportedConversation)
+                .filter(ReportedConversation.user_id == report_user.id)
+                .count()
+            )
+            assert count == 0
+        finally:
+            db.close()


### PR DESCRIPTION
## Description

Adds an inline `/report [reason]` command that any user can text through any channel (Telegram, iMessage, SMS, webchat) to flag the current conversation for admin review. Persists a `ReportedConversation` row and sends a fixed acknowledgement, without ever invoking the LLM for the report message itself.

This is item 5 of the clawbolt-premium privacy redesign, [issue #325](https://github.com/mozilla-ai/clawbolt-premium/issues/325). The premium `/admin/reported-conversations` router (separate follow-up PR) will consume the rows.

## Why an inline command rather than a web-app form

The original issue called this out as an open question. The honest answer: most clawbolt users never open the web app (they live on iMessage or Telegram), so a web-only report flow misses the population that most needs it. An inline command is:

- **Verifiable**: the text comes through the user's own authenticated channel route. Spoofing the report would require spoofing the channel, which the existing allowlist already gates.
- **Zero-friction to build**: no new auth surface, no email integration, no spam-filter dance.
- **Discoverable enough**: future docs can mention it; channel handlers can also surface it on `/help`.

## What ships

| Piece | Notes |
|---|---|
| `ReportedConversation` model | `user_id` / `session_id` FKs (CASCADE), `anchor_seq` (latest message seq at report time, so admin UI can highlight the surrounding window), `reason`, `created_at`, `dismissed_at`, `reviewed_admin_user_id` (FK with SET NULL on admin deletion). Indices on user_id / session_id / created_at. |
| Migration 021 | `server_default=func.now()` on `created_at`, `server_default=''` on `reason`. Stacks cleanly on `020`. |
| `_parse_report_command(text)` | Recognizes `/report` and `/report <reason>`, case-insensitive on the command word (autocap), whitespace stripped. Rejects `/reportbot` (different word) and `please /report this` (mid-sentence) so normal conversation isn't surprised by a flag. |
| `_handle_report_command` | Resolves the session, captures `anchor_seq`, persists the row, publishes the canonical ack to the bus. Failures inside persistence still send the ack — users should never see silence for `/report`. |
| Intercept call site | Runs BEFORE the approval-response intercept so a user mid-approval can still file a report. Short-circuits the agent pipeline. |

## Acknowledgement copy

`"Got it. I've flagged this conversation for our team to review. They'll only look at messages you've already sent through this chat."`

The "only look at messages you've already sent" line previews the consent gate from #1100 — admins reading via `/admin/shared-data` only see opted-in users; reports surface the conversation regardless. Worth setting expectations up front.

## Tests

11 tests across `tests/test_report_command.py`:

- 8 parser tests: bare `/report`, with reason, case-insensitive, whitespace, `/reportbot` rejection, mid-sentence rejection, empty input, plain prose.
- 3 end-to-end intercept tests: persists row + sends ack + doesn't call agent pipeline; `anchor_seq` points at the latest message in the session; non-`/report` messages reach the pipeline normally and don't write rows.

## Type
- [x] Feature

## Checklist
- [x] Tests pass — `uv run pytest -v` not exercised in this dev sandbox (no Postgres). CI will run them.
- [x] Lint passes (`ruff check`, `ruff format --check`)
- [x] Type check passes (`ty check`)
- [x] New tests added for new functionality

## AI Usage
- [x] AI-assisted: drafted by Claude via discussion with @njbrake. The reasoning and decisions are his; the prose is Claude's.