### PR TITLE
fix(ingestion): recover orphan inbound messages on app startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,7 @@ STORAGE_PROVIDER=local
 # APPROVAL_TIMEOUT_SECONDS=120  # Seconds to wait for user approval before denying
 # AGENT_PROCESSING_TIMEOUT_SECONDS=300  # Max seconds for agent processing (includes lock wait)
 # MESSAGE_BATCH_WINDOW_MS=1500  # Batch rapid-fire messages per user (0 to disable)
+# INBOUND_RECOVERY_LOOKBACK_MINUTES=30  # Sweep for inbound messages persisted but never run on startup (0 disables)
 # MAX_TOOL_ROUNDS=10
 # MAX_INPUT_TOKENS=120000
 # CONTEXT_TRIM_TARGET_TOKENS=80000

--- a/backend/app/agent/inbound_recovery.py
+++ b/backend/app/agent/inbound_recovery.py
@@ -1,0 +1,244 @@
+"""Startup recovery for orphaned inbound messages.
+
+The ingestion path persists every inbound to ``messages`` *before* the
+``MessageBatcher`` schedules an in-memory flush timer (1.5 s by default).
+When a worker dies during that window (deploy, OOM, crash), the timer
+task is lost. The message is durable in the DB but the pipeline never
+runs, so the user gets silence: no agent reply, no outbound, just a
+message sitting in history that the next inbound proceeds past.
+
+We saw this in production: a contractor's "Can you change my calendar
+reminders to my work iCloud?" landed in the DB at 2026-04-30 15:01 UTC
+but received no reply for 29 hours, until the next message woke a fresh
+batcher state.
+
+This module sweeps for those orphans on app startup. The sweep is
+narrowly scoped:
+
+- Only inbound messages from the last ``inbound_recovery_lookback_minutes``
+  (default 30) are considered. Older orphans are unlikely to still be
+  relevant to the user and re-dispatching would produce a stale reply.
+- A message is "orphaned" when there is no outbound ``message`` in the
+  same session with a higher seq. Outbound is the only structural
+  signal that the agent loop ran for that inbound.
+- We re-dispatch through ``_dispatch_to_pipeline`` rather than the bus,
+  so ``add_message`` does not duplicate the persisted row. The agent
+  loop sees the same session state it would have seen at the original
+  dispatch.
+
+The mechanism is structurally similar to ``cleanup_orphaned_approvals``:
+both run in ``lifespan`` after channels start, both are best-effort, and
+both log every recovery decision so an operator can see what fired on
+the boot after an incident.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from sqlalchemy import and_, exists
+
+from backend.app.agent.context import get_or_create_conversation
+from backend.app.agent.dto import SessionState, StoredMessage
+from backend.app.config import settings
+from backend.app.database import SessionLocal
+from backend.app.enums import MessageDirection
+from backend.app.models import ChatSession, Message, User
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def _find_orphaned_inbounds(
+    db: Session,
+    cutoff_utc: datetime.datetime,
+) -> list[tuple[Message, ChatSession]]:
+    """Return (message, session) pairs for inbound rows with no outbound after.
+
+    "Outbound after" means a Message in the same session with strictly
+    higher seq and direction='outbound'. The seq comparison handles the
+    case where a heartbeat or compaction event might have raced past
+    the inbound and flushed a follow-on message: any outbound at all
+    after the inbound is enough to declare it processed.
+    """
+    OutboundAfter = Message.__table__.alias("ob")
+    has_outbound_after = exists().where(
+        and_(
+            OutboundAfter.c.session_id == Message.session_id,
+            OutboundAfter.c.seq > Message.seq,
+            OutboundAfter.c.direction == MessageDirection.OUTBOUND,
+        )
+    )
+    rows = (
+        db.query(Message, ChatSession)
+        .join(ChatSession, Message.session_id == ChatSession.id)
+        .filter(
+            Message.direction == MessageDirection.INBOUND,
+            Message.timestamp >= cutoff_utc,
+            ~has_outbound_after,
+        )
+        .order_by(Message.timestamp.asc())
+        .all()
+    )
+    # Convert Row objects to plain tuples so callers don't need to know
+    # the Row API.
+    return [(row[0], row[1]) for row in rows]
+
+
+def _build_dispatch_inputs(
+    db: Session,
+    msg: Message,
+    chat_session: ChatSession,
+) -> tuple[User, SessionState, StoredMessage] | None:
+    """Reconstruct the (user, session_state, stored_message) tuple needed by
+    ``_dispatch_to_pipeline``. Returns None when the user row is missing
+    (extremely unlikely outside of a manual delete during the window)."""
+    user = db.query(User).filter_by(id=chat_session.user_id).first()
+    if user is None:
+        logger.warning(
+            "Skipping orphan recovery for message %d: user %s not found",
+            msg.id,
+            chat_session.user_id,
+        )
+        return None
+    db.expunge(user)
+
+    stored = StoredMessage(
+        direction=msg.direction,
+        body=msg.body or "",
+        processed_context=msg.processed_context or "",
+        tool_interactions_json=msg.tool_interactions_json or "",
+        external_message_id=msg.external_message_id or "",
+        media_urls_json=msg.media_urls_json or "[]",
+        timestamp=msg.timestamp.isoformat() if msg.timestamp else "",
+        seq=msg.seq,
+    )
+
+    state = SessionState(
+        session_id=chat_session.session_id,
+        user_id=chat_session.user_id,
+        messages=[stored],
+        is_active=chat_session.is_active,
+        created_at=chat_session.created_at.isoformat() if chat_session.created_at else "",
+        last_message_at=(
+            chat_session.last_message_at.isoformat() if chat_session.last_message_at else ""
+        ),
+        channel=chat_session.channel or "",
+        last_compacted_seq=chat_session.last_compacted_seq,
+    )
+    return user, state, stored
+
+
+def _parse_media_refs(media_urls_json: str) -> list[tuple[str, str]]:
+    """Reconstruct ``media_refs`` from the persisted JSON list of file ids.
+
+    The original ``InboundMessage.media_refs`` is ``list[tuple[str, str]]``
+    (file_id, mime_type). The DB only persists the file_ids list, so the
+    mime_type is unrecoverable. Empty string is the safe fallback: the
+    media pipeline re-derives mime types from the stored file when needed.
+    """
+    if not media_urls_json:
+        return []
+    try:
+        ids = json.loads(media_urls_json)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(ids, list):
+        return []
+    return [(str(fid), "") for fid in ids]
+
+
+async def recover_orphan_inbound_messages() -> int:
+    """Re-dispatch any inbound messages that look like they never ran.
+
+    Called from ``lifespan`` after channels start. Returns the number of
+    messages re-dispatched, mostly for the startup log line. Best-effort:
+    the sweep itself is wrapped in try/except by the caller so a recovery
+    bug never blocks app startup.
+    """
+    # Imported here to avoid a circular import: ingestion imports from this
+    # module's siblings, and we only need the dispatch function at call time.
+    from backend.app.agent.ingestion import _dispatch_to_pipeline
+
+    lookback_minutes = settings.inbound_recovery_lookback_minutes
+    if lookback_minutes == 0:
+        logger.debug("Inbound recovery disabled (inbound_recovery_lookback_minutes=0)")
+        return 0
+
+    lookback = datetime.timedelta(minutes=lookback_minutes)
+    cutoff = datetime.datetime.now(datetime.UTC) - lookback
+
+    db = SessionLocal()
+    try:
+        rows = _find_orphaned_inbounds(db, cutoff)
+        if not rows:
+            return 0
+
+        logger.info(
+            "Inbound recovery: found %d orphan(s) since %s",
+            len(rows),
+            cutoff.isoformat(),
+        )
+
+        dispatched = 0
+        for msg, chat_session in rows:
+            inputs = _build_dispatch_inputs(db, msg, chat_session)
+            if inputs is None:
+                continue
+            user, state, stored = inputs
+            channel = chat_session.channel or ""
+            media_refs = _parse_media_refs(msg.media_urls_json or "")
+            try:
+                # Re-run the original conversation lookup so any session
+                # rotation that happened since the message was written is
+                # honored. Falls back to the reconstructed state above if
+                # this raises.
+                refreshed_state, _ = await get_or_create_conversation(
+                    user.id, external_session_id=chat_session.session_id
+                )
+                state = refreshed_state if refreshed_state is not None else state
+            except Exception:
+                logger.exception(
+                    "get_or_create_conversation failed during inbound recovery for user %s",
+                    user.id,
+                )
+
+            logger.info(
+                "Re-dispatching orphan inbound seq=%d session=%s user=%s",
+                msg.seq,
+                chat_session.session_id,
+                user.id,
+            )
+            try:
+                await _dispatch_to_pipeline(
+                    user=user,
+                    session=state,
+                    message=stored,
+                    media_urls=media_refs,
+                    channel=channel,
+                    request_id="",
+                    downloaded_media=None,
+                    download_media=None,
+                )
+                dispatched += 1
+            except Exception:
+                logger.exception(
+                    "Failed to re-dispatch orphan inbound seq=%d (session %s, user %s)",
+                    msg.seq,
+                    chat_session.session_id,
+                    user.id,
+                )
+
+        return dispatched
+    finally:
+        db.close()
+
+
+__all__ = [
+    "recover_orphan_inbound_messages",
+]

--- a/backend/app/agent/inbound_recovery.py
+++ b/backend/app/agent/inbound_recovery.py
@@ -18,6 +18,10 @@ narrowly scoped:
 - Only inbound messages from the last ``inbound_recovery_lookback_minutes``
   (default 30) are considered. Older orphans are unlikely to still be
   relevant to the user and re-dispatching would produce a stale reply.
+- Only inbounds at least ``_FRESHNESS_FLOOR_SECONDS`` old are considered,
+  so a NEW inbound arriving on a freshly-started worker (concurrent with
+  this sweep) doesn't get racing dispatched once by the normal ingestion
+  path and again by recovery.
 - A message is "orphaned" when there is no outbound ``message`` in the
   same session with a higher seq. Outbound is the only structural
   signal that the agent loop ran for that inbound.
@@ -25,6 +29,18 @@ narrowly scoped:
   so ``add_message`` does not duplicate the persisted row. The agent
   loop sees the same session state it would have seen at the original
   dispatch.
+- A Postgres advisory lock (``inbound_recovery:cleanup``) ensures
+  exactly one worker runs the sweep on a rolling restart, mirroring the
+  pattern in ``cleanup_orphaned_approvals``.
+
+Known limitation: a heartbeat or compaction outbound that landed AFTER
+the orphan inbound but BEFORE the worker recovered will mask the orphan
+(the EXISTS subquery sees that outbound and treats the inbound as
+processed). This is structural to using "any later outbound" as the
+signal. Fixing it would require either a column distinguishing
+heartbeat-origin outbounds from agent-loop replies, or a
+``responding_to_seq`` foreign key on outbound rows; both are larger
+changes deferred until the heuristic produces a real false negative.
 
 The mechanism is structurally similar to ``cleanup_orphaned_approvals``:
 both run in ``lifespan`` after channels start, both are best-effort, and
@@ -39,10 +55,11 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from sqlalchemy import and_, exists
+from sqlalchemy import and_, exists, text
 
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.dto import SessionState, StoredMessage
+from backend.app.agent.ingestion import _dispatch_to_pipeline
 from backend.app.config import settings
 from backend.app.database import SessionLocal
 from backend.app.enums import MessageDirection
@@ -54,17 +71,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Postgres advisory lock key. ``hashtext`` reduces the string to an int
+# the lock function accepts. Same shape as ``approval._CLEANUP_LOCK_KEY``.
+_RECOVERY_LOCK_KEY = "inbound_recovery:cleanup"
+
+# Don't try to recover messages younger than this. The normal ingestion
+# path is dispatching them right now (via the in-memory MessageBatcher
+# timer), and a parallel recovery would race it. 5 s comfortably covers
+# the 1.5 s batcher window plus pipeline acquisition latency.
+_FRESHNESS_FLOOR_SECONDS = 5
+
+
 def _find_orphaned_inbounds(
     db: Session,
     cutoff_utc: datetime.datetime,
+    freshness_floor_utc: datetime.datetime,
 ) -> list[tuple[Message, ChatSession]]:
     """Return (message, session) pairs for inbound rows with no outbound after.
 
     "Outbound after" means a Message in the same session with strictly
     higher seq and direction='outbound'. The seq comparison handles the
     case where a heartbeat or compaction event might have raced past
