### PR TITLE
feat(agent): cap conversation turns to dilute pattern reinforcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,7 @@ STORAGE_PROVIDER=local
 # MAX_TOOL_ROUNDS=10
 # MAX_INPUT_TOKENS=120000
 # CONTEXT_TRIM_TARGET_TOKENS=80000
+# CONTEXT_TRIM_TARGET_TURNS=80  # Cap user turns kept verbatim. Older turns roll into MEMORY.md / USER.md / SOUL.md via compaction
 # LLM_MAX_RETRIES=3
 # LLM_CACHE_EXTENDED_TTL=true  # Use Anthropic's 1h cache TTL (vs default 5min); set false on providers that reject the ttl field
 

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1008,9 +1008,10 @@ class ClawboltAgent:
         trimmed_count = original_count - len(messages)
         if trimmed_count > 0:
             logger.warning(
-                "Trimmed %d message(s) from conversation history (limit %d tokens)",
+                "Trimmed %d message(s) from conversation history (limit %d tokens, %d user turns)",
                 trimmed_count,
                 settings.context_trim_target_tokens,
+                settings.context_trim_target_turns,
             )
 
         llm_kwargs: dict[str, Any] = {}

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -993,11 +993,14 @@ class ClawboltAgent:
 
         # Trim oldest conversation history if content exceeds the limit.
         # Uses the block-based trimmer which preserves tool-call/result pairing
-        # and injects a summary of dropped messages.
+        # and injects a summary of dropped messages. The turn-count cap fires
+        # independently of the token budget so chatty long conversations get
+        # rolled through compaction even when they stay under the token limit.
         original_count = len(messages)
         trim_result = trim_messages(
             messages,
             target_tokens=settings.context_trim_target_tokens,
+            target_turns=settings.context_trim_target_turns,
             input_tokens=self._last_input_tokens or None,
         )
         messages = trim_result.messages

--- a/backend/app/agent/trimming.py
+++ b/backend/app/agent/trimming.py
@@ -20,9 +20,20 @@ from backend.app.config import settings
 _SUMMARY_MAX_CHARS = 500
 
 CONTEXT_TRIM_TARGET_TOKENS = settings.context_trim_target_tokens
+CONTEXT_TRIM_TARGET_TURNS = settings.context_trim_target_turns
 
 _OVERHEAD_TOKEN_ESTIMATE = 10_000
 _CHARS_PER_TOKEN = 4
+
+
+def _count_user_turns(msgs: list[AgentMessage]) -> int:
+    """Count user-authored turns in *msgs*.
+
+    Used as the unit for the turn-count cap. The system prompt and
+    summary placeholders are not user turns; only the original
+    ``UserMessage`` objects from the conversation count.
+    """
+    return sum(1 for m in msgs if isinstance(m, UserMessage))
 
 
 @dataclass
@@ -94,9 +105,10 @@ def _content_length(msgs: list[AgentMessage]) -> int:
 def trim_messages(
     messages: list[AgentMessage],
     target_tokens: int = CONTEXT_TRIM_TARGET_TOKENS,
+    target_turns: int | None = CONTEXT_TRIM_TARGET_TURNS,
     input_tokens: int | None = None,
 ) -> TrimResult:
-    """Trim conversation messages to fit within a token budget.
+    """Trim conversation messages to fit within a token and turn budget.
 
     Uses *input_tokens* (from ``response.usage.input_tokens``) to make
     accurate trimming decisions using the API-reported token count. When
