### PR TITLE
feat(extensions): let nav items hook navigation clicks

### DIFF
--- a/frontend/src/extensions/nav.ts
+++ b/frontend/src/extensions/nav.ts
@@ -4,6 +4,8 @@ export interface NavExtensionItem {
   to: string;
   label: string;
   icon: ComponentType;
+  /** Fired in addition to navigation, so extensions can reset internal state (e.g. hash-routed tabs). */
+  onClick?: () => void;
 }
 
 function ShieldIcon() {

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -176,11 +176,14 @@ export default function AppShell() {
               {label}
             </NavLink>
           ))}
-          {extraNavItems.map(({ to, label, icon: Icon }) => (
+          {extraNavItems.map(({ to, label, icon: Icon, onClick: onExtensionClick }) => (
             <NavLink
               key={to}
               to={to}
-              onClick={closeSidebar}
+              onClick={() => {
+                onExtensionClick?.();
+                closeSidebar();
+              }}
               className={({ isActive }) =>
                 `flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-all duration-150 ${
                   isActive


### PR DESCRIPTION
## Description

Adds an optional `onClick` callback to `NavExtensionItem` and wires it into the sidebar's extra-nav `NavLink`s in `AppShell`. The callback fires alongside React Router's navigation, so an extension whose target page does internal routing the host shell does not know about can reset its own state when the sidebar entry is clicked.

Concrete motivation: the premium admin panel uses `window.location.hash` for its tabs and per-user detail view. If an admin is on `/app/admin#users/{id}` and clicks the Admin entry in the sidebar, React Router sees the same pathname and the panel's hash-driven state is not reset, so they stay stuck on user-detail. With this hook, premium can clear the hash from its own `getExtraNavItems` and the panel resets to the overview as expected.

The change is backward compatible: the field is optional, existing entries (none in OSS today, but conceptually) keep working unchanged.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — frontend-only change, no backend tests affected
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) — no Python touched
- [ ] New tests added for new functionality — interface plumbing only, exercised by premium consumer
- [ ] Bug fixes include regression tests — N/A (feature)

## AI Usage
- [x] AI-assisted (describe how) — drafted with Claude Code; reviewed and refined by @njbrake
- [ ] No AI used