### PR TITLE
fix(channels): skip cloudflared discovery when APP_BASE_URL is https

### DIFF
--- a/backend/app/channels/linq.py
+++ b/backend/app/channels/linq.py
@@ -17,7 +17,11 @@ from backend.app.config import settings
 from backend.app.logging_utils import mask_pii
 from backend.app.media.download import DownloadedMedia, download_bounded, generate_filename
 from backend.app.services.rate_limiter import check_webhook_rate_limit
-from backend.app.services.webhook import discover_tunnel_url, wait_for_dns
+from backend.app.services.webhook import (
+    discover_tunnel_url,
+    should_skip_tunnel_discovery,
+    wait_for_dns,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -180,12 +184,7 @@ class LinqChannel(BaseChannel):
         if not settings.linq_api_token:
             return
 
-        # Cloudflared quick-tunnel discovery is a local-dev convenience for
-        # ``cloudflared tunnel --url http://localhost:...``. Deployments with
-        # a real public domain are served over HTTPS and register via
-        # ``register_paas_webhook`` instead, so an https APP_BASE_URL is a
-        # reliable signal that the localhost sidecar will never appear.
-        if settings.app_base_url.startswith("https://"):
+        if should_skip_tunnel_discovery():
             return
 
         await asyncio.sleep(STARTUP_DELAY_SECONDS)

--- a/backend/app/channels/linq.py
+++ b/backend/app/channels/linq.py
@@ -180,6 +180,14 @@ class LinqChannel(BaseChannel):
         if not settings.linq_api_token:
             return
 
+        # Cloudflared quick-tunnel discovery is a local-dev convenience for
+        # ``cloudflared tunnel --url http://localhost:...``. Deployments with
+        # a real public domain are served over HTTPS and register via
+        # ``register_paas_webhook`` instead, so an https APP_BASE_URL is a
+        # reliable signal that the localhost sidecar will never appear.
+        if settings.app_base_url.startswith("https://"):
+            return
+
         await asyncio.sleep(STARTUP_DELAY_SECONDS)
         if self.webhook_registered:
             return

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -237,6 +237,13 @@ class TelegramChannel(BaseChannel):
         Runs as a fire-and-forget task after the server is listening so that
         Telegram can reach the webhook URL during its validation check.
         """
+        # Cloudflared quick-tunnel discovery is a local-dev convenience for
+        # ``cloudflared tunnel --url http://localhost:...``. Deployments with
+        # a real public domain are served over HTTPS and register via
+        # ``register_paas_webhook`` instead, so an https APP_BASE_URL is a
+        # reliable signal that the localhost sidecar will never appear.
+        if settings.app_base_url.startswith("https://"):
+            return
         await asyncio.sleep(STARTUP_DELAY_SECONDS)
         if self.webhook_registered:
             return

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -23,6 +23,7 @@ from backend.app.services.rate_limiter import check_webhook_rate_limit
 from backend.app.services.webhook import (
     discover_tunnel_url,
     register_telegram_webhook,
+    should_skip_tunnel_discovery,
     wait_for_dns,
 )
 
@@ -237,12 +238,7 @@ class TelegramChannel(BaseChannel):
         Runs as a fire-and-forget task after the server is listening so that
         Telegram can reach the webhook URL during its validation check.
         """
-        # Cloudflared quick-tunnel discovery is a local-dev convenience for
-        # ``cloudflared tunnel --url http://localhost:...``. Deployments with
-        # a real public domain are served over HTTPS and register via
-        # ``register_paas_webhook`` instead, so an https APP_BASE_URL is a
-        # reliable signal that the localhost sidecar will never appear.
-        if settings.app_base_url.startswith("https://"):
+        if should_skip_tunnel_discovery():
             return
         await asyncio.sleep(STARTUP_DELAY_SECONDS)
         if self.webhook_registered:

--- a/backend/app/services/webhook.py
+++ b/backend/app/services/webhook.py
@@ -18,6 +18,19 @@ DNS_RESOLUTION_MAX_RETRIES = 30
 DNS_RESOLUTION_RETRY_DELAY = 2.0
 
 
+def should_skip_tunnel_discovery() -> bool:
+    """Return True when cloudflared quick-tunnel discovery is dead code here.
+
+    The discovery loop polls a localhost sidecar that only exists for the
+    ``cloudflared tunnel --url http://localhost:...`` local-dev workflow.
+    Any deployment with a real public domain is served over HTTPS and
+    registers webhooks via ``register_paas_webhook(APP_BASE_URL)``, so an
+    https APP_BASE_URL is a reliable signal that the sidecar will never
+    appear and polling for it just delays startup.
+    """
+    return settings.app_base_url.lower().startswith("https://")
+
+
 async def discover_tunnel_url(
     max_retries: int = TUNNEL_DISCOVERY_MAX_RETRIES,
     delay: float = TUNNEL_DISCOVERY_RETRY_DELAY,

--- a/tests/test_linq_channel.py
+++ b/tests/test_linq_channel.py
@@ -560,3 +560,26 @@ async def test_start_registers_webhook_on_success() -> None:
         await channel.start()
 
     mock_register.assert_called_once_with("https://tunnel.example.com/api/webhooks/linq")
+
+
+async def test_start_skips_cloudflared_discovery_when_app_base_url_is_https() -> None:
+    """start() must not poll cloudflared when APP_BASE_URL is https.
+
+    Mirrors the Telegram channel behavior: the cloudflared quick-tunnel
+    discovery loop is a local-dev convenience and should be skipped in
+    any deployment served over a real public https domain.
+    """
+    channel = LinqChannel()
+    with (
+        patch("backend.app.channels.linq.settings.linq_api_token", "test-token"),
+        patch("backend.app.channels.linq.settings.app_base_url", "https://prod.example.com"),
+        patch("backend.app.channels.linq.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        patch(
+            "backend.app.channels.linq.discover_tunnel_url",
+            new_callable=AsyncMock,
+        ) as mock_discover,
+    ):
+        await channel.start()
+
+    mock_discover.assert_not_called()
+    mock_sleep.assert_not_called()

--- a/tests/test_telegram_service.py
+++ b/tests/test_telegram_service.py
@@ -198,6 +198,61 @@ async def test_send_typing_indicator_failure_does_not_raise(
 
 
 # ---------------------------------------------------------------------------
+# start() lifecycle: cloudflared discovery gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_start_skips_cloudflared_discovery_when_app_base_url_is_https() -> None:
+    """start() must not poll cloudflared when APP_BASE_URL is https.
+
+    The cloudflared quick-tunnel discovery loop is a local-dev convenience
+    for ``cloudflared tunnel --url http://localhost:...``. Any deployment
+    served over https has a real public domain and registers webhooks via
+    ``register_paas_webhook(APP_BASE_URL)``, so polling the localhost
+    sidecar would just waste ~20s of startup.
+    """
+    channel = TelegramChannel.__new__(TelegramChannel)
+    with (
+        patch("backend.app.channels.telegram.settings.app_base_url", "https://prod.example.com"),
+        patch(
+            "backend.app.channels.telegram.discover_tunnel_url",
+            new_callable=AsyncMock,
+        ) as mock_discover,
+        patch(
+            "backend.app.channels.telegram.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep,
+    ):
+        await channel.start()
+
+    mock_discover.assert_not_called()
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_start_runs_cloudflared_discovery_when_app_base_url_is_http() -> None:
+    """start() polls cloudflared when APP_BASE_URL is http (local dev).
+
+    Covers any local-dev port, not just the 8000 default, so a developer
+    running on ``http://localhost:9000`` still gets tunnel discovery.
+    """
+    channel = TelegramChannel.__new__(TelegramChannel)
+    with (
+        patch("backend.app.channels.telegram.settings.app_base_url", "http://localhost:9000"),
+        patch("backend.app.channels.telegram.asyncio.sleep", new_callable=AsyncMock),
+        patch(
+            "backend.app.channels.telegram.discover_tunnel_url",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_discover,
+    ):
+        await channel.start()
+
+    mock_discover.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # markdown_to_telegram_mdv2
 # ---------------------------------------------------------------------------
 

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -9,6 +9,7 @@ import pytest
 from backend.app.services.webhook import (
     discover_tunnel_url,
     register_telegram_webhook,
+    should_skip_tunnel_discovery,
     wait_for_dns,
 )
 
@@ -161,3 +162,32 @@ async def test_wait_for_dns_exhausts_retries() -> None:
 
     assert result is False
     assert mock_dns.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# should_skip_tunnel_discovery
+# ---------------------------------------------------------------------------
+
+
+def test_should_skip_tunnel_discovery_skips_https() -> None:
+    """https APP_BASE_URL should skip the cloudflared discovery loop."""
+    with patch("backend.app.services.webhook.settings.app_base_url", "https://prod.example.com"):
+        assert should_skip_tunnel_discovery() is True
+
+
+def test_should_skip_tunnel_discovery_runs_for_http_localhost() -> None:
+    """Default localhost http URL should still run discovery (local dev path)."""
+    with patch("backend.app.services.webhook.settings.app_base_url", "http://localhost:8000"):
+        assert should_skip_tunnel_discovery() is False
+
+
+def test_should_skip_tunnel_discovery_runs_for_http_alt_port() -> None:
+    """Any localhost dev port should still run discovery (port not hardcoded)."""
+    with patch("backend.app.services.webhook.settings.app_base_url", "http://localhost:9000"):
+        assert should_skip_tunnel_discovery() is False
+
+
+def test_should_skip_tunnel_discovery_is_case_insensitive() -> None:
+    """Uppercase HTTPS scheme should still trigger the skip."""
+    with patch("backend.app.services.webhook.settings.app_base_url", "HTTPS://prod.example.com"):
+        assert should_skip_tunnel_discovery() is True


### PR DESCRIPTION
## Description

Cloudflared quick-tunnel discovery (`cloudflared tunnel --url http://localhost:...`) is a local-dev convenience. In any deployment served over https, the localhost cloudflared sidecar will never appear, and webhook registration happens via `register_paas_webhook(APP_BASE_URL)` instead. Polling the sidecar 10x with 2s delay was wasting roughly 20s of startup before timing out, with noisy debug logs every attempt.

Observed in prod logs at startup:

```
DEBUG cloudflared not ready (attempt 1/10), retrying…
... (10 attempts, ~20s) ...
DEBUG Cloudflare tunnel not found after 10 attempts
DEBUG Cloudflare tunnel not detected: skipping webhook auto-registration
```

This change gates `TelegramChannel.start()` and `LinqChannel.start()` on `settings.app_base_url.startswith("https://")` so prod startups skip the loop entirely. Local dev workflows on any port keep working unchanged.

The https check is more general than comparing to a specific localhost URL: any real public deployment is served over https, while every local-dev setup uses http. A developer running on `http://localhost:9000` instead of `:8000` still gets tunnel discovery.

Fixes #1186

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Drafted with Claude Code via back-and-forth: investigation of prod startup logs, agreed on https as the gate (more general than a hardcoded URL/port compare), implementation, and tests.