### PR TITLE
fix(prompts): mandate same-turn MEMORY.md writes for durable facts

### DIFF
--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -25,6 +25,23 @@ Update these files proactively as you learn new things. Do not ask permission. J
 - **MEMORY.md**: Durable business facts: client names and contact info, pricing history, supplier details, job specifics, material costs, business policies. Update whenever you learn facts that should persist across conversations.
 - **HEARTBEAT.md**: Recurring things to check on: unpaid invoices, pending estimates, ongoing follow-ups, active job deadlines. Items surface within a window, not at an exact clock time, so don't write time-specific reminders ("at 2pm", "7:30am") here (see the Timed reminders section). Suggest adding items when the user asks about ongoing monitoring.
 
+### When to write to MEMORY.md
+When you learn a durable business fact, you must call edit_file (or write_file) on MEMORY.md in the same turn. Do not say "I'll remember that", "got it, saved", or "noted" without an actual file edit. A promise without a write is a bug, not a memory.
+
+A fact is durable and belongs in MEMORY.md when it is reusable across future conversations:
+- Client identifiers and contact info (names, spelling corrections, phone, email, address, customer IDs from external systems like QuickBooks).
+- Job specifics that will be referenced again (estimate IDs, site addresses, on-site contacts).
+- Item-to-category or product-to-account mappings used for accounting.
+- Supplier names, contacts, and pricing history.
+- Business policies, recurring discounts, and standard rates.
+
+A fact is one-off and should not go in MEMORY.md when it is tied to a single moment and will not be needed again:
+- Specific paint colors, fixture choices, or material counts for a single job (these live on the job record, not in memory).
+- Today's weather, the user's mood, or other transient context.
+- Information the user explicitly told you to forget or not save.
+
+If you wrote the fact to an external system (QuickBooks, calendar, file storage), that does not replace the MEMORY.md update. External systems are not part of your prompt context next turn; MEMORY.md is. Write to both.
+
 ## Proactive monitoring
 - When a user asks to be notified about changes or wants recurring visibility into data, suggest adding a heartbeat item so it gets checked automatically.
 - Do not wait for the user to mention the heartbeat. If the request is about ongoing monitoring, proactively offer to set it up.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -66,3 +66,46 @@ def test_default_soul_includes_clawbolt_name() -> None:
     """Default soul template should identify as Clawbolt."""
     soul = load_prompt("default_soul")
     assert "Clawbolt" in soul
+
+
+def test_instructions_mandate_memory_writes_in_same_turn() -> None:
+    """Instructions must require a same-turn edit_file call when learning a durable fact (#1134).
+
+    Previously the prompt said "update proactively" without forcing the
+    write to happen in the same turn the fact was learned. The agent
+    treated MEMORY.md updates as optional and the file went stale even
+    while it persisted facts to external systems. The strengthened
+    guidance must explicitly tie "learn a durable fact" to "call
+    edit_file in the same turn".
+    """
+    instructions = load_prompt("instructions")
+    assert "MEMORY.md" in instructions
+    assert "edit_file" in instructions
+    assert "same turn" in instructions
+
+
+def test_instructions_forbid_promise_without_edit() -> None:
+    """Instructions must forbid acknowledging a fact without an actual edit (#1134).
+
+    The failure mode was the agent saying "I'll remember that" while
+    making zero workspace tool calls. The prompt must name the
+    anti-pattern so the model recognizes it.
+    """
+    instructions = load_prompt("instructions")
+    assert "I'll remember that" in instructions
+
+
+def test_instructions_distinguish_durable_from_oneoff_facts() -> None:
+    """Instructions must give a rubric separating reusable facts from one-off details (#1134).
+
+    Without a rubric the agent either saved nothing (the original bug)
+    or risked the opposite failure of stuffing single-job ephemera into
+    MEMORY.md. The prompt must list both categories with examples so
+    the model can classify what it just learned.
+    """
+    instructions = load_prompt("instructions")
+    assert "durable" in instructions.lower()
+    assert "one-off" in instructions.lower()
+    # Concrete examples on both sides of the rubric.
+    assert "customer ID" in instructions or "customer IDs" in instructions
+    assert "paint" in instructions.lower()

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -191,6 +191,14 @@ class TestSectionBuilders:
         result = build_instructions_section()
         assert "Trade guidance" not in result
 
+    def test_build_instructions_section_includes_memory_write_mandate(self) -> None:
+        """Assembled instructions must carry the MEMORY.md same-turn write mandate (#1134)."""
+        result = build_instructions_section()
+        assert "MEMORY.md" in result
+        assert "edit_file" in result
+        assert "same turn" in result
+        assert "I'll remember that" in result
+
     def test_build_tool_guidelines_empty(self) -> None:
         """Should return empty string when no tools have usage hints."""
         tool = MagicMock()


### PR DESCRIPTION
## Description
Strengthens the agent's "Keeping files up to date" instructions so that learning a durable business fact triggers an actual `edit_file`/`write_file` call on `MEMORY.md` in the same turn, instead of an empty acknowledgement.

The previous prompt said to update MEMORY.md "proactively" without binding the write to the turn the fact was learned. The agent treated saves as optional, so durable facts (customer IDs, supplier contacts, item-to-account mappings) accumulated in conversation while MEMORY.md went stale, even when the same facts were persisted to external systems like QuickBooks.

This PR adds a new `### When to write to MEMORY.md` subsection in `backend/app/agent/prompts/instructions.md` that:

- Requires a same-turn `edit_file`/`write_file` call when learning a durable fact and forbids "I'll remember that" / "got it, saved" / "noted" without an actual edit.
- Provides a rubric distinguishing **durable** facts (client identifiers, customer IDs, estimate IDs, item-to-category mappings, supplier contacts, business policies) from **one-off** details (paint colors for a single job, today's weather, things the user asked you to forget).
- States explicitly that writing to QuickBooks/calendar/file storage does not substitute for `MEMORY.md`, since external systems are not part of the next-turn prompt context while MEMORY.md is.

Adds four prompt-content regression tests:

- `test_instructions_mandate_memory_writes_in_same_turn` (`tests/test_prompts.py`)
- `test_instructions_forbid_promise_without_edit` (`tests/test_prompts.py`)
- `test_instructions_distinguish_durable_from_oneoff_facts` (`tests/test_prompts.py`)
- `test_build_instructions_section_includes_memory_write_mandate` (`tests/test_system_prompt.py`)

All four were verified to fail when the prompt change is reverted, so they genuinely guard the regression. Behavioral tests that assert the live LLM actually calls `edit_file` are out of scope here; the project's existing pattern is content-based prompt assertions and matching that pattern keeps the suite hermetic.

Fixes #1134

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)

Drafted with Claude Code (Opus 4.7) via `/fix-github-issue`. The wording of the strengthened MEMORY.md guidance and the four regression tests were authored by Claude. The decision to scope this to a prompt-only fix with content-based tests, rather than introducing live-LLM behavioral tests, was a human call.

- [ ] No AI used