### PR TITLE
feat(llm): compute per-row cost on llm_usage_logs

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -208,7 +208,7 @@ async def compact_session(
         logger.exception("Compaction LLM call failed for user %s", user_id)
         return "", None
 
-    log_llm_usage(user_id, model, response, purpose="compaction")
+    log_llm_usage(user_id, model, response, purpose="compaction", provider=provider)
 
     raw_content = get_response_text(response)
     result = _parse_compaction_response(raw_content)

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1047,6 +1047,7 @@ class ClawboltAgent:
                 self._llm_model_override or settings.llm_model,
                 response,
                 purpose,
+                provider=self._llm_provider_override or settings.llm_provider,
             )
             if response.usage and response.usage.input_tokens:
                 self._last_input_tokens = response.usage.input_tokens

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -483,7 +483,7 @@ async def evaluate_heartbeat_need(
     if response is None:
         raise RuntimeError("Heartbeat LLM retry loop exited without response")
 
-    log_llm_usage(user.id, model, response, "heartbeat_decision")
+    log_llm_usage(user.id, model, response, "heartbeat_decision", provider=provider)
     decision = _parse_decision_response(response)
     if response.usage:
         decision.input_tokens = response.usage.input_tokens or 0

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -423,11 +423,12 @@ class IdempotencyStore:
 # ---------------------------------------------------------------------------
 
 
-# Models we have already warned about lacking a pricing entry. Bounded
-# in practice by the number of distinct model strings the deployment
-# emits, which is typically 1-3. Avoids 437 identical warnings per session
-# when a new provider lands without a pricing table update.
-_warned_unpriced_models: set[str] = set()
+# (provider, model) tuples we have already warned about lacking pricing
+# data. Bounded in practice by the number of distinct (provider, model)
+# pairs the deployment emits, which is typically 1-3. Avoids one
+# warning per LLM call when a new model lands ahead of a genai-prices
+# data refresh.
+_warned_unpriced_models: set[tuple[str, str]] = set()
 
 
 class LLMUsageStore:
@@ -442,42 +443,48 @@ class LLMUsageStore:
         prompt_tokens: int,
         completion_tokens: int,
         purpose: str,
+        provider: str = "",
         cache_creation_input_tokens: int | None = None,
         cache_read_input_tokens: int | None = None,
     ) -> None:
         """Insert a LLMUsageLog row with computed cost.
 
         Maps prompt_tokens -> input_tokens, completion_tokens -> output_tokens
-        as the ORM model uses input_tokens/output_tokens naming. Cost is
-        computed via ``services.llm_pricing`` (a thin wrapper around the
-        ``genai-prices`` library); unknown models fall through with
-        ``cost=0.000000`` and a once-per-process warning log so we
-        notice when our pricing data is stale.
+        as the ORM model uses input_tokens/output_tokens naming. *provider*
+        is the any-llm provider id (``"anthropic"``, ``"openai"``, etc.) and
+        is persisted alongside the model so downstream analytics never has
+        to re-derive it from the model string. Cost is computed via
+        ``services.llm_pricing`` (a thin wrapper around the ``genai-prices``
+        library); unknown (provider, model) combinations fall through with
+        ``cost=0.000000`` and a once-per-process warning so we notice when
+        our pricing data is stale.
         """
         cost = compute_cost(
             model,
+            provider=provider,
             input_tokens=prompt_tokens,
             output_tokens=completion_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
         )
         if (
-            not is_known_model(model)
+            not is_known_model(model, provider=provider)
             and (prompt_tokens or completion_tokens)
-            and model not in _warned_unpriced_models
+            and (provider, model) not in _warned_unpriced_models
         ):
