### PR TITLE
feat(calendar): auto-resolve to primary when calendar_id is omitted

### DIFF
--- a/alembic/versions/025_add_calendar_is_primary.py
+++ b/alembic/versions/025_add_calendar_is_primary.py
@@ -1,0 +1,51 @@
+"""Add is_primary flag to calendar_configs.
+
+Mirrors the ``primary: true`` flag Google returns on the calendarList
+entry that represents the user's own (default) calendar. The agent uses
+it to disambiguate when the user has multiple enabled calendars and the
+LLM omits ``calendar_id``, so we no longer surface "Multiple calendars
+available. Please specify calendar_id." on every event the agent tries
+to create for a contractor with crew sub-calendars.
+
+Backfill heuristic for existing rows: mark ``calendar_id == 'primary'``
+True (the OSS pre-multi-calendar default) and otherwise leave False. The
+``update_calendar_config`` route resyncs from Google on next save and
+sets the flag correctly for users who have moved past the legacy
+default.
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-05-03
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "025"
+down_revision: str = "024"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "calendar_configs",
+        sa.Column(
+            "is_primary",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    # Best-effort backfill: the legacy single-calendar default uses the
+    # literal ``"primary"`` magic alias, which Google routes to the user's
+    # own primary calendar. Mark those rows True so the new disambiguation
+    # logic agrees with the historical behavior.
+    op.execute("UPDATE calendar_configs SET is_primary = TRUE WHERE calendar_id = 'primary'")
+
+
+def downgrade() -> None:
+    op.drop_column("calendar_configs", "is_primary")

--- a/backend/app/integrations/calendar/factory.py
+++ b/backend/app/integrations/calendar/factory.py
@@ -208,6 +208,7 @@ def _validate_calendar_id(
     calendar_id: str,
     enabled_calendars: list[tuple[str, str, list[str], str]],
     tool_name: str = "",
+    primary_calendar_id: str = "",
 ) -> tuple[str, str | None]:
     """Resolve and validate a calendar_id against the enabled set.
 
