### PR TITLE
feat(privacy): user-facing data-sharing consent UX

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,6 +5,8 @@ import type {
   ChatResponse,
   UserProfileResponse,
   UserProfileUpdate,
+  DataSharingConsentRequest,
+  DataSharingConsentResponse,
   MemoryResponse,
   MemoryUpdate,
   PermissionsResponse,
@@ -84,6 +86,22 @@ const api = {
     });
     if (error) _throwApiError(error, 'Failed to update profile');
     return data as UserProfileResponse;
+  },
+
+  // Data sharing consent (kept off the generic profile PUT so every
+  // toggle stamps data_sharing_consent_at server-side, preserving an
+  // audit trail of opt-in/opt-out moments).
+  getDataSharingConsent: async () => {
+    const { data, error } = await client.GET('/api/user/data-sharing-consent');
+    if (error) _throwApiError(error, 'Failed to get data sharing consent');
+    return data as DataSharingConsentResponse;
+  },
+  updateDataSharingConsent: async (body: DataSharingConsentRequest) => {
+    const { data, error } = await client.PUT('/api/user/data-sharing-consent', {
+      body: body as never,
+    });
+    if (error) _throwApiError(error, 'Failed to update data sharing consent');
+    return data as DataSharingConsentResponse;
   },
 
   // Sessions