-            _warned_unpriced_models.add(model)
+            _warned_unpriced_models.add((provider, model))
             logger.warning(
-                "genai-prices does not know model %r; logging usage with "
-                "cost=0. Bump the genai-prices dependency to pick up new "
-                "model pricing.",
+                "genai-prices does not know provider=%r model=%r; logging "
+                "usage with cost=0. Bump the genai-prices dependency to "
+                "pick up new model pricing.",
+                provider,
                 model,
             )
 
         with db_session() as db:
             entry = LLMUsageLog(
                 user_id=self.user_id,
-                provider="",
+                provider=provider,
                 model=model,
                 input_tokens=prompt_tokens,
                 output_tokens=completion_tokens,

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -449,10 +449,10 @@ class LLMUsageStore:
 
         Maps prompt_tokens -> input_tokens, completion_tokens -> output_tokens
         as the ORM model uses input_tokens/output_tokens naming. Cost is
-        computed from the per-model pricing table in
-        ``services.llm_pricing``; unknown models fall through with
-        ``cost=0.000000`` and a once-per-process warning log so we notice
-        when a new provider lands without a pricing entry.
+        computed via ``services.llm_pricing`` (a thin wrapper around the
+        ``genai-prices`` library); unknown models fall through with
+        ``cost=0.000000`` and a once-per-process warning log so we
+        notice when our pricing data is stale.
         """
         cost = compute_cost(
             model,
@@ -468,8 +468,9 @@ class LLMUsageStore:
         ):
             _warned_unpriced_models.add(model)
             logger.warning(
-                "No pricing entry for model %r; logging usage with cost=0. "
-                "Add it to backend/app/services/llm_pricing.py.",
+                "genai-prices does not know model %r; logging usage with "
+                "cost=0. Bump the genai-prices dependency to pick up new "
+                "model pricing.",
                 model,
             )
 

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -423,6 +423,13 @@ class IdempotencyStore:
 # ---------------------------------------------------------------------------
 
 
+# Models we have already warned about lacking a pricing entry. Bounded
+# in practice by the number of distinct model strings the deployment
+# emits, which is typically 1-3. Avoids 437 identical warnings per session
+# when a new provider lands without a pricing table update.
+_warned_unpriced_models: set[str] = set()
+
+
 class LLMUsageStore:
     """Database-backed LLM usage logging using LLMUsageLog ORM model."""
 
@@ -444,8 +451,8 @@ class LLMUsageStore:
         as the ORM model uses input_tokens/output_tokens naming. Cost is
         computed from the per-model pricing table in
         ``services.llm_pricing``; unknown models fall through with
-        ``cost=0.000000`` and a warning log so we notice when a new
-        provider lands without a pricing entry.
+        ``cost=0.000000`` and a once-per-process warning log so we notice
+        when a new provider lands without a pricing entry.
         """
         cost = compute_cost(
             model,
@@ -454,7 +461,12 @@ class LLMUsageStore:
             cache_creation_input_tokens=cache_creation_input_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
         )
-        if not is_known_model(model) and (prompt_tokens or completion_tokens):
+        if (
+            not is_known_model(model)
+            and (prompt_tokens or completion_tokens)
+            and model not in _warned_unpriced_models
+        ):
+            _warned_unpriced_models.add(model)
             logger.warning(
                 "No pricing entry for model %r; logging usage with cost=0. "
                 "Add it to backend/app/services/llm_pricing.py.",

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -33,6 +33,7 @@ from backend.app.models import (
     ToolConfig,
     User,
 )
+from backend.app.services.llm_pricing import compute_cost, is_known_model
 
 logger = logging.getLogger(__name__)
 
@@ -437,12 +438,29 @@ class LLMUsageStore:
         cache_creation_input_tokens: int | None = None,
         cache_read_input_tokens: int | None = None,
     ) -> None:
-        """Insert a LLMUsageLog row.
+        """Insert a LLMUsageLog row with computed cost.
 
         Maps prompt_tokens -> input_tokens, completion_tokens -> output_tokens
-        as the ORM model uses input_tokens/output_tokens naming.  Sets
-        provider="" and cost=0.0 since the file store did not track those.
+        as the ORM model uses input_tokens/output_tokens naming. Cost is
+        computed from the per-model pricing table in
+        ``services.llm_pricing``; unknown models fall through with
+        ``cost=0.000000`` and a warning log so we notice when a new
+        provider lands without a pricing entry.
         """
+        cost = compute_cost(
+            model,
+            input_tokens=prompt_tokens,
+            output_tokens=completion_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+        )
+        if not is_known_model(model) and (prompt_tokens or completion_tokens):
+            logger.warning(
+                "No pricing entry for model %r; logging usage with cost=0. "
+                "Add it to backend/app/services/llm_pricing.py.",
+                model,
+            )
+
         with db_session() as db:
             entry = LLMUsageLog(
                 user_id=self.user_id,
@@ -451,7 +469,7 @@ class LLMUsageStore:
                 input_tokens=prompt_tokens,
                 output_tokens=completion_tokens,
                 total_tokens=prompt_tokens + completion_tokens,
-                cost=0.0,
+                cost=cost,
                 purpose=purpose,
                 cache_creation_input_tokens=cache_creation_input_tokens,
                 cache_read_input_tokens=cache_read_input_tokens,

--- a/backend/app/services/llm_pricing.py
+++ b/backend/app/services/llm_pricing.py
@@ -1,0 +1,120 @@
+"""Per-model pricing for LLM usage cost computation.
+
+Used by ``LLMUsageStore.log`` to populate the ``cost`` column on every
+``llm_usage_logs`` row instead of leaving it hardcoded at 0. The table
+covers the models clawbolt actually invokes via any-llm. Adding a new
+provider is one line; unknown models fall back to ``UNKNOWN_PRICING``
+which charges nothing rather than guess.
+
+Prices are dollars per million tokens. Cache write surcharge and cache
+read discount follow Anthropic's published multipliers (1.25x and 0.1x
+of the input rate, respectively); they apply to the cache-specific
+token columns we already record on each row. Update the table here when
+Anthropic / OpenAI ship new SKUs or revise rates; the database column
+type (Numeric(12,6)) accommodates further precision if needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """Dollars per million tokens for a single model SKU.
+
+    ``cache_write`` and ``cache_read`` are the rates that apply to the
+    ``cache_creation_input_tokens`` and ``cache_read_input_tokens``
+    columns respectively. Anthropic charges a 25% premium on cache
+    writes and a 90% discount on cache reads relative to ``input``. We
+    store these explicitly rather than re-deriving them so providers
+    that price caching differently in future are easy to fit.
+    """
+
+    input: Decimal
+    output: Decimal
+    cache_write: Decimal
+    cache_read: Decimal
+
+
+# Anthropic published rates as of 2026-05.
+_SONNET_4_6 = ModelPricing(
+    input=Decimal("3.00"),
+    output=Decimal("15.00"),
+    cache_write=Decimal("3.75"),
+    cache_read=Decimal("0.30"),
+)
+_OPUS_4_7 = ModelPricing(
+    input=Decimal("15.00"),
+    output=Decimal("75.00"),
+    cache_write=Decimal("18.75"),
+    cache_read=Decimal("1.50"),
+)
+_HAIKU_4_5 = ModelPricing(
+    input=Decimal("0.80"),
+    output=Decimal("4.00"),
+    cache_write=Decimal("1.00"),
+    cache_read=Decimal("0.08"),
+)
+
+UNKNOWN_PRICING = ModelPricing(
+    input=Decimal("0"),
+    output=Decimal("0"),
+    cache_write=Decimal("0"),
+    cache_read=Decimal("0"),
+)
+
+# Lookup table. Keys match the model identifiers our config emits. Both
+# the bare ID and the dated ID forms are covered so a clawbolt instance
+# pinned to e.g. ``claude-haiku-4-5-20251001`` resolves correctly.
+_PRICING_BY_MODEL: dict[str, ModelPricing] = {
+    "claude-sonnet-4-6": _SONNET_4_6,
+    "claude-opus-4-7": _OPUS_4_7,
+    "claude-haiku-4-5": _HAIKU_4_5,
+    "claude-haiku-4-5-20251001": _HAIKU_4_5,
+}
+
+
+def lookup_pricing(model: str) -> ModelPricing:
+    """Return pricing for *model*, or ``UNKNOWN_PRICING`` when unmapped.
+
+    A miss is logged at the call site (in ``LLMUsageStore.log``) so we
+    notice when a new provider lands without a pricing entry.
+    """
+    return _PRICING_BY_MODEL.get(model, UNKNOWN_PRICING)
+
+
+def is_known_model(model: str) -> bool:
+    """Whether *model* has a pricing entry. Used by the logger to decide
+    when to emit a "no pricing" warning."""
+    return model in _PRICING_BY_MODEL
+
+
+def compute_cost(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_creation_input_tokens: int | None = None,
+    cache_read_input_tokens: int | None = None,
+) -> Decimal:
+    """Return the dollar cost for a single LLM call as a 6-decimal Decimal.
+
+    Charges ``input_tokens`` at the model's input rate, ``output_tokens``
+    at the output rate, and the cache columns at their dedicated rates.
+    The caller passes ``input_tokens`` as Anthropic reports it: the
+    *non-cached* prompt tokens, with cache reads / writes accounted
+    separately. We do not double-count.
+
+    Returns ``Decimal('0.000000')`` for models without a pricing entry,
+    and quantises the result to six decimal places (matching the
+    ``Numeric(12, 6)`` column on ``llm_usage_logs``).
+    """
+    pricing = lookup_pricing(model)
+    cost = (
+        pricing.input * Decimal(input_tokens)
+        + pricing.output * Decimal(output_tokens)
+        + pricing.cache_write * Decimal(cache_creation_input_tokens or 0)
+        + pricing.cache_read * Decimal(cache_read_input_tokens or 0)
+    ) / Decimal("1000000")
+    return cost.quantize(Decimal("0.000001"))

