### PR TITLE
feat(heartbeat): skip LLM call when user is in active conversation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,10 @@ HEARTBEAT_QUIET_HOURS_END=7
 # HEARTBEAT_PROVIDER=           # empty = fall back to LLM_PROVIDER
 # HEARTBEAT_CONCURRENCY=5
 # HEARTBEAT_RECENT_MESSAGES_COUNT=5
+# Minutes since the user's last message to skip the heartbeat LLM call.
+# Avoids burning tokens on "skip" decisions during an active conversation.
+# Set to 0 to disable the throttle.
+# HEARTBEAT_USER_QUIET_PERIOD_MINUTES=5
 
 # -- Observability --
 # LOG_REQUEST_TIMING=false

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -711,6 +711,40 @@ def _dispatch_heartbeat_usage(
             logger.exception("heartbeat usage hook failed for user %s", user_id)
 
 
+def _user_messaged_within(user_id: str, minutes: int) -> bool:
+    """Return True if the user sent an inbound message in the last *minutes*.
+
+    Backs the heartbeat quiet-period gate. Used to skip the heartbeat
+    LLM call for users in an active conversation, where the scheduler
+    would otherwise tick → LLM call → "skip" decision once per interval
+    until the user goes quiet. Cheap point lookup against the indexed
+    ``messages`` table (filtered to the user's sessions).
+
+    Returns False on any DB hiccup so a transient failure does not
+    silently wedge the heartbeat path; the caller will fall through to
+    the normal LLM evaluation, which is the safer failure mode.
+    """
+    from backend.app.models import ChatSession, Message
+
+    cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=minutes)
+    db = SessionLocal()
+    try:
+        latest = (
+            db.query(Message.timestamp)
+            .join(ChatSession, ChatSession.id == Message.session_id)
+            .filter(ChatSession.user_id == user_id, Message.direction == "inbound")
+            .order_by(Message.timestamp.desc())
+            .limit(1)
+            .scalar()
+        )
+    except Exception:
+        logger.exception("Failed to check recent-message gate for user %s", user_id)
+        return False
+    finally:
+        db.close()
+    return latest is not None and latest >= cutoff
+
+
 # ---------------------------------------------------------------------------
 # Per-user runner (orchestrates Phase 1 + Phase 2)
 # ---------------------------------------------------------------------------
@@ -747,6 +781,19 @@ async def run_heartbeat_for_user(
             user.id,
             daily_count,
             max_daily,
+        )
+        return None
+
+    # Gate: user is in an active conversation. The scheduler ticks on a
+    # fixed interval; without this check, a chatty user produces a "skip"
+    # LLM call every tick that adds nothing the user will see. Cheap DB
+    # lookup, runs after the in-memory gates and before the LLM call.
+    quiet_minutes = settings.heartbeat_user_quiet_period_minutes
+    if quiet_minutes > 0 and _user_messaged_within(user.id, quiet_minutes):
+        logger.debug(
+            "Heartbeat skip user %s: messaged within last %d min",
+            user.id,
+            quiet_minutes,
         )
         return None
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -161,6 +161,14 @@ class Settings(BaseSettings):
     heartbeat_provider: str = ""  # empty = fall back to llm_provider
     heartbeat_concurrency: int = Field(default=5, ge=1)
     heartbeat_recent_messages_count: int = Field(default=5, ge=1)
+    # Skip the heartbeat LLM call for a user who messaged recently. The
+    # scheduler ticks every ``heartbeat_interval_minutes`` regardless of
+    # user activity; without this gate, an active conversation produces
+    # a tick → LLM call → "skip" decision every interval, burning tokens
+    # for no user value. The default 5-minute window is short enough not
+    # to delay genuinely overdue nudges and long enough to absorb a
+    # multi-turn back-and-forth. Set to 0 to disable the throttle.
+    heartbeat_user_quiet_period_minutes: int = Field(default=5, ge=0)
 
     # Observability
     log_request_timing: bool = False  # Set True (or LOG_REQUEST_TIMING=1) to log per-request timing

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -145,6 +145,7 @@ See [Storage Providers](./storage.md) for setup instructions.
 | `HEARTBEAT_PROVIDER` | (same as `LLM_PROVIDER`) | Provider used for heartbeat messages |
 | `HEARTBEAT_CONCURRENCY` | `5` | Max concurrent user evaluations per tick |
 | `HEARTBEAT_RECENT_MESSAGES_COUNT` | `5` | Number of recent messages included in heartbeat context |
