### PR TITLE
feat(heartbeat): warmup delay before first scheduler tick

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,11 @@ HEARTBEAT_QUIET_HOURS_END=7
 # HEARTBEAT_PROVIDER=           # empty = fall back to LLM_PROVIDER
 # HEARTBEAT_CONCURRENCY=5
 # HEARTBEAT_RECENT_MESSAGES_COUNT=5
+# Seconds the scheduler sleeps before its first tick after process start.
+# Lets in-flight work from the previous container settle and queued inbound
+# messages drain through normal processing, avoiding double-execution of
+# side-effecting tools. Set to 0 to disable.
+# HEARTBEAT_STARTUP_WARMUP_SECONDS=60
 
 # -- Observability --
 # LOG_REQUEST_TIMING=false

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -1018,10 +1018,7 @@ class HeartbeatScheduler:
         warmup = settings.heartbeat_startup_warmup_seconds
         if warmup > 0:
             logger.info("Heartbeat warmup: sleeping %ds before first tick", warmup)
-            try:
-                await asyncio.sleep(warmup)
-            except asyncio.CancelledError:
-                raise
+            await asyncio.sleep(warmup)
 
         while True:
             try:

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -1004,7 +1004,25 @@ class HeartbeatScheduler:
     # -- internals --
 
     async def _run(self) -> None:
-        """Loop forever, running one tick per resolution interval."""
+        """Loop forever, running one tick per resolution interval.
+
+        Sleeps for ``heartbeat_startup_warmup_seconds`` BEFORE the first
+        tick so a fresh process (e.g. just after a deploy) has time to
+        let any in-flight work from the previous container settle and
+        for queued inbound messages to drain through normal processing.
+        Without this gate, a Phase 1 LLM that fires within seconds of
+        boot can decide to "complete" a request the previous container
+        was already partway through — risking double execution of
+        side-effecting tools (qb_send, qb_create, etc.).
+        """
+        warmup = settings.heartbeat_startup_warmup_seconds
+        if warmup > 0:
+            logger.info("Heartbeat warmup: sleeping %ds before first tick", warmup)
+            try:
+                await asyncio.sleep(warmup)
+            except asyncio.CancelledError:
+                raise
+
         while True:
             try:
                 await self.tick()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -168,6 +168,18 @@ class Settings(BaseSettings):
     heartbeat_provider: str = ""  # empty = fall back to llm_provider
     heartbeat_concurrency: int = Field(default=5, ge=1)
     heartbeat_recent_messages_count: int = Field(default=5, ge=1)
+    # Delay the first scheduler tick after process start. Without this,
+    # a deploy mid-conversation produces a tick on the new container
+    # within ~2 seconds of boot — before any in-flight work on the old
+    # container has had a chance to settle, and before any queued
+    # inbound messages have drained from the bus into normal processing.
+    # The Phase 1 LLM then sees the user's pending request in recent
+    # context and decides to act, racing the agent path that would have
+    # handled it normally. 60 seconds is short enough not to delay
+    # genuine proactive nudges in long-running deployments and long
+    # enough to absorb the post-restart settle window. Set to 0 to
+    # disable the warmup (the previous behavior).
+    heartbeat_startup_warmup_seconds: int = Field(default=60, ge=0)
 
     # Observability
     log_request_timing: bool = False  # Set True (or LOG_REQUEST_TIMING=1) to log per-request timing

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -145,6 +145,7 @@ See [Storage Providers](./storage.md) for setup instructions.
 | `HEARTBEAT_PROVIDER` | (same as `LLM_PROVIDER`) | Provider used for heartbeat messages |
 | `HEARTBEAT_CONCURRENCY` | `5` | Max concurrent user evaluations per tick |
 | `HEARTBEAT_RECENT_MESSAGES_COUNT` | `5` | Number of recent messages included in heartbeat context |