--- a/backend/app/services/llm_pricing.py
+++ b/backend/app/services/llm_pricing.py
@@ -1,16 +1,20 @@
 """LLM cost computation backed by the ``genai-prices`` library.
 
-Replaces the hand-rolled per-model pricing table this module used to
-keep in code with a thin wrapper around `pydantic/genai-prices
+Thin wrapper around `pydantic/genai-prices
 <https://github.com/pydantic/genai-prices>`_, the community-maintained
-source of truth for provider pricing. Adding a new model now means
-``uv lock --upgrade-package genai-prices``; we no longer carry the
-risk of stale rates drifting out of sync with what the providers
-actually charge.
+source of truth for provider pricing. Adding a new model means
+``uv lock --upgrade-package genai-prices``; we do not keep our own
+rate table in code.
 
-The library's price table is bundled at install time, so this module
+The library's price data is bundled at install time, so this module
 makes no network call. Pricing data refreshes when we bump the
 ``genai-prices`` dependency.
+
+The caller passes the any-llm provider id alongside the model name,
+since both are known at every dispatch site (see
+``settings.llm_provider``). Authoritative provider routing means we
+never have to guess "which vendor does this model name belong to" from
+prefixes; we just forward what the agent loop already knew.
 
 Used by ``LLMUsageStore.log`` to populate the ``cost`` column on every
 ``llm_usage_logs`` row instead of leaving it hardcoded at 0.
@@ -32,30 +36,8 @@ logger = logging.getLogger(__name__)
 _QUANT = Decimal("0.000001")
 
 
-# Map our canonical model-name prefixes to ``genai-prices`` provider
-# ids. Supplying the provider id skips the library's auto-detection
-# scan and disambiguates models whose names appear under more than one
-# provider. Unmapped prefixes fall through with ``provider_id=None``;
-# the library then probes all providers.
-_PROVIDER_ID_BY_PREFIX: tuple[tuple[str, str], ...] = (
-    ("claude-", "anthropic"),
-    ("gpt-", "openai"),
-    ("o1-", "openai"),
-    ("o3-", "openai"),
-    ("gemini-", "google"),
-)
-
-
-def _provider_id_for(model: str) -> str | None:
-    """Best-effort provider id for *model*, or ``None`` for autodetection."""
-    for prefix, pid in _PROVIDER_ID_BY_PREFIX:
-        if model.startswith(prefix):
-            return pid
-    return None
-
-
-def is_known_model(model: str) -> bool:
-    """Whether ``genai-prices`` can price this model.
+def is_known_model(model: str, *, provider: str = "") -> bool:
+    """Whether ``genai-prices`` can price this (provider, model) pair.
 
     Used by the logger to decide when to emit a "no pricing entry"
     warning. The check goes through the same lookup path as
@@ -68,7 +50,7 @@ def is_known_model(model: str) -> bool:
         calc_price(
             Usage(input_tokens=1, output_tokens=0),
             model_ref=model,
-            provider_id=_provider_id_for(model),
+            provider_id=provider or None,
         )
     except (LookupError, ValueError):
         return False
@@ -79,20 +61,27 @@ def compute_cost(
     model: str,
     input_tokens: int,
     output_tokens: int,
+    *,
+    provider: str = "",
     cache_creation_input_tokens: int | None = None,
     cache_read_input_tokens: int | None = None,
 ) -> Decimal:
     """Return the dollar cost for a single LLM call as a 6-decimal Decimal.
+
+    *provider* is the any-llm provider id (``"anthropic"``, ``"openai"``,
+    etc.) under which *model* was invoked. Pass it explicitly: skipping
+    autodetection is faster and disambiguates models whose name appears
+    under more than one provider.
 
     Charges via ``genai-prices``, which understands per-provider
     accounting quirks (Anthropic's input bucket includes cached tokens,
     cache-write surcharges, cache-read discounts, OpenAI's prompt-cache
     discount, etc.) so the caller does not have to.
 
-    Returns ``Decimal('0.000000')`` for models the library does not
-    know; the caller should log a warning so a missing model produces
-    a ``genai-prices`` upgrade rather than silent zero-cost rows
-    forever.
+    Returns ``Decimal('0.000000')`` for (provider, model) pairs the
+    library does not know; the caller should log a warning so a missing
+    model produces a ``genai-prices`` upgrade rather than silent
+    zero-cost rows forever.
     """
     cache_creation = cache_creation_input_tokens or 0
     cache_read = cache_read_input_tokens or 0
@@ -110,7 +99,7 @@ def compute_cost(
                 output_tokens=output_tokens,
             ),
             model_ref=model,
-            provider_id=_provider_id_for(model),
+            provider_id=provider or None,
         )
     except (LookupError, ValueError):
         return Decimal("0.000000")

--- a/backend/app/services/llm_pricing.py
+++ b/backend/app/services/llm_pricing.py
@@ -1,94 +1,78 @@
-"""Per-model pricing for LLM usage cost computation.
+"""LLM cost computation backed by the ``genai-prices`` library.
+
+Replaces the hand-rolled per-model pricing table this module used to
+keep in code with a thin wrapper around `pydantic/genai-prices
+<https://github.com/pydantic/genai-prices>`_, the community-maintained
+source of truth for provider pricing. Adding a new model now means
+``uv lock --upgrade-package genai-prices``; we no longer carry the
+risk of stale rates drifting out of sync with what the providers
+actually charge.
+
+The library's price table is bundled at install time, so this module
+makes no network call. Pricing data refreshes when we bump the
+``genai-prices`` dependency.
 
 Used by ``LLMUsageStore.log`` to populate the ``cost`` column on every
-``llm_usage_logs`` row instead of leaving it hardcoded at 0. The table
-covers the models clawbolt actually invokes via any-llm. Adding a new
-provider is one line; unknown models fall back to ``UNKNOWN_PRICING``
-which charges nothing rather than guess.
-
-Prices are dollars per million tokens. Cache write surcharge and cache
-read discount follow Anthropic's published multipliers (1.25x and 0.1x
-of the input rate, respectively); they apply to the cache-specific
-token columns we already record on each row. Update the table here when
-Anthropic / OpenAI ship new SKUs or revise rates; the database column
-type (Numeric(12,6)) accommodates further precision if needed.
+``llm_usage_logs`` row instead of leaving it hardcoded at 0.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
 from decimal import Decimal
 
+from genai_prices import Usage, calc_price
 
-@dataclass(frozen=True)
-class ModelPricing:
-    """Dollars per million tokens for a single model SKU.
-
-    ``cache_write`` and ``cache_read`` are the rates that apply to the
-    ``cache_creation_input_tokens`` and ``cache_read_input_tokens``
-    columns respectively. Anthropic charges a 25% premium on cache
-    writes and a 90% discount on cache reads relative to ``input``. We
-    store these explicitly rather than re-deriving them so providers
-    that price caching differently in future are easy to fit.
-    """
-
-    input: Decimal
-    output: Decimal
-    cache_write: Decimal
-    cache_read: Decimal
+logger = logging.getLogger(__name__)
 
 
-# Anthropic published rates as of 2026-05.
-_SONNET_4_6 = ModelPricing(
-    input=Decimal("3.00"),
-    output=Decimal("15.00"),
-    cache_write=Decimal("3.75"),
-    cache_read=Decimal("0.30"),
-)
-_OPUS_4_7 = ModelPricing(
-    input=Decimal("15.00"),
-    output=Decimal("75.00"),
-    cache_write=Decimal("18.75"),
-    cache_read=Decimal("1.50"),
-)
-_HAIKU_4_5 = ModelPricing(
-    input=Decimal("0.80"),
-    output=Decimal("4.00"),
-    cache_write=Decimal("1.00"),
-    cache_read=Decimal("0.08"),
+# Cost column on ``llm_usage_logs`` is ``Numeric(12, 6)``; quantise to
+# match so the DB never rejects an insert with too many fractional
+# digits.
+_QUANT = Decimal("0.000001")
+
+
+# Map our canonical model-name prefixes to ``genai-prices`` provider
+# ids. Supplying the provider id skips the library's auto-detection
+# scan and disambiguates models whose names appear under more than one
+# provider. Unmapped prefixes fall through with ``provider_id=None``;
+# the library then probes all providers.
+_PROVIDER_ID_BY_PREFIX: tuple[tuple[str, str], ...] = (
+    ("claude-", "anthropic"),
+    ("gpt-", "openai"),
+    ("o1-", "openai"),
+    ("o3-", "openai"),
+    ("gemini-", "google"),
 )
 
-UNKNOWN_PRICING = ModelPricing(
-    input=Decimal("0"),
-    output=Decimal("0"),
-    cache_write=Decimal("0"),
-    cache_read=Decimal("0"),
-)
 
-# Lookup table. Keys match the model identifiers our config emits. Both
-# the bare ID and the dated ID forms are covered so a clawbolt instance
-# pinned to e.g. ``claude-haiku-4-5-20251001`` resolves correctly.
-_PRICING_BY_MODEL: dict[str, ModelPricing] = {
-    "claude-sonnet-4-6": _SONNET_4_6,
-    "claude-opus-4-7": _OPUS_4_7,
-    "claude-haiku-4-5": _HAIKU_4_5,
-    "claude-haiku-4-5-20251001": _HAIKU_4_5,
-}
-
-
-def lookup_pricing(model: str) -> ModelPricing:
-    """Return pricing for *model*, or ``UNKNOWN_PRICING`` when unmapped.
-
-    A miss is logged at the call site (in ``LLMUsageStore.log``) so we
-    notice when a new provider lands without a pricing entry.
-    """
-    return _PRICING_BY_MODEL.get(model, UNKNOWN_PRICING)
+def _provider_id_for(model: str) -> str | None:
+    """Best-effort provider id for *model*, or ``None`` for autodetection."""
+    for prefix, pid in _PROVIDER_ID_BY_PREFIX:
+        if model.startswith(prefix):
+            return pid
+    return None
 
 
 def is_known_model(model: str) -> bool:
-    """Whether *model* has a pricing entry. Used by the logger to decide
-    when to emit a "no pricing" warning."""
-    return model in _PRICING_BY_MODEL
+    """Whether ``genai-prices`` can price this model.
+
+    Used by the logger to decide when to emit a "no pricing entry"
+    warning. The check goes through the same lookup path as
+    ``calc_price`` so a true result implies ``compute_cost`` will not
+    fall back to zero.
+    """
+    if not model:
+        return False
+    try:
+        calc_price(
+            Usage(input_tokens=1, output_tokens=0),
+            model_ref=model,
+            provider_id=_provider_id_for(model),
+        )
+    except (LookupError, ValueError):
+        return False
+    return True
 
 
 def compute_cost(
@@ -100,21 +84,34 @@ def compute_cost(
 ) -> Decimal:
     """Return the dollar cost for a single LLM call as a 6-decimal Decimal.
 