+| `HEARTBEAT_USER_QUIET_PERIOD_MINUTES` | `5` | Minutes since the user's last message during which the heartbeat LLM call is skipped, to avoid burning tokens on "skip" decisions during an active conversation. Set to `0` to disable. |
 
 ## Observability
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -870,12 +870,14 @@ class TestRunHeartbeatForUser:
         assert result is None
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
     @patch("backend.app.agent.heartbeat._user_messaged_within")
     @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
     async def test_skip_when_user_recently_messaged(
         self,
         mock_count: AsyncMock,
         mock_recent: MagicMock,
+        mock_eval: AsyncMock,
         user: User,
     ) -> None:
         """Quiet-period gate: skip the LLM call when the user is in an
@@ -885,8 +887,10 @@ class TestRunHeartbeatForUser:
         result = await run_heartbeat_for_user(user, "telegram", "+15550000000", 5)
         assert result is None
         mock_recent.assert_called_once()
-        # Quiet-period must run BEFORE any LLM evaluation, so the
-        # mock for evaluate_heartbeat_need is never called here.
+        # Quiet-period must run BEFORE any LLM evaluation. Asserting the
+        # evaluator was never awaited makes the gate's ordering explicit
+        # and would catch a regression that re-arranged the gates.
+        mock_eval.assert_not_awaited()
 
     @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.HeartbeatStore")

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -26,6 +27,7 @@ from backend.app.agent.heartbeat import (
     _heartbeat_usage_hooks,
     _parse_decision_response,
     _parse_tool_call_response,
+    _user_messaged_within,
     evaluate_heartbeat_need,
     execute_heartbeat_tasks,
     get_daily_heartbeat_count,
@@ -35,7 +37,7 @@ from backend.app.agent.heartbeat import (
     run_heartbeat_for_user,
 )
 from backend.app.agent.system_prompt import to_local_time
-from backend.app.models import ChannelRoute, User
+from backend.app.models import ChannelRoute, ChatSession, Message, User
 from tests.mocks.llm import (
     make_text_response,
     make_tool_call_response,
@@ -1389,6 +1391,137 @@ class TestHeartbeatUsageHooks:
         await run_heartbeat_for_user(u, "telegram", u.phone, 5)
 
         assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# _user_messaged_within (quiet-period gate, integration with real DB rows)
+#
+# The unit tests above mock _user_messaged_within directly. This class
+# exercises the actual SQL query against a real Postgres test DB so we
+# catch a class of regressions the unit tests cannot:
+#
+# - Message.timestamp is currently DateTime(timezone=True) with a
+#   datetime.now(UTC) default, so the comparison against a tz-aware
+#   cutoff works. If anyone migrated this column to a naive type, the
+#   gate's ">=" comparison would raise TypeError, get swallowed by the
+#   broad except in _user_messaged_within, and the gate would silently
+#   never fire. The unit tests would still pass; this one would not.
+# - Confirms the join filters to the user's own sessions and ignores
+#   outbound messages.
+# ---------------------------------------------------------------------------
+
+
+def _seed_message(
+    db: Any,
+    *,
+    user_id: str,
+    direction: str,
+    timestamp: datetime.datetime,
+    seq: int = 1,
+    session_external_id: str | None = None,
+) -> int:
+    """Insert one ChatSession + one Message and return the message id."""
+    cs = ChatSession(
+        session_id=session_external_id or f"sess-{user_id[:8]}-{seq}",
+        user_id=user_id,
+        channel="telegram",
+    )
+    db.add(cs)
+    db.flush()
+    msg = Message(
+        session_id=cs.id,
+        seq=seq,
+        direction=direction,
+        body="hi",
+        timestamp=timestamp,
+    )
+    db.add(msg)
+    db.commit()
+    return msg.id
+
+
+class TestUserMessagedWithinIntegration:
+    def test_returns_false_when_no_messages(self, user: User) -> None:
+        assert _user_messaged_within(user.id, minutes=5) is False
+
+    def test_returns_true_for_recent_inbound(self, user: User) -> None:
+        now = datetime.datetime.now(datetime.UTC)
+        db = _db_module.SessionLocal()
+        try:
+            _seed_message(
+                db,
+                user_id=user.id,
+                direction="inbound",
+                timestamp=now - datetime.timedelta(minutes=1),
+            )
+        finally:
+            db.close()
+        assert _user_messaged_within(user.id, minutes=5) is True
+
+    def test_returns_false_for_old_inbound(self, user: User) -> None:
+        now = datetime.datetime.now(datetime.UTC)
+        db = _db_module.SessionLocal()
+        try:
+            _seed_message(
+                db,
+                user_id=user.id,
+                direction="inbound",
+                timestamp=now - datetime.timedelta(minutes=30),
+            )
+        finally:
+            db.close()
+        assert _user_messaged_within(user.id, minutes=5) is False
+
+    def test_ignores_outbound_messages(self, user: User) -> None:
+        """Outbound (assistant-authored) messages must not satisfy the gate.
+
+        The gate exists to detect that the *user* is mid-conversation,
+        not that the *assistant* recently replied. An outbound-only
+        session should leave the gate False so a heartbeat can still
+        fire if the user has gone quiet.
+        """
+        now = datetime.datetime.now(datetime.UTC)
+        db = _db_module.SessionLocal()
+        try:
+            _seed_message(
+                db,
+                user_id=user.id,
+                direction="outbound",
+                timestamp=now - datetime.timedelta(minutes=1),
+            )
+        finally:
+            db.close()
+        assert _user_messaged_within(user.id, minutes=5) is False
+
+    def test_other_users_messages_do_not_leak(self, user: User) -> None:
+        """A different user's recent inbound must not trigger this user's gate."""
+        other_db = _db_module.SessionLocal()
+        try:
+            other = User(
+                user_id="hb-quiet-other",
+                phone="+15559998888",
+                onboarding_complete=True,
+            )
+            other_db.add(other)
+            other_db.commit()
+            other_db.refresh(other)
+            other_id = other.id
+        finally:
+            other_db.close()
+
+        now = datetime.datetime.now(datetime.UTC)
+        db = _db_module.SessionLocal()
+        try:
+            _seed_message(
+                db,
+                user_id=other_id,
+                direction="inbound",
+                timestamp=now - datetime.timedelta(minutes=1),
+                session_external_id="sess-other-1",
+            )
+        finally:
+            db.close()
+        assert _user_messaged_within(user.id, minutes=5) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -870,6 +870,52 @@ class TestRunHeartbeatForUser:
         assert result is None
 
     @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat._user_messaged_within")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_skip_when_user_recently_messaged(
+        self,
+        mock_count: AsyncMock,
+        mock_recent: MagicMock,
+        user: User,
+    ) -> None:
+        """Quiet-period gate: skip the LLM call when the user is in an
+        active conversation. Pre-LLM, runs after the daily-rate gate."""
+        mock_count.return_value = 0
+        mock_recent.return_value = True
+        result = await run_heartbeat_for_user(user, "telegram", "+15550000000", 5)
+        assert result is None
+        mock_recent.assert_called_once()
+        # Quiet-period must run BEFORE any LLM evaluation, so the
+        # mock for evaluate_heartbeat_need is never called here.
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.HeartbeatStore")
+    @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
+    @patch("backend.app.agent.heartbeat._user_messaged_within")
+    @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")
+    async def test_quiet_period_does_not_block_when_user_silent(
+        self,
+        mock_count: AsyncMock,
+        mock_recent: MagicMock,
+        mock_eval: AsyncMock,
+        mock_hb_store_cls: MagicMock,
+        user: User,
+    ) -> None:
+        """If the user has not messaged recently, the heartbeat runs
+        normally — the gate does not gum up legitimate proactive sends."""
+        mock_count.return_value = 0
+        mock_recent.return_value = False
+        mock_eval.return_value = HeartbeatDecision(
+            action="skip", tasks="", reasoning="Nothing actionable"
+        )
+        mock_hb_store = MagicMock()
+        mock_hb_store.log_heartbeat = AsyncMock()
+        mock_hb_store_cls.return_value = mock_hb_store
+
+        await run_heartbeat_for_user(user, "telegram", "+15550000000", 5)
+        mock_eval.assert_awaited_once()
+
+    @pytest.mark.asyncio
     @patch("backend.app.agent.heartbeat.HeartbeatStore")
     @patch("backend.app.agent.heartbeat.evaluate_heartbeat_need")
     @patch("backend.app.agent.heartbeat.get_daily_heartbeat_count")


### PR DESCRIPTION
## Summary

The heartbeat scheduler ticks every \`heartbeat_interval_minutes\` regardless of whether the user is actively messaging. Production telemetry shows this drives a heavy "skip" rate — most ticks fire the Phase-1 LLM evaluator, which decides "no, the user is doing fine without us right now," and returns. Cheap individually, expensive at fleet scale: an active conversation produces an LLM call every interval that adds nothing the user will ever see.

## What this PR does

Adds a **quiet-period gate** that runs before the LLM call: if the user sent an inbound message within the last \`heartbeat_user_quiet_period_minutes\` (default **5**), the heartbeat returns early without an LLM round trip.

### Gate ordering

\`\`\`
onboarding-complete  ->  opt-in  ->  daily-rate  ->  [NEW] quiet-period  ->  heartbeat-text-empty  ->  LLM
\`\`\`

Quiet-period runs after the in-memory checks (cheap) and before the LLM evaluator (expensive). Cheap point lookup against the existing \`(session_id, seq)\` index on messages.

### Failure mode

DB hiccup **falls open**: a transient lookup failure logs the exception and returns \`False\`, so the heartbeat continues to the LLM evaluation path rather than silently suppressing proactive messages.

### Config

Disable the throttle by setting:

\`\`\`
HEARTBEAT_USER_QUIET_PERIOD_MINUTES=0
\`\`\`

Default of 5 minutes is short enough not to delay genuinely overdue nudges and long enough to absorb a multi-turn back-and-forth.

## Test plan
- [x] \`test_skip_when_user_recently_messaged\` — gate triggers and returns None when \`_user_messaged_within\` returns True; LLM evaluator is not called
- [x] \`test_quiet_period_does_not_block_when_user_silent\` — gate falls through when no recent message; LLM evaluator IS called
- [x] All 12 orchestrator tests pass

## Checklist
- [x] Tests pass
- [x] Lint passes (\`ruff check\`, \`ruff format --check\`)
- [x] Type checking passes (\`uv run ty check\`)
- [x] New tests added for new functionality

## Companion PRs
- #1110 — clearer approval prompt wording (in flight)
- #1111 — raise default \`llm_max_tokens_agent\` (in flight)

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._