### PR TITLE
fix(agent): add per-(user, tool, args) cooldown for transient failures

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -45,6 +45,7 @@ from backend.app.agent.messages import (
     messages_to_messages_api,
 )
 from backend.app.agent.system_prompt import build_agent_system_prompt, build_time_user_context
+from backend.app.agent.tool_cooldown import get_tool_cooldown_tracker
 from backend.app.agent.tool_errors import (
     _DEFAULT_ERROR_HINT,
     _ERROR_KIND_HINTS,
@@ -582,6 +583,50 @@ class ClawboltAgent:
         is_error = False
         action_label = ""
         record: StoredToolInteraction
+
+        # Cooldown check: if this exact (user, tool, args) tuple just
+        # failed transiently, short-circuit instead of slamming the
+        # downstream again. The LLM sees a tool error explaining the
+        # cooldown and can either wait or report back to the user.
+        cooldown = get_tool_cooldown_tracker()
+        cooldown_hit = cooldown.is_cooling_down(self.user.id, tool_name, validated_args)
+        if cooldown_hit is not None:
+            wait = max(1, round(cooldown_hit.seconds_remaining))
+            result_str = (
+                f"Skipped {tool_name}: same call failed {cooldown_hit.last_error_kind.value} "
+                f"a moment ago. Wait ~{wait}s before trying again with the same arguments, or "
+                f"adjust the call. Inform the user."
+            )
+            logger.info(
+                "Tool %s on cooldown for user %s (%.1fs remaining)",
+                tool_name,
+                self.user.id,
+                cooldown_hit.seconds_remaining,
+            )
+            record = StoredToolInteraction(
+                tool_call_id=tc_req.id,
+                name=tool_name,
+                args=validated_args,
+                result=result_str,
+                is_error=True,
+                tags=set(tool_tags),
+                receipt=None,
+            )
+            await self._emit(
+                ToolExecutionEndEvent(
+                    tool_name=tool_name,
+                    result=result_str,
+                    is_error=True,
+                    duration_ms=(time.monotonic() - tool_start) * 1000,
+                )
+            )
+            tool_message = ToolResultMessage(
+                tool_call_id=tc_req.id,
+                content=result_str,
+                is_error=True,
+            )
+            return record, tool_message, f"Skipped (cooldown): {tool_name}"
+
         try:
             result = await tool_obj.function(**validated_args)
             result_str = result.content
@@ -590,6 +635,9 @@ class ClawboltAgent:
                 hint = build_error_hint(result)
                 result_str += "\n\n" + hint
                 action_label = f"Failed: {tool_name}"
+                # Record transient failures so a retry within the
+                # cooldown window short-circuits instead of re-firing.
+                cooldown.record_failure(self.user.id, tool_name, validated_args, result.error_kind)
             else:
                 action_label = f"Called {tool_name}"
             stored_receipt = None
@@ -628,6 +676,7 @@ class ClawboltAgent:
             result_str = f"Error: tool {tool_name} raised {err_text}\n\n{hint}"[:1500]
             is_error = True
             action_label = f"Failed: {tool_name}"
+            cooldown.record_failure(self.user.id, tool_name, validated_args, ToolErrorKind.INTERNAL)
             record = StoredToolInteraction(
                 tool_call_id=tc_req.id,
                 name=tool_name,

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -588,6 +588,11 @@ class ClawboltAgent:
         # failed transiently, short-circuit instead of slamming the
         # downstream again. The LLM sees a tool error explaining the
         # cooldown and can either wait or report back to the user.
+        # Intentionally not race-safe across in-batch siblings: two
+        # parallel tool calls in the same LLM-emitted batch will both
+        # pass this check (neither has recorded a failure yet) and
+        # both fire. The design intent is to throttle re-fires across
+        # user turns, not within a single batch.
         cooldown = get_tool_cooldown_tracker()
         cooldown_hit = cooldown.is_cooling_down(self.user.id, tool_name, validated_args)
         if cooldown_hit is not None:

--- a/backend/app/agent/tool_cooldown.py
+++ b/backend/app/agent/tool_cooldown.py
@@ -1,0 +1,151 @@
+"""Per-(user, tool, args) cooldown for transient tool failures.
+
+Stops the agent from re-firing an idempotent-looking tool call against a
+flaky downstream within seconds of a failure. The agent loop has no
+intrinsic backoff: if a user says "send it" three times after the first
+QuickBooks ``qb_send`` returns 500, the agent sends three identical
+requests in ~10 seconds, hammering the same broken endpoint.
+
+When ``_execute_single_tool`` is about to dispatch a call that recently
+failed transiently (``SERVICE`` or ``INTERNAL`` error_kind), we
+short-circuit with a clear "I just tried that" message instead. The
+synthetic result is recorded as a tool error so the LLM can adapt its
+reply, and the user sees deterministic behavior instead of three
+identical 500 receipts.
+
+Cooldown is keyed on (user_id, tool_name, args_hash) so a different
+arg shape (e.g. ``send`` to a different recipient) is not blocked. The
+hash is a SHA-256 of the canonical JSON form of ``validated_args`` so
+dict ordering does not skew the key.
+
+State lives in process memory: a worker restart drops the cache, which
+is fine because failures recorded across a restart almost certainly
+predate a fix. We intentionally avoid persisting this so the cache
+cannot become stale across deploys.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any
+
+from backend.app.agent.tools.base import ToolErrorKind
+
+logger = logging.getLogger(__name__)
+
+
+# Error kinds that warrant a cooldown. Validation/permission/auth/etc.
+# are not transient: re-firing won't suddenly succeed and the LLM should
+# adjust args or escalate to the user instead.
+_TRANSIENT_KINDS: frozenset[ToolErrorKind] = frozenset(
+    {ToolErrorKind.SERVICE, ToolErrorKind.INTERNAL}
+)
+
+# Default cooldown window. 30s is long enough to absorb back-to-back
+# user "send it" messages but short enough that a real "try again later"
+# from the user (after the downstream recovers) is unaffected.
+DEFAULT_COOLDOWN_SECONDS: float = 30.0
+
+
+@dataclass(frozen=True)
+class CooldownHit:
+    """Returned when a call is on cooldown.
+
+    ``seconds_remaining`` is the lower bound on how long the LLM should
+    wait before retrying the same args. ``last_error`` is included so the
+    synthetic result can echo what the user originally got.
+    """
+
+    seconds_remaining: float
+    last_error_kind: ToolErrorKind
+
+
+def _hash_args(args: dict[str, Any]) -> str:
+    """Stable hash of validated tool args.
+
+    Uses ``sort_keys=True`` so ``{"a": 1, "b": 2}`` and ``{"b": 2, "a": 1}``
+    produce the same key. Falls back to ``repr`` when args contain a
+    non-JSON-serializable value (rare; tools are validated against a
+    Pydantic model which only allows JSON-compatible types in practice).
+    """
+    try:
+        canonical = json.dumps(args, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        canonical = repr(sorted(args.items()))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class ToolCooldownTracker:
+    """Bounded in-memory cooldown cache.
+
+    Thread-safe via a single ``Lock`` because the agent loop runs tool
+    batches concurrently with ``asyncio.gather``: parallel calls in the
+    same turn can read/write this cache from different tasks scheduled
+    on the same event loop, but the GIL plus the lock keep the dict
+    coherent. ``_evict_expired`` is called inline on each ``record_failure``
+    so the dict cannot grow without bound.
+    """
+
+    def __init__(self, cooldown_seconds: float = DEFAULT_COOLDOWN_SECONDS) -> None:
+        self._cooldown = cooldown_seconds
+        # key -> (expires_at_monotonic, error_kind)
+        self._entries: dict[tuple[str, str, str], tuple[float, ToolErrorKind]] = {}
+        self._lock = Lock()
+
+    def is_cooling_down(
+        self, user_id: str, tool_name: str, validated_args: dict[str, Any]
+    ) -> CooldownHit | None:
+        """Return a CooldownHit if the call is on cooldown, else None."""
+        key = (user_id, tool_name, _hash_args(validated_args))
+        now = time.monotonic()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            expires_at, kind = entry
+            if expires_at <= now:
+                # Lazy eviction.
+                self._entries.pop(key, None)
+                return None
+            return CooldownHit(seconds_remaining=expires_at - now, last_error_kind=kind)
+
+    def record_failure(
+        self,
+        user_id: str,
+        tool_name: str,
+        validated_args: dict[str, Any],
+        error_kind: ToolErrorKind | None,
+    ) -> None:
+        """Record a transient tool failure. No-op for non-transient kinds."""
+        if error_kind not in _TRANSIENT_KINDS:
+            return
+        key = (user_id, tool_name, _hash_args(validated_args))
+        now = time.monotonic()
+        with self._lock:
+            self._entries[key] = (now + self._cooldown, error_kind)
+            # Evict any expired entries opportunistically so the dict
+            # stays bounded under sustained call volume. Cheap because
+            # the dict is small in normal operation (one entry per
+            # active user with a recent transient failure).
+            expired = [k for k, (exp, _) in self._entries.items() if exp <= now]
+            for k in expired:
+                self._entries.pop(k, None)
+
+    def reset(self) -> None:
+        """Clear all entries. Used by tests."""
+        with self._lock:
+            self._entries.clear()
+
+
+# Module-level singleton. Reset only by tests via the fixture below.
+_tracker = ToolCooldownTracker()
+
+
+def get_tool_cooldown_tracker() -> ToolCooldownTracker:
+    """Accessor for the singleton tracker."""
+    return _tracker

--- a/backend/app/agent/tool_cooldown.py
+++ b/backend/app/agent/tool_cooldown.py
@@ -69,9 +69,12 @@ def _hash_args(args: dict[str, Any]) -> str:
     """Stable hash of validated tool args.
 
     Uses ``sort_keys=True`` so ``{"a": 1, "b": 2}`` and ``{"b": 2, "a": 1}``
-    produce the same key. Falls back to ``repr`` when args contain a
-    non-JSON-serializable value (rare; tools are validated against a
-    Pydantic model which only allows JSON-compatible types in practice).
+    produce the same key. Recurses into nested dicts. Non-JSON-serializable
+    values fall through ``default=str`` (rare in practice: tools validate
+    args via a Pydantic model and ``model_dump()`` produces JSON-shaped
+    dicts). The outer ``except`` is a belt-and-braces fallback in case
+    a value rejects ``str()`` itself; it serializes the sorted ``items``
+    via ``repr`` so the hash never raises and we degrade to a usable key.
     """
     try:
         canonical = json.dumps(args, sort_keys=True, default=str)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from backend.app.agent.approval import reset_approval_gate
 from backend.app.agent.file_store import SessionState, StoredMessage, reset_stores
 from backend.app.agent.memory_db import reset_memory_stores
 from backend.app.agent.session_db import reset_session_stores
+from backend.app.agent.tool_cooldown import get_tool_cooldown_tracker
 from backend.app.auth.dependencies import get_current_user
 from backend.app.bus import message_bus
 from backend.app.channels import unknown_sender as unknown_sender_module
@@ -67,6 +68,7 @@ def _isolate_stores(_pg_engine: Engine, tmp_path: Path) -> Generator[None]:
         reset_session_stores()
         reset_memory_stores()
         reset_approval_gate()
+        get_tool_cooldown_tracker().reset()
         yield
 
     # Rollback undoes all data written during the test.
@@ -83,6 +85,7 @@ def _isolate_stores(_pg_engine: Engine, tmp_path: Path) -> Generator[None]:
     reset_session_stores()
     reset_memory_stores()
     reset_approval_gate()
+    get_tool_cooldown_tracker().reset()
 
 
 @pytest.fixture()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -22,6 +22,7 @@ from backend.app.agent.messages import (
     ToolResultMessage,
     UserMessage,
 )
+from backend.app.agent.tool_cooldown import get_tool_cooldown_tracker
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.trimming import trim_messages
 from backend.app.models import User
@@ -1738,8 +1739,6 @@ async def test_different_error_kinds_produce_different_hints(
     test_user: User,
 ) -> None:
     """Each error kind should produce a distinct guidance message."""
-    from backend.app.agent.tool_cooldown import get_tool_cooldown_tracker
-
     collected_hints: dict[str, str] = {}
 
     for kind in ToolErrorKind:
@@ -1875,7 +1874,6 @@ async def test_cooldown_short_circuits_repeat_service_failure(
     # cooldown and short-circuited without invoking the tool function.
     assert call_count["n"] == 1
     # The third turn's tool result reflects the cooldown message.
-    assert "cooldown" not in response.tool_calls[0].result.lower() or True
     assert "Skipped flaky_tool" in response.tool_calls[0].result
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1738,9 +1738,16 @@ async def test_different_error_kinds_produce_different_hints(
     test_user: User,
 ) -> None:
     """Each error kind should produce a distinct guidance message."""
+    from backend.app.agent.tool_cooldown import get_tool_cooldown_tracker
+
     collected_hints: dict[str, str] = {}
 
     for kind in ToolErrorKind:
+        # Reset cooldown between iterations: this test reuses the same
+        # tool name + args across every kind, and SERVICE/INTERNAL on
+        # one iteration would short-circuit later iterations with a
+        # cooldown message instead of the expected error hint.
+        get_tool_cooldown_tracker().reset()
 
         async def make_tool(error_kind: ToolErrorKind = kind, **kwargs: object) -> ToolResult:
             return ToolResult(
@@ -1814,6 +1821,113 @@ async def test_unhandled_exception_uses_internal_hint(
     content = tool_msg["content"][0]["content"]
 
     assert "[An internal error occurred" in content
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_cooldown_short_circuits_repeat_service_failure(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """Real-world scenario: QB returns 500 on qb_send. The user says 'send
+    it' twice more in quick succession. The agent fires the same call each
+    time. The cooldown should short-circuit the second and third firings
+    so we stop slamming the broken downstream.
+    """
+    call_count = {"n": 0}
+
+    async def flaky_tool(**kwargs: object) -> ToolResult:
+        call_count["n"] += 1
+        return ToolResult(
+            content="Failed: 500 Internal Server Error",
+            is_error=True,
+            error_kind=ToolErrorKind.SERVICE,
+        )
+
+    tool = Tool(
+        name="flaky_tool", description="flaky", function=flaky_tool, params_model=_EmptyParams
+    )
+
+    # Three rounds: each round fires the same tool with the same args.
+    mock_amessages.side_effect = [
+        make_tool_call_response(
+            tool_calls=[{"id": "c1", "name": "flaky_tool", "arguments": json.dumps({})}]
+        ),
+        make_text_response("first reply"),
+        make_tool_call_response(
+            tool_calls=[{"id": "c2", "name": "flaky_tool", "arguments": json.dumps({})}]
+        ),
+        make_text_response("second reply"),
+        make_tool_call_response(
+            tool_calls=[{"id": "c3", "name": "flaky_tool", "arguments": json.dumps({})}]
+        ),
+        make_text_response("third reply"),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+
+    await agent.process_message("first send", system_prompt_override="system")
+    await agent.process_message("second send", system_prompt_override="system")
+    response = await agent.process_message("third send", system_prompt_override="system")
+
+    # Tool only ran once: the first turn. The second and third hit the
+    # cooldown and short-circuited without invoking the tool function.
+    assert call_count["n"] == 1
+    # The third turn's tool result reflects the cooldown message.
+    assert "cooldown" not in response.tool_calls[0].result.lower() or True
+    assert "Skipped flaky_tool" in response.tool_calls[0].result
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_cooldown_does_not_block_validation_retry(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """Validation errors must not engage the cooldown: the LLM is meant to
+    fix its args and retry, not wait. Mirror of the QB JSON-string fix
+    flow where the second call (with corrected args) should land
+    cleanly.
+    """
+    call_count = {"n": 0}
+
+    async def validation_then_success(**kwargs: object) -> ToolResult:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return ToolResult(
+                content="Validation failed",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        return ToolResult(content="ok")
+
+    tool = Tool(
+        name="picky_tool",
+        description="picky",
+        function=validation_then_success,
+        params_model=_EmptyParams,
+    )
+
+    mock_amessages.side_effect = [
+        make_tool_call_response(
+            tool_calls=[{"id": "c1", "name": "picky_tool", "arguments": json.dumps({})}]
+        ),
+        make_text_response("first reply"),
+        make_tool_call_response(
+            tool_calls=[{"id": "c2", "name": "picky_tool", "arguments": json.dumps({})}]
+        ),
+        make_text_response("second reply"),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+
+    await agent.process_message("first", system_prompt_override="system")
+    await agent.process_message("second", system_prompt_override="system")
+
+    # Both calls reached the tool function: cooldown ignored validation errors.
+    assert call_count["n"] == 2
 
 
 # ---- Tool Registry Tests ----

--- a/tests/test_tool_cooldown.py
+++ b/tests/test_tool_cooldown.py
@@ -1,0 +1,159 @@
+"""Tests for the per-(user, tool, args) cooldown tracker.
+
+Covers the unit behavior of ``ToolCooldownTracker`` (hashing, eviction,
+transient-vs-permanent error filtering). The end-to-end short-circuit
+path through ``_execute_single_tool`` is exercised in
+``test_agent_loop.py``.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from backend.app.agent.tool_cooldown import (
+    DEFAULT_COOLDOWN_SECONDS,
+    CooldownHit,
+    ToolCooldownTracker,
+    _hash_args,
+    get_tool_cooldown_tracker,
+)
+from backend.app.agent.tools.base import ToolErrorKind
+
+
+@pytest.fixture()
+def tracker() -> ToolCooldownTracker:
+    """Fresh tracker per test, unused otherwise the module singleton
+    leaks state across tests."""
+    return ToolCooldownTracker(cooldown_seconds=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Hash stability
+# ---------------------------------------------------------------------------
+
+
+def test_hash_args_is_dict_order_invariant() -> None:
+    """JSON canonicalisation must absorb dict insertion order, otherwise
+    two structurally identical calls hash differently and the cooldown
+    fails to fire."""
+    a = _hash_args({"a": 1, "b": 2, "c": 3})
+    b = _hash_args({"c": 3, "a": 1, "b": 2})
+    assert a == b
+
+
+def test_hash_args_distinguishes_value_changes() -> None:
+    a = _hash_args({"recipient": "alice@example.com"})
+    b = _hash_args({"recipient": "bob@example.com"})
+    assert a != b
+
+
+def test_hash_args_handles_non_jsonable_values() -> None:
+    """Tools should only emit JSON-shaped args, but if a corner case
+    smuggles in something exotic the helper must not raise."""
+    h = _hash_args({"x": object()})
+    assert isinstance(h, str)
+    assert len(h) == 64  # SHA-256 hex digest
+
+
+# ---------------------------------------------------------------------------
+# Cooldown semantics
+# ---------------------------------------------------------------------------
+
+
+def test_no_cooldown_for_fresh_call(tracker: ToolCooldownTracker) -> None:
+    assert tracker.is_cooling_down("u1", "qb_send", {"id": "543"}) is None
+
+
+def test_records_service_failure_and_blocks_retry(tracker: ToolCooldownTracker) -> None:
+    """SERVICE errors (e.g. QB 500) trigger the cooldown."""
+    args = {"entity_type": "Estimate", "entity_id": "543", "email": "x@example.com"}
+    tracker.record_failure("u1", "qb_send", args, ToolErrorKind.SERVICE)
+
+    hit = tracker.is_cooling_down("u1", "qb_send", args)
+    assert isinstance(hit, CooldownHit)
+    assert hit.last_error_kind == ToolErrorKind.SERVICE
+    assert hit.seconds_remaining > 0
+
+
+def test_records_internal_failure_and_blocks_retry(tracker: ToolCooldownTracker) -> None:
+    """Unhandled exceptions get classified as INTERNAL and also cool down."""
+    args = {"path": "/etc/passwd"}
+    tracker.record_failure("u1", "read_file", args, ToolErrorKind.INTERNAL)
+    assert tracker.is_cooling_down("u1", "read_file", args) is not None
+
+
+def test_does_not_cooldown_validation_error(tracker: ToolCooldownTracker) -> None:
+    """Validation errors mean the LLM sent bad args. A retry with the
+    same args won't succeed but a retry with corrected args should not
+    be blocked. So we deliberately do not cool down VALIDATION."""
+    args = {"entity_type": "Estimate"}  # missing data field
+    tracker.record_failure("u1", "qb_create", args, ToolErrorKind.VALIDATION)
+    assert tracker.is_cooling_down("u1", "qb_create", args) is None
+
+
+def test_does_not_cooldown_permission_or_auth(tracker: ToolCooldownTracker) -> None:
+    args = {"x": 1}
+    tracker.record_failure("u1", "qb_create", args, ToolErrorKind.PERMISSION)
+    tracker.record_failure("u1", "calendar_create_event", args, ToolErrorKind.AUTH)
+    assert tracker.is_cooling_down("u1", "qb_create", args) is None
+    assert tracker.is_cooling_down("u1", "calendar_create_event", args) is None
+
+
+def test_does_not_cooldown_when_error_kind_missing(tracker: ToolCooldownTracker) -> None:
+    """Tools sometimes return is_error=True without setting error_kind.
+    Treat absence as "don't cool down" — be conservative."""
+    tracker.record_failure("u1", "qb_send", {"id": "1"}, None)
+    assert tracker.is_cooling_down("u1", "qb_send", {"id": "1"}) is None
+
+
+def test_per_user_isolation(tracker: ToolCooldownTracker) -> None:
+    """One user's failure must not block another user's identical call."""
+    args = {"id": "543"}
+    tracker.record_failure("alice", "qb_send", args, ToolErrorKind.SERVICE)
+    assert tracker.is_cooling_down("alice", "qb_send", args) is not None
+    assert tracker.is_cooling_down("bob", "qb_send", args) is None
+
+
+def test_per_args_isolation(tracker: ToolCooldownTracker) -> None:
+    """Different args = different cooldown key. Sending estimate 543 is
+    independent of sending estimate 544 even when both are flaky."""
+    tracker.record_failure("u1", "qb_send", {"id": "543"}, ToolErrorKind.SERVICE)
+    assert tracker.is_cooling_down("u1", "qb_send", {"id": "544"}) is None
+
+
+def test_per_tool_isolation(tracker: ToolCooldownTracker) -> None:
+    """A failed qb_send does not block qb_query with the same args."""
+    args = {"x": 1}
+    tracker.record_failure("u1", "qb_send", args, ToolErrorKind.SERVICE)
+    assert tracker.is_cooling_down("u1", "qb_query", args) is None
+
+
+def test_cooldown_expires_after_window() -> None:
+    """Use a microsecond cooldown to keep the test fast."""
+    tracker = ToolCooldownTracker(cooldown_seconds=0.05)
+    args = {"id": "1"}
+    tracker.record_failure("u1", "qb_send", args, ToolErrorKind.SERVICE)
+    assert tracker.is_cooling_down("u1", "qb_send", args) is not None
+    time.sleep(0.1)
+    assert tracker.is_cooling_down("u1", "qb_send", args) is None
+
+
+def test_reset_clears_all_entries(tracker: ToolCooldownTracker) -> None:
+    tracker.record_failure("u1", "qb_send", {"id": "1"}, ToolErrorKind.SERVICE)
+    tracker.reset()
+    assert tracker.is_cooling_down("u1", "qb_send", {"id": "1"}) is None
+
+
+def test_module_singleton_returns_same_tracker() -> None:
+    a = get_tool_cooldown_tracker()
+    b = get_tool_cooldown_tracker()
+    assert a is b
+
+
+def test_default_cooldown_is_30_seconds() -> None:
+    """Long enough to absorb three back-to-back 'send it' messages,
+    short enough that a real follow-up after the downstream recovers
+    is unaffected."""
+    assert DEFAULT_COOLDOWN_SECONDS == 30.0


### PR DESCRIPTION
## Description

When a tool fails with a SERVICE or INTERNAL error, the agent loop has no intrinsic backoff. If the user follows up with \"send it\" twice more in quick succession the agent dutifully re-fires the same call each time, slamming the same broken endpoint and burning the same exception into session history three times.

Real example from a contractor's session: QuickBooks \`qb_send\` returned 500 three times in 90 seconds because the agent retried each \"Send it\" verbatim.

## Implementation

Add a \`ToolCooldownTracker\` keyed on \`(user_id, tool_name, args_hash)\` with a 30s window. \`_execute_single_tool\` consults it before dispatching; on a hit, the tool function is not called, the LLM receives a synthetic tool error with a \"wait Ns or change args\" hint, and the user gets a coherent response instead of a third identical 500 receipt.

Cooldown only applies to transient kinds:

- **SERVICE**: external service down (QB 500, etc.)
- **INTERNAL**: unhandled exception (also recorded explicitly in the except branch since \`result.error_kind\` is not populated there)

Validation, permission, auth, not_found, and interrupted are deliberately excluded: those want a different next call from the LLM (corrected args, escalation to user, fresh auth) and a cooldown would just block the legitimate retry.

Args hash uses canonical JSON (\`sort_keys=True\`) so dict insertion order doesn't change the key. State is in-process only and resets on worker restart, since failures recorded across a deploy almost certainly predate a fix.

## Test changes

The previous \`test_different_error_kinds_produce_different_hints\` exercised every kind sequentially against the same (tool, args) tuple for the same user; updated to reset the tracker between iterations since SERVICE/INTERNAL on iteration N would now short-circuit iteration N+1.

Added 16 unit tests for the tracker (hash stability, per-user/tool/args isolation, expiry, exclusion of non-transient kinds) plus 2 integration tests for the wired path through \`_execute_single_tool\`:

- \`test_cooldown_short_circuits_repeat_service_failure\`: three sequential turns firing the same flaky tool: only the first reaches the tool function.
- \`test_cooldown_does_not_block_validation_retry\`: validation errors don't engage cooldown, so the LLM's next attempt with corrected args lands.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`) - 103 tests pass (16 new unit + 2 new integration + 85 existing)
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] Type checking passes (\`ty check\`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake while reviewing a real production session)
- [ ] No AI used