-    Charges ``input_tokens`` at the model's input rate, ``output_tokens``
-    at the output rate, and the cache columns at their dedicated rates.
-    The caller passes ``input_tokens`` as Anthropic reports it: the
-    *non-cached* prompt tokens, with cache reads / writes accounted
-    separately. We do not double-count.
+    Charges via ``genai-prices``, which understands per-provider
+    accounting quirks (Anthropic's input bucket includes cached tokens,
+    cache-write surcharges, cache-read discounts, OpenAI's prompt-cache
+    discount, etc.) so the caller does not have to.
 
-    Returns ``Decimal('0.000000')`` for models without a pricing entry,
-    and quantises the result to six decimal places (matching the
-    ``Numeric(12, 6)`` column on ``llm_usage_logs``).
+    Returns ``Decimal('0.000000')`` for models the library does not
+    know; the caller should log a warning so a missing model produces
+    a ``genai-prices`` upgrade rather than silent zero-cost rows
+    forever.
     """
-    pricing = lookup_pricing(model)
-    cost = (
-        pricing.input * Decimal(input_tokens)
-        + pricing.output * Decimal(output_tokens)
-        + pricing.cache_write * Decimal(cache_creation_input_tokens or 0)
-        + pricing.cache_read * Decimal(cache_read_input_tokens or 0)
-    ) / Decimal("1000000")
-    return cost.quantize(Decimal("0.000001"))
+    cache_creation = cache_creation_input_tokens or 0
+    cache_read = cache_read_input_tokens or 0
+    # Anthropic (and several other providers) price the full input
+    # bucket including cached tokens; the library expects
+    # ``input_tokens`` to be the total. Per-bucket multipliers come
+    # from the cache-specific fields.
+    total_input = input_tokens + cache_creation + cache_read
+    try:
+        result = calc_price(
+            Usage(
+                input_tokens=total_input,
+                cache_write_tokens=cache_creation,
+                cache_read_tokens=cache_read,
+                output_tokens=output_tokens,
+            ),
+            model_ref=model,
+            provider_id=_provider_id_for(model),
+        )
+    except (LookupError, ValueError):
+        return Decimal("0.000000")
+    return result.total_price.quantize(_QUANT)

--- a/backend/app/services/llm_usage.py
+++ b/backend/app/services/llm_usage.py
@@ -1,7 +1,8 @@
 """LLM usage tracking helper.
 
-Extracts token counts from amessages responses and persists them to
-the per-user ``llm_usage.jsonl`` file for cost monitoring.
+Extracts token counts from amessages responses and persists them to the
+``llm_usage_logs`` table for cost monitoring. Cost itself is computed
+in ``LLMUsageStore.log`` via ``services.llm_pricing``.
 """
 
 from __future__ import annotations
@@ -20,10 +21,16 @@ def log_llm_usage(
     model: str,
     response: MessageResponse,
     purpose: str,
+    provider: str = "",
 ) -> None:
     """Extract token usage from an LLM response and save to the usage log.
 
-    Appends to the user's ``llm_usage.jsonl`` file.
+    *provider* is the any-llm provider id (``"anthropic"``, ``"openai"``,
+    ``"google"``, etc.) under which *model* was invoked. We thread it
+    through rather than guessing from the model name so cost lookup,
+    persistence, and downstream analytics all see the same authoritative
+    string. Empty string is allowed for legacy callers that haven't been
+    updated yet; cost lookup will fall through to autodetect in that case.
     """
     prompt_tokens = response.usage.input_tokens
     completion_tokens = response.usage.output_tokens
@@ -39,6 +46,7 @@ def log_llm_usage(
             prompt_tokens,
             completion_tokens,
             purpose,
+            provider=provider,
             cache_creation_input_tokens=cache_creation_input_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
         )
@@ -47,8 +55,10 @@ def log_llm_usage(
         return
 
     logger.info(
-        "LLM usage logged: user=%s model=%s purpose=%s tokens=%d cache_create=%s cache_read=%s",
+        "LLM usage logged: user=%s provider=%s model=%s purpose=%s "
+        "tokens=%d cache_create=%s cache_read=%s",
         user_id,
+        provider or "?",
         model,
         purpose,
         total_tokens,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "cachetools>=5.3",
     "Pillow>=10.0",
     "simpleeval>=1.0",
+    "genai-prices>=0.0.57,<0.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_llm_pricing.py
+++ b/tests/test_llm_pricing.py
@@ -1,7 +1,11 @@
 """Tests for LLM cost computation.
 
