### PR TITLE
refactor(db): add async engine + session foundation alongside sync

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,30 +1,68 @@
 import contextlib
 import threading
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 
 from sqlalchemy import Engine, create_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 from .config import settings
 
 _engine: Engine | None = None
 _SessionLocal: sessionmaker[Session] | None = None
+_async_engine: AsyncEngine | None = None
+_async_session_factory: async_sessionmaker[AsyncSession] | None = None
 _lock = threading.RLock()
 
 
-def get_engine() -> Engine:
-    """Return the singleton engine, creating it on first call.
+# Pool tuning constants shared by sync and async engines.
+#
+# Pool tuning is defensive against silent connection drops in cloud
+# environments. Hosted Postgres setups (Railway, RDS proxies, NAT
+# gateways) routinely close idle TCP sockets without sending a FIN,
+# leaving the client end half-open. A sync DB call from an async route
+# that hits such a socket can block the event loop for the kernel's
+# default ~2h TCP retransmit window: zero CPU, no logs, no crash, and
+# the platform's liveness probe still passes because /health/live
+# never touches the DB. ``pool_recycle`` rotates connections before
+# any reasonable NAT timeout.
+_POOL_RECYCLE_SECONDS = 1800
+# 30s is well above the tail of legitimate queries observed in prod
+# (<1s) but bounded enough that an orphaned advisory-lock wait or
+# runaway query can't silently freeze a worker for hours.
+_STATEMENT_TIMEOUT_MS = 30000
 
-    Pool tuning is defensive against silent connection drops in cloud
-    environments. Hosted Postgres setups (Railway, RDS proxies, NAT
-    gateways) routinely close idle TCP sockets without sending a FIN,
-    leaving the client end half-open. A sync DB call from an async route
-    that hits such a socket can block the event loop for the kernel's
-    default ~2h TCP retransmit window: zero CPU, no logs, no crash, and
-    the platform's liveness probe still passes because /health/live
-    never touches the DB. ``pool_recycle`` rotates connections before
-    any reasonable NAT timeout, and the TCP keepalive options let the
-    kernel detect a dead socket within ~80s instead.
+
+def _async_database_url(url: str) -> str:
+    """Translate a sync postgres URL to its asyncpg equivalent.
+
+    SQLAlchemy uses driver-specific URL prefixes. The sync path uses
+    ``postgresql://`` (psycopg2) and the async path uses
+    ``postgresql+asyncpg://``. Settings ship one ``database_url`` value;
+    we derive the async form here so callers don't need to know which
+    driver they are picking up.
+    """
+    if url.startswith("postgresql+asyncpg://"):
+        return url
+    if url.startswith("postgresql://"):
+        return "postgresql+asyncpg://" + url[len("postgresql://") :]
+    if url.startswith("postgresql+psycopg2://"):
+        return "postgresql+asyncpg://" + url[len("postgresql+psycopg2://") :]
+    return url
+
+
+def get_engine() -> Engine:
+    """Return the singleton sync engine, creating it on first call.
+
+    The TCP keepalive options let the kernel detect a dead socket
+    within ~80s instead of the default ~2h retransmit window. asyncpg
+    sets its own keepalives by default so the async engine does not
+    need the same ``connect_args`` payload.
     """
     global _engine
     if _engine is None:
@@ -33,23 +71,49 @@ def get_engine() -> Engine:
                 _engine = create_engine(
                     settings.database_url,
                     pool_pre_ping=True,
-                    pool_recycle=1800,
+                    pool_recycle=_POOL_RECYCLE_SECONDS,
                     connect_args={
                         "keepalives": 1,
                         "keepalives_idle": 30,
                         "keepalives_interval": 10,
                         "keepalives_count": 5,
-                        # Backstop against any single statement wedging the
-                        # connection (and any sync DB call inside an async
-                        # route, the event loop). 30s is well above the
-                        # tail of legitimate queries observed in prod
-                        # (<1s) but bounded enough that an orphaned
-                        # advisory-lock wait or runaway query can't
-                        # silently freeze a worker for hours.
-                        "options": "-c statement_timeout=30000",
+                        # Backstop against any single statement wedging
+                        # the connection (and any sync DB call inside
+                        # an async route, the event loop).
+                        "options": f"-c statement_timeout={_STATEMENT_TIMEOUT_MS}",
                     },
                 )
     return _engine
+
+
+def get_async_engine() -> AsyncEngine:
+    """Return the singleton async engine, creating it on first call.
+
+    Mirrors ``get_engine()`` but uses asyncpg as the driver. The async
+    engine coexists with the sync engine: both pull from the same
+    ``settings.database_url`` value and target the same database, but
+    each maintains its own connection pool. This is the foundation for
+    the dual-API (sync + async) store rollout in #1150-1157.
+    """
+    global _async_engine
+    if _async_engine is None:
+        with _lock:
+            if _async_engine is None:
+                _async_engine = create_async_engine(
+                    _async_database_url(settings.database_url),
+                    pool_pre_ping=True,
+                    pool_recycle=_POOL_RECYCLE_SECONDS,
+                    # asyncpg uses a different connect_args shape than
+                    # psycopg2. ``server_settings`` maps to libpq's
+                    # ``options`` parameter; keepalives are on by
+                    # default in asyncpg so we don't repeat them here.
+                    connect_args={
+                        "server_settings": {
+                            "statement_timeout": str(_STATEMENT_TIMEOUT_MS),
+                        },
+                    },
+                )
+    return _async_engine
 
 
 def get_session_factory() -> sessionmaker[Session]:
@@ -62,10 +126,29 @@ def get_session_factory() -> sessionmaker[Session]:
     return _SessionLocal
 
 
+def get_async_session_factory() -> async_sessionmaker[AsyncSession]:
+    """Return the singleton async session factory, creating it on first call."""
+    global _async_session_factory
+    if _async_session_factory is None:
+        with _lock:
+            if _async_session_factory is None:
+                _async_session_factory = async_sessionmaker(
+                    bind=get_async_engine(),
+                    autoflush=False,
+                    expire_on_commit=False,
+                )
+    return _async_session_factory
+
+
 # Convenience alias for direct use outside of FastAPI dependency injection
 def SessionLocal() -> Session:
     """Create a new session from the singleton factory."""
     return get_session_factory()()
+
+
+def AsyncSessionLocal() -> AsyncSession:
+    """Create a new async session from the singleton factory."""
+    return get_async_session_factory()()
 
 
 class Base(DeclarativeBase):
@@ -92,9 +175,49 @@ def db_session() -> Generator[Session]:
         db.close()
 
 
+@contextlib.asynccontextmanager
+async def db_session_async() -> AsyncGenerator[AsyncSession]:
+    """Async context manager mirroring ``db_session()``.
+
+    Usage::
+
+        async with db_session_async() as db:
+            db.add(obj)
+            await db.commit()
+
+    Same lifecycle semantics as the sync version: rollback on
+    exception, always close. The session factory's
+    ``expire_on_commit=False`` matches the SQLAlchemy async-default
+    recommendation (avoids implicit IO on attribute access after
+    commit, which would surface as ``MissingGreenlet`` errors).
+    """
+    db = AsyncSessionLocal()
+    try:
+        yield db
+    except Exception:
+        await db.rollback()
+        raise
+    finally:
+        await db.close()
+
+
 def get_db() -> Generator[Session]:
     db = get_session_factory()()
     try:
         yield db
     finally:
         db.close()
+
+
+async def get_async_db() -> AsyncGenerator[AsyncSession]:
+    """FastAPI dependency that yields an ``AsyncSession``.
+
+    Symmetric with ``get_db()``. Routes converted to async DB access
+    can ``Depends(get_async_db)`` while routes still on sync continue
+    to ``Depends(get_db)``.
+    """
+    db = get_async_session_factory()()
+    try:
+        yield db
+    finally:
+        await db.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "google-auth-oauthlib>=1.0",
     "sqlalchemy>=2.0",
     "psycopg2-binary>=2.9",
+    "asyncpg>=0.29",
     "alembic>=1.13",
     "cryptography>=42.0",
     "cachetools>=5.3",

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,8 +3,14 @@
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import Engine, text
+from sqlalchemy import Engine, select, text
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 import backend.app.database as _db_module
 from backend.app.models import ChannelRoute, User
@@ -97,6 +103,95 @@ def test_engine_uses_pool_recycle_and_tcp_keepalives() -> None:
         }
     finally:
         _db_module._engine = saved_engine
+
+
+def test_async_database_url_translates_postgresql_prefix() -> None:
+    """``_async_database_url`` swaps the sync prefix for the asyncpg one."""
+    assert (
+        _db_module._async_database_url("postgresql://u:p@h:5432/db")
+        == "postgresql+asyncpg://u:p@h:5432/db"
+    )
+    assert (
+        _db_module._async_database_url("postgresql+psycopg2://u:p@h:5432/db")
+        == "postgresql+asyncpg://u:p@h:5432/db"
+    )
+    # Already async-prefixed URLs pass through unchanged.
+    assert (
+        _db_module._async_database_url("postgresql+asyncpg://u:p@h:5432/db")
+        == "postgresql+asyncpg://u:p@h:5432/db"
+    )
+
+
+def test_async_engine_singleton_and_pool_settings() -> None:
+    """``get_async_engine`` returns a singleton with async-specific pool args."""
+    saved_engine = _db_module._async_engine
+    _db_module._async_engine = None
+    try:
+        with patch.object(_db_module, "create_async_engine") as mock_create:
+            _db_module.get_async_engine()
+            _db_module.get_async_engine()  # second call must reuse the singleton
+
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["pool_pre_ping"] is True
+        assert kwargs["pool_recycle"] == 1800
+        # asyncpg surfaces libpq's ``options`` parameter via
+        # ``server_settings``; statement_timeout should still be set.
+        assert kwargs["connect_args"] == {
+            "server_settings": {"statement_timeout": "30000"},
+        }
+    finally:
+        _db_module._async_engine = saved_engine
+
+
+async def test_async_session_can_execute_trivial_select() -> None:
+    """End-to-end smoke: an ``AsyncSession`` can run ``select(1)``.
+
+    Builds its own engine so the test does not depend on the conftest
+    sync-rollback fixture (which manipulates ``_engine`` /
+    ``_SessionLocal`` only). This is the foundation-level proof that
+    asyncpg + async_sessionmaker + ``AsyncSession`` are wired
+    correctly. Per-store dual-API conversions live in #1150-1157.
+    """
+    url = _db_module._async_database_url(
+        "postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_test"
+    )
+    engine: AsyncEngine = create_async_engine(url, pool_pre_ping=True)
+    factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    try:
+        async with factory() as session:
+            result = await session.execute(select(1))
+            assert result.scalar_one() == 1
+    finally:
+        await engine.dispose()
+
+
+async def test_db_session_async_rollback_on_exception() -> None:
+    """``db_session_async`` rolls back when the body raises.
+
+    Mirrors the sync ``db_session`` lifecycle contract: exceptions
+    trigger rollback before the session closes.
+    """
+    url = _db_module._async_database_url(
+        "postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_test"
+    )
+    engine: AsyncEngine = create_async_engine(url, pool_pre_ping=True)
+    factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    saved_factory = _db_module._async_session_factory
+    _db_module._async_session_factory = factory
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            async with _db_module.db_session_async() as session:
+                # Touch the connection so rollback is observable.
+                await session.execute(select(1))
+                raise RuntimeError("boom")
+    finally:
+        _db_module._async_session_factory = saved_factory
+        await engine.dispose()
 
 
 def test_user_defaults() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-27T09:34:23.543148262Z"
+exclude-newer = "2026-04-28T12:30:13.637691092Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -286,6 +286,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159, upload-time = "2025-11-24T23:25:36.443Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157, upload-time = "2025-11-24T23:25:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051, upload-time = "2025-11-24T23:25:39.461Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640, upload-time = "2025-11-24T23:25:41.512Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050, upload-time = "2025-11-24T23:25:43.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574, upload-time = "2025-11-24T23:25:44.942Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076, upload-time = "2025-11-24T23:25:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980, upload-time = "2025-11-24T23:25:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
 ]
 
 [[package]]
@@ -585,6 +633,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "any-llm-sdk", extra = ["all"] },
+    { name = "asyncpg" },
     { name = "cachetools" },
     { name = "cryptography" },
     { name = "dropbox" },
@@ -624,6 +673,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.13" },
+    { name = "asyncpg", specifier = ">=0.29" },
     { name = "cachetools", specifier = ">=5.3" },
     { name = "cryptography", specifier = ">=42.0" },
     { name = "dropbox", specifier = ">=12.0" },


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Closes #1149. Re-lands the 672eff6 spike additively: async primitives are added alongside the existing sync primitives in `backend/app/database.py` rather than replacing them. No callers are touched; that work lives in the per-store follow-ups (#1150 through #1157).

What changed:

- `get_async_engine()` / `_async_engine` mirror `get_engine()` / `_engine`. Same singleton + double-checked-locking pattern. Driven off the same `settings.database_url`, with a `_async_database_url()` helper that swaps the prefix to `postgresql+asyncpg://`. asyncpg sets TCP keepalives by default, so the async `connect_args` only carries the `statement_timeout` (via `server_settings`); the sync engine still carries the explicit libpq keepalive options.
- `get_async_session_factory()` / `_async_session_factory` mirror `get_session_factory()` / `_SessionLocal`. Sets `expire_on_commit=False` to match the SQLAlchemy async-default recommendation (avoids implicit IO on attribute access after commit, which would surface as `MissingGreenlet`).
- `db_session_async()` mirrors the existing `db_session()` context manager: rollback on exception, always close.
- `get_async_db()` mirrors `get_db()` for FastAPI dependency injection.
- `AsyncSessionLocal()` mirrors the `SessionLocal()` convenience callable.
- `asyncpg>=0.29` added to `pyproject.toml`.

The shared pool tuning (`pool_recycle`, statement timeout) lives in module-level constants (`_POOL_RECYCLE_SECONDS`, `_STATEMENT_TIMEOUT_MS`) so the two engines stay in lockstep.

What did not change:

- Every existing sync export (`Engine`, `SessionLocal`, `get_db`, `get_session_factory`, `db_session`, `Base`, `get_engine`) keeps its name, signature, and behavior. The connection pool args for the sync engine are byte-identical (the regression test `test_engine_uses_pool_recycle_and_tcp_keepalives` still passes unchanged).
- No store APIs touched. No routers touched. No conftest fixture touched.

## Type
- [x] Refactor

## Checklist
- [x] Tests pass (`uv run pytest -v`): 2176 passed, 13 deselected
- [x] Lint passes (`uv run ruff check backend/ tests/ alembic/`)
- [x] Format passes (`uv run ruff format --check backend/ tests/ alembic/`)
- [x] Type check passes (`uv run ty check --python .venv backend/ tests/ alembic/`)
- [x] New tests added: `_async_database_url()` translation, async engine pool args, end-to-end `select(1)` over `AsyncSession`, `db_session_async` rollback contract
- [ ] Bug fixes include regression tests (n/a, foundation refactor)

## AI Usage
- [x] AI-assisted: drafted by Claude after back-and-forth with @njbrake on the additive vs big-bang strategy.

## Context

Part of #1139 (epic). This is the foundation re-land of the 672eff6 spike under the dual-API plan. Per-store conversions follow in #1150-1157. After premium fully migrates (mozilla-ai/clawbolt-premium#387), OSS removes the sync APIs in #1160.