### PR TITLE
feat(compaction): persist per-event metrics to compaction_events table

### DIFF
--- a/alembic/versions/023_add_compaction_events.py
+++ b/alembic/versions/023_add_compaction_events.py
@@ -1,0 +1,66 @@
+"""Add compaction_events table for per-event compaction metrics.
+
+Followup to the consent-gated admin viewer (clawbolt-premium #346 / #347).
+The compaction summary line in ``backend/app/agent/compaction.py`` was
+INFO-logged only, so admins debugging "why did this turn lose context?"
+or "how often does this user compact?" had to grep Railway. This table
+gives every compaction run a queryable row with sizes / costs / outcome
+flags. The actual extracted content stays in MemoryDocument.history_text
+(envelope-encrypted at rest); this table is metadata, not content.
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-05-01
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "023"
+down_revision: str = "022"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "compaction_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.String(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "triggered_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("duration_ms", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("trimmed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("trimmed_chars", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("max_message_seq", sa.Integer(), nullable=True),
+        sa.Column("memory_updated", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("user_profile_updated", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("soul_updated", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("summary_len", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_index("ix_compaction_events_user_id", "compaction_events", ["user_id"])
+    op.create_index(
+        "ix_compaction_events_triggered_at",
+        "compaction_events",
+        ["triggered_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_compaction_events_triggered_at", table_name="compaction_events")
+    op.drop_index("ix_compaction_events_user_id", table_name="compaction_events")
+    op.drop_table("compaction_events")

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -263,4 +263,67 @@ async def compact_session(
         len(result.summary or ""),
     )
 
+    # Persist the same metrics so admins can query "when did this user
+    # last compact / how big was the input / what got updated" without
+    # grepping Railway logs. Best-effort: a DB hiccup must not lose the
+    # compacted memory we just wrote upstream.
+    try:
+        _persist_compaction_event(
+            user_id=user_id,
+            trimmed_count=_trimmed_count,
+            trimmed_chars=_input_chars,
+            input_tokens=_input_tokens,
+            output_tokens=_output_tokens,
+            duration_ms=_duration_ms,
+            max_message_seq=max_message_seq,
+            memory_updated=bool(result.memory_update),
+            user_profile_updated=bool(result.user_profile_update),
+            soul_updated=bool(result.soul_update),
+            summary_len=len(result.summary or ""),
+        )
+    except Exception:
+        logger.exception("Failed to persist compaction event for user %s", user_id)
+
     return result.memory_update, max_message_seq
+
+
+def _persist_compaction_event(
+    *,
+    user_id: str,
+    trimmed_count: int,
+    trimmed_chars: int,
+    input_tokens: int,
+    output_tokens: int,
+    duration_ms: int,
+    max_message_seq: int | None,
+    memory_updated: bool,
+    user_profile_updated: bool,
+    soul_updated: bool,
+    summary_len: int,
+) -> None:
+    """Write one ``CompactionEvent`` row.
+
+    Imports the model + SessionLocal lazily so the agent module does
+    not pull SQLAlchemy at import time on every test that exercises
+    pure compaction logic with mocked LLM calls.
+    """
+    from backend.app.database import SessionLocal
+    from backend.app.models import CompactionEvent
+
+    with SessionLocal() as db:
+        db.add(
+            CompactionEvent(
+                user_id=user_id,
+                trimmed_count=trimmed_count,
+                trimmed_chars=trimmed_chars,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                duration_ms=duration_ms,
+                max_message_seq=max_message_seq,
+                memory_updated=memory_updated,
+                user_profile_updated=user_profile_updated,
+                soul_updated=soul_updated,
+                summary_len=summary_len,
+            )
+        )
+        db.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -625,6 +625,48 @@ class PendingApprovalRow(Base):
     )
 
 
+class CompactionEvent(Base):
+    """One row per session-compaction run.
+
+    Compaction is the agent's mechanism for trimming a long session and
+    extracting durable facts into ``MemoryDocument``. Per-event timing,
+    sizes, and outcome flags used to live only in ``logger.info(
+    "compaction.summary user=...")`` lines, which made cross-event
+    queries ("how often does this user compact? how big are the
+    inputs?") impossible without grepping logs.
+
+    All columns are metadata; the actual extracted content (the
+    summary appended to ``MemoryDocument.history_text``) stays
+    envelope-encrypted at rest under that column. Surfacing this
+    table to admins still goes through the consent gate on the
+    premium ``/admin/shared-data/users/{id}/compaction-events``
+    endpoint; we keep the writes unconditional since the columns
+    carry no user-authored content.
+
+    See ``backend/app/agent/compaction.py`` for the call site.
+    """
+
+    __tablename__ = "compaction_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(
+        String, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    triggered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), index=True
+    )
+    duration_ms: Mapped[int] = mapped_column(Integer, default=0)
+    trimmed_count: Mapped[int] = mapped_column(Integer, default=0)
+    trimmed_chars: Mapped[int] = mapped_column(Integer, default=0)
+    input_tokens: Mapped[int] = mapped_column(Integer, default=0)
+    output_tokens: Mapped[int] = mapped_column(Integer, default=0)
+    max_message_seq: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    memory_updated: Mapped[bool] = mapped_column(Boolean, default=False)
+    user_profile_updated: Mapped[bool] = mapped_column(Boolean, default=False)
+    soul_updated: Mapped[bool] = mapped_column(Boolean, default=False)
+    summary_len: Mapped[int] = mapped_column(Integer, default=0)
+
+
 class UserPermissionSet(Base):
     """Per-user tool/resource permission overrides (formerly PERMISSIONS.json).
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1345,3 +1345,91 @@ async def test_concurrent_get_or_create_session_does_not_duplicate() -> None:
         db.close()
 
     assert active_count == 1, f"expected 1 active session, got {active_count}"
+
+
+# --- CompactionEvent persistence ---
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_writes_event_row(test_user: UserData) -> None:
+    """Every successful compaction must leave one CompactionEvent row.
+
+    Pins the regression we just fixed: pre-this-PR the metrics were
+    INFO-logged only, so admins debugging "when did this user last
+    compact" had to grep Railway. Now they can query.
+    """
+    from backend.app.models import CompactionEvent
+
+    llm_response_content = json.dumps(
+        {
+            "memory_update": "## Notes\n- prefers terse replies",
+            "user_profile_update": "Likes pizza.",
+            "summary": "[TIMESTAMP] talked about lunch",
+        }
+    )
+    mock_response = make_text_response(llm_response_content)
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="i like pizza"),
+        AssistantMessage(content="noted"),
+    ]
+
+    db = _db_module.SessionLocal()
+    try:
+        before = db.query(CompactionEvent).filter_by(user_id=test_user.id).count()
+    finally:
+        db.close()
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, messages, max_message_seq=2)
+
+    db = _db_module.SessionLocal()
+    try:
+        rows = (
+            db.query(CompactionEvent)
+            .filter_by(user_id=test_user.id)
+            .order_by(CompactionEvent.id.desc())
+            .all()
+        )
+    finally:
+        db.close()
+
+    assert len(rows) == before + 1
+    row = rows[0]
+    assert row.trimmed_count == 2
+    assert row.trimmed_chars > 0
+    assert row.duration_ms >= 0
+    assert row.max_message_seq == 2
+    assert row.memory_updated is True
+    assert row.user_profile_updated is True
+    assert row.soul_updated is False
+    assert row.summary_len > 0
+    assert row.triggered_at is not None
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_db_failure_does_not_fail_compaction(
+    test_user: UserData,
+) -> None:
+    """If the event-row write throws, compaction must still succeed.
+
+    The memory write happened upstream of the persistence call; we must
+    not fail the whole compaction (and lose the memory_update return
+    value the caller is about to act on) just because audit-style
+    persistence broke.
+    """
+    llm_response_content = json.dumps({"memory_update": "## A\n- b", "summary": "[TIMESTAMP] x"})
+    mock_response = make_text_response(llm_response_content)
+    messages: list[AgentMessage] = [UserMessage(content="hi")]
+
+    with (
+        patch("backend.app.agent.compaction.amessages", return_value=mock_response),
+        patch(
+            "backend.app.agent.compaction._persist_compaction_event",
+            side_effect=RuntimeError("db down"),
+        ),
+    ):
+        memory_update, max_seq = await compact_session(test_user.id, messages, max_message_seq=1)
+
+    assert "## A" in memory_update
+    assert max_seq == 1


