### PR TITLE
fix(companycam): accept JSON-string tags on upload_photo and tag_photo

### DIFF
--- a/backend/app/integrations/companycam/params.py
+++ b/backend/app/integrations/companycam/params.py
@@ -7,7 +7,34 @@ focused on registration and factory wiring. Imported by
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+def _coerce_tags_to_list(value: Any) -> Any:
+    """Parse JSON-encoded strings into lists so the LLM can pass either shape.
+
+    Mirrors the ``_coerce_data_to_dict`` helper in the QuickBooks factory:
+    Sonnet occasionally over-quotes the ``tags`` argument and emits it as
+    ``"[]"`` or ``"[\\"kitchen\\"]"`` instead of a real JSON array. Accept
+    both forms on the first round to avoid a wasted retry.
+    """
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "tags must be a JSON array or a JSON-encoded array string; "
+                f"could not parse string as JSON: {exc.msg}"
+            ) from exc
+        if not isinstance(parsed, list):
+            raise ValueError(
+                f"tags must be a JSON array; got a JSON-encoded {type(parsed).__name__}"
+            )
+        return parsed
+    return value
 
 
 class CompanyCamSearchParams(BaseModel):
@@ -36,6 +63,8 @@ class CompanyCamUploadPhotoParams(BaseModel):
     )
     description: str = Field(default="", description="Photo description")
     tags: list[str] = Field(default_factory=list, description="Tags to apply to the photo")
+
+    _coerce_tags = field_validator("tags", mode="before")(_coerce_tags_to_list)
 
 
 class CompanyCamGetProjectParams(BaseModel):
@@ -75,6 +104,8 @@ class CompanyCamListCommentsParams(BaseModel):
 class CompanyCamTagPhotoParams(BaseModel):
     photo_id: str = Field(description="CompanyCam photo ID to tag")
     tags: list[str] = Field(description="Tags to add to the photo")
+
+    _coerce_tags = field_validator("tags", mode="before")(_coerce_tags_to_list)
 
 
 class CompanyCamDeletePhotoParams(BaseModel):

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -214,6 +214,74 @@ def test_companycam_tools_registered() -> None:
     assert "companycam" in default_registry.factory_names
 
 
+# ---------------------------------------------------------------------------
+# Tags JSON-string coercion (regression for #1066-style serialization quirks)
+# ---------------------------------------------------------------------------
+
+
+class TestTagsJsonStringCoercion:
+    """The LLM occasionally emits ``tags`` as a JSON-encoded string instead
+    of a real array (e.g. ``tags="[]"`` or ``tags='["kitchen"]'``). The
+    field validator parses these so the call lands successfully on the
+    first try instead of burning a tool error and waiting for retry.
+    """
+
+    def test_upload_photo_accepts_real_list(self) -> None:
+        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
+
+        p = CompanyCamUploadPhotoParams(project_id="p1", tags=["kitchen", "demo"])
+        assert p.tags == ["kitchen", "demo"]
+
+    def test_upload_photo_accepts_json_string_array(self) -> None:
+        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
+
+        p = CompanyCamUploadPhotoParams(
+            project_id="p1",
+            tags='["kitchen", "demo"]',  # type: ignore[arg-type]
+        )
+        assert p.tags == ["kitchen", "demo"]
+
+    def test_upload_photo_accepts_empty_json_string_array(self) -> None:
+        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
+
+        p = CompanyCamUploadPhotoParams(
+            project_id="p1",
+            tags="[]",  # type: ignore[arg-type]
+        )
+        assert p.tags == []
+
+    def test_upload_photo_rejects_unparseable_string(self) -> None:
+        from pydantic import ValidationError
+
+        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
+
+        with pytest.raises(ValidationError, match="could not parse string as JSON"):
+            CompanyCamUploadPhotoParams(
+                project_id="p1",
+                tags="not-json",  # type: ignore[arg-type]
+            )
+
+    def test_upload_photo_rejects_json_string_that_decodes_to_non_list(self) -> None:
+        from pydantic import ValidationError
+
+        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
+
+        with pytest.raises(ValidationError, match="must be a JSON array"):
+            CompanyCamUploadPhotoParams(
+                project_id="p1",
+                tags='{"a": 1}',  # type: ignore[arg-type]
+            )
+
+    def test_tag_photo_accepts_json_string_array(self) -> None:
+        from backend.app.integrations.companycam.params import CompanyCamTagPhotoParams
+
+        p = CompanyCamTagPhotoParams(
+            photo_id="42",
+            tags='["before", "kitchen"]',  # type: ignore[arg-type]
+        )
+        assert p.tags == ["before", "kitchen"]
+
+
 def test_companycam_auth_check_not_connected() -> None:
     """Auth check should return a reason when OAuth is not connected."""
     from backend.app.config import settings

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
+from backend.app.integrations.companycam.params import (
+    CompanyCamTagPhotoParams,
+    CompanyCamUploadPhotoParams,
+)
 from backend.app.integrations.companycam.service import CompanyCamService, get_photo_url
 
 # ---------------------------------------------------------------------------
