### PR TITLE
test(infra)+feat(stores): async fixture + IdempotencyStore async API

### DIFF
--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -14,7 +14,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import Select, delete, func, or_, select
+from sqlalchemy import Delete, Select, delete, func, or_, select
 from sqlalchemy.exc import IntegrityError
 
 if TYPE_CHECKING:
@@ -362,7 +362,7 @@ def _count_select() -> Select[tuple[int]]:
     return select(func.count(IdempotencyKey.id))
 
 
-def _prune_delete() -> Any:
+def _prune_delete() -> Delete[tuple[IdempotencyKey]]:
     """Build the DELETE that keeps the newest ``_SEEN_MAX`` rows.
 
     Uses a single DELETE with a NOT-IN subquery so the whole thing

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -14,9 +14,11 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import delete, func, or_, select
+from sqlalchemy import Select, delete, func, or_, select
+from sqlalchemy.exc import IntegrityError
 
 if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
     from sqlalchemy.orm import Session
 
 from backend.app.agent.dto import (
@@ -24,7 +26,7 @@ from backend.app.agent.dto import (
     MediaData,
     ToolConfigEntry,
 )
-from backend.app.database import SessionLocal, db_session
+from backend.app.database import AsyncSessionLocal, SessionLocal, db_session, db_session_async
 from backend.app.models import (
     HeartbeatLog,
     IdempotencyKey,
@@ -344,23 +346,70 @@ class MediaStore:
 _SEEN_MAX = 10_000
 
 
+# Pilot for the per-store dual-API rollout (issue #1150). Internal
+# logic is factored into pure ``select(...) / delete(...)`` builders
+# so the sync and async methods stay in lockstep without a class
+# hierarchy. Each public sync method has an ``*_async`` peer; both
+# forward through the same builders. Stores #1151-#1157 should
+# follow this pattern.
+def _seen_select(external_id: str) -> Select[tuple[IdempotencyKey]]:
+    """Builder shared by ``has_seen`` and ``has_seen_async``."""
+    return select(IdempotencyKey).filter_by(external_id=external_id)
+
+
+def _count_select() -> Select[tuple[int]]:
+    """Builder shared by the sync and async ``_prune`` paths."""
+    return select(func.count(IdempotencyKey.id))
+
+
+def _prune_delete() -> Any:
+    """Build the DELETE that keeps the newest ``_SEEN_MAX`` rows.
+
+    Uses a single DELETE with a NOT-IN subquery so the whole thing
+    runs in one snapshot under READ COMMITTED; concurrent prunes
+    just delete the same set of rows instead of cascading.
+    """
+    keep = select(IdempotencyKey.id).order_by(IdempotencyKey.id.desc()).limit(_SEEN_MAX)
+    return (
+        delete(IdempotencyKey)
+        .where(IdempotencyKey.id.notin_(keep))
+        .execution_options(synchronize_session=False)
+    )
+
+
 class IdempotencyStore:
     """Database-backed idempotency tracking for webhook deduplication.
 
     Uses the IdempotencyKey ORM model. No user_id scoping -- external_id
     is globally unique.