--- a/frontend/src/components/DataSharingConsentSection.test.tsx
+++ b/frontend/src/components/DataSharingConsentSection.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '@/test/test-utils';
+import DataSharingConsentSection from './DataSharingConsentSection';
+
+const mockGet = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock('@/api', () => ({
+  default: {
+    getDataSharingConsent: (...args: unknown[]) => mockGet(...args),
+    updateDataSharingConsent: (...args: unknown[]) => mockUpdate(...args),
+  },
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DataSharingConsentSection', () => {
+  it('renders an unchecked checkbox when consent is false', async () => {
+    mockGet.mockResolvedValue({
+      data_sharing_consent: false,
+      data_sharing_consent_at: null,
+    });
+
+    renderWithRouter(<DataSharingConsentSection />);
+
+    const checkbox = await screen.findByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    // No "last updated" line when there's no timestamp.
+    expect(screen.queryByText(/Last updated/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a checked checkbox + last-updated line when consent is true', async () => {
+    mockGet.mockResolvedValue({
+      data_sharing_consent: true,
+      data_sharing_consent_at: '2026-04-15T12:34:56+00:00',
+    });
+
+    renderWithRouter(<DataSharingConsentSection />);
+
+    const checkbox = await screen.findByRole('checkbox');
+    expect(checkbox).toBeChecked();
+    expect(await screen.findByText(/Last updated/i)).toBeInTheDocument();
+  });
+
+  it('toggling on calls updateDataSharingConsent({ consent: true })', async () => {
+    mockGet.mockResolvedValue({
+      data_sharing_consent: false,
+      data_sharing_consent_at: null,
+    });
+    mockUpdate.mockResolvedValue({
+      data_sharing_consent: true,
+      data_sharing_consent_at: '2026-05-01T00:00:00+00:00',
+    });
+
+    const user = userEvent.setup();
+    renderWithRouter(<DataSharingConsentSection />);
+
+    const checkbox = await screen.findByRole('checkbox');
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({ consent: true });
+    });
+  });
+
+  it('toggling off calls updateDataSharingConsent({ consent: false })', async () => {
+    mockGet.mockResolvedValue({
+      data_sharing_consent: true,
+      data_sharing_consent_at: '2026-04-15T12:34:56+00:00',
+    });
+    mockUpdate.mockResolvedValue({
+      data_sharing_consent: false,
+      data_sharing_consent_at: '2026-05-01T00:00:00+00:00',
+    });
+
+    const user = userEvent.setup();
+    renderWithRouter(<DataSharingConsentSection />);
+
+    const checkbox = await screen.findByRole('checkbox');
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({ consent: false });
+    });
+  });
+
+  it('renders a custom heading when provided', async () => {
+    mockGet.mockResolvedValue({
+      data_sharing_consent: false,
+      data_sharing_consent_at: null,
+    });
+
+    renderWithRouter(<DataSharingConsentSection heading="Custom title" />);
+
+    expect(await screen.findByText('Custom title')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DataSharingConsentSection.tsx
+++ b/frontend/src/components/DataSharingConsentSection.tsx
@@ -1,0 +1,104 @@
+import { useCallback } from 'react';
+import { Spinner } from '@heroui/spinner';
+import Checkbox from '@/components/ui/checkbox';
+import { toast } from '@/lib/toast';
+import {
+  useDataSharingConsent,
+  useUpdateDataSharingConsent,
+} from '@/hooks/queries';
+
+interface Props {
+  /** Heading rendered above the checkbox. Falls back to "Help improve Clawbolt". */
+  heading?: string;
+  /** Visible only on first-run flows (e.g. Get Started) where we want a softer affordance. */
+  variant?: 'default' | 'compact';
+}
+
+function formatToggledAt(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export default function DataSharingConsentSection({
+  heading = 'Help improve Clawbolt',
+  variant = 'default',
+}: Props) {
+  const { data, isLoading } = useDataSharingConsent();
+  const updateConsent = useUpdateDataSharingConsent();
+
+  const consent = data?.data_sharing_consent ?? false;
+  const lastChange = formatToggledAt(data?.data_sharing_consent_at ?? null);
+
+  const handleToggle = useCallback(
+    (next: boolean) => {
+      // Optimistic-ish: react-query updates the cache after the mutation
+      // resolves via setQueryData. If it fails, we surface the error and
+      // the cached value stays at its prior truth.
+      updateConsent.mutate(
+        { consent: next },
+        {
+          onSuccess: () =>
+            toast.success(
+              next
+                ? "Thanks. We'll use your chats to improve Clawbolt."
+                : 'Sharing turned off. Your chats are private again.',
+            ),
+          onError: (e) => toast.error(e.message),
+        },
+      );
+    },
+    [updateConsent],
+  );
+
+  const headingClass =
+    variant === 'compact'
+      ? 'text-sm font-semibold font-display'
+      : 'text-sm font-medium';
+
+  return (
+    <div className="grid gap-3">
+      <div>
+        <h3 className={headingClass}>{heading}</h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Let our team read your chat history to improve Clawbolt and study
+          how people use AI assistants. You can turn this off any time and
+          we'll stop reading from that moment on.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Spinner size="sm" aria-label="Loading consent" />
+          <span>Loading…</span>
+        </div>
+      ) : (
+        <div>
+          <Checkbox
+            id="data-sharing-consent"
+            checked={consent}
+            disabled={updateConsent.isPending}
+            onChange={(e) => handleToggle(e.target.checked)}
+          >
+            <span className="text-sm">
+              Share my chat history with the Clawbolt team for product
+              research.
+            </span>
+          </Checkbox>
+          {lastChange && (
+            <p className="text-xs text-muted-foreground mt-2">
+              Last updated {lastChange}.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -9,6 +9,7 @@ import type {
   StorageConfigUpdate,
   ToolConfigUpdateEntry,
   ChannelConfigUpdate,
+  DataSharingConsentRequest,
 } from '@/types';
 
 // --- Profile ---
@@ -40,6 +41,27 @@ export function useUpdateProfile() {
   return useMutation({
     mutationFn: api.updateProfile,
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.profile });
+    },
+  });
+}
+
+// --- Data sharing consent ---
+
+export function useDataSharingConsent(opts: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: queryKeys.dataSharingConsent,
+    queryFn: () => api.getDataSharingConsent(),
+    enabled: opts.enabled ?? true,
+  });
+}
+
+export function useUpdateDataSharingConsent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: DataSharingConsentRequest) => api.updateDataSharingConsent(body),
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.dataSharingConsent, data);
       void queryClient.invalidateQueries({ queryKey: queryKeys.profile });
     },
   });

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -1,5 +1,6 @@
 export const queryKeys = {
   profile: ['profile'] as const,
+  dataSharingConsent: ['dataSharingConsent'] as const,
   sessions: {
     all: ['sessions'] as const,
     detail: (id: string) => ['sessions', 'detail', id] as const,

--- a/frontend/src/pages/GetStartedPage.test.tsx
+++ b/frontend/src/pages/GetStartedPage.test.tsx
@@ -75,6 +75,14 @@ vi.mock('@/api', () => ({
     getLinqLink: vi.fn().mockResolvedValue({ phone_number: null, connected: false }),
     setLinqLink: vi.fn().mockResolvedValue({ phone_number: '+15551234567', connected: true }),
     setTelegramLink: vi.fn().mockResolvedValue({ telegram_user_id: '12345', connected: true }),
+    getDataSharingConsent: vi.fn().mockResolvedValue({
+      data_sharing_consent: false,
+      data_sharing_consent_at: null,
+    }),
+    updateDataSharingConsent: vi.fn().mockResolvedValue({
+      data_sharing_consent: true,
+      data_sharing_consent_at: '2026-05-01T00:00:00+00:00',
+    }),
   },
 }));
 

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -5,6 +5,7 @@ import Button from '@/components/ui/button';
 import Input from '@/components/ui/input';
 import Field from '@/components/ui/field';
 import TextAssistantCard from '@/components/TextAssistantCard';
+import DataSharingConsentSection from '@/components/DataSharingConsentSection';
 import { toast } from '@/lib/toast';
 import {
   useChannelConfig,
@@ -354,6 +355,21 @@ export default function GetStartedPage() {
                   You can always fine-tune settings later from the sidebar.
                 </p>
               )}
+            </div>
+          </div>
+        </Card>
+
+        {/* Privacy: optional opt-in. Not numbered, not blocking — first-run is the natural
+            moment to ask, but the same toggle lives on the User page so people can change
+            their mind any time. Default off; the API stamps a timestamp on every flip so
+            consent history is reconstructable from data_sharing_consent_at. */}
+        <Card>
+          <div className="flex items-start gap-4">
+            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-primary-light text-primary shrink-0">
+              <ShieldIcon />
+            </div>
+            <div className="flex-1 min-w-0">
+              <DataSharingConsentSection variant="compact" />
             </div>
           </div>
         </Card>
@@ -848,6 +864,14 @@ function RocketIcon() {
   return (
     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.63 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.841M3.75 21h.008v.008H3.75V21z" />
+    </svg>
+  );
+}
+
+function ShieldIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12.75 11.25 15 15 9.75M21 12c0 4.97-3.582 9-8 9s-8-4.03-8-9c0-1.07.166-2.097.473-3.06A11.95 11.95 0 0 0 12 5.25a11.95 11.95 0 0 0 7.527-1.31A9.954 9.954 0 0 1 21 12Z" />
     </svg>
   );
 }

