### PR TITLE
fix(oauth): bound advisory-lock wait to keep event loop responsive

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -39,6 +39,14 @@ def get_engine() -> Engine:
                         "keepalives_idle": 30,
                         "keepalives_interval": 10,
                         "keepalives_count": 5,
+                        # Backstop against any single statement wedging the
+                        # connection (and any sync DB call inside an async
+                        # route, the event loop). 30s is well above the
+                        # tail of legitimate queries observed in prod
+                        # (<1s) but bounded enough that an orphaned
+                        # advisory-lock wait or runaway query can't
+                        # silently freeze a worker for hours.
+                        "options": "-c statement_timeout=30000",
                     },
                 )
     return _engine

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -35,6 +35,59 @@ def _refresh_lock_key(user_id: str, integration: str) -> str:
     return f"oauth_refresh:{user_id}:{integration}"
 
 
+# Bound on how long we'll wait for an OAuth refresh advisory lock.
+# Session-scoped advisory locks survive only as long as the holder's PG
+# session does, but a connection that drops without proper teardown can
+# leave a lock held until Postgres notices the peer is gone, which on a
+# proxied/NAT'd setup can take an hour or more. ``pg_advisory_lock`` would
+# block the calling thread (and a sync DB call inside an async route would
+# block the entire event loop) for that whole window. Polling
+# ``pg_try_advisory_lock`` with a bounded wait fails fast instead: a
+# legitimate peer normally releases within milliseconds, and a stale lock
+# means we skip this refresh attempt and let the next one (sweep tick or
+# next get_valid_token call) try again.
+_LOCK_RETRY_INTERVAL_S = 0.1
+_LOCK_MAX_WAIT_S = 5.0
+
+
+async def _try_acquire_advisory_lock_async(db: Any, lock_key: str) -> bool:
+    """Async-safe bounded acquire of a session-scoped advisory lock.
+
+    Returns True on acquire, False if the wait expires. Uses
+    ``await asyncio.sleep`` between polls so the event loop stays
+    responsive during contention.
+    """
+    deadline = time.monotonic() + _LOCK_MAX_WAIT_S
+    while True:
+        acquired = db.execute(
+            text("SELECT pg_try_advisory_lock(hashtext(:k))"),
+            {"k": lock_key},
+        ).scalar()
+        # Always commit so we don't sit idle-in-transaction between polls.
+        db.commit()
+        if acquired:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(_LOCK_RETRY_INTERVAL_S)
+
+
+def _try_acquire_advisory_lock_sync(db: Any, lock_key: str) -> bool:
+    """Sync variant for use from sync callbacks (e.g. on_refresh)."""
+    deadline = time.monotonic() + _LOCK_MAX_WAIT_S
+    while True:
+        acquired = db.execute(
+            text("SELECT pg_try_advisory_lock(hashtext(:k))"),
+            {"k": lock_key},
+        ).scalar()
+        db.commit()
+        if acquired:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_LOCK_RETRY_INTERVAL_S)
+
+
 # Per-process TTL on cached tokens. A single agent turn loads OAuth
 # credentials repeatedly (auth_check during registry build, factory
 # create() during tool instantiation, then again per actual tool call).
@@ -565,13 +618,15 @@ class OAuthService:
             db = SessionLocal()
             lock_key = _refresh_lock_key(user_id, integration)
             try:
-                db.execute(
-                    text("SELECT pg_advisory_lock(hashtext(:k))"),
-                    {"k": lock_key},
-                )
-                # Close the implicit read transaction; the advisory lock is
-                # session-scoped and survives the commit.
-                db.commit()
+                if not _try_acquire_advisory_lock_sync(db, lock_key):
+                    logger.warning(
+                        "on_refresh callback could not acquire OAuth lock within %.1fs, "
+                        "skipping persist: user=%s integration=%s",
+                        _LOCK_MAX_WAIT_S,
+                        user_id,
+                        integration,
+                    )
+                    return
                 try:
                     # Bypass the cache: this load is the peer-write detection
                     # point for the on_refresh callback path. Same race as
@@ -673,14 +728,15 @@ class OAuthService:
         db = SessionLocal()
         lock_key = _refresh_lock_key(user_id, integration)
         try:
-            db.execute(
-                text("SELECT pg_advisory_lock(hashtext(:k))"),
-                {"k": lock_key},
-            )
-            # Close the implicit read transaction so we aren't idle-in-
-            # transaction across the httpx POST. The advisory lock is
-            # session-scoped and survives the commit.
-            db.commit()
+            if not await _try_acquire_advisory_lock_async(db, lock_key):
+                logger.warning(
+                    "OAuth refresh lock contended for >%.1fs, skipping refresh: "
+                    "user=%s integration=%s",
+                    _LOCK_MAX_WAIT_S,
+                    user_id,
+                    integration,
+                )
+                return None
             try:
                 # Bypass the cache: the post-lock reload exists to detect
                 # a peer worker's just-persisted refresh, which an in-memory

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -93,6 +93,7 @@ def test_engine_uses_pool_recycle_and_tcp_keepalives() -> None:
             "keepalives_idle": 30,
             "keepalives_interval": 10,
             "keepalives_count": 5,
+            "options": "-c statement_timeout=30000",
         }
     finally:
         _db_module._engine = saved_engine

--- a/tests/test_oauth_refresh.py
+++ b/tests/test_oauth_refresh.py
@@ -7,12 +7,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from sqlalchemy import Engine, text
 
 from backend.app.services.oauth import (
     _PERMANENT_OAUTH_ERROR_CODES,
     OAuthConfig,
     OAuthService,
     OAuthTokenData,
+    _refresh_lock_key,
+    _try_acquire_advisory_lock_async,
+    _try_acquire_advisory_lock_sync,
 )
 
 # ---------------------------------------------------------------------------