-    the inbound and flushed a follow-on message: any outbound at all
-    after the inbound is enough to declare it processed.
+    the inbound: any outbound at all after the inbound is enough to
+    declare it processed (with the documented heartbeat-masking
+    limitation).
+
+    *freshness_floor_utc* excludes messages newer than this timestamp so
+    the sweep doesn't race the normal ingestion path on a brand-new
+    inbound that arrived during the sweep itself.
     """
     OutboundAfter = Message.__table__.alias("ob")
     has_outbound_after = exists().where(
@@ -80,6 +114,7 @@ def _find_orphaned_inbounds(
         .filter(
             Message.direction == MessageDirection.INBOUND,
             Message.timestamp >= cutoff_utc,
+            Message.timestamp <= freshness_floor_utc,
             ~has_outbound_after,
         )
         .order_by(Message.timestamp.asc())
@@ -96,8 +131,19 @@ def _build_dispatch_inputs(
     chat_session: ChatSession,
 ) -> tuple[User, SessionState, StoredMessage] | None:
     """Reconstruct the (user, session_state, stored_message) tuple needed by
-    ``_dispatch_to_pipeline``. Returns None when the user row is missing
-    (extremely unlikely outside of a manual delete during the window)."""
+    ``_dispatch_to_pipeline``.
+
+    The returned ``SessionState`` carries only the orphan message in its
+    ``messages`` list. That is intentional: ``_dispatch_to_pipeline``
+    re-loads the full session from the DB before invoking the agent loop
+    (see ``ingestion.py:_dispatch_to_pipeline`` -> ``handle_inbound_message``
+    -> ``router._build_message_context``). The single-message state here
+    just carries the ``session_id`` so the dispatcher knows which session
+    to load.
+
+    Returns None when the user row is missing (extremely unlikely outside
+    of a manual delete during the recovery window).
+    """
     user = db.query(User).filter_by(id=chat_session.user_id).first()
     if user is None:
         logger.warning(
@@ -153,6 +199,38 @@ def _parse_media_refs(media_urls_json: str) -> list[tuple[str, str]]:
     return [(str(fid), "") for fid in ids]
 
 
+def _try_acquire_lock(db: Session) -> bool:
+    """Acquire the per-process recovery lock, mirroring approval cleanup.
+
+    ``pg_try_advisory_lock`` returns True on first acquisition, False if
+    another connection (i.e. another worker on a rolling restart) holds
+    the lock. We commit immediately to release the implicit read
+    transaction; the advisory lock itself is session-scoped and survives.
+    """
+    try:
+        got_lock = db.execute(
+            text("SELECT pg_try_advisory_lock(hashtext(:k))"),
+            {"k": _RECOVERY_LOCK_KEY},
+        ).scalar()
+        db.commit()
+    except Exception:
+        logger.exception("Failed to acquire inbound-recovery advisory lock")
+        return False
+    return bool(got_lock)
+
+
+def _release_lock(db: Session) -> None:
+    """Best-effort release of the recovery lock."""
+    try:
+        db.execute(
+            text("SELECT pg_advisory_unlock(hashtext(:k))"),
+            {"k": _RECOVERY_LOCK_KEY},
+        )
+        db.commit()
+    except Exception:
+        logger.exception("Failed to release inbound-recovery advisory lock")
+
+
 async def recover_orphan_inbound_messages() -> int:
     """Re-dispatch any inbound messages that look like they never ran.
 
@@ -161,28 +239,32 @@ async def recover_orphan_inbound_messages() -> int:
     the sweep itself is wrapped in try/except by the caller so a recovery
     bug never blocks app startup.
     """
-    # Imported here to avoid a circular import: ingestion imports from this
-    # module's siblings, and we only need the dispatch function at call time.
-    from backend.app.agent.ingestion import _dispatch_to_pipeline
-
     lookback_minutes = settings.inbound_recovery_lookback_minutes
     if lookback_minutes == 0:
         logger.debug("Inbound recovery disabled (inbound_recovery_lookback_minutes=0)")
         return 0
 
-    lookback = datetime.timedelta(minutes=lookback_minutes)
-    cutoff = datetime.datetime.now(datetime.UTC) - lookback
+    now = datetime.datetime.now(datetime.UTC)
+    cutoff = now - datetime.timedelta(minutes=lookback_minutes)
+    freshness_floor = now - datetime.timedelta(seconds=_FRESHNESS_FLOOR_SECONDS)
 
     db = SessionLocal()
+    lock_acquired = False
     try:
-        rows = _find_orphaned_inbounds(db, cutoff)
+        if not _try_acquire_lock(db):
+            logger.info("Another worker is running inbound recovery; skipping on this boot")
+            return 0
+        lock_acquired = True
+
+        rows = _find_orphaned_inbounds(db, cutoff, freshness_floor)
         if not rows:
             return 0
 
         logger.info(
-            "Inbound recovery: found %d orphan(s) since %s",
+            "Inbound recovery: found %d orphan(s) between %s and %s",
             len(rows),
             cutoff.isoformat(),
+            freshness_floor.isoformat(),
         )
 
         dispatched = 0
@@ -236,6 +318,8 @@ async def recover_orphan_inbound_messages() -> int:
 
         return dispatched
     finally:
+        if lock_acquired:
+            _release_lock(db)
         db.close()
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -74,6 +74,14 @@ class Settings(BaseSettings):
     approval_timeout_seconds: int = Field(default=120, ge=1)
     agent_processing_timeout_seconds: float = Field(default=300.0, gt=0)
     message_batch_window_ms: int = Field(default=1500, ge=100)
+    # Inbound messages are persisted before MessageBatcher schedules an
+    # in-memory flush task. If the worker dies during that window the
+    # message lives in the DB but never reaches the agent. On startup we
+    # sweep for inbound rows from the last N minutes that have no
+    # outbound after them and re-dispatch each. Older orphans are
+    # unlikely to still be relevant; tune up if you have evidence
+    # otherwise. 0 disables the sweep entirely.
+    inbound_recovery_lookback_minutes: int = Field(default=30, ge=0)
     max_tool_rounds: int = Field(default=10, ge=1)
     max_input_tokens: int = Field(default=600_000, ge=1)
     context_trim_target_tokens: int = Field(default=400_000, ge=1)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from sqlalchemy import text
 
 from backend.app.agent.approval import cleanup_orphaned_approvals
 from backend.app.agent.heartbeat import heartbeat_scheduler
+from backend.app.agent.inbound_recovery import recover_orphan_inbound_messages
 from backend.app.channels import get_manager, register_channel
 from backend.app.channels.bluebubbles import BlueBubblesChannel
 from backend.app.channels.linq import LinqChannel
@@ -275,8 +276,6 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     # the agent loop (worker died during the MessageBatcher window).
     # Same shape as the approval cleanup above, runs after channels start.
     try:
-        from backend.app.agent.inbound_recovery import recover_orphan_inbound_messages
-
         recovered_inbounds = await recover_orphan_inbound_messages()
         if recovered_inbounds:
             logger.info("Re-dispatched %d orphan inbound message(s) on startup", recovered_inbounds)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -271,6 +271,18 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     except Exception:
         logger.exception("Orphaned approval cleanup failed on startup")
 
+    # Re-dispatch any inbound messages that were persisted but never ran
+    # the agent loop (worker died during the MessageBatcher window).
+    # Same shape as the approval cleanup above, runs after channels start.
+    try:
+        from backend.app.agent.inbound_recovery import recover_orphan_inbound_messages
+
+        recovered_inbounds = await recover_orphan_inbound_messages()
+        if recovered_inbounds:
+            logger.info("Re-dispatched %d orphan inbound message(s) on startup", recovered_inbounds)
+    except Exception:
+        logger.exception("Orphan inbound recovery failed on startup")
+
     yield
 
     # Cancel any channel start tasks still running.

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -104,6 +104,7 @@ See [Storage Providers](./storage.md) for setup instructions.
 | `APPROVAL_TIMEOUT_SECONDS` | `120` | Seconds to wait for user approval of a tool call before automatically denying |
 | `AGENT_PROCESSING_TIMEOUT_SECONDS` | `300` | Maximum seconds for a single message's agent processing (includes waiting for the per-user lock). Prevents one hung LLM call from blocking all subsequent messages for the same user |
 | `MESSAGE_BATCH_WINDOW_MS` | `1500` | Milliseconds to wait for more messages before processing. Groups rapid-fire messages into one agent call. Set to `0` to disable |
+| `INBOUND_RECOVERY_LOOKBACK_MINUTES` | `30` | On startup, sweep for inbound messages persisted but never dispatched to the agent (worker died during the batcher window). Re-dispatch each one. Older orphans are skipped. Set to `0` to disable |
 | `MAX_TOOL_ROUNDS` | `10` | Maximum tool-calling rounds per agent invocation |
 | `MAX_INPUT_TOKENS` | `120000` | Max input token budget before context trimming |
 | `CONTEXT_TRIM_TARGET_TOKENS` | `80000` | Target token count after trimming |

--- a/tests/test_inbound_recovery.py
+++ b/tests/test_inbound_recovery.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -96,7 +95,7 @@ def _add_message(
 # ---------------------------------------------------------------------------
 
 
-def test_inbound_with_no_outbound_is_orphan(tmp_path: Path) -> None:
+def test_inbound_with_no_outbound_is_orphan() -> None:
     db = SessionLocal()
     try:
         user = _make_user(db)
@@ -104,7 +103,7 @@ def test_inbound_with_no_outbound_is_orphan(tmp_path: Path) -> None:
         _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="hello?", minutes_ago=2)
 
         cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
-        rows = _find_orphaned_inbounds(db, cutoff)
+        rows = _find_orphaned_inbounds(db, cutoff, datetime.datetime.now(datetime.UTC))
     finally:
         db.close()
 
@@ -114,7 +113,7 @@ def test_inbound_with_no_outbound_is_orphan(tmp_path: Path) -> None:
     assert found_cs.session_id == cs.session_id
 
 
-def test_inbound_followed_by_outbound_is_not_orphan(tmp_path: Path) -> None:
+def test_inbound_followed_by_outbound_is_not_orphan() -> None:
     db = SessionLocal()
     try:
         user = _make_user(db)
@@ -123,14 +122,14 @@ def test_inbound_followed_by_outbound_is_not_orphan(tmp_path: Path) -> None:
         _add_message(db, cs, MessageDirection.OUTBOUND, seq=2, body="hi back", minutes_ago=1)
 
         cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
-        rows = _find_orphaned_inbounds(db, cutoff)
+        rows = _find_orphaned_inbounds(db, cutoff, datetime.datetime.now(datetime.UTC))
     finally:
         db.close()
 
     assert rows == []
 
 
-def test_inbound_outside_lookback_is_ignored(tmp_path: Path) -> None:
+def test_inbound_outside_lookback_is_ignored() -> None:
     """Messages older than the cutoff are excluded so we don't dispatch a
     stale reply for something the user has long since moved past."""
     db = SessionLocal()
@@ -140,14 +139,14 @@ def test_inbound_outside_lookback_is_ignored(tmp_path: Path) -> None:
         _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="long ago", minutes_ago=120)
 
         cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
