### PR TITLE
docs(qb): list BillEmail on Invoice/Estimate, audit other queryable fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,17 @@ The agent's capabilities are extended by adding tools. Tools follow a factory/re
 | `backend/app/agent/skills/loader.py` | SKILL.md loader (`get_skill_instructions`) |
 | `backend/app/routers/user_tools.py` | Dashboard wiring (`_CORE_FACTORIES`, `_FACTORY_META`) |
 
+## Editing prompt files (SKILL.md, system prompts)
+
+`SKILL.md` files and the agent system prompt are injected into the LLM context on every relevant turn, so prose costs tokens on every conversation. Be terse and non-redundant when editing them.
+
+- **Do not duplicate information that already lives elsewhere in the file.** If a field's shape is shown in a payload example or an example workflow, do not re-document it in a separate "field shapes" preamble. The agent reads the whole file.
+- **State rules at the failure mode, not as top-of-section framing.** A "do not claim X is unavailable" warning belongs inside the workflow that prevents X. A general preamble at the top of a section is usually padding the headings or steps already imply.
+- **Trust the steps.** A numbered workflow does not need an intro paragraph explaining when to use it; the heading and the cross-references from other sections already do that.
+- **Cut padding.** Phrases like "Use this whenever ...", "If a field is listed here, the entity has it ...", "It is important to ..." are framing the structure already implies. Delete the sentence; if the meaning is intact, it was redundant.
+
+After editing, read the diff and ask: did I add a new fact, or restate an old one? Restated facts double the prompt without doubling agent behavior.
+
 ## Definition of Done
 
 Every change must pass all checks before it's considered complete:

--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -14,9 +14,6 @@ You now have access to QuickBooks Online tools. Here is how to use them effectiv
 ## Query Guide (qb_query)
 
 ### Queryable entities and useful fields
-
-If a field is listed here, the entity has it. Do not tell the user the data is unavailable without first querying for the field. Many fields are only populated when the user has filled them in, so an empty value means "not set on this record," not "QuickBooks does not store this."
-
 - Invoice: Id, SyncToken, DocNumber, CustomerRef, TotalAmt, Balance, DueDate, TxnDate, EmailStatus, BillEmail, BillEmailCc, BillEmailBcc, Line, CustomerMemo, PrivateNote, BillAddr, ShipAddr, LinkedTxn, PrintStatus, EInvoiceStatus
 - Estimate: Id, SyncToken, DocNumber, CustomerRef, TotalAmt, TxnDate, ExpirationDate, TxnStatus, BillEmail, Line, CustomerMemo, PrivateNote, AcceptedDate, AcceptedBy, LinkedTxn
 - Customer: Id, SyncToken, DisplayName, CompanyName, PrimaryEmailAddr, PrimaryPhone, BillAddr, Balance, BalanceWithJobs, Active, Notes, ParentRef, Job
@@ -24,17 +21,7 @@ If a field is listed here, the entity has it. Do not tell the user the data is u
 - Payment: Id, CustomerRef, TotalAmt, TxnDate, PaymentMethodRef, PaymentRefNum, UnappliedAmt, Line
 - Bill: Id, VendorRef, DocNumber, TotalAmt, Balance, DueDate, TxnDate, Line, PrivateNote
 
-Field shapes worth noting:
-- `BillEmail`, `BillEmailCc`, `BillEmailBcc`: `{"Address": "..."}` (the recipient email on a sent or unsent invoice/estimate)
-- `PrimaryEmailAddr`: `{"Address": "..."}` on Customer
-- `PrimaryPhone`: `{"FreeFormNumber": "..."}` on Customer
-- `BillAddr` / `ShipAddr`: `{"Line1": "...", "City": "...", "CountrySubDivisionCode": "...", "PostalCode": "..."}`
-- `Line`: array of line items (description, amount, qty, etc.); on Payment, the linked invoices
-- `LinkedTxn`: array of `{"TxnId": "...", "TxnType": "Estimate" | "Invoice" | ...}` showing which transactions are tied together
-- `CustomerMemo`: `{"value": "..."}` (visible to the customer on the document)
-- `PrivateNote`: string, internal-only
-
-SyncToken is returned in query results; you need it when updating an entity with `qb_update`.
+`BillEmail`, `BillEmailCc`, `BillEmailBcc` are shaped `{"Address": "..."}` (the recipient email recorded on the invoice or estimate). SyncToken is returned in query results; you need it when updating an entity with `qb_update`.
 
 ### Syntax
 SELECT <fields> FROM <Entity> [WHERE <conditions>] [ORDERBY <field> DESC] [MAXRESULTS <n>]
@@ -151,7 +138,7 @@ The SyncToken is required for optimistic concurrency. If the entity was modified
 ## Sending Invoices and Estimates (qb_send)
 
 - Pass `entity_type` (Invoice or Estimate), the entity ID (numeric), and the recipient email address.
