### PR TITLE
chore(agent): raise default llm_max_tokens_agent 1024 -> 2048

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1186,10 +1186,13 @@ class ClawboltAgent:
 
             # If the response was truncated and produced validation errors,
             # auto-increase max_tokens for the next round so the LLM has
-            # enough room to generate the full tool call payload.
+            # enough room to generate the full tool call payload. The
+            # 8192 cap leaves one further recovery step beyond the
+            # current 2048 default (2048 -> 4096 -> 8192) before we
+            # give up and surface the truncation to the user.
             if response_truncated and any(r.is_error for r in tool_results):
                 effective = max_tokens or settings.llm_max_tokens_agent
-                max_tokens = min(effective * 2, 4096)
+                max_tokens = min(effective * 2, 8192)
                 logger.info(
                     "Response truncated with errors, increasing max_tokens to %d",
                     max_tokens,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,7 +53,14 @@ class Settings(BaseSettings):
     vision_model: str = ""  # empty = fall back to llm_model
     vision_provider: str = ""  # empty = fall back to llm_provider
     reasoning_effort: str = "auto"  # none, minimal, low, medium, high, xhigh, auto
-    llm_max_tokens_agent: int = Field(default=1024, ge=1)
+    # 2048 is sized to fit a typical multi-tool turn (one ~200-token reply
+    # plus a tool call whose JSON args can run 500-1500 tokens for nested
+    # entity payloads in the QuickBooks / CompanyCam tools). The previous
+    # 1024 default truncated mid-tool-call on real workloads, leaving the
+    # validator to catch the malformed args; auto-recovery in
+    # ``core.py:_call_llm_with_retry`` doubles ``max_tokens`` on the next
+    # round, but a higher floor avoids the wasted round entirely.
+    llm_max_tokens_agent: int = Field(default=2048, ge=1)
     llm_max_tokens_heartbeat: int = Field(default=12000, ge=1)
     llm_max_tokens_vision: int = Field(default=1000, ge=1)
 


### PR DESCRIPTION
## Summary

Production telemetry shows occasional mid-tool-call truncation when the LLM emits a deeply-nested entity payload (QuickBooks Estimate / Invoice with line items, CompanyCam upload with multiple tags). The agent loop already auto-recovers by doubling \`max_tokens\` on the next round when truncation produced validation errors (\`core.py:1190\`), but the wasted round shows up to the user as a generic "request was incomplete" error before the recovery turn lands.

## What this PR does

1. **`config.llm_max_tokens_agent` default raised 1024 → 2048**. 2048 fits a typical multi-tool turn (one ~200-token reply plus a tool call whose JSON args run 500-1500 tokens for nested entity payloads). Heartbeat already floors at \`max(setting, 1024)\` so the bump only affects the agent path that's the actual bottleneck.

2. **Auto-recovery cap in core.py raised 4096 → 8192** so we keep the same number of recovery steps available beyond the new default (2048 → 4096 → 8192) before surfacing the failure to the user.

## Impact

- One-line change to the default. Existing \`LLM_MAX_TOKENS_AGENT\` env-var overrides remain hard caps.
- Modest cost increase per agent turn — but only on turns where the LLM actually uses the headroom; cached turns and short replies pay nothing extra.
- Removes a class of "truncation cascade" failures where a tool call's JSON args got cut mid-string and the validator rejected it.

## Test plan
- [x] Existing test suite passes (90 tests in compaction + config validation, no regressions)
- [x] Lint passes
- No new tests — this is a default-value tweak; existing auto-recovery + truncation tests in \`test_truncation.py\` cover the behavior.

## Checklist
- [x] Tests pass
- [x] Lint passes (\`ruff check\`, \`ruff format --check\`)
- [x] Type checking passes

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._