@@ -463,3 +467,78 @@ class TestNotifyReauthNeeded:
         assert msg.chat_id == "12345"
         assert "Google Calendar" in msg.content
         assert "expired" in msg.content
+
+
+# ---------------------------------------------------------------------------
+# Bounded advisory-lock acquisition
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryLockBounded:
+    """Regression for a prod hang: ``pg_advisory_lock`` blocked the event loop
+    indefinitely when the lock was held by an orphaned session-scoped lock from
+    a dropped connection. The acquire path must fail fast under contention."""
+
+    @pytest.mark.asyncio()
+    async def test_async_acquire_returns_false_when_lock_held_by_peer(
+        self, _pg_engine: Engine
+    ) -> None:
+        lock_key = _refresh_lock_key("contended-user", "google_calendar")
+        peer = _pg_engine.raw_connection()
+        try:
+            cur = peer.cursor()
+            cur.execute("SELECT pg_advisory_lock(hashtext(%s))", (lock_key,))
+            peer.commit()
+
+            db = _pg_engine.connect()
+            try:
+                with patch("backend.app.services.oauth._LOCK_MAX_WAIT_S", 0.3):
+                    start = time.monotonic()
+                    acquired = await _try_acquire_advisory_lock_async(db, lock_key)
+                    elapsed = time.monotonic() - start
+            finally:
+                db.close()
+
+            assert acquired is False
+            # Bounded wait, not the multi-hour pg_advisory_lock freeze.
+            assert elapsed < 1.0
+        finally:
+            cur.execute("SELECT pg_advisory_unlock_all()")
+            peer.commit()
+            peer.close()
+
+    @pytest.mark.asyncio()
+    async def test_async_acquire_succeeds_when_lock_free(self, _pg_engine: Engine) -> None:
+        lock_key = _refresh_lock_key("free-user", "google_calendar")
+        db = _pg_engine.connect()
+        try:
+            acquired = await _try_acquire_advisory_lock_async(db, lock_key)
+            assert acquired is True
+            db.execute(text("SELECT pg_advisory_unlock(hashtext(:k))"), {"k": lock_key})
+            db.commit()
+        finally:
+            db.close()
+
+    def test_sync_acquire_returns_false_when_lock_held_by_peer(self, _pg_engine: Engine) -> None:
+        lock_key = _refresh_lock_key("contended-user-sync", "quickbooks")
+        peer = _pg_engine.raw_connection()
+        try:
+            cur = peer.cursor()
+            cur.execute("SELECT pg_advisory_lock(hashtext(%s))", (lock_key,))
+            peer.commit()
+
+            db = _pg_engine.connect()
+            try:
+                with patch("backend.app.services.oauth._LOCK_MAX_WAIT_S", 0.3):
+                    start = time.monotonic()
+                    acquired = _try_acquire_advisory_lock_sync(db, lock_key)
+                    elapsed = time.monotonic() - start
+            finally:
+                db.close()
+
+            assert acquired is False
+            assert elapsed < 1.0
+        finally:
+            cur.execute("SELECT pg_advisory_unlock_all()")
+            peer.commit()
+            peer.close()


### PR DESCRIPTION
## Description

OAuth refresh used `pg_advisory_lock` (blocking) inside an `async def`. A session-scoped advisory lock left held by a dropped connection is not released until Postgres notices the peer is gone, which on a NAT'd / proxied setup can take an hour or more. `pg_advisory_lock` will sit waiting for that whole window, blocking the calling thread, and a sync DB call inside an async route blocks the entire event loop.

The freeze signature observed in prod twice (2026-05-03 and 2026-05-04):

- Last log: `OAuth refresh sweep: 2 token(s) due for refresh` -> `credential.read action=refresh integration=quickbooks`
- Then silence for hours; CPU at 0.
- `/health/live` continues to return 200 (intentionally, it doesn't hit the DB), so Railway doesn't notice and never auto-redeploys.

PR #1138 fixed the dead-socket path (TCP keepalives + pool_recycle), but didn't catch the orphaned-advisory-lock path because `pg_advisory_lock` itself blocks waiting on the lock, not on a socket.

## Fix

- Replace `pg_advisory_lock` with a bounded poll on `pg_try_advisory_lock` (5s max wait) at both call sites in `oauth.py`:
  - `refresh_token` (async): uses `await asyncio.sleep` between polls so the event loop stays responsive during contention.
  - `_persist` (sync on_refresh callback): uses `time.sleep`.
- On contention timeout, log a warning and skip; the next sweep tick or `get_valid_token` call retries naturally. The skipped operation is idempotent (sweep retries every ~30 min, `get_valid_token` retries on next tool call).
- Add `statement_timeout=30000` (30s) to engine `connect_args` as a backstop against any other sync DB call wedging a connection. 30s is well above the tail of legitimate queries (<1s in prod) but bounded enough that a runaway query can't silently freeze a worker for hours.

This is a tactical short-term fix. The deeper architectural issue (sync SQLAlchemy inside async routes) is tracked in #1139.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (\`uv run pytest -v\`) - 2134 passed
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Three regression tests in \`tests/test_oauth_refresh.py::TestAdvisoryLockBounded\` hold the lock from a peer connection and verify the helpers return False within the bounded window instead of blocking. The existing \`test_engine_uses_pool_recycle_and_tcp_keepalives\` was extended to assert the \`statement_timeout\` connect arg.

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 wrote the patch and tests under @njbrake's direction during incident investigation)