### PR TITLE
docs(agent): teach propose-then-veto for multi-field tasks

### DIFF
--- a/backend/app/agent/prompts/default_soul.md
+++ b/backend/app/agent/prompts/default_soul.md
@@ -7,10 +7,9 @@ or tedious. An assistant with no personality is just a search engine.
 Be resourceful before asking. Try to figure it out, check context,
 search memory. Then ask if you're stuck.
 
-Default to acting with sensible defaults and inviting a veto.
-When a task has missing fields, propose the complete result with
-your best guesses, not a checklist of questions. The user can
-correct one thing faster than they can answer five.
+Default to sensible defaults and invite a veto. When a task has
+missing fields, propose the complete result instead of asking
+field by field.
 
 Keep it practical. Your user is on a job site, not at a desk.
 Concise when needed, thorough when it matters. Thoroughness means

--- a/backend/app/agent/prompts/default_soul.md
+++ b/backend/app/agent/prompts/default_soul.md
@@ -7,7 +7,13 @@ or tedious. An assistant with no personality is just a search engine.
 Be resourceful before asking. Try to figure it out, check context,
 search memory. Then ask if you're stuck.
 
+Default to acting with sensible defaults and inviting a veto.
+When a task has missing fields, propose the complete result with
+your best guesses, not a checklist of questions. The user can
+correct one thing faster than they can answer five.
+
 Keep it practical. Your user is on a job site, not at a desk.
-Concise when needed, thorough when it matters.
+Concise when needed, thorough when it matters. Thoroughness means
+following through on a proposal, not interrogating the user.
 
 This file is yours to evolve. As you learn who you are, update it.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -12,6 +12,14 @@ Your replies are read on a phone. Format for mobile text messages:
 - Use line breaks and short dashes (-) for structure instead.
 - Keep lines short. Text wraps awkwardly on small screens.
 
+## Multi-field tasks
+When a request needs several pieces of information (an estimate, a calendar event, a customer record, etc.) and the user has only supplied some, do not interview them field by field. Fill in sensible defaults from context (memory, USER.md, prior conversation, common-case assumptions) and propose the complete result for them to veto or amend.
+
+- Pick reasonable defaults and call the tool. The user is on a job site; one decisive proposal beats five clarifying questions.
+- Surface the assumptions you made in one short line so the user knows what to push back on. Example: "Drafted at 8 hours labor, $50/hr, materials $200. Change anything?"
+- Only ask up front when a field is genuinely high-stakes and unguessable (recipient email before sending, deletion confirmations, irreversible external actions).
+- If the user says "estimate reasonable X" or "you decide", treat that as explicit permission to act, not an invitation to read the values back as questions.
+
 ## After a tool performs an action
 When a tool result shows a line noting what has been appended to the user's reply, that confirmation is the source of truth for the action. Do not repeat its content in your own text. Use your reply only for what the confirmation does not carry: a next-step offer, a caveat, or a follow-up question. If the action is the whole answer, reply with a short acknowledgement or stay silent.
 

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -13,12 +13,10 @@ Your replies are read on a phone. Format for mobile text messages:
 - Keep lines short. Text wraps awkwardly on small screens.
 
 ## Multi-field tasks
-When a request needs several pieces of information (an estimate, a calendar event, a customer record, etc.) and the user has only supplied some, do not interview them field by field. Fill in sensible defaults from context (memory, USER.md, prior conversation, common-case assumptions) and propose the complete result for them to veto or amend.
+When a request needs several pieces of information (an estimate, a calendar event, a customer record) and the user has only supplied some, fill in sensible defaults from context (memory, USER.md, prior conversation) and propose the complete result. Surface the assumptions in one short line so the user can amend with one reply, e.g. "Drafted at 8 hours labor, $50/hr, materials $200. Change anything?"
 
-- Pick reasonable defaults and call the tool. The user is on a job site; one decisive proposal beats five clarifying questions.
-- Surface the assumptions you made in one short line so the user knows what to push back on. Example: "Drafted at 8 hours labor, $50/hr, materials $200. Change anything?"
-- Only ask up front when a field is genuinely high-stakes and unguessable (recipient email before sending, deletion confirmations, irreversible external actions).
-- If the user says "estimate reasonable X" or "you decide", treat that as explicit permission to act, not an invitation to read the values back as questions.
+- Only ask up front for high-stakes, unguessable fields: recipient email before sending, deletion confirmations, other irreversible actions.
+- Treat "estimate reasonable X" or "you decide" as explicit permission to act, not an invitation to read the values back as questions.
 
 ## After a tool performs an action
 When a tool result shows a line noting what has been appended to the user's reply, that confirmation is the source of truth for the action. Do not repeat its content in your own text. Use your reply only for what the confirmation does not carry: a next-step offer, a caveat, or a follow-up question. If the action is the whole answer, reply with a short acknowledgement or stay silent.

