### PR TITLE
test(approval): regression test for advisory lock serialization

### DIFF
--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,11 +1,14 @@
 """Tests for the progressive approval system."""
 
 import asyncio
+import threading
+import time
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic import BaseModel
+from sqlalchemy import Engine
 
 from backend.app.agent.approval import (
     ApprovalDecision,
@@ -13,6 +16,7 @@ from backend.app.agent.approval import (
     ApprovalPolicy,
     ApprovalStore,
     PermissionLevel,
+    _lock_user_permissions,
     _parse_approval_response,
     classify_approval_response,
     format_approval_message,
@@ -202,6 +206,187 @@ class TestApprovalStoreComplete:
         # All tools should still be present
         assert len(data["tools"]) >= original_count
         assert data["tools"]["send_media_reply"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# ApprovalStore: pg_advisory_xact_lock concurrency regression
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalLockSerialization:
+    """Regression tests for the ``pg_advisory_xact_lock`` in
+    ``_lock_user_permissions``.
+
+    Concurrent permission writes for the same user must serialize so that
+    a read-modify-write sequence cannot lose updates. Writes for different
+    users must not block each other, otherwise the dashboard becomes a
+    single-writer queue under load.
+
+    Concurrency primitive: ``threading.Thread`` with ``threading.Event``
+    coordination. The approval-gate code path is currently sync, so threads
+    plus real Postgres connections are the right shape. When the path
+    converts to async (issue #1158), this same matrix can be ported to
+    ``asyncio.gather`` against ``AsyncSession`` with the same assertions.
+
+    Database setup: each thread opens its own connection from the
+    session-scoped ``_pg_engine`` rather than reusing ``SessionLocal`` from
+    the per-test transaction fixture. ``pg_advisory_xact_lock`` is a real
+    Postgres feature scoped to the holding transaction; sharing a single
+    connection across threads would serialize on the connection itself
+    rather than on the database lock, so the threads need independent
+    connections to actually exercise the primitive. The threads only call
+    the lock helper (no INSERT / UPDATE), so nothing leaks past the test.
+    """
+
+    # How long the holder of the same-user lock keeps it before releasing.
+    # Long enough that a contender thread reliably observes the block,
+    # short enough that the test stays fast.
+    _HOLD_S = 0.4
+
+    # Upper bound for how long a contender should ever take to acquire a
+    # free or just-released lock. Tuned generously so a slow CI runner
+    # does not flake.
+    _ACQUIRE_TIMEOUT_S = 5.0
+
+    def _acquire_in_thread(
+        self,
+        engine: Engine,
+        user_id: str,
+        ready: threading.Event,
+        release: threading.Event,
+        result: dict[str, float],
+        label: str,
+    ) -> None:
+        """Run inside a worker thread.
+
+        Opens a fresh connection, BEGINs, acquires
+        ``_lock_user_permissions`` for ``user_id``, signals ``ready``,
+        waits for ``release``, then commits. ``result`` records when the
+        lock was acquired and when the transaction committed so the test
+        can assert ordering.
+        """
+        connection = engine.connect()
+        try:
+            transaction = connection.begin()
+            _lock_user_permissions(connection, user_id)
+            result[f"{label}_acquired"] = time.monotonic()
+            ready.set()
+            # Hold the lock until the test signals it is safe to release.
+            release.wait(timeout=self._ACQUIRE_TIMEOUT_S)
+            transaction.commit()
+            result[f"{label}_committed"] = time.monotonic()
+        finally:
+            connection.close()
+
+    def test_same_user_lock_serializes_concurrent_writers(self, _pg_engine: Engine) -> None:
+        """Two threads acquiring the lock for the same user must run
+        strictly one at a time. The second thread must not acquire until
+        the first commits."""
+        user_id = "lock-serial-user"
+        a_ready = threading.Event()
+        a_release = threading.Event()
+        b_ready = threading.Event()
+        b_release = threading.Event()
+        results: dict[str, float] = {}
+
+        thread_a = threading.Thread(
+            target=self._acquire_in_thread,
+            args=(_pg_engine, user_id, a_ready, a_release, results, "a"),
+        )
+        thread_b = threading.Thread(
+            target=self._acquire_in_thread,
+            args=(_pg_engine, user_id, b_ready, b_release, results, "b"),
+        )
+
+        thread_a.start()
+        # Wait for A to actually hold the lock before starting B, so the
+        # ordering is deterministic regardless of OS scheduling.
+        assert a_ready.wait(timeout=self._ACQUIRE_TIMEOUT_S), (
+            "thread A failed to acquire the advisory lock"
+        )
+
+        thread_b.start()
+        # While A still holds the lock, B must NOT have acquired it.
+        # A short wait here would falsely succeed by racing the scheduler;
+        # use a bounded sleep that is much longer than any reasonable
+        # acquisition path through Postgres.
+        assert not b_ready.wait(timeout=self._HOLD_S), (
+            "thread B acquired the lock before thread A released it; "
+            "pg_advisory_xact_lock did not serialize same-user writers"
+        )
+
+        # Release A; B should now proceed.
+        a_release.set()
+        thread_a.join(timeout=self._ACQUIRE_TIMEOUT_S)
+        assert not thread_a.is_alive(), "thread A did not commit and release"
+
+        assert b_ready.wait(timeout=self._ACQUIRE_TIMEOUT_S), (
+            "thread B never acquired the lock after thread A committed"
+        )
+
+        b_release.set()
+        thread_b.join(timeout=self._ACQUIRE_TIMEOUT_S)
+        assert not thread_b.is_alive(), "thread B did not commit and release"
+
+        # B's acquire must come after A's commit. This is the load-bearing
+        # ordering check; the pg_advisory_xact_lock contract is "released
+        # at COMMIT / ROLLBACK", not "released when the Python code stops
+        # blocking".
+        assert results["b_acquired"] >= results["a_committed"], (
+            f"thread B acquired the lock at {results['b_acquired']:.4f} "
+            f"before thread A committed at {results['a_committed']:.4f}; "
+            "lock did not serialize on transaction boundary"
+        )
+
+    def test_different_users_do_not_contend(self, _pg_engine: Engine) -> None:
+        """A third thread holding the lock for a DIFFERENT user must run
+        in parallel with the same-user pair above. Different lock keys do
+        not contend."""
+        user_a = "lock-parallel-user-a"
+        user_c = "lock-parallel-user-c"
+
+        a_ready = threading.Event()
+        a_release = threading.Event()
+        c_ready = threading.Event()
+        c_release = threading.Event()
+        results: dict[str, float] = {}
+
+        thread_a = threading.Thread(
+            target=self._acquire_in_thread,
+            args=(_pg_engine, user_a, a_ready, a_release, results, "a"),
+        )
+        thread_c = threading.Thread(
+            target=self._acquire_in_thread,
+            args=(_pg_engine, user_c, c_ready, c_release, results, "c"),
+        )
+
+        thread_a.start()
+        assert a_ready.wait(timeout=self._ACQUIRE_TIMEOUT_S), (
+            "thread A failed to acquire the advisory lock"
+        )
+
+        # Start C while A is still holding its lock for user_a. Because
+        # user_c hashes to a different advisory-lock key, C must acquire
+        # immediately rather than waiting on A.
+        thread_c.start()
+        assert c_ready.wait(timeout=self._ACQUIRE_TIMEOUT_S), (
+            "thread C blocked on a different user's lock; advisory locks "
+            "are not isolated by user_id"
+        )
+
+        # C acquired while A was still in its critical section.
+        assert "a_committed" not in results, (
+            "thread A committed before C acquired; the parallelism check "
+            "did not actually exercise overlapping critical sections"
+        )
+
+        # Tear down in either order.
+        c_release.set()
+        thread_c.join(timeout=self._ACQUIRE_TIMEOUT_S)
+        a_release.set()
+        thread_a.join(timeout=self._ACQUIRE_TIMEOUT_S)
+        assert not thread_a.is_alive()
+        assert not thread_c.is_alive()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds `TestApprovalLockSerialization` in `tests/test_approval.py`, a concurrency regression suite for the `pg_advisory_xact_lock` call inside `_lock_user_permissions` (`backend/app/agent/approval.py`).

Two tests:

1. `test_same_user_lock_serializes_concurrent_writers`. Two threads acquire the lock for the same `user_id` against real Postgres. Asserts the second thread is blocked while the first holds the lock, and only acquires after the first commits. Includes a load-bearing timestamp check (`b_acquired >= a_committed`) so the test pins the "released at COMMIT / ROLLBACK" contract, not just "released when the Python code stops blocking".
2. `test_different_users_do_not_contend`. A thread holding the lock for user A does not block a thread acquiring the lock for user C. The test asserts C acquires while A is still in its critical section, so it actually exercises overlapping critical sections rather than accidentally serializing.

Concurrency primitives:

- `threading.Thread` plus `threading.Event` coordination. The approval-gate code path is currently sync, so threads plus real Postgres connections are the right shape. After OSS #1158 (advisory locks to async) lands, the same matrix can be ported to `asyncio.gather` against `AsyncSession` with the same assertions.
- Each thread opens its own connection from the session-scoped `_pg_engine` rather than reusing `SessionLocal` from the per-test transaction fixture. `pg_advisory_xact_lock` is scoped to the holding transaction, so sharing one connection across threads would serialize on the connection itself, not on the database lock.
- The threads only call the lock helper (no INSERT / UPDATE), so nothing leaks past the test.

Caveats for running:

- Requires real PostgreSQL (the test DB at `postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_test`). SQLite cannot exercise advisory locks.
- The same-user test deliberately holds a lock for ~0.4s to observe the block reliably. The hold is bounded and the contender timeout is 5s, generous enough to absorb slow CI without flaking.

Verification that the test catches a real regression: I temporarily replaced the `_lock_user_permissions` body with `pass` and reran. `test_same_user_lock_serializes_concurrent_writers` failed at the "B must NOT have acquired the lock before A released" assertion, then I restored the original implementation and both tests passed.

Note on issue wording vs. code: the issue mentions "N concurrent message arrivals on the same conversation". The actual `pg_advisory_xact_lock` in `_lock_user_permissions` is keyed on `user_permissions:{user_id}`, so the test serializes by `user_id`. The test exercises the real primitive; flagging in case the issue's mental model expected per-conversation keying.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude drafted the test design and prose via back-and-forth with @njbrake; the reasoning and decisions are his.)
- [ ] No AI used

Closes #1146
Part of #1139