### PR TITLE
feat(stores): add async API to MemoryStore alongside sync

### DIFF
--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -8,49 +8,141 @@ user_text.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
+from sqlalchemy import Select, Update, literal_column, select, update
 from sqlalchemy import case as sa_case
-from sqlalchemy import literal_column, select, update
 
 from backend.app.agent.store_cache import StoreCache
-from backend.app.database import SessionLocal, db_session
+from backend.app.database import (
+    AsyncSessionLocal,
+    SessionLocal,
+    db_session,
+    db_session_async,
+)
 from backend.app.models import MemoryDocument, User
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Pure typed builders shared by sync and async paths.
+#
+# Mirrors the IdempotencyStore pilot (issue #1150 / PR #1199): each
+# public sync method has an ``*_async`` peer; both forward through the
+# same ``select(...) / update(...)`` builders so the two paths cannot
+# drift. Builders return concretely-typed SQLAlchemy core constructs;
+# no ``Any`` so ``ty`` can verify call sites end-to-end.
+# ---------------------------------------------------------------------------
+
+
+def _doc_select(user_id: str) -> Select[tuple[MemoryDocument]]:
+    """Builder shared by every read of the user's MemoryDocument row."""
+    return select(MemoryDocument).filter_by(user_id=user_id)
+
+
+def _user_select(user_id: str) -> Select[tuple[User]]:
+    """Builder shared by every read of the user's User row."""
+    return select(User).filter_by(id=user_id)
+
+
+def _append_history_update(doc_id: int, entry: str) -> Update:
+    """Build the SQL-level history-append used by both sync and async paths.
+
+    Uses a CASE expression to substitute an empty string when the
+    column is NULL so concatenation yields the expected text instead
+    of NULL. Pulls the suffix into a single value so the SQL emitted
+    matches what the original sync path produced.
+    """
+    suffix = entry + "\n"
+    return (
+        update(MemoryDocument)
+        .where(MemoryDocument.id == doc_id)
+        .values(
+            history_text=sa_case(
+                (MemoryDocument.history_text.is_(None), literal_column("''")),
+                else_=MemoryDocument.history_text,
+            )
+            + suffix
+        )
+        .execution_options(synchronize_session="fetch")
+    )
+
+
+def _strip_section_prefix(raw: str, prefix: str) -> str:
+    """Strip an optional leading ``# Soul`` / ``# User`` header.
+
+    Pulled out of the read methods so sync and async produce the same
+    string for the same DB content.
+    """
+    raw = raw.strip()
+    if raw.startswith(prefix):
+        raw = raw[len(prefix) :].strip()
+    return raw
+
+
 class MemoryStore:
-    """Database-backed memory storage using MemoryDocument ORM model."""
+    """Database-backed memory storage using MemoryDocument ORM model.
+
+    Dual-API store (issue #1153, part of #1139). Each public sync
+    method has an ``*_async`` peer with identical semantics. The two
+    paths share query construction via the module-level builders
+    above; only the session acquisition and ``await`` placement
+    differ. Sync callers (CLI, premium, legacy paths) keep working
+    unchanged while OSS-internal callers migrate to the async API one
+    site at a time. Follows the IdempotencyStore pilot from PR #1199.
+    """
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
 
-    def _get_or_create_doc(self, db: object) -> MemoryDocument:
-        """Get or create the MemoryDocument row for this user."""
-        from sqlalchemy.orm import Session as SASession
+    # -- internal helpers --------------------------------------------------
 
-        assert isinstance(db, SASession)
-        doc = db.execute(
-            select(MemoryDocument).filter_by(user_id=self.user_id)
-        ).scalar_one_or_none()
+    def _get_or_create_doc(self, db: Session) -> MemoryDocument:
+        """Get or create the MemoryDocument row for this user."""
+        doc = db.execute(_doc_select(self.user_id)).scalar_one_or_none()
         if doc is None:
             doc = MemoryDocument(user_id=self.user_id, memory_text="", history_text="")
             db.add(doc)
             db.flush()
         return doc
 
+    async def _get_or_create_doc_async(self, db: AsyncSession) -> MemoryDocument:
+        """Async peer of ``_get_or_create_doc``."""
+        doc = (await db.execute(_doc_select(self.user_id))).scalar_one_or_none()
+        if doc is None:
+            doc = MemoryDocument(user_id=self.user_id, memory_text="", history_text="")
+            db.add(doc)
+            await db.flush()
+        return doc
+
+    # -- memory text -------------------------------------------------------
+
     def read_memory(self) -> str:
         """Read memory text (equivalent of MEMORY.md)."""
         db = SessionLocal()
         try:
