### PR TITLE
feat(compaction): capture LLM prompt, raw response, and parsed fields

### DIFF
--- a/alembic/versions/031_add_compaction_llm_call_columns.py
+++ b/alembic/versions/031_add_compaction_llm_call_columns.py
@@ -1,0 +1,57 @@
+"""Capture the compaction LLM call (prompt, raw response, parsed result).
+
+Layer 5 follow-up to migration 030. Migration 030 added before/after
+snapshots of the four memory files this event touched, which answers
+"what changed?" but not "why did the LLM choose to update only some
+files?" These three columns close that gap so an admin reviewing a
+compaction event can see the trimmed conversation that was passed to
+the LLM, the raw text it returned (useful when JSON parsing falls back
+to the empty result), and the parsed-fields-as-JSON structure that the
+``*_updated`` flags + ``summary_len`` only summarize.
+
+- ``prompt_text``: the trimmed conversation text fed to the compaction
+  LLM as the ``<conversation>`` block. Excludes the static system
+  prompt and the four current memory-file inputs (those are already
+  captured by the ``*_text_before`` snapshots from migration 030 and
+  the static system prompt is identical across events).
+- ``raw_response_text``: ``get_response_text(response)`` before
+  ``_parse_compaction_response`` runs. Catches malformed JSON, prompt
+  drift, and the markdown-fence path that today produces a silent empty
+  result.
+- ``parsed_response_json``: a JSON string of the four parsed fields
+  (memory_update / summary / user_profile_update / soul_update). Lets
+  admins see the exact strings the LLM produced rather than only the
+  derived bool flags.
+
+All three columns are nullable so existing rows and pending rows
+remain readable without a backfill. Same envelope-encrypted text shape
+as the 030 snapshot columns.
+
+Revision ID: 031
+Revises: 030
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "031"
+down_revision: str = "030"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    for col in ("prompt_text", "raw_response_text", "parsed_response_json"):
+        op.add_column(
+            "compaction_events",
+            sa.Column(col, sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    for col in ("parsed_response_json", "raw_response_text", "prompt_text"):
+        op.drop_column("compaction_events", col)

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -350,6 +350,28 @@ async def compact_session(
         soul_before=current_soul,
         soul_after=new_soul,
     )
+    # Capture the LLM call itself for Layer 5 admin observability:
+    # the trimmed conversation that was sent (the static system prompt
+    # and the four current memory files are excluded; the system prompt
+    # is identical across events and the memory inputs are already in
+    # the ``*_text_before`` snapshots), the unparsed response text, and
+    # the parsed fields as a JSON string. All three share the per-file
+    # truncation cap so an unusually long conversation does not blow up
+    # the row.
+    parsed_response_json = json.dumps(
+        {
+            "memory_update": result.memory_update,
+            "summary": result.summary,
+            "user_profile_update": result.user_profile_update,
+            "soul_update": result.soul_update,
+        },
+        ensure_ascii=False,
+    )
+    llm_call = {
+        "prompt_text": _serialize_snapshot(conversation_text, cap),
+        "raw_response_text": _serialize_snapshot(raw_content, cap),
+        "parsed_response_json": _serialize_snapshot(parsed_response_json, cap),
+    }
 
     # Persist the metrics + snapshots. Either UPDATE the pending row that
     # ``trigger_compaction_for_dropped`` pre-inserted (event_id provided),
@@ -370,6 +392,7 @@ async def compact_session(
             soul_updated=bool(result.soul_update),
             summary_len=len(result.summary or ""),
             snapshots=snapshots,
+            llm_call=llm_call,
         )
     except Exception:
         logger.exception("Failed to persist compaction event for user %s", user_id)
@@ -434,13 +457,18 @@ def _persist_compaction_event(
     soul_updated: bool,
     summary_len: int,
     snapshots: dict[str, str | None],
+    llm_call: dict[str, str | None],
 ) -> None:
     """Write or update one ``CompactionEvent`` row.
 
     When ``event_id`` is provided, UPDATE the pre-inserted ``'pending'``
     row (the agent-loop path). Otherwise INSERT a new ``'completed'`` row