-        rows = _find_orphaned_inbounds(db, cutoff)
+        rows = _find_orphaned_inbounds(db, cutoff, datetime.datetime.now(datetime.UTC))
     finally:
         db.close()
 
     assert rows == []
 
 
-def test_orphan_detection_is_per_session(tmp_path: Path) -> None:
+def test_orphan_detection_is_per_session() -> None:
     """A second session's outbound must not satisfy the first session's
     inbound. Without the per-session join the EXISTS would let one user's
     activity declare another user's inbound 'processed'."""
@@ -162,7 +161,7 @@ def test_orphan_detection_is_per_session(tmp_path: Path) -> None:
         _add_message(db, cs_b, MessageDirection.OUTBOUND, seq=1, body="B reply", minutes_ago=1)
 
         cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
-        rows = _find_orphaned_inbounds(db, cutoff)
+        rows = _find_orphaned_inbounds(db, cutoff, datetime.datetime.now(datetime.UTC))
     finally:
         db.close()
 
@@ -178,7 +177,7 @@ def test_orphan_detection_is_per_session(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_build_dispatch_inputs_round_trips_message_fields(tmp_path: Path) -> None:
+def test_build_dispatch_inputs_round_trips_message_fields() -> None:
     db = SessionLocal()
     try:
         user = _make_user(db)
@@ -201,7 +200,7 @@ def test_build_dispatch_inputs_round_trips_message_fields(tmp_path: Path) -> Non
     assert stored.direction == MessageDirection.INBOUND
 
 
-def test_build_dispatch_inputs_returns_none_when_user_missing(tmp_path: Path) -> None:
+def test_build_dispatch_inputs_returns_none_when_user_missing() -> None:
     """Defense in depth: if the user row was deleted in the window between
     persist and recovery, log and skip rather than crash."""
     db = SessionLocal()
@@ -247,7 +246,7 @@ def test_parse_media_refs_handles_invalid_json() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_recover_dispatches_each_orphan(tmp_path: Path) -> None:
+async def test_recover_dispatches_each_orphan() -> None:
     """The recovery loop calls ``_dispatch_to_pipeline`` once per orphan
     and returns the count of successes."""
     db = SessionLocal()
@@ -271,7 +270,7 @@ async def test_recover_dispatches_each_orphan(tmp_path: Path) -> None:
         captured_bodies.append(kwargs["message"].body)  # type: ignore[attr-defined]
 
     with patch(
-        "backend.app.agent.ingestion._dispatch_to_pipeline",
+        "backend.app.agent.inbound_recovery._dispatch_to_pipeline",
         new=capture_dispatch,
     ):
         recovered = await recover_orphan_inbound_messages()
@@ -282,7 +281,7 @@ async def test_recover_dispatches_each_orphan(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_recover_short_circuits_when_lookback_zero(tmp_path: Path) -> None:
+async def test_recover_short_circuits_when_lookback_zero() -> None:
     db = SessionLocal()
     try:
         user = _make_user(db)
@@ -294,7 +293,7 @@ async def test_recover_short_circuits_when_lookback_zero(tmp_path: Path) -> None
     with (
         patch.object(settings, "inbound_recovery_lookback_minutes", 0),
         patch(
-            "backend.app.agent.ingestion._dispatch_to_pipeline",
+            "backend.app.agent.inbound_recovery._dispatch_to_pipeline",
             new=AsyncMock(),
         ) as mock_dispatch,
     ):
@@ -305,9 +304,7 @@ async def test_recover_short_circuits_when_lookback_zero(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio()
-async def test_recover_continues_past_individual_dispatch_failure(
-    tmp_path: Path,
-) -> None:
+async def test_recover_continues_past_individual_dispatch_failure() -> None:
     """One failing dispatch must not abort the whole sweep; the other
     orphan should still be recovered. Caller wraps the whole thing in a
     try/except too, but per-row resilience is what lets us deploy this
@@ -329,7 +326,7 @@ async def test_recover_continues_past_individual_dispatch_failure(
             raise RuntimeError("simulated dispatch failure")
 
     with patch(
-        "backend.app.agent.ingestion._dispatch_to_pipeline",
+        "backend.app.agent.inbound_recovery._dispatch_to_pipeline",
         new=flaky_dispatch,
     ):
         recovered = await recover_orphan_inbound_messages()
@@ -337,3 +334,113 @@ async def test_recover_continues_past_individual_dispatch_failure(
     # Two attempts, one succeeded.
     assert call_count["n"] == 2
     assert recovered == 1
+
+
+# ---------------------------------------------------------------------------
+# Freshness floor (race with concurrent normal ingestion)
+# ---------------------------------------------------------------------------
+
+
+def test_freshness_floor_excludes_brand_new_inbounds() -> None:
+    """A message that landed milliseconds ago is the normal ingestion
+    path's responsibility, not recovery. Without this floor a worker
+    could race the in-flight MessageBatcher and double-dispatch a message
+    that was about to be processed normally."""
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="just now", minutes_ago=0)
+
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
+        # Floor at -30s: anything newer is excluded as too-fresh.
+        floor = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=30)
+        rows = _find_orphaned_inbounds(db, cutoff, floor)
+    finally:
+        db.close()
+
+    assert rows == []
+
+
+def test_freshness_floor_includes_messages_older_than_floor() -> None:
+    """Sanity: floor at +0s (now) includes messages from the past."""
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="2m ago", minutes_ago=2)
+
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
+        floor = datetime.datetime.now(datetime.UTC)
+        rows = _find_orphaned_inbounds(db, cutoff, floor)
+    finally:
+        db.close()
+
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Idempotency (a successful dispatch should produce an outbound that
+# masks the orphan on a subsequent sweep)
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_is_no_longer_detected_after_outbound_lands() -> None:
+    """The whole design rests on this invariant: once the agent loop runs
+    and persists an outbound, the next sweep doesn't see the inbound as
+    an orphan anymore. Simulate that by adding the outbound by hand and
+    re-running the query."""
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="hi", minutes_ago=2)
+
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
+        floor = datetime.datetime.now(datetime.UTC)
+        before = _find_orphaned_inbounds(db, cutoff, floor)
+        assert len(before) == 1
+
+        # Simulate the agent loop running and persisting its reply.
+        _add_message(db, cs, MessageDirection.OUTBOUND, seq=2, body="ok", minutes_ago=1)
+
+        after = _find_orphaned_inbounds(db, cutoff, floor)
+    finally:
+        db.close()
+
+    assert after == []
+
+
+# ---------------------------------------------------------------------------
+# Multi-worker advisory lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_recovery_skips_when_another_worker_holds_the_lock() -> None:
+    """``pg_try_advisory_lock`` returns False to a second caller when
+    another connection already holds the lock. The sweep must short-circuit
+    in that case, otherwise N workers in a rolling restart would each
+    re-dispatch the same orphans N times."""
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="one", minutes_ago=2)
+    finally:
+        db.close()
+
+    with (
+        patch(
+            "backend.app.agent.inbound_recovery._try_acquire_lock",
+            return_value=False,
+        ),
+        patch(
+            "backend.app.agent.inbound_recovery._dispatch_to_pipeline",
+            new=AsyncMock(),
+        ) as mock_dispatch,
+    ):
+        recovered = await recover_orphan_inbound_messages()
+
+    assert recovered == 0
+    mock_dispatch.assert_not_awaited()

--- a/tests/test_inbound_recovery.py
+++ b/tests/test_inbound_recovery.py
@@ -1,0 +1,339 @@
+"""Tests for the orphan inbound startup recovery sweep.
+
+The sweep finds inbound messages that landed in the DB but never produced
+an outbound (worker died during the MessageBatcher window), and
+re-dispatches each via ``_dispatch_to_pipeline``. These tests exercise:
+
+* The orphan-detection SQL: an inbound with no following outbound is a
+  candidate; an inbound followed by any outbound is not.
+* The lookback window: messages older than the cutoff are ignored.
+* The disable switch: ``inbound_recovery_lookback_minutes=0`` short-circuits.
+* End-to-end dispatch: the recovery path calls ``_dispatch_to_pipeline``
+  with the right arguments and counts successes correctly.
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.app.agent.inbound_recovery import (
+    _build_dispatch_inputs,
+    _find_orphaned_inbounds,
+    _parse_media_refs,
+    recover_orphan_inbound_messages,
+)
+from backend.app.config import settings
+from backend.app.database import SessionLocal
+from backend.app.enums import MessageDirection
+from backend.app.models import ChatSession, Message, User
+
+
+def _make_user(db: Session) -> User:
+    user = User(
+        id=str(uuid.uuid4()),
+        user_id=f"recovery-test-{uuid.uuid4().hex[:8]}",
+        phone="+15555550101",
+        channel_identifier="+15555550101",
+        preferred_channel="bluebubbles",
+        onboarding_complete=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_session(db: Session, user: User, channel: str = "bluebubbles") -> ChatSession:
+    now = datetime.datetime.now(datetime.UTC)
+    cs = ChatSession(
+        session_id=f"sess-{uuid.uuid4().hex[:8]}",
+        user_id=user.id,
+        is_active=True,
+        channel=channel,
+        last_compacted_seq=0,
+        created_at=now,
+        last_message_at=now,
+    )
+    db.add(cs)
+    db.commit()
+    db.refresh(cs)
+    return cs
+
+
+def _add_message(
+    db: Session,
+    cs: ChatSession,
+    direction: str,
+    seq: int,
+    body: str,
+    *,
+    minutes_ago: int = 0,
+) -> Message:
+    ts = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=minutes_ago)
+    msg = Message(
+        session_id=cs.id,
+        seq=seq,
+        direction=direction,
+        body=body,
+        external_message_id=f"ext-{seq}",
+        media_urls_json="[]",
+        timestamp=ts,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Orphan detection
+# ---------------------------------------------------------------------------
+
+
+def test_inbound_with_no_outbound_is_orphan(tmp_path: Path) -> None:
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="hello?", minutes_ago=2)
+
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
+        rows = _find_orphaned_inbounds(db, cutoff)
+    finally:
+        db.close()
+
+    assert len(rows) == 1
+    msg, found_cs = rows[0]
+    assert msg.body == "hello?"
+    assert found_cs.session_id == cs.session_id
+
+
+def test_inbound_followed_by_outbound_is_not_orphan(tmp_path: Path) -> None:
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="hi", minutes_ago=2)
+        _add_message(db, cs, MessageDirection.OUTBOUND, seq=2, body="hi back", minutes_ago=1)
+
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
+        rows = _find_orphaned_inbounds(db, cutoff)
+    finally:
+        db.close()
+
+    assert rows == []
+
+
+def test_inbound_outside_lookback_is_ignored(tmp_path: Path) -> None:
+    """Messages older than the cutoff are excluded so we don't dispatch a
+    stale reply for something the user has long since moved past."""
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="long ago", minutes_ago=120)
+
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
+        rows = _find_orphaned_inbounds(db, cutoff)
+    finally:
+        db.close()
+
+    assert rows == []
+
+
+def test_orphan_detection_is_per_session(tmp_path: Path) -> None:
+    """A second session's outbound must not satisfy the first session's
+    inbound. Without the per-session join the EXISTS would let one user's
+    activity declare another user's inbound 'processed'."""
+    db = SessionLocal()
+    try:
+        user_a = _make_user(db)
+        user_b = _make_user(db)
+        cs_a = _make_session(db, user_a)
+        cs_b = _make_session(db, user_b)
+
+        _add_message(db, cs_a, MessageDirection.INBOUND, seq=1, body="A asks", minutes_ago=2)
+        _add_message(db, cs_b, MessageDirection.OUTBOUND, seq=1, body="B reply", minutes_ago=1)
+
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=30)
+        rows = _find_orphaned_inbounds(db, cutoff)
+    finally:
+        db.close()
+
+    # User A's inbound is still orphaned. User B has no inbound so nothing
+    # to recover for them.
+    assert len(rows) == 1
+    msg, _ = rows[0]
+    assert msg.body == "A asks"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch input reconstruction
+# ---------------------------------------------------------------------------
+
+
+def test_build_dispatch_inputs_round_trips_message_fields(tmp_path: Path) -> None:
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        msg = _add_message(
+            db, cs, MessageDirection.INBOUND, seq=7, body="rebuild me", minutes_ago=5
+        )
+
+        result = _build_dispatch_inputs(db, msg, cs)
+    finally:
+        db.close()
+
+    assert result is not None
+    rebuilt_user, state, stored = result
+    assert rebuilt_user.id == user.id
+    assert state.session_id == cs.session_id
+    assert state.user_id == user.id
+    assert stored.seq == 7
+    assert stored.body == "rebuild me"
+    assert stored.direction == MessageDirection.INBOUND
+
+
+def test_build_dispatch_inputs_returns_none_when_user_missing(tmp_path: Path) -> None:
+    """Defense in depth: if the user row was deleted in the window between
+    persist and recovery, log and skip rather than crash."""
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        msg = _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="x", minutes_ago=1)
+
+        # Hard-delete user row so the rebuild lookup misses.
+        db.delete(user)
+        db.commit()
+
+        result = _build_dispatch_inputs(db, msg, cs)
+    finally:
+        db.close()
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Media refs reconstruction
+# ---------------------------------------------------------------------------
+
+
+def test_parse_media_refs_handles_empty_string() -> None:
+    assert _parse_media_refs("") == []
+
+
+def test_parse_media_refs_returns_pairs_with_empty_mime() -> None:
+    """Mime types are not persisted; recovery returns empty mime so the
+    media pipeline re-derives from the stored file."""
+    assert _parse_media_refs('["abc", "def"]') == [("abc", ""), ("def", "")]
+
+
+def test_parse_media_refs_handles_invalid_json() -> None:
+    assert _parse_media_refs("not-json") == []
+    assert _parse_media_refs("{}") == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end recovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_recover_dispatches_each_orphan(tmp_path: Path) -> None:
+    """The recovery loop calls ``_dispatch_to_pipeline`` once per orphan
+    and returns the count of successes."""
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="one", minutes_ago=2)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=2, body="two", minutes_ago=1)
+        expected_user_id = user.id
+    finally:
+        db.close()
+
+    captured_user_ids: list[str] = []
+    captured_bodies: list[str] = []
+
+    async def capture_dispatch(**kwargs: object) -> None:
+        # Read the user id while the recovery's session is still open
+        # in this same task (kwargs["user"] is detached but its id was
+        # loaded before expunge, so this access is safe).
+        captured_user_ids.append(kwargs["user"].id)  # type: ignore[attr-defined]
+        captured_bodies.append(kwargs["message"].body)  # type: ignore[attr-defined]
+
+    with patch(
+        "backend.app.agent.ingestion._dispatch_to_pipeline",
+        new=capture_dispatch,
+    ):
+        recovered = await recover_orphan_inbound_messages()
+
+    assert recovered == 2
+    assert captured_user_ids == [expected_user_id, expected_user_id]
+    assert set(captured_bodies) == {"one", "two"}
+
+
+@pytest.mark.asyncio()
+async def test_recover_short_circuits_when_lookback_zero(tmp_path: Path) -> None:
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="should not run", minutes_ago=1)
+    finally:
+        db.close()
+
+    with (
+        patch.object(settings, "inbound_recovery_lookback_minutes", 0),
+        patch(
+            "backend.app.agent.ingestion._dispatch_to_pipeline",
+            new=AsyncMock(),
+        ) as mock_dispatch,
+    ):
+        recovered = await recover_orphan_inbound_messages()
+
+    assert recovered == 0
+    mock_dispatch.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_recover_continues_past_individual_dispatch_failure(
+    tmp_path: Path,
+) -> None:
+    """One failing dispatch must not abort the whole sweep; the other
+    orphan should still be recovered. Caller wraps the whole thing in a
+    try/except too, but per-row resilience is what lets us deploy this
+    in front of an in-flight queue without an all-or-nothing failure."""
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        cs = _make_session(db, user)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="one", minutes_ago=2)
+        _add_message(db, cs, MessageDirection.INBOUND, seq=2, body="two", minutes_ago=1)
+    finally:
+        db.close()
+
+    call_count = {"n": 0}
+
+    async def flaky_dispatch(**kwargs: object) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated dispatch failure")
+
+    with patch(
+        "backend.app.agent.ingestion._dispatch_to_pipeline",
+        new=flaky_dispatch,
+    ):
+        recovered = await recover_orphan_inbound_messages()
+
+    # Two attempts, one succeeded.
+    assert call_count["n"] == 2
+    assert recovered == 1