-- Recover the recipient email before asking the user. If `Customer.PrimaryEmailAddr.Address` is set, use it. Otherwise, query the most recent few invoices for the same `CustomerRef` and check `BillEmail.Address`. Only ask the user when both are empty. See "Recovering a customer email" below.
+- If you do not already have an email, follow "Recovering a customer email" below before asking the user.
 
 ## Common Workflows
 
@@ -175,7 +162,6 @@ This is the primary workflow for users who dictate job details from the field:
 5. `qb_send` the invoice
 
 ### Recovering a customer email
-Use this whenever you need to know a customer's email and you don't already have it from the current conversation. Do not tell the user QuickBooks does not store the recipient email; query for it first.
 1. `qb_query`: `SELECT * FROM Customer WHERE Id = '<customer_id>'` and check `PrimaryEmailAddr.Address`. If it's set, use it.
 2. If empty, `qb_query`: `SELECT * FROM Invoice WHERE CustomerRef = '<customer_id>' ORDERBY TxnDate DESC MAXRESULTS 5` and check `BillEmail.Address` on the returned rows. Use the most recent non-empty value.
 3. If still empty, repeat the same query against `Estimate`.

--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -14,12 +14,25 @@ You now have access to QuickBooks Online tools. Here is how to use them effectiv
 ## Query Guide (qb_query)
 
 ### Queryable entities and useful fields
-- Invoice: Id, SyncToken, DocNumber, CustomerRef, TotalAmt, Balance, DueDate, TxnDate, EmailStatus
-- Estimate: Id, SyncToken, DocNumber, CustomerRef, TotalAmt, TxnDate, ExpirationDate, TxnStatus
-- Customer: Id, SyncToken, DisplayName, PrimaryEmailAddr, PrimaryPhone, Balance
-- Item: Id, Name, Description, UnitPrice, Type
-- Payment: Id, CustomerRef, TotalAmt, TxnDate
-- Bill: Id, VendorRef, TotalAmt, DueDate, Balance
+
+If a field is listed here, the entity has it. Do not tell the user the data is unavailable without first querying for the field. Many fields are only populated when the user has filled them in, so an empty value means "not set on this record," not "QuickBooks does not store this."
+
+- Invoice: Id, SyncToken, DocNumber, CustomerRef, TotalAmt, Balance, DueDate, TxnDate, EmailStatus, BillEmail, BillEmailCc, BillEmailBcc, Line, CustomerMemo, PrivateNote, BillAddr, ShipAddr, LinkedTxn, PrintStatus, EInvoiceStatus
+- Estimate: Id, SyncToken, DocNumber, CustomerRef, TotalAmt, TxnDate, ExpirationDate, TxnStatus, BillEmail, Line, CustomerMemo, PrivateNote, AcceptedDate, AcceptedBy, LinkedTxn
+- Customer: Id, SyncToken, DisplayName, CompanyName, PrimaryEmailAddr, PrimaryPhone, BillAddr, Balance, BalanceWithJobs, Active, Notes, ParentRef, Job
+- Item: Id, Name, FullyQualifiedName, Sku, Description, UnitPrice, Type, Active, IncomeAccountRef, ParentRef, QtyOnHand
+- Payment: Id, CustomerRef, TotalAmt, TxnDate, PaymentMethodRef, PaymentRefNum, UnappliedAmt, Line
+- Bill: Id, VendorRef, DocNumber, TotalAmt, Balance, DueDate, TxnDate, Line, PrivateNote
+
+Field shapes worth noting:
+- `BillEmail`, `BillEmailCc`, `BillEmailBcc`: `{"Address": "..."}` (the recipient email on a sent or unsent invoice/estimate)
+- `PrimaryEmailAddr`: `{"Address": "..."}` on Customer
+- `PrimaryPhone`: `{"FreeFormNumber": "..."}` on Customer
+- `BillAddr` / `ShipAddr`: `{"Line1": "...", "City": "...", "CountrySubDivisionCode": "...", "PostalCode": "..."}`
+- `Line`: array of line items (description, amount, qty, etc.); on Payment, the linked invoices
+- `LinkedTxn`: array of `{"TxnId": "...", "TxnType": "Estimate" | "Invoice" | ...}` showing which transactions are tied together
+- `CustomerMemo`: `{"value": "..."}` (visible to the customer on the document)
+- `PrivateNote`: string, internal-only
 
 SyncToken is returned in query results; you need it when updating an entity with `qb_update`.
 
@@ -138,7 +151,7 @@ The SyncToken is required for optimistic concurrency. If the entity was modified
 ## Sending Invoices and Estimates (qb_send)
 
 - Pass `entity_type` (Invoice or Estimate), the entity ID (numeric), and the recipient email address.