-            doc = db.execute(
-                select(MemoryDocument).filter_by(user_id=self.user_id)
-            ).scalar_one_or_none()
+            doc = db.execute(_doc_select(self.user_id)).scalar_one_or_none()
             if doc is None:
                 return ""
             return (doc.memory_text or "").strip()
         finally:
             db.close()
+
+    async def read_memory_async(self) -> str:
+        """Async peer of ``read_memory``."""
+        db = AsyncSessionLocal()
+        try:
+            doc = (await db.execute(_doc_select(self.user_id))).scalar_one_or_none()
+            if doc is None:
+                return ""
+            return (doc.memory_text or "").strip()
+        finally:
+            await db.close()
 
     def write_memory(self, content: str) -> None:
         """Write memory text (full rewrite, equivalent of MEMORY.md)."""
@@ -59,86 +151,149 @@ class MemoryStore:
             doc.memory_text = content.rstrip() + "\n"
             db.commit()
 
+    async def write_memory_async(self, content: str) -> None:
+        """Async peer of ``write_memory``."""
+        async with db_session_async() as db:
+            doc = await self._get_or_create_doc_async(db)
+            doc.memory_text = content.rstrip() + "\n"
+            await db.commit()
+
+    # -- history text ------------------------------------------------------
+
     def read_history(self) -> str:
         """Read history text (equivalent of HISTORY.md)."""
         db = SessionLocal()
         try:
-            doc = db.execute(
-                select(MemoryDocument).filter_by(user_id=self.user_id)
-            ).scalar_one_or_none()
+            doc = db.execute(_doc_select(self.user_id)).scalar_one_or_none()
             if doc is None:
                 return ""
             return (doc.history_text or "").strip()
         finally:
             db.close()
 
+    async def read_history_async(self) -> str:
+        """Async peer of ``read_history``."""
+        db = AsyncSessionLocal()
+        try:
+            doc = (await db.execute(_doc_select(self.user_id))).scalar_one_or_none()
+            if doc is None:
+                return ""
+            return (doc.history_text or "").strip()
+        finally:
+            await db.close()
+
     async def append_history(self, entry: str) -> None:
-        """Append an entry to history text (equivalent of HISTORY.md)."""
+        """Append an entry to history text (equivalent of HISTORY.md).
+
+        Uses SQL-level concatenation to avoid lost-update races when
+        two callers append concurrently.
+        """
         with db_session() as db:
             doc = self._get_or_create_doc(db)
-            # Use SQL-level concatenation to avoid lost-update races
-            suffix = entry + "\n"
-            db.execute(
-                update(MemoryDocument)
-                .where(MemoryDocument.id == doc.id)
-                .values(
-                    history_text=sa_case(
-                        (MemoryDocument.history_text.is_(None), literal_column("''")),
-                        else_=MemoryDocument.history_text,
-                    )
-                    + suffix
-                )
-                .execution_options(synchronize_session="fetch")
-            )
+            db.execute(_append_history_update(doc.id, entry))
             db.commit()
+
+    async def append_history_async(self, entry: str) -> None:
+        """Async peer of ``append_history``.
+
+        Same SQL-level concatenation contract as the sync path; the
+        only difference is session acquisition and ``await``
+        placement.
+        """
+        async with db_session_async() as db:
+            doc = await self._get_or_create_doc_async(db)
+            await db.execute(_append_history_update(doc.id, entry))
+            await db.commit()
+
+    # -- soul text ---------------------------------------------------------
 
     def read_soul(self) -> str:
         """Read soul text from User model."""
         db = SessionLocal()
         try:
-            user = db.execute(select(User).filter_by(id=self.user_id)).scalar_one_or_none()
+            user = db.execute(_user_select(self.user_id)).scalar_one_or_none()
             if user is None:
                 return ""
-            raw = (user.soul_text or "").strip()
-            if raw.startswith("# Soul"):
-                raw = raw[len("# Soul") :].strip()
-            return raw
+            return _strip_section_prefix(user.soul_text or "", "# Soul")
         finally:
             db.close()
+
+    async def read_soul_async(self) -> str:
+        """Async peer of ``read_soul``."""
+        db = AsyncSessionLocal()
+        try:
+            user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
+            if user is None:
+                return ""
+            return _strip_section_prefix(user.soul_text or "", "# Soul")
+        finally:
+            await db.close()
 
     def write_soul(self, content: str) -> None:
         """Write soul text to User model."""
         with db_session() as db:
-            user = db.execute(select(User).filter_by(id=self.user_id)).scalar_one_or_none()
+            user = db.execute(_user_select(self.user_id)).scalar_one_or_none()
             if user is not None:
                 user.soul_text = f"# Soul\n\n{content}\n"
                 db.commit()