@@ -105,7 +117,14 @@ def trim_messages(
     estimate whether trimming is needed.
 
     Keeps the system prompt (first message) and removes the oldest
-    conversation messages until the content fits within *target_tokens*.
+    conversation messages until the content fits within *target_tokens*
+    and the number of remaining user turns is within *target_turns*
+    (counting the current message). The turn cap fires independently
+    of the token budget so a chatty conversation that stays under the
+    token limit still rolls older turns through compaction, diluting
+    the influence of accumulated conversational patterns. Pass
+    ``target_turns=None`` to disable the turn-count guard.
+
     Tool-call / tool-result pairs are treated as atomic units: an
     ``AssistantMessage`` with ``tool_calls`` is never removed without also
     removing the ``ToolResultMessage`` entries that follow it (and
@@ -134,7 +153,9 @@ def trim_messages(
         orig_len = _content_length(messages) or 1
         return int(actual_input_tokens * _content_length(msgs) / orig_len)
 
-    if _tokens_for(messages) <= target_tokens:
+    over_token_budget = _tokens_for(messages) > target_tokens
+    over_turn_budget = target_turns is not None and _count_user_turns(messages) > target_turns
+    if not over_token_budget and not over_turn_budget:
         return TrimResult(messages=messages)
 
     system = messages[0]
@@ -160,14 +181,19 @@ def trim_messages(
             blocks.append([msg])
             i += 1
 
-    # Remove blocks from the front (oldest) until we fit the budget,
-    # but always keep at least the last block.
+    def _fits(remaining: list[AgentMessage]) -> bool:
+        if _tokens_for(remaining) > target_tokens:
+            return False
+        return not (target_turns is not None and _count_user_turns(remaining) > target_turns)
+
+    # Remove blocks from the front (oldest) until both budgets are
+    # satisfied, but always keep at least the last block.
     dropped: list[AgentMessage] = []
     while len(blocks) > 1:
         remaining: list[AgentMessage] = [system]
         for blk in blocks:
             remaining.extend(blk)
-        if _tokens_for(remaining) <= target_tokens:
+        if _fits(remaining):
             break
         removed_block = blocks.pop(0)
         dropped.extend(removed_block)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -85,6 +85,14 @@ class Settings(BaseSettings):
     max_tool_rounds: int = Field(default=10, ge=1)
     max_input_tokens: int = Field(default=600_000, ge=1)
     context_trim_target_tokens: int = Field(default=400_000, ge=1)
+    # Cap user turns kept verbatim in LLM context. Long single-conversation
+    # histories reinforce their own dominant tone, so new requests inherit
+    # prior conversational patterns rather than optimal procedural ones.
+    # Trimming oldest turns past this cap (independent of token budget)
+    # rolls them through compaction into MEMORY.md / USER.md / SOUL.md.
+    # Set ge=2 so at least one prior turn is always retained alongside the
+    # current one. Tune up if compaction proves too aggressive.
+    context_trim_target_turns: int = Field(default=80, ge=2)
     llm_max_retries: int = Field(default=3, ge=1)
     # Use Anthropic's 1-hour extended-TTL cache instead of the default
     # 5-minute ephemeral cache. Inactive users with conversation gaps

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -110,6 +110,7 @@ See [Storage Providers](./storage.md) for setup instructions.
 | `MAX_TOOL_ROUNDS` | `10` | Maximum tool-calling rounds per agent invocation |
 | `MAX_INPUT_TOKENS` | `120000` | Max input token budget before context trimming |
 | `CONTEXT_TRIM_TARGET_TOKENS` | `80000` | Target token count after trimming |
+| `CONTEXT_TRIM_TARGET_TURNS` | `80` | Cap on user turns kept verbatim in LLM context. Long single-conversation histories reinforce their own dominant tone, so this trims oldest turns past the cap (independent of the token budget) and rolls them through compaction into `MEMORY.md`, `USER.md`, and `SOUL.md` |
 | `LLM_MAX_RETRIES` | `3` | Maximum number of retry attempts on rate limit errors |
 | `LLM_CACHE_EXTENDED_TTL` | `true` | Use Anthropic's 1-hour extended cache TTL instead of the default 5 minutes. Reduces cold-start cache misses for users with multi-hour gaps between messages. Set to `false` on non-Anthropic providers that reject the `ttl` field |
 

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -30,6 +30,7 @@ async def test_agent_returns_nonempty_reply(
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
         mock_settings.context_trim_target_tokens = 400_000
+        mock_settings.context_trim_target_turns = 80
 
         agent = ClawboltAgent(user=integration_user)
         response = await agent.process_message(
@@ -52,6 +53,7 @@ async def test_agent_message_format_accepted(
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
         mock_settings.context_trim_target_tokens = 400_000
+        mock_settings.context_trim_target_turns = 80
 
         agent = ClawboltAgent(user=integration_user)
         history: list[AgentMessage] = [

--- a/tests/integration/test_onboarding_integration.py
+++ b/tests/integration/test_onboarding_integration.py
@@ -62,6 +62,8 @@ async def test_onboarding_extracts_profile_from_intro() -> None:
         mock_settings.llm_model = _ANTHROPIC_MODEL
         mock_settings.llm_api_base = None
         mock_settings.llm_max_tokens_agent = 500
+        mock_settings.context_trim_target_tokens = 400_000
+        mock_settings.context_trim_target_turns = 80
 
         agent = ClawboltAgent(user=user)
         tools = create_workspace_tools(user.id)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1141,6 +1141,156 @@ def test_trim_messages_no_summary_when_not_trimmed() -> None:
             assert "[Summary of earlier conversation:" not in msg.content
 
 
+# ---------------------------------------------------------------------------
+# Turn-count cap tests: long single-conversation pattern reinforcement guard
+# (issue #1135). The token budget alone cannot stop a chatty conversation
+# from drifting into pattern lock-in if it stays under the token limit.
+# ---------------------------------------------------------------------------
+
+
+def _build_turn_history(turn_pairs: int) -> list[AgentMessage]:
+    """Build a conversation with *turn_pairs* alternating user / assistant turns."""
+    history: list[AgentMessage] = []
+    for i in range(turn_pairs):
+        history.append(UserMessage(content=f"User turn {i}"))
+        history.append(AssistantMessage(content=f"Assistant reply {i}"))
+    return history
+
+
+def test_trim_messages_caps_turn_count() -> None:
+    """When user-turn count exceeds target_turns, oldest blocks should be dropped."""
+    # 200 turn pairs (chatty) but tiny content. Under any token budget but
+    # well past the turn cap. Without the turn cap this would not trim.
+    history = _build_turn_history(turn_pairs=200)
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        *history,
+        UserMessage(content="Current message"),
+    ]
+    result = trim_messages(messages, target_tokens=10_000_000, target_turns=20, input_tokens=500)
+
+    # Token budget alone would not have trimmed; the turn cap did.
+    assert len(result.dropped) > 0
+    # Remaining user-turn count (history + current) is at or below the cap.
+    user_turns_remaining = sum(1 for m in result.messages if isinstance(m, UserMessage))
+    # At most target_turns + 1 (the injected summary placeholder).
+    assert user_turns_remaining <= 20 + 1
+    # Most recent turn survives.
+    assert result.messages[-1].content == "Current message"
+    # System prompt survives.
+    assert isinstance(result.messages[0], SystemMessage)
+
+
+def test_trim_messages_turn_cap_does_not_fire_below_threshold() -> None:
+    """Conversations under the turn cap should pass through unchanged."""
+    history = _build_turn_history(turn_pairs=10)
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        *history,
+        UserMessage(content="Current message"),
+    ]
+    result = trim_messages(messages, target_tokens=10_000_000, target_turns=80, input_tokens=500)
+    assert result.dropped == []
+    assert result.messages == messages
+
+
+def test_trim_messages_turn_cap_disabled_when_none() -> None:
+    """target_turns=None should disable the turn-count guard entirely."""
+    history = _build_turn_history(turn_pairs=200)
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        *history,
+        UserMessage(content="Current message"),
+    ]
+    result = trim_messages(messages, target_tokens=10_000_000, target_turns=None, input_tokens=500)
+    assert result.dropped == []
+    assert result.messages == messages
+
+
+def test_trim_messages_turn_cap_preserves_tool_call_pairs() -> None:
+    """Block-aware removal must not orphan tool results when the turn cap fires."""
+    # Build a long history where the oldest "turn" includes a tool call/result
+    # block so we can confirm the block is removed atomically.
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        UserMessage(content="Old user with tool"),
+        AssistantMessage(
+            content=None,
+            tool_calls=[ToolCallRequest(id="call_old", name="save_fact", arguments={})],
+        ),
+        ToolResultMessage(tool_call_id="call_old", content="Saved"),
+        AssistantMessage(content="Done!"),
+    ]
+    # Pad with many short turn pairs to push the conversation past the cap.
+    messages.extend(_build_turn_history(turn_pairs=50))
+    messages.append(UserMessage(content="Current message"))
+
+    result = trim_messages(messages, target_tokens=10_000_000, target_turns=10, input_tokens=500)
+
+    # Oldest "Old user with tool" turn should have been dropped along with
+    # its full tool block, and tool messages must stay paired.
+    assert all(m.content != "Old user with tool" for m in result.messages if hasattr(m, "content"))
+    has_tool_msg = any(isinstance(m, ToolResultMessage) for m in result.messages)
+    has_tc_msg = any(isinstance(m, AssistantMessage) and m.tool_calls for m in result.messages)
+    assert has_tool_msg == has_tc_msg
+
+
+def test_trim_messages_combined_token_and_turn_budgets() -> None:
+    """Whichever budget binds first should drive trimming; both stay respected."""
+    # Long, fat content: both budgets are violated.
+    big = "x" * 4000
+    fat_history: list[AgentMessage] = []
+    for i in range(150):
+        fat_history.append(UserMessage(content=f"Turn {i}: {big}"))
+        fat_history.append(AssistantMessage(content=f"Reply {i}: {big}"))
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        *fat_history,
+        UserMessage(content="Current message"),
+    ]
+    result = trim_messages(messages, target_tokens=5000, target_turns=20, input_tokens=500_000)
+    # Both caps satisfied after trimming.
+    user_turns_remaining = sum(1 for m in result.messages if isinstance(m, UserMessage))
+    assert user_turns_remaining <= 20 + 1  # +1 for the injected summary
+    assert len(result.messages) < len(messages)
+    assert len(result.dropped) > 0
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_trims_chatty_conversation_below_token_limit(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """A 200-turn chatty conversation under the token budget should still be trimmed.
+
+    Regression test for issue #1135: pattern lock-in from accumulated
+    conversational tone, even when total tokens stay well under the limit.
+    """
+    mock_amessages.return_value = make_text_response("Ok!")
+
+    # 200 short turn pairs: trivial token footprint, well under the 400K cap.
+    long_history = _build_turn_history(turn_pairs=200)
+
+    agent = ClawboltAgent(user=test_user)
+    # Simulate the API reporting a low token count so the token budget is
+    # not violated; only the turn cap should fire.
+    agent._last_input_tokens = 5_000
+
+    await agent.process_message(
+        "Current message",
+        conversation_history=long_history,
+        system_prompt_override="Short system prompt",
+    )
+
+    call_args = mock_amessages.call_args
+    sent_messages = call_args.kwargs["messages"]
+    # First non-system message should be the trim summary.
+    assert "[Summary of earlier conversation:" in sent_messages[0]["content"]
+    # Far fewer than the original 400 messages should reach the LLM.
+    assert len(sent_messages) < 400
+
+
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_process_message_injects_summary_when_trimming(


### PR DESCRIPTION
## Description

Long single-conversation histories let the dominant tone of the existing conversation reinforce itself. New requests inherit prior conversational styles instead of optimal procedural patterns, even when total tokens stay well under the 400K trim budget.

This adds a turn-count cap (`context_trim_target_turns`, default 80) that fires independently of the token budget. When the user-turn count exceeds the cap, oldest blocks are dropped and routed through the existing `trigger_compaction_for_dropped` path, which is already wired to update `MEMORY.md`, `USER.md`, and `SOUL.md` via `compact_session`. So the new dial layers three of the four approaches in the issue on top of one mechanism:

- (2) time-ish trimming: oldest turns roll out first
- (3) behavioural summary: existing compaction extracts facts into persistent files
- (4) aggressive whole-block pruning: the trimmer already operates on tool-pair-aware blocks

Tool-call / tool-result pairs remain atomic. Passing `target_turns=None` disables the guard for callers that want token-only behaviour.

Out of scope per the issue: bulk historical compaction of existing conversations, multi-conversation threading.

Fixes #1135

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

New tests in `tests/test_agent.py`:

- `test_trim_messages_caps_turn_count`: 200-turn history under any token budget gets trimmed by the turn cap
- `test_trim_messages_turn_cap_does_not_fire_below_threshold`: small histories pass through unchanged
- `test_trim_messages_turn_cap_disabled_when_none`: `target_turns=None` opts out
- `test_trim_messages_turn_cap_preserves_tool_call_pairs`: block-aware removal does not orphan tool results
- `test_trim_messages_combined_token_and_turn_budgets`: both caps respected when both bind
- `test_agent_trims_chatty_conversation_below_token_limit`: end-to-end via `process_message` on a 200-turn chatty history that stays under the token limit

## AI Usage
- [x] AI-assisted (drafted with Claude based on the issue description; reasoning and decisions are mine)
- [ ] No AI used