--- a/frontend/src/pages/UserPage.tsx
+++ b/frontend/src/pages/UserPage.tsx
@@ -4,6 +4,8 @@ import { Spinner } from '@heroui/spinner';
 import { toast } from '@/lib/toast';
 import { useUpdateProfile } from '@/hooks/queries';
 import MarkdownEditor from '@/components/ui/MarkdownEditor';
+import Card from '@/components/ui/card';
+import DataSharingConsentSection from '@/components/DataSharingConsentSection';
 import type { AppShellContext } from '@/layouts/AppShell';
 
 export default function UserPage() {
@@ -36,20 +38,34 @@ export default function UserPage() {
   }
 
   return (
-    <div>
-      <div className="mb-4">
-        <h2 className="text-xl font-semibold font-display">About You</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Updated over time as your assistant learns about you.
-        </p>
+    <div className="grid gap-6">
+      <div>
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold font-display">About You</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Updated over time as your assistant learns about you.
+          </p>
+        </div>
+        <MarkdownEditor
+          value={profile.user_text}
+          onSave={handleSave}
+          isSaving={updateProfile.isPending}
+          placeholder="Tell your assistant about yourself: your name, phone, timezone, preferences, what projects you're working on..."
+          emptyMessage="No user info yet. Click Edit to tell your assistant about yourself."
+        />
       </div>
-      <MarkdownEditor
-        value={profile.user_text}
-        onSave={handleSave}
-        isSaving={updateProfile.isPending}
-        placeholder="Tell your assistant about yourself: your name, phone, timezone, preferences, what projects you're working on..."
-        emptyMessage="No user info yet. Click Edit to tell your assistant about yourself."
-      />
+
+      <div>
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold font-display">Privacy</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Control whether the Clawbolt team can read your conversations.
+          </p>
+        </div>
+        <Card>
+          <DataSharingConsentSection />
+        </Card>
+      </div>
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,8 @@ import type { components } from '@/generated/api';
 
 export type UserProfileResponse = components['schemas']['UserProfileResponse'];
 export type UserProfileUpdate = components['schemas']['UserProfileUpdate'];
+export type DataSharingConsentRequest = components['schemas']['DataSharingConsentRequest'];
+export type DataSharingConsentResponse = components['schemas']['DataSharingConsentResponse'];
 export type SessionDetailResponse = components['schemas']['SessionDetailResponse'];
 export type SessionListResponse = components['schemas']['SessionListResponse'];
 export type SessionSystemPromptResponse = components['schemas']['SessionSystemPromptResponse'];


### PR DESCRIPTION
## Description

Adds an end-user surface for the ``data_sharing_consent`` flag. Until now the column was settable only via ``PUT /api/user/data-sharing-consent`` with no UI consumer (the admin "Shared" tab was the only reader); end users had no way to opt in even if they wanted to share their chats for product research.

Two surfaces, one shared component (``DataSharingConsentSection``):

1. **Onboarding** (Get Started page): a non-numbered "Help improve Clawbolt" card sits after Step 4. Visible during first run, not blocking, captures the moment-of-signup intent.
2. **Settings** (About You page): a new "Privacy" section under the user bio so people can change their mind any direction at any time.

### Why two surfaces

People's comfort with sharing usually grows with trust, so a one-shot onboarding ask would lose later opt-ins. Conversely, a hidden settings-only toggle would never get found by people who want to help. Both surfaces hit the same ``PUT /api/user/data-sharing-consent`` endpoint, so the audit trail (``data_sharing_consent_at`` stamped on every toggle) is unified.

### Behavior

- **Default OFF.** Opt-in only.
- The setter endpoint stamps ``data_sharing_consent_at`` on every flip, so opt-out moments stay auditable.
- Admin reads continue to re-check ``data_sharing_consent`` at fetch time, so toggling off has immediate effect.
- Toast on success: "Thanks. We'll use your chats to improve Clawbolt." or "Sharing turned off. Your chats are private again."
- "Last updated" timestamp shown when present.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v` and `npm run test`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted with Claude via back-and-forth with @njbrake; reasoning and decisions are mine, prose is Claude's)
- [ ] No AI used

## Test plan

- [x] ``npm run test -- DataSharingConsentSection`` (5/5 passed)
- [x] ``npm run test -- GetStartedPage`` (23/23 passed)
- [x] ``npm run test -- queries`` (7/7 passed)
- [x] ``npm run typecheck`` clean
- [x] ``npm run deadcode`` clean
- [ ] Manual: open ``/app/user``, see Privacy section, toggle on/off, verify toast and last-updated timestamp updates.
- [ ] Manual: as a fresh user on ``/app/get-started``, see the shielded "Help improve Clawbolt" card after Step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)