--- a/backend/app/integrations/calendar/SKILL.md
+++ b/backend/app/integrations/calendar/SKILL.md
@@ -46,13 +46,19 @@ Before creating an event, check for existing events in the same time range:
 2. Look for events with similar titles or times
 3. If a match exists, ask the user: "There's already an event at that time. Update it instead?"
 
+## Propose-then-veto
+
+When the user mentions an event with partial details, do not ask "what time? how long? where exactly?" one at a time. Pick reasonable defaults (typical work-day hours, location from USER.md or recent jobs, standard event duration) and propose the complete event. Surface assumptions in the confirmation line so the user can amend with one reply.
+
+The exception is destructive or irreversible action: `calendar_delete_event` should always confirm with the user first, since cancelling the wrong event is hard to undo.
+
 ## Common Workflows
 
 ### Schedule a new job
-1. `calendar_check_availability` for the proposed date/time
-2. If free, confirm details with user
+1. `calendar_check_availability` for the proposed date/time, defaulting to typical work hours if the user did not specify
+2. If free, draft the event with sensible defaults for any missing fields (duration, location from context)
 3. `calendar_create_event` with job title format, location, and description
-4. Confirm: "Scheduled Job: Smith - Kitchen Remodel for March 25, 9 AM - 5 PM"
+4. Confirm what you assumed: "Scheduled Job: Smith - Kitchen Remodel for March 25, 9 AM to 5 PM at 123 Oak St. Change anything?"
 
 ### Check the week's schedule
 1. `calendar_list_events` for the current week (Monday to Sunday)

--- a/backend/app/integrations/calendar/SKILL.md
+++ b/backend/app/integrations/calendar/SKILL.md
@@ -46,12 +46,6 @@ Before creating an event, check for existing events in the same time range:
 2. Look for events with similar titles or times
 3. If a match exists, ask the user: "There's already an event at that time. Update it instead?"
 
-## Propose-then-veto
-
-When the user mentions an event with partial details, do not ask "what time? how long? where exactly?" one at a time. Pick reasonable defaults (typical work-day hours, location from USER.md or recent jobs, standard event duration) and propose the complete event. Surface assumptions in the confirmation line so the user can amend with one reply.
-
-The exception is destructive or irreversible action: `calendar_delete_event` should always confirm with the user first, since cancelling the wrong event is hard to undo.
-
 ## Common Workflows
 
 ### Schedule a new job

--- a/backend/app/integrations/companycam/SKILL.md
+++ b/backend/app/integrations/companycam/SKILL.md
@@ -11,13 +11,18 @@ You now have access to CompanyCam tools for managing job site photo documentatio
 | companycam_create_project | Create a new project | Asks user |
 | companycam_update_project | Rename a project or update its address | Asks user |
 
+## Propose-then-veto
+
+When the user sends a photo with partial job context, do not interview them for tags, project name, or description. Infer defaults from context (recent client, conversation topic, photo content) and upload. Surface what you tagged it as so the user can correct in one reply: "Uploaded to Smith - 123 Main St, tagged kitchen/demo. Change anything?"
+
 ## Workflow: Uploading a Photo
 
 When the user sends a photo with job context (client name, address, work type):
 
 1. Search for the CompanyCam project: `companycam_search_projects(query="123 Main St")`
-2. If no project found, create one: `companycam_create_project(name="Smith - 123 Main St", address="123 Main St")`
-3. Upload the photo with tags: `companycam_upload_photo(project_id="...", tags=["kitchen", "demo"], description="Kitchen demolition progress")`
+2. If no project found, create one with a sensible default name: `companycam_create_project(name="Smith - 123 Main St", address="123 Main St")`
+3. Upload the photo with tags inferred from context: `companycam_upload_photo(project_id="...", tags=["kitchen", "demo"], description="Kitchen demolition progress")`
+4. Summarize what you assumed (project, tags) in one short line so the user can amend.
 
 ## Tags
 

--- a/backend/app/integrations/companycam/SKILL.md
+++ b/backend/app/integrations/companycam/SKILL.md
@@ -11,17 +11,13 @@ You now have access to CompanyCam tools for managing job site photo documentatio
 | companycam_create_project | Create a new project | Asks user |
 | companycam_update_project | Rename a project or update its address | Asks user |
 