+| `HEARTBEAT_STARTUP_WARMUP_SECONDS` | `60` | Seconds the scheduler sleeps before its first tick after process start, so post-deploy in-flight work and queued inbound messages can drain. Set to `0` to disable. |
 
 ## Observability
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1634,24 +1634,44 @@ class TestHeartbeatScheduler:
     @patch("backend.app.agent.heartbeat.settings")
     async def test_run_skips_warmup_when_disabled(self, mock_settings: MagicMock) -> None:
         """heartbeat_startup_warmup_seconds=0 disables the warmup so we
-        keep an escape hatch for environments that don't need it."""
+        keep an escape hatch for environments that don't need it.
+
+        We pin the gate by recording the order of sleep and tick calls.
+        With warmup=0, the FIRST event must be a tick, not a sleep with
+        warmup arguments. A regression like ``if warmup >= 0:`` (which
+        would still sleep on the disabled path) must fail this test.
+        """
         mock_settings.heartbeat_enabled = True
         mock_settings.heartbeat_startup_warmup_seconds = 0
         mock_settings.heartbeat_max_daily_messages = 5
 
         scheduler = HeartbeatScheduler()
 
+        events: list[tuple[str, float | None]] = []
+
         async def stub_tick() -> None:
+            events.append(("tick", None))
             # Cancel the loop after the first tick so the test terminates.
             raise asyncio.CancelledError
+
+        async def fake_sleep(secs: float) -> None:
+            events.append(("sleep", secs))
 
         scheduler.tick = stub_tick  # type: ignore[method-assign]
 
         with (
-            patch("backend.app.agent.heartbeat.asyncio.sleep", new=AsyncMock()),
+            patch("backend.app.agent.heartbeat.asyncio.sleep", side_effect=fake_sleep),
             pytest.raises(asyncio.CancelledError),
         ):
             await scheduler._run()
+
+        # The first observable event must be the tick, not a warmup sleep.
+        # If the gate regressed and slept anyway, the first event would be
+        # ``("sleep", 0)`` and this assertion would fail.
+        assert events, "scheduler did not run any observable steps"
+        assert events[0] == ("tick", None), (
+            f"expected tick first when warmup=0, got events={events}"
+        )
 
     @pytest.mark.asyncio
     async def test_tick_queries_onboarded(self) -> None:

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1592,6 +1593,65 @@ class TestHeartbeatScheduler:
         scheduler = HeartbeatScheduler()
         scheduler.stop()  # Should not raise
         assert scheduler._task is None
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_run_sleeps_warmup_before_first_tick(self, mock_settings: MagicMock) -> None:
+        """The scheduler must wait heartbeat_startup_warmup_seconds before
+        the first tick. Regression: a fresh container racing the previous
+        one's in-flight work was the root of the recent double-execution
+        risk on deploys."""
+        mock_settings.heartbeat_enabled = True
+        mock_settings.heartbeat_startup_warmup_seconds = 60
+        mock_settings.heartbeat_max_daily_messages = 5
+
+        scheduler = HeartbeatScheduler()
+        # Stub tick so we can assert it is NOT called before the warmup
+        # sleeps, and use a sleep stub that records its arguments.
+        scheduler.tick = AsyncMock()  # type: ignore[method-assign]
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs: float) -> None:
+            sleep_calls.append(secs)
+            # After we observe the warmup sleep, raise CancelledError to
+            # break out of the infinite loop without racing real timers.
+            if len(sleep_calls) == 1:
+                raise asyncio.CancelledError
+
+        with (
+            patch("backend.app.agent.heartbeat.asyncio.sleep", side_effect=fake_sleep),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await scheduler._run()
+
+        # First sleep must be the warmup, not the per-tick interval. tick()
+        # must not have been called yet.
+        assert sleep_calls[0] == 60
+        scheduler.tick.assert_not_called()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_run_skips_warmup_when_disabled(self, mock_settings: MagicMock) -> None:
+        """heartbeat_startup_warmup_seconds=0 disables the warmup so we
+        keep an escape hatch for environments that don't need it."""
+        mock_settings.heartbeat_enabled = True
+        mock_settings.heartbeat_startup_warmup_seconds = 0
+        mock_settings.heartbeat_max_daily_messages = 5
+
+        scheduler = HeartbeatScheduler()
+
+        async def stub_tick() -> None:
+            # Cancel the loop after the first tick so the test terminates.
+            raise asyncio.CancelledError
+
+        scheduler.tick = stub_tick  # type: ignore[method-assign]
+
+        with (
+            patch("backend.app.agent.heartbeat.asyncio.sleep", new=AsyncMock()),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await scheduler._run()
 
     @pytest.mark.asyncio
     async def test_tick_queries_onboarded(self) -> None:


### PR DESCRIPTION
## Summary

A fresh container's first heartbeat tick used to fire ~2 seconds after boot — before any in-flight work from the previous container had settled and before queued inbound messages had drained through normal processing. The Phase 1 LLM, looking at recent conversation context, could decide to "complete" a request the previous container was already partway through. **With side-effecting tools (`qb_send`, `qb_create`, etc.) that's a real double-execution risk**: send the same estimate twice, create the same invoice twice. Production telemetry showed the bullet whizzed past once already, accidentally helped, but the next time it could hurt.

## What this PR does

Adds a warmup gate in the scheduler's `_run()`:

```python
warmup = settings.heartbeat_startup_warmup_seconds  # default 60
if warmup > 0:
    await asyncio.sleep(warmup)

while True:
    await self.tick()
    await asyncio.sleep(_TICK_RESOLUTION_MINUTES * 60)
```

60s is short enough not to delay genuine proactive nudges in long-running deployments, and long enough to absorb the post-restart settle window typical for Railway / k8s rolling deploys.

Set `HEARTBEAT_STARTUP_WARMUP_SECONDS=0` to disable (preserves the previous behavior). `CancelledError` propagates correctly inside the warmup sleep so `stop()` during warmup terminates cleanly.

## Test plan
- [x] `test_run_sleeps_warmup_before_first_tick` — verifies the first sleep is the warmup interval and `tick()` is NOT called before it completes
- [x] `test_run_skips_warmup_when_disabled` — `heartbeat_startup_warmup_seconds=0` keeps the previous (warmup-less) behavior
- [x] All 133 heartbeat tests pass

## Companion PRs
- #1110 — clearer approval prompt + accept compound replies
- #1112 — heartbeat quiet-period throttle
- #1113 — persist tool_interactions_json on heartbeat outbounds

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._