### PR TITLE
fix(quickbooks): surface email, phone, address fields in qb_query results

### DIFF
--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -244,12 +244,37 @@ def _format_results(rows: list[dict[str, Any]]) -> str:
             if key in ("domain", "sparse", "MetaData"):
                 continue
             if isinstance(val, dict):
-                name = val.get("name", "")
-                ref_val = val.get("value", "")
-                if name:
-                    parts.append(f"{key}: {name} ({ref_val})")
-                elif ref_val:
-                    parts.append(f"{key}: {ref_val}")
+                if "name" in val or "value" in val:
+                    name = val.get("name", "")
+                    ref_val = val.get("value", "")
+                    if name and ref_val:
+                        parts.append(f"{key}: {name} ({ref_val})")
+                    elif name or ref_val:
+                        parts.append(f"{key}: {name or ref_val}")
+                elif "Address" in val:
+                    parts.append(f"{key}: {val['Address']}")
+                elif "FreeFormNumber" in val:
+                    parts.append(f"{key}: {val['FreeFormNumber']}")
+                elif "URI" in val:
+                    parts.append(f"{key}: {val['URI']}")
+                elif any(k in val for k in ("Line1", "City", "PostalCode")):
+                    addr_bits = [
+                        val[k]
+                        for k in (
+                            "Line1",
+                            "Line2",
+                            "City",
+                            "CountrySubDivisionCode",
+                            "PostalCode",
+                        )
+                        if val.get(k)
+                    ]
+                    if addr_bits:
+                        parts.append(f"{key}: {', '.join(addr_bits)}")
+                else:
+                    # Fail loud on unknown dict shapes so future QBO fields
+                    # surface (verbose but visible) rather than disappearing.
+                    parts.append(f"{key}: {json.dumps(val)}")
             elif isinstance(val, list):
                 if key == "Line" and val:
                     items = []

--- a/tests/test_quickbooks_tools.py
+++ b/tests/test_quickbooks_tools.py
@@ -12,6 +12,7 @@ from backend.app.agent.tools.registry import ToolContext
 from backend.app.integrations.quickbooks.factory import (
     _describe_qb_query,
     _format_intuit_fault,
+    _format_results,
     _quickbooks_factory,
     create_quickbooks_tools,
 )
@@ -298,3 +299,107 @@ class TestFormatIntuitFault:
         out = _format_intuit_fault(exc, entity="Estimate")
         assert "502" in out
         assert "Bad Gateway" in out