+
+    Pilot store for the dual-API (sync + async) rollout (issue #1150).
+    Each public sync method has an ``*_async`` peer with identical
+    semantics; the two share query construction via the
+    ``_seen_select`` / ``_count_select`` / ``_prune_delete`` builders
+    above. Sync callers (CLI, Alembic, premium) keep working unchanged
+    while OSS-internal callers migrate to the async API one site at a
+    time. Future store conversions (#1151-#1157) follow the same
+    pattern.
     """
 
     def has_seen(self, external_id: str) -> bool:
         """Check if an external message ID has been seen."""
         db = SessionLocal()
         try:
-            row = db.execute(
-                select(IdempotencyKey).filter_by(external_id=external_id)
-            ).scalar_one_or_none()
+            row = db.execute(_seen_select(external_id)).scalar_one_or_none()
             return row is not None
         finally:
             db.close()
+
+    async def has_seen_async(self, external_id: str) -> bool:
+        """Async peer of ``has_seen``."""
+        db = AsyncSessionLocal()
+        try:
+            row = (await db.execute(_seen_select(external_id))).scalar_one_or_none()
+            return row is not None
+        finally:
+            await db.close()
 
     def try_mark_seen(self, external_id: str) -> bool:
         """Atomically insert an IdempotencyKey row and return whether it was new.
@@ -369,8 +418,6 @@ class IdempotencyStore:
         ``False`` if it already existed (duplicate). This replaces the
         separate has_seen + mark_seen pattern to eliminate the TOCTOU race.
         """
-        from sqlalchemy.exc import IntegrityError
-
         with db_session() as db:
             key = IdempotencyKey(external_id=external_id)
             db.add(key)
@@ -388,6 +435,30 @@ class IdempotencyStore:
                 logger.warning("IdempotencyStore prune failed", exc_info=True)
         return True
 
+    async def try_mark_seen_async(self, external_id: str) -> bool:
+        """Async peer of ``try_mark_seen``.
+
+        Same TOCTOU-free contract: the unique-constraint violation on
+        ``external_id`` is the source of truth for "already seen". A
+        prune failure is logged and swallowed so a transient prune
+        error never makes a duplicate webhook re-fire.
+        """
+        async with db_session_async() as db:
+            key = IdempotencyKey(external_id=external_id)
+            db.add(key)
+            try:
+                await db.commit()
+            except IntegrityError:
+                await db.rollback()
+                return False
+
+            try:
+                await self._prune_async(db)
+            except Exception:
+                await db.rollback()
+                logger.warning("IdempotencyStore prune failed", exc_info=True)
+        return True
+
     def _prune(self, db: Session | None = None) -> None:
         """Remove the oldest rows when the table exceeds ``_SEEN_MAX``.
 
@@ -397,9 +468,6 @@ class IdempotencyStore:
 
         Keeps the newest rows by ``id`` (autoincrement, so allocation
         order is monotonic even if commit order isn't -- fine for dedup).
-        Uses a single DELETE with a NOT-IN subquery so the whole thing
-        runs in one snapshot under READ COMMITTED; concurrent prunes
-        just delete the same set of rows instead of cascading.
         We order by ``id`` rather than ``created_at`` because
         app-generated timestamps can drift across workers.
         """
@@ -407,16 +475,23 @@ class IdempotencyStore:
             with db_session() as db:
                 self._prune(db)
             return
-        count = db.scalar(select(func.count(IdempotencyKey.id))) or 0
+        count = db.scalar(_count_select()) or 0
         if count <= _SEEN_MAX:
             return
-        keep = select(IdempotencyKey.id).order_by(IdempotencyKey.id.desc()).limit(_SEEN_MAX)
-        db.execute(
-            delete(IdempotencyKey)
-            .where(IdempotencyKey.id.notin_(keep))
-            .execution_options(synchronize_session=False)
-        )
+        db.execute(_prune_delete())
         db.commit()
+
+    async def _prune_async(self, db: AsyncSession | None = None) -> None:
+        """Async peer of ``_prune``. Same semantics, awaitable."""
+        if db is None:
+            async with db_session_async() as db:
+                await self._prune_async(db)
+            return
+        count = (await db.scalar(_count_select())) or 0
+        if count <= _SEEN_MAX:
+            return
+        await db.execute(_prune_delete())
+        await db.commit()
 
     async def mark_seen(self, external_id: str) -> None:
         """Insert an IdempotencyKey row (ignore if it already exists).
@@ -424,6 +499,13 @@ class IdempotencyStore:
         Prefer ``try_mark_seen`` for atomic check-and-insert.
         """
         self.try_mark_seen(external_id)
+
+    async def mark_seen_async(self, external_id: str) -> None:
+        """Async peer of ``mark_seen``.
+
+        Prefer ``try_mark_seen_async`` for atomic check-and-insert.
+        """
+        await self.try_mark_seen_async(external_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,17 @@
 import uuid
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import pytest_asyncio
 from fastapi.testclient import TestClient
 from sqlalchemy import Engine, create_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.orm import sessionmaker
 
 import backend.app.database as _db_module
@@ -23,6 +29,7 @@ from backend.app.models import ChatSession, Message, User
 from backend.app.services.rate_limiter import webhook_rate_limiter
 
 _TEST_DB_URL = "postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_test"
+_ASYNC_TEST_DB_URL = "postgresql+asyncpg://clawbolt:clawbolt@localhost:5432/clawbolt_test"
 
 
 @pytest.fixture(scope="session")
@@ -34,6 +41,30 @@ def _pg_engine() -> Generator[Engine]:
     yield engine
     Base.metadata.drop_all(engine)
     engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def _pg_async_engine(_pg_engine: Engine) -> AsyncGenerator[AsyncEngine]:
+    """Function-scoped async PostgreSQL engine.
+
+    Depends on ``_pg_engine`` so the sync engine fixture has already
+    created (and will later drop) the schema. The async engine only
+    opens connections; it never runs DDL. Both engines target the
+    same database; each maintains its own connection pool, mirroring
+    the production setup in ``backend.app.database``.
+
+    Scope is per-test rather than per-session because asyncpg
+    connections bind to the event loop they were created on, and
+    pytest-asyncio runs each test on a fresh function-scoped loop by
+    default. A session-scoped engine would surface as
+    ``RuntimeError: Future attached to a different loop`` on the
+    second test. We pay one engine setup per async test (a few ms)
+    in exchange for not having to widen the loop scope across the
+    whole suite, which would entangle sync and async tests.
+    """
+    engine = create_async_engine(_ASYNC_TEST_DB_URL, pool_pre_ping=True)
+    yield engine
+    await engine.dispose()
 
 
 @pytest.fixture(autouse=True)
@@ -83,6 +114,101 @@ def _isolate_stores(_pg_engine: Engine, tmp_path: Path) -> Generator[None]:
     reset_session_stores()
     reset_memory_stores()
     reset_approval_gate()
+
+
+# ---------------------------------------------------------------------------
+# Async DB isolation fixture (issue #1148)
+# ---------------------------------------------------------------------------
+#
+# Pattern: per-test ``AsyncConnection`` + outer transaction, with the
+# module-level ``_async_session_factory`` rebound to an
+# ``async_sessionmaker(bind=connection, join_transaction_mode=
+# "create_savepoint")`` for the duration of the test. The async store
+# API (``IdempotencyStore.try_mark_seen_async`` etc.) calls
+# ``AsyncSessionLocal()``/``db_session_async()`` -> picks up the
+# rebound factory -> shares the per-test connection. Each
+# ``factory()``/``db_session_async()`` opens a new SAVEPOINT under the
+# outer transaction; ``await session.commit()`` releases that
+# SAVEPOINT only; ``await session.rollback()`` (e.g. on
+# ``IntegrityError``) unwinds to the SAVEPOINT and leaves the outer
+# transaction intact. The outer ``await connection.begin()``
+# transaction is rolled back at teardown, leaving a clean DB
+# regardless of how many awaits or commit/rollback cycles the test
+# performed.
+#
+# Differences from the sync ``_isolate_stores`` analog above:
+#   * Driver: asyncpg vs psycopg2. The async engine is built from
+#     ``postgresql+asyncpg://`` and lives on a function-scoped
+#     ``_pg_async_engine`` fixture (asyncpg connections bind to the
+#     event loop they were created on, so a session-scoped engine
+#     dies when pytest-asyncio rotates loops between tests).
+#   * Join mode: ``create_savepoint``, not ``conditional_savepoint``.
+#     The sync version's ``conditional_savepoint`` survives an
+#     ``IntegrityError`` because psycopg2 keeps the outer transaction
+#     alive when only the savepoint aborts. The asyncpg path detaches
+#     the outer transaction in the same scenario, which would surface
+#     to tests as "the row I just committed disappeared after a
+#     duplicate-insert error in a later session". Forcing every
+#     session into its own SAVEPOINT (``create_savepoint``) keeps the
+#     contract consistent across drivers.
+#   * Scope: opt-in. Sync tests do not request this fixture, so they
+#     pay no async setup cost. Tests that exercise the async store API
+#     add ``async_db`` to their parameter list.
+#   * Cross-API caveat: the sync and async per-test transactions live
+#     on independent connections. A sync write committed from
+#     ``_isolate_stores`` is NOT visible to an async read in the same
+#     test (each transaction sees its own snapshot under READ
+#     COMMITTED). Pure-async store tests are fine; mixed-API tests
+#     should drive their setup through the matching API.
+#
+# Future store-conversion PRs (#1151, #1152, #1153, #1154, #1155,
+# #1156, #1157, #1175) and the premium analog (premium #390) should
+# mirror this pattern: one ``AsyncConnection``, one outer transaction,
+# ``create_savepoint`` mode, rebind the factory, rollback at teardown.
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def async_db(
+    _pg_async_engine: AsyncEngine,
+) -> AsyncGenerator[async_sessionmaker]:
+    """Per-test async DB isolation via SAVEPOINT-on-connection rollback.
+
+    Opt-in: request ``async_db`` from any test that needs the async
+    store API to run inside a per-test transaction. The fixture
+    rebinds ``backend.app.database._async_session_factory`` (and
+    ``_async_engine`` for completeness) so calls to
+    ``AsyncSessionLocal()`` / ``db_session_async()`` pick up the
+    test-scoped factory. See the design comment block above for the
+    full rationale and the pattern future store tests should mirror.
+    """
+    connection = await _pg_async_engine.connect()
+    transaction = await connection.begin()
+
+    test_async_factory: async_sessionmaker = async_sessionmaker(
+        bind=connection,
+        autoflush=False,
+        expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
+    )
+
+    old_async_engine = _db_module._async_engine
+    old_async_factory = _db_module._async_session_factory
+    _db_module._async_engine = _pg_async_engine
+    _db_module._async_session_factory = test_async_factory
+
+    try:
+        yield test_async_factory
+    finally:
+        # Rollback unwinds the outer transaction; any inner SAVEPOINTs
+        # the test left open go with it. Mirrors the sync fixture's
+        # ``is_active`` guard: an unrecovered error inside the test
+        # may have already detached the transaction.
+        if transaction.is_active:
+            await transaction.rollback()
+        await connection.close()
+        _db_module._async_engine = old_async_engine
+        _db_module._async_session_factory = old_async_factory
 
 
 @pytest.fixture()

--- a/tests/test_idempotency_pruning_async.py
+++ b/tests/test_idempotency_pruning_async.py
@@ -1,0 +1,226 @@
+"""Tests for the async API of ``IdempotencyStore`` (issue #1150).
+
+Mirrors ``tests/test_idempotency_pruning.py`` for the ``*_async`` peers
+added in the dual-API rollout pilot. All tests opt into the per-test
+``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
+back at teardown. Future per-store conversions (#1151-#1157) should
+mirror this file when validating their async peers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from backend.app.agent.stores import IdempotencyStore
+from backend.app.models import IdempotencyKey
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _row_count(factory: async_sessionmaker) -> int:
+    """Return the total number of IdempotencyKey rows in the DB."""
+    async with factory() as db:
+        return (await db.scalar(select(func.count(IdempotencyKey.id)))) or 0
+
+
+async def _surviving_ids(factory: async_sessionmaker) -> set[str]:
+    """Return the set of external_id values still present in the table."""
+    async with factory() as db:
+        rows = (await db.execute(select(IdempotencyKey.external_id))).all()
+        return {row[0] for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_async_prune_removes_oldest_keeps_newest(
+    async_db: async_sessionmaker,
+) -> None:
+    """``_prune_async`` deletes the oldest rows and keeps the newest up to the cap."""
+    store = IdempotencyStore()
+    small_max = 10
+
+    with patch("backend.app.agent.stores._SEEN_MAX", small_max):
+        for i in range(small_max + 5):
+            assert await store.try_mark_seen_async(f"ext-{i}") is True
+
+    # Oldest 5 pruned, newest 10 survive.
+    for i in range(5):
+        assert not await store.has_seen_async(f"ext-{i}")
+    for i in range(5, small_max + 5):
+        assert await store.has_seen_async(f"ext-{i}")
+
+
+async def test_async_prune_deterministic_on_every_insert(
+    async_db: async_sessionmaker,
+) -> None:
+    """Pruning fires on every insert, enforcing a hard cap."""
+    store = IdempotencyStore()
+    small_max = 20
+
+    with patch("backend.app.agent.stores._SEEN_MAX", small_max):
+        for i in range(small_max + 50):
+            await store.try_mark_seen_async(f"det-{i}")
+
+    assert await _row_count(async_db) == small_max
+
+    surviving = await _surviving_ids(async_db)
+    for i in range(small_max + 50 - small_max, small_max + 50):
+        assert f"det-{i}" in surviving
+
+
+async def test_async_prune_noop_at_exact_max(
+    async_db: async_sessionmaker,
+) -> None:
+    """``_prune_async`` is a no-op when row count equals exactly ``_SEEN_MAX``."""
+    store = IdempotencyStore()
+    small_max = 10
+
+    with patch("backend.app.agent.stores._SEEN_MAX", small_max):
+        for i in range(small_max):
+            await store.try_mark_seen_async(f"exact-{i}")
+        await store._prune_async()
+
+    assert await _row_count(async_db) == small_max
+    for i in range(small_max):
+        assert await store.has_seen_async(f"exact-{i}")
+
+
+async def test_async_prune_noop_when_below_max(
+    async_db: async_sessionmaker,
+) -> None:
+    """``_prune_async`` is a no-op when row count is below ``_SEEN_MAX``."""
+    store = IdempotencyStore()
+    for i in range(5):
+        await store.try_mark_seen_async(f"below-{i}")
+
+    await store._prune_async()
+
+    assert await _row_count(async_db) == 5
+    for i in range(5):
+        assert await store.has_seen_async(f"below-{i}")
+
+
+async def test_async_prune_on_empty_table(
+    async_db: async_sessionmaker,
+) -> None:
+    """``_prune_async`` on an empty table does not raise."""
+    store = IdempotencyStore()
+    await store._prune_async()
+    assert await _row_count(async_db) == 0
+
+
+async def test_async_prune_with_seen_max_one(
+    async_db: async_sessionmaker,
+) -> None:
+    """``_SEEN_MAX = 1`` keeps only the latest row."""
+    store = IdempotencyStore()
+
+    with patch("backend.app.agent.stores._SEEN_MAX", 1):
+        await store.try_mark_seen_async("first")
+        await store.try_mark_seen_async("second")
+        await store.try_mark_seen_async("third")
+
+    assert await _row_count(async_db) == 1
+    assert await store.has_seen_async("third")
+    assert not await store.has_seen_async("first")
+    assert not await store.has_seen_async("second")
+
+
+async def test_async_duplicate_returns_false(
+    async_db: async_sessionmaker,
+) -> None:
+    """Duplicate ``external_id`` returns ``False``."""
+    store = IdempotencyStore()
+    assert await store.try_mark_seen_async("dup-1") is True
+    assert await store.try_mark_seen_async("dup-1") is False
+
+
+async def test_async_prune_exception_does_not_block_return(
+    async_db: async_sessionmaker,
+) -> None:
+    """If ``_prune_async`` raises, ``try_mark_seen_async`` still returns True."""
+    store = IdempotencyStore()
+
+    with patch.object(
+        store,
+        "_prune_async",
+        new=AsyncMock(side_effect=RuntimeError("db exploded")),
+    ):
+        result = await store.try_mark_seen_async("safe-1")
+
+    assert result is True
+    assert await store.has_seen_async("safe-1")
+
+
+async def test_async_mark_seen_alias(
+    async_db: async_sessionmaker,
+) -> None:
+    """``mark_seen_async`` is the fire-and-forget peer of ``try_mark_seen_async``."""
+    store = IdempotencyStore()
+    await store.mark_seen_async("alias-1")
+    assert await store.has_seen_async("alias-1")
+    # No-op on second call (no exception, even though duplicate).
+    await store.mark_seen_async("alias-1")
+    assert await store.has_seen_async("alias-1")
+
+
+async def test_async_isolation_rolls_back_between_tests_part_a(
+    async_db: async_sessionmaker,
+) -> None:
+    """Half 1 of a paired check that the async fixture rolls back between tests.
+
+    Writes a row; the paired test below must not see it.
+    """
+    store = IdempotencyStore()
+    assert await store.try_mark_seen_async("iso-canary") is True
+    assert await store.has_seen_async("iso-canary") is True
+
+
+async def test_async_isolation_rolls_back_between_tests_part_b(
+    async_db: async_sessionmaker,
+) -> None:
+    """Half 2: confirms the previous test's row was rolled back."""
+    store = IdempotencyStore()
+    assert await store.has_seen_async("iso-canary") is False
+
+
+# ---------------------------------------------------------------------------
+# Sync/async parity smoke (read-after-commit through the same connection)
+# ---------------------------------------------------------------------------
+
+
+async def test_async_writer_reads_back_through_async_session(
+    async_db: async_sessionmaker,
+) -> None:
+    """End-to-end: an async write is visible via an async read in the same test.
+
+    This is the smallest possible cross-call check and validates that
+    the per-test ``AsyncConnection`` rebinding in
+    ``conftest._isolate_stores_async`` actually plumbs through to the
+    store's ``AsyncSessionLocal()`` calls.
+    """
+    store = IdempotencyStore()
+    assert await store.try_mark_seen_async("smoke-1") is True
+    assert await store.has_seen_async("smoke-1") is True
+
+
+@pytest.mark.parametrize("count", [1, 50])
+async def test_async_bulk_inserts(
+    async_db: async_sessionmaker,
+    count: int,
+) -> None:
+    """Bulk async inserts all visible without pruning kicking in."""
+    store = IdempotencyStore()
+    for i in range(count):
+        assert await store.try_mark_seen_async(f"bulk-{count}-{i}") is True
+    for i in range(count):
+        assert await store.has_seen_async(f"bulk-{count}-{i}") is True

--- a/tests/test_idempotency_pruning_async.py
+++ b/tests/test_idempotency_pruning_async.py
@@ -204,8 +204,8 @@ async def test_async_writer_reads_back_through_async_session(
     """End-to-end: an async write is visible via an async read in the same test.
 
     This is the smallest possible cross-call check and validates that
-    the per-test ``AsyncConnection`` rebinding in
-    ``conftest._isolate_stores_async`` actually plumbs through to the
+    the per-test ``AsyncConnection`` rebinding in the ``async_db``
+    fixture (``tests/conftest.py``) actually plumbs through to the
     store's ``AsyncSessionLocal()`` calls.
     """
     store = IdempotencyStore()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Closes #1148 and #1150 in one combined change. Part of #1139.

The two issues were paired on purpose: #1148's acceptance criterion is "validated end-to-end against at least one async store test", and #1150's is "tests cover both APIs". Without an async store API there is nothing for the fixture to validate against; without an async fixture the new async tests have no per-test rollback. Doing them together avoids a chicken-and-egg landing order and lets reviewers see the dual-API contract end to end on a single store before committing to the wider rollout.

This PR is the **pilot pattern** for the remaining per-store dual-API tickets: #1151, #1152, #1153, #1154, #1155, #1156, #1157, #1175. Reviewing this PR is, in effect, greenlighting the shape those PRs will follow (`*_async` naming, shared `select(...) / delete(...)` builders, opt-in `async_db` fixture, `create_savepoint` join mode).

### Part 1: async test fixture (#1148)

- New `async_db` opt-in `pytest_asyncio` fixture in `tests/conftest.py`. Opens a per-test `AsyncConnection`, begins an outer transaction, rebinds `backend.app.database._async_session_factory` to an `async_sessionmaker(bind=connection, join_transaction_mode="create_savepoint")`, and rolls back at teardown.
- The existing sync `_isolate_stores` autouse fixture is unchanged; the two coexist on independent connections.
- Function-scoped `_pg_async_engine` (asyncpg connections bind to the loop they were created on; pytest-asyncio rotates loops between tests, so a session-scoped engine surfaces as `RuntimeError: Future attached to a different loop` on the second test).
- Long comment block on the fixture documents the design (driver choice, savepoint mode, scope, cross-API caveat) so future store-conversion PRs and the premium analog (mozilla-ai/clawbolt-premium#390) can mirror it without re-deriving the trade-offs.

### Part 2: IdempotencyStore async API (#1150)

- Adds `has_seen_async`, `try_mark_seen_async`, `mark_seen_async`, and `_prune_async` alongside the existing sync methods. Naming follows the `_async` suffix already used in `backend/app/services/oauth.py` (`_try_acquire_advisory_lock_async` / `_sync`).
- Sync methods are untouched; sync callers (CLI, Alembic, premium) keep working.
- Internal logic is factored into pure `_seen_select`, `_count_select`, and `_prune_delete` builders shared by both paths. The TOCTOU-free contract (rely on the unique-constraint violation as the source of truth) and the swallow-and-log prune-failure handling are preserved exactly.

### Part 3: tests for both

- New `tests/test_idempotency_pruning_async.py` mirrors the existing sync test file: pruning behavior, duplicate-returns-false, exception-doesn't-block-return, isolation-rolls-back-between-tests, plus a small bulk-insert smoke. All 14 tests opt into `async_db`.
- Existing sync `tests/test_idempotency_pruning.py` continues to pass unchanged.

### Notable design choice: `create_savepoint` vs `conditional_savepoint`

The async fixture uses `create_savepoint` where the sync analog uses `conditional_savepoint`. Discovered while wiring up `test_async_mark_seen_alias`: the sync version survives an `IntegrityError` in a later session because psycopg2 keeps the outer transaction alive when the savepoint aborts; the asyncpg path detaches the outer transaction in the same scenario, which surfaced as "the row I just committed disappeared" in the dup-insert tests. Forcing every async session into its own SAVEPOINT keeps the contract identical across drivers, at the cost of one extra `SAVEPOINT` per session begin.

## Type
- [x] Feature
- [x] Test

## Checklist
- [x] Tests pass (`uv run pytest -v`): 2220 passed, 13 deselected
- [x] Lint passes (`ruff check backend/ tests/ alembic/`)
- [x] Format passes (`ruff format --check backend/ tests/ alembic/`)
- [x] Type checking passes (`ty check --python .venv backend/ tests/ alembic/`)
- [x] New tests added for new functionality (14 async tests in `tests/test_idempotency_pruning_async.py`)
- [x] Existing sync tests pass unchanged
- [ ] Bug fixes include regression tests (n/a; this is feature + test infra)

## AI Usage
- [x] AI-assisted: Claude (Opus 4.7) drafted the implementation and prose via back-and-forth with @njbrake. Reasoning and decisions are his.