-    (test / legacy path). Imports SQLAlchemy lazily so the agent module
-    does not pull it at import time on every pure-logic test.
+    (test / legacy path). ``llm_call`` carries the migration-031 columns
+    (``prompt_text``, ``raw_response_text``, ``parsed_response_json``);
+    keeping it as a dict mirrors the ``snapshots`` shape so adding more
+    audit columns later does not require re-threading positional args.
+    Imports SQLAlchemy lazily so the agent module does not pull it at
+    import time on every pure-logic test.
     """
     from backend.app.database import SessionLocal
     from backend.app.models import CompactionEvent
@@ -471,6 +499,8 @@ def _persist_compaction_event(
                 event.status = "completed"
                 for col, value in snapshots.items():
                     setattr(event, col, value)
+                for col, value in llm_call.items():
+                    setattr(event, col, value)
         if event_id is None:
             db.add(
                 CompactionEvent(
@@ -487,6 +517,7 @@ def _persist_compaction_event(
                     summary_len=summary_len,
                     status="completed",
                     **snapshots,
+                    **llm_call,
                 )
             )
         db.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -782,6 +782,31 @@ class CompactionEvent(Base):
         EncryptedString(table="compaction_events", column="soul_text_after"),
         nullable=True,
     )
+    # Capture of the actual compaction LLM call. Lets admins answer
+    # "why did the LLM only update MEMORY.md and not USER.md / SOUL.md?"
+    # which the ``*_updated`` boolean flags above cannot. ``prompt_text``
+    # is the trimmed conversation passed as the ``<conversation>`` block
+    # (the four memory inputs to the prompt are already covered by the
+    # ``*_text_before`` snapshots above). ``raw_response_text`` is the
+    # unparsed model output, useful when ``_parse_compaction_response``
+    # falls back to the empty result. ``parsed_response_json`` is a
+    # JSON-serialized ``CompactionResult`` so the four field strings
+    # are inspectable without re-parsing the raw response. All three
+    # share the migration-031 nullable / envelope-encrypted shape and
+    # are subject to the same per-file truncation cap as the 030
+    # snapshots.
+    prompt_text: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="prompt_text"),
+        nullable=True,
+    )
+    raw_response_text: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="raw_response_text"),
+        nullable=True,
+    )
+    parsed_response_json: Mapped[str | None] = mapped_column(
+        EncryptedString(table="compaction_events", column="parsed_response_json"),
+        nullable=True,
+    )
 
 
 class UserPermissionSet(Base):

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -24,6 +24,7 @@ from backend.app.agent.memory_db import get_memory_store
 from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
 from backend.app.agent.session_db import get_session_store
 from backend.app.agent.stores import HeartbeatStore
+from backend.app.config import settings
 from backend.app.enums import MessageDirection
 from backend.app.models import ChatSession, CompactionEvent, User
 from tests.mocks.llm import extract_system_text, make_text_response
@@ -745,6 +746,7 @@ async def test_compact_session_uses_configured_model(test_user: UserData) -> Non
         mock_settings.compaction_model = "test-compact-model"
         mock_settings.compaction_provider = "test-provider"
         mock_settings.compaction_max_tokens = 300
+        mock_settings.compaction_event_snapshot_max_bytes_per_file = 100_000
         mock_settings.llm_model = "test-model"
         mock_settings.llm_provider = "test-provider"
         mock_settings.llm_api_base = None
@@ -770,6 +772,7 @@ async def test_compact_session_falls_back_to_llm_model(test_user: UserData) -> N
         mock_settings.compaction_model = ""
         mock_settings.compaction_provider = ""
         mock_settings.compaction_max_tokens = 500
+        mock_settings.compaction_event_snapshot_max_bytes_per_file = 100_000
         mock_settings.llm_model = "test-model"
         mock_settings.llm_provider = "test-provider"
         mock_settings.llm_api_base = None
@@ -799,6 +802,7 @@ async def test_compact_session_logs_llm_usage(test_user: UserData) -> None:
         mock_settings.compaction_model = "test-compact-model"
         mock_settings.compaction_provider = "test-provider"
         mock_settings.compaction_max_tokens = 300
+        mock_settings.compaction_event_snapshot_max_bytes_per_file = 100_000
         mock_settings.llm_model = "test-model"
         mock_settings.llm_provider = "test-provider"
         mock_settings.llm_api_base = None
@@ -1457,5 +1461,114 @@ async def test_compact_session_with_event_id_updates_existing_row(
         # Total compaction events: still exactly one (UPDATE, not INSERT).
         all_events = db.query(CompactionEvent).filter_by(user_id=test_user.id).count()
         assert all_events == 1
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration 031 capture (prompt / raw response / parsed fields)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_captures_llm_prompt_raw_and_parsed(
+    test_user: User,
+) -> None:
+    """compact_session must populate prompt_text, raw_response_text, and
+    parsed_response_json on the persisted row so admins can answer 'why
+    did the LLM only update some files?' from the UI rather than from
+    raw-SQL spelunking. The parsed JSON must round-trip the four
+    CompactionResult fields including empty strings for files the LLM
+    chose not to update.
+    """
+    raw_llm_text = json.dumps(
+        {
+            "memory_update": "# New MEMORY\n- learned",
+            "summary": "[TIMESTAMP] s",
+            # Mirrors the prod observation that motivated #414: the LLM
+            # routinely returns empty user_profile_update / soul_update.
+            "user_profile_update": "",
+            "soul_update": "",
+        }
+    )
+    mock_response = make_text_response(raw_llm_text)
+    dropped: list[AgentMessage] = [
+        UserMessage(content="tell me about the new project", seq=1),
+        AssistantMessage(content="sure, here is the plan", seq=2),
+    ]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, dropped, max_message_seq=2)
+
+    db = _db_module.SessionLocal()
+    try:
+        ev = (
+            db.query(CompactionEvent)
+            .filter_by(user_id=test_user.id)
+            .order_by(CompactionEvent.id.desc())
+            .first()
+        )
+        assert ev is not None
+        # Prompt is the trimmed conversation block exactly. The static
+        # system prompt and the four current-memory inputs are NOT in
+        # this column (system is invariant across events; current
+        # memory is already in the *_text_before snapshots).
+        assert ev.prompt_text is not None
+        assert "tell me about the new project" in ev.prompt_text
+        assert "sure, here is the plan" in ev.prompt_text
+        # Raw response is the unparsed model output.
+        assert ev.raw_response_text == raw_llm_text
+        # Parsed JSON round-trips all four fields, including empties so
+        # the UI can render "(empty, file unchanged)" instead of hiding
+        # them.
+        assert ev.parsed_response_json is not None
+        parsed = json.loads(ev.parsed_response_json)
+        assert parsed["memory_update"] == "# New MEMORY\n- learned"
+        assert parsed["summary"] == "[TIMESTAMP] s"
+        assert parsed["user_profile_update"] == ""
+        assert parsed["soul_update"] == ""
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_truncates_oversized_prompt(
+    test_user: User,
+) -> None:
+    """A conversation that exceeds the per-file truncation cap must
+    write a structured truncation record into prompt_text rather than
+    blowing up the row. The cap is shared with the snapshot columns
+    from migration 030.
+    """
+    huge_user_message = "x" * 60_000
+    raw_llm_text = json.dumps({"memory_update": "ok", "summary": "[TIMESTAMP]"})
+    mock_response = make_text_response(raw_llm_text)
+    dropped: list[AgentMessage] = [
+        UserMessage(content=huge_user_message, seq=1),
+    ]
+
+    with (
+        patch("backend.app.agent.compaction.amessages", return_value=mock_response),
+        patch.object(
+            settings,
+            "compaction_event_snapshot_max_bytes_per_file",
+            10_000,
+        ),
+    ):
+        await compact_session(test_user.id, dropped, max_message_seq=1)
+
+    db = _db_module.SessionLocal()
+    try:
+        ev = (
+            db.query(CompactionEvent)
+            .filter_by(user_id=test_user.id)
+            .order_by(CompactionEvent.id.desc())
+            .first()
+        )
+        assert ev is not None
+        assert ev.prompt_text is not None
+        record = json.loads(ev.prompt_text)
+        assert record["truncated"] is True
+        assert record["size_bytes"] >= 60_000
     finally:
         db.close()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Layer 5 follow-up to migration 030. Migration 030 added before/after snapshots of the four memory files this event touched, which answers "what changed?" but not "why did the LLM only update some files?" Three new envelope-encrypted columns close the gap.

- `prompt_text`: trimmed conversation passed to the compaction LLM as the `<conversation>` block. Static system prompt and current memory inputs are intentionally excluded; the system prompt is identical across events and the memory inputs are already in the `*_text_before` snapshots from 030.
- `raw_response_text`: `get_response_text(response)` before `_parse_compaction_response` runs. Useful when the LLM returns malformed JSON or hits the markdown-fence path, both of which currently produce a silent empty result.
- `parsed_response_json`: JSON-serialized `CompactionResult` so admins see the four field strings, including empties (the LLM routinely returns empty `user_profile_update` and `soul_update`), rather than only the derived bool flags.

All three share the existing per-file truncation cap (`compaction_event_snapshot_max_bytes_per_file`) so an unusually long conversation does not blow up the row. `_persist_compaction_event` takes a new `llm_call` dict that mirrors the `snapshots` dict so adding more audit columns later does not require re-threading positional args.

The premium admin UI (mozilla-ai/clawbolt-premium#414) consumes these once this lands and OSS_REF is bumped.

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2201 passed
- [x] Lint passes (`ruff check` and `ruff format --check`)
- [x] Type checking passes (`uv run ty check`)
- [x] Frontend typecheck + deadcode pass (no schema changes for OSS frontend, verified clean)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests (n/a, this is a feature)

## AI Usage
- [x] AI-assisted (Claude drafted the migration, model fields, capture wiring, and tests via back-and-forth with @njbrake; reasoning and architectural decisions are his)