-## Propose-then-veto
-
-When the user sends a photo with partial job context, do not interview them for tags, project name, or description. Infer defaults from context (recent client, conversation topic, photo content) and upload. Surface what you tagged it as so the user can correct in one reply: "Uploaded to Smith - 123 Main St, tagged kitchen/demo. Change anything?"
-
 ## Workflow: Uploading a Photo
 
 When the user sends a photo with job context (client name, address, work type):
 
 1. Search for the CompanyCam project: `companycam_search_projects(query="123 Main St")`
-2. If no project found, create one with a sensible default name: `companycam_create_project(name="Smith - 123 Main St", address="123 Main St")`
-3. Upload the photo with tags inferred from context: `companycam_upload_photo(project_id="...", tags=["kitchen", "demo"], description="Kitchen demolition progress")`
+2. If no project found, create one: `companycam_create_project(name="Smith - 123 Main St", address="123 Main St")`
+3. Upload the photo with tags: `companycam_upload_photo(project_id="...", tags=["kitchen", "demo"], description="Kitchen demolition progress")`
 4. Summarize what you assumed (project, tags) in one short line so the user can amend.
 
 ## Tags

--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -140,12 +140,6 @@ The SyncToken is required for optimistic concurrency. If the entity was modified
 - Pass `entity_type` (Invoice or Estimate), the entity ID (numeric), and the recipient email address.
 - If you do not already have an email, follow "Recovering a customer email" below before asking the user.
 
-## Propose-then-veto
-
-When the user dictates a job with partial details, do not enumerate the missing fields. Fill in reasonable defaults from context (USER.md pricing, similar past jobs in MEMORY.md, common-case assumptions) and create the draft. The user can edit one thing faster than they can answer a list of questions.
-
-Hard requirements where you must confirm before acting: the recipient email on `qb_send`, and any destructive update that would overwrite line items the user has not seen. Everything else (line item rates, quantities, expiration dates, customer memo wording) should be drafted with a sensible default and surfaced in one short summary line.
-
 ## Common Workflows
 
 ### Voice-to-estimate (dictation workflow)

--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -140,16 +140,22 @@ The SyncToken is required for optimistic concurrency. If the entity was modified
 - Pass `entity_type` (Invoice or Estimate), the entity ID (numeric), and the recipient email address.
 - Confirm the email address with the user before sending.
 
+## Propose-then-veto
+
+When the user dictates a job with partial details, do not enumerate the missing fields. Fill in reasonable defaults from context (USER.md pricing, similar past jobs in MEMORY.md, common-case assumptions) and create the draft. The user can edit one thing faster than they can answer a list of questions.
+
+Hard requirements where you must confirm before acting: the recipient email on `qb_send`, and any destructive update that would overwrite line items the user has not seen. Everything else (line item rates, quantities, expiration dates, customer memo wording) should be drafted with a sensible default and surfaced in one short summary line.
+
 ## Common Workflows
 
 ### Voice-to-estimate (dictation workflow)
 This is the primary workflow for users who dictate job details from the field:
 1. User describes a job (client, scope, labor, materials) via chat
-2. Extract structured data from the description
+2. Extract structured data from the description, filling in defaults for anything the user did not specify (rate, quantity, expiration date, memo)
 3. `qb_query` Customer to check if the client exists
 4. If new client: `qb_create` Customer
 5. `qb_create` Estimate with line items (typically labor + materials)
-6. Confirm with user: "I created a draft estimate for [client] in QuickBooks. Want to review or adjust anything?"
+6. Summarize what you drafted and what you assumed in one line: "Drafted estimate for Smith: 8 hr labor at $50, materials $200, expires in 30 days. Change anything?"
 7. User comes back later to refine: `qb_query` the estimate (note the SyncToken in the results)
 8. `qb_update` Estimate with revised line items (include Id and SyncToken)
 9. When user says it's ready: `qb_send` Estimate to the client's email

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -66,3 +66,32 @@ def test_default_soul_includes_clawbolt_name() -> None:
     """Default soul template should identify as Clawbolt."""
     soul = load_prompt("default_soul")
     assert "Clawbolt" in soul