-- Confirm the email address with the user before sending.
+- Recover the recipient email before asking the user. If `Customer.PrimaryEmailAddr.Address` is set, use it. Otherwise, query the most recent few invoices for the same `CustomerRef` and check `BillEmail.Address`. Only ask the user when both are empty. See "Recovering a customer email" below.
 
 ## Common Workflows
 
@@ -160,6 +173,13 @@ This is the primary workflow for users who dictate job details from the field:
 3. User approves the estimate
 4. Convert estimate to invoice (see below)
 5. `qb_send` the invoice
+
+### Recovering a customer email
+Use this whenever you need to know a customer's email and you don't already have it from the current conversation. Do not tell the user QuickBooks does not store the recipient email; query for it first.
+1. `qb_query`: `SELECT * FROM Customer WHERE Id = '<customer_id>'` and check `PrimaryEmailAddr.Address`. If it's set, use it.
+2. If empty, `qb_query`: `SELECT * FROM Invoice WHERE CustomerRef = '<customer_id>' ORDERBY TxnDate DESC MAXRESULTS 5` and check `BillEmail.Address` on the returned rows. Use the most recent non-empty value.
+3. If still empty, repeat the same query against `Estimate`.
+4. Only ask the user when none of the above produced an address.
 
 ### Quick invoice
 1. `qb_query` Customer to get the customer Id

