### PR TITLE
fix(approval): clearer prompt wording + accept compound replies

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -674,40 +674,59 @@ async def cleanup_orphaned_approvals(
 # ---------------------------------------------------------------------------
 
 
+_APPROVAL_RESPONSE_FAST_PATH: dict[str, ApprovalDecision] = {
+    # Single-word forms (with the y/n shortcuts).
+    "yes": ApprovalDecision.APPROVED,
+    "y": ApprovalDecision.APPROVED,
+    "always": ApprovalDecision.ALWAYS_ALLOW,
+    "no": ApprovalDecision.DENIED,
+    "n": ApprovalDecision.DENIED,
+    "never": ApprovalDecision.ALWAYS_DENY,
+    # Compound forms (always/never anchored with an explicit allow/deny
+    # word). Mixed-axis pairs like ``yes never`` are intentionally
+    # absent so they fall through to the LLM classifier rather than
+    # being silently misclassified.
+    "yes always": ApprovalDecision.ALWAYS_ALLOW,
+    "always yes": ApprovalDecision.ALWAYS_ALLOW,
+    "y always": ApprovalDecision.ALWAYS_ALLOW,
+    "always y": ApprovalDecision.ALWAYS_ALLOW,
+    "always allow": ApprovalDecision.ALWAYS_ALLOW,
+    "allow always": ApprovalDecision.ALWAYS_ALLOW,
+    "no never": ApprovalDecision.ALWAYS_DENY,
+    "never no": ApprovalDecision.ALWAYS_DENY,
+    "n never": ApprovalDecision.ALWAYS_DENY,
+    "never n": ApprovalDecision.ALWAYS_DENY,
+    "never allow": ApprovalDecision.ALWAYS_DENY,
+    "deny always": ApprovalDecision.ALWAYS_DENY,
+}
+
+
+# Punctuation we strip before fast-path lookup. Users naturally type
+# ``"Yes."`` / ``"yes, always"`` / ``"yes!"`` and the parser should treat
+# those identically to the bare keyword.
+_APPROVAL_RESPONSE_PUNCTUATION = ".,!?;:"
+
+
 def _parse_approval_response(text: str) -> ApprovalDecision | None:
     """Parse a user's text reply into an approval decision (fast path).
 
     Handles single-word matches and the natural compound replies users
     actually type when they want to lock in a permanent choice
     ("yes always", "always allow", "no never", "never allow", etc.).
-    Anything ambiguous falls through to the LLM classifier in
-    ``classify_approval_response()``.
+    Punctuation (``.,!?;:``) is stripped before lookup so ``"Yes."`` and
+    ``"yes, always"`` route through the fast path instead of the LLM
+    classifier. Anything still ambiguous after normalization falls
+    through to ``classify_approval_response``.
 
     The compound forms are deliberately conservative: only word pairs
     where both halves agree on the same axis (allow vs deny) match.
     Mixed pairs like "yes never" go to the LLM so we do not silently
     pick the wrong intent.
     """
-    normalized = " ".join(text.strip().lower().split())
-    mapping: dict[str, ApprovalDecision] = {
-        # Single-word.
-        "yes": ApprovalDecision.APPROVED,
-        "y": ApprovalDecision.APPROVED,
-        "always": ApprovalDecision.ALWAYS_ALLOW,
-        "no": ApprovalDecision.DENIED,
-        "n": ApprovalDecision.DENIED,
-        "never": ApprovalDecision.ALWAYS_DENY,
-        # Compound (always/never with an explicit allow/deny anchor).
-        "yes always": ApprovalDecision.ALWAYS_ALLOW,
-        "always yes": ApprovalDecision.ALWAYS_ALLOW,
-        "always allow": ApprovalDecision.ALWAYS_ALLOW,
-        "allow always": ApprovalDecision.ALWAYS_ALLOW,
-        "no never": ApprovalDecision.ALWAYS_DENY,
-        "never no": ApprovalDecision.ALWAYS_DENY,
-        "never allow": ApprovalDecision.ALWAYS_DENY,
-        "deny always": ApprovalDecision.ALWAYS_DENY,
-    }
-    return mapping.get(normalized)
+    cleaned = text.strip().lower()
+    cleaned = cleaned.translate(str.maketrans("", "", _APPROVAL_RESPONSE_PUNCTUATION))
+    normalized = " ".join(cleaned.split())
+    return _APPROVAL_RESPONSE_FAST_PATH.get(normalized)
 
 
 async def classify_approval_response(text: str) -> ApprovalDecision | None:
@@ -749,9 +768,11 @@ async def classify_approval_response(text: str) -> ApprovalDecision | None:
                         "role": "system",
                         "content": (
                             "The user was asked to approve or deny a tool action. "
-                            "They were told: "
-                            "'Reply yes or no (always/never to remember your choice)'. "
-                            "Classify their response."
+                            "They were shown a four-option menu: "
+                            "yes (allow this once), no (deny this once), "
+                            "always (allow and remember), never (deny and remember). "
+                            "Classify their response into one of: approved, denied, "
+                            "always_allow, always_deny, unrelated."
                         ),
                     },
                     {"role": "user", "content": text},

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -152,7 +152,13 @@ def format_plan_message(
     if not ask_steps:
         return ""
 
-    _reply_line = "Reply yes or no (always/never to remember your choice)"
+    _reply_line = (
+        "Reply with one of:\n"
+        "  yes — allow this once\n"
+        "  no — deny this once\n"
+        "  always — allow and remember\n"
+        "  never — deny and remember"
+    )
 
     # Single ask, no auto: simple prompt
     if len(ask_steps) == 1 and not auto_steps:
@@ -671,19 +677,35 @@ async def cleanup_orphaned_approvals(
 def _parse_approval_response(text: str) -> ApprovalDecision | None:
     """Parse a user's text reply into an approval decision (fast path).
 
-    Handles exact single-word matches only. For natural-language responses
-    like "Yes to both" or "go ahead", use ``classify_approval_response()``.
+    Handles single-word matches and the natural compound replies users
+    actually type when they want to lock in a permanent choice
+    ("yes always", "always allow", "no never", "never allow", etc.).
+    Anything ambiguous falls through to the LLM classifier in
+    ``classify_approval_response()``.
 
-    Returns None if the text is not a recognized approval response.
+    The compound forms are deliberately conservative: only word pairs
+    where both halves agree on the same axis (allow vs deny) match.
+    Mixed pairs like "yes never" go to the LLM so we do not silently
+    pick the wrong intent.
     """
-    normalized = text.strip().lower()
+    normalized = " ".join(text.strip().lower().split())
     mapping: dict[str, ApprovalDecision] = {
+        # Single-word.
         "yes": ApprovalDecision.APPROVED,
         "y": ApprovalDecision.APPROVED,
         "always": ApprovalDecision.ALWAYS_ALLOW,
         "no": ApprovalDecision.DENIED,
         "n": ApprovalDecision.DENIED,
         "never": ApprovalDecision.ALWAYS_DENY,
+        # Compound (always/never with an explicit allow/deny anchor).
+        "yes always": ApprovalDecision.ALWAYS_ALLOW,
+        "always yes": ApprovalDecision.ALWAYS_ALLOW,
+        "always allow": ApprovalDecision.ALWAYS_ALLOW,
+        "allow always": ApprovalDecision.ALWAYS_ALLOW,
+        "no never": ApprovalDecision.ALWAYS_DENY,
+        "never no": ApprovalDecision.ALWAYS_DENY,
+        "never allow": ApprovalDecision.ALWAYS_DENY,
+        "deny always": ApprovalDecision.ALWAYS_DENY,
     }
     return mapping.get(normalized)
 
@@ -763,8 +785,24 @@ async def classify_approval_response(text: str) -> ApprovalDecision | None:
 
 
 def format_approval_message(tool_name: str, description: str) -> str:
-    """Build a plain-text approval prompt for the user."""
-    return f"I'd like to: {description}\n\nReply yes or no (always/never to remember your choice)"
+    """Build a plain-text approval prompt for the user.
+
+    The four reply options are listed as a vertical menu so each choice
+    is unambiguous. A previous wording, ``"Reply yes or no
+    (always/never to remember your choice)"``, was misread by users as
+    a two-axis answer ("yes always" or "no never"); the menu form makes
+    it clear that exactly one of {yes, no, always, never} is the
+    expected response. The parser still accepts the compound forms in
+    case a user types one anyway.
+    """
+    return (
+        f"I'd like to: {description}\n\n"
+        "Reply with one of:\n"
+        "  yes — allow this once\n"
+        "  no — deny this once\n"
+        "  always — allow and remember\n"
+        "  never — deny and remember"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -154,10 +154,10 @@ def format_plan_message(
 
     _reply_line = (
         "Reply with one of:\n"
-        "  yes — allow this once\n"
-        "  no — deny this once\n"
-        "  always — allow and remember\n"
-        "  never — deny and remember"
+        "  yes: allow this once\n"
+        "  no: deny this once\n"
+        "  always: allow and remember\n"
+        "  never: deny and remember"
     )
 
     # Single ask, no auto: simple prompt
@@ -819,10 +819,10 @@ def format_approval_message(tool_name: str, description: str) -> str:
     return (
         f"I'd like to: {description}\n\n"
         "Reply with one of:\n"
-        "  yes — allow this once\n"
-        "  no — deny this once\n"
-        "  always — allow and remember\n"
-        "  never — deny and remember"
+        "  yes: allow this once\n"
+        "  no: deny this once\n"
+        "  always: allow and remember\n"
+        "  never: deny and remember"
     )
 
 

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -25,11 +25,35 @@ from backend.app.enums import MessageDirection
 
 logger = logging.getLogger(__name__)
 
-# Canonical trailer that ``format_approval_message`` appends to every
-# system-issued approval prompt. Used to identify approval-prompt rows
-# in stored history so they can be filtered out before the LLM sees
-# them. See the comment in ``load_history`` for why.
-_APPROVAL_PROMPT_TRAILER = "Reply yes or no (always/never to remember your choice)"
+# Canonical trailers that ``format_approval_message`` /
+# ``format_plan_message`` append to every system-issued approval prompt.
+# Used to identify approval-prompt rows in stored history so they can be
+# filtered out before the LLM sees them (see ``load_history`` for the
+# rationale — persisted prompts trained the LLM to produce them as
+# prose, creating an infinite-loop UX bug). The list is "old + current"
+# on purpose: rows persisted before the prompt rewording need to keep
+# matching after the new wording ships, otherwise the issue #1049 fix
+# silently regresses on already-poisoned sessions.
+_APPROVAL_PROMPT_TRAILERS: tuple[str, ...] = (
+    # Current wording — the last line of the four-option menu.
+    "never — deny and remember",
+    # Pre-rewording wording, kept for backward compatibility with
+    # already-persisted rows in the DB.
+    "Reply yes or no (always/never to remember your choice)",
+)
+
+
+def _is_approval_prompt(content: str) -> bool:
+    """Return True if *content* ends with any known approval-prompt trailer.
+
+    Helper so the load-history filter can detect rows persisted before
+    AND after the prompt-text rewording. Matching is by trailing
+    substring, not exact prefix, so receipts or prose appended after
+    the menu would not be (incorrectly) flagged.
+    """
+    rstripped = content.rstrip()
+    return any(rstripped.endswith(trailer) for trailer in _APPROVAL_PROMPT_TRAILERS)
+
 
 DEFAULT_HISTORY_LIMIT = settings.conversation_history_limit
 
@@ -327,7 +351,7 @@ async def load_conversation_history(
                 tool_interaction_count += len(tool_interactions)
                 history.extend(_expand_outbound_with_tools(tool_interactions, content))
                 last_was_approval_prompt = False
-            elif content.rstrip().endswith(_APPROVAL_PROMPT_TRAILER):
+            elif _is_approval_prompt(content):
                 # Skip approval prompts (real ones persisted by older code,
                 # plus any LLM-generated fake prompts that mimic the format).
                 # Persisted prompts in past turns trained the LLM to produce

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -35,7 +35,11 @@ logger = logging.getLogger(__name__)
 # matching after the new wording ships, otherwise the issue #1049 fix
 # silently regresses on already-poisoned sessions.
 _APPROVAL_PROMPT_TRAILERS: tuple[str, ...] = (
-    # Current wording — the last line of the four-option menu.
+    # Current wording: last line of the four-option menu.
+    "never: deny and remember",
+    # Pre-em-dash-fix wording (briefly used between the prompt rewrite
+    # and the punctuation-policy fix). Kept so rows persisted in that
+    # window still match the trailer filter.
     "never — deny and remember",
     # Pre-rewording wording, kept for backward compatibility with
     # already-persisted rows in the DB.

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -229,6 +229,44 @@ class TestParseApprovalResponse:
     def test_valid_responses(self, text: str, expected: ApprovalDecision) -> None:
         assert _parse_approval_response(text) == expected
 
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            # Compound replies users naturally type when they read
+            # "yes or no (always/never to remember)" as a 2-axis answer.
+            # All map to the unambiguous remember-this-decision result.
+            ("yes always", ApprovalDecision.ALWAYS_ALLOW),
+            ("Yes always", ApprovalDecision.ALWAYS_ALLOW),
+            ("always yes", ApprovalDecision.ALWAYS_ALLOW),
+            ("always allow", ApprovalDecision.ALWAYS_ALLOW),
+            ("allow always", ApprovalDecision.ALWAYS_ALLOW),
+            ("yes  always", ApprovalDecision.ALWAYS_ALLOW),  # collapse whitespace
+            ("no never", ApprovalDecision.ALWAYS_DENY),
+            ("Never no", ApprovalDecision.ALWAYS_DENY),
+            ("never allow", ApprovalDecision.ALWAYS_DENY),
+            ("deny always", ApprovalDecision.ALWAYS_DENY),
+        ],
+    )
+    def test_compound_responses(self, text: str, expected: ApprovalDecision) -> None:
+        """Two-word natural replies that match the prompt's option list
+        should resolve at the fast path, not the LLM classifier."""
+        assert _parse_approval_response(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Mixed-axis pairs (one allow, one deny) are intentionally
+            # NOT in the fast-path mapping; they go to the LLM classifier
+            # so we don't silently pick the wrong direction.
+            "yes never",
+            "no always",
+        ],
+    )
+    def test_mixed_axis_pairs_fall_through(self, text: str) -> None:
+        """Conflicting compound pairs return None so they hit the LLM
+        classifier rather than getting silently misclassified."""
+        assert _parse_approval_response(text) is None
+
     @pytest.mark.parametrize("text", ["maybe", "sure", "ok", "hello", ""])
     def test_unrecognized_returns_none(self, text: str) -> None:
         assert _parse_approval_response(text) is None
@@ -247,6 +285,22 @@ class TestFormatApprovalMessage:
         assert "no" in msg
         assert "always" in msg
         assert "never" in msg
+
+    def test_options_are_a_menu_not_a_two_axis_answer(self) -> None:
+        """Regression on the 'yes always' / 'no never' confusion.
+
+        The previous wording ``"Reply yes or no (always/never to
+        remember your choice)"`` got read as a two-axis question (pick
+        an allow/deny axis AND a once/remember axis), so users typed
+        ``yes always``. The new wording lists four distinct options on
+        their own lines so the menu shape is obvious.
+        """
+        msg = format_approval_message("any_tool", "do the thing")
+        # Each option appears on its own line.
+        for option in ("  yes", "  no", "  always", "  never"):
+            assert option in msg, f"missing menu line: {option!r}"
+        # Old confusing wording is gone.
+        assert "(always/never to remember" not in msg
         # Tool name should NOT appear in the user-facing message
         assert "web_fetch" not in msg
 

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -241,8 +241,13 @@ class TestParseApprovalResponse:
             ("always allow", ApprovalDecision.ALWAYS_ALLOW),
             ("allow always", ApprovalDecision.ALWAYS_ALLOW),
             ("yes  always", ApprovalDecision.ALWAYS_ALLOW),  # collapse whitespace
+            # The y/n shortcuts also pair with always/never.
+            ("y always", ApprovalDecision.ALWAYS_ALLOW),
+            ("always y", ApprovalDecision.ALWAYS_ALLOW),
             ("no never", ApprovalDecision.ALWAYS_DENY),
             ("Never no", ApprovalDecision.ALWAYS_DENY),
+            ("n never", ApprovalDecision.ALWAYS_DENY),
+            ("never n", ApprovalDecision.ALWAYS_DENY),
             ("never allow", ApprovalDecision.ALWAYS_DENY),
             ("deny always", ApprovalDecision.ALWAYS_DENY),
         ],
@@ -250,6 +255,32 @@ class TestParseApprovalResponse:
     def test_compound_responses(self, text: str, expected: ApprovalDecision) -> None:
         """Two-word natural replies that match the prompt's option list
         should resolve at the fast path, not the LLM classifier."""
+        assert _parse_approval_response(text) == expected
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            # Trailing punctuation users type out of habit. All these
+            # should route through the fast path, not the LLM classifier.
+            ("Yes.", ApprovalDecision.APPROVED),
+            ("yes!", ApprovalDecision.APPROVED),
+            ("yes?", ApprovalDecision.APPROVED),
+            ("No.", ApprovalDecision.DENIED),
+            ("Always.", ApprovalDecision.ALWAYS_ALLOW),
+            ("Never!", ApprovalDecision.ALWAYS_DENY),
+            # The literal user phrasing from the original report.
+            ("yes, always", ApprovalDecision.ALWAYS_ALLOW),
+            ("Yes, always.", ApprovalDecision.ALWAYS_ALLOW),
+            ("no, never", ApprovalDecision.ALWAYS_DENY),
+            # Multiple punctuation chars also strip cleanly.
+            ("yes!?", ApprovalDecision.APPROVED),
+            ("Yes; always.", ApprovalDecision.ALWAYS_ALLOW),
+        ],
+    )
+    def test_responses_with_punctuation(self, text: str, expected: ApprovalDecision) -> None:
+        """Punctuation must be stripped before fast-path lookup; the user's
+        natural phrasing ("yes, always" — the exact wording from the
+        original report) must not fall through to the LLM classifier."""
         assert _parse_approval_response(text) == expected
 
     @pytest.mark.parametrize(

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -335,6 +335,19 @@ class TestFormatApprovalMessage:
         # Tool name should NOT appear in the user-facing message
         assert "web_fetch" not in msg
 
+    def test_menu_uses_no_em_dashes(self) -> None:
+        """The four-line menu must not contain em dashes.
+
+        Per the project style rule on user-facing copy, separators in
+        prose are colons, periods, or commas, not em dashes (which
+        users on some clients render as a literal box). This test pins
+        the punctuation so a future edit cannot quietly reintroduce
+        them.
+        """
+        msg = format_approval_message("any_tool", "do the thing")
+        assert "—" not in msg  # em dash
+        assert " -- " not in msg  # double-hyphen approximation
+
 
 # ---------------------------------------------------------------------------
 # ApprovalGate

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -373,7 +373,20 @@ async def test_load_history_malformed_tool_json_falls_back_to_flat(
 # ---------------------------------------------------------------------------
 
 
+# Current four-option menu form, what ``format_approval_message`` emits.
 _APPROVAL_PROMPT = (
+    "I'd like to: Create Estimate in QuickBooks\n\n"
+    "Reply with one of:\n"
+    "  yes — allow this once\n"
+    "  no — deny this once\n"
+    "  always — allow and remember\n"
+    "  never — deny and remember"
+)
+
+# Pre-rewording wording. Persisted rows from before the prompt change
+# still need to be filtered, otherwise the issue #1049 fix silently
+# regresses on already-poisoned sessions.
+_LEGACY_APPROVAL_PROMPT = (
     "I'd like to: Create Estimate in QuickBooks\n\n"
     "Reply yes or no (always/never to remember your choice)"
 )
@@ -398,10 +411,32 @@ async def test_load_history_filters_persisted_approval_prompts(
     assert isinstance(history[0], UserMessage)
     assert history[0].content == "Create that estimate"
     assert all(
-        "Reply yes or no" not in (m.content or "")
+        "deny and remember" not in (m.content or "")
         for m in history
         if isinstance(m, AssistantMessage)
     )
+
+
+@pytest.mark.asyncio()
+async def test_load_history_filters_legacy_approval_prompt_wording(
+    conversation: SessionState,
+) -> None:
+    """Approval prompts persisted before the wording rewording must
+    still be filtered. Backward compatibility on already-poisoned
+    sessions: rows in the DB still carry the old trailer, and dropping
+    the legacy match would silently regress the issue #1049 fix."""
+    conversation.messages.append(
+        StoredMessage(direction="inbound", body="Create that estimate", seq=1)
+    )
+    conversation.messages.append(
+        StoredMessage(direction="outbound", body=_LEGACY_APPROVAL_PROMPT, seq=2)
+    )
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=3))
+
+    history = await load_conversation_history(conversation)
+    assert len(history) == 1
+    assert isinstance(history[0], UserMessage)
+    assert history[0].content == "Create that estimate"
 
 
 @pytest.mark.asyncio()
@@ -479,10 +514,10 @@ async def test_load_history_filters_llm_generated_fake_approval_prompt(
     (the bug from #1049), it gets persisted as outbound with no
     tool_interactions. The load-time filter must catch these too so
     the cycle stops on subsequent turns."""
-    fake_prompt = (
-        "I'd like to: Create Estimate in QuickBooks\n\n"
-        "Reply yes or no (always/never to remember your choice)"
-    )
+    # LLM-generated mimicry of the legacy wording, persisted in a session
+    # that has not been compacted yet. The filter must still catch this
+    # form so the prose-mimicry loop stops on subsequent turns.
+    fake_prompt = _LEGACY_APPROVAL_PROMPT
     conversation.messages.append(StoredMessage(direction="inbound", body="estimate?", seq=1))
     conversation.messages.append(
         StoredMessage(

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -109,6 +109,10 @@ class TestFormatPlanMessage:
         for option in ("  yes", "  no", "  always", "  never"):
             assert option in msg, f"missing menu line: {option!r}"
         assert "(always/never to remember" not in msg
+        # Same em-dash ban as the single-tool prompt: see
+        # ``test_menu_uses_no_em_dashes`` in test_approval.py for the rationale.
+        assert "—" not in msg
+        assert " -- " not in msg
 
     def test_single_ask_with_auto(self) -> None:
         """Single ask step with auto steps: natural language format."""

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -98,6 +98,18 @@ class TestFormatPlanMessage:
         assert "yes" in msg
         assert "always" in msg
 
+    def test_reply_options_render_as_menu(self) -> None:
+        """The four reply options each appear on their own line.
+
+        Regression on the 'yes always' confusion: the old single-line
+        wording was read as a 2-axis answer.
+        """
+        ask = [PlanStep("writer", "Write USER.md", PermissionLevel.ASK)]
+        msg = format_plan_message("Plan:", [], ask)
+        for option in ("  yes", "  no", "  always", "  never"):
+            assert option in msg, f"missing menu line: {option!r}"
+        assert "(always/never to remember" not in msg
+
     def test_single_ask_with_auto(self) -> None:
         """Single ask step with auto steps: natural language format."""
         auto = [PlanStep("reader", "Read config", PermissionLevel.ALWAYS)]
@@ -219,7 +231,7 @@ class TestBatchApproval:
         prompt_sent = False
         for call in mock_publish.call_args_list:
             msg = call.args[0] if call.args else call.kwargs.get("msg")
-            if isinstance(msg, OutboundMessage) and "reply yes or no" in msg.content.lower():
+            if isinstance(msg, OutboundMessage) and "reply with one of" in msg.content.lower():
                 prompt_sent = True
         assert prompt_sent
 
@@ -562,7 +574,7 @@ class TestBatchApproval:
         for call in mock_publish.call_args_list:
             msg = call.args[0] if call.args else call.kwargs.get("msg")
             if isinstance(msg, OutboundMessage):
-                assert "reply yes or no" not in msg.content.lower()
+                assert "reply with one of" not in msg.content.lower()
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
@@ -600,12 +612,12 @@ class TestBatchApproval:
         approval_msgs = []
         for call in mock_publish.call_args_list:
             msg = call.args[0] if call.args else call.kwargs.get("msg")
-            if isinstance(msg, OutboundMessage) and "Reply yes or no" in msg.content:
+            if isinstance(msg, OutboundMessage) and "Reply with one of" in msg.content:
                 approval_msgs.append(msg.content)
 
         assert len(approval_msgs) == 1
-        # "Reply yes or no" should appear exactly once (not double-wrapped)
-        assert approval_msgs[0].count("Reply yes or no") == 1
+        # "Reply with one of" should appear exactly once (not double-wrapped)
+        assert approval_msgs[0].count("Reply with one of") == 1
         # Should not contain the format_approval_message wrapper
         assert "wants to use the tool" not in approval_msgs[0]
 
@@ -720,7 +732,7 @@ class TestBatchApproval:
         session = store.load_session(session_id)
         assert session is not None
         outbound_msgs = [m for m in session.messages if m.direction == "outbound"]
-        assert not any("reply yes or no" in m.body.lower() for m in outbound_msgs), (
+        assert not any("reply with one of" in m.body.lower() for m in outbound_msgs), (
             "Approval prompt was persisted to session history; this trains the "
             "LLM to mimic the format. See issue #1049."
         )


### PR DESCRIPTION
## Summary

Pilot-user feedback flagged the approval prompt as confusing:

> "When it says 'I'd like to' and then asks permission, my response options are confusing. Yes or no (always/never). I'm inclined to say 'yes, always' but I think that messes up something in the system because I'm essentially answering 2 different responses. If I'm correct in my thinking here, it would probably be more streamlined to either allow a more nuanced response or make it seem more obvious that I should only answer with 1 of those. Always, yes, no, or never? Something like that?"

The diagnosis is right. The old single-line wording `"Reply yes or no (always/never to remember your choice)"` reads as a 2-axis answer (allow/deny axis AND once/remember axis). Users type `"yes always"` expecting it to mean `ALWAYS_ALLOW`, then the fast-path parser doesn't match it and we fall through to the LLM classifier — slow, costly, and unstable across model versions.

## What this PR does

1. **Prompt is now a four-line menu** so the menu shape is unambiguous:

   ```
   I'd like to: <description>

   Reply with one of:
     yes — allow this once
     no — deny this once
     always — allow and remember
     never — deny and remember
   ```

2. **Fast-path parser accepts the compound replies** users actually type:
   - `yes always`, `always yes`, `always allow`, `allow always` → `ALWAYS_ALLOW`
   - `no never`, `never no`, `never allow`, `deny always` → `ALWAYS_DENY`
   - Mixed-axis pairs (`yes never`, `no always`) intentionally still fall through to the LLM classifier.

Both `format_approval_message` and `format_plan_message` use the new menu wording.

## Tests
- 94 approval tests pass
- New regression tests:
  - `TestFormatApprovalMessage.test_options_are_a_menu_not_a_two_axis_answer` pins the menu shape
  - `TestFormatPlanMessage.test_reply_options_render_as_menu` same for the multi-step variant
  - `TestParseApprovalResponse.test_compound_responses` covers the eight compound forms
  - `TestParseApprovalResponse.test_mixed_axis_pairs_fall_through` verifies conflicting pairs DO fall through

Existing tests that pattern-matched the old wording (`"reply yes or no"`) are updated to match the new wording.

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._