### PR DESCRIPTION
## Summary

Followup to the consent-gated admin viewer (clawbolt-premium #346 / #347). The compaction summary line in \`backend/app/agent/compaction.py:250\` (\`compaction.summary user=...\`) was INFO-logged only. Admins debugging \"when did this user last compact, how big are the inputs, what got updated\" had to grep Railway logs.

## What this PR does

Adds a \`compaction_events\` table (migration 023) holding metadata only:

\`\`\`
triggered_at, duration_ms, trimmed_count, trimmed_chars,
input_tokens, output_tokens, max_message_seq,
memory_updated, user_profile_updated, soul_updated, summary_len.
\`\`\`

The actual extracted summary stays in \`MemoryDocument.history_text\` (envelope-encrypted at rest); this table is **metadata only, queryable**. Writes are unconditional. Surfacing rows to admins still goes through the consent gate, via a follow-up clawbolt-premium PR adding \`/admin/shared-data/users/{id}/compaction-events\`.

Persistence is best-effort: the \`_persist_compaction_event\` call is wrapped in a logged try/except so a DB hiccup cannot fail the compaction (which has already written \`memory_update\` upstream).

## Why this shape

- **Metadata, not content.** All columns are integers, booleans, or timestamps. No user-authored text. Safe to keep unencrypted; safe to write unconditionally.
- **No FK to ChatSession.** A compaction can span multiple sessions / consolidations; it is keyed to the user only. \`max_message_seq\` is the most useful single anchor.
- **Indexed on \`user_id\` + \`triggered_at\`.** The two queries we expect: \"events for one user, newest first\" and \"events in a time window across users.\"
- **No \`summary\` column.** The full summary is already persisted in \`MemoryDocument.history_text\`; duplicating it here would double the privacy surface for no admin benefit.

## Test plan
- [x] \`test_compact_session_writes_event_row\` — every successful compaction leaves one row with the right metrics
- [x] \`test_compact_session_db_failure_does_not_fail_compaction\` — best-effort guarantee: a persistence failure does not lose \`memory_update\`
- [x] All 53 existing compaction tests still pass

## Checklist
- [x] Tests pass
- [x] Lint passes (\`ruff check\`, \`ruff format --check\`)
- [x] Type checking passes (\`uv run ty check\`)
- [x] New tests added for new functionality

## Migration safety
Migration 023 is additive: new table only, no changes to existing columns. All new columns have defaults so the DEFAULT-with-server-side write completes synchronously on prod. Safe to apply via the standard Railway pre-deploy step.

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._