### PR TITLE
fix(agent): stop per-message compaction via trim hysteresis + watermark

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,8 @@ STORAGE_PROVIDER=local
 # MAX_INPUT_TOKENS=120000
 # CONTEXT_TRIM_TARGET_TOKENS=80000
 # CONTEXT_TRIM_TARGET_TURNS=80  # Cap user turns kept verbatim. Older turns roll into MEMORY.md / USER.md / SOUL.md via compaction
+# CONTEXT_TRIM_TRIGGER_TURNS=  # Trim fires when user-turn count exceeds this and drops to CONTEXT_TRIM_TARGET_TURNS, leaving headroom. Defaults to target+16 if unset
+# COMPACTION_EVENT_SNAPSHOT_MAX_BYTES_PER_FILE=100000  # Per-file truncation cap for memory diff snapshots stored on compaction_events rows
 # LLM_MAX_RETRIES=3
 # LLM_CACHE_EXTENDED_TTL=true  # Use Anthropic's 1h cache TTL (vs default 5min); set false on providers that reject the ttl field
 

--- a/alembic/versions/028_add_last_trim_seq_to_sessions.py
+++ b/alembic/versions/028_add_last_trim_seq_to_sessions.py
@@ -1,0 +1,39 @@
+"""Add ``sessions.last_trim_seq`` for the per-session trim watermark.
+
+When the agent loop's trim path drops messages from LLM context (turn-cap
+or token-budget driven), it advances this watermark to the highest dropped
+``messages.seq``. ``load_conversation_history`` then filters to
+``seq > last_trim_seq``, so the trimmed rows are no longer fed to the LLM
+on subsequent inbounds. Without this, the agent loop would reload the full
+DB history every message and re-trigger compaction every turn.
+
+NULL on existing sessions (nothing has been trimmed yet); the load path
+treats NULL as no filter, preserving today's behavior until the first
+trim writes a value.
+
+Revision ID: 028
+Revises: 027
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "028"
+down_revision: str = "027"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sessions",
+        sa.Column("last_trim_seq", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sessions", "last_trim_seq")

--- a/alembic/versions/029_add_memory_diff_snapshots_to_compaction_events.py
+++ b/alembic/versions/029_add_memory_diff_snapshots_to_compaction_events.py
@@ -1,0 +1,79 @@
+"""Add memory-diff snapshots and pending/completed status to compaction_events.
+
+Each compaction run now records:
+
+- ``min_message_seq``: lowest ``messages.seq`` covered by this event (the
+  highest is already in ``max_message_seq``).
+- ``status``: ``'pending'`` while the async LLM call is in flight,
+  ``'completed'`` once it lands. Legacy rows default to ``'completed'``.
+- Eight envelope-encrypted text columns: before/after snapshots of the
+  four memory files the compaction LLM touches (memory, history, user,
+  soul). Admins can read these via the premium shared-data endpoint
+  to see what each compaction event actually distilled into MEMORY.md.
+
+All new columns are nullable so existing rows remain readable. The
+``status`` column has a server-side default of ``'completed'`` so the
+NOT NULL constraint can be enforced without a backfill (existing rows
+ran the prior synchronous-write path and are effectively complete).
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "029"
+down_revision: str = "028"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "compaction_events",
+        sa.Column("min_message_seq", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "compaction_events",
+        sa.Column(
+            "status",
+            sa.String(),
+            nullable=False,
+            server_default="completed",
+        ),
+    )
+    for col in (
+        "memory_text_before",
+        "memory_text_after",
+        "history_text_before",
+        "history_text_after",
+        "user_text_before",
+        "user_text_after",
+        "soul_text_before",
+        "soul_text_after",
+    ):
+        op.add_column(
+            "compaction_events",
+            sa.Column(col, sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    for col in (
+        "soul_text_after",
+        "soul_text_before",
+        "user_text_after",
+        "user_text_before",
+        "history_text_after",
+        "history_text_before",
+        "memory_text_after",
+        "memory_text_before",
+        "status",
+        "min_message_seq",
+    ):
+        op.drop_column("compaction_events", col)

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -9,6 +9,7 @@ remains searchable after the raw messages are gone.
 """
 
 import datetime
+import hashlib
 import json
 import logging
 import time
@@ -32,6 +33,45 @@ from backend.app.services.llm_usage import log_llm_usage
 logger = logging.getLogger(__name__)
 
 COMPACTION_SYSTEM_PROMPT = load_prompt("compaction")
+
+# Snapshot truncation hint sizes. The head and tail are full plaintext so an
+# admin reviewing a truncation record can still read the start and end of
+# what changed; the sha256 lets a determined operator compare two records
+# without storing the full body twice.
+_SNAPSHOT_HEAD_BYTES = 2_000
+_SNAPSHOT_TAIL_BYTES = 2_000
+
+
+def _serialize_snapshot(text: str | None, cap: int) -> str | None:
+    """Return *text* itself if under *cap* bytes, else a truncation record.
+
+    The returned string is what eventually lands in a ``compaction_events``
+    encrypted column. ``None`` in, ``None`` out (for the
+    skip-if-nothing-to-store path). When *text* exceeds *cap* bytes encoded
+    as UTF-8, returns a JSON record with ``truncated``, ``size_bytes``,
+    ``head``, ``tail`` and ``sha256`` so admins can still see the shape of
+    what was compacted without storing the full body. The cap bounds the
+    worst-case row size at roughly ``2 * (HEAD + TAIL + sha256 overhead)``
+    per file, regardless of how large MEMORY.md grows.
+    """
+    if text is None:
+        return None
+    encoded = text.encode("utf-8")
+    if len(encoded) <= cap:
+        return text
+    digest = hashlib.sha256(encoded).hexdigest()
+    head = encoded[:_SNAPSHOT_HEAD_BYTES].decode("utf-8", errors="replace")
+    tail = encoded[-_SNAPSHOT_TAIL_BYTES:].decode("utf-8", errors="replace")
+    return json.dumps(
+        {
+            "truncated": True,
+            "size_bytes": len(encoded),
+            "head": head,
+            "tail": tail,
+            "sha256": digest,
+        },
+        ensure_ascii=False,
+    )
 
 
 def _format_messages_for_compaction(messages: list[AgentMessage]) -> str:
@@ -119,6 +159,7 @@ async def compact_session(
     user_id: str,
     trimmed_messages: list[AgentMessage],
     max_message_seq: int | None = None,
+    event_id: int | None = None,
 ) -> tuple[str, int | None]:
     """Consolidate messages into an updated MEMORY.md via LLM rewrite.
 
@@ -131,6 +172,13 @@ async def compact_session(
         trimmed_messages: Messages that are about to be dropped from context.
         max_message_seq: The highest message seq among the trimmed messages,
             used to track compaction progress. Passed through to the return value.
+        event_id: When provided, the existing ``compaction_events`` row to
+            update with snapshots and flip from ``'pending'`` to
+            ``'completed'``. Set by ``trigger_compaction_for_dropped`` which
+            pre-inserts the row in the same transaction that advances the
+            trim watermark. When ``None`` (e.g. test invocations or any
+            future caller that has not pre-inserted), a new completed row
+            is inserted.
 
     Returns:
         A tuple of (memory_update, max_message_seq) where memory_update is the
@@ -159,6 +207,7 @@ async def compact_session(
     current_memory = memory_store.read_memory()
     current_user_profile = memory_store.read_user()
     current_soul = memory_store.read_soul()
+    current_history = memory_store.read_history()
     heartbeat_store = HeartbeatStore(user_id)
     current_heartbeat = heartbeat_store.read_heartbeat_md()
 
@@ -263,12 +312,35 @@ async def compact_session(
         len(result.summary or ""),
     )
 
-    # Persist the same metrics so admins can query "when did this user
-    # last compact / how big was the input / what got updated" without
-    # grepping Railway logs. Best-effort: a DB hiccup must not lose the
-    # compacted memory we just wrote upstream.
+    # Re-read the four memory files to capture the post-write state. These
+    # become the "after" snapshots stored on the compaction_events row so
+    # admins can diff what each event actually changed in MEMORY.md /
+    # HISTORY.md / USER.md / SOUL.md.
+    new_memory = memory_store.read_memory()
+    new_history = memory_store.read_history()
+    new_user = memory_store.read_user()
+    new_soul = memory_store.read_soul()
+
+    cap = settings.compaction_event_snapshot_max_bytes_per_file
+    snapshots = _build_snapshot_pairs(
+        cap=cap,
+        memory_before=current_memory,
+        memory_after=new_memory,
+        history_before=current_history,
+        history_after=new_history,
+        user_before=current_user_profile,
+        user_after=new_user,
+        soul_before=current_soul,
+        soul_after=new_soul,
+    )
+
+    # Persist the metrics + snapshots. Either UPDATE the pending row that
+    # ``trigger_compaction_for_dropped`` pre-inserted (event_id provided),
+    # or INSERT a fresh completed row (legacy/test paths). A DB hiccup
+    # here must not lose the compacted memory we just wrote upstream.
     try:
         _persist_compaction_event(
+            event_id=event_id,
             user_id=user_id,
             trimmed_count=_trimmed_count,
             trimmed_chars=_input_chars,
@@ -280,6 +352,7 @@ async def compact_session(
             user_profile_updated=bool(result.user_profile_update),
             soul_updated=bool(result.soul_update),
             summary_len=len(result.summary or ""),
+            snapshots=snapshots,
         )
     except Exception:
         logger.exception("Failed to persist compaction event for user %s", user_id)
@@ -287,8 +360,51 @@ async def compact_session(
     return result.memory_update, max_message_seq
 
 
+def _build_snapshot_pairs(
+    *,
+    cap: int,
+    memory_before: str,
+    memory_after: str,
+    history_before: str,
+    history_after: str,
+    user_before: str,
+    user_after: str,
+    soul_before: str,
+    soul_after: str,
+) -> dict[str, str | None]:
+    """Apply the truncation cap and the skip-if-unchanged optimization.
+
+    Returns a dict keyed by ``CompactionEvent`` column name. A column whose
+    before and after match (file unchanged this event) maps to ``None`` so
+    the persist path leaves both columns NULL and saves the encryption
+    overhead plus the row bytes.
+    """
+    pairs: dict[str, str | None] = {
+        "memory_text_before": None,
+        "memory_text_after": None,
+        "history_text_before": None,
+        "history_text_after": None,
+        "user_text_before": None,
+        "user_text_after": None,
+        "soul_text_before": None,
+        "soul_text_after": None,
+    }
+    for prefix, before, after in (
+        ("memory_text", memory_before, memory_after),
+        ("history_text", history_before, history_after),
+        ("user_text", user_before, user_after),
+        ("soul_text", soul_before, soul_after),
+    ):
+        if before == after:
+            continue
+        pairs[f"{prefix}_before"] = _serialize_snapshot(before, cap)
+        pairs[f"{prefix}_after"] = _serialize_snapshot(after, cap)
+    return pairs
+
+
 def _persist_compaction_event(
     *,
+    event_id: int | None,
     user_id: str,
     trimmed_count: int,
     trimmed_chars: int,
@@ -300,30 +416,60 @@ def _persist_compaction_event(
     user_profile_updated: bool,
     soul_updated: bool,
     summary_len: int,
+    snapshots: dict[str, str | None],
 ) -> None:
-    """Write one ``CompactionEvent`` row.
+    """Write or update one ``CompactionEvent`` row.
 
-    Imports the model + SessionLocal lazily so the agent module does
-    not pull SQLAlchemy at import time on every test that exercises
-    pure compaction logic with mocked LLM calls.
+    When ``event_id`` is provided, UPDATE the pre-inserted ``'pending'``
+    row (the agent-loop path). Otherwise INSERT a new ``'completed'`` row
+    (test / legacy path). Imports SQLAlchemy lazily so the agent module
+    does not pull it at import time on every pure-logic test.
     """
     from backend.app.database import SessionLocal
     from backend.app.models import CompactionEvent
 
     with SessionLocal() as db:
-        db.add(
-            CompactionEvent(
-                user_id=user_id,
-                trimmed_count=trimmed_count,
-                trimmed_chars=trimmed_chars,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                duration_ms=duration_ms,
-                max_message_seq=max_message_seq,
-                memory_updated=memory_updated,
-                user_profile_updated=user_profile_updated,
-                soul_updated=soul_updated,
-                summary_len=summary_len,
+        if event_id is not None:
+            event = db.query(CompactionEvent).filter_by(id=event_id).first()
+            if event is None:
+                logger.warning(
+                    "Compaction event id=%d not found for user %s; "
+                    "inserting a fresh completed row instead",
+                    event_id,
+                    user_id,
+                )
+                event_id = None
+            else:
+                event.trimmed_count = trimmed_count
+                event.trimmed_chars = trimmed_chars
+                event.input_tokens = input_tokens
+                event.output_tokens = output_tokens
+                event.duration_ms = duration_ms
+                if max_message_seq is not None:
+                    event.max_message_seq = max_message_seq
+                event.memory_updated = memory_updated
+                event.user_profile_updated = user_profile_updated
+                event.soul_updated = soul_updated
+                event.summary_len = summary_len
+                event.status = "completed"
+                for col, value in snapshots.items():
+                    setattr(event, col, value)
+        if event_id is None:
+            db.add(
+                CompactionEvent(
+                    user_id=user_id,
+                    trimmed_count=trimmed_count,
+                    trimmed_chars=trimmed_chars,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    duration_ms=duration_ms,
+                    max_message_seq=max_message_seq,
+                    memory_updated=memory_updated,
+                    user_profile_updated=user_profile_updated,
+                    soul_updated=soul_updated,
+                    summary_len=summary_len,
+                    status="completed",
+                    **snapshots,
+                )
             )
-        )
         db.commit()

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -262,6 +262,11 @@ async def compact_session(
     raw_content = get_response_text(response)
     result = _parse_compaction_response(raw_content)
 
+    # Capture exactly what got appended to HISTORY.md so we can compute the
+    # "after" snapshot deterministically below. ``None`` means no append
+    # happened this event.
+    appended_history_entry: str | None = None
+
     # Write updated MEMORY.md if the LLM produced content
     if result.memory_update:
         memory_store.write_memory(result.memory_update)
@@ -273,6 +278,9 @@ async def compact_session(
         entry = result.summary.replace("[TIMESTAMP]", f"[{timestamp}]")
         try:
             await memory_store.append_history(entry)
+            # Mirror the suffix that ``MemoryStore.append_history`` adds at
+            # the SQL level so the deterministic snapshot below matches.
+            appended_history_entry = entry + "\n"
             logger.info("Compaction appended history entry for user %s", user_id)
         except Exception:
             logger.exception("Failed to append history for user %s", user_id)
@@ -312,14 +320,23 @@ async def compact_session(
         len(result.summary or ""),
     )
 
-    # Re-read the four memory files to capture the post-write state. These
-    # become the "after" snapshots stored on the compaction_events row so
-    # admins can diff what each event actually changed in MEMORY.md /
-    # HISTORY.md / USER.md / SOUL.md.
-    new_memory = memory_store.read_memory()
-    new_history = memory_store.read_history()
-    new_user = memory_store.read_user()
-    new_soul = memory_store.read_soul()
+    # Compute "after" snapshots deterministically from what was written
+    # rather than re-reading the memory store. Two compact_session tasks
+    # for the same user can run concurrently (e.g. burst traffic crosses
+    # the trigger again during a still-running LLM compaction call), and
+    # they share ``get_memory_store(user_id)``. A re-read could pick up the
+    # other task's write and record a misleading "after" in this row's
+    # audit log. The compaction prompt returns full rewrites for memory /
+    # user / soul, and ``append_history`` is a SQL-level concatenation we
+    # mirror via ``appended_history_entry`` above, so all four "after"
+    # values are computable without re-reading.
+    new_memory = result.memory_update if result.memory_update else current_memory
+    new_user = result.user_profile_update if result.user_profile_update else current_user_profile
+    new_soul = result.soul_update if result.soul_update else current_soul
+    if appended_history_entry is not None:
+        new_history = (current_history or "") + appended_history_entry
+    else:
+        new_history = current_history
 
     cap = settings.compaction_event_snapshot_max_bytes_per_file
     snapshots = _build_snapshot_pairs(

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -148,7 +148,7 @@ def trigger_compaction_for_dropped(
     triggered_at = datetime.datetime.now(datetime.UTC)
 
     # Phase 1: synchronous insert + watermark advance, in one transaction.
-    event_id: int | None = None
+    event_id: int
     try:
         with db_session() as db:
             event = CompactionEvent(
@@ -161,6 +161,7 @@ def trigger_compaction_for_dropped(
             )
             db.add(event)
             db.flush()
+            assert event.id is not None, "flush() must populate the autoincrement id"
             event_id = event.id
 
             cs = db.query(ChatSession).filter_by(user_id=user_id).first()
@@ -175,10 +176,6 @@ def trigger_compaction_for_dropped(
             "watermark not advanced and async compaction skipped",
             user_id,
         )
-        return
-
-    if event_id is None:
-        # Defensive: db.flush() failed silently. Nothing to update.
         return
 
     async def _run_trim_compaction(event_id: int) -> None:

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -1,6 +1,7 @@
 """Conversation context loading and session management."""
 
 import asyncio
+import datetime
 import json
 import logging
 from typing import Any
@@ -19,7 +20,9 @@ from backend.app.agent.messages import (
 )
 from backend.app.agent.session_db import get_session_store
 from backend.app.config import settings
+from backend.app.database import db_session
 from backend.app.enums import MessageDirection
+from backend.app.models import ChatSession, CompactionEvent
 
 logger = logging.getLogger(__name__)
 
@@ -89,46 +92,130 @@ class StoredToolInteraction(BaseModel):
     receipt: StoredToolReceipt | None = None
 
 
+def _seqs_from_dropped(dropped: list[AgentMessage]) -> list[int]:
+    """Return the persisted ``messages.seq`` values carried by *dropped*.
+
+    Only ``UserMessage`` and ``AssistantMessage`` carry seq, and only when
+    they were loaded from the DB (in-memory constructions, e.g. the summary
+    placeholder injected by ``trim_messages``, are skipped).
+    """
+    seqs: list[int] = []
+    for m in dropped:
+        seq = getattr(m, "seq", None)
+        if isinstance(seq, int):
+            seqs.append(seq)
+    return seqs
+
+
 def trigger_compaction_for_dropped(
     user_id: str,
     dropped_messages: list[AgentMessage],
 ) -> None:
-    """Fire background compaction for messages that were trimmed from context.
+    """Fire compaction for messages that were trimmed from context.
 
     Called from the agent loop (``process_message``) when ``trim_messages``
-    drops messages. The compaction task extracts durable facts from the
-    dropped messages and stores them in MEMORY.md.
+    drops messages. Two-phase to keep the watermark and the audit log
+    consistent under crash:
 
-    The dropped messages are ``AgentMessage`` objects without DB sequence
-    numbers, so ``max_message_seq`` is passed as None and no compaction
-    watermark is advanced. This is the only compaction trigger in the
-    system.
+    1. Synchronously, in one transaction: insert a ``'pending'``
+       ``CompactionEvent`` row (with ``min_message_seq`` /
+       ``max_message_seq`` populated) AND advance ``sessions.last_trim_seq``
+       to ``max_message_seq``. After this commits, the next inbound's
+       ``load_conversation_history`` will already filter out the dropped
+       messages, so compaction will not re-fire for the same range.
+
+    2. Asynchronously: ``compact_session`` runs the LLM call, fills in the
+       four memory-file before/after snapshots on the same row, and flips
+       ``status`` to ``'completed'``. If the async task crashes, the row
+       stays ``'pending'`` so an admin (or a CLI replay) can identify the
+       seq range whose facts were never extracted. The watermark stays
+       advanced regardless: this is the design tradeoff (no per-message
+       compaction churn) for losing facts on a crashed compaction call.
+
+    This is the only compaction trigger in the system.
     """
     if not dropped_messages or not settings.compaction_enabled:
         return
 
-    async def _run_trim_compaction() -> None:
+    dropped_seqs = _seqs_from_dropped(dropped_messages)
+    if not dropped_seqs:
+        # All dropped messages were in-memory placeholders (e.g. an injected
+        # summary) with no DB rows to watermark against. Nothing to compact.
+        return
+
+    min_seq = min(dropped_seqs)
+    max_seq = max(dropped_seqs)
+    triggered_at = datetime.datetime.now(datetime.UTC)
+
+    # Phase 1: synchronous insert + watermark advance, in one transaction.
+    event_id: int | None = None
+    try:
+        with db_session() as db:
+            event = CompactionEvent(
+                user_id=user_id,
+                triggered_at=triggered_at,
+                status="pending",
+                min_message_seq=min_seq,
+                max_message_seq=max_seq,
+                trimmed_count=len(dropped_messages),
+            )
+            db.add(event)
+            db.flush()
+            event_id = event.id
+
+            cs = db.query(ChatSession).filter_by(user_id=user_id).first()
+            if cs is not None:
+                current = cs.last_trim_seq or 0
+                if max_seq > current:
+                    cs.last_trim_seq = max_seq
+            db.commit()
+    except Exception:
+        logger.exception(
+            "Failed to record pending compaction event for user %s; "
+            "watermark not advanced and async compaction skipped",
+            user_id,
+        )
+        return
+
+    if event_id is None:
+        # Defensive: db.flush() failed silently. Nothing to update.
+        return
+
+    async def _run_trim_compaction(event_id: int) -> None:
         try:
-            saved, _ = await compact_session(user_id, dropped_messages, max_message_seq=None)
+            saved, _ = await compact_session(
+                user_id,
+                dropped_messages,
+                max_message_seq=max_seq,
+                event_id=event_id,
+            )
             if saved:
                 logger.info(
-                    "Trim-based compaction extracted facts from %d dropped message(s) for user %s",
+                    "Trim-based compaction extracted facts from %d dropped "
+                    "message(s) for user %s (event_id=%d)",
                     len(dropped_messages),
                     user_id,
+                    event_id,
                 )
         except Exception:
             logger.exception(
-                "Trim-based compaction failed for user %s",
+                "Trim-based compaction failed for user %s (event_id=%d); "
+                "watermark stays advanced, event row stays 'pending'",
                 user_id,
+                event_id,
             )
 
-    task = asyncio.create_task(_run_trim_compaction())
+    task = asyncio.create_task(_run_trim_compaction(event_id))
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
     logger.info(
-        "Triggered trim-based compaction for user %s: %d dropped message(s)",
+        "Triggered trim-based compaction for user %s: %d dropped "
+        "message(s), seq range [%d, %d], event_id=%d",
         user_id,
         len(dropped_messages),
+        min_seq,
+        max_seq,
+        event_id,
     )
 
 
@@ -165,6 +252,7 @@ def _parse_tool_interactions(raw: str) -> list[StoredToolInteraction]:
 def _expand_outbound_with_tools(
     tool_interactions: list[StoredToolInteraction],
     reply_text: str,
+    seq: int | None = None,
 ) -> list[AgentMessage]:
     """Expand an outbound message with tool interactions into typed messages.
 
@@ -172,6 +260,13 @@ def _expand_outbound_with_tools(
     1. AssistantMessage with tool_calls (what the LLM requested)
     2. ToolResultMessage for each tool result
     3. AssistantMessage with the final reply text
+
+    *seq* is the source DB row's ``messages.seq``. When provided, both
+    AssistantMessage instances carry it, so the trim watermark write in
+    ``trigger_compaction_for_dropped`` can find the right value regardless
+    of which one ends up in the dropped list. ``ToolResultMessage`` does
+    not carry seq because tool results live inside the parent's
+    ``tool_interactions_json`` and share the parent's row.
     """
     messages: list[AgentMessage] = []
 
@@ -187,7 +282,7 @@ def _expand_outbound_with_tools(
         )
 
     # AssistantMessage requesting the tool calls (content is typically None)
-    messages.append(AssistantMessage(content=None, tool_calls=tool_call_requests))
+    messages.append(AssistantMessage(content=None, tool_calls=tool_call_requests, seq=seq))
 
     # ToolResultMessages for each tool execution
     for tc in tool_interactions:
@@ -199,7 +294,7 @@ def _expand_outbound_with_tools(
         )
 
     # Final AssistantMessage with the reply text
-    messages.append(AssistantMessage(content=reply_text))
+    messages.append(AssistantMessage(content=reply_text, seq=seq))
 
     return messages
 
@@ -223,6 +318,14 @@ async def load_conversation_history(
     guard against exceeding the LLM context window.
     """
     all_messages = session.messages
+
+    # Apply the trim watermark before any other filtering: messages with
+    # ``seq <= last_trim_seq`` have been compacted out of LLM context and
+    # their durable facts now live in MEMORY.md / USER.md / SOUL.md. Loading
+    # them again would re-trigger trim and re-fire compaction every message.
+    # NULL watermark = no filter (preserves pre-feature behavior).
+    if session.last_trim_seq is not None:
+        all_messages = [m for m in all_messages if m.seq > session.last_trim_seq]
     total_count = len(all_messages)
 
     # Get the most recent `limit` messages, excluding the current (last) one
@@ -248,13 +351,13 @@ async def load_conversation_history(
                 last_was_approval_prompt = False
                 continue
             last_was_approval_prompt = False
-            history.append(UserMessage(content=content))
+            history.append(UserMessage(content=content, seq=msg.seq))
         else:
             # Check for stored tool interactions
             tool_interactions = _parse_tool_interactions(msg.tool_interactions_json)
             if tool_interactions:
                 tool_interaction_count += len(tool_interactions)
-                history.extend(_expand_outbound_with_tools(tool_interactions, content))
+                history.extend(_expand_outbound_with_tools(tool_interactions, content, seq=msg.seq))
                 last_was_approval_prompt = False
             elif _is_approval_prompt(content):
                 # Skip approval prompts (real ones persisted by older code,
@@ -265,7 +368,7 @@ async def load_conversation_history(
                 # already-poisoned sessions without a DB migration.
                 last_was_approval_prompt = True
             else:
-                history.append(AssistantMessage(content=content))
+                history.append(AssistantMessage(content=content, seq=msg.seq))
                 last_was_approval_prompt = False
     logger.debug(
         "Loaded %d history messages (%d with tool interactions) for session %s",

--- a/backend/app/agent/dto.py
+++ b/backend/app/agent/dto.py
@@ -79,6 +79,11 @@ class SessionState(BaseModel):
     last_message_at: str = ""
     channel: str = ""
     initial_system_prompt: str = ""
+    # Highest ``messages.seq`` that has been trimmed out of the LLM context.
+    # ``load_conversation_history`` filters to ``seq > last_trim_seq`` so
+    # rolled-up turns are not re-fed to the agent on subsequent inbounds.
+    # ``None`` means nothing has been trimmed yet (no filter applied).
+    last_trim_seq: int | None = None
 
 
 class MediaData(BaseModel):

--- a/backend/app/agent/messages.py
+++ b/backend/app/agent/messages.py
@@ -35,9 +35,17 @@ class SystemMessage:
 
 @dataclass(frozen=True)
 class UserMessage:
-    """User (user) message."""
+    """User (user) message.
+
+    ``seq`` is the persisted ``messages.seq`` for messages loaded from the
+    database. ``None`` for messages constructed in-memory (e.g. the current
+    inbound's user-context wrapper, or summary placeholders injected after
+    trimming). Used by ``trigger_compaction_for_dropped`` to advance the
+    per-session trim watermark when this message is dropped from context.
+    """
 
     content: str
+    seq: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {"role": "user", "content": self.content}
@@ -45,10 +53,18 @@ class UserMessage:
 
 @dataclass(frozen=True)
 class AssistantMessage:
-    """Assistant response, optionally containing tool calls."""
+    """Assistant response, optionally containing tool calls.
+
+    ``seq`` is the persisted ``messages.seq`` for messages loaded from the
+    database. A single DB row may expand into one ``AssistantMessage`` plus
+    several ``ToolResultMessage`` entries (the tool results share the
+    parent's seq via ``tool_interactions_json``); the seq here is therefore
+    the watermark-relevant value for the whole assistant block.
+    """
 
     content: str | None = None
     tool_calls: list[ToolCallRequest] = field(default_factory=list)
+    seq: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         blocks: list[dict[str, Any]] = []

--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -359,35 +359,6 @@ class SessionStore:
                             setattr(m, k, v)
                     break
 
-    async def advance_last_trim_seq(self, session: SessionState, new_value: int) -> None:
-        """Advance the per-session trim watermark.
-
-        Writes ``sessions.last_trim_seq = max(current, new_value)`` so a
-        racing trim with a lower seq cannot regress the watermark. Updates
-        the in-memory ``SessionState`` to match.
-
-        Called from ``trigger_compaction_for_dropped`` in the same
-        transaction that inserts the synchronous ``'pending'``
-        ``CompactionEvent`` row, so a crash between the two cannot leave
-        the watermark and the audit log out of sync.
-        """
-        with db_session() as db:
-            cs = (
-                db.query(ChatSession)
-                .filter_by(session_id=session.session_id, user_id=self.user_id)
-                .first()
-            )
-            if cs is None:
-                return
-            current = cs.last_trim_seq or 0
-            if new_value > current:
-                cs.last_trim_seq = new_value
-                db.commit()
-                session.last_trim_seq = new_value
-            else:
-                # Idempotent: nothing to do.
-                pass
-
     async def update_initial_system_prompt(self, session: SessionState, system_prompt: str) -> None:
         """Store the system prompt on the session if not already set."""
         if session.initial_system_prompt:

--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -58,6 +58,7 @@ def _session_to_state(
         last_message_at=cs.last_message_at.isoformat() if cs.last_message_at else "",
         channel=cs.channel,
         initial_system_prompt=cs.initial_system_prompt,
+        last_trim_seq=cs.last_trim_seq,
     )
 
 
@@ -357,6 +358,35 @@ class SessionStore:
                         if k in _MESSAGE_UPDATABLE_FIELDS and hasattr(m, k):
                             setattr(m, k, v)
                     break
+
+    async def advance_last_trim_seq(self, session: SessionState, new_value: int) -> None:
+        """Advance the per-session trim watermark.
+
+        Writes ``sessions.last_trim_seq = max(current, new_value)`` so a
+        racing trim with a lower seq cannot regress the watermark. Updates
+        the in-memory ``SessionState`` to match.
+
+        Called from ``trigger_compaction_for_dropped`` in the same
+        transaction that inserts the synchronous ``'pending'``
+        ``CompactionEvent`` row, so a crash between the two cannot leave
+        the watermark and the audit log out of sync.
+        """
+        with db_session() as db:
+            cs = (
+                db.query(ChatSession)
+                .filter_by(session_id=session.session_id, user_id=self.user_id)
+                .first()
+            )
+            if cs is None:
+                return
+            current = cs.last_trim_seq or 0
+            if new_value > current:
+                cs.last_trim_seq = new_value
+                db.commit()
+                session.last_trim_seq = new_value
+            else:
+                # Idempotent: nothing to do.
+                pass
 
     async def update_initial_system_prompt(self, session: SessionState, system_prompt: str) -> None:
         """Store the system prompt on the session if not already set."""

--- a/backend/app/agent/trimming.py
+++ b/backend/app/agent/trimming.py
@@ -21,9 +21,15 @@ _SUMMARY_MAX_CHARS = 500
 
 CONTEXT_TRIM_TARGET_TOKENS = settings.context_trim_target_tokens
 CONTEXT_TRIM_TARGET_TURNS = settings.context_trim_target_turns
+CONTEXT_TRIM_TRIGGER_TURNS = settings.context_trim_trigger_turns
 
 _OVERHEAD_TOKEN_ESTIMATE = 10_000
 _CHARS_PER_TOKEN = 4
+
+# When ``trigger_turns`` is unset and ``target_turns`` is set, the trigger
+# defaults to ``target_turns + _DEFAULT_TRIGGER_BUFFER_TURNS``. Hysteresis
+# prevents per-message re-triggering once the conversation crosses the cap.
+_DEFAULT_TRIGGER_BUFFER_TURNS = 16
 
 
 def _count_user_turns(msgs: list[AgentMessage]) -> int:
@@ -106,6 +112,7 @@ def trim_messages(
     messages: list[AgentMessage],
     target_tokens: int = CONTEXT_TRIM_TARGET_TOKENS,
     target_turns: int | None = CONTEXT_TRIM_TARGET_TURNS,
+    trigger_turns: int | None = CONTEXT_TRIM_TRIGGER_TURNS,
     input_tokens: int | None = None,
 ) -> TrimResult:
     """Trim conversation messages to fit within a token and turn budget.
@@ -118,12 +125,18 @@ def trim_messages(
 
     Keeps the system prompt (first message) and removes the oldest
     conversation messages until the content fits within *target_tokens*
-    and the number of remaining user turns is within *target_turns*
-    (counting the current message). The turn cap fires independently
-    of the token budget so a chatty conversation that stays under the
-    token limit still rolls older turns through compaction, diluting
-    the influence of accumulated conversational patterns. Pass
-    ``target_turns=None`` to disable the turn-count guard.
+    and the number of remaining user turns is within *target_turns*.
+
+    The turn cap fires when user-turn count exceeds *trigger_turns* and
+    drops down to *target_turns*, leaving ``trigger - target`` turns of
+    headroom before the next trim fires. This hysteresis prevents
+    per-message re-triggering: a single threshold (target == trigger)
+    would leave the resting state exactly at the ceiling, so the next
+    user message would push count back over the cap and re-fire trim
+    plus the downstream compaction LLM call. When ``trigger_turns`` is
+    ``None``, defaults to ``target_turns + 16``. When ``target_turns``
+    is ``None``, the turn-count guard is disabled entirely (token
+    budget only).
 
     Tool-call / tool-result pairs are treated as atomic units: an
     ``AssistantMessage`` with ``tool_calls`` is never removed without also
@@ -138,6 +151,15 @@ def trim_messages(
     """
     if len(messages) <= 2:
         return TrimResult(messages=messages)
+
+    # Resolve the trigger threshold. Hysteresis = trigger - target.
+    effective_trigger_turns: int | None
+    if trigger_turns is not None:
+        effective_trigger_turns = trigger_turns
+    elif target_turns is not None:
+        effective_trigger_turns = target_turns + _DEFAULT_TRIGGER_BUFFER_TURNS
+    else:
+        effective_trigger_turns = None
 
     actual_input_tokens: int
     if input_tokens is not None:
@@ -154,7 +176,10 @@ def trim_messages(
         return int(actual_input_tokens * _content_length(msgs) / orig_len)
 
     over_token_budget = _tokens_for(messages) > target_tokens
-    over_turn_budget = target_turns is not None and _count_user_turns(messages) > target_turns
+    over_turn_budget = (
+        effective_trigger_turns is not None
+        and _count_user_turns(messages) > effective_trigger_turns
+    )
     if not over_token_budget and not over_turn_budget:
         return TrimResult(messages=messages)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -93,6 +93,22 @@ class Settings(BaseSettings):
     # Set ge=2 so at least one prior turn is always retained alongside the
     # current one. Tune up if compaction proves too aggressive.
     context_trim_target_turns: int = Field(default=80, ge=2)
+    # Trim trigger threshold: trim only fires when user-turn count exceeds
+    # this. Trim then drops down to ``context_trim_target_turns``, leaving
+    # ``trigger - target`` turns of headroom before the next trim fires.
+    # A single threshold (target == trigger) re-fires compaction on every
+    # message after the first overflow because the resting state sits
+    # exactly at the ceiling. When ``None``, defaults to
+    # ``context_trim_target_turns + 16`` inside ``trim_messages``.
+    context_trim_trigger_turns: int | None = Field(default=None)
+    # Per-file truncation cap for memory-text snapshots persisted on
+    # ``compaction_events`` rows. A user with a 500KB MEMORY.md would
+    # otherwise produce ~4MB rows once before/after for all four files
+    # (memory, history, user, soul) is included. When a file exceeds the
+    # cap, the snapshot column stores a structured truncation record
+    # (head, tail, size, sha256) rather than the full text. Bounds the
+    # worst-case row size while keeping admin diff visibility intact.
+    compaction_event_snapshot_max_bytes_per_file: int = Field(default=100_000, ge=1024)
     llm_max_retries: int = Field(default=3, ge=1)
     # Use Anthropic's 1-hour extended-TTL cache instead of the default
     # 5-minute ephemeral cache. Inactive users with conversation gaps

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -266,6 +266,13 @@ class ChatSession(Base):
     last_message_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC)
     )
+    # Highest ``messages.seq`` that has been trimmed out of the LLM context.
+    # ``load_conversation_history`` filters to ``seq > last_trim_seq``, so
+    # rows below this threshold are no longer fed to the agent. Their durable
+    # facts live in MEMORY.md / USER.md / SOUL.md via the compaction path;
+    # the original rows remain in the DB for audit. ``NULL`` means nothing
+    # has been trimmed yet (default for fresh sessions and pre-feature rows).
+    last_trim_seq: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     user: Mapped["User"] = relationship("User", back_populates="sessions")
     messages: Mapped[list["Message"]] = relationship(
@@ -673,11 +680,66 @@ class CompactionEvent(Base):
     trimmed_chars: Mapped[int] = mapped_column(Integer, default=0)
     input_tokens: Mapped[int] = mapped_column(Integer, default=0)
     output_tokens: Mapped[int] = mapped_column(Integer, default=0)
+    # Range of ``messages.seq`` that this compaction event covers.
+    # ``min_message_seq`` is NULL on legacy rows (pre-feature). Going
+    # forward, both are populated when the agent loop's trim path inserts
+    # the pending row.
+    min_message_seq: Mapped[int | None] = mapped_column(Integer, nullable=True)
     max_message_seq: Mapped[int | None] = mapped_column(Integer, nullable=True)
     memory_updated: Mapped[bool] = mapped_column(Boolean, default=False)
     user_profile_updated: Mapped[bool] = mapped_column(Boolean, default=False)
     soul_updated: Mapped[bool] = mapped_column(Boolean, default=False)
     summary_len: Mapped[int] = mapped_column(Integer, default=0)
+    # Two-phase lifecycle. The agent loop synchronously inserts a
+    # ``'pending'`` row in the same transaction that advances the per-session
+    # trim watermark. The async compaction task then runs the LLM call,
+    # fills in the snapshot fields below, and flips this to ``'completed'``.
+    # If the async task crashes, the row stays ``'pending'`` so an operator
+    # can see which seq range was trimmed without facts being extracted, and
+    # re-run that compaction manually. Existing pre-feature rows are
+    # ``'completed'`` via the server-side default in migration 029.
+    status: Mapped[str] = mapped_column(String, default="completed")
+    # Before/after snapshots of the four memory files this event touched.
+    # Stored as envelope-encrypted text so an admin can inspect what the
+    # compaction LLM call actually changed. ``None`` means either the field
+    # was not changed by this event (skip-if-unchanged optimization), the
+    # row is still ``'pending'``, or the row predates the feature. When the
+    # plaintext exceeds ``settings.compaction_event_snapshot_max_bytes_per_file``,
+    # the column stores a structured truncation record (head, tail, size,
+    # sha256) instead of the full text. Same EncryptedString pattern as
+    # ``MemoryDocument.memory_text`` (migration 022).
+    memory_text_before: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="memory_text_before"),
+        nullable=True,
+    )
+    memory_text_after: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="memory_text_after"),
+        nullable=True,
+    )
+    history_text_before: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="history_text_before"),
+        nullable=True,
+    )
+    history_text_after: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="history_text_after"),
+        nullable=True,
+    )
+    user_text_before: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="user_text_before"),
+        nullable=True,
+    )
+    user_text_after: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="user_text_after"),
+        nullable=True,
+    )
+    soul_text_before: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="soul_text_before"),
+        nullable=True,
+    )
+    soul_text_after: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="soul_text_after"),
+        nullable=True,
+    )
 
 
 class UserPermissionSet(Base):

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -111,6 +111,8 @@ See [Storage Providers](./storage.md) for setup instructions.
 | `MAX_INPUT_TOKENS` | `120000` | Max input token budget before context trimming |
 | `CONTEXT_TRIM_TARGET_TOKENS` | `80000` | Target token count after trimming |
 | `CONTEXT_TRIM_TARGET_TURNS` | `80` | Cap on user turns kept verbatim in LLM context. Long single-conversation histories reinforce their own dominant tone, so this trims oldest turns past the cap (independent of the token budget) and rolls them through compaction into `MEMORY.md`, `USER.md`, and `SOUL.md` |
+| `CONTEXT_TRIM_TRIGGER_TURNS` | unset (defaults to `CONTEXT_TRIM_TARGET_TURNS + 16`) | Trim fires when user-turn count exceeds this threshold and drops down to `CONTEXT_TRIM_TARGET_TURNS`, leaving headroom before the next trim. Without this hysteresis (single threshold), the resting state sits exactly at the cap and every subsequent user message re-fires trim plus the downstream compaction LLM call. Set to `None` (omit the env var entirely) for the default 16-turn buffer |
+| `COMPACTION_EVENT_SNAPSHOT_MAX_BYTES_PER_FILE` | `100000` | Per-file truncation cap for memory-text snapshots persisted on `compaction_events` rows. When `MEMORY.md` / `HISTORY.md` / `USER.md` / `SOUL.md` exceeds this size, the snapshot column stores a structured truncation record (head, tail, size, sha256) so admin diff visibility is preserved while bounding worst-case row size |
 | `LLM_MAX_RETRIES` | `3` | Maximum number of retry attempts on rate limit errors |
 | `LLM_CACHE_EXTENDED_TTL` | `true` | Use Anthropic's 1-hour extended cache TTL instead of the default 5 minutes. Reduces cold-start cache misses for users with multi-hour gaps between messages. Set to `false` on non-Anthropic providers that reject the `ttl` field |
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1207,6 +1207,97 @@ def test_trim_messages_turn_cap_disabled_when_none() -> None:
     assert result.messages == messages
 
 
+def test_trim_messages_resting_state_does_not_re_trigger() -> None:
+    """Regression: after a trim crosses the trigger, a follow-up call on the
+    trimmed result must not drop again while user-turn count remains at or
+    below the trigger threshold.
+
+    Without hysteresis (single threshold), the resting state sits exactly at
+    the cap, so the next user message pushes the count back over and
+    re-fires trim every message. The plan's PR #1167 shipped a single
+    threshold and caused per-message compaction in production.
+    """
+    history = _build_turn_history(turn_pairs=200)
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        *history,
+        UserMessage(content="Current message"),
+    ]
+
+    first = trim_messages(
+        messages,
+        target_tokens=10_000_000,
+        target_turns=20,
+        trigger_turns=36,
+        input_tokens=500,
+    )
+    assert len(first.dropped) > 0
+
+    # Simulate the next-message cycle: feed the trimmed result back in.
+    # Hysteresis means user-turn count is at most target_turns + summary
+    # placeholder = 21, well below the trigger of 36, so trim is a no-op.
+    second = trim_messages(
+        first.messages,
+        target_tokens=10_000_000,
+        target_turns=20,
+        trigger_turns=36,
+        input_tokens=500,
+    )
+    assert second.dropped == [], (
+        "Second trim must not re-fire while count stays below trigger; "
+        "otherwise compaction churns on every message."
+    )
+
+
+def test_trim_messages_trigger_defaults_to_target_plus_buffer() -> None:
+    """When trigger_turns is unset, it defaults to target_turns + 16.
+
+    A conversation just over target but under target+16 should NOT trim.
+    A conversation past target+16 SHOULD trim.
+    """
+    # 25 user turns: above target=20, below trigger=36. No trim.
+    history = _build_turn_history(turn_pairs=24)
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        *history,
+        UserMessage(content="Current message"),
+    ]
+    result = trim_messages(messages, target_tokens=10_000_000, target_turns=20, input_tokens=500)
+    assert result.dropped == [], "25 turns is below default trigger of 36"
+
+    # 50 user turns: well above default trigger of 36. Trim fires.
+    history2 = _build_turn_history(turn_pairs=49)
+    messages2: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        *history2,
+        UserMessage(content="Current message"),
+    ]
+    result2 = trim_messages(messages2, target_tokens=10_000_000, target_turns=20, input_tokens=500)
+    assert len(result2.dropped) > 0
+
+
+def test_trim_messages_preserves_seq_through_drop() -> None:
+    """Dropped UserMessages and AssistantMessages must carry seq through to
+    the dropped list so trigger_compaction_for_dropped can compute a
+    watermark from them.
+    """
+    history: list[AgentMessage] = []
+    for i in range(50):
+        history.append(UserMessage(content=f"User turn {i}", seq=2 * i + 1))
+        history.append(AssistantMessage(content=f"Assistant reply {i}", seq=2 * i + 2))
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        *history,
+        UserMessage(content="Current message"),  # in-memory, no seq
+    ]
+    result = trim_messages(messages, target_tokens=10_000_000, target_turns=10, input_tokens=500)
+    assert len(result.dropped) > 0
+    seqs = [m.seq for m in result.dropped if isinstance(m, (UserMessage, AssistantMessage))]
+    assert all(s is not None for s in seqs)
+    # Dropped messages are the OLDEST, so their seqs should start at 1.
+    assert min(seqs) == 1
+
+
 def test_trim_messages_turn_cap_preserves_tool_call_pairs() -> None:
     """Block-aware removal must not orphan tool results when the turn cap fires."""
     # Build a long history where the oldest "turn" includes a tool call/result

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -2,26 +2,30 @@
 
 import asyncio
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 import backend.app.database as _db_module
 from backend.app.agent.compaction import (
     COMPACTION_SYSTEM_PROMPT,
+    _build_snapshot_pairs,
     _format_messages_for_compaction,
     _parse_compaction_response,
+    _serialize_snapshot,
     compact_session,
 )
 from backend.app.agent.context import (
     load_conversation_history,
+    trigger_compaction_for_dropped,
 )
 from backend.app.agent.file_store import SessionState, StoredMessage, UserData
 from backend.app.agent.memory_db import get_memory_store
 from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
 from backend.app.agent.session_db import get_session_store
 from backend.app.agent.stores import HeartbeatStore
-from backend.app.models import User
+from backend.app.enums import MessageDirection
+from backend.app.models import ChatSession, CompactionEvent, User
 from tests.mocks.llm import extract_system_text, make_text_response
 
 
@@ -917,9 +921,13 @@ async def test_trigger_compaction_for_dropped_fires_background_task(
     """trigger_compaction_for_dropped should fire a background compaction task."""
     from backend.app.agent.context import trigger_compaction_for_dropped
 
+    # Dropped messages must carry seq so the trigger can advance the
+    # per-session watermark in the same transaction as the pending event
+    # row insert. Without seq, the trigger is a no-op (in-memory
+    # placeholders cannot pin a DB row range).
     dropped: list[AgentMessage] = [
-        UserMessage(content="Old message 1"),
-        AssistantMessage(content="Old reply 1"),
+        UserMessage(content="Old message 1", seq=1),
+        AssistantMessage(content="Old reply 1", seq=2),
     ]
 
     mock_response = make_text_response(
@@ -1158,3 +1166,296 @@ async def test_compact_session_db_failure_does_not_fail_compaction(
 
     assert "## A" in memory_update
     assert max_seq == 1
+
+
+# ---------------------------------------------------------------------------
+# Snapshot serialization (truncation cap + skip-if-unchanged)
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_snapshot_under_cap_returns_text() -> None:
+    """Plaintext within the cap passes through unchanged."""
+    text = "small content"
+    assert _serialize_snapshot(text, cap=10_000) == text
+
+
+def test_serialize_snapshot_none_returns_none() -> None:
+    assert _serialize_snapshot(None, cap=10_000) is None
+
+
+def test_serialize_snapshot_over_cap_returns_truncation_record() -> None:
+    """Plaintext over the cap returns a structured truncation record so the
+    row size stays bounded regardless of how large MEMORY.md grows.
+    """
+    big = "x" * 50_000
+    out = _serialize_snapshot(big, cap=10_000)
+    assert out is not None
+    record = json.loads(out)
+    assert record["truncated"] is True
+    assert record["size_bytes"] == 50_000
+    assert len(record["sha256"]) == 64  # sha256 hex digest length
+    # Head and tail are bounded by their internal sizes (2KB each in module).
+    assert len(record["head"]) <= 2_000
+    assert len(record["tail"]) <= 2_000
+
+
+def test_build_snapshot_pairs_skips_unchanged() -> None:
+    """Files with before == after produce None for both columns; the persist
+    path will leave both columns NULL, saving encryption + storage overhead.
+    """
+    pairs = _build_snapshot_pairs(
+        cap=10_000,
+        memory_before="same memory",
+        memory_after="same memory",
+        history_before="old history",
+        history_after="old history\nnew entry",
+        user_before="same user",
+        user_after="same user",
+        soul_before="",
+        soul_after="",
+    )
+    assert pairs["memory_text_before"] is None
+    assert pairs["memory_text_after"] is None
+    assert pairs["history_text_before"] == "old history"
+    assert pairs["history_text_after"] == "old history\nnew entry"
+    assert pairs["user_text_before"] is None
+    assert pairs["user_text_after"] is None
+    assert pairs["soul_text_before"] is None
+    assert pairs["soul_text_after"] is None
+
+
+# ---------------------------------------------------------------------------
+# load_conversation_history watermark filter
+# ---------------------------------------------------------------------------
+
+
+def _seed_session_with_messages(user: User, message_count: int) -> ChatSession:
+    """Insert a ChatSession for *user* with *message_count* alternating
+    inbound/outbound messages, returning the persisted ChatSession.
+    """
+    db = _db_module.SessionLocal()
+    try:
+        cs = ChatSession(
+            session_id=f"session-{user.id}",
+            user_id=user.id,
+            channel="webchat",
+            initial_system_prompt="",
+        )
+        db.add(cs)
+        db.flush()
+        for i in range(1, message_count + 1):
+            from backend.app.models import Message
+
+            db.add(
+                Message(
+                    session_id=cs.id,
+                    seq=i,
+                    direction=(
+                        MessageDirection.INBOUND if i % 2 == 1 else MessageDirection.OUTBOUND
+                    ),
+                    body=f"msg {i}",
+                    processed_context="",
+                    tool_interactions_json="",
+                    external_message_id="",
+                    media_urls_json="[]",
+                )
+            )
+        db.commit()
+        db.refresh(cs)
+        db.expunge(cs)
+        return cs
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio()
+async def test_load_conversation_history_respects_last_trim_seq(test_user: User) -> None:
+    """Messages with seq <= last_trim_seq must be filtered out."""
+    cs = _seed_session_with_messages(test_user, message_count=20)
+    db = _db_module.SessionLocal()
+    try:
+        cs_ref = db.query(ChatSession).filter_by(id=cs.id).first()
+        assert cs_ref is not None
+        cs_ref.last_trim_seq = 10
+        db.commit()
+    finally:
+        db.close()
+
+    session = get_session_store(test_user.id).load_session(cs.session_id)
+    assert session is not None
+    history = await load_conversation_history(session)
+
+    # Excludes the most recent (current message). Filtered to seq > 10.
+    # So we keep seqs 11..19 (the last one, seq=20, is the "current" excluded).
+    contents = {getattr(m, "content", None) for m in history}
+    assert "msg 1" not in contents
+    assert "msg 10" not in contents
+    assert "msg 11" in contents
+    assert "msg 19" in contents
+
+
+@pytest.mark.asyncio()
+async def test_load_conversation_history_null_watermark_no_filter(test_user: User) -> None:
+    """NULL watermark (default) is the back-compat behavior: no filtering."""
+    cs = _seed_session_with_messages(test_user, message_count=10)
+    session = get_session_store(test_user.id).load_session(cs.session_id)
+    assert session is not None
+    assert session.last_trim_seq is None
+
+    history = await load_conversation_history(session)
+    contents = {getattr(m, "content", None) for m in history}
+    # All non-current messages present.
+    assert "msg 1" in contents
+    assert "msg 9" in contents
+
+
+# ---------------------------------------------------------------------------
+# trigger_compaction_for_dropped: synchronous pre-insert + watermark advance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_trigger_compaction_for_dropped_no_seqs_skips(test_user: User) -> None:
+    """When no dropped messages carry seq (all in-memory placeholders),
+    trigger_compaction must NOT insert an event or advance the watermark.
+    """
+    in_memory_only: list[AgentMessage] = [
+        UserMessage(content="placeholder"),  # seq=None
+    ]
+    trigger_compaction_for_dropped(test_user.id, in_memory_only)
+    db = _db_module.SessionLocal()
+    try:
+        rows = db.query(CompactionEvent).filter_by(user_id=test_user.id).count()
+    finally:
+        db.close()
+    assert rows == 0
+
+
+@pytest.mark.asyncio()
+async def test_trigger_compaction_for_dropped_inserts_pending_and_advances_watermark(
+    test_user: User,
+) -> None:
+    """The synchronous phase must insert a 'pending' CompactionEvent row
+    AND advance sessions.last_trim_seq to max(dropped seqs), atomically.
+    """
+    cs = _seed_session_with_messages(test_user, message_count=20)
+    dropped: list[AgentMessage] = [
+        UserMessage(content="m1", seq=3),
+        AssistantMessage(content="r1", seq=4),
+        UserMessage(content="m2", seq=5),
+    ]
+    # Mock the async compaction call so the test asserts only the
+    # synchronous behavior.
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("", 5)),
+    ):
+        trigger_compaction_for_dropped(test_user.id, dropped)
+        # Yield to let the (mocked) background task run.
+        await asyncio.sleep(0)
+
+    db = _db_module.SessionLocal()
+    try:
+        cs_ref = db.query(ChatSession).filter_by(id=cs.id).first()
+        assert cs_ref is not None
+        assert cs_ref.last_trim_seq == 5
+
+        events = db.query(CompactionEvent).filter_by(user_id=test_user.id).all()
+        assert len(events) == 1
+        event = events[0]
+        assert event.min_message_seq == 3
+        assert event.max_message_seq == 5
+        # Status is whatever the (mocked) compaction left it at; with our
+        # AsyncMock, _persist_compaction_event was not called, so the row
+        # stays at the synchronously-inserted 'pending'.
+        assert event.status == "pending"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio()
+async def test_watermark_event_seq_invariant_after_compaction(test_user: User) -> None:
+    """After a successful compaction, sessions.last_trim_seq must equal
+    compaction_events.max_message_seq for that event's row.
+    """
+    cs = _seed_session_with_messages(test_user, message_count=20)
+    dropped: list[AgentMessage] = [
+        UserMessage(content="m", seq=7),
+        AssistantMessage(content="r", seq=8),
+    ]
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("", 8)),
+    ):
+        trigger_compaction_for_dropped(test_user.id, dropped)
+        await asyncio.sleep(0)
+
+    db = _db_module.SessionLocal()
+    try:
+        cs_ref = db.query(ChatSession).filter_by(id=cs.id).first()
+        event = db.query(CompactionEvent).filter_by(user_id=test_user.id).first()
+        assert cs_ref is not None
+        assert event is not None
+        assert cs_ref.last_trim_seq == event.max_message_seq == 8
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# compact_session with event_id: UPDATE the pre-inserted row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_with_event_id_updates_existing_row(
+    test_user: User,
+) -> None:
+    """When event_id is provided, compact_session must UPDATE that row
+    (flip status to 'completed', fill in snapshots) instead of inserting.
+    """
+    db = _db_module.SessionLocal()
+    try:
+        ev = CompactionEvent(
+            user_id=test_user.id,
+            status="pending",
+            min_message_seq=1,
+            max_message_seq=5,
+            trimmed_count=2,
+        )
+        db.add(ev)
+        db.commit()
+        db.refresh(ev)
+        event_id = ev.id
+    finally:
+        db.close()
+
+    # Seed memory before so the LLM-driven write produces a diff.
+    memory_store = get_memory_store(test_user.id)
+    memory_store.write_memory("# Old MEMORY\n- nothing here yet")
+
+    llm_response = json.dumps(
+        {"memory_update": "# New MEMORY\n- learned something", "summary": "[TIMESTAMP] s"}
+    )
+    mock_response = make_text_response(llm_response)
+    dropped: list[AgentMessage] = [
+        UserMessage(content="hello world", seq=4),
+        AssistantMessage(content="hello back", seq=5),
+    ]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, dropped, max_message_seq=5, event_id=event_id)
+
+    db = _db_module.SessionLocal()
+    try:
+        ev = db.query(CompactionEvent).filter_by(id=event_id).first()
+        assert ev is not None
+        assert ev.status == "completed"
+        # Memory changed, so before/after columns are populated.
+        assert ev.memory_text_before == "# Old MEMORY\n- nothing here yet"
+        assert ev.memory_text_after is not None
+        assert "learned something" in ev.memory_text_after
+        # Total compaction events: still exactly one (UPDATE, not INSERT).
+        all_events = db.query(CompactionEvent).filter_by(user_id=test_user.id).count()
+        assert all_events == 1
+    finally:
+        db.close()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #1185.

After PR #1167 shipped, ``trigger_compaction_for_dropped`` started firing on every inbound message for any user with conversation history above ``context_trim_target_turns`` (default 80). Two-layer root cause:

1. ``trim_messages`` had no hysteresis. Trigger condition (count > target) and stop condition (count <= target) were adjacent, so the resting state sat exactly at the cap and every subsequent user message re-fired trim plus the downstream compaction LLM call.
2. The agent loop reloads ``session.messages`` from the DB on every inbound (``ingestion.py:375``), so even with function-level hysteresis, every load re-created the over-cap state. The dropped messages still had their DB rows; no watermark connected the trim path to the load path.

### Fix

* **Hysteresis in ``trim_messages``.** New ``context_trim_trigger_turns`` setting (default ``target + 16`` when unset). Trim fires when count exceeds trigger, drops down to target, leaving headroom before the next trim.
* **Per-session trim watermark.** ``sessions.last_trim_seq INTEGER NULL``. ``UserMessage`` and ``AssistantMessage`` carry their persisted ``messages.seq``. ``load_conversation_history`` filters ``seq > last_trim_seq``. NULL watermark preserves pre-feature behavior.
* **Two-phase ``trigger_compaction_for_dropped`` for crash safety.** Phase 1 synchronously inserts a ``'pending'`` ``CompactionEvent`` row AND advances the watermark in one transaction. Phase 2 (async LLM call) fills in the snapshots and flips ``status`` to ``'completed'``. If the async task crashes, the row stays ``'pending'`` so an admin can see which seq range was trimmed without facts being extracted.
* **Memory-diff audit on ``compaction_events``.** Eight envelope-encrypted text columns capture before/after snapshots of MEMORY.md / HISTORY.md / USER.md / SOUL.md per event. Files unchanged across the event are skipped (both columns stay NULL). New ``compaction_event_snapshot_max_bytes_per_file`` setting (default 100KB) bounds row size when memory files are large; over-cap snapshots become structured truncation records (head, tail, size, sha256).

### Migrations

Two additive nullable migrations, safe online:

* 028: ``sessions.last_trim_seq INTEGER NULL``
* 029: ``compaction_events`` gains ``min_message_seq``, ``status`` (default ``'completed'`` for legacy rows), and 8 nullable text columns for snapshots

### Tests

13 new tests added. Highlights:

* ``test_trim_messages_resting_state_does_not_re_trigger``: the production-symptom regression test. Feed a trimmed result back through ``trim_messages`` and assert the second call drops zero. Without hysteresis, the second call drops because the summary placeholder pushes count back over the cap.
* Watermark/event-seq consistency invariant: after a successful compaction, ``session.last_trim_seq == compaction_events.max_message_seq``.
* Snapshot truncation, skip-if-unchanged, two-phase pending/completed lifecycle, in-memory-placeholder no-op path, ``compact_session(event_id=...)`` UPDATE-vs-INSERT.

One existing test (``test_trigger_compaction_for_dropped_fires_background_task``) was updated to pass ``seq`` on dropped messages, since the new contract requires seq for the synchronous watermark advance.

## Type
- [x] Bug fix
- [x] Feature (new ``CompactionEvent`` audit columns + admin observability primitives)

## Checklist
- [x] Tests pass (``uv run pytest -v``: 2185 passed, 0 failed)
- [x] Lint passes (``uv run ruff check backend/ tests/ alembic/``)
- [x] Format passes (``uv run ruff format --check``)
- [x] Type checking passes (``uv run ty check --python .venv backend/ tests/ alembic/``)
- [x] New tests added for new functionality (13 new tests)
- [x] Bug fixes include regression tests (``test_trim_messages_resting_state_does_not_re_trigger``)

## Follow-up

A premium PR will bump ``OSS_REF`` to this commit and add the admin UI: a ``/admin/shared-data/users/{id}/compaction-events`` endpoint that reads the new snapshot columns, plus a frontend overlay rendering a watermark line on the conversation timeline and a Compaction Events tab with before/after diff views.

## AI Usage
- [x] AI-assisted (Claude wrote the implementation and tests after a multi-phase review identifying the two-layer root cause and locking the design decisions with the user)