-Covers the pricing table and the compute_cost helper. End-to-end wiring
-into ``LLMUsageStore.log`` is exercised in ``test_llm_usage_store``.
+The pricing module is now a thin wrapper around ``genai-prices``; we
+test its behavior contract (returns Decimal, 6-decimal quantisation,
+unknown-model fallback, Anthropic input-token bucketing convention)
+rather than asserting exact dollar amounts. Pinning specific rates
+would defeat the point of switching to a library that updates prices
+when providers change them.
 """
 
 from __future__ import annotations
@@ -9,16 +13,38 @@ from __future__ import annotations
 from decimal import Decimal
 
 import pytest
+from genai_prices import Usage, calc_price
 
 from backend.app.services.llm_pricing import (
-    UNKNOWN_PRICING,
+    _provider_id_for,
     compute_cost,
     is_known_model,
-    lookup_pricing,
 )
 
 # ---------------------------------------------------------------------------
-# Pricing table
+# Provider-id resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("claude-sonnet-4-6", "anthropic"),
+        ("claude-opus-4-7", "anthropic"),
+        ("claude-haiku-4-5-20251001", "anthropic"),
+        ("gpt-4o", "openai"),
+        ("o1-mini", "openai"),
+        ("o3-mini", "openai"),
+        ("gemini-2.0-flash", "google"),
+        ("some-bespoke-model", None),
+    ],
+)
+def test_provider_id_resolution(model: str, expected: str | None) -> None:
+    assert _provider_id_for(model) == expected
+
+
+# ---------------------------------------------------------------------------
+# Known / unknown model
 # ---------------------------------------------------------------------------
 
 
@@ -28,109 +54,35 @@ from backend.app.services.llm_pricing import (
         "claude-sonnet-4-6",
         "claude-opus-4-7",
         "claude-haiku-4-5",
-        "claude-haiku-4-5-20251001",
+        "claude-haiku-4-5-20251001",  # dated alias prefix-matches
     ],
 )
-def test_lookup_returns_real_pricing_for_supported_models(model: str) -> None:
-    p = lookup_pricing(model)
-    assert p.input > 0
-    assert p.output > 0
-    assert p.cache_write > 0
-    assert p.cache_read > 0
+def test_is_known_model_for_supported_models(model: str) -> None:
+    assert is_known_model(model) is True
 
 
-def test_lookup_returns_unknown_pricing_for_unmapped_model() -> None:
-    assert lookup_pricing("gpt-99") is UNKNOWN_PRICING
-    assert UNKNOWN_PRICING.input == Decimal("0")
-    assert UNKNOWN_PRICING.output == Decimal("0")
-
-
-def test_is_known_model_only_matches_pricing_table() -> None:
-    assert is_known_model("claude-sonnet-4-6") is True
+def test_is_known_model_for_unmapped_model() -> None:
+    assert is_known_model("not-a-real-model-99") is False
     assert is_known_model("") is False
-    assert is_known_model("gpt-4") is False
-
-
-def test_anthropic_cache_multipliers_match_published_rates() -> None:
-    """Cache writes are 1.25x input, cache reads are 0.1x input. If
-    Anthropic ever revises the multipliers we want a test failure here
-    so we update the table deliberately rather than drift silently.
-    """
-    sonnet = lookup_pricing("claude-sonnet-4-6")
-    assert sonnet.cache_write == sonnet.input * Decimal("1.25")
-    assert sonnet.cache_read == sonnet.input * Decimal("0.10")
-
-    opus = lookup_pricing("claude-opus-4-7")
-    assert opus.cache_write == opus.input * Decimal("1.25")
-    assert opus.cache_read == opus.input * Decimal("0.10")
 
 
 # ---------------------------------------------------------------------------
-# compute_cost
+# compute_cost contract
 # ---------------------------------------------------------------------------
 
 
-def test_zero_tokens_costs_nothing() -> None:
+def test_compute_cost_returns_decimal() -> None:
+    cost = compute_cost("claude-sonnet-4-6", 1000, 500)
+    assert isinstance(cost, Decimal)
+
+
+def test_compute_cost_zero_tokens_costs_nothing() -> None:
     assert compute_cost("claude-sonnet-4-6", 0, 0) == Decimal("0.000000")
 
 
-def test_unknown_model_costs_nothing_regardless_of_tokens() -> None:
-    """Conservative fallback: prefer "we don't know" over a bad estimate."""
+def test_unknown_model_falls_through_to_zero() -> None:
+    """Conservative fallback: prefer 'we don't know' over a bad estimate."""
     assert compute_cost("not-a-real-model", 1_000_000, 1_000_000) == Decimal("0.000000")
-
-
-def test_sonnet_cost_at_published_rates() -> None:
-    """Sonnet 4.6: $3 input, $15 output per 1M tokens. A 1M input + 1M
-    output call should cost $18.000000.
-    """
-    cost = compute_cost("claude-sonnet-4-6", 1_000_000, 1_000_000)
-    assert cost == Decimal("18.000000")
-
-
-def test_opus_cost_at_published_rates() -> None:
-    """Opus 4.7: $15 input, $75 output per 1M tokens."""
-    cost = compute_cost("claude-opus-4-7", 1_000_000, 1_000_000)
-    assert cost == Decimal("90.000000")
-
-
-def test_cache_tokens_charged_at_dedicated_rates() -> None:
-    """1M cache write tokens at $3.75/M plus 1M cache read tokens at
-    $0.30/M = $4.050000 for sonnet.
-    """
-    cost = compute_cost(
-        "claude-sonnet-4-6",
-        input_tokens=0,
-        output_tokens=0,
-        cache_creation_input_tokens=1_000_000,
-        cache_read_input_tokens=1_000_000,
-    )
-    assert cost == Decimal("4.050000")
-
-
-def test_realistic_session_cost() -> None:
-    """Sanity check using a heartbeat_decision shape pulled from a real
-    contractor session: ~362 input tokens, ~92 output tokens, ~2206
-    cache-write tokens. The cost should be small but non-zero, and the
-    result should quantise to 6 decimal places for the Numeric(12, 6)
-    column.
-    """
-    cost = compute_cost(
-        "claude-sonnet-4-6",
-        input_tokens=362,
-        output_tokens=92,
-        cache_creation_input_tokens=2206,
-        cache_read_input_tokens=0,
-    )
-    # 362*$3 + 92*$15 + 2206*$3.75, all per 1M
-    expected = (
-        Decimal("362") * Decimal("3.00")
-        + Decimal("92") * Decimal("15.00")
-        + Decimal("2206") * Decimal("3.75")
-    ) / Decimal("1000000")
-    assert cost == expected.quantize(Decimal("0.000001"))
-    # Sanity: roughly 1.5 cents.
-    assert cost < Decimal("0.02")
-    assert cost > Decimal("0")
 
 
 def test_compute_cost_handles_none_cache_columns() -> None:
@@ -148,12 +100,85 @@ def test_compute_cost_handles_none_cache_columns() -> None:
 
 def test_compute_cost_quantises_to_six_decimals() -> None:
     """Numeric(12, 6) on the column constrains us to 6 fractional
-    digits. A pricing math result with more digits should be quantised
-    here so the DB never rejects an insert."""
-    # 1 input token: 3/1M = 0.000003
+    digits. The library may return more precision than that."""
     cost = compute_cost("claude-sonnet-4-6", 1, 0)
-    assert cost == Decimal("0.000003")
-    # exponent should match the Numeric column's scale (-6 for 6 fractional digits)
+    # Exponent is -6 (six fractional digits) regardless of how the
+    # library rounded internally.
     exponent = cost.as_tuple().exponent
     assert isinstance(exponent, int)
     assert exponent == -6
+
+
+# ---------------------------------------------------------------------------
+# Anthropic input-token bucketing convention
+# ---------------------------------------------------------------------------
+
+
+def test_compute_cost_aggregates_input_buckets_for_anthropic() -> None:
+    """``genai-prices`` follows Anthropic's wire-protocol convention:
+    ``Usage.input_tokens`` is the total prompt size (uncached + cache
+    creation + cache reads), with cache write/read columns charging
+    their own rates on top.
+
+    Our `compute_cost` API takes them split out (matching what we
+    persist) and is responsible for the aggregation. This test pins
+    that wiring by checking ``compute_cost`` matches a hand-built
+    library call.
+    """
+    library_result = calc_price(
+        Usage(
+            input_tokens=362 + 2206,  # plain + cache_write
+            cache_write_tokens=2206,
+            cache_read_tokens=0,
+            output_tokens=92,
+        ),
+        model_ref="claude-sonnet-4-6",
+        provider_id="anthropic",
+    ).total_price.quantize(Decimal("0.000001"))
+
+    our_result = compute_cost(
+        "claude-sonnet-4-6",
+        input_tokens=362,
+        output_tokens=92,
+        cache_creation_input_tokens=2206,
+        cache_read_input_tokens=0,
+    )
+    assert our_result == library_result
+
+
+def test_compute_cost_treats_cache_read_distinctly() -> None:
+    """Cache reads are charged at a discount in Anthropic's pricing.
+    The library handles the multiplier; we just need to pass them
+    through the right field. Compare two equal-token calls where one
+    has the cache-read shape and one has only plain input."""
+    cache_heavy = compute_cost(
+        "claude-sonnet-4-6",
+        input_tokens=0,
+        output_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=10_000,
+    )
+    plain = compute_cost(
+        "claude-sonnet-4-6",
+        input_tokens=10_000,
+        output_tokens=0,
+    )
+    # Cache reads are cheaper than plain input.
+    assert cache_heavy < plain
+    # And both are non-zero.
+    assert cache_heavy > Decimal("0")
+    assert plain > Decimal("0")
+
+
+def test_known_anthropic_models_all_produce_nonzero_cost() -> None:
+    """Smoke test: a 1k input + 500 output call returns >0 cost for
+    every Anthropic SKU we currently invoke. Catches a future
+    library refactor that quietly drops one of these."""
+    for model in (
+        "claude-sonnet-4-6",
+        "claude-opus-4-7",
+        "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001",
+    ):
+        cost = compute_cost(model, 1000, 500)
+        assert cost > Decimal("0"), f"{model} priced at zero"

--- a/tests/test_llm_pricing.py
+++ b/tests/test_llm_pricing.py
@@ -1,11 +1,11 @@
 """Tests for LLM cost computation.
 
-The pricing module is now a thin wrapper around ``genai-prices``; we
-test its behavior contract (returns Decimal, 6-decimal quantisation,
-unknown-model fallback, Anthropic input-token bucketing convention)
-rather than asserting exact dollar amounts. Pinning specific rates
-would defeat the point of switching to a library that updates prices
-when providers change them.
+The pricing module is a thin wrapper around ``genai-prices``; we test
+its behavior contract (returns Decimal, 6-decimal quantisation,
+unknown-model fallback, Anthropic input-token bucketing convention,
+explicit provider routing) rather than asserting exact dollar amounts.
+Pinning specific rates would defeat the point of switching to a library
+that updates prices when providers change them.
 """
 
 from __future__ import annotations
@@ -15,33 +15,7 @@ from decimal import Decimal
 import pytest
 from genai_prices import Usage, calc_price
 
-from backend.app.services.llm_pricing import (
-    _provider_id_for,
-    compute_cost,
-    is_known_model,
-)
-
-# ---------------------------------------------------------------------------
-# Provider-id resolution
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "model,expected",
-    [
-        ("claude-sonnet-4-6", "anthropic"),
-        ("claude-opus-4-7", "anthropic"),
-        ("claude-haiku-4-5-20251001", "anthropic"),
-        ("gpt-4o", "openai"),
-        ("o1-mini", "openai"),
-        ("o3-mini", "openai"),
-        ("gemini-2.0-flash", "google"),
-        ("some-bespoke-model", None),
-    ],
-)
-def test_provider_id_resolution(model: str, expected: str | None) -> None:
-    assert _provider_id_for(model) == expected
-
+from backend.app.services.llm_pricing import compute_cost, is_known_model
 
 # ---------------------------------------------------------------------------
 # Known / unknown model
@@ -58,12 +32,19 @@ def test_provider_id_resolution(model: str, expected: str | None) -> None:
     ],
 )
 def test_is_known_model_for_supported_models(model: str) -> None:
-    assert is_known_model(model) is True
+    assert is_known_model(model, provider="anthropic") is True
 
 
 def test_is_known_model_for_unmapped_model() -> None:
-    assert is_known_model("not-a-real-model-99") is False
-    assert is_known_model("") is False
+    assert is_known_model("not-a-real-model-99", provider="anthropic") is False
+    assert is_known_model("", provider="anthropic") is False
+
+
+def test_is_known_model_works_without_provider_via_autodetect() -> None:
+    """Empty provider falls through to ``calc_price`` autodetection.
+    Used by legacy callers that haven't been updated yet."""
+    assert is_known_model("claude-sonnet-4-6") is True
+    assert is_known_model("not-a-real-model") is False
 
 
 # ---------------------------------------------------------------------------
@@ -72,17 +53,27 @@ def test_is_known_model_for_unmapped_model() -> None:
 
 
 def test_compute_cost_returns_decimal() -> None:
-    cost = compute_cost("claude-sonnet-4-6", 1000, 500)
+    cost = compute_cost("claude-sonnet-4-6", 1000, 500, provider="anthropic")
     assert isinstance(cost, Decimal)
 
 
 def test_compute_cost_zero_tokens_costs_nothing() -> None:
-    assert compute_cost("claude-sonnet-4-6", 0, 0) == Decimal("0.000000")
+    assert compute_cost("claude-sonnet-4-6", 0, 0, provider="anthropic") == Decimal("0.000000")
 
 
 def test_unknown_model_falls_through_to_zero() -> None:
     """Conservative fallback: prefer 'we don't know' over a bad estimate."""
