### PR TITLE
fix(heartbeat): treat header-only HEARTBEAT.md as empty; drop dead quiet-hours code

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -179,30 +179,6 @@ class HeartbeatAction:
     priority: int
 
 
-# ---------------------------------------------------------------------------
-# Business-hours gate
-# ---------------------------------------------------------------------------
-
-
-def is_within_business_hours(
-    user: User,
-    now: datetime.datetime | None = None,
-) -> bool:
-    """Return *True* if *now* falls outside the quiet-hours window."""
-    now = now or datetime.datetime.now(datetime.UTC)
-    local_now = to_local_time(now, user.timezone)
-    current_hour = local_now.hour
-
-    qstart = settings.heartbeat_quiet_hours_start
-    qend = settings.heartbeat_quiet_hours_end
-    if qstart > qend:
-        # Quiet hours span midnight (e.g. 20-7)
-        in_quiet = current_hour >= qstart or current_hour < qend
-    else:
-        in_quiet = qstart <= current_hour < qend
-    return not in_quiet
-
-
 async def _publish_heartbeat_typing(channel: str, chat_id: str, *, stop: bool) -> None:
     """Publish a typing indicator (or stop) via the bus, swallowing errors.
 
@@ -748,6 +724,32 @@ def _dispatch_heartbeat_usage(
             logger.exception("heartbeat usage hook failed for user %s", user_id)
 
 
+def _has_actionable_heartbeat_content(text: str) -> bool:
+    """Return True if HEARTBEAT.md has any non-header, non-blank line.
+
+    The Phase 1 LLM gate uses this to short-circuit the LLM call when
+    the file is effectively empty. A pure header document (just
+    "# Reminders\n" with nothing under it) is treated as empty: there
+    is nothing for the evaluator to act on, so calling the LLM only
+    burns tokens to return skip.
+
+    A "header line" here is any line whose first non-whitespace
+    character is "#". Blank lines and whitespace-only lines also do
+    not count as actionable. Anything else (a list item starting with
+    "-", "*", "1.", or a free-text paragraph) does count.
+    """
+    if not text:
+        return False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        return True
+    return False
+
+
 def _user_messaged_within(user_id: str, minutes: int) -> bool:
     """Return True if the user sent an inbound message in the last *minutes*.
 