+
+    async def write_soul_async(self, content: str) -> None:
+        """Async peer of ``write_soul``."""
+        async with db_session_async() as db:
+            user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
+            if user is not None:
+                user.soul_text = f"# Soul\n\n{content}\n"
+                await db.commit()
+
+    # -- user text ---------------------------------------------------------
 
     def read_user(self) -> str:
         """Read user text from User model."""
         db = SessionLocal()
         try:
-            user = db.execute(select(User).filter_by(id=self.user_id)).scalar_one_or_none()
+            user = db.execute(_user_select(self.user_id)).scalar_one_or_none()
             if user is None:
                 return ""
-            raw = (user.user_text or "").strip()
-            if raw.startswith("# User"):
-                raw = raw[len("# User") :].strip()
-            return raw
+            return _strip_section_prefix(user.user_text or "", "# User")
         finally:
             db.close()
+
+    async def read_user_async(self) -> str:
+        """Async peer of ``read_user``."""
+        db = AsyncSessionLocal()
+        try:
+            user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
+            if user is None:
+                return ""
+            return _strip_section_prefix(user.user_text or "", "# User")
+        finally:
+            await db.close()
 
     def write_user(self, content: str) -> None:
         """Write user text to User model."""
         with db_session() as db:
-            user = db.execute(select(User).filter_by(id=self.user_id)).scalar_one_or_none()
+            user = db.execute(_user_select(self.user_id)).scalar_one_or_none()
             if user is not None:
                 user.user_text = f"# User\n\n{content}\n"
                 db.commit()
 
+    async def write_user_async(self, content: str) -> None:
+        """Async peer of ``write_user``."""
+        async with db_session_async() as db:
+            user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
+            if user is not None:
+                user.user_text = f"# User\n\n{content}\n"
+                await db.commit()
+
+    # -- composite helpers -------------------------------------------------
+
     async def build_memory_context(self) -> str:
         """Build memory context for injection into the agent prompt."""
         return self.read_memory()
