### PR TITLE
feat(llm): add per-user LLM override resolver hook

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -141,6 +141,8 @@ class ClawboltAgent:
         excluded_tool_names: set[str] | None = None,
         request_id: str = "",
         activated_specialists: set[str] | None = None,
+        llm_provider_override: str = "",
+        llm_model_override: str = "",
     ) -> None:
         self.user = user
         self._channel = channel
@@ -158,6 +160,8 @@ class ClawboltAgent:
         self._session_id = session_id
         self._excluded_tool_names = excluded_tool_names
         self._request_id = request_id
+        self._llm_provider_override = llm_provider_override
+        self._llm_model_override = llm_model_override
         # Previous round's tool-name sequence, used to detect when a newly
         # built tool list fails to preserve the prefix (which busts the
         # Anthropic tools prompt cache). The list is append-only by design;
@@ -406,10 +410,12 @@ class ClawboltAgent:
             tool_schemas = apply_tool_caching(tool_schemas)
         tool_count = len(tool_schemas) if tool_schemas else 0
         thinking = reasoning_effort_to_thinking(settings.reasoning_effort)
+        effective_model = self._llm_model_override or settings.llm_model
+        effective_provider = self._llm_provider_override or settings.llm_provider
         logger.debug(
             "Calling LLM: model=%s provider=%s messages=%d tools=%d max_tokens=%d",
-            settings.llm_model,
-            settings.llm_provider,
+            effective_model,
+            effective_provider,
             len(msg_dicts),
             tool_count,
             effective_max_tokens,
@@ -419,8 +425,8 @@ class ClawboltAgent:
                 return cast(
                     MessageResponse,
                     await amessages(
-                        model=settings.llm_model,
-                        provider=settings.llm_provider,
+                        model=effective_model,
+                        provider=effective_provider,
                         api_base=settings.llm_api_base,
                         system=system,
                         messages=msg_dicts,
@@ -461,8 +467,8 @@ class ClawboltAgent:
                 return cast(
                     MessageResponse,
                     await amessages(
-                        model=settings.llm_model,
-                        provider=settings.llm_provider,
+                        model=effective_model,
+                        provider=effective_provider,
                         api_base=settings.llm_api_base,
                         system=system,
                         messages=trimmed_dicts,
@@ -945,7 +951,12 @@ class ClawboltAgent:
                 messages, tool_schemas, llm_kwargs, max_tokens=max_tokens
             )
             purpose = "agent_main" if _round == 0 else "agent_followup"
-            log_llm_usage(self.user.id, settings.llm_model, response, purpose)
+            log_llm_usage(
+                self.user.id,
+                self._llm_model_override or settings.llm_model,
+                response,
+                purpose,
+            )
             if response.usage and response.usage.input_tokens:
                 self._last_input_tokens = response.usage.input_tokens
                 _total_input_tokens += response.usage.input_tokens

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -49,6 +49,7 @@ from backend.app.enums import MessageDirection
 from backend.app.media.download import DownloadedMedia
 from backend.app.media.pipeline import process_message_media
 from backend.app.models import ChannelRoute, User
+from backend.app.services.llm_service import resolve_user_llm_override
 from backend.app.services.storage_service import StorageBackend, get_storage_service
 
 logger = logging.getLogger(__name__)
@@ -236,6 +237,8 @@ async def run_agent(
     event_subscribers: list[Callable[[AgentEvent], Awaitable[None]]] | None = None,
     session_id: str = "",
     request_id: str = "",
+    llm_provider_override: str = "",
+    llm_model_override: str = "",
 ) -> AgentResponse:
     """Initialize agent with tools and process the message.
 
@@ -284,6 +287,8 @@ async def run_agent(
         excluded_tool_names=disabled_sub_tools or None,
         request_id=request_id,
         activated_specialists=activated_specialists,
+        llm_provider_override=llm_provider_override,
+        llm_model_override=llm_model_override,
     )
 
     # Core tools (always-on). Exclude user-disabled groups and sub-tools.
@@ -479,6 +484,19 @@ async def load_history_step(ctx: PipelineContext) -> PipelineContext:
 
 async def run_agent_step(ctx: PipelineContext) -> PipelineContext:
     """Initialize agent with tools and process the message."""
+    # Premium can register a per-user LLM resolver (see
+    # ``set_user_llm_resolver``) so individual users can be pinned to a
+    # different model than the global default. Resolver failures fall
+    # through to the global setting rather than wedging the message path.
+    provider_override, model_override = "", ""
+    try:
+        override = await resolve_user_llm_override(ctx.user.id)
+    except Exception:
+        logger.exception("user LLM resolver failed for user %s", ctx.user.id)
+        override = None
+    if override is not None:
+        provider_override, model_override = override
+
     ctx.response = await run_agent(
         user=ctx.user,
         message=ctx.message,
@@ -493,6 +511,8 @@ async def run_agent_step(ctx: PipelineContext) -> PipelineContext:
         event_subscribers=ctx.event_subscribers,
         session_id=ctx.session.session_id,
         request_id=ctx.request_id,
+        llm_provider_override=provider_override,
+        llm_model_override=model_override,
     )
     return ctx
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from any_llm import LLMProvider, alist_models
@@ -62,6 +63,44 @@ async def get_models(
     """Fetch available models for a provider."""
     raw = await alist_models(provider=provider, api_key=api_key, api_base=api_base)
     return [m.id if hasattr(m, "id") else str(m) for m in raw]
+
+
+# ---------------------------------------------------------------------------
+# Per-user LLM override resolver
+# ---------------------------------------------------------------------------
+
+# Premium (or another plugin) registers a resolver that returns a per-user
+# (provider, model) override, or ``None`` when the user has no override
+# configured. Either field of the returned tuple may be empty, in which case
+# the agent falls back to the global ``settings.llm_provider`` /
+# ``settings.llm_model`` value for that field.
+UserLLMResolver = Callable[[str], Awaitable[tuple[str, str] | None]]
+
+_user_llm_resolver: UserLLMResolver | None = None
+
+
+def set_user_llm_resolver(fn: UserLLMResolver | None) -> None:
+    """Register an async resolver that returns a per-user (provider, model) override.
+
+    Premium calls this at startup with a function that queries its
+    subscription DB. OSS leaves it unset, in which case all users use the
+    global ``settings.llm_*`` values.
+    """
+    global _user_llm_resolver
+    _user_llm_resolver = fn
+
+
+async def resolve_user_llm_override(user_id: str) -> tuple[str, str] | None:
+    """Look up a per-user LLM override via the registered resolver, if any.
+
+    Returns ``None`` when no resolver is registered or the resolver
+    returns ``None`` for this user. Resolver exceptions are not caught
+    here; callers can choose to log-and-fall-through if they want
+    defensive behavior.
+    """
+    if _user_llm_resolver is None:
+        return None
+    return await _user_llm_resolver(user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2450,3 +2450,62 @@ async def test_agent_response_rolls_up_cache_tokens_across_rounds(
     assert response.total_output_tokens == 70
     assert response.total_cache_creation_input_tokens == 800
     assert response.total_cache_read_input_tokens == 800
+
+
+# ---------------------------------------------------------------------------
+# Per-user LLM override (issue: admin LLM control)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_uses_provider_and_model_override(
+    mock_amessages: object, test_user: User
+) -> None:
+    """Both override fields, when set, take precedence over the global settings.llm_*."""
+    mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
+
+    agent = ClawboltAgent(
+        user=test_user,
+        llm_provider_override="anthropic",
+        llm_model_override="claude-haiku-4-5",
+    )
+    await agent.process_message("hi")
+
+    call_args = mock_amessages.call_args  # type: ignore[union-attr]
+    assert call_args.kwargs["provider"] == "anthropic"
+    assert call_args.kwargs["model"] == "claude-haiku-4-5"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_override_falls_back_to_settings_when_field_empty(
+    mock_amessages: object, test_user: User
+) -> None:
+    """Empty override fields fall through to settings.llm_*.
+
+    This is the "use the global provider but pin a specific model"
+    case: provider_override="" + model_override="<id>" keeps the
+    deployment provider but switches the model for one user.
+    """
+    from backend.app.config import settings
+
+    mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
+
+    original_provider = settings.llm_provider
+    original_model = settings.llm_model
+    settings.llm_provider = "anthropic"
+    settings.llm_model = "claude-opus-4-5"
+    try:
+        agent = ClawboltAgent(
+            user=test_user,
+            llm_provider_override="",
+            llm_model_override="claude-haiku-4-5",
+        )
+        await agent.process_message("hi")
+        call_args = mock_amessages.call_args  # type: ignore[union-attr]
+        assert call_args.kwargs["provider"] == "anthropic"  # global default
+        assert call_args.kwargs["model"] == "claude-haiku-4-5"  # override wins
+    finally:
+        settings.llm_provider = original_provider
+        settings.llm_model = original_model

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import patch
 
-from backend.app.services.llm_service import apply_tool_caching, prepare_system_with_caching
+import pytest
+
+from backend.app.services.llm_service import (
+    apply_tool_caching,
+    prepare_system_with_caching,
+    resolve_user_llm_override,
+    set_user_llm_resolver,
+)
 
 
 def test_prepare_system_with_caching_returns_content_block() -> None:
@@ -124,3 +132,48 @@ def test_prepare_system_with_cache_boundary_marks_only_stable_prefix() -> None:
     assert result[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
     assert result[1]["text"] == "dynamic suffix"
     assert "cache_control" not in result[1]
+
+
+# ---------------------------------------------------------------------------
+# Per-user LLM override resolver hook (premium plug-point)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_user_llm_resolver() -> Generator[None]:
+    """Each test starts with no resolver installed and resets afterwards.
+
+    OSS code under test must not leak resolver state across tests.
+    """
+    set_user_llm_resolver(None)
+    yield
+    set_user_llm_resolver(None)
+
+
+async def test_resolve_user_llm_override_returns_none_when_no_resolver() -> None:
+    """With no resolver installed, every user falls through to global settings."""
+    assert await resolve_user_llm_override("user-123") is None
+
+
+async def test_resolve_user_llm_override_calls_registered_resolver() -> None:
+    """Installed resolver is invoked with the user_id and its result is returned."""
+    received: list[str] = []
+
+    async def fake_resolver(user_id: str) -> tuple[str, str] | None:
+        received.append(user_id)
+        return ("anthropic", "claude-haiku-4-5")
+
+    set_user_llm_resolver(fake_resolver)
+    result = await resolve_user_llm_override("user-abc")
+    assert result == ("anthropic", "claude-haiku-4-5")
+    assert received == ["user-abc"]
+
+
+async def test_resolve_user_llm_override_passes_through_none() -> None:
+    """Resolver may return None to indicate "no override for this user"."""
+
+    async def fake_resolver(_: str) -> tuple[str, str] | None:
+        return None
+
+    set_user_llm_resolver(fake_resolver)
+    assert await resolve_user_llm_override("user-xyz") is None


### PR DESCRIPTION
## Description

OSS today resolves the agent's model from the global ``settings.llm_*`` singleton on every LLM call. Multi-tenant deployments need a way to pin individual users to a different model than the deployment default; the premium layer wants to expose that as an admin control.

This change adds a small extension point that lets a plugin (premium) provide per-user overrides without OSS taking on a multi-tenant data model.

## What this PR does

- ``set_user_llm_resolver(fn)`` in ``backend/app/services/llm_service`` registers an async callback. ``run_agent_step`` awaits it once per inbound message and threads the result through ``ClawboltAgent.__init__``. Resolver failures fall through to the global setting rather than wedging the message path.
- ``ClawboltAgent`` accepts ``llm_provider_override`` and ``llm_model_override``. When a field is set, it wins over ``settings.llm_*``; when empty, the global default is used. So a caller can keep the deployment provider but pin a specific model for one user by setting only the model override.
- ``log_llm_usage`` records the effective model, not the global one, so per-user usage analytics reflect what was actually called.

OSS users see no behavioral change: with no resolver registered, every user resolves to ``settings.llm_*`` exactly as before. The premium plug-in (separate PR in clawbolt-premium) registers the resolver against its ``Subscription`` table.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest tests/test_llm_service.py tests/test_agent.py\`: 92 passed)
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] Type check passes (\`uv run ty check --python .venv backend/ tests/\`)
- [x] New tests added for new functionality

## AI Usage
- [x] AI-assisted: design and implementation drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's.

## Companion PR

The premium-side counterpart (admin endpoints, per-user override DB column, admin UI) lives in clawbolt-premium and is opened against that repo separately. Premium will pick up these OSS changes via OSS_REF once this lands.