### PR TITLE
feat(bluebubbles): replay missed messages on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@ TELEGRAM_ALLOWED_CHAT_ID=
 # BLUEBUBBLES_ALLOWED_NUMBERS=        # E.164 phone or email, "*" for all, empty = deny
 # BLUEBUBBLES_SEND_METHOD=apple-script # "apple-script" (default) or "private-api"
 # BLUEBUBBLES_IMESSAGE_ADDRESS=       # iCloud email or phone shown in the UI for users to text
+# BLUEBUBBLES_BACKFILL_LOOKBACK_MINUTES=30 # On startup, replay iMessages from the last N minutes whose webhook never reached us. 0 disables.
 
 # E2E testing
 # TELEGRAM_TEST_CHAT_ID=

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -1,6 +1,7 @@
 """BlueBubbles channel: inbound webhook + outbound messaging (iMessage via self-hosted Mac bridge)."""
 
 import asyncio
+import datetime
 import hashlib
 import hmac
 import logging
@@ -11,10 +12,13 @@ import httpx
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import text
+from sqlalchemy.orm import Session
 
 from backend.app.agent.ingestion import InboundMessage
 from backend.app.channels.base import BaseChannel, handle_webhook_inbound
 from backend.app.config import settings
+from backend.app.database import SessionLocal
 from backend.app.logging_utils import mask_pii
 from backend.app.media.download import DownloadedMedia, download_bounded, generate_filename
 from backend.app.services.rate_limiter import check_webhook_rate_limit
@@ -23,6 +27,23 @@ from backend.app.services.webhook import discover_tunnel_url, wait_for_dns
 logger = logging.getLogger(__name__)
 
 STARTUP_DELAY_SECONDS = 3
+
+# Postgres advisory lock key for the startup backfill, mirroring the
+# pattern in ``inbound_recovery._RECOVERY_LOCK_KEY``. ``hashtext`` reduces
+# the string to an int the lock function accepts.
+_BACKFILL_LOCK_KEY = "bluebubbles_backfill:cleanup"
+
+# Cap on messages returned from a single backfill query. The BlueBubbles
+# server itself caps at 1000; 200 is well above what a real outage produces
+# (a heavy iMessage user gets maybe 30 messages in 30 minutes) and bounds
+# the worst-case replay backlog.
+_BACKFILL_QUERY_LIMIT = 200
+
+# Per-attempt timeout for the backfill HTTP call. Generous enough for a
+# slow Mac to walk its message DB; bounded so a wedged server cannot
+# stretch startup indefinitely. Falls back to ``http_timeout_seconds`` if
+# that is shorter.
+_BACKFILL_TIMEOUT_SECONDS = 30.0
 
 # Typing indicators run as fire-and-forget tasks (see ChannelManager).
 # Bound them tightly so even if the BlueBubbles server is wedged the task
@@ -601,3 +622,171 @@ class BlueBubblesChannel(BaseChannel):
             original_url=file_id,
             filename=filename,
         )