@@ -219,6 +220,12 @@ def _validate_calendar_id(
 
     When *tool_name* is set, also checks that the tool is not disabled
     on the resolved calendar.
+
+    *primary_calendar_id* (if provided) is used as a tiebreaker when the
+    LLM omits ``calendar_id`` and multiple calendars are allowed for the
+    tool. Without it, the agent would otherwise see a "Multiple calendars
+    available" error every time a contractor with crew sub-calendars
+    asks the agent to add an event.
     """
     enabled_ids = {cid for cid, _, _, _ in enabled_calendars}
 
@@ -236,6 +243,13 @@ def _validate_calendar_id(
         if not allowed:
             display = tool_name.replace("calendar_", "").replace("_", " ")
             return "", f"No calendars allow {display}. Update calendar permissions in Settings."
+        # Prefer the user's primary calendar (Google's ``primary: true``
+        # entry) when it is in the allowed set. The LLM has already
+        # signalled "no preference" by omitting calendar_id.
+        if primary_calendar_id:
+            for cid, _ in allowed:
+                if cid == primary_calendar_id:
+                    return cid, None
         return (
             "",
             f"Multiple calendars available. Please specify calendar_id. Options: {', '.join(f'{name} ({cid})' for cid, name in allowed)}",
@@ -291,6 +305,7 @@ def create_calendar_tools(
     service: GoogleCalendarService | Any,
     user_timezone: str = "",
     enabled_calendars: list[tuple[str, str, list[str], str]] | None = None,
+    primary_calendar_id: str = "",
 ) -> list[Tool]:
     """Create calendar tools bound to a calendar service instance.
 
@@ -304,6 +319,10 @@ def create_calendar_tools(
     *disabled_tools* is a list of tool names disabled on that calendar.
     *access_role* is the Google Calendar access role (owner/writer/reader/freeBusyReader).
     When empty or ``None``, defaults to ``[("primary", "Primary", [], "owner")]``.
+
+    *primary_calendar_id* is the calendar Google flags as ``primary: true``
+    on the user's calendarList. Used as a tiebreaker when the LLM omits
+    ``calendar_id`` and multiple calendars are enabled.
     """
     default_tz = _resolve_tz(user_timezone)
     raw: list[tuple[str, str, list[str], str]] = enabled_calendars or [
@@ -324,6 +343,10 @@ def create_calendar_tools(
     _enabled_ids = {cid for cid, _, _, _ in _enabled}
     _cal_name_map = {cid: name for cid, name, _, _ in _enabled}
     _disabled_map = {cid: set(disabled) for cid, _, disabled, _ in _enabled}
+    # Default to the OSS single-calendar fallback when caller didn't
+    # specify a primary, so the new tiebreaker matches historical
+    # behavior for users who haven't synced multi-calendar yet.
+    _primary_id = primary_calendar_id or (raw[0][0] if len(raw) == 1 else "")
 
     async def calendar_list_calendars() -> ToolResult:
         """List enabled calendars for the user."""
@@ -377,7 +400,9 @@ def create_calendar_tools(
         # Determine which calendars to query
         tool = ToolName.CALENDAR_LIST_EVENTS
         if calendar_id:
-            resolved_id, err = _validate_calendar_id(calendar_id, _enabled, tool_name=tool)
+            resolved_id, err = _validate_calendar_id(
+                calendar_id, _enabled, tool_name=tool, primary_calendar_id=_primary_id
+            )
             if err:
                 return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
             query_cals = [(resolved_id, _cal_name_map[resolved_id])]
@@ -452,7 +477,10 @@ def create_calendar_tools(
         """Create a new calendar event."""
         logger.debug("create_event called: title=%r calendar_id=%r", title, calendar_id)
         resolved_id, err = _validate_calendar_id(
-            calendar_id, _enabled, tool_name=ToolName.CALENDAR_CREATE_EVENT
+            calendar_id,
+            _enabled,
+            tool_name=ToolName.CALENDAR_CREATE_EVENT,
+            primary_calendar_id=_primary_id,
         )
         if err:
             return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
@@ -528,7 +556,10 @@ def create_calendar_tools(
         """Update an existing calendar event."""
         logger.debug("update_event called: event_id=%r calendar_id=%r", event_id, calendar_id)
         resolved_id, err = _validate_calendar_id(
-            calendar_id, _enabled, tool_name=ToolName.CALENDAR_UPDATE_EVENT
+            calendar_id,
+            _enabled,
+            tool_name=ToolName.CALENDAR_UPDATE_EVENT,
+            primary_calendar_id=_primary_id,
         )
         if err:
             return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
@@ -597,7 +628,10 @@ def create_calendar_tools(
         """Delete a calendar event."""
         logger.debug("delete_event called: event_id=%r calendar_id=%r", event_id, calendar_id)
         resolved_id, err = _validate_calendar_id(
-            calendar_id, _enabled, tool_name=ToolName.CALENDAR_DELETE_EVENT
+            calendar_id,
+            _enabled,
+            tool_name=ToolName.CALENDAR_DELETE_EVENT,
+            primary_calendar_id=_primary_id,
         )
         if err:
             return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
@@ -956,6 +990,26 @@ def _get_enabled_calendars(user_id: str) -> list[tuple[str, str, list[str], str]
     return [("primary", "Primary", [], "owner")]
 
 
+def _get_primary_calendar_id(user_id: str) -> str:
+    """Return the calendar_id of the row marked is_primary, or empty string.
+
+    Mirrors ``_get_enabled_calendars`` but pulls only the
+    ``is_primary=True`` row's calendar_id. Empty when the user has no
+    config at all (the literal ``"primary"`` magic alias is the implicit
+    default in that case) or when no row is flagged primary.
+    """
+    db = SessionLocal()
+    try:
+        row = (
+            db.query(CalendarConfig)
+            .filter_by(user_id=user_id, provider="google_calendar", is_primary=True)
+            .first()
+        )
+        return row.calendar_id if row is not None else ""
+    finally:
+        db.close()
+
+
 async def _calendar_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for calendar tools, used by the registry."""
     if not settings.google_calendar_client_id or not settings.google_calendar_client_secret:
@@ -972,10 +1026,12 @@ async def _calendar_factory(ctx: ToolContext) -> list[Tool]:
         on_token_refresh=oauth_service.build_on_refresh_callback(ctx.user.id, "google_calendar"),
     )
     enabled_calendars = _get_enabled_calendars(ctx.user.id)
+    primary_calendar_id = _get_primary_calendar_id(ctx.user.id)
     return create_calendar_tools(
         service,
         user_timezone=ctx.user.timezone,
         enabled_calendars=enabled_calendars,
+        primary_calendar_id=primary_calendar_id,
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -524,6 +524,13 @@ class CalendarConfig(Base):
     disabled_tools: Mapped[str] = mapped_column(Text, default="")
     access_role: Mapped[str] = mapped_column(String, default="")
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Mirrors Google Calendar's ``primary`` flag on the calendarList entry.
+    # When the agent fires a calendar tool without an explicit calendar_id
+    # and the user has multiple enabled calendars, the row marked
+    # is_primary wins. Avoids the "Multiple calendars available, please
+    # specify calendar_id" error every time a contractor with crew
+    # sub-calendars asks the agent to add an event.
+    is_primary: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC)
     )