@@ -227,14 +232,10 @@ class TestTagsJsonStringCoercion:
     """
 
     def test_upload_photo_accepts_real_list(self) -> None:
-        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
-
         p = CompanyCamUploadPhotoParams(project_id="p1", tags=["kitchen", "demo"])
         assert p.tags == ["kitchen", "demo"]
 
     def test_upload_photo_accepts_json_string_array(self) -> None:
-        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
-
         p = CompanyCamUploadPhotoParams(
             project_id="p1",
             tags='["kitchen", "demo"]',  # type: ignore[arg-type]
@@ -242,8 +243,6 @@ class TestTagsJsonStringCoercion:
         assert p.tags == ["kitchen", "demo"]
 
     def test_upload_photo_accepts_empty_json_string_array(self) -> None:
-        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
-
         p = CompanyCamUploadPhotoParams(
             project_id="p1",
             tags="[]",  # type: ignore[arg-type]
@@ -251,10 +250,6 @@ class TestTagsJsonStringCoercion:
         assert p.tags == []
 
     def test_upload_photo_rejects_unparseable_string(self) -> None:
-        from pydantic import ValidationError
-
-        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
-
         with pytest.raises(ValidationError, match="could not parse string as JSON"):
             CompanyCamUploadPhotoParams(
                 project_id="p1",
@@ -262,10 +257,6 @@ class TestTagsJsonStringCoercion:
             )
 
     def test_upload_photo_rejects_json_string_that_decodes_to_non_list(self) -> None:
-        from pydantic import ValidationError
-
-        from backend.app.integrations.companycam.params import CompanyCamUploadPhotoParams
-
         with pytest.raises(ValidationError, match="must be a JSON array"):
             CompanyCamUploadPhotoParams(
                 project_id="p1",
@@ -273,8 +264,6 @@ class TestTagsJsonStringCoercion:
             )
 
     def test_tag_photo_accepts_json_string_array(self) -> None:
-        from backend.app.integrations.companycam.params import CompanyCamTagPhotoParams
-
         p = CompanyCamTagPhotoParams(
             photo_id="42",
             tags='["before", "kitchen"]',  # type: ignore[arg-type]


### PR DESCRIPTION
## Description

The LLM occasionally over-quotes the \`tags\` argument and emits it as a JSON-encoded string (e.g. \`tags=\"[]\"\` or \`tags='[\"kitchen\"]'\`) instead of a real JSON array. The strict \`list[str]\` Pydantic field rejects these, forcing a retry on the next round and wasting an LLM round-trip plus one tool error in the conversation history.

This mirrors the fix in #1073 for \`qb_create\` / \`qb_update\`: add a \`field_validator(mode=\"before\")\` on the \`tags\` field of \`CompanyCamUploadPhotoParams\` and \`CompanyCamTagPhotoParams\` that parses JSON strings into lists on the way in.

Behavior is strictly more permissive: existing list callers are unaffected, and unparseable or non-array strings still surface as \`ValidationError\` so the agent's existing retry hint runs instead of blowing up later in the call.

## Real-world hit

A contractor uploading 4 photos in a single turn errored 4 times with \`tags: Input should be a valid list\` because Sonnet emitted \`tags: \"[]\"\`. The retry succeeded but the session carried 4 visible tool errors that show up on admin review.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`)
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake while reviewing a real production session)
- [ ] No AI used