+
+    # -- Startup backfill ------------------------------------------------------
+
+    async def run_startup_backfill(self) -> int:
+        """Replay BlueBubbles messages received during a Clawbolt outage.
+
+        The webhook from BlueBubbles to ``POST /api/webhooks/bluebubbles`` is
+        fire-and-forget. If Clawbolt was hung when the webhook fired, the
+        message never reached our DB. ``recover_orphan_inbound_messages``
+        only handles messages that landed in the DB and then crashed the
+        in-memory pipeline, so it cannot help here.
+
+        On startup we ask the BlueBubbles server for any messages dated in
+        the last ``settings.bluebubbles_backfill_lookback_minutes`` and run
+        each through ``handle_webhook_inbound``. The idempotency store
+        rejects anything we already processed via the live webhook, so this
+        is safe to run on every boot, including healthy ones, where it
+        becomes a no-op after dedup.
+
+        Returns the number of messages we attempted to replay (before
+        idempotency dedup), mostly for the startup log line. Best-effort:
+        swallows query failures so a wedged BlueBubbles server cannot
+        block startup.
+        """
+        if not settings.bluebubbles_server_url or not settings.bluebubbles_password:
+            return 0
+
+        lookback_minutes = settings.bluebubbles_backfill_lookback_minutes
+        if lookback_minutes == 0:
+            logger.debug("BlueBubbles backfill disabled (bluebubbles_backfill_lookback_minutes=0)")
+            return 0
+
+        db = SessionLocal()
+        lock_acquired = False
+        try:
+            if not _try_acquire_backfill_lock(db):
+                logger.info("Another worker is running BlueBubbles backfill; skipping on this boot")
+                return 0
+            lock_acquired = True
+
+            cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+                minutes=lookback_minutes
+            )
+            cutoff_ms = int(cutoff.timestamp() * 1000)
+
+            try:
+                resp = await self._http.post(
+                    "/api/v1/message/query",
+                    params={"password": settings.bluebubbles_password},
+                    json={
+                        "with": ["chat", "handle", "attachment"],
+                        "after": cutoff_ms,
+                        "sort": "ASC",
+                        "limit": _BACKFILL_QUERY_LIMIT,
+                    },
+                    timeout=_BACKFILL_TIMEOUT_SECONDS,
+                )
+            except httpx.HTTPError:
+                logger.warning(
+                    "BlueBubbles backfill query failed (server unreachable or slow)",
+                    exc_info=True,
+                )
+                return 0
+
+            if resp.status_code >= 400:
+                logger.warning(
+                    "BlueBubbles backfill query returned %d: %s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+                return 0
+
+            try:
+                body = resp.json()
+            except ValueError:
+                logger.warning("BlueBubbles backfill query returned non-JSON body")
+                return 0
+
+            raw_messages = body.get("data") or []
+            if not raw_messages:
+                return 0
+
+            attempted = 0
+            for raw in raw_messages:
+                try:
+                    data = BBMessageData.model_validate(raw)
+                except Exception:
+                    logger.debug("BlueBubbles backfill: skipping malformed message")
+                    continue
+
+                payload = BBWebhookPayload(type="new-message", data=data)
+                inbound = BlueBubblesChannel.parse_webhook(payload)
+                if inbound is None:
+                    continue
+
+                # Mirror the live webhook's chat-cache population so any
+                # outbound replies the agent produces can find the chat
+                # GUID without reconstructing it from sender_id.
+                def _cache_chat_guid(
+                    d: BBMessageData = data, sender: str = inbound.sender_id
+                ) -> None:
+                    if d.chats and d.chats[0].guid:
+                        self._chat_cache[sender] = d.chats[0].guid
+
+                try:
+                    await handle_webhook_inbound(self, inbound, on_accepted=_cache_chat_guid)
+                    attempted += 1
+                except Exception:
+                    logger.exception(
+                        "BlueBubbles backfill: handle_webhook_inbound failed for extId=%s",
+                        inbound.external_message_id,
+                    )
+
+            if attempted:
+                logger.info(
+                    "BlueBubbles backfill: replayed %d message(s) since %s "
+                    "(idempotency dedups already-seen)",
+                    attempted,
+                    cutoff.isoformat(),
+                )
+            return attempted
+        finally:
+            if lock_acquired:
+                _release_backfill_lock(db)
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# Startup backfill helpers
+# ---------------------------------------------------------------------------
+#
+# The backfill itself is a method on ``BlueBubblesChannel`` (see
+# ``run_startup_backfill``); these advisory-lock helpers live at module
+# level because they mirror the shape of ``inbound_recovery._try_acquire_lock``
+# and have no per-instance state.
+
+
+def _try_acquire_backfill_lock(db: Session) -> bool:
+    """Acquire the per-process backfill advisory lock.
+
+    Mirrors ``inbound_recovery._try_acquire_lock``. ``pg_try_advisory_lock``
+    returns True on first acquisition, False if another worker on a
+    rolling restart already holds the lock. We commit to release the
+    implicit read transaction; the advisory lock itself is session-scoped
+    and survives until ``_release_backfill_lock``.
+    """
+    try:
+        got = db.execute(
+            text("SELECT pg_try_advisory_lock(hashtext(:k))"),
+            {"k": _BACKFILL_LOCK_KEY},
+        ).scalar()
+        db.commit()
+    except Exception:
+        logger.exception("Failed to acquire BlueBubbles backfill advisory lock")
+        return False
+    return bool(got)
+
+
+def _release_backfill_lock(db: Session) -> None:
+    """Best-effort release of the backfill lock."""
+    try:
+        db.execute(
+            text("SELECT pg_advisory_unlock(hashtext(:k))"),
+            {"k": _BACKFILL_LOCK_KEY},
+        )
+        db.commit()
+    except Exception:
+        logger.exception("Failed to release BlueBubbles backfill advisory lock")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -139,6 +139,13 @@ class Settings(BaseSettings):
     bluebubbles_allowed_numbers: str = ""  # E.164 phone, "*", or empty (deny all)
     bluebubbles_send_method: str = "apple-script"  # "apple-script" or "private-api"
     bluebubbles_imessage_address: str = ""  # iCloud email or phone to display in the UI
+    # On startup, query the BlueBubbles server for messages received in the
+    # last N minutes and replay any whose webhook never reached us (Clawbolt
+    # was down or unreachable). Dedup is structural: the idempotency store
+    # rejects messages we already processed via the live webhook path.
+    # 0 disables the sweep entirely. Tune up for tolerance of longer
+    # outages, down for stricter "no replies to stale messages" behavior.
+    bluebubbles_backfill_lookback_minutes: int = Field(default=30, ge=0)
 
     # Google Calendar
     google_calendar_client_id: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -298,6 +298,21 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     except Exception:
         logger.exception("Orphan inbound recovery failed on startup")
 
+    # Replay any BlueBubbles iMessages that arrived while Clawbolt was down.
+    # The orphan recovery above only handles messages that reached our DB;
+    # a webhook delivery that failed because Clawbolt was unreachable
+    # leaves no DB row, so we have to ask the BlueBubbles server for them.
+    try:
+        bb_channel = manager.get("bluebubbles")
+        if isinstance(bb_channel, BlueBubblesChannel):
+            replayed = await bb_channel.run_startup_backfill()
+            if replayed:
+                logger.info("Replayed %d BlueBubbles message(s) from startup backfill", replayed)
+    except KeyError:
+        pass
+    except Exception:
+        logger.exception("BlueBubbles startup backfill failed")
+
     yield
 
     # Cancel any channel start tasks still running.

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -75,6 +75,7 @@ When `LINQ_API_TOKEN` is set, the iMessage channel is powered by Linq and users 
 | `BLUEBUBBLES_ALLOWED_NUMBERS` | (empty) | E.164 phone number or email, `*` for all, or empty to deny all |
 | `BLUEBUBBLES_SEND_METHOD` | `apple-script` | Send method: `apple-script` (default) or `private-api` |
 | `BLUEBUBBLES_IMESSAGE_ADDRESS` | (empty) | iCloud email or phone number displayed in the UI for users to text |
+| `BLUEBUBBLES_BACKFILL_LOOKBACK_MINUTES` | `30` | On startup, ask the BlueBubbles server for messages dated in the last N minutes and replay any whose webhook never reached us during a Clawbolt outage. Idempotency dedup makes this safe on healthy boots. `0` disables the sweep. |
 
 When `BLUEBUBBLES_SERVER_URL` and `BLUEBUBBLES_PASSWORD` are set, the iMessage channel is powered by BlueBubbles. [BlueBubbles](https://github.com/BlueBubblesApp/bluebubbles-server) is a free, open-source iMessage bridge that runs on any Mac with iMessage signed in.
 

--- a/tests/test_bluebubbles_backfill.py
+++ b/tests/test_bluebubbles_backfill.py
@@ -22,7 +22,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.app.channels.bluebubbles import BlueBubblesChannel
+from backend.app.channels.bluebubbles import BlueBubblesChannel, _derive_webhook_token
 from tests.mocks.bluebubbles import make_bluebubbles_webhook_payload
 
 _PATCH_BUS_PUBLISH = "backend.app.bus.message_bus.publish_inbound"
@@ -216,9 +216,15 @@ async def test_webhook_processed_message_is_not_replayed_after_restart(
     fake_client = MagicMock()
     fake_client.post = AsyncMock(return_value=_make_query_response([raw_message]))
 
+    # Real password is required: backfill short-circuits when
+    # ``bluebubbles_password`` is empty, which would silently neuter
+    # this test (it would pass trivially without ever invoking dedup).
+    password = "test-password"
+    token = _derive_webhook_token(password)
+
     with (
         patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
-        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", ""),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", password),
         patch(
             "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
             30,
@@ -230,15 +236,22 @@ async def test_webhook_processed_message_is_not_replayed_after_restart(
         # Step 1: live webhook delivers the message via the running app.
         # Goes through the real router -> handle_webhook_inbound ->
         # IdempotencyStore.try_mark_seen, which commits the seen-row.
-        webhook_resp = bluebubbles_client.post("/api/webhooks/bluebubbles", json=webhook_payload)
+        webhook_resp = bluebubbles_client.post(
+            f"/api/webhooks/bluebubbles?token={token}", json=webhook_payload
+        )
         assert webhook_resp.status_code == 200
         assert mock_pub.call_count == 1, "live webhook should publish to bus on first delivery"
 
         # Step 2: server restarts. Backfill runs against the same
         # BlueBubbles server, which still has the message in its
         # lookback window. Idempotency must reject it.
-        await channel.run_startup_backfill()
+        replayed = await channel.run_startup_backfill()
 
+    # Backfill saw 1 message and ran it through handle_webhook_inbound,
+    # so its return value (attempted-before-dedup) is 1; the bus publish
+    # count is what protects against re-pinging the user.
+    assert replayed == 1, "backfill should have attempted the message (then deduped)"
+    fake_client.post.assert_called_once()  # backfill actually ran the query
     assert mock_pub.call_count == 1, (
         "backfill replayed a message the live webhook already handled; "
         "users would be re-pinged with stale replies on every restart"

--- a/tests/test_bluebubbles_backfill.py
+++ b/tests/test_bluebubbles_backfill.py
@@ -1,0 +1,383 @@
+"""Tests for BlueBubbles startup backfill.
+
+Covers the gap between the live webhook (fire-and-forget from BlueBubbles)
+and the orphan inbound recovery sweep (which only handles DB-persisted
+messages whose pipeline crashed): messages that arrived during a
+Clawbolt outage and never reached our DB at all.
+
+The backfill queries the BlueBubbles server for messages dated in the
+last N minutes and replays each through ``handle_webhook_inbound``. The
+existing idempotency store dedups anything we already saw via the live
+webhook, so these tests assert both the replay-on-outage path and the
+no-op-on-healthy-boot path.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.channels.bluebubbles import BlueBubblesChannel
+from tests.mocks.bluebubbles import make_bluebubbles_webhook_payload
+
+_PATCH_BUS_PUBLISH = "backend.app.bus.message_bus.publish_inbound"
+
+
+def _make_query_response(messages: list[dict[str, Any]], status_code: int = 200) -> MagicMock:
+    """Build a mock httpx.Response for /api/v1/message/query."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value={"data": messages, "metadata": {"count": len(messages)}})
+    resp.text = ""
+    return resp
+
+
+def _query_message(
+    sender: str = "+15551234567",
+    text: str = "missed this one",
+    message_guid: str = "missed-001",
+    is_from_me: bool = False,
+) -> dict[str, Any]:
+    """A single message in the shape /api/v1/message/query returns.
+
+    Matches the webhook payload's ``data`` field shape exactly: BlueBubbles
+    serializes the same way for both, which is why a single Pydantic model
+    parses both.
+    """
+    payload = make_bluebubbles_webhook_payload(
+        sender=sender,
+        text=text,
+        message_guid=message_guid,
+        is_from_me=is_from_me,
+    )
+    return payload["data"]
+
+
+# ---------------------------------------------------------------------------
+# Disabled / unconfigured short-circuits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_lookback_returns_zero_without_http() -> None:
+    """``bluebubbles_backfill_lookback_minutes=0`` short-circuits before HTTP."""
+    channel = BlueBubblesChannel()
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            0,
+        ),
+        patch.object(BlueBubblesChannel, "_http", new=MagicMock()) as mock_http,
+    ):
+        result = await channel.run_startup_backfill()
+
+    assert result == 0
+    mock_http.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_returns_zero_without_http() -> None:
+    """No server_url or password short-circuits before HTTP."""
+    channel = BlueBubblesChannel()
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", ""),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", ""),
+        patch.object(BlueBubblesChannel, "_http", new=MagicMock()) as mock_http,
+    ):
+        result = await channel.run_startup_backfill()
+
+    assert result == 0
+    mock_http.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Replay path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missed_message_is_replayed(bluebubbles_client: object) -> None:
+    """A message returned by /api/v1/message/query is replayed onto the bus.
+
+    The ``bluebubbles_client`` fixture is here to set up settings, allowlist,
+    and reset state. We don't use the TestClient itself.
+    """
+    channel = BlueBubblesChannel()
+    msg = _query_message(text="hello after outage", message_guid="missed-001")
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_query_response([msg]))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            30,
+        ),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+    ):
+        result = await channel.run_startup_backfill()
+
+    assert result == 1
+    mock_pub.assert_called_once()
+    inbound = mock_pub.call_args[0][0]
+    assert inbound.channel == "bluebubbles"
+    assert inbound.text == "hello after outage"
+    assert inbound.external_message_id == "bb_missed-001"
+
+
+@pytest.mark.asyncio
+async def test_is_from_me_messages_are_skipped(bluebubbles_client: object) -> None:
+    """Outgoing messages echoed back by the query API are not replayed."""
+    channel = BlueBubblesChannel()
+    incoming = _query_message(text="from contact", message_guid="in-1")
+    outgoing = _query_message(text="from me", message_guid="out-1", is_from_me=True)
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_query_response([incoming, outgoing]))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            30,
+        ),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+    ):
+        result = await channel.run_startup_backfill()
+
+    assert result == 1
+    mock_pub.assert_called_once()
+    assert mock_pub.call_args[0][0].external_message_id == "bb_in-1"
+
+
+@pytest.mark.asyncio
+async def test_already_seen_messages_are_deduped(bluebubbles_client: object) -> None:
+    """Messages we already processed via the live webhook are not re-replayed.
+
+    Idempotency is enforced by ``IdempotencyStore.try_mark_seen`` keyed off
+    ``external_message_id``. Calling backfill twice for the same message
+    must publish only once.
+    """
+    channel = BlueBubblesChannel()
+    msg = _query_message(text="dup test", message_guid="dup-001")
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_query_response([msg]))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            30,
+        ),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+    ):
+        await channel.run_startup_backfill()
+        await channel.run_startup_backfill()
+
+    assert mock_pub.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_processed_message_is_not_replayed_after_restart(
+    bluebubbles_client: TestClient,
+) -> None:
+    """End-to-end production scenario: the live webhook delivered a message,
+    the agent replied, the server later restarts, and the BlueBubbles query
+    still returns that message in its lookback window. The user must NOT be
+    re-pinged.
+
+    This is the critical safety check: if dedup ever broke, restarts would
+    spam users with replies to messages already handled. We exercise the
+    real webhook path (idempotency_keys row written via ``try_mark_seen``)
+    and only then run the backfill, asserting zero additional bus publishes.
+    """
+    channel = BlueBubblesChannel()
+    raw_message = _query_message(text="already replied to", message_guid="prior-reply-001")
+    webhook_payload = {"type": "new-message", "data": raw_message}
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_query_response([raw_message]))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", ""),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            30,
+        ),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+    ):
+        # Step 1: live webhook delivers the message via the running app.
+        # Goes through the real router -> handle_webhook_inbound ->
+        # IdempotencyStore.try_mark_seen, which commits the seen-row.
+        webhook_resp = bluebubbles_client.post("/api/webhooks/bluebubbles", json=webhook_payload)
+        assert webhook_resp.status_code == 200
+        assert mock_pub.call_count == 1, "live webhook should publish to bus on first delivery"
+
+        # Step 2: server restarts. Backfill runs against the same
+        # BlueBubbles server, which still has the message in its
+        # lookback window. Idempotency must reject it.
+        await channel.run_startup_backfill()
+
+    assert mock_pub.call_count == 1, (
+        "backfill replayed a message the live webhook already handled; "
+        "users would be re-pinged with stale replies on every restart"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_guid_is_cached_for_outbound_replies(bluebubbles_client: object) -> None:
+    """Backfill populates the chat-guid cache so replies don't reconstruct it."""
+    channel = BlueBubblesChannel()
+    msg = _query_message(message_guid="cache-001")
+    msg["chats"] = [{"guid": "iMessage;-;groupchat-abc"}]
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_query_response([msg]))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            30,
+        ),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock),
+    ):
+        await channel.run_startup_backfill()
+
+    assert channel._chat_cache.get("+15551234567") == "iMessage;-;groupchat-abc"
+
+
+# ---------------------------------------------------------------------------
+# Failure modes don't block startup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_error_returns_zero_without_raising(bluebubbles_client: object) -> None:
+    """A wedged BlueBubbles server cannot block app startup."""
+    channel = BlueBubblesChannel()
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(side_effect=httpx.ConnectError("server down"))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            30,
+        ),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+    ):
+        result = await channel.run_startup_backfill()
+
+    assert result == 0
+    mock_pub.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_4xx_response_returns_zero(bluebubbles_client: object) -> None:
+    """A 4xx (e.g. wrong password) is logged but does not block startup."""
+    channel = BlueBubblesChannel()
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_query_response([], status_code=401))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            30,
+        ),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+    ):
+        result = await channel.run_startup_backfill()
+
+    assert result == 0
+    mock_pub.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_response_returns_zero(bluebubbles_client: object) -> None:
+    """No messages in the lookback window is the common healthy-boot case."""
+    channel = BlueBubblesChannel()
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_query_response([]))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            30,
+        ),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+    ):
+        result = await channel.run_startup_backfill()
+
+    assert result == 0
+    mock_pub.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Query parameters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lookback_minutes_drives_after_param(bluebubbles_client: object) -> None:
+    """The ``after`` parameter is now-minus-lookback in unix milliseconds."""
+    channel = BlueBubblesChannel()
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_query_response([]))
+
+    with (
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_server_url", "https://x"),
+        patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "pw"),
+        patch(
+            "backend.app.channels.bluebubbles.settings.bluebubbles_backfill_lookback_minutes",
+            45,
+        ),
+        patch.object(BlueBubblesChannel, "_http", new=fake_client),
+    ):
+        await channel.run_startup_backfill()
+
+    fake_client.post.assert_called_once()
+    call_kwargs = fake_client.post.call_args.kwargs
+    body = call_kwargs["json"]
+    assert body["sort"] == "ASC"
+    assert "chat" in body["with"]
+    # ``after`` should be roughly now - 45 minutes in ms. Allow generous slack
+    # for clock drift inside the test runner.
+    expected_ms = int((time.time() - 45 * 60) * 1000)
+    assert abs(body["after"] - expected_ms) < 60_000  # within 60s