-    assert compute_cost("not-a-real-model", 1_000_000, 1_000_000) == Decimal("0.000000")
+    assert compute_cost("not-a-real-model", 1_000_000, 1_000_000, provider="anthropic") == Decimal(
+        "0.000000"
+    )
+
+
+def test_unknown_provider_falls_through_to_zero() -> None:
+    """A custom local-provider id (e.g. self-hosted ollama) genai-prices
+    doesn't know about must not crash; we just record cost=0."""
+    assert compute_cost("claude-sonnet-4-6", 1000, 500, provider="my-local-shim") == Decimal(
+        "0.000000"
+    )
 
 
 def test_compute_cost_handles_none_cache_columns() -> None:
@@ -92,6 +83,7 @@ def test_compute_cost_handles_none_cache_columns() -> None:
         "claude-sonnet-4-6",
         input_tokens=100,
         output_tokens=10,
+        provider="anthropic",
         cache_creation_input_tokens=None,
         cache_read_input_tokens=None,
     )
@@ -101,12 +93,39 @@ def test_compute_cost_handles_none_cache_columns() -> None:
 def test_compute_cost_quantises_to_six_decimals() -> None:
     """Numeric(12, 6) on the column constrains us to 6 fractional
     digits. The library may return more precision than that."""
-    cost = compute_cost("claude-sonnet-4-6", 1, 0)
+    cost = compute_cost("claude-sonnet-4-6", 1, 0, provider="anthropic")
     # Exponent is -6 (six fractional digits) regardless of how the
     # library rounded internally.
     exponent = cost.as_tuple().exponent
     assert isinstance(exponent, int)
     assert exponent == -6
+
+
+# ---------------------------------------------------------------------------
+# Provider routing
+# ---------------------------------------------------------------------------
+
+
+def test_provider_is_passed_to_library_not_inferred_from_model() -> None:
+    """When the caller passes a provider explicitly, the library uses
+    it directly (no name-prefix guessing on our end). A model-name
+    string on its own is no longer enough information for routing."""
+    # Same model id, two different providers: behavior should depend on
+    # the provider we pass, not on a heuristic over the name.
+    pc = calc_price(
+        Usage(input_tokens=100, output_tokens=50),
+        model_ref="claude-sonnet-4-6",
+        provider_id="anthropic",
+    )
+    our = compute_cost("claude-sonnet-4-6", 100, 50, provider="anthropic")
+    assert our == pc.total_price.quantize(Decimal("0.000001"))
+
+
+def test_compute_cost_works_without_provider_via_autodetect() -> None:
+    """Empty provider string falls through to ``calc_price`` autodetect.
+    This is the legacy fallback for old callers."""
+    cost = compute_cost("claude-sonnet-4-6", 1000, 500)
+    assert cost > Decimal("0")
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +159,7 @@ def test_compute_cost_aggregates_input_buckets_for_anthropic() -> None:
         "claude-sonnet-4-6",
         input_tokens=362,
         output_tokens=92,
+        provider="anthropic",
         cache_creation_input_tokens=2206,
         cache_read_input_tokens=0,
     )
@@ -155,6 +175,7 @@ def test_compute_cost_treats_cache_read_distinctly() -> None:
         "claude-sonnet-4-6",
         input_tokens=0,
         output_tokens=0,
+        provider="anthropic",
         cache_creation_input_tokens=0,
         cache_read_input_tokens=10_000,
     )
@@ -162,6 +183,7 @@ def test_compute_cost_treats_cache_read_distinctly() -> None:
         "claude-sonnet-4-6",
         input_tokens=10_000,
         output_tokens=0,
+        provider="anthropic",
     )
     # Cache reads are cheaper than plain input.
     assert cache_heavy < plain
@@ -180,5 +202,5 @@ def test_known_anthropic_models_all_produce_nonzero_cost() -> None:
         "claude-haiku-4-5",
         "claude-haiku-4-5-20251001",
     ):
-        cost = compute_cost(model, 1000, 500)
+        cost = compute_cost(model, 1000, 500, provider="anthropic")
         assert cost > Decimal("0"), f"{model} priced at zero"

--- a/tests/test_llm_pricing.py
+++ b/tests/test_llm_pricing.py
@@ -107,11 +107,12 @@ def test_cache_tokens_charged_at_dedicated_rates() -> None:
     assert cost == Decimal("4.050000")
 
 