+
+
+# -- Query result formatter --
+
+
+class TestFormatResults:
+    """The query result formatter is the agent's only window into QBO records.
+    Each known dict-envelope shape (Address, FreeFormNumber, URI, postal
+    address, name+value ref) must surface; unknown shapes must fail loud
+    via json.dumps rather than silently disappearing."""
+
+    def test_zero_rows(self) -> None:
+        assert _format_results([]) == "Query returned 0 results."
+
+    def test_name_value_ref(self) -> None:
+        """{name, value} refs format as 'name (value)'."""
+        out = _format_results([{"Id": "1", "CustomerRef": {"name": "Acme", "value": "42"}}])
+        assert "CustomerRef: Acme (42)" in out
+
+    def test_value_only_ref(self) -> None:
+        """A ref with only `value` (e.g. CustomerMemo) keeps the field name."""
+        out = _format_results([{"Id": "1", "CustomerMemo": {"value": "Thanks!"}}])
+        assert "CustomerMemo: Thanks!" in out
+
+    def test_name_only_ref(self) -> None:
+        """A ref with only `name` keeps the field name and shows the name."""
+        out = _format_results([{"Id": "1", "CustomerRef": {"name": "Acme"}}])
+        assert "CustomerRef: Acme" in out
+
+    def test_email_address_envelope(self) -> None:
+        """{Address} envelopes (BillEmail, PrimaryEmailAddr) surface the email."""
+        out = _format_results(
+            [
+                {
+                    "Id": "1",
+                    "BillEmail": {"Address": "ar@example.com"},
+                    "PrimaryEmailAddr": {"Address": "primary@example.com"},
+                }
+            ]
+        )
+        assert "BillEmail: ar@example.com" in out
+        assert "PrimaryEmailAddr: primary@example.com" in out
+
+    def test_phone_freeformnumber_envelope(self) -> None:
+        """{FreeFormNumber} envelopes (PrimaryPhone, Mobile, etc.) surface the number."""
+        out = _format_results(
+            [
+                {
+                    "Id": "1",
+                    "PrimaryPhone": {"FreeFormNumber": "555-0100"},
+                    "Mobile": {"FreeFormNumber": "555-0200"},
+                }
+            ]
+        )
+        assert "PrimaryPhone: 555-0100" in out
+        assert "Mobile: 555-0200" in out
+
+    def test_web_uri_envelope(self) -> None:
+        """{URI} envelopes (WebAddr) surface the URL."""
+        out = _format_results([{"Id": "1", "WebAddr": {"URI": "https://example.com"}}])
+        assert "WebAddr: https://example.com" in out
+
+    def test_postal_address_envelope(self) -> None:
+        """Address-shaped dicts (BillAddr, ShipAddr) join their parts."""
+        out = _format_results(
+            [
+                {
+                    "Id": "1",
+                    "BillAddr": {
+                        "Line1": "123 Main St",
+                        "City": "Pittsburgh",
+                        "CountrySubDivisionCode": "PA",
+                        "PostalCode": "15220",
+                    },
+                }
+            ]
+        )
+        assert "BillAddr: 123 Main St, Pittsburgh, PA, 15220" in out
+
+    def test_unknown_dict_shape_is_json_dumped(self) -> None:
+        """Unknown dict shapes must surface via json.dumps, never silently drop."""
+        out = _format_results([{"Id": "1", "MysteryField": {"weird": "shape"}}])
+        assert 'MysteryField: {"weird": "shape"}' in out
+
+    def test_customer_with_email_and_address_regression(self) -> None:
+        """Regression for issue #1137: a Customer query result with both
+        PrimaryEmailAddr and BillAddr must surface both fields. Before the
+        fix, both were silently dropped because their dicts had neither
+        `name` nor `value`."""
+        row = {
+            "Id": "540",
+            "DisplayName": "Acme Plumbing",
+            "BillEmail": {"Address": "billing@example.com"},
+            "PrimaryEmailAddr": {"Address": "primary@example.com"},
+            "PrimaryPhone": {"FreeFormNumber": "555-1234"},
+            "BillAddr": {"Line1": "1 Test Ave", "City": "Pittsburgh"},
+            "CustomerRef": {"name": "Acme Plumbing", "value": "16"},
+        }
+        out = _format_results([row])
+        assert "BillEmail: billing@example.com" in out
+        assert "PrimaryEmailAddr: primary@example.com" in out
+        assert "PrimaryPhone: 555-1234" in out
+        assert "BillAddr: 1 Test Ave, Pittsburgh" in out
+        assert "CustomerRef: Acme Plumbing (16)" in out


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

`_format_results` in `backend/app/integrations/quickbooks/factory.py` only handled dict-shaped fields with `name`/`value` keys (i.e. QBO refs). Every other QBO dict envelope (`{Address}`, `{FreeFormNumber}`, `{URI}`, postal `{Line1, City, ...}`) was silently dropped. As a result, the agent could `SELECT BillEmail FROM Invoice` and see no email in the formatted output.

This PR extends the dict branch to recognize the common QBO envelope shapes:

- `{Address: ...}` for `BillEmail`, `PrimaryEmailAddr`
- `{FreeFormNumber: ...}` for `PrimaryPhone`, `Mobile`, `Fax`, `AlternatePhone`
- `{URI: ...}` for `WebAddr`
- `{Line1, City, CountrySubDivisionCode, PostalCode, ...}` for `BillAddr`, `ShipAddr`

Unknown dict shapes now fall through to `json.dumps` instead of disappearing, so a future QBO field with a new shape surfaces verbose-but-visible rather than silently going missing.

Also tightens the `{name, value}` branch so a ref with an empty `value` no longer prints a stray `()`.

Coordinates with #1131 (the SKILL.md doc half of this fix); the schema doc and the formatter together unlock the email-recovery workflow.

Fixes #1137

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Drafted by Claude (Opus 4.7, 1M context) via the `/fix-github-issue` skill: read the issue, branched off `main`, implemented the formatter fix following the layered approach proposed in the issue, added 10 unit/regression tests covering each known envelope shape plus the unknown-dict json-dump fallback, and ran the full Definition of Done locally (lint, format, ty, full pytest suite). Reasoning and decisions reviewed and approved by @njbrake.