### PR TITLE
fix(agent): require same-turn persistence to SOUL.md and MEMORY.md

### DIFF
--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -18,11 +18,11 @@ When a tool result shows a line noting what has been appended to the user's repl
 When a tool fails, no confirmation is appended. Explain plainly what went wrong so the user knows the action did not complete.
 
 ## Keeping files up to date
-Update these files proactively as you learn new things. Do not ask permission. Just do it naturally as part of the conversation.
+You must persist new information to these files in the same turn you learn it. Call edit_file or write_file directly. Do not ask permission, do not defer to "later", and do not rely on the conversation history to remember the rule. Conversation history rolls out of context; these files do not. A verbal acknowledgement without a file edit in the same turn is a bug.
 
-- **SOUL.md**: Your personality, communication style, and identity. Update when the user gives you feedback about how to talk ("be more blunt", "stop using emojis") or when your working relationship evolves. This file defines who you are.
+- **SOUL.md**: Your personality, communication style, and identity. Any time the user gives behavioral feedback about how to talk or interact ("be more blunt", "stop using emojis", "treat 'looks good' as confirmation", "stop asking before saving files"), call edit_file on SOUL.md in the same turn to record the rule. Do not just say "got it" and move on. This file defines who you are.
 - **USER.md**: The user's business profile: name, trade, crew size, pricing approach, geographic area, tools they use, preferred working hours, timezone. Update whenever you learn new business details. The richer this file, the better your estimates and recommendations.
-- **MEMORY.md**: Durable business facts: client names and contact info, pricing history, supplier details, job specifics, material costs, business policies. Update whenever you learn facts that should persist across conversations.
+- **MEMORY.md**: Durable business facts: client names and contact info, pricing history, supplier details, job specifics, material costs, business policies. When the user states a durable fact ("Acme Plumbing's contact is jane@acme.example", "I charge $95/hr for emergency calls", "the Smith job is $4,200"), call edit_file or write_file on MEMORY.md in the same turn. Do not wait for a "good" stopping point.
 - **HEARTBEAT.md**: Recurring things to check on: unpaid invoices, pending estimates, ongoing follow-ups, active job deadlines. Items surface within a window, not at an exact clock time, so don't write time-specific reminders ("at 2pm", "7:30am") here (see the Timed reminders section). Suggest adding items when the user asks about ongoing monitoring.
 
 ## Proactive monitoring

