### PR TITLE
fix(dashboard): hide LLM provider/model card for premium users

### DIFF
--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -566,15 +566,20 @@ describe('DashboardPage', () => {
     expect(mockGetModelConfig).not.toHaveBeenCalled();
   });
 
-  it('shows the Settings card for admin users in premium', async () => {
+  it('hides the Settings card for admin users in premium too', async () => {
+    // In premium, LLM config lives in the admin panel Config tab. The dashboard
+    // card linked to /app/settings, where the Model tab is hidden for premium
+    // users -> dead-end click. Hide the card for premium admins as well.
     authMock.state.isPremium = true;
     authMock.state.currentAuthUser = { id: 1, name: 'Admin', role: 'admin' };
     setupMocks();
     renderWithRouter(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Settings')).toBeInTheDocument();
+      expect(screen.getByText('Channels')).toBeInTheDocument();
     });
-    expect(mockGetModelConfig).toHaveBeenCalled();
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('AI model and provider configuration.')).not.toBeInTheDocument();
+    expect(mockGetModelConfig).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -102,10 +102,12 @@ export default function DashboardPage() {
   const oauth = useOAuthStatus();
   const calendarConfig = useCalendarConfig();
   const memory = useMemory();
-  const { currentAuthUser, isPremium } = useAuth();
-  // In premium, the LLM model/provider is an admin-only operational detail.
-  // OSS single-tenant deployments have no role concept, so the card always shows.
-  const canSeeModelConfig = !isPremium || currentAuthUser?.role === 'admin';
+  const { isPremium } = useAuth();
+  // The LLM provider/model card is an OSS single-tenant convenience. In premium,
+  // LLM config lives in the admin panel (admin -> Config tab); the card linked
+  // to /app/settings, where the Model tab is hidden for premium users, leaving
+  // a dead-end click. Hide it for all premium users (admin and non-admin).
+  const canSeeModelConfig = !isPremium;
   const modelConfig = useModelConfig({ enabled: canSeeModelConfig });
   const updateProfile = useUpdateProfile();
 


### PR DESCRIPTION
## Description

The Settings card on the dashboard (\`DashboardPage.tsx\`) renders \`llm_provider\` / \`llm_model\` and links to \`/app/settings\`. In premium, the Model tab is hidden on the Settings page for both admin and non-admin users (premium expects LLM config to live in the admin panel's Config tab), so clicking the card is a dead end for premium admins: they see provider/model values they can't change from the destination page.

The previous gate only hid the card from premium non-admins, leaving premium admins with the broken UX. Switch to \`!isPremium\` so OSS single-tenant deployments still see the card (no role concept; the Model tab is fully visible there) but premium hides it for everyone, pushing admins to the admin-panel Config tab where LLM settings actually live.

Reported by an admin on a fresh deploy who saw a \"Settings\" card surfacing \`Sonnet\` (the env-var-clobber side of the same investigation is fixed in the premium repo separately).

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (\`npm test src/pages/DashboardPage.test.tsx\` — 27/27 passing locally)
- [x] Lint passes (typecheck clean)
- [x] Bug fixes include regression tests (existing premium-non-admin test stays; flipped the premium-admin test to assert the card is now hidden too)

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 drafted patch and tests via back-and-forth with @njbrake; reasoning and decisions are his)