### PR TITLE
refactor(privacy): move data-sharing consent to a Privacy settings tab

### DIFF
--- a/frontend/src/extensions/settings.tsx
+++ b/frontend/src/extensions/settings.tsx
@@ -14,5 +14,5 @@ export function renderPremiumSettingsTab(_key: string, _isAdmin: boolean): React
 }
 
 export function showOssSettingsTabs(_isPremium: boolean, _isAdmin: boolean): string[] {
-  return ['model', 'storage', 'heartbeat', 'telegram'];
+  return ['model', 'storage', 'heartbeat', 'telegram', 'privacy'];
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import Field from '@/components/ui/field';
 import api from '@/api';
 import { toast } from '@/lib/toast';
 import { useModelConfig, useUpdateModelConfig, useStorageConfig, useUpdateStorageConfig, useUpdateProfile, useChannelConfig, useUpdateChannelConfig } from '@/hooks/queries';
+import DataSharingConsentSection from '@/components/DataSharingConsentSection';
 import type { AppShellContext } from '@/layouts/AppShell';
 import {
   getExtraSettingsTabs,
@@ -40,6 +41,7 @@ export default function SettingsPage() {
     { key: 'storage', label: 'Storage' },
     { key: 'heartbeat', label: 'Heartbeat' },
     { key: 'telegram', label: 'Telegram' },
+    { key: 'privacy', label: 'Privacy' },
   ].filter((t) => visibleOssKeys.includes(t.key));
   const allTabs = [...ossTabs, ...extraTabs.map((t) => ({ key: t.key, label: t.label }))];
   const activeTab = (tab && allTabs.some((t) => t.key === tab)) ? tab : allTabs[0]?.key || 'model';
@@ -55,6 +57,7 @@ export default function SettingsPage() {
       case 'storage': return <StorageTab />;
       case 'heartbeat': return profile ? <HeartbeatTab profile={profile} /> : null;
       case 'telegram': return <TelegramTab />;
+      case 'privacy': return <PrivacyTab />;
       default: return null;
     }
   };
@@ -677,5 +680,15 @@ function TelegramTab() {
         </Button>
       </div>
     </div>
+  );
+}
+
+// --- Privacy Tab ---
+
+function PrivacyTab() {
+  return (
+    <Card>
+      <DataSharingConsentSection />
+    </Card>
   );
 }

--- a/frontend/src/pages/UserPage.tsx
+++ b/frontend/src/pages/UserPage.tsx
@@ -4,8 +4,6 @@ import { Spinner } from '@heroui/spinner';
 import { toast } from '@/lib/toast';
 import { useUpdateProfile } from '@/hooks/queries';
 import MarkdownEditor from '@/components/ui/MarkdownEditor';
-import Card from '@/components/ui/card';
-import DataSharingConsentSection from '@/components/DataSharingConsentSection';
 import type { AppShellContext } from '@/layouts/AppShell';
 
 export default function UserPage() {
@@ -38,34 +36,20 @@ export default function UserPage() {
   }
 
   return (
-    <div className="grid gap-6">
-      <div>
-        <div className="mb-4">
-          <h2 className="text-xl font-semibold font-display">About You</h2>
-          <p className="text-sm text-muted-foreground mt-1">
-            Updated over time as your assistant learns about you.
-          </p>
-        </div>
-        <MarkdownEditor
-          value={profile.user_text}
-          onSave={handleSave}
-          isSaving={updateProfile.isPending}
-          placeholder="Tell your assistant about yourself: your name, phone, timezone, preferences, what projects you're working on..."
-          emptyMessage="No user info yet. Click Edit to tell your assistant about yourself."
-        />
+    <div>
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold font-display">About You</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Updated over time as your assistant learns about you.
+        </p>
       </div>
-
-      <div>
-        <div className="mb-4">
-          <h2 className="text-xl font-semibold font-display">Privacy</h2>
-          <p className="text-sm text-muted-foreground mt-1">
-            Control whether the Clawbolt team can read your conversations.
-          </p>
-        </div>
-        <Card>
-          <DataSharingConsentSection />
-        </Card>
-      </div>
+      <MarkdownEditor
+        value={profile.user_text}
+        onSave={handleSave}
+        isSaving={updateProfile.isPending}
+        placeholder="Tell your assistant about yourself: your name, phone, timezone, preferences, what projects you're working on..."
+        emptyMessage="No user info yet. Click Edit to tell your assistant about yourself."
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description

Users were looking on the Settings page for the privacy toggle, not on About You where #1105 first wired it up. Move the ``DataSharingConsentSection`` to a new "Privacy" tab in ``SettingsPage`` so it sits next to Model / Storage / Heartbeat / Telegram, where people expect config knobs to live.

Same component, no API or behavior change. The onboarding card on Get Started is unchanged.

## Type
- [x] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`npm run test`, `npm run typecheck`, `npm run deadcode` clean)
- [x] Lint passes
- [x] New tests added for new functionality (existing ``DataSharingConsentSection`` tests cover the component; SettingsPage tab plumbing is structurally trivial)
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted with Claude via back-and-forth with @njbrake; reasoning and decisions are mine, prose is Claude's)
- [ ] No AI used

## Test plan

- [x] ``npm run typecheck`` clean
- [x] ``npm run deadcode`` clean
- [x] ``npm run test -- DataSharingConsentSection GetStartedPage queries`` -> 35/35 passed
- [ ] Manual: open ``/app/settings/privacy``, see the consent checkbox, toggle on/off, confirm toast and timestamp.
- [ ] Manual: open ``/app/user``, confirm the Privacy section is gone (back to just About You).

🤖 Generated with [Claude Code](https://claude.com/claude-code)