--- a/tests/integration/test_workspace_persistence_integration.py
+++ b/tests/integration/test_workspace_persistence_integration.py
@@ -1,0 +1,116 @@
+"""Integration tests for mid-conversation persistence to SOUL.md and MEMORY.md.
+
+Regression coverage for #1133: when the user gives behavioral feedback
+("treat 'looks good' as confirmation") or states a durable business fact
+("Acme Plumbing's contact is jane@acme.example"), the agent must call
+edit_file or write_file in the same turn rather than only acknowledging
+verbally. Verbal-only acknowledgement is the bug.
+
+Requires ANTHROPIC_API_KEY set in environment:
+    ANTHROPIC_API_KEY=sk-... uv run pytest -m integration -v --timeout=120
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.system_prompt import build_agent_system_prompt
+from backend.app.agent.tools.workspace_tools import create_workspace_tools
+from backend.app.models import User
+
+from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
+
+_PERSISTENCE_TOOLS = {"write_file", "edit_file"}
+
+
+def _persistence_call_for_path(response: object, path_token: str) -> tuple[bool, list[str]]:
+    """Return (matched, tool_calls_seen) for a write/edit on *path_token*.
+
+    The match is loose: any write_file or edit_file whose serialized args
+    mention the file name. Different models structure tool args slightly
+    differently, so we match on substring rather than exact path equality.
+    """
+    seen: list[str] = []
+    matched = False
+    for call in response.tool_calls:  # type: ignore[attr-defined]
+        seen.append(call.name)
+        if call.name not in _PERSISTENCE_TOOLS:
+            continue
+        if path_token in str(call.args):
+            matched = True
+    return matched, seen
+
+
+@pytest.mark.integration()
+@skip_without_anthropic_key
+async def test_behavioral_feedback_persists_to_soul_md(
+    onboarded_user: User,
+) -> None:
+    """Behavioral feedback must trigger an edit_file/write_file on SOUL.md (#1133)."""
+    with patch("backend.app.agent.core.settings") as mock_settings:
+        mock_settings.llm_provider = "anthropic"
+        mock_settings.llm_model = _ANTHROPIC_MODEL
+        mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_agent = 800
+        mock_settings.context_trim_target_tokens = 400_000
+
+        agent = ClawboltAgent(user=onboarded_user)
+        tools = create_workspace_tools(onboarded_user.id)
+        agent.register_tools(tools)
+
+        system_prompt = await build_agent_system_prompt(
+            user=onboarded_user,
+            tools=tools,
+            message_context="",
+        )
+        response = await agent.process_message(
+            "From now on, treat 'looks good' from me as confirmation. "
+            "Stop asking me to confirm before saving files.",
+            system_prompt_override=system_prompt,
+            temperature=0,
+        )
+
+    matched, seen = _persistence_call_for_path(response, "SOUL.md")
+    assert matched, (
+        "Expected edit_file or write_file on SOUL.md after behavioral feedback. "
+        f"Tool calls seen: {seen}. Reply: {response.reply_text[:200]!r}"
+    )
+
+
+@pytest.mark.integration()
+@skip_without_anthropic_key
+async def test_durable_business_fact_persists_to_memory_md(
+    onboarded_user: User,
+) -> None:
+    """Durable business facts must trigger an edit_file/write_file on MEMORY.md (#1133)."""
+    with patch("backend.app.agent.core.settings") as mock_settings:
+        mock_settings.llm_provider = "anthropic"
+        mock_settings.llm_model = _ANTHROPIC_MODEL
+        mock_settings.llm_api_base = None
+        mock_settings.llm_max_tokens_agent = 800
+        mock_settings.context_trim_target_tokens = 400_000
+
+        agent = ClawboltAgent(user=onboarded_user)
+        tools = create_workspace_tools(onboarded_user.id)
+        agent.register_tools(tools)
+
+        system_prompt = await build_agent_system_prompt(
+            user=onboarded_user,
+            tools=tools,
+            message_context="",
+        )
+        response = await agent.process_message(
+            "Quick fact for the file: Acme Plumbing's billing contact is "
+            "jane@acme.example, and we charge them $95/hr for emergency calls.",
+            system_prompt_override=system_prompt,
+            temperature=0,
+        )
+
+    matched, seen = _persistence_call_for_path(response, "MEMORY.md")
+    assert matched, (
+        "Expected edit_file or write_file on MEMORY.md after a durable business fact. "
+        f"Tool calls seen: {seen}. Reply: {response.reply_text[:200]!r}"
+    )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -66,3 +66,41 @@ def test_default_soul_includes_clawbolt_name() -> None:
     """Default soul template should identify as Clawbolt."""
     soul = load_prompt("default_soul")
     assert "Clawbolt" in soul
+
+
+def test_instructions_require_same_turn_persistence() -> None:
+    """Instructions must require same-turn file persistence (#1133).
+
+    The prior wording ("Update when the user gives you feedback") was too
+    permissive: the model would acknowledge feedback verbally and never
+    actually call edit_file. Mid-conversation rules then got lost when the
+    transcript rolled out of context. Lock the rule in here so a future edit
+    that softens the directive trips immediately.
+    """
+    instructions = load_prompt("instructions")
+    assert "same turn" in instructions
+    # The instructions must explicitly mention the file-write tool the model
+    # is expected to call, not just "update SOUL.md".
+    assert "edit_file" in instructions
+
+
+def test_instructions_call_out_soul_md_behavioral_feedback() -> None:
+    """SOUL.md guidance must tell the model to write the rule, not just acknowledge.
+
+    Regression guard for #1133: a verbal-only acknowledgement is the bug we
+    are trying to prevent.
+    """
+    instructions = load_prompt("instructions")
+    assert "SOUL.md" in instructions
+    # The phrase "behavioral feedback" anchors the SOUL.md trigger condition.
+    assert "behavioral feedback" in instructions
+
+
+def test_instructions_call_out_memory_md_durable_facts() -> None:
+    """MEMORY.md guidance must require same-turn persistence of durable facts.
+
+    Regression guard for #1133.
+    """
+    instructions = load_prompt("instructions")
+    assert "MEMORY.md" in instructions
+    assert "durable fact" in instructions.lower()


### PR DESCRIPTION
## Description

Fixes #1133.

The previous instructions told the agent to "update when the user gives you feedback about how to talk." That phrasing let the model verbally acknowledge behavioral feedback (or a durable business fact) and skip the actual file write. When the conversation rolled out of context, the rule was lost and the user had to repeat it.

This PR strengthens `backend/app/agent/prompts/instructions.md` so the model must call `edit_file` or `write_file` in the same turn it learns the rule. The new wording:

- frames verbal-only acknowledgement as a bug, not a soft suggestion
- gives concrete trigger examples for SOUL.md ("treat 'looks good' as confirmation", "stop asking before saving files")
- gives concrete trigger examples for MEMORY.md (client contacts, hourly rates, job totals)

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

### Tests added

- `tests/test_prompts.py`: three unit tests that lock in the strengthened wording (`same turn`, `edit_file`, `behavioral feedback`, `durable fact`). A future softening of the prompt trips them immediately.
- `tests/integration/test_workspace_persistence_integration.py`: two new integration tests gated on `ANTHROPIC_API_KEY` (matching the existing `test_onboarding_integration.py` pattern). They drive a real LLM with the real agent system prompt and assert that:
  1. behavioral feedback ("treat 'looks good' as confirmation") triggers a write/edit on `SOUL.md`
  2. a durable business fact (synthetic Acme Plumbing contact + hourly rate) triggers a write/edit on `MEMORY.md`

Local results:

- `uv run pytest -q`: 2145 passed, 15 deselected
- `uv run ruff check backend/ tests/ alembic/`: clean
- `uv run ruff format --check backend/ tests/ alembic/`: clean
- `uv run ty check --python .venv backend/ tests/ alembic/`: clean

## AI Usage
- [x] AI-assisted (Claude drafted the prompt rewrite, the unit tests, the integration tests, and this PR body via back-and-forth with @njbrake; reasoning and decisions are mine)
- [ ] No AI used