--- a/backend/app/routers/user_calendar.py
+++ b/backend/app/routers/user_calendar.py
@@ -104,7 +104,33 @@ async def update_calendar_config(
     body: CalendarConfigUpdate,
     current_user: User = Depends(get_current_user),
 ) -> CalendarConfigResponse:
-    """Replace all enabled calendars (delete existing, insert new)."""
+    """Replace all enabled calendars (delete existing, insert new).
+
+    The ``is_primary`` flag is auto-detected by querying Google's
+    calendarList for the current user, so the frontend does not need to
+    pass it through. The agent uses it to disambiguate when the LLM
+    omits ``calendar_id`` and the user has multiple enabled calendars.
+    """
+    # Best-effort lookup of the user's primary calendar from Google.
+    # If this fails (rate limit, transient error) we fall through with
+    # primary_id = "" so the row stays is_primary=False rather than
+    # blocking the save.
+    primary_id = ""
+    try:
+        service = await _get_calendar_service(current_user)
+        google_cals = await service.list_calendars()
+        for c in google_cals:
+            if c.primary:
+                primary_id = c.id
+                break
+    except HTTPException:
+        # Calendar not configured / not connected. Skip the lookup.
+        pass
+    except Exception:
+        logger.exception(
+            "Failed to fetch calendarList for is_primary detection (user %s)", current_user.id
+        )
+
     db = SessionLocal()
     try:
         db.query(CalendarConfig).filter_by(
@@ -120,6 +146,7 @@ async def update_calendar_config(
                 display_name=entry.display_name,
                 disabled_tools=json.dumps(entry.disabled_tools) if entry.disabled_tools else "",
                 access_role=entry.access_role,
+                is_primary=bool(primary_id) and entry.calendar_id == primary_id,
             )
             db.add(config)
             new_configs.append(config)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1486,7 +1486,7 @@
       },
       "put": {
         "summary": "Update Calendar Config",
-        "description": "Replace all enabled calendars (delete existing, insert new).",
+        "description": "Replace all enabled calendars (delete existing, insert new).\n\nThe ``is_primary`` flag is auto-detected by querying Google's\ncalendarList for the current user, so the frontend does not need to\npass it through. The agent uses it to disambiguate when the LLM\nomits ``calendar_id`` and the user has multiple enabled calendars.",
         "operationId": "update_calendar_config_api_user_calendar_config_put",
         "requestBody": {
           "content": {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -855,6 +855,11 @@ export interface paths {
         /**
          * Update Calendar Config
          * @description Replace all enabled calendars (delete existing, insert new).
+         *
+         *     The ``is_primary`` flag is auto-detected by querying Google's
+         *     calendarList for the current user, so the frontend does not need to
+         *     pass it through. The agent uses it to disambiguate when the LLM
+         *     omits ``calendar_id`` and the user has multiple enabled calendars.
          */
         put: operations["update_calendar_config_api_user_calendar_config_put"];
         post?: never;

--- a/tests/test_calendar_tools.py
+++ b/tests/test_calendar_tools.py
@@ -421,7 +421,7 @@ async def test_create_event_auto_select_single_calendar() -> None:
 
 @pytest.mark.asyncio()
 async def test_create_event_requires_calendar_id_multi(cal_tools: list[Tool]) -> None:
-    """With multiple enabled calendars, must specify calendar_id."""
+    """With multiple enabled calendars and no primary marked, must specify calendar_id."""
     tool = _get_tool(cal_tools, ToolName.CALENDAR_CREATE_EVENT)
     result = await tool.function(
         title="Job: Test",
@@ -431,6 +431,96 @@ async def test_create_event_requires_calendar_id_multi(cal_tools: list[Tool]) ->
     assert result.is_error is True
     assert result.error_kind == ToolErrorKind.VALIDATION
     assert "Multiple calendars available" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_create_event_uses_primary_when_id_omitted(
+    cal_service: MockGoogleCalendarService,
+) -> None:
+    """When primary_calendar_id is set and the LLM omits calendar_id, the
+    tool resolves to the primary instead of erroring on ambiguity. This
+    is the case the contractor with crew sub-calendars hits constantly:
+    "add to my calendar" used to fail because Personal/Vinny/Isaac were
+    all enabled and the LLM didn't pick one.
+    """
+    tools = create_calendar_tools(
+        cal_service,
+        enabled_calendars=_DEFAULT_ENABLED,
+        primary_calendar_id="primary",
+    )
+    tool = _get_tool(tools, ToolName.CALENDAR_CREATE_EVENT)
+    result = await tool.function(
+        title="Job: Test",
+        start="2026-03-28T09:00:00",
+        end="2026-03-28T17:00:00",
+    )
+    assert result.is_error is False, result.content
+    # Mock service records the calendar_id each event was created on.
+    new_event = cal_service.events[-1]
+    assert cal_service._event_calendar_map[new_event.id] == "primary"
+
+
+@pytest.mark.asyncio()
+async def test_create_event_falls_through_when_primary_not_in_allowed_set(
+    cal_service: MockGoogleCalendarService,
+) -> None:
+    """If the configured primary is not in the enabled-and-allowed set
+    (e.g. user revoked write access on it), the tiebreaker silently
+    declines and the historical "Multiple calendars" error returns. This
+    keeps the change strictly additive: no new failure modes.
+    """
+    tools = create_calendar_tools(
+        cal_service,
+        enabled_calendars=_DEFAULT_ENABLED,
+        primary_calendar_id="not-in-enabled-set@example.com",
+    )
+    tool = _get_tool(tools, ToolName.CALENDAR_CREATE_EVENT)
+    result = await tool.function(
+        title="Job: Test",
+        start="2026-03-28T09:00:00",
+        end="2026-03-28T17:00:00",
+    )
+    assert result.is_error is True
+    assert "Multiple calendars available" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_validate_calendar_id_prefers_primary() -> None:
+    """Direct test of the helper: when calendar_id is empty and primary
+    is in the allowed set, return it instead of the ambiguity error.
+    """
+    from backend.app.integrations.calendar.factory import _validate_calendar_id
+
+    enabled: list[tuple[str, str, list[str], str]] = [
+        ("primary", "Personal", [], "owner"),
+        ("jobs@example.com", "Jobs", [], "writer"),
+    ]
+    resolved, err = _validate_calendar_id(
+        "",
+        enabled,
+        tool_name=ToolName.CALENDAR_CREATE_EVENT,
+        primary_calendar_id="primary",
+    )
+    assert err is None
+    assert resolved == "primary"
+
+
+@pytest.mark.asyncio()
+async def test_validate_calendar_id_single_calendar_unaffected() -> None:
+    """Single-calendar users still auto-resolve regardless of primary
+    flag (preserves the historical fast path).
+    """
+    from backend.app.integrations.calendar.factory import _validate_calendar_id
+
+    enabled: list[tuple[str, str, list[str], str]] = [("primary", "Personal", [], "owner")]
+    resolved, err = _validate_calendar_id(
+        "",
+        enabled,
+        tool_name=ToolName.CALENDAR_CREATE_EVENT,
+        primary_calendar_id="",  # No primary flag, single cal still resolves.
+    )
+    assert err is None
+    assert resolved == "primary"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description

Contractors with crew sub-calendars (Personal + Vinny + Isaac, etc.) hit \`Multiple calendars available. Please specify calendar_id.\` every time they ask the agent to add an event without naming a calendar. The LLM was forced to retry with an explicit calendar_id picked from the error message; the user paid the latency.

Add an \`is_primary\` boolean to \`CalendarConfig\` mirroring Google's \`primary: true\` flag on calendarList entries. When the LLM omits \`calendar_id\` and multiple enabled calendars are allowed for the requested tool, \`_validate_calendar_id\` now resolves to the primary instead of erroring on ambiguity.

## Wiring

- **Schema**: \`calendar_configs.is_primary\` BOOLEAN NOT NULL DEFAULT FALSE
- **Migration 025**: backfills \`is_primary=true\` for rows where \`calendar_id == 'primary'\` (the OSS pre-multi-calendar default)
- \`_validate_calendar_id\` accepts an optional \`primary_calendar_id\` and returns it when ambiguous; absent or not-in-allowed-set falls back to the existing error
- \`create_calendar_tools\` accepts a \`primary_calendar_id\` parameter, threaded through to all four \`_validate_calendar_id\` call sites
- \`_get_primary_calendar_id\` helper queries CalendarConfig
- \`_calendar_factory\` looks it up alongside \`_get_enabled_calendars\`
- \`update_calendar_config\` makes a best-effort calendarList query to Google at save time and stamps \`is_primary=true\` on the matching row, so the frontend stays untouched. Failure of that lookup falls through silently with \`is_primary=false\` everywhere.

## Backward compatibility

Strictly additive: when no primary is set or the primary is not in the allowed-and-enabled set for the tool, the historical \`Multiple calendars available\` error returns. Single-calendar users are unaffected (their fast path runs before the tiebreaker).

## Real-world hit

A contractor's \`calendar_create_event(...)\` errored with \`Multiple calendars available. Please specify calendar_id. Options: Vinny (...), Isaac (...), [primary] (...)\` the first time he tried to add an event. The retry succeeded but the session carried a visible tool error and burned an LLM round-trip.

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`) - 105 calendar tests pass
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] Type checking passes (\`ty check\`)
- [x] Migration round-trips (\`alembic upgrade head && alembic downgrade -1 && alembic upgrade head\`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake while reviewing a real production session)
- [ ] No AI used