+
+    async def build_memory_context_async(self) -> str:
+        """Async peer of ``build_memory_context``."""
+        return await self.read_memory_async()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Select, Update, literal_column, select, update
-from sqlalchemy import case as sa_case
+from sqlalchemy import Select, Update, select, update
 
 from backend.app.agent.store_cache import StoreCache
 from backend.app.database import (
@@ -50,25 +49,32 @@ def _user_select(user_id: str) -> Select[tuple[User]]:
     return select(User).filter_by(id=user_id)
 
 
-def _append_history_update(doc_id: int, entry: str) -> Update:
-    """Build the SQL-level history-append used by both sync and async paths.
+def _doc_select_for_update(user_id: str) -> Select[tuple[MemoryDocument]]:
+    """Builder for the locked read used by ``append_history*``.
 
-    Uses a CASE expression to substitute an empty string when the
-    column is NULL so concatenation yields the expected text instead
-    of NULL. Pulls the suffix into a single value so the SQL emitted
-    matches what the original sync path produced.
+    ``MemoryDocument.history_text`` is an ``EncryptedString`` column,
+    so we cannot append ciphertext on the SQL side: each row carries
+    its own DEK and the envelope format is not concat-friendly.
+    Instead, both sync and async append paths SELECT the row under
+    ``FOR UPDATE``, decrypt automatically on read, concatenate in
+    Python, and write the full new plaintext back. The row-level lock
+    serializes concurrent appenders so neither side loses its update.
     """
-    suffix = entry + "\n"
+    return select(MemoryDocument).filter_by(user_id=user_id).with_for_update()
+
+
+def _append_history_update(doc_id: int, full_new_text: str) -> Update:
+    """Build the UPDATE used by both sync and async ``append_history`` paths.
+
+    The caller has already read the current ``history_text`` under a
+    row-level lock, decrypted it, appended the new entry in Python, and
+    passes the full plaintext here. Encryption is automatic on bind,
+    so the column is rewritten with a fresh envelope every time.
+    """
     return (
         update(MemoryDocument)
         .where(MemoryDocument.id == doc_id)
-        .values(
-            history_text=sa_case(
-                (MemoryDocument.history_text.is_(None), literal_column("''")),
-                else_=MemoryDocument.history_text,
-            )
-            + suffix
-        )
+        .values(history_text=full_new_text)
         .execution_options(synchronize_session="fetch")
     )
 
@@ -185,24 +191,49 @@ class MemoryStore:
     async def append_history(self, entry: str) -> None:
         """Append an entry to history text (equivalent of HISTORY.md).
 
-        Uses SQL-level concatenation to avoid lost-update races when
-        two callers append concurrently.
+        Reads the current row under ``SELECT ... FOR UPDATE`` to
+        serialize concurrent appenders, decrypts and concatenates in
+        Python, then rewrites the column with the full plaintext.
+        SQL-side concatenation is not viable because
+        ``history_text`` is an ``EncryptedString`` column whose
+        envelope format is not concat-safe.
         """
+        suffix = entry + "\n"
         with db_session() as db:
-            doc = self._get_or_create_doc(db)
-            db.execute(_append_history_update(doc.id, entry))
+            doc = db.execute(_doc_select_for_update(self.user_id)).scalar_one_or_none()
+            if doc is None:
+                db.add(
+                    MemoryDocument(
+                        user_id=self.user_id,
+                        memory_text="",
+                        history_text=suffix,
+                    )
+                )
+            else:
+                full_new_text = (doc.history_text or "") + suffix
+                db.execute(_append_history_update(doc.id, full_new_text))
             db.commit()
 
     async def append_history_async(self, entry: str) -> None:
         """Async peer of ``append_history``.
 
-        Same SQL-level concatenation contract as the sync path; the
-        only difference is session acquisition and ``await``
-        placement.
+        Same lock-and-rewrite contract as the sync path; only the
+        session acquisition and ``await`` placement differ.
         """
+        suffix = entry + "\n"
         async with db_session_async() as db:
-            doc = await self._get_or_create_doc_async(db)
-            await db.execute(_append_history_update(doc.id, entry))
+            doc = (await db.execute(_doc_select_for_update(self.user_id))).scalar_one_or_none()
+            if doc is None:
+                db.add(
+                    MemoryDocument(
+                        user_id=self.user_id,
+                        memory_text="",
+                        history_text=suffix,
+                    )
+                )
+            else:
+                full_new_text = (doc.history_text or "") + suffix
+                await db.execute(_append_history_update(doc.id, full_new_text))
             await db.commit()
 
     # -- soul text ---------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,41 @@ async def test_user(tmp_path: Path) -> User:
     return user
 
 
+@pytest_asyncio.fixture
+async def async_test_user(async_db: async_sessionmaker) -> User:
+    """Insert a User row through the async per-test transaction.
+
+    Async peer of the sync ``test_user`` fixture above. Routes the
+    write through the async connection so the row is visible to async
+    store reads in the same test. The sync ``test_user`` fixture opens
+    its own per-test transaction on a separate connection; rows
+    committed there are invisible to the async store under READ
+    COMMITTED, which is the cross-API caveat called out in the design
+    comment block above.
+
+    The async fixture's outer transaction rollback unwinds the insert
+    at teardown, so no explicit cleanup is needed. Shared by store
+    test files exercising the dual-API (#1153, #1151, #1152, #1154,
+    #1155, #1156, #1157, #1175).
+    """
+    async with async_db() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id="async-test-user",
+            phone="+15555550123",
+            channel_identifier="async-test-channel",
+            preferred_channel="telegram",
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        # Detach so attribute access after the session closes does not
+        # trigger lazy IO.
+        db.expunge(user)
+    return user
+
+
 def create_test_session(
     user_id: str,
     session_id: str = "test-conv",

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -49,3 +49,42 @@ async def test_build_memory_context_empty(test_user: User) -> None:
     """build_memory_context returns empty string when no memory."""
     context = await build_memory_context(test_user.id)
     assert context == ""
+
+
+@pytest.mark.asyncio()
+async def test_append_history_multi_append_round_trips(test_user: User) -> None:
+    """Sequential ``append_history`` calls all round-trip through ``read_history``.
+
+    Regression test for the encrypted-history concat bug.
+    ``MemoryDocument.history_text`` is an ``EncryptedString`` column,
+    so the original SQL-level ``history_text + suffix`` builder
+    concatenated ciphertext envelopes and broke decryption on read
+    after the second append. The fix reads the row under
+    ``SELECT ... FOR UPDATE``, concatenates plaintext in Python, and
+    rewrites the column with a fresh envelope.
+    """
+    store = get_memory_store(test_user.id)
+    await store.append_history("first entry")
+    await store.append_history("second entry")
+    await store.append_history("third entry")
+
+    history = store.read_history()
+    # ``read_history`` strips trailing whitespace, so the final entry's
+    # newline is gone but the inter-entry newlines remain.
+    assert history == "first entry\nsecond entry\nthird entry"
+
+
+@pytest.mark.asyncio()
+async def test_append_history_after_seed_round_trips(test_user: User) -> None:
+    """Appending against a row that already exists keeps every prior entry.
+
+    Targets the second-and-later append path (``UPDATE`` branch), as
+    opposed to the create-on-first-append branch. The pre-fix builder
+    silently corrupted ``history_text`` here because SQL-side
+    concatenation glued two ciphertext envelopes together.
+    """
+    store = get_memory_store(test_user.id)
+    await store.append_history("seed")
+    await store.append_history("follow-up")
+
+    assert store.read_history() == "seed\nfollow-up"

--- a/tests/test_memory_db_async.py
+++ b/tests/test_memory_db_async.py
@@ -5,57 +5,23 @@ the dual-API rollout. All tests opt into the per-test ``async_db``
 fixture (see ``tests/conftest.py``) so writes are rolled back at
 teardown. Follows the IdempotencyStore pilot pattern from PR #1199.
 
-User-row setup runs through the async connection (see
-``async_test_user`` below) because the sync ``test_user`` fixture
-opens its own per-test transaction on a separate connection; rows
-committed there are invisible to the async store under READ
-COMMITTED. This matches the cross-API caveat called out in the
-design comment block in ``tests/conftest.py``.
+User-row setup runs through the shared ``async_test_user`` fixture in
+``tests/conftest.py``; that fixture routes the insert through the
+async connection because the sync ``test_user`` fixture opens its
+own per-test transaction on a separate connection and rows committed
+there are invisible to the async store under READ COMMITTED. This
+matches the cross-API caveat called out in the design comment block
+in ``tests/conftest.py``.
 """
 
 from __future__ import annotations
 
-import uuid
-
 import pytest
-import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from backend.app.agent.memory_db import MemoryStore, get_memory_store
 from backend.app.models import MemoryDocument, User
-
-# ---------------------------------------------------------------------------
-# Fixture: create a User row inside the async per-test transaction.
-# ---------------------------------------------------------------------------
-
-
-@pytest_asyncio.fixture
-async def async_test_user(async_db: async_sessionmaker) -> User:
-    """Insert a User row through the async per-test transaction.
-
-    Mirrors the sync ``test_user`` fixture (see ``tests/conftest.py``)
-    but routes the write through the async connection so the row is
-    visible to async store reads in the same test. The async fixture's
-    outer transaction rollback unwinds the insert at teardown.
-    """
-    async with async_db() as db:
-        user = User(
-            id=str(uuid.uuid4()),
-            user_id="async-memory-test-user",
-            phone="+15555550123",
-            channel_identifier="async-memory-test-channel",
-            preferred_channel="telegram",
-            onboarding_complete=True,
-        )
-        db.add(user)
-        await db.commit()
-        await db.refresh(user)
-        # Detach so attribute access after the session closes does not
-        # trigger lazy IO.
-        db.expunge(user)
-    return user
-
 
 # ---------------------------------------------------------------------------
 # memory_text: read / write

--- a/tests/test_memory_db_async.py
+++ b/tests/test_memory_db_async.py
@@ -102,29 +102,51 @@ async def test_async_append_history_creates_row(
     assert "first entry" in history
 
 
-async def test_async_append_history_persists_first_entry(
+async def test_async_append_history_multi_append_round_trips(
     async_db: async_sessionmaker,
     async_test_user: User,
 ) -> None:
-    """A first ``append_history_async`` call is readable via ``read_history_async``.
+    """Multiple sequential appends round-trip through ``read_history_async``.
 
+    Regression test for the encrypted-history concat bug.
     ``MemoryDocument.history_text`` is an ``EncryptedString`` column,
-    so the SQL-level ``history_text + suffix`` concatenation used by
-    both sync and async paths operates on ciphertext rather than
-    plaintext. Repeated appends do not produce a readable
-    concatenated transcript today; that is a pre-existing limitation
-    of the sync path which the async peer reproduces by design
-    (dual-API parity per #1153). The fix belongs in a follow-up that
-    rewrites the builder; both paths will pick it up via the shared
-    ``_append_history_update`` helper.
-
-    Contract this test pins down: the first append round-trips. The
-    multi-append behavior is intentionally out of scope here so we
-    do not lock in the broken contract.
+    so the original SQL-level ``history_text + suffix`` builder
+    concatenated ciphertext envelopes and broke decryption on read
+    after the second append. The fix reads the row under
+    ``SELECT ... FOR UPDATE``, concatenates plaintext in Python, and
+    rewrites the column with a fresh envelope. Both sync and async
+    paths share the rewritten ``_append_history_update`` helper.
     """
     store = MemoryStore(async_test_user.id)
     await store.append_history_async("first entry")
-    assert "first entry" in await store.read_history_async()
+    await store.append_history_async("second entry")
+    await store.append_history_async("third entry")
+
+    history = await store.read_history_async()
+    # Each entry was appended with a trailing newline. ``read_history_async``
+    # strips the outer whitespace, so the final entry's newline is gone but
+    # the inter-entry newlines remain.
+    assert history == "first entry\nsecond entry\nthird entry"
+
+
+async def test_async_append_history_sequential_appends_after_seed(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Appending after a row already exists keeps every prior entry.
+
+    Targets the second-and-later append path (``UPDATE`` branch), as
+    opposed to the create-on-first-append branch covered by
+    ``test_async_append_history_creates_row``. The pre-fix builder
+    silently corrupted ``history_text`` here because SQL-side
+    concatenation glued two ciphertext envelopes together.
+    """
+    store = MemoryStore(async_test_user.id)
+    await store.append_history_async("seed")
+    await store.append_history_async("follow-up")
+
+    history = await store.read_history_async()
+    assert history == "seed\nfollow-up"
 
 
 async def test_async_append_history_does_not_disturb_memory_text(

--- a/tests/test_memory_db_async.py
+++ b/tests/test_memory_db_async.py
@@ -1,0 +1,332 @@
+"""Tests for the async API of ``MemoryStore`` (issue #1153).
+
+Mirrors ``tests/test_memory.py`` for the ``*_async`` peers added in
+the dual-API rollout. All tests opt into the per-test ``async_db``
+fixture (see ``tests/conftest.py``) so writes are rolled back at
+teardown. Follows the IdempotencyStore pilot pattern from PR #1199.
+
+User-row setup runs through the async connection (see
+``async_test_user`` below) because the sync ``test_user`` fixture
+opens its own per-test transaction on a separate connection; rows
+committed there are invisible to the async store under READ
+COMMITTED. This matches the cross-API caveat called out in the
+design comment block in ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from backend.app.agent.memory_db import MemoryStore, get_memory_store
+from backend.app.models import MemoryDocument, User
+
+# ---------------------------------------------------------------------------
+# Fixture: create a User row inside the async per-test transaction.
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def async_test_user(async_db: async_sessionmaker) -> User:
+    """Insert a User row through the async per-test transaction.
+
+    Mirrors the sync ``test_user`` fixture (see ``tests/conftest.py``)
+    but routes the write through the async connection so the row is
+    visible to async store reads in the same test. The async fixture's
+    outer transaction rollback unwinds the insert at teardown.
+    """
+    async with async_db() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id="async-memory-test-user",
+            phone="+15555550123",
+            channel_identifier="async-memory-test-channel",
+            preferred_channel="telegram",
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        # Detach so attribute access after the session closes does not
+        # trigger lazy IO.
+        db.expunge(user)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# memory_text: read / write
+# ---------------------------------------------------------------------------
+
+
+async def test_async_write_and_read_memory(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``write_memory_async`` / ``read_memory_async`` round-trip content."""
+    store = MemoryStore(async_test_user.id)
+    await store.write_memory_async("## Pricing\n- Deck: $45/sqft")
+    content = await store.read_memory_async()
+    assert "Deck: $45/sqft" in content
+
+
+async def test_async_read_memory_empty(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``read_memory_async`` returns ``""`` when no MemoryDocument row exists."""
+    store = MemoryStore(async_test_user.id)
+    assert await store.read_memory_async() == ""
+
+
+async def test_async_write_memory_overwrites(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``write_memory_async`` fully replaces the existing memory text."""
+    store = MemoryStore(async_test_user.id)
+    await store.write_memory_async("old content")
+    await store.write_memory_async("new content")
+    content = await store.read_memory_async()
+    assert "new content" in content
+    assert "old content" not in content
+
+
+async def test_async_write_memory_normalises_trailing_newline(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Sync and async paths must persist the same trailing-newline form."""
+    store = MemoryStore(async_test_user.id)
+    await store.write_memory_async("body without newline")
+
+    async with async_db() as db:
+        row = (
+            await db.execute(select(MemoryDocument).filter_by(user_id=async_test_user.id))
+        ).scalar_one()
+        assert row.memory_text == "body without newline\n"
+
+
+# ---------------------------------------------------------------------------
+# history_text: read / append
+# ---------------------------------------------------------------------------
+
+
+async def test_async_read_history_empty(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``read_history_async`` returns ``""`` when no row exists."""
+    store = MemoryStore(async_test_user.id)
+    assert await store.read_history_async() == ""
+
+
+async def test_async_append_history_creates_row(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``append_history_async`` creates the MemoryDocument row on first call."""
+    store = MemoryStore(async_test_user.id)
+    await store.append_history_async("first entry")
+
+    history = await store.read_history_async()
+    assert "first entry" in history
+
+
+async def test_async_append_history_persists_first_entry(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """A first ``append_history_async`` call is readable via ``read_history_async``.
+
+    ``MemoryDocument.history_text`` is an ``EncryptedString`` column,
+    so the SQL-level ``history_text + suffix`` concatenation used by
+    both sync and async paths operates on ciphertext rather than
+    plaintext. Repeated appends do not produce a readable
+    concatenated transcript today; that is a pre-existing limitation
+    of the sync path which the async peer reproduces by design
+    (dual-API parity per #1153). The fix belongs in a follow-up that
+    rewrites the builder; both paths will pick it up via the shared
+    ``_append_history_update`` helper.
+
+    Contract this test pins down: the first append round-trips. The
+    multi-append behavior is intentionally out of scope here so we
+    do not lock in the broken contract.
+    """
+    store = MemoryStore(async_test_user.id)
+    await store.append_history_async("first entry")
+    assert "first entry" in await store.read_history_async()
+
+
+async def test_async_append_history_does_not_disturb_memory_text(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Appending history must not clobber memory_text on the same row."""
+    store = MemoryStore(async_test_user.id)
+    await store.write_memory_async("memory body")
+    await store.append_history_async("history line")
+
+    assert await store.read_memory_async() == "memory body"
+    assert await store.read_history_async() == "history line"
+
+
+# ---------------------------------------------------------------------------
+# soul_text and user_text on the User row
+# ---------------------------------------------------------------------------
+
+
+async def test_async_soul_round_trip_strips_header(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``write_soul_async`` writes a ``# Soul`` envelope; ``read_soul_async`` strips it."""
+    store = MemoryStore(async_test_user.id)
+    await store.write_soul_async("calm and curious")
+    assert await store.read_soul_async() == "calm and curious"
+
+
+async def test_async_user_round_trip_strips_header(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``write_user_async`` writes a ``# User`` envelope; ``read_user_async`` strips it."""
+    store = MemoryStore(async_test_user.id)
+    await store.write_user_async("prefers concise replies")
+    assert await store.read_user_async() == "prefers concise replies"
+
+
+async def test_async_read_soul_for_missing_user(
+    async_db: async_sessionmaker,
+) -> None:
+    """``read_soul_async`` returns ``""`` for an unknown user_id."""
+    store = MemoryStore("missing-user-id")
+    assert await store.read_soul_async() == ""
+
+
+async def test_async_read_user_for_missing_user(
+    async_db: async_sessionmaker,
+) -> None:
+    """``read_user_async`` returns ``""`` for an unknown user_id."""
+    store = MemoryStore("missing-user-id")
+    assert await store.read_user_async() == ""
+
+
+async def test_async_write_soul_noop_for_missing_user(
+    async_db: async_sessionmaker,
+) -> None:
+    """Writes against a missing user must not raise (sync path swallows it)."""
+    store = MemoryStore("missing-user-id")
+    await store.write_soul_async("ignored")
+    await store.write_user_async("ignored")
+
+
+# ---------------------------------------------------------------------------
+# Composite helpers
+# ---------------------------------------------------------------------------
+
+
+async def test_async_build_memory_context_with_memory(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``build_memory_context_async`` returns the memory text."""
+    store = get_memory_store(async_test_user.id)
+    await store.write_memory_async("## Pricing\n- Deck: $35/sqft")
+
+    context = await store.build_memory_context_async()
+    assert "$35/sqft" in context
+
+
+async def test_async_build_memory_context_empty(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``build_memory_context_async`` returns ``""`` when no memory exists."""
+    store = get_memory_store(async_test_user.id)
+    assert await store.build_memory_context_async() == ""
+
+
+# ---------------------------------------------------------------------------
+# Iso-canary pair: prove the async fixture rolls back between tests.
+# Mirrors ``test_idempotency_pruning_async`` (PR #1199). Uses a fixed
+# user_id so the pair sees the same key without depending on the
+# uuid-generating ``async_test_user`` fixture.
+# ---------------------------------------------------------------------------
+
+_ISO_USER_ID = "iso-canary-user"
+
+
+async def _seed_iso_user(async_db: async_sessionmaker) -> None:
+    """Insert the iso-canary User row through the async connection."""
+    async with async_db() as db:
+        db.add(
+            User(
+                id=_ISO_USER_ID,
+                user_id="iso-canary",
+                phone="+15555550199",
+                channel_identifier="iso-canary-channel",
+                preferred_channel="telegram",
+                onboarding_complete=True,
+            )
+        )
+        await db.commit()
+
+
+async def test_async_isolation_rolls_back_between_tests_part_a(
+    async_db: async_sessionmaker,
+) -> None:
+    """Half 1: write a row; the paired test must not observe it."""
+    await _seed_iso_user(async_db)
+    store = MemoryStore(_ISO_USER_ID)
+    await store.write_memory_async("iso-canary value")
+    assert await store.read_memory_async() == "iso-canary value"
+
+
+async def test_async_isolation_rolls_back_between_tests_part_b(
+    async_db: async_sessionmaker,
+) -> None:
+    """Half 2: confirm part A's write was rolled back.
+
+    The User row from part A must be gone, and so must the
+    MemoryDocument row attached to it. Both checks together confirm
+    the outer transaction in the ``async_db`` fixture wound back the
+    full state.
+    """
+    async with async_db() as db:
+        user = (await db.execute(select(User).filter_by(id=_ISO_USER_ID))).scalar_one_or_none()
+        assert user is None
+
+    store = MemoryStore(_ISO_USER_ID)
+    assert await store.read_memory_async() == ""
+
+
+# ---------------------------------------------------------------------------
+# Sync/async parity smoke: an async write is visible via an async read in
+# the same test, going through the rebound ``AsyncSessionLocal()``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("attr_writer", "attr_reader"),
+    [
+        ("write_memory_async", "read_memory_async"),
+        ("write_soul_async", "read_soul_async"),
+        ("write_user_async", "read_user_async"),
+    ],
+)
+async def test_async_writer_reads_back_through_async_session(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+    attr_writer: str,
+    attr_reader: str,
+) -> None:
+    """End-to-end: async writes round-trip through an async read."""
+    store = MemoryStore(async_test_user.id)
+    writer = getattr(store, attr_writer)
+    reader = getattr(store, attr_reader)
+    await writer("smoke value")
+    assert await reader() == "smoke value"


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds async peers to every public sync method on ``MemoryStore``, mirroring the IdempotencyStore pilot from PR #1199. Sync callers (CLI, premium, legacy paths) keep working unchanged; OSS-internal callers can migrate to the async API one site at a time.

The two paths share query construction via pure typed builders so they cannot drift:

- ``_doc_select(user_id) -> Select[tuple[MemoryDocument]]``
- ``_user_select(user_id) -> Select[tuple[User]]``
- ``_append_history_update(doc_id, entry) -> Update``
- ``_strip_section_prefix(raw, prefix) -> str``

New ``*_async`` methods on ``MemoryStore``:

- ``read_memory_async`` / ``write_memory_async``
- ``read_history_async`` / ``append_history_async``
- ``read_soul_async`` / ``write_soul_async``
- ``read_user_async`` / ``write_user_async``
- ``build_memory_context_async``
- ``_get_or_create_doc_async`` (internal helper)

The internal sync ``_get_or_create_doc`` signature changes from ``db: object`` (with a runtime ``isinstance`` check) to ``db: Session``, since we now have a proper async peer and the runtime narrowing is no longer needed. No external callers; only used inside ``memory_db.py``.

## Tests

``tests/test_memory_db_async.py`` covers each ``*_async`` method, plus the iso-canary pair that proves the per-test ``async_db`` fixture rolls back between tests, and a parity smoke that round-trips writes through the rebound ``AsyncSessionLocal()``. The User row is seeded through the async connection (via a new ``async_test_user`` fixture) per the cross-API caveat in ``tests/conftest.py``: rows committed by the sync per-test fixture are invisible to the async store under READ COMMITTED.

One observation surfaced while writing tests: ``MemoryDocument.history_text`` is an ``EncryptedString`` column, so the SQL-level ``history_text + suffix`` concatenation in ``append_history`` operates on ciphertext. Repeated appends do not produce a readable concatenated transcript today; this is a pre-existing bug in the sync path, and the async peer reproduces it by design (parity is the explicit contract for the dual-API rollout). The fix belongs in a follow-up that rewrites the builder; both paths will pick it up via the shared ``_append_history_update`` helper. The async test asserts only the first-append round-trip so we do not lock in the broken multi-append contract.

Closes #1153.
Part of #1139.

Follows pilot #1199.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (``uv run pytest -v`` for the touched files; full-suite errors observed are pre-existing on ``main`` and unrelated to this change)
- [x] Lint passes (``ruff check`` + ``ruff format --check``)
- [x] Type checking passes (``ty check``)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests (n/a)

## AI Usage
- [x] AI-assisted: drafted by Claude (Opus 4.7) following the PR #1199 pilot pattern. Implementation, tests, and prose iterated with the human author.
- [ ] No AI used