### PR TITLE
feat: envelope-encrypt heartbeat_logs + memory_documents content

### DIFF
--- a/alembic/versions/022_envelope_encrypt_heartbeat_and_memory.py
+++ b/alembic/versions/022_envelope_encrypt_heartbeat_and_memory.py
@@ -1,0 +1,151 @@
+"""Envelope-encrypt heartbeat_logs + memory_documents content columns.
+
+Extends the at-rest encryption coverage from migration 020 (Message
+body / processed_context). Same pattern: per-row DEKs wrapped by
+``LocalKEKProvider`` (or the premium KMS-backed provider). Five
+columns get re-encrypted in this migration:
+
+- ``heartbeat_logs.message_text`` (proactive message body)
+- ``heartbeat_logs.reasoning`` (LLM rationale, often paraphrases user)
+- ``heartbeat_logs.tasks`` (serialized task state with user-authored
+  task descriptions)
+- ``memory_documents.memory_text`` (working memory file)
+- ``memory_documents.history_text`` (compacted older sessions)
+
+Operator preflight: refuses to run on non-empty target tables when
+``ENCRYPTION_KEY`` is unset, matching the migration-020 contract.
+Empty tables pass through (nothing to lose).
+
+Idempotent: rows already in envelope format are returned by identity
+from ``_rekey`` and the loop skips the UPDATE.
+
+Performance: streams in 1000-row batches with ``WHERE id > :last``
+cursor advancement (heartbeat_logs can grow large on chatty
+deployments). Memory_documents has at most one row per user, so the
+batching there is overkill but keeps the code uniform.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-05-01
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+from backend.app.config import settings
+from backend.app.security.encryption import (
+    LocalKEKProvider,
+    is_envelope,
+)
+from backend.app.security.encryption import (
+    encrypt as envelope_encrypt,
+)
+
+revision: str = "022"
+down_revision: str = "021"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+_BATCH_SIZE = 1000
+
+
+# Each entry: (table, [columns to encrypt]). Keep this list aligned
+# with the ``EncryptedString(table=..., column=...)`` declarations in
+# ``backend/app/models.py`` so the on-disk envelope context matches
+# what ``EncryptedString.process_result_value`` will pass on read.
+_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("heartbeat_logs", ("message_text", "reasoning", "tasks")),
+    ("memory_documents", ("memory_text", "history_text")),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Refuse to run on non-empty target tables when ENCRYPTION_KEY is
+    # unset. ``LocalKEKProvider()`` with no configured key falls back
+    # to an ephemeral process-local KEK; encrypting under it would
+    # leave content unrecoverable after the next process restart. An
+    # empty table is fine: nothing to lose.
+    if not settings.encryption_key.get_secret_value():
+        for table, _cols in _TARGETS:
+            first_row = bind.execute(sa.text(f"SELECT 1 FROM {table} LIMIT 1")).first()
+            if first_row is not None:
+                raise RuntimeError(
+                    f"Migration 022 requires ENCRYPTION_KEY to be set when "
+                    f"the {table} table is non-empty. Without a stable key, "
+                    f"content would become unrecoverable after the next "
+                    f"process restart. Set ENCRYPTION_KEY (any random 32-byte "
+                    f"value) and re-run the migration."
+                )
+
+    provider = LocalKEKProvider()
+
+    for table, cols in _TARGETS:
+        _backfill_table(bind, provider, table, cols)
+
+
+def _backfill_table(
+    bind: sa.Connection,
+    provider: LocalKEKProvider,
+    table: str,
+    cols: tuple[str, ...],
+) -> None:
+    """Stream the rows of *table* in batches, re-encrypting *cols*.
+
+    The cursor advancement at the end of every batch (regardless of
+    whether anything was updated) handles the all-already-encrypted
+    case on a re-run. Without it, a re-run on a fully-migrated DB
+    would loop forever on the same SELECT.
+    """
+    select_cols = ", ".join(["id", *cols])
+    set_clause = ", ".join(f"{c} = :{c}" for c in cols)
+    update_sql = sa.text(f"UPDATE {table} SET {set_clause} WHERE id = :id")
+    select_sql = sa.text(
+        f"SELECT {select_cols} FROM {table} WHERE id > :last ORDER BY id LIMIT :limit"
+    )
+
+    last_id = 0
+    while True:
+        rows = bind.execute(select_sql, {"last": last_id, "limit": _BATCH_SIZE}).fetchall()
+        if not rows:
+            break
+        for row in rows:
+            row_id = row[0]
+            old_values = {col: row[i + 1] for i, col in enumerate(cols)}
+            new_values = {col: _rekey(old_values[col], provider, table, col) for col in cols}
+            if all(new_values[c] is old_values[c] for c in cols):
+                continue
+            params: dict[str, object] = {"id": row_id, **new_values}
+            bind.execute(update_sql, params)
+            last_id = row_id
+        last_id = max(last_id, rows[-1][0])
+
+
+def _rekey(value: str | None, provider: LocalKEKProvider, table: str, column: str) -> str | None:
+    """Re-encrypt one column value under the envelope format.
+
+    Idempotent: rows already in envelope format are returned unchanged
+    by identity so the caller can detect "nothing to do" and skip the
+    UPDATE. Empty strings and NULLs pass through untouched (matches
+    ``EncryptedString.process_bind_param`` on writes).
+    """
+    if not value:
+        return value
+    if is_envelope(value):
+        return value
+    return envelope_encrypt(value, provider, {"table": table, "column": column})
+
+
+def downgrade() -> None:
+    """No automatic downgrade.
+
+    Decrypting back to plaintext would require unwrapping every
+    envelope at a moment in time, which fails if the KEK rotates
+    between upgrade and downgrade. Restore from backup is the
+    documented recovery path.
+    """
+    raise NotImplementedError("Cannot downgrade revision 022; restore from backup if needed.")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -335,14 +335,31 @@ class MediaFile(Base):
 
 
 class MemoryDocument(Base):
+    """Per-user memory document and compaction history.
+
+    ``memory_text`` and ``history_text`` are envelope-encrypted at rest
+    via ``EncryptedString`` (same pattern as ``Message.body`` from
+    migration 020). This is the user's working memory file (notes,
+    reminders, recent context) plus the compacted history of older
+    sessions; both contain everything the agent has been told and is
+    among the most sensitive content in the database.
+
+    ORM reads decrypt transparently. Direct SQL reads return the
+    envelope blob and require ``decrypt()`` to recover plaintext.
+    """
+
     __tablename__ = "memory_documents"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[str] = mapped_column(
         String, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False
     )
-    memory_text: Mapped[str] = mapped_column(Text, default="")
-    history_text: Mapped[str] = mapped_column(Text, default="")
+    memory_text: Mapped[str] = mapped_column(
+        EncryptedString(table="memory_documents", column="memory_text"), default=""
+    )
+    history_text: Mapped[str] = mapped_column(
+        EncryptedString(table="memory_documents", column="history_text"), default=""
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC)
     )
@@ -356,6 +373,23 @@ class MemoryDocument(Base):
 
 
 class HeartbeatLog(Base):
+    """A single heartbeat scheduler run.
+
+    Three text columns carry user-facing content and are envelope-
+    encrypted at rest via ``EncryptedString`` (same pattern as
+    ``Message.body``):
+
+    - ``message_text``: the actual proactive message we sent (or would
+      have sent, on a skip).
+    - ``reasoning``: the LLM's free-text rationale for sending /
+      skipping. Often includes user content paraphrased back.
+    - ``tasks``: serialized task state the heartbeat was deciding from.
+      Contains user-authored task descriptions.
+
+    ``action_type`` and ``channel`` stay plaintext: short enums needed
+    for filtering / aggregation, no PII.
+    """
+
     __tablename__ = "heartbeat_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -363,10 +397,16 @@ class HeartbeatLog(Base):
         String, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
     )
     action_type: Mapped[str] = mapped_column(String, default="send")
-    message_text: Mapped[str] = mapped_column(Text, default="")
+    message_text: Mapped[str] = mapped_column(
+        EncryptedString(table="heartbeat_logs", column="message_text"), default=""
+    )
     channel: Mapped[str] = mapped_column(String, default="")
-    reasoning: Mapped[str] = mapped_column(Text, default="")
-    tasks: Mapped[str] = mapped_column(Text, default="")
+    reasoning: Mapped[str] = mapped_column(
+        EncryptedString(table="heartbeat_logs", column="reasoning"), default=""
+    )
+    tasks: Mapped[str] = mapped_column(
+        EncryptedString(table="heartbeat_logs", column="tasks"), default=""
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC)
     )

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -74,6 +74,21 @@ def _load_migration_020():  # noqa: ANN202
     return module
 
 
+def _load_migration_022():  # noqa: ANN202
+    """Load migration 022 by file path; module names can't start with a digit."""
+    spec = importlib.util.spec_from_file_location(
+        "migration_022",
+        Path(__file__).parent.parent
+        / "alembic"
+        / "versions"
+        / "022_envelope_encrypt_heartbeat_and_memory.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _legacy_fernet_for(key_material: bytes) -> Fernet:
     """Reproduce the pre-envelope HKDF/Fernet derivation for tests."""
     hkdf = HKDF(
@@ -679,3 +694,177 @@ def test_migration_018_falls_back_to_plaintext_on_invalid_legacy_token() -> None
         decrypt(rekeyed, provider, {"table": "oauth_tokens", "column": "access_token"})
         == "not-a-fernet-token"
     )
+
+
+def test_migration_022_rekey_helper_envelopes_plaintext_per_table_column() -> None:
+    """The helper threads ``(table, column)`` into the envelope context
+    so each column's envelopes decrypt under the matching context tag.
+    Without this the on-disk envelope would carry one context but the
+    application's ``EncryptedString`` reads would expect another, and
+    cross-context decrypts would silently succeed under
+    ``LocalKEKProvider`` while breaking on a per-tenant KMS provider.
+    """
+    migration = _load_migration_022()
+    provider = LocalKEKProvider()
+
+    cases = [
+        ("heartbeat_logs", "message_text", "I noticed you've been working late"),
+        ("heartbeat_logs", "reasoning", "user mentioned feeling burnt out"),
+        ("heartbeat_logs", "tasks", '[{"title": "reply to client"}]'),
+        ("memory_documents", "memory_text", "user prefers being called Alex"),
+        ("memory_documents", "history_text", "older session compaction"),
+    ]
+    for table, column, plaintext in cases:
+        rekeyed = migration._rekey(plaintext, provider, table, column)
+        assert isinstance(rekeyed, str)
+        assert rekeyed.startswith(ENVELOPE_PREFIX + ".")
+        assert decrypt(rekeyed, provider, {"table": table, "column": column}) == plaintext
+        # Idempotent re-run.
+        assert migration._rekey(rekeyed, provider, table, column) is rekeyed
+        # Empty / None pass through.
+        assert migration._rekey("", provider, table, column) == ""
+        assert migration._rekey(None, provider, table, column) is None
+
+
+def test_migration_022_full_upgrade_loop_against_real_db(
+    install_recording_provider: _RecordingProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: insert plaintext rows directly into both target
+    tables, run ``upgrade()``, assert envelopes on disk for non-empty
+    rows + empty-string passthrough for empty rows. Re-run confirms
+    idempotency.
+    """
+    monkeypatch.setattr(_app_settings, "encryption_key", SecretStr("a" * 32))
+
+    db = _db_module.SessionLocal()
+    try:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id="hb-mem-mig-test",
+            onboarding_complete=True,
+        )
+        db.add(user)
+        db.flush()
+
+        # MemoryDocument: one row with non-empty text.
+        db.execute(
+            _sa_text(
+                "INSERT INTO memory_documents (user_id, memory_text, history_text, "
+                "created_at, updated_at) VALUES (:u, :m, :h, NOW(), NOW())"
+            ),
+            {"u": user.id, "m": "memory plaintext", "h": "history plaintext"},
+        )
+        # HeartbeatLog: three rows. One full, one partial (empty
+        # reasoning + tasks), one all-empty.
+        for i, (msg, reason, tasks_) in enumerate(
+            [
+                ("first message", "first reasoning", "first tasks"),
+                ("second message", "", ""),
+                ("", "", ""),
+            ],
+            start=1,
+        ):
+            db.execute(
+                _sa_text(
+                    "INSERT INTO heartbeat_logs (user_id, action_type, message_text, "
+                    "channel, reasoning, tasks, created_at) VALUES "
+                    "(:u, 'send', :m, 'imessage', :r, :t, NOW())"
+                ),
+                {"u": user.id, "m": msg, "r": reason, "t": tasks_},
+            )
+            assert i  # silence unused var
+        db.commit()
+        user_id = user.id
+    finally:
+        db.close()
+
+    migration = _load_migration_022()
+    db = _db_module.SessionLocal()
+    try:
+        monkeypatch.setattr(_alembic_op, "get_bind", lambda: db.connection())
+        migration.upgrade()
+        db.commit()
+    finally:
+        db.close()
+
+    # Verify envelopes on disk for non-empty rows; empties stay empty.
+    db = _db_module.SessionLocal()
+    try:
+        mem = db.execute(
+            _sa_text("SELECT memory_text, history_text FROM memory_documents WHERE user_id = :u"),
+            {"u": user_id},
+        ).one()
+        assert mem.memory_text.startswith(ENVELOPE_PREFIX + ".")
+        assert mem.history_text.startswith(ENVELOPE_PREFIX + ".")
+
+        hb_rows = db.execute(
+            _sa_text(
+                "SELECT message_text, reasoning, tasks FROM heartbeat_logs "
+                "WHERE user_id = :u ORDER BY id"
+            ),
+            {"u": user_id},
+        ).all()
+        # Row 1: all three columns envelope-encrypted.
+        assert hb_rows[0].message_text.startswith(ENVELOPE_PREFIX + ".")
+        assert hb_rows[0].reasoning.startswith(ENVELOPE_PREFIX + ".")
+        assert hb_rows[0].tasks.startswith(ENVELOPE_PREFIX + ".")
+        # Row 2: message envelope, reasoning + tasks stay empty.
+        assert hb_rows[1].message_text.startswith(ENVELOPE_PREFIX + ".")
+        assert hb_rows[1].reasoning == ""
+        assert hb_rows[1].tasks == ""
+        # Row 3: all empty, must remain empty.
+        assert hb_rows[2].message_text == ""
+        assert hb_rows[2].reasoning == ""
+        assert hb_rows[2].tasks == ""
+    finally:
+        db.close()
+
+    # Idempotent re-run terminates instead of looping forever (regression
+    # for the cursor reach-around at end of batch).
+    db = _db_module.SessionLocal()
+    try:
+        monkeypatch.setattr(_alembic_op, "get_bind", lambda: db.connection())
+        migration.upgrade()
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_migration_022_refuses_when_encryption_key_unset_and_data_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator preflight: a non-empty target table + unset
+    ``ENCRYPTION_KEY`` raises rather than silently encrypting under an
+    ephemeral key that vanishes on the next process restart."""
+    monkeypatch.setattr(_app_settings, "encryption_key", SecretStr(""))
+
+    db = _db_module.SessionLocal()
+    try:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id="hb-mem-preflight-test",
+            onboarding_complete=True,
+        )
+        db.add(user)
+        db.flush()
+        db.execute(
+            _sa_text(
+                "INSERT INTO heartbeat_logs (user_id, action_type, message_text, "
+                "channel, reasoning, tasks, created_at) VALUES "
+                "(:u, 'send', 'x', '', '', '', NOW())"
+            ),
+            {"u": user.id},
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    migration = _load_migration_022()
+    db = _db_module.SessionLocal()
+    try:
+        monkeypatch.setattr(_alembic_op, "get_bind", lambda: db.connection())
+        with pytest.raises(RuntimeError, match="ENCRYPTION_KEY"):
+            migration.upgrade()
+    finally:
+        db.close()


### PR DESCRIPTION
## Description

Extends at-rest encryption coverage from migration 020 (Message.body, processed_context) to five more user-content columns. Same pattern: per-row DEKs wrapped by `LocalKEKProvider` (or the premium KMS-backed provider). The `EncryptedString` type decorator on each ORM column transparently decrypts on read.

Closes the optional follow-up tracked from clawbolt-premium [issue #325](https://github.com/mozilla-ai/clawbolt-premium/issues/325).

## What's now encrypted

| Table | Column | Notes |
|---|---|---|
| `heartbeat_logs` | `message_text` | Proactive message text |
| `heartbeat_logs` | `reasoning` | LLM rationale, often paraphrases user content |
| `heartbeat_logs` | `tasks` | Serialized task state with user-authored descriptions |
| `memory_documents` | `memory_text` | User's working memory file |
| `memory_documents` | `history_text` | Compacted older sessions |

## What stays plaintext

- `HeartbeatLog.action_type` and `channel` — short enums needed for filtering / aggregation, no PII.
- All timestamps and FK columns.

## Migration 022

- **Operator preflight** (mirrors migration 020): refuses to run on a non-empty target table when `ENCRYPTION_KEY` is unset. Without a stable key, `LocalKEKProvider()` falls back to an ephemeral process-local KEK and content becomes unrecoverable on the next restart. Empty tables pass through (nothing to lose).
- **Streams in 1000-row batches** with `WHERE id > :last` cursor advancement. `heartbeat_logs` can grow large on chatty deployments.
- **Idempotent** on re-run via the `is_envelope` check + identity-comparison short-circuit. End-of-batch cursor reach-around guarantees an already-migrated DB doesn't loop forever.
- **No automatic downgrade**. Restore from backup is the recovery path.

## ⚠️ Deployment ordering

Same as migration 020. Run `alembic upgrade head` BEFORE rolling out the new application code. `EncryptedString` raises on a non-envelope read, so a code-deployed / migration-not-run gap fails the very first request rather than silently corrupting data.

## Tests

- `test_migration_022_rekey_helper_envelopes_plaintext_per_table_column` covers all five (table, column) targets, idempotent re-run, empty/None passthrough.
- `test_migration_022_full_upgrade_loop_against_real_db` inserts plaintext rows via raw SQL (bypassing the type decorator), runs `upgrade()`, asserts envelopes on disk for non-empty rows + empty-string passthrough on all-empty rows. Re-runs `upgrade()` to confirm termination.
- `test_migration_022_refuses_when_encryption_key_unset_and_data_exists` covers the operator preflight.

## Type
- [x] Feature

## Checklist
- [x] Tests pass — new tests added; existing heartbeat / memory tests still pass because the type decorator is transparent to ORM reads
- [x] Lint passes (`ruff check`, `ruff format --check`)
- [x] Type check passes (`ty check`)
- [x] No raw SQL queries hit these columns outside the migration itself

## AI Usage
- [x] AI-assisted: drafted by Claude via discussion with @njbrake. The reasoning and decisions are his; the prose is Claude's.