### PR TITLE
fix(db): recycle pooled connections and enable TCP keepalives

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -13,12 +13,34 @@ _lock = threading.RLock()
 
 
 def get_engine() -> Engine:
-    """Return the singleton engine, creating it on first call."""
+    """Return the singleton engine, creating it on first call.
+
+    Pool tuning is defensive against silent connection drops in cloud
+    environments. Hosted Postgres setups (Railway, RDS proxies, NAT
+    gateways) routinely close idle TCP sockets without sending a FIN,
+    leaving the client end half-open. A sync DB call from an async route
+    that hits such a socket can block the event loop for the kernel's
+    default ~2h TCP retransmit window: zero CPU, no logs, no crash, and
+    the platform's liveness probe still passes because /health/live
+    never touches the DB. ``pool_recycle`` rotates connections before
+    any reasonable NAT timeout, and the TCP keepalive options let the
+    kernel detect a dead socket within ~80s instead.
+    """
     global _engine
     if _engine is None:
         with _lock:
             if _engine is None:
-                _engine = create_engine(settings.database_url, pool_pre_ping=True)
+                _engine = create_engine(
+                    settings.database_url,
+                    pool_pre_ping=True,
+                    pool_recycle=1800,
+                    connect_args={
+                        "keepalives": 1,
+                        "keepalives_idle": 30,
+                        "keepalives_interval": 10,
+                        "keepalives_count": 5,
+                    },
+                )
     return _engine
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,5 +1,7 @@
 """Smoke tests for the database models and test infrastructure."""
 
+from unittest.mock import patch
+
 import pytest
 from sqlalchemy import Engine, text
 from sqlalchemy.exc import IntegrityError
@@ -64,6 +66,36 @@ def test_all_tables_created(_pg_engine: Engine) -> None:
         result = conn.execute(text("SELECT tablename FROM pg_tables WHERE schemaname = 'public'"))
         actual = {row[0] for row in result}
     assert expected <= actual
+
+
+def test_engine_uses_pool_recycle_and_tcp_keepalives() -> None:
+    """Engine creation passes pool_recycle and TCP keepalive args.
+
+    Regression: a hosted Postgres in front of a NAT/proxy can silently
+    drop idle TCP sockets, leaving the client half-open. Without
+    ``pool_recycle`` and OS-level keepalives, a sync DB call from an
+    async route blocks the event loop on the dead socket for the
+    kernel's TCP retransmit window (~2h on Linux). The whole worker
+    appears frozen at zero CPU while ``/health/live`` keeps passing.
+    """
+    saved_engine = _db_module._engine
+    _db_module._engine = None
+    try:
+        with patch.object(_db_module, "create_engine") as mock_create:
+            _db_module.get_engine()
+
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["pool_pre_ping"] is True
+        assert kwargs["pool_recycle"] == 1800
+        assert kwargs["connect_args"] == {
+            "keepalives": 1,
+            "keepalives_idle": 30,
+            "keepalives_interval": 10,
+            "keepalives_count": 5,
+        }
+    finally:
+        _db_module._engine = saved_engine
 
 
 def test_user_defaults() -> None:


### PR DESCRIPTION
## Description

Add `pool_recycle=1800` and libpq TCP keepalive options to the singleton SQLAlchemy engine. This is a defensive fix for a runtime hang we observed in a Railway-hosted deployment of `clawbolt-premium` (which imports this module's `get_engine` / `Base`), but the failure mode applies to any hosted Postgres setup where an idle TCP socket can be silently dropped by intermediate infrastructure (NAT, proxy, load balancer).

### Symptom

A long-running deployment freezes mid-life: zero CPU, no logs for 60+ minutes, no crash. `/api/health/live` keeps passing because it's intentionally DB-free, so the platform's liveness probe never restarts the container. A manual redeploy (fresh process) clears it; the underlying issue recurs on the next idle window.

### Root cause

A pooled connection's underlying TCP socket is silently closed by the network. With only `pool_pre_ping=True` configured:

1. The next sync DB call (e.g. heartbeat scheduler, OAuth refresh sweep, or any `async def` route using sync SQLAlchemy) runs `SELECT 1` against the half-dead socket.
2. With no socket-level keepalives and no recycle window, the call blocks on the kernel's TCP retransmit timeout (~2 hours on Linux defaults).
3. The single uvicorn worker's event loop is now parked on a syscall. Every other coroutine waits behind it. CPU drops to exactly 0.

### Fix

- `pool_recycle=1800` rotates pooled connections every 30 minutes, well under any reasonable platform NAT idle timeout.
- `connect_args` enables OS-level TCP keepalives (`keepalives_idle=30s`, `keepalives_interval=10s`, `keepalives_count=5`), so the kernel detects a dead peer within ~80s instead of hours.
- `pool_pre_ping=True` is preserved as a backstop for connections that fail in flight.

This is library-agnostic SQLAlchemy + libpq behavior and changes nothing about query semantics.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) - 2131 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake; root-cause analysis from Railway logs/metrics, fix and tests authored in collaboration)