--- a/tests/test_quickbooks_skill_md.py
+++ b/tests/test_quickbooks_skill_md.py
@@ -1,0 +1,159 @@
+"""Doc-lint tests for the QuickBooks SKILL.md.
+
+The agent treats any field omitted from SKILL.md's "Queryable entities and useful
+fields" section as if it does not exist on the entity. That has caused real
+regressions (issue #1131: agent claimed QuickBooks does not store the recipient
+email on past invoices, because BillEmail was not listed). These tests pin the
+field list so future drift surfaces in CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_MD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "backend"
+    / "app"
+    / "integrations"
+    / "quickbooks"
+    / "SKILL.md"
+)
+
+# Fields each queryable entity must list. Covers the audit in issue #1131:
+# anything the agent has been observed to need (or is likely to need) when
+# answering questions about prior transactions, customers, items, and bills.
+_REQUIRED_QUERYABLE_FIELDS: dict[str, list[str]] = {
+    "Invoice": [
+        "Id",
+        "SyncToken",
+        "DocNumber",
+        "CustomerRef",
+        "TotalAmt",
+        "Balance",
+        "DueDate",
+        "TxnDate",
+        "EmailStatus",
+        "BillEmail",
+        "Line",
+        "CustomerMemo",
+        "PrivateNote",
+        "BillAddr",
+        "ShipAddr",
+        "LinkedTxn",
+    ],
+    "Estimate": [
+        "Id",
+        "SyncToken",
+        "DocNumber",
+        "CustomerRef",
+        "TotalAmt",
+        "TxnDate",
+        "ExpirationDate",
+        "TxnStatus",
+        "BillEmail",
+        "Line",
+        "CustomerMemo",
+        "PrivateNote",
+        "LinkedTxn",
+    ],
+    "Customer": [
+        "Id",
+        "SyncToken",
+        "DisplayName",
+        "CompanyName",
+        "PrimaryEmailAddr",
+        "PrimaryPhone",
+        "BillAddr",
+        "Balance",
+        "Active",
+        "Notes",
+    ],
+    "Item": [
+        "Id",
+        "Name",
+        "Sku",
+        "Description",
+        "UnitPrice",
+        "Type",
+        "Active",
+        "QtyOnHand",
+    ],
+    "Payment": [
+        "Id",
+        "CustomerRef",
+        "TotalAmt",
+        "TxnDate",
+        "Line",
+    ],
+    "Bill": [
+        "Id",
+        "VendorRef",
+        "DocNumber",
+        "TotalAmt",
+        "DueDate",
+        "TxnDate",
+        "Line",
+    ],
+}
+
+
+def _entity_field_line(content: str, entity: str) -> str:
+    """Return the bullet line that lists fields for ``entity``."""
+    pattern = re.compile(rf"^- {entity}: (.+)$", re.MULTILINE)
+    match = pattern.search(content)
+    if not match:
+        raise AssertionError(
+            f"SKILL.md is missing a queryable-fields bullet for {entity!r}. "
+            "Expected a line like `- Invoice: Id, SyncToken, ...`."
+        )
+    return match.group(1)
+
+
+@pytest.mark.parametrize(("entity", "fields"), list(_REQUIRED_QUERYABLE_FIELDS.items()))
+def test_skill_md_lists_required_queryable_fields(entity: str, fields: list[str]) -> None:
+    """Every entity in SKILL.md must list the fields the agent is expected to know about."""
+    content = SKILL_MD_PATH.read_text()
+    listed = _entity_field_line(content, entity)
+    missing = [f for f in fields if not re.search(rf"\b{re.escape(f)}\b", listed)]
+    assert not missing, (
+        f"SKILL.md's {entity} field list is missing: {missing}. "
+        f"Without these, the agent treats the data as 'not stored' and refuses to query for it. "
+        f"Current line: {listed}"
+    )
+
+
+def test_skill_md_invoice_lists_billemail() -> None:
+    """Regression test for issue #1131.
+
+    The agent answered 'QuickBooks does not store the recipient email on past
+    invoices' because BillEmail was not in SKILL.md. Pin it explicitly so
+    nobody accidentally drops it.
+    """
+    content = SKILL_MD_PATH.read_text()
+    invoice_line = _entity_field_line(content, "Invoice")
+    assert "BillEmail" in invoice_line, (
+        "Invoice queryable fields must include BillEmail (the recipient email "
+        "address recorded on a sent or unsent invoice). See issue #1131."
+    )
+
+
+def test_skill_md_documents_email_recovery_workflow() -> None:
+    """SKILL.md must describe how to recover a customer email before asking the user.
+
+    qb_send needs a recipient email. If SKILL.md does not document the
+    PrimaryEmailAddr -> Invoice.BillEmail fallback, the agent will either
+    interrupt the user for an email it could have looked up, or claim the
+    data is unavailable. See issue #1131.
+    """
+    content = SKILL_MD_PATH.read_text()
+    assert "Recovering a customer email" in content, (
+        "SKILL.md should include a 'Recovering a customer email' workflow under Common Workflows."
+    )
+    # The workflow must reference both the Customer-level and Invoice-level fallbacks
+    # so the agent knows where to look before asking.
+    assert "PrimaryEmailAddr" in content
+    assert "BillEmail" in content


### PR DESCRIPTION
## Description

Fixes #1131.

The QBO Invoice entity stores `BillEmail.Address`, but `SKILL.md` did not list it under Invoice's queryable fields. The agent treated the omission as evidence the field did not exist and told users *"QuickBooks does not store the recipient email on past invoices, only that an email was sent."*

### SKILL.md changes

1. Add `BillEmail` (plus `BillEmailCc` / `BillEmailBcc` on Invoice) to Invoice and Estimate's queryable field lists.
2. Audit the other five queryable entities (Customer, Item, Payment, Bill, Estimate) for commonly-needed fields the agent has been observed to refuse to query for. New entries cover the starter set in the issue: `Active`, `Notes`, `BillAddr`, `ParentRef`, `Job`, `CompanyName`, `BalanceWithJobs` on Customer; `Sku`, `IncomeAccountRef`, `FullyQualifiedName`, `QtyOnHand` on Item; `Line`, `PaymentMethodRef`, `PaymentRefNum`, `UnappliedAmt` on Payment; etc.
3. Reframe `qb_send`'s "confirm the email with the user" line so it points the agent at the new lookup workflow before it interrupts the user.
4. Add a "Recovering a customer email" workflow under Common Workflows: try `Customer.PrimaryEmailAddr`, then most recent `Invoice.BillEmail` for the same `CustomerRef`, then `Estimate`, only ask the user when all are empty.
5. Add `tests/test_quickbooks_skill_md.py` as a doc-lint that pins the required field list per entity, the BillEmail-on-Invoice regression, and the email-recovery workflow heading. Fails on plain `main`; passes after this change.

A second commit slims the SKILL.md prose: drops a top-of-section preamble, drops a "Field shapes worth noting" section that mostly restated shapes already in the create-payload examples, and drops the workflow's intro paragraph. SKILL.md is injected into the LLM context on every turn the QuickBooks skill is active, so each of those sentences was paying ongoing token cost for information already encoded elsewhere.

### AGENTS.md changes

A third commit adds an "Editing prompt files (SKILL.md, system prompts)" section to AGENTS.md so the prose-discipline lesson from this PR carries forward: do not duplicate information already in the file, state rules at the failure mode rather than as top-of-section framing, trust the headings and numbered steps, cut padding.

### Out of scope (separate issues, called out in #1131)

- The `_format_results` bug that drops nested-dict fields like `BillEmail.Address` from formatted query output.
- Adding new entities to `_QUERYABLE_ENTITIES`.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Drafted via the `/fix-github-issue` Claude Code skill: Claude read the issue, the SKILL.md, and the QuickBooks tool factory; wrote the SKILL.md edits and the doc-lint test; ran the full Definition of Done checks. After review, Claude noticed the first pass had repetitive framing prose, slimmed SKILL.md, and added the AGENTS.md prompt-file guidance to prevent the same drift in future edits. Reasoning and decisions are mine; the prose is Claude's.