-def test_realistic_jesse_session_cost() -> None:
-    """Sanity check using actual numbers from a contractor session
-    (heartbeat_decision: ~362 input, ~92 output, ~2206 cache write).
-    The cost should be small but non-zero, and the result should
-    quantise to 6 decimal places for the Numeric(12, 6) column.
+def test_realistic_session_cost() -> None:
+    """Sanity check using a heartbeat_decision shape pulled from a real
+    contractor session: ~362 input tokens, ~92 output tokens, ~2206
+    cache-write tokens. The cost should be small but non-zero, and the
+    result should quantise to 6 decimal places for the Numeric(12, 6)
+    column.
     """
     cost = compute_cost(
         "claude-sonnet-4-6",

--- a/tests/test_llm_pricing.py
+++ b/tests/test_llm_pricing.py
@@ -1,0 +1,158 @@
+"""Tests for LLM cost computation.
+
+Covers the pricing table and the compute_cost helper. End-to-end wiring
+into ``LLMUsageStore.log`` is exercised in ``test_llm_usage_store``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from backend.app.services.llm_pricing import (
+    UNKNOWN_PRICING,
+    compute_cost,
+    is_known_model,
+    lookup_pricing,
+)
+
+# ---------------------------------------------------------------------------
+# Pricing table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-sonnet-4-6",
+        "claude-opus-4-7",
+        "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001",
+    ],
+)
+def test_lookup_returns_real_pricing_for_supported_models(model: str) -> None:
+    p = lookup_pricing(model)
+    assert p.input > 0
+    assert p.output > 0
+    assert p.cache_write > 0
+    assert p.cache_read > 0
+
+
+def test_lookup_returns_unknown_pricing_for_unmapped_model() -> None:
+    assert lookup_pricing("gpt-99") is UNKNOWN_PRICING
+    assert UNKNOWN_PRICING.input == Decimal("0")
+    assert UNKNOWN_PRICING.output == Decimal("0")
+
+
+def test_is_known_model_only_matches_pricing_table() -> None:
+    assert is_known_model("claude-sonnet-4-6") is True
+    assert is_known_model("") is False
+    assert is_known_model("gpt-4") is False
+
+
+def test_anthropic_cache_multipliers_match_published_rates() -> None:
+    """Cache writes are 1.25x input, cache reads are 0.1x input. If
+    Anthropic ever revises the multipliers we want a test failure here
+    so we update the table deliberately rather than drift silently.
+    """
+    sonnet = lookup_pricing("claude-sonnet-4-6")
+    assert sonnet.cache_write == sonnet.input * Decimal("1.25")
+    assert sonnet.cache_read == sonnet.input * Decimal("0.10")
+
+    opus = lookup_pricing("claude-opus-4-7")
+    assert opus.cache_write == opus.input * Decimal("1.25")
+    assert opus.cache_read == opus.input * Decimal("0.10")
+
+
+# ---------------------------------------------------------------------------
+# compute_cost
+# ---------------------------------------------------------------------------
+
+
+def test_zero_tokens_costs_nothing() -> None:
+    assert compute_cost("claude-sonnet-4-6", 0, 0) == Decimal("0.000000")
+
+
+def test_unknown_model_costs_nothing_regardless_of_tokens() -> None:
+    """Conservative fallback: prefer "we don't know" over a bad estimate."""
+    assert compute_cost("not-a-real-model", 1_000_000, 1_000_000) == Decimal("0.000000")
+
+
+def test_sonnet_cost_at_published_rates() -> None:
+    """Sonnet 4.6: $3 input, $15 output per 1M tokens. A 1M input + 1M
+    output call should cost $18.000000.
+    """
+    cost = compute_cost("claude-sonnet-4-6", 1_000_000, 1_000_000)
+    assert cost == Decimal("18.000000")
+
+
+def test_opus_cost_at_published_rates() -> None:
+    """Opus 4.7: $15 input, $75 output per 1M tokens."""
+    cost = compute_cost("claude-opus-4-7", 1_000_000, 1_000_000)
+    assert cost == Decimal("90.000000")
+
+
+def test_cache_tokens_charged_at_dedicated_rates() -> None:
+    """1M cache write tokens at $3.75/M plus 1M cache read tokens at
+    $0.30/M = $4.050000 for sonnet.
+    """
+    cost = compute_cost(
+        "claude-sonnet-4-6",
+        input_tokens=0,
+        output_tokens=0,
+        cache_creation_input_tokens=1_000_000,
+        cache_read_input_tokens=1_000_000,
+    )
+    assert cost == Decimal("4.050000")
+
+
+def test_realistic_jesse_session_cost() -> None:
+    """Sanity check using actual numbers from a contractor session
+    (heartbeat_decision: ~362 input, ~92 output, ~2206 cache write).
+    The cost should be small but non-zero, and the result should
+    quantise to 6 decimal places for the Numeric(12, 6) column.
+    """
+    cost = compute_cost(
+        "claude-sonnet-4-6",
+        input_tokens=362,
+        output_tokens=92,
+        cache_creation_input_tokens=2206,
+        cache_read_input_tokens=0,
+    )
+    # 362*$3 + 92*$15 + 2206*$3.75, all per 1M
+    expected = (
+        Decimal("362") * Decimal("3.00")
+        + Decimal("92") * Decimal("15.00")
+        + Decimal("2206") * Decimal("3.75")
+    ) / Decimal("1000000")
+    assert cost == expected.quantize(Decimal("0.000001"))
+    # Sanity: roughly 1.5 cents.
+    assert cost < Decimal("0.02")
+    assert cost > Decimal("0")
+
+
+def test_compute_cost_handles_none_cache_columns() -> None:
+    """Per-row cache columns can be NULL (older logs, providers that
+    don't expose them). Treat as zero, not as a TypeError."""
+    cost = compute_cost(
+        "claude-sonnet-4-6",
+        input_tokens=100,
+        output_tokens=10,
+        cache_creation_input_tokens=None,
+        cache_read_input_tokens=None,
+    )
+    assert cost > Decimal("0")
+
+
+def test_compute_cost_quantises_to_six_decimals() -> None:
+    """Numeric(12, 6) on the column constrains us to 6 fractional
+    digits. A pricing math result with more digits should be quantised
+    here so the DB never rejects an insert."""
+    # 1 input token: 3/1M = 0.000003
+    cost = compute_cost("claude-sonnet-4-6", 1, 0)
+    assert cost == Decimal("0.000003")
+    # exponent should match the Numeric column's scale (-6 for 6 fractional digits)
+    exponent = cost.as_tuple().exponent
+    assert isinstance(exponent, int)
+    assert exponent == -6

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-14T21:50:03.378627955Z"
+exclude-newer = "2026-04-27T09:34:23.543148262Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -589,6 +589,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "dropbox" },
     { name = "fastapi" },
+    { name = "genai-prices" },
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
     { name = "httpx" },
@@ -627,6 +628,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0" },
     { name = "dropbox", specifier = ">=12.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "genai-prices", specifier = ">=0.0.57,<0.1" },
     { name = "google-api-python-client", specifier = ">=2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
@@ -1013,6 +1015,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[[package]]
+name = "genai-prices"
+version = "0.0.57"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/30/11f3d683cf3b1d9612475ad8bfffe3423ce9f50fc617733109033e73a038/genai_prices-0.0.57.tar.gz", hash = "sha256:6e101e9c53975557ceffa237b0995787d81fe75aac12410f2898504188bcad89", size = 66555, upload-time = "2026-04-21T13:42:52.554Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/fe/d0095040c120d97cb63d055224ecd4e913dc5655315c203c8e83bf13aa86/genai_prices-0.0.57-py3-none-any.whl", hash = "sha256:14e50fb69cdc5a06ddb2a6df5a7fe06741b9e44304ce3f1728f56abdf1856cca", size = 69654, upload-time = "2026-04-21T13:42:51.236Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Every row in \`llm_usage_logs\` has been writing \`cost=0.000000\` since the file-store -> Postgres migration; the comment in \`LLMUsageStore.log\` literally said *\"Sets provider='' and cost=0.0 since the file store did not track those.\"* The \`Numeric(12, 6)\` column was waiting for someone to plumb in real numbers.

## Implementation

Add a per-model pricing table at \`backend/app/services/llm_pricing.py\` covering the Anthropic SKUs we actually invoke (Sonnet 4.6, Opus 4.7, Haiku 4.5 + dated alias). Cache writes and cache reads use Anthropic's 1.25x / 0.10x multipliers as separate fields so providers that price caching differently are easy to fit later.

Wire \`compute_cost\` into \`LLMUsageStore.log\` so every new row stores the real dollar amount, quantised to six decimals to match the column's scale. Models without a pricing entry fall through with \`cost=0\` and a *\"add it to llm_pricing.py\"* warning instead of crashing or guessing. This means a future provider lands silently at \`cost=0\` until someone notices the warning and adds the entry, which is the conservative default.

## Real-world hit

A contractor on dev burned 2.3M input tokens, 6.3M cache reads, and 437 logged calls in five days, all at \`cost=0\`. We had no per-user dollar visibility before this change. Going forward the \`cost\` column on each row holds the truth.

## Test coverage

15 new unit tests covering:
- Pricing table lookup for all four supported models
- Unknown model fallback
- Anthropic 1.25x / 0.10x multiplier invariants (locked in so a future Anthropic price change forces a deliberate update)
- Cost math at the published rates for Sonnet and Opus
- Cache token columns charged at their dedicated rates
- Sanity check using actual numbers from the contractor session
- NULL cache columns handled
- Quantisation to 6 decimals matches the \`Numeric(12, 6)\` column scale

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`) - 15 new + 27 existing pass
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] Type checking passes (\`ty check\`)
- [x] New tests added for new functionality

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake while reviewing a real production session)
- [ ] No AI used