@@ -838,9 +840,19 @@ async def run_heartbeat_for_user(
     # HEARTBEAT.md, there is nothing for the evaluator to act on. Skip the
     # LLM call entirely to save tokens and avoid the LLM hallucinating tasks
     # from conversation history or past heartbeat activity.
+    #
+    # The check looks for any non-heading, non-blank line. The earlier
+    # ``.strip()`` test let header-only documents like "# Reminders\n"
+    # pass — Phase 2 would rewrite the file to that header after handling
+    # one-time items (#1116), and the next 30m tick would call the LLM
+    # to evaluate an empty list and return skip. Production telemetry
+    # showed one user burning ~48 LLM calls/day on a header-only file.
+    # Treating header-only as empty fixes that without changing
+    # ``read_heartbeat_md``, which is also called by compaction and the
+    # heartbeat tools where the raw text is the right return.
     heartbeat_store = HeartbeatStore(user.id)
     heartbeat_text = heartbeat_store.read_heartbeat_md()
-    if not heartbeat_text or not heartbeat_text.strip():
+    if not _has_actionable_heartbeat_content(heartbeat_text):
         logger.debug("Heartbeat skip user %s: no heartbeat items configured", user.id)
         return None
 

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -733,10 +733,13 @@ def _has_actionable_heartbeat_content(text: str) -> bool:
     is nothing for the evaluator to act on, so calling the LLM only
     burns tokens to return skip.
 
-    A "header line" here is any line whose first non-whitespace
-    character is "#". Blank lines and whitespace-only lines also do
-    not count as actionable. Anything else (a list item starting with
-    "-", "*", "1.", or a free-text paragraph) does count.
+    "Header line" follows markdown's ATX-heading rule: one or more
+    "#" followed by either end-of-line OR a whitespace character.
+    Hashtag-style lines like "#urgent task" don't count as headers
+    and remain actionable, while "# Reminders" or "##" do.
+    Blank and whitespace-only lines are also not actionable.
+    Anything else (list items "- task", "* task", "1. task", or a
+    free-text paragraph) is actionable.
     """
     if not text:
         return False
@@ -744,10 +747,29 @@ def _has_actionable_heartbeat_content(text: str) -> bool:
         stripped = line.strip()
         if not stripped:
             continue
-        if stripped.startswith("#"):
+        if _is_atx_heading(stripped):
             continue
         return True
     return False
+
+
+def _is_atx_heading(stripped_line: str) -> bool:
+    """Return True if *stripped_line* is a markdown ATX heading.
+
+    A heading is one or more "#" characters followed by either end of
+    line or whitespace. This rejects "#hashtag" / "#urgent" patterns
+    that the spec also rejects, while still accepting "#", "##",
+    "# Title", "### Title".
+    """
+    if not stripped_line.startswith("#"):
+        return False
+    # Strip the run of leading "#"s.
+    i = 0
+    while i < len(stripped_line) and stripped_line[i] == "#":
+        i += 1
+    # Either we consumed the entire line ("#" or "##"), or the next
+    # char is whitespace ("# Title"). Anything else is non-heading.
+    return i == len(stripped_line) or stripped_line[i] in (" ", "\t")
 
 
 def _user_messaged_within(user_id: str, minutes: int) -> bool:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -162,8 +162,6 @@ class Settings(BaseSettings):
     heartbeat_default_frequency: str = "30m"
     heartbeat_interval_minutes: int = Field(default=30, ge=1)
     heartbeat_max_daily_messages: int = Field(default=5, ge=1)
-    heartbeat_quiet_hours_start: int = Field(default=20, ge=0, le=23)  # 8 PM
-    heartbeat_quiet_hours_end: int = Field(default=7, ge=0, le=23)  # 7 AM
     heartbeat_model: str = ""  # empty = fall back to llm_model
     heartbeat_provider: str = ""  # empty = fall back to llm_provider
     heartbeat_concurrency: int = Field(default=5, ge=1)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -64,19 +64,6 @@ class TestFieldConstraints:
         with pytest.raises(ValidationError):
             Settings(http_timeout_seconds=0)
 
-    def test_heartbeat_quiet_hours_start_rejects_24(self) -> None:
-        with pytest.raises(ValidationError):
-            Settings(heartbeat_quiet_hours_start=24)
-
-    def test_heartbeat_quiet_hours_end_rejects_negative(self) -> None:
-        with pytest.raises(ValidationError):
-            Settings(heartbeat_quiet_hours_end=-1)
-
-    def test_heartbeat_quiet_hours_accepts_bounds(self) -> None:
-        s = Settings(heartbeat_quiet_hours_start=0, heartbeat_quiet_hours_end=23)
-        assert s.heartbeat_quiet_hours_start == 0
-        assert s.heartbeat_quiet_hours_end == 23
-
     def test_defaults_are_valid(self) -> None:
         """The default Settings() should construct without errors."""
         s = Settings()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -32,7 +32,6 @@ from backend.app.agent.heartbeat import (
     evaluate_heartbeat_need,
     execute_heartbeat_tasks,
     get_daily_heartbeat_count,
-    is_within_business_hours,
     parse_frequency_to_minutes,
     register_heartbeat_usage_hook,
     run_heartbeat_for_user,
@@ -123,38 +122,54 @@ def _make_decision_tool_call(
     return make_tool_call_response([{"name": tool_name, "arguments": args, "id": "call_mock_002"}])
 
 
-# ---------------------------------------------------------------------------
-# is_within_business_hours
-# ---------------------------------------------------------------------------
+class TestHasActionableHeartbeatContent:
+    """Gate that decides whether HEARTBEAT.md is worth evaluating.
 
+    Lifted out of the inline `.strip()` check so a header-only file
+    short-circuits the Phase 1 LLM call. Production telemetry caught
+    one user burning ~48 LLM calls/day on a "# Reminders\\n" file
+    after Phase 2 cleaned up the only one-time item.
+    """
 
-class TestIsWithinBusinessHours:
-    @patch("backend.app.agent.heartbeat.settings")
-    def test_outside_quiet_hours(self, mock_settings: MagicMock, user: User) -> None:
-        mock_settings.heartbeat_quiet_hours_start = 20
-        mock_settings.heartbeat_quiet_hours_end = 7
+    def test_empty_string_is_not_actionable(self) -> None:
+        from backend.app.agent.heartbeat import _has_actionable_heartbeat_content
 
-        # 10 AM -- outside quiet hours, should be True
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(user, now) is True
+        assert _has_actionable_heartbeat_content("") is False
 
-    @patch("backend.app.agent.heartbeat.settings")
-    def test_inside_quiet_hours_evening(self, mock_settings: MagicMock, user: User) -> None:
-        mock_settings.heartbeat_quiet_hours_start = 20
-        mock_settings.heartbeat_quiet_hours_end = 7
+    def test_whitespace_only_is_not_actionable(self) -> None:
+        from backend.app.agent.heartbeat import _has_actionable_heartbeat_content
 
-        # 22:00 -- inside quiet hours, should be False
-        now = datetime.datetime(2025, 6, 15, 22, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(user, now) is False
+        assert _has_actionable_heartbeat_content("   \n\n  \t\n") is False
 
-    @patch("backend.app.agent.heartbeat.settings")
-    def test_inside_quiet_hours_early_morning(self, mock_settings: MagicMock, user: User) -> None:
-        mock_settings.heartbeat_quiet_hours_start = 20
-        mock_settings.heartbeat_quiet_hours_end = 7
+    def test_header_only_is_not_actionable(self) -> None:
+        from backend.app.agent.heartbeat import _has_actionable_heartbeat_content
 
-        # 3 AM -- inside quiet hours, should be False
-        now = datetime.datetime(2025, 6, 15, 3, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(user, now) is False
+        # The exact pattern that motivated this gate: Phase 2 wrote
+        # back the file with only the header after pruning the last
+        # one-time item.
+        assert _has_actionable_heartbeat_content("# Reminders\n") is False
+        assert _has_actionable_heartbeat_content("# Reminders\n\n## Today\n\n") is False
+
+    def test_list_item_is_actionable(self) -> None:
+        from backend.app.agent.heartbeat import _has_actionable_heartbeat_content
+
+        assert (
+            _has_actionable_heartbeat_content("# Reminders\n\n- At 3pm: check the queue\n") is True
+        )
+
+    def test_free_text_paragraph_is_actionable(self) -> None:
+        from backend.app.agent.heartbeat import _has_actionable_heartbeat_content
+
+        assert (
+            _has_actionable_heartbeat_content("# Reminders\n\nFollow up on the estimate.\n") is True
+        )
+
+    def test_indented_header_is_still_a_header(self) -> None:
+        from backend.app.agent.heartbeat import _has_actionable_heartbeat_content
+
+        # Markdown allows leading whitespace before "#" and still
+        # treats it as a header. The gate matches that.
+        assert _has_actionable_heartbeat_content("   # Reminders\n") is False
 
 
 class TestToLocalTime:
@@ -181,57 +196,6 @@ class TestToLocalTime:
         utc_time = datetime.datetime(2025, 6, 15, 17, 0, tzinfo=datetime.UTC)
         result = to_local_time(utc_time, "Not/A_Real_Zone")
         assert result.hour == 17
-
-
-class TestIsWithinBusinessHoursTimezone:
-    """Tests for timezone-correct quiet hour checks."""
-
-    @patch("backend.app.agent.heartbeat.settings")
-    def test_timezone_converts_before_quiet_check(
-        self, mock_settings: MagicMock, user_with_timezone: User
-    ) -> None:
-        mock_settings.heartbeat_quiet_hours_start = 20
-        mock_settings.heartbeat_quiet_hours_end = 7
-
-        # 2 PM UTC -> 7 AM Pacific (PDT). Outside quiet hours.
-        now = datetime.datetime(2025, 6, 15, 14, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(user_with_timezone, now) is True
-
-    @patch("backend.app.agent.heartbeat.settings")
-    def test_utc_morning_is_night_in_pacific(
-        self, mock_settings: MagicMock, user_with_timezone: User
-    ) -> None:
-        mock_settings.heartbeat_quiet_hours_start = 20
-        mock_settings.heartbeat_quiet_hours_end = 7
-
-        # 5 AM UTC -> 10 PM Pacific (PDT, previous day). Inside quiet hours.
-        now = datetime.datetime(2025, 6, 15, 5, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(user_with_timezone, now) is False
-
-    @patch("backend.app.agent.heartbeat.settings")
-    def test_no_timezone_uses_utc(self, mock_settings: MagicMock, user: User) -> None:
-        mock_settings.heartbeat_quiet_hours_start = 20
-        mock_settings.heartbeat_quiet_hours_end = 7
-
-        # User without timezone uses UTC directly.
-        # 10 AM UTC, outside quiet hours.
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(user, now) is True
-
-    @patch("backend.app.agent.heartbeat.settings")
-    def test_invalid_timezone_falls_back_to_utc(self, mock_settings: MagicMock) -> None:
-        mock_settings.heartbeat_quiet_hours_start = 20
-        mock_settings.heartbeat_quiet_hours_end = 7
-
-        c = User(
-            id="99",
-            user_id="hb-user-bad-tz",
-            timezone="Invalid/Timezone",
-            onboarding_complete=True,
-        )
-        # 10 AM UTC -> falls back to UTC -> outside quiet hours
-        now = datetime.datetime(2025, 6, 15, 10, 0, tzinfo=datetime.UTC)
-        assert is_within_business_hours(c, now) is True
 
 
 # ---------------------------------------------------------------------------
@@ -916,6 +880,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="Nothing actionable"
         )
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_hb_store_cls.return_value = mock_hb_store
 
@@ -939,6 +904,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="Nothing actionable right now"
         )
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -996,6 +962,7 @@ class TestRunHeartbeatForUser:
         mock_get_session_store.return_value = mock_session_store
 
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1090,6 +1057,7 @@ class TestRunHeartbeatForUser:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1164,6 +1132,7 @@ class TestRunHeartbeatForUser:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1357,6 +1326,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="nothing to do"
         )
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1391,6 +1361,7 @@ class TestRunHeartbeatForUser:
             action="run", tasks="", reasoning="empty tasks for some reason"
         )
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1533,6 +1504,7 @@ class TestHeartbeatUsageHooks:
             output_tokens=30,
         )
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1591,6 +1563,7 @@ class TestHeartbeatUsageHooks:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1623,6 +1596,7 @@ class TestHeartbeatUsageHooks:
             output_tokens=5,
         )
         mock_hb_store = MagicMock()
+        mock_hb_store.read_heartbeat_md.return_value = "- task"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -3888,6 +3862,7 @@ async def test_heartbeat_skips_manual_delivery_when_agent_sent_reply(user: User)
         mock_get_ss.return_value = mock_ss
 
         mock_hb = MagicMock()
+        mock_hb.read_heartbeat_md.return_value = "- task"
         mock_hb.log_heartbeat = AsyncMock()
         mock_hb_cls.return_value = mock_hb
 
@@ -3948,6 +3923,7 @@ async def test_heartbeat_logs_when_sent_reply_but_empty_reply_text(user: User) -
         mock_get_ss.return_value = mock_ss
 
         mock_hb = MagicMock()
+        mock_hb.read_heartbeat_md.return_value = "- task"
         mock_hb.log_heartbeat = AsyncMock()
         mock_hb_cls.return_value = mock_hb
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -171,6 +171,24 @@ class TestHasActionableHeartbeatContent:
         # treats it as a header. The gate matches that.
         assert _has_actionable_heartbeat_content("   # Reminders\n") is False
 
+    def test_hashtag_line_is_actionable(self) -> None:
+        from backend.app.agent.heartbeat import _has_actionable_heartbeat_content
+
+        # Markdown's ATX-heading rule requires "#" followed by space or
+        # end-of-line; "#urgent" is a hashtag, not a heading. The gate
+        # treats hashtag-style lines as actionable so a future style
+        # drift doesn't silently lose work.
+        assert _has_actionable_heartbeat_content("#urgent: ping the customer\n") is True
+
+    def test_bare_hash_is_a_heading(self) -> None:
+        from backend.app.agent.heartbeat import _has_actionable_heartbeat_content
+
+        # A single "#" or "##" with no body is a degenerate heading.
+        # Matches the markdown rule (one or more "#" + EOL counts as a
+        # heading) and matches the empty-content intent of the gate.
+        assert _has_actionable_heartbeat_content("#\n") is False
+        assert _has_actionable_heartbeat_content("##\n") is False
+
 
 class TestToLocalTime:
     """Tests for the to_local_time helper."""
@@ -880,7 +898,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="Nothing actionable"
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_hb_store_cls.return_value = mock_hb_store
 
@@ -904,7 +922,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="Nothing actionable right now"
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -962,7 +980,7 @@ class TestRunHeartbeatForUser:
         mock_get_session_store.return_value = mock_session_store
 
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1057,7 +1075,7 @@ class TestRunHeartbeatForUser:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1132,7 +1150,7 @@ class TestRunHeartbeatForUser:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1326,7 +1344,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="nothing to do"
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1361,7 +1379,7 @@ class TestRunHeartbeatForUser:
             action="run", tasks="", reasoning="empty tasks for some reason"
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1504,7 +1522,7 @@ class TestHeartbeatUsageHooks:
             output_tokens=30,
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1563,7 +1581,7 @@ class TestHeartbeatUsageHooks:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1596,7 +1614,7 @@ class TestHeartbeatUsageHooks:
             output_tokens=5,
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- task"
+        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -3862,7 +3880,7 @@ async def test_heartbeat_skips_manual_delivery_when_agent_sent_reply(user: User)
         mock_get_ss.return_value = mock_ss
 
         mock_hb = MagicMock()
-        mock_hb.read_heartbeat_md.return_value = "- task"
+        mock_hb.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb.log_heartbeat = AsyncMock()
         mock_hb_cls.return_value = mock_hb
 
@@ -3923,7 +3941,7 @@ async def test_heartbeat_logs_when_sent_reply_but_empty_reply_text(user: User) -
         mock_get_ss.return_value = mock_ss
 
         mock_hb = MagicMock()
-        mock_hb.read_heartbeat_md.return_value = "- task"
+        mock_hb.read_heartbeat_md.return_value = "- At 3pm: check the queue"
         mock_hb.log_heartbeat = AsyncMock()
         mock_hb_cls.return_value = mock_hb
 


### PR DESCRIPTION
## Description

Phase 1 had two related issues that combined to burn ~48 LLM calls/day on at least one production user.

### 1. Header-only HEARTBEAT.md slips through the empty-content gate

The gate at \`run_heartbeat_for_user\` used \`.strip()\` to test whether the file had content:

\`\`\`python
if not heartbeat_text or not heartbeat_text.strip():
    return None
\`\`\`

After Phase 2 cleaned up the user's last one-time item (#1116), it left the file as just \`"# Reminders\n"\`, which \`.strip()\` returns as \`"# Reminders"\` — truthy. The next 30m tick called the LLM to evaluate an empty list, the LLM returned skip, the cycle repeated. Production telemetry caught one user generating 48 such skip calls/day.

**Fix:** add \`_has_actionable_heartbeat_content\` that walks each line and returns True only when there is at least one non-blank, non-header line (a list item or paragraph). Header-only documents now short-circuit without an LLM call. \`read_heartbeat_md\` itself is unchanged (compaction and the heartbeat tools want the raw text).

### 2. \`is_within_business_hours\` is dead code

Defined at \`heartbeat.py:187\`, plus \`heartbeat_quiet_hours_start=20\` and \`_end=7\` in config. \`grep -rn is_within_business_hours\` returns only the definition site. No caller. Production telemetry confirms heartbeats fire every 30m regardless of local time.

**Fix:** delete the function, the two config fields, and the tests. If we want a real time-of-day gate later, it goes in \`run_heartbeat_for_user\` alongside the other gates with a deliberate decision about how it interacts with \`quiet_period_minutes\` and \`max_daily\`.

## Tests

* New \`TestHasActionableHeartbeatContent\` (6 cases: empty, whitespace, header-only, list item, paragraph, indented header).
* Deleted \`TestIsWithinBusinessHours\`, \`TestIsWithinBusinessHoursTimezone\`, and the corresponding config-validation cases.
* Existing \`TestRunHeartbeatForUser\` tests mocked \`HeartbeatStore\` with bare \`MagicMock()\` and relied on duck-typed truthiness through the old gate. They now set \`read_heartbeat_md.return_value = "- task"\` explicitly.
* Full suite: 2100 passed.

## Type
- [x] Feature
- [x] Bug fix
- [x] Refactor
- [x] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (2100)
- [x] Lint passes
- [x] Format passes
- [x] Type checking passes
- [x] New tests added (the new gate helper)
- [x] Bug fixes include regression tests (the header-only case)

## AI Usage
- [x] AI-assisted (Claude diagnosed the issue from production telemetry on @njbrake's request and drafted the fix; reasoning and decisions are his)
- [ ] No AI used