### PR DESCRIPTION
## Description

The ingestion path persists every inbound to \`messages\` **before** the \`MessageBatcher\` schedules an in-memory flush timer (1.5 s by default). When a worker dies during that window (deploy, OOM, crash), the timer task is lost. The message is durable in the DB but the pipeline never runs, so the user gets silence: no agent reply, no outbound, just a message sitting in history that the next inbound proceeds past.

## Real example

A contractor's *\"Can you change my calendar reminders to my work iCloud?\"* landed in the DB at 2026-04-30 15:01 UTC but received no reply for 29 hours, until the next message woke a fresh batcher state. The inbound was visible in the heartbeat decider's reasoning (*\"the most recent user message about changing calendar reminders\"*) for the entire 29 hours, so the system saw it but never ran the agent loop.

## Implementation

Adds a startup sweep that finds inbound rows from the last N minutes (default 30, configurable via \`inbound_recovery_lookback_minutes\`, 0 disables) with no outbound after them in the same session, and re-dispatches each via \`_dispatch_to_pipeline\`. Re-dispatch bypasses \`add_message\` so we do not duplicate the persisted row.

Structurally the same shape as \`cleanup_orphaned_approvals\`: runs in \`lifespan\` after channels start, best-effort, logs every recovery decision so an operator can see what fired on the boot after an incident. Per-row try/except so one failing dispatch doesn't abort the whole sweep.

## Test coverage

12 new tests:

- Inbound with no outbound: orphan
- Inbound followed by outbound: not orphan
- Inbound older than the lookback cutoff: ignored
- Per-session isolation: another user's outbound doesn't satisfy
- \`inbound_recovery_lookback_minutes=0\`: short-circuits
- Reconstructed user/session/stored message round-trip
- Defense-in-depth when user row is missing
- Media refs reconstruction from JSON list
- End-to-end: dispatch is called once per orphan with the right user and message body
- Per-row failure resilience: one failed dispatch doesn't abort the rest of the sweep

## Operator notes

This is the highest-priority fix from the recent contractor session review (the only \"trust killer\" issue, per maintainer's prioritization). The mechanism is conservative: lookback is short (30m), the sweep only fires once on startup, dispatch failures are isolated per-row, and the entire sweep is wrapped in try/except by the \`lifespan\` caller so a recovery bug never blocks startup. To disable in an emergency, set \`INBOUND_RECOVERY_LOOKBACK_MINUTES=0\`.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`)
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] Type checking passes (\`ty check\`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake while reviewing a real production session)
- [ ] No AI used