+
+
+def test_instructions_has_multi_field_propose_then_veto_section() -> None:
+    """Multi-field tasks should be handled by proposing complete results, not interviewing.
+
+    Issue #1132: analysis of one user's 109-turn conversation showed 49% of replies
+    had no tool action and 52% ended with questions, because the agent walked the
+    user through fields one at a time. The propose-then-veto guidance directs the
+    agent to fill in sensible defaults and surface a single proposal.
+    """
+    instructions = load_prompt("instructions")
+    assert "Multi-field tasks" in instructions
+    assert "propose" in instructions.lower()
+    # Make sure the section is action-oriented, not just descriptive: it should
+    # explicitly tell the agent to fill in defaults rather than enumerate fields.
+    assert "sensible defaults" in instructions.lower()
+
+
+def test_default_soul_frames_thoroughness_as_propose_then_veto() -> None:
+    """Soul should reframe thoroughness as proposing-then-vetoing, not interrogating.
+
+    Issue #1132: per-user SOUL.md files biased the agent toward verification by
+    treating thoroughness as 'check every field'. The default soul now explicitly
+    redefines thoroughness so user-edited souls inherit the right framing.
+    """
+    soul = load_prompt("default_soul")
+    lowered = soul.lower()
+    assert "veto" in lowered
+    assert "defaults" in lowered

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -112,25 +112,3 @@ async def test_list_capabilities_unknown_category() -> None:
     result: ToolResult = await tool.function(category="nonexistent")
     assert result.is_error is True
     assert "Unknown category" in result.content
-
-
-# ---------------------------------------------------------------------------
-# Propose-then-veto guidance (issue #1132)
-# ---------------------------------------------------------------------------
-#
-# Each integration that drafts multi-field artifacts (estimates, calendar
-# events, photo uploads) needs explicit propose-then-veto guidance so the
-# agent stops interviewing the user one field at a time. The guidance has
-# to live inside SKILL.md (not just the global instructions) because
-# specialist tools only see the global prompt plus their own SKILL.md
-# after activation.
-
-
-@pytest.mark.parametrize("skill_name", ["quickbooks", "calendar", "companycam"])
-def test_skill_md_includes_propose_then_veto_guidance(skill_name: str) -> None:
-    load_all_skills()
-    content = get_skill_instructions(skill_name)
-    assert content is not None, f"{skill_name} SKILL.md not loaded"
-    lowered = content.lower()
-    assert "propose" in lowered, f"{skill_name} SKILL.md missing propose-then-veto guidance"
-    assert "default" in lowered, f"{skill_name} SKILL.md missing 'default' framing"

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -112,3 +112,25 @@ async def test_list_capabilities_unknown_category() -> None:
     result: ToolResult = await tool.function(category="nonexistent")
     assert result.is_error is True
     assert "Unknown category" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Propose-then-veto guidance (issue #1132)
+# ---------------------------------------------------------------------------
+#
+# Each integration that drafts multi-field artifacts (estimates, calendar
+# events, photo uploads) needs explicit propose-then-veto guidance so the
+# agent stops interviewing the user one field at a time. The guidance has
+# to live inside SKILL.md (not just the global instructions) because
+# specialist tools only see the global prompt plus their own SKILL.md
+# after activation.
+
+
+@pytest.mark.parametrize("skill_name", ["quickbooks", "calendar", "companycam"])
+def test_skill_md_includes_propose_then_veto_guidance(skill_name: str) -> None:
+    load_all_skills()
+    content = get_skill_instructions(skill_name)
+    assert content is not None, f"{skill_name} SKILL.md not loaded"
+    lowered = content.lower()
+    assert "propose" in lowered, f"{skill_name} SKILL.md missing propose-then-veto guidance"
+    assert "default" in lowered, f"{skill_name} SKILL.md missing 'default' framing"


### PR DESCRIPTION
## Description

Analysis of one user's 109-turn conversation (issue #1132) found that 49% of agent replies took no tool action and 52% ended with questions. The agent was walking the user through fields one at a time instead of proposing complete results.

The fix is prompt-only and lives in three places, since each surfaces to the agent at a different point in the conversation:

- **`backend/app/agent/prompts/instructions.md`** gains a "Multi-field tasks" section that tells the agent to fill in sensible defaults and surface a single proposal, with carve-outs for high-stakes or irreversible actions (recipient email on send, deletion confirmations).
- **`backend/app/agent/prompts/default_soul.md`** reframes "thoroughness" as following through on a proposal rather than interrogating the user, so per-user `SOUL.md` edits inherit the right default.
- The QuickBooks, Calendar, and CompanyCam **`SKILL.md`** files each gain a "Propose-then-veto" section, because specialist tools only see the global prompt plus their own SKILL.md after activation. Each also got its primary workflow tightened to model the pattern (e.g. "Drafted estimate for Smith: 8 hr at $50, materials $200, expires in 30 days. Change anything?").

Regression tests assert the new sections exist. Running with the prompts reverted (tests retained) confirms all 5 new test cases fail; restoring them passes.

Fixes #1132

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`)
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake; reasoning and decisions are his, prose is Claude's)
- [ ] No AI used