### PR DESCRIPTION
## Description

If the Clawbolt server is hung or unreachable while the BlueBubbles server successfully receives an iMessage, that message never reaches our database. The existing orphan recovery sweep (`recover_orphan_inbound_messages`) only handles messages that landed in the DB and then crashed the in-memory pipeline, so it cannot help here.

This PR adds a startup backfill that POSTs `/api/v1/message/query` to the BlueBubbles server with `after=now-N` (default 30 minutes, configurable via `BLUEBUBBLES_BACKFILL_LOOKBACK_MINUTES`) and replays each result through `handle_webhook_inbound`. The existing `IdempotencyStore` rejects anything the live webhook already processed, so the sweep is safe on every boot, including healthy ones where it becomes a no-op after dedup.

Bounded by:
- Per-call timeout of 30s so a wedged Mac cannot stretch startup
- Query `limit=200` (BlueBubbles caps at 1000; a heavy iMessage user produces maybe 30 in 30 min)
- Postgres advisory lock `bluebubbles_backfill:cleanup` so a rolling restart only replays once

Fixes #1140

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2141 passed
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (11 new tests in `tests/test_bluebubbles_backfill.py`)
- [x] Bug fixes include regression tests

The 11 tests cover: disabled lookback short-circuit, unconfigured short-circuit, replay path, `is_from_me` skipped, dedup-on-double-run, end-to-end safety check (live webhook delivers + reply sent → backfill must not replay), chat-cache populated, HTTP error swallowed, 4xx swallowed, empty response, `after` param shape.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Designed and implemented end-to-end with Claude (Opus 4.7) via `/fix-github-issue`. The contributor verified the BlueBubbles `POST /api/v1/message/query` contract by reading the upstream `bluebubbles-server` source (validator + router + serializer) before writing code, and validated dedup semantics with a test that drives the real webhook path against the real Postgres `idempotency_keys` table before invoking the backfill.