### PR TITLE
fix(alembic): renumber trim-watermark migrations to resolve revision collision

### DIFF
--- a/alembic/versions/029_add_last_trim_seq_to_sessions.py
+++ b/alembic/versions/029_add_last_trim_seq_to_sessions.py
@@ -11,8 +11,8 @@ NULL on existing sessions (nothing has been trimmed yet); the load path
 treats NULL as no filter, preserving today's behavior until the first
 trim writes a value.
 
-Revision ID: 028
-Revises: 027
+Revision ID: 029
+Revises: 028
 Create Date: 2026-05-05
 """
 
@@ -22,8 +22,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "028"
-down_revision: str = "027"
+revision: str = "029"
+down_revision: str = "028"
 branch_labels: tuple[str, ...] | None = None
 depends_on: tuple[str, ...] | None = None
 

--- a/alembic/versions/030_add_memory_diff_snapshots_to_compaction_events.py
+++ b/alembic/versions/030_add_memory_diff_snapshots_to_compaction_events.py
@@ -16,8 +16,8 @@ All new columns are nullable so existing rows remain readable. The
 NOT NULL constraint can be enforced without a backfill (existing rows
 ran the prior synchronous-write path and are effectively complete).
 
-Revision ID: 029
-Revises: 028
+Revision ID: 030
+Revises: 029
 Create Date: 2026-05-05
 """
 
@@ -27,8 +27,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "029"
-down_revision: str = "028"
+revision: str = "030"
+down_revision: str = "029"
 branch_labels: tuple[str, ...] | None = None
 depends_on: tuple[str, ...] | None = None
 


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning is his; the prose is Claude's._

## Description

**Hot fix.** Production deploy is failing with:

```
Multiple head revisions are present for given argument 'head'
```

#1192 (approval_events audit log) and #1193 (trim watermark + memory snapshots) both numbered their first migration ``028`` while open in parallel. Filenames differ so git did not flag the collision; alembic only enforces unique revision IDs at runtime, after deploy.

This PR renumbers the two trim-watermark migrations to chain after #1192:

* ``028_add_last_trim_seq_to_sessions.py`` -> ``029_add_last_trim_seq_to_sessions.py`` (revision 028 -> 029, down_revision 027 -> 028)
* ``029_add_memory_diff_snapshots_to_compaction_events.py`` -> ``030_add_memory_diff_snapshots_to_compaction_events.py`` (revision 029 -> 030, down_revision 028 -> 029)

Final chain: 027 -> 028 (approval_events) -> 029 (last_trim_seq) -> 030 (memory_diff_snapshots).

## Verification

```
$ alembic upgrade head
INFO  ... Running upgrade 027 -> 028, Add approval_events audit log.
INFO  ... Running upgrade 028 -> 029, Add ``sessions.last_trim_seq`` for the per-session trim watermark.
INFO  ... Running upgrade 029 -> 030, Add memory-diff snapshots and pending/completed status to compaction_events.
```

Tests pass: ``uv run pytest tests/test_agent.py tests/test_compaction.py`` (143 passed). Lint and types clean.

No application-code changes. Both migrations are still additive (nullable columns plus one NOT NULL with server-side default for ``status``), so the renumber is safe regardless of which order they ran in for any DB that already applied a previous broken state.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (``uv run pytest``: 143 passed in test_agent + test_compaction)
- [x] Lint passes (``ruff check alembic/``)
- [x] Format passes (``ruff format --check``)
- [x] Type checking passes (``ty check``)
- [x] Verified ``alembic upgrade head`` against a fresh database (027 -> 028 -> 029 -> 030)

## AI Usage
- [x] AI-assisted (Claude opened the hot fix after the production deploy log surfaced the duplicate-revision error)