### PR TITLE
fix(quickbooks): structured 400 error messages with enum-value hints

### DIFF
--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -82,9 +82,84 @@ class QBQueryParams(BaseModel):
 
     query: str = Field(
         description=(
-            "A QBO query string (SELECT only). Example: SELECT * FROM Invoice MAXRESULTS 20"
+            "A QBO query string (SELECT only). Example: SELECT * FROM Invoice MAXRESULTS 20.\n"
+            "Common string-enum values that the model often gets wrong:\n"
+            "  Estimate.TxnStatus = 'Pending' | 'Accepted' | 'Closed' | 'Rejected'\n"
+            "  Invoice.EmailStatus = 'NotSet' | 'NeedToSend' | 'EmailSent'\n"
+            "  Bill / Invoice / Estimate balance filtering uses Balance numeric, "
+            "  not a status enum."
         )
     )
+
+
+_TXNSTATUS_VALID_BY_ENTITY: dict[str, tuple[str, ...]] = {
+    "Estimate": ("Pending", "Accepted", "Closed", "Rejected"),
+}
+"""Known string-enum value sets per entity. Used to enrich 400 errors so a
+hallucinated value like ``TxnStatus='In Progress'`` comes back with the
+right list instead of the model retrying the same wrong guess."""
+
+
+def _format_intuit_fault(exc: httpx.HTTPStatusError, *, entity: str | None = None) -> str:
+    """Convert a QBO HTTPStatusError into a model-readable error message.
+
+    Intuit returns a structured ``Fault.Error[]`` payload that the LLM
+    has trouble parsing reliably. We pull out ``Message`` + ``Detail``
+    + ``code`` and concatenate them. When ``Detail`` mentions a value
+    that maps to a known enum (``TxnStatus`` on Estimate so far), we
+    append the valid set so the next turn does not retry the same bad
+    guess.
+
+    Falls back to the raw JSON (then the raw exception string) when the
+    response is not JSON or is shaped differently than expected.
+    """
+    raw_body: Any
+    try:
+        raw_body = exc.response.json()
+    except Exception:
+        return f"HTTP {exc.response.status_code} from QuickBooks: {exc.response.text or exc!s}"
+
+    fault = (raw_body or {}).get("Fault") if isinstance(raw_body, dict) else None
+    errors = (fault or {}).get("Error") if isinstance(fault, dict) else None
+    if not isinstance(errors, list) or not errors:
+        return f"HTTP {exc.response.status_code} from QuickBooks: {json.dumps(raw_body)[:500]}"
+
+    parts: list[str] = []
+    for err in errors:
+        if not isinstance(err, dict):
+            continue
+        code = err.get("code", "")
+        message = (err.get("Message") or "").strip()
+        detail = (err.get("Detail") or "").strip()
+        # Most-specific first: Detail usually contains the bad value;
+        # Message is the category.
+        line = " | ".join(p for p in (f"code={code}" if code else "", message, detail) if p)
+        if line:
+            parts.append(line)
+
+    body = "; ".join(parts) or json.dumps(raw_body)[:500]
+
+    # Enrich when the failure looks like a hallucinated enum value. The
+    # set is small and curated so the false-positive rate stays low.
+    hint = _enum_hint(body, entity)
+    if hint:
+        body = f"{body}\nHint: {hint}"
+    return body
+
+
+def _enum_hint(error_body: str, entity: str | None) -> str:
+    """Map a QBO error blob to a one-line hint when it looks enum-shaped.
+
+    Intentionally conservative: matches on substrings the LLM is likely
+    to also see. Returns empty string when no hint applies.
+    """
+    if not entity:
+        return ""
+    lowered = error_body.lower()
+    if "txnstatus" in lowered and entity in _TXNSTATUS_VALID_BY_ENTITY:
+        valid = ", ".join(_TXNSTATUS_VALID_BY_ENTITY[entity])
+        return f"Valid TxnStatus for {entity}: {valid}"
+    return ""
 
 
 def _coerce_data_to_dict(value: Any) -> Any:
@@ -310,19 +385,21 @@ def create_quickbooks_tools(
                 error_kind=ToolErrorKind.VALIDATION,
             )
 
+        # Resolve the entity name from the SELECT clause once so the
+        # error formatter can attach the right enum-hint set when QBO
+        # returns a 400.
+        entity_name = entity_match.group(1).capitalize()
+
         try:
             rows = await qb_service.query(normalized)
         except Exception as exc:
             logger.exception("QuickBooks query failed")
-            error_str = str(exc)
             if isinstance(exc, httpx.HTTPStatusError):
-                try:
-                    error_body = exc.response.json()
-                    error_str = json.dumps(error_body, indent=2)
-                except Exception:
-                    pass
+                error_str = _format_intuit_fault(exc, entity=entity_name)
+            else:
+                error_str = str(exc)
             return ToolResult(
-                content=f"QuickBooks query error:\n{error_str}",
+                content=f"QuickBooks query error: {error_str}",
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
             )
@@ -343,13 +420,10 @@ def create_quickbooks_tools(
             result = await qb_service.create_entity(entity_type, data)
         except Exception as exc:
             logger.exception("QB create %s failed", entity_type)
-            error_str = str(exc)
             if isinstance(exc, httpx.HTTPStatusError):
-                try:
-                    error_body = exc.response.json()
-                    error_str = json.dumps(error_body, indent=2)
-                except Exception:
-                    pass
+                error_str = _format_intuit_fault(exc, entity=entity_type)
+            else:
+                error_str = str(exc)
             return ToolResult(
                 content=f"Failed to create {entity_type}: {error_str}",
                 is_error=True,
@@ -392,13 +466,10 @@ def create_quickbooks_tools(
             result = await qb_service.update_entity(entity_type, data)
         except Exception as exc:
             logger.exception("QB update %s failed", entity_type)
-            error_str = str(exc)
             if isinstance(exc, httpx.HTTPStatusError):
-                try:
-                    error_body = exc.response.json()
-                    error_str = json.dumps(error_body, indent=2)
-                except Exception:
-                    pass
+                error_str = _format_intuit_fault(exc, entity=entity_type)
+            else:
+                error_str = str(exc)
             return ToolResult(
                 content=f"Failed to update {entity_type}: {error_str}",
                 is_error=True,
@@ -441,13 +512,10 @@ def create_quickbooks_tools(
             await qb_service.send_entity_email(entity_type, entity_id, email)
         except Exception as exc:
             logger.exception("QB send %s email failed", entity_type)
-            error_str = str(exc)
             if isinstance(exc, httpx.HTTPStatusError):
-                try:
-                    error_body = exc.response.json()
-                    error_str = json.dumps(error_body, indent=2)
-                except Exception:
-                    pass
+                error_str = _format_intuit_fault(exc, entity=entity_type)
+            else:
+                error_str = str(exc)
             return ToolResult(
                 content=f"Failed to send {entity_type.lower()}: {error_str}",
                 is_error=True,

--- a/tests/test_quickbooks_tools.py
+++ b/tests/test_quickbooks_tools.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from backend.app.agent.tools.base import Tool
 from backend.app.agent.tools.registry import ToolContext
 from backend.app.integrations.quickbooks.factory import (
     _describe_qb_query,
+    _format_intuit_fault,
     _quickbooks_factory,
     create_quickbooks_tools,
 )
@@ -231,3 +233,68 @@ class TestDescribeQbQuery:
         """Empty query returns generic fallback."""
         desc = _describe_qb_query({})
         assert desc == "Look up data in QuickBooks"
+
+
+# -- Intuit fault formatting --
+
+
+def _make_http_error(status: int, body: object) -> httpx.HTTPStatusError:
+    """Build a fake HTTPStatusError with a JSON body for the formatter."""
+    request = httpx.Request("GET", "https://example.invalid/q")
+    response = httpx.Response(status, json=body, request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+class TestFormatIntuitFault:
+    """The error formatter is the one place that converts QBO's nested
+    ``Fault.Error[]`` JSON into a single line the LLM can act on. These
+    tests pin the contract: the formatter must always return SOMETHING
+    useful, even on malformed input."""
+
+    def test_pulls_message_and_detail_from_fault(self) -> None:
+        body = {
+            "Fault": {
+                "Error": [
+                    {
+                        "Message": "Invalid enumeration value",
+                        "Detail": "TxnStatus 'In Progress' is not valid.",
+                        "code": "2030",
+                    }
+                ],
+                "type": "ValidationFault",
+            }
+        }
+        out = _format_intuit_fault(_make_http_error(400, body), entity="Estimate")
+        assert "code=2030" in out
+        assert "Invalid enumeration value" in out
+        assert "TxnStatus 'In Progress' is not valid" in out
+
+    def test_appends_enum_hint_when_entity_is_known(self) -> None:
+        """A 400 mentioning TxnStatus on Estimate should append the
+        full valid set so the model self-corrects on the next turn."""
+        body = {
+            "Fault": {
+                "Error": [{"Message": "validation", "Detail": "TxnStatus 'Frozen' is invalid"}]
+            }
+        }
+        out = _format_intuit_fault(_make_http_error(400, body), entity="Estimate")
+        assert "Hint: Valid TxnStatus for Estimate:" in out
+        for valid in ("Pending", "Accepted", "Closed", "Rejected"):
+            assert valid in out
+
+    def test_no_hint_when_entity_unknown(self) -> None:
+        """The hint set is curated; unknown entities get the raw error only."""
+        body = {"Fault": {"Error": [{"Message": "X", "Detail": "TxnStatus blah"}]}}
+        out = _format_intuit_fault(_make_http_error(400, body), entity="Customer")
+        assert "Hint:" not in out
+
+    def test_falls_back_to_raw_body_on_unexpected_shape(self) -> None:
+        """When QBO returns something unfaultlike (e.g. an HTML 502), the
+        formatter must still return a non-empty message containing the
+        status code so the LLM is not left guessing."""
+        request = httpx.Request("GET", "https://example.invalid/q")
+        response = httpx.Response(502, content=b"<html>Bad Gateway</html>", request=request)
+        exc = httpx.HTTPStatusError("error", request=request, response=response)
+        out = _format_intuit_fault(exc, entity="Estimate")
+        assert "502" in out
+        assert "Bad Gateway" in out


### PR DESCRIPTION
## Summary

When QBO returns a 400 (e.g. \`Estimate.TxnStatus = 'Frozen'\`, missing required field) the model previously got a JSON dump of the Fault payload with three levels of nesting and \`Detail\` buried inside. The model sometimes parsed it, often retried the same hallucinated value.

Two changes:

1. **`_format_intuit_fault()`** pulls Message + Detail + code out of the structured \`Fault.Error[]\` response and formats them on one line. On unexpected response shapes (HTML 502 from a load balancer, plain text), falls back to the status code + body so the LLM is never left with a bare \`HTTP 500\` to guess at.

2. **Enum hint** — when the failure looks enum-shaped (Detail mentions \`TxnStatus\` on an entity in \`_TXNSTATUS_VALID_BY_ENTITY\`), the formatter appends a one-line hint with the valid set. Today this covers Estimate; the map is the single edit point for adding more entities.

\`QBQueryParams\` description also gets common string-enum values added inline so the model has guidance even without an error round-trip.

Wired into qb_query, qb_create, qb_update, qb_send error paths.

## Source

Dev log 2026-05-01 20:28:46 — qb_query failed with 400 Bad Request on a \`TxnStatus=Pending\` query that the admin had no good way to debug. Followup #59 from the conversation-inspector office-hours design pass.

## Checklist
- [x] Tests pass — 23 QB tool tests pass (4 new ones cover the formatter and the hint path)
- [x] Lint passes (ruff check, ruff format --check)
- [x] Type checking passes (\`uv run ty check\`)
- [x] New tests added for new functionality

## Test plan
- [x] Unit: \`TestFormatIntuitFault\` covers the structured fault path, enum hint enrichment, hint suppression for unknown entities, and the malformed-body fallback.
- [ ] Manual: open Jesse's conversation in the admin Turns view after this lands and verify the qb_query error there is now a one-line message with the hint instead of a JSON wall.

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._