### PR TITLE
feat(approval): add approval_events audit log for admin observability

### DIFF
--- a/alembic/versions/028_add_approval_events.py
+++ b/alembic/versions/028_add_approval_events.py
@@ -1,0 +1,60 @@
+"""Add approval_events audit log.
+
+Records every transition in the tool-approval lifecycle so admins can
+see when the agent was blocked on a permission prompt, what tool it was
+gating, and how the request resolved (approved, denied, timed out,
+recovered after a worker crash, ...). The existing ``pending_approvals``
+table only carries in-flight rows and is deleted on resolve, so it
+cannot answer "what happened to that approval ten minutes ago?".
+
+Append-only. No retention sweep ships with this migration; the table
+is small (handful of rows per user per active session).
+
+Revision ID: 028
+Revises: 027
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "028"
+down_revision: str = "027"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "approval_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.String(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("tool_name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("channel", sa.String(), nullable=False, server_default=""),
+        sa.Column("chat_id", sa.String(), nullable=False, server_default=""),
+        sa.Column("decision", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_approval_events_user_id", "approval_events", ["user_id"])
+    op.create_index("ix_approval_events_created_at", "approval_events", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_approval_events_created_at", "approval_events")
+    op.drop_index("ix_approval_events_user_id", "approval_events")
+    op.drop_table("approval_events")

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -34,7 +34,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from backend.app.bus import OutboundMessage
 from backend.app.config import settings
 from backend.app.database import SessionLocal, db_session
-from backend.app.models import PendingApprovalRow, UserPermissionSet
+from backend.app.models import ApprovalEvent, PendingApprovalRow, UserPermissionSet
 
 logger = logging.getLogger(__name__)
 
@@ -414,6 +414,7 @@ class ApprovalGate:
         pending = PendingApproval(tool_name=tool_name, description=description)
         self._pending[user_id] = pending
         _persist_pending_row(user_id, tool_name, description, channel, chat_id)
+        _log_approval_event(user_id, "requested", tool_name, description, channel, chat_id)
 
         if prompt is None:
             prompt = format_approval_message(tool_name, description)
@@ -440,6 +441,7 @@ class ApprovalGate:
             )
             self._pending.pop(user_id, None)
             _delete_pending_row(user_id)
+            _log_approval_event(user_id, "timed_out", tool_name, description, channel, chat_id)
             return ApprovalDecision.DENIED
 
         if pending.decision is None:
@@ -472,6 +474,20 @@ class ApprovalGate:
             return False
         pending.decision = decision
         _delete_pending_row(user_id)
+        # The audit log mirrors what was sent to the user: tool_name and
+        # description come from the in-memory PendingApproval. channel /
+        # chat_id are not threaded through resolve() (callers don't know
+        # them); they're already on the matching ``requested`` row, so
+        # admins can join by user_id + ordering.
+        _log_approval_event(
+            user_id,
+            "decided",
+            pending.tool_name,
+            pending.description,
+            channel="",
+            chat_id="",
+            decision=decision,
+        )
         pending.event.set()
         return True
 
@@ -542,6 +558,49 @@ def _delete_pending_row(user_id: str) -> None:
                 db.commit()
     except Exception:
         logger.exception("Failed to delete pending approval row for user %s", user_id)
+
+
+# ---------------------------------------------------------------------------
+# Approval audit log
+# ---------------------------------------------------------------------------
+
+
+def _log_approval_event(
+    user_id: str,
+    event_type: str,
+    tool_name: str,
+    description: str,
+    channel: str,
+    chat_id: str,
+    decision: ApprovalDecision | None = None,
+) -> None:
+    """Append one ``approval_events`` row for an approval-lifecycle transition.
+
+    Failures are logged and swallowed: the audit log is observability,
+    not a correctness prerequisite. The in-memory gate still drives the
+    live wake-up flow.
+    """
+    try:
+        with db_session() as db:
+            db.add(
+                ApprovalEvent(
+                    user_id=user_id,
+                    event_type=event_type,
+                    tool_name=tool_name,
+                    description=description,
+                    channel=channel,
+                    chat_id=chat_id,
+                    decision=str(decision) if decision is not None else None,
+                )
+            )
+            db.commit()
+    except Exception:
+        logger.exception(
+            "Failed to record approval_event(%s) for user %s tool %s",
+            event_type,
+            user_id,
+            tool_name,
+        )
 
 
 _ORPHAN_MAX_AGE = timedelta(hours=1)
@@ -634,6 +693,7 @@ async def cleanup_orphaned_approvals(
                     )
                 )
                 _delete_pending_row(user_id)
+                _log_approval_event(user_id, "recovered", tool_name, "", channel, chat_id)
                 recovered += 1
                 logger.info(
                     "Recovered orphaned approval for user %s (tool=%s)",
@@ -832,11 +892,77 @@ def format_approval_message(tool_name: str, description: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# ApprovalEventStore (read-side audit-log access)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApprovalEventRecord:
+    """Read-side projection of one ``approval_events`` row."""
+
+    id: int
+    user_id: str
+    event_type: str
+    tool_name: str
+    description: str
+    channel: str
+    chat_id: str
+    decision: str | None
+    created_at: datetime
+
+
+class ApprovalEventStore:
+    """Read-side accessor for ``approval_events``.
+
+    Premium admin endpoints import this rather than reaching into the
+    table directly so the underlying schema can evolve without churn in
+    the premium repo.
+    """
+
+    def list_for_user(
+        self,
+        user_id: str,
+        limit: int = 500,
+        since: datetime | None = None,
+    ) -> list[ApprovalEventRecord]:
+        """Return approval events for *user_id* in chronological order.
+
+        ``limit`` caps the query so a long-running admin dashboard
+        cannot OOM the response. ``since`` is an inclusive lower bound
+        on ``created_at``; pass it to scope to a recent window.
+        """
+        with db_session() as db:
+            q = db.query(ApprovalEvent).filter(ApprovalEvent.user_id == user_id)
+            if since is not None:
+                q = q.filter(ApprovalEvent.created_at >= since)
+            rows = (
+                q.order_by(ApprovalEvent.created_at.asc(), ApprovalEvent.id.asc())
+                .limit(limit)
+                .all()
+            )
+            return [
+                ApprovalEventRecord(
+                    id=r.id,
+                    user_id=r.user_id,
+                    event_type=r.event_type,
+                    tool_name=r.tool_name,
+                    description=r.description or "",
+                    channel=r.channel or "",
+                    chat_id=r.chat_id or "",
+                    decision=r.decision,
+                    created_at=r.created_at,
+                )
+                for r in rows
+            ]
+
+
+# ---------------------------------------------------------------------------
 # Module-level singleton
 # ---------------------------------------------------------------------------
 
 _approval_gate: ApprovalGate | None = None
 _approval_store: ApprovalStore | None = None
+_approval_event_store: ApprovalEventStore | None = None
 
 
 def get_approval_gate() -> ApprovalGate:
@@ -855,8 +981,17 @@ def get_approval_store() -> ApprovalStore:
     return _approval_store
 
 
+def get_approval_event_store() -> ApprovalEventStore:
+    """Get or create the global ApprovalEventStore."""
+    global _approval_event_store
+    if _approval_event_store is None:
+        _approval_event_store = ApprovalEventStore()
+    return _approval_event_store
+
+
 def reset_approval_gate() -> None:
     """Reset cached approval singletons. Used by tests."""
-    global _approval_gate, _approval_store
+    global _approval_gate, _approval_store, _approval_event_store
     _approval_gate = None
     _approval_store = None
+    _approval_event_store = None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -638,6 +638,48 @@ class PendingApprovalRow(Base):
     )
 
 
+class ApprovalEvent(Base):
+    """Append-only audit log for tool-approval lifecycle transitions.
+
+    Companion to ``PendingApprovalRow``: that row tracks the single
+    in-flight request per user and is deleted on resolve, so it cannot
+    answer "what was the agent blocked on ten minutes ago?". Each
+    transition (``requested``, ``decided``, ``timed_out``, ``recovered``)
+    appends one row here so admins can replay the full sequence in the
+    activity feed.
+
+    ``decision`` is populated only on ``decided`` rows and carries the
+    ``ApprovalDecision`` value (``approved`` / ``denied`` /
+    ``always_allow`` / ``always_deny`` / ``interrupted``).
+
+    ``description`` echoes the tool's human-readable description that
+    was shown to the user. It can include user-pasted content (filenames,
+    URLs, message bodies), so admin surfaces must run it through PII
+    redaction before display, the same way ``Message.body`` is handled.
+
+    No retention sweep ships with this table. Volume is small (one row
+    per approval transition; an active session generates a handful per
+    day) and the data is the audit trail itself, so we let it
+    accumulate. Reconsider if a single user crosses ~10k rows.
+    """
+
+    __tablename__ = "approval_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(
+        String, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    event_type: Mapped[str] = mapped_column(String, nullable=False)
+    tool_name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str] = mapped_column(Text, default="")
+    channel: Mapped[str] = mapped_column(String, default="")
+    chat_id: Mapped[str] = mapped_column(String, default="")
+    decision: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), index=True
+    )
+
+
 class CompactionEvent(Base):
     """One row per session-compaction run.
 

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1464,3 +1464,200 @@ class TestClassifyApprovalResponseCallShape:
         assert "response_format" in kwargs, (
             "response_format is what actually constrains the output to the enum"
         )
+
+
+class TestApprovalEvents:
+    """The audit log appends one row per lifecycle transition so admins
+    can replay what happened to an approval (requested, decided,
+    timed_out, recovered) instead of seeing the prompt text only.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_requested_and_decided_pair_logged(self, test_user: User) -> None:
+        from backend.app.agent.approval import get_approval_event_store
+        from backend.app.database import db_session
+        from backend.app.models import ApprovalEvent
+
+        gate = ApprovalGate()
+        mock_publish = AsyncMock()
+
+        async def _resolve_soon() -> None:
+            await asyncio.sleep(0.01)
+            gate.resolve(test_user.id, ApprovalDecision.APPROVED)
+
+        task = asyncio.create_task(_resolve_soon())
+        await gate.request_approval(
+            user_id=test_user.id,
+            tool_name="write_file",
+            description="write a file",
+            publish_outbound=mock_publish,
+            channel="telegram",
+            chat_id="chat_1",
+            timeout=5.0,
+        )
+        await task
+
+        with db_session() as db:
+            rows = (
+                db.query(ApprovalEvent)
+                .filter(ApprovalEvent.user_id == test_user.id)
+                .order_by(ApprovalEvent.id.asc())
+                .all()
+            )
+        assert [r.event_type for r in rows] == ["requested", "decided"]
+        assert rows[0].tool_name == "write_file"
+        assert rows[0].description == "write a file"
+        assert rows[0].channel == "telegram"
+        assert rows[0].chat_id == "chat_1"
+        assert rows[0].decision is None
+        assert rows[1].decision == "approved"
+
+        # Read-side store returns them in chronological order.
+        events = get_approval_event_store().list_for_user(test_user.id)
+        assert [e.event_type for e in events] == ["requested", "decided"]
+        assert events[1].decision == "approved"
+
+    @pytest.mark.asyncio()
+    async def test_timeout_logs_timed_out_event(self, test_user: User) -> None:
+        from backend.app.database import db_session
+        from backend.app.models import ApprovalEvent
+
+        gate = ApprovalGate()
+        mock_publish = AsyncMock()
+
+        decision = await gate.request_approval(
+            user_id=test_user.id,
+            tool_name="write_file",
+            description="write a file",
+            publish_outbound=mock_publish,
+            channel="telegram",
+            chat_id="chat_1",
+            timeout=0.01,
+        )
+        assert decision == ApprovalDecision.DENIED
+
+        with db_session() as db:
+            rows = (
+                db.query(ApprovalEvent)
+                .filter(ApprovalEvent.user_id == test_user.id)
+                .order_by(ApprovalEvent.id.asc())
+                .all()
+            )
+        assert [r.event_type for r in rows] == ["requested", "timed_out"]
+        # No `decided` row on timeout: the gate never received a decision.
+        assert all(r.decision is None for r in rows)
+
+    @pytest.mark.asyncio()
+    async def test_resolve_records_interrupted_decision(self, test_user: User) -> None:
+        from backend.app.database import db_session
+        from backend.app.models import ApprovalEvent
+
+        gate = ApprovalGate()
+        mock_publish = AsyncMock()
+
+        async def _interrupt_soon() -> None:
+            await asyncio.sleep(0.01)
+            gate.resolve(test_user.id, ApprovalDecision.INTERRUPTED)
+
+        task = asyncio.create_task(_interrupt_soon())
+        await gate.request_approval(
+            user_id=test_user.id,
+            tool_name="discard_media",
+            description="discard staged media",
+            publish_outbound=mock_publish,
+            channel="telegram",
+            chat_id="chat_2",
+            timeout=5.0,
+        )
+        await task
+
+        with db_session() as db:
+            rows = (
+                db.query(ApprovalEvent)
+                .filter(ApprovalEvent.user_id == test_user.id)
+                .order_by(ApprovalEvent.id.asc())
+                .all()
+            )
+        assert rows[-1].event_type == "decided"
+        assert rows[-1].decision == "interrupted"
+
+    @pytest.mark.asyncio()
+    async def test_recovered_event_logged_on_orphan_cleanup(self, test_user: User) -> None:
+        from backend.app.agent.approval import cleanup_orphaned_approvals
+        from backend.app.database import db_session
+        from backend.app.models import ApprovalEvent, PendingApprovalRow
+
+        with db_session() as db:
+            db.add(
+                PendingApprovalRow(
+                    user_id=test_user.id,
+                    tool_name="write_file",
+                    description="write a file",
+                    channel="telegram",
+                    chat_id="chat_99",
+                )
+            )
+            db.commit()
+
+        async def _publish(msg: OutboundMessage) -> None:
+            return None
+
+        recovered = await cleanup_orphaned_approvals(_publish)
+        assert recovered == 1
+
+        with db_session() as db:
+            rows = (
+                db.query(ApprovalEvent)
+                .filter(ApprovalEvent.user_id == test_user.id)
+                .order_by(ApprovalEvent.id.asc())
+                .all()
+            )
+        assert [r.event_type for r in rows] == ["recovered"]
+        assert rows[0].tool_name == "write_file"
+        assert rows[0].channel == "telegram"
+        assert rows[0].chat_id == "chat_99"
+
+    @pytest.mark.asyncio()
+    async def test_event_store_respects_since_and_limit(self, test_user: User) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from backend.app.agent.approval import get_approval_event_store
+        from backend.app.database import db_session
+        from backend.app.models import ApprovalEvent
+
+        old = datetime.now(UTC) - timedelta(hours=2)
+        recent = datetime.now(UTC)
+        with db_session() as db:
+            db.add_all(
+                [
+                    ApprovalEvent(
+                        user_id=test_user.id,
+                        event_type="requested",
+                        tool_name="t",
+                        description="",
+                        channel="",
+                        chat_id="",
+                        created_at=old,
+                    ),
+                    ApprovalEvent(
+                        user_id=test_user.id,
+                        event_type="decided",
+                        tool_name="t",
+                        description="",
+                        channel="",
+                        chat_id="",
+                        decision="approved",
+                        created_at=recent,
+                    ),
+                ]
+            )
+            db.commit()
+
+        store = get_approval_event_store()
+        only_recent = store.list_for_user(
+            test_user.id, since=datetime.now(UTC) - timedelta(minutes=5)
+        )
+        assert [e.event_type for e in only_recent] == ["decided"]
+
+        capped = store.list_for_user(test_user.id, limit=1)
+        assert len(capped) == 1


### PR DESCRIPTION
## Description

Add an `approval_events` audit log so the admin Activity feed in clawbolt-premium can show what approval prompts the agent has sent, what tool was being gated, and how each request resolved.

The existing approval system persists in-flight requests in `pending_approvals` for crash recovery, but rows are deleted on resolve. Approval prompts ride through `publish_outbound` and end up in the `messages` table, so the prompt text is visible to admins, but with no semantic marker, no tool name, and no lifecycle. Premium maintainers debugging tester reports cannot tell whether the agent went silent because it was blocked on approval, timed out, or was interrupted.

This PR adds an append-only `approval_events` table written by `ApprovalGate` at every lifecycle transition:

- `requested` on `request_approval()` entry
- `decided` on `resolve()`, with the `ApprovalDecision` (covers `approved`, `denied`, `always_allow`, `always_deny`, and the `interrupted` path that fires when the user sends an unrelated message during a pending approval)
- `timed_out` on the `TimeoutError` branch
- `recovered` from `cleanup_orphaned_approvals()`

`ApprovalEventStore.list_for_user(user_id, limit, since)` is the read API premium will consume from a new admin endpoint.

Forward-only: prompts persisted before this migration stay unlabeled. No retention sweep ships with this; the table is small (handful of rows per user per day) and the data is the audit trail itself.

Refs mozilla-ai/clawbolt-premium#405.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests _(n/a; feature)_

## AI Usage
- [x] AI-assisted (Claude Code drafted the implementation and tests via back-and-forth with @njbrake; design decisions are his)
- [ ] No AI used