### PR TITLE
fix(bus): keep response future after resolve so SSE handler can read it

### DIFF
--- a/backend/app/bus.py
+++ b/backend/app/bus.py
@@ -112,8 +112,24 @@ class MessageBus:
         return fut
 
     def resolve_response(self, request_id: str, msg: OutboundMessage) -> bool:
-        """Resolve a pending response future. Returns True if found."""
-        fut = self._response_futures.pop(request_id, None)
+        """Resolve a pending response future. Returns True if found.
+
+        Does NOT remove the future from the registry. The webchat SSE
+        endpoint calls ``get_response_future(request_id)`` to fetch the
+        future after the request was already submitted (the chat router
+        registers the future first, then the bus consumer / dispatcher
+        run, then the client opens the SSE stream). If the dispatcher
+        finishes before the SSE opens (which can happen for fast
+        short-circuit replies like the ``/report`` ack or approval
+        responses), popping here leaves the SSE side looking up a
+        missing entry, which then registers a fresh future that nobody
+        will ever resolve and the spinner hangs until the SSE timeout.
+
+        Memory bounded by the TTL cleanup task scheduled in
+        ``register_response_future``: 300s after registration, the entry
+        is evicted regardless of whether it was resolved.
+        """
+        fut = self._response_futures.get(request_id)
         if fut is not None and not fut.done():
             fut.set_result(msg)
             return True

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -149,9 +149,7 @@ async def test_sse_handler_can_read_already_resolved_future() -> None:
     bus = MessageBus()
     request_id = "req-race"
     fut = bus.register_response_future(request_id)
-    msg = OutboundMessage(
-        channel="webchat", chat_id="user-1", content="ack", request_id=request_id
-    )
+    msg = OutboundMessage(channel="webchat", chat_id="user-1", content="ack", request_id=request_id)
 
     # Dispatcher path: resolve the response.
     assert bus.resolve_response(request_id, msg) is True

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -130,6 +130,41 @@ async def test_resolve_cleans_up_future() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sse_handler_can_read_already_resolved_future() -> None:
+    """Race: dispatcher resolves the response BEFORE the SSE client opens
+    the event stream. The SSE handler then calls
+    ``get_response_future(request_id)`` and must find the resolved
+    future so it can yield ``{'reply': ...}`` and close the stream.
+
+    Pre-fix, ``resolve_response`` popped the future from the registry,
+    so ``get_response_future`` returned None, the SSE handler then
+    registered a fresh future, and the spinner hung until the
+    server-side approval timeout. Reproduced when the ``/report``
+    short-circuit reply hit the bus before the client's SSE GET
+    landed.
+
+    The fix: ``resolve_response`` now leaves the future in the
+    registry; the TTL cleanup evicts it after the SSE handler is done.
+    """
+    bus = MessageBus()
+    request_id = "req-race"
+    fut = bus.register_response_future(request_id)
+    msg = OutboundMessage(
+        channel="webchat", chat_id="user-1", content="ack", request_id=request_id
+    )
+
+    # Dispatcher path: resolve the response.
+    assert bus.resolve_response(request_id, msg) is True
+    assert fut.done()
+
+    # SSE handler path (running AFTER resolve): must find the same
+    # future and read its result.
+    fetched = bus.get_response_future(request_id)
+    assert fetched is fut
+    assert fetched.result().content == "ack"
+
+
+@pytest.mark.asyncio
 async def test_ttl_cleanup_removes_event_queue() -> None:
     """TTL cleanup should remove orphaned event queues when SSE is never opened."""
     bus = MessageBus()


### PR DESCRIPTION
## Description

The webchat SSE flow has a race: for fast short-circuit replies (e.g. ``/report`` ack, approval responses), the dispatcher resolves the response future **before** the client opens the SSE stream. Pre-fix, ``resolve_response`` popped the future from the registry, so the SSE handler then registered a fresh future that nobody would ever resolve. The spinner hung until the server-side SSE timeout fired (~30s).

### Fix

``resolve_response`` no longer pops. The TTL cleanup task already scheduled by ``register_response_future`` (300s) evicts the entry regardless, so memory stays bounded.

Added a regression test that resolves the future first, then reads it via ``get_response_future``, mirroring the exact race.

### Why this matters for users

``/report`` is meant to be instant. Pre-fix, users typing ``/report`` saw a "thinking..." spinner that hung until timeout, then either errored or showed the reply 30+ seconds late. Post-fix, the ack arrives in ~1s.

### Reproduction (pre-fix)

```bash
curl -X POST /api/user/chat -F "message=/report repro"
# returns request_id immediately
curl -N /api/user/chat/events/$RID
# hung indefinitely until SSE timeout
```

### Verification (post-fix)

End-to-end against a local dev server seeded with a real user:

```
POST /api/user/chat (message=/report post-fix repro test)
-> {"request_id":"846d1ef9-...", "session_id":"..."}

GET /api/user/chat/events/846d1ef9-...
-> data: {"reply": "Got it. I've flagged this conversation..."}
```

Stream closes within ~1s.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted with Claude via back-and-forth with @njbrake; reasoning and decisions are mine, prose is Claude's)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)