### PR TITLE
feat(stores): add async API to DbSettingsStore alongside sync

### DIFF
--- a/backend/app/config_store.py
+++ b/backend/app/config_store.py
@@ -31,8 +31,10 @@ from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import Any, Protocol
 
-from sqlalchemy import text
+from sqlalchemy import Row, text
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import TextClause
 
 from backend.app.config import (
     PERSISTABLE_SETTINGS,
@@ -175,6 +177,116 @@ class SettingsStore(Protocol):
 # ---------------------------------------------------------------------------
 
 
+# Dual-API rollout (issue #1175, follows the IdempotencyStore pilot in
+# #1199). Internal logic is factored into pure module-level helpers so
+# the sync and async methods stay in lockstep without a class
+# hierarchy. Each existing public method keeps its plain name; the new
+# ``*_async`` peer uses real async DB access via the configured async
+# session factory (default: ``AsyncSessionLocal``).
+#
+# These helpers are intentionally not parameterized over the bind type:
+# they return raw-SQL TextClauses and pure Python payloads, which both
+# ``Session.execute`` and ``AsyncSession.execute`` accept.
+def _load_select_sql() -> TextClause:
+    """Builder shared by ``load`` / ``load_async``."""
+    return text("SELECT key, value, is_secret FROM app_settings")
+
+
+def _save_upsert_sql() -> TextClause:
+    """Builder shared by ``save`` / ``save_async``.
+
+    One round-trip: ON CONFLICT upsert for the whole batch.
+    """
+    return text(
+        """
+        INSERT INTO app_settings (key, value, is_secret, updated_by_user_id)
+        VALUES (:key, :value, :is_secret, :actor)
+        ON CONFLICT (key) DO UPDATE SET
+            value = EXCLUDED.value,
+            is_secret = EXCLUDED.is_secret,
+            updated_at = NOW(),
+            updated_by_user_id = EXCLUDED.updated_by_user_id
+        """
+    )
+
+
+def _delete_sql() -> TextClause:
+    """Builder shared by ``delete`` / ``delete_async``."""
+    return text("DELETE FROM app_settings WHERE key = ANY(:keys)")
+
+
+def _encryption_context() -> _encryption.EncryptionContext:
+    """Encryption context shared by both sync and async paths.
+
+    Module-level so the sync and async methods see identical (table,
+    column) bindings without going through an instance method.
+    """
+    return {"table": "app_settings", "column": "value"}
+
+
+def _build_save_rows(
+    updates: Mapping[str, str],
+    kek: KEKProvider,
+    *,
+    actor_user_id: str | None,
+) -> list[dict[str, Any]]:
+    """Validate updates and prepare rows for the upsert statement.
+
+    Pure helper so ``save`` / ``save_async`` use identical
+    persistable-key validation and secret-encryption semantics. Raises
+    ``ValueError`` for keys outside ``PERSISTABLE_SETTINGS`` so the
+    failure mode does not depend on which code path the caller picked.
+    """
+    rows: list[dict[str, Any]] = []
+    ctx = _encryption_context()
+    for key, value in updates.items():
+        if key not in PERSISTABLE_SETTINGS:
+            raise ValueError(
+                f"{key!r} is not a persistable setting (allowed: {sorted(PERSISTABLE_SETTINGS)})"
+            )
+        secret = is_secret(key)
+        stored_value = _encryption.encrypt(value, kek, ctx) if secret and value else value
+        rows.append(
+            {
+                "key": key,
+                "value": stored_value,
+                "is_secret": secret,
+                "actor": actor_user_id,
+            }
+        )
+    return rows
+
+
+def _decode_load_rows(rows: Iterable[Row[Any]], kek: KEKProvider) -> dict[str, str]:
+    """Decrypt secret values and assemble the load() return dict.
+
+    Pure helper so ``load`` / ``load_async`` use identical decryption
+    semantics. Empty values short-circuit to "" without a decrypt call,
+    matching the original behavior. Decryption failures are wrapped in
+    ``ConfigStoreError`` so the failure mode is the same regardless of
+    which path discovered the bad row.
+
+    Accepts ``Row[Any]`` because SQLAlchemy's ``Result.all()`` returns
+    ``Sequence[Row[Any]]`` for both sync and async paths; positional
+    unpacking matches the (key, value, is_secret) shape of the SELECT.
+    """
+    result: dict[str, str] = {}
+    ctx = _encryption_context()
+    for row in rows:
+        key, value, is_secret_flag = row[0], row[1], row[2]
+        if not value:
+            result[key] = ""
+            continue
+        if is_secret_flag:
+            try:
+                result[key] = _encryption.decrypt(value, kek, ctx)
+            except Exception as exc:
+                raise ConfigStoreError(f"Failed to decrypt app_settings.{key}: {exc}") from exc
+        else:
+            result[key] = value
+    return result
+
+
 class DbSettingsStore:
     """Stores settings in the ``app_settings`` table.
 
@@ -186,90 +298,131 @@ class DbSettingsStore:
     in tests, the same bound transaction) as the rest of the app. That
     keeps FK references like ``updated_by_user_id`` consistent with
     rows the route handler just inserted in the same request.
+
+    Dual-API store (issue #1175). Each public method has an ``*_async``
+    peer with identical semantics; the two share validation, encryption,
+    and SQL construction via the module-level ``_build_save_rows`` /
+    ``_decode_load_rows`` / ``_load_select_sql`` / ``_save_upsert_sql`` /
+    ``_delete_sql`` helpers above. Sync callers (lifespan boot, admin
+    routes still on sync) keep working unchanged while async callers
+    can opt into the ``*_async`` peers without falling back to a sync
+    DB call from async context. Follows the IdempotencyStore pilot
+    pattern (#1199) and mirrors the per-store conversions in #1200,
+    #1201, #1203.
     """
 
     _CONTEXT_TABLE = "app_settings"
     _CONTEXT_COLUMN = "value"
 
-    def __init__(self, session_factory: Callable[[], Session], kek_provider: KEKProvider) -> None:
+    def __init__(
+        self,
+        session_factory: Callable[[], Session],
+        kek_provider: KEKProvider,
+        async_session_factory: Callable[[], AsyncSession] | None = None,
+    ) -> None:
+        """Construct a store bound to the given session factories.
+
+        ``session_factory`` is the existing sync factory. The optional
+        ``async_session_factory`` is used by the ``*_async`` methods.
+        When omitted, the async methods resolve the singleton
+        ``AsyncSessionLocal`` factory at call time. Tests that drive
+        the async API through a per-test transaction can pass the
+        rebound ``async_sessionmaker`` from the ``async_db`` fixture
+        explicitly, mirroring how sync tests pass ``SessionLocal``
+        rebound by the autouse ``_isolate_stores`` fixture.
+        """
         self._session_factory = session_factory
         self._kek = kek_provider
+        self._async_session_factory = async_session_factory
+
+    def _resolve_async_factory(self) -> Callable[[], AsyncSession]:
+        """Return the async session factory to use for this call.
+
+        Deferred lookup: the constructor default is ``None`` so that a
+        store instantiated before the async engine has booted (e.g. at
+        import time) doesn't capture a stale factory. The first
+        ``*_async`` call resolves the factory from
+        ``backend.app.database`` (which honors test rebinding of the
+        module-level ``_async_session_factory``).
+        """
+        if self._async_session_factory is not None:
+            return self._async_session_factory
+        # Local import to avoid a cycle with backend.app.database at
+        # module load (config_store is imported during settings boot
+        # via the lifespan handler, before some test fixtures have run).
+        from backend.app.database import AsyncSessionLocal
+
+        return AsyncSessionLocal
 
     def load(self) -> dict[str, str]:
         try:
             with self._session_factory() as db:
-                rows = db.execute(text("SELECT key, value, is_secret FROM app_settings")).all()
+                rows = db.execute(_load_select_sql()).all()
         except Exception as exc:
             raise ConfigStoreError(f"Failed to query app_settings: {exc}") from exc
 
-        result: dict[str, str] = {}
-        for key, value, is_secret_flag in rows:
-            if not value:
-                result[key] = ""
-                continue
-            if is_secret_flag:
-                try:
-                    result[key] = _encryption.decrypt(value, self._kek, self._encryption_context())
-                except Exception as exc:
-                    raise ConfigStoreError(f"Failed to decrypt app_settings.{key}: {exc}") from exc
-            else:
-                result[key] = value
-        return result
+        return _decode_load_rows(rows, self._kek)
+
+    async def load_async(self) -> dict[str, str]:
+        """Async peer of ``load``."""
+        factory = self._resolve_async_factory()
+        try:
+            async with factory() as db:
+                rows = (await db.execute(_load_select_sql())).all()
+        except Exception as exc:
+            raise ConfigStoreError(f"Failed to query app_settings: {exc}") from exc
+
+        return _decode_load_rows(rows, self._kek)
 
     def save(self, updates: Mapping[str, str], *, actor_user_id: str | None = None) -> None:
         if not updates:
             return
-        rows: list[dict[str, Any]] = []
-        for key, value in updates.items():
-            if key not in PERSISTABLE_SETTINGS:
-                raise ValueError(
-                    f"{key!r} is not a persistable setting "
-                    f"(allowed: {sorted(PERSISTABLE_SETTINGS)})"
-                )
-            secret = is_secret(key)
-            stored_value = (
-                _encryption.encrypt(value, self._kek, self._encryption_context())
-                if secret and value
-                else value
-            )
-            rows.append(
-                {
-                    "key": key,
-                    "value": stored_value,
-                    "is_secret": secret,
-                    "actor": actor_user_id,
-                }
-            )
-
-        # One round-trip: ON CONFLICT upsert for the whole batch.
-        stmt = text(
-            """
-            INSERT INTO app_settings (key, value, is_secret, updated_by_user_id)
-            VALUES (:key, :value, :is_secret, :actor)
-            ON CONFLICT (key) DO UPDATE SET
-                value = EXCLUDED.value,
-                is_secret = EXCLUDED.is_secret,
-                updated_at = NOW(),
-                updated_by_user_id = EXCLUDED.updated_by_user_id
-            """
-        )
+        rows = _build_save_rows(updates, self._kek, actor_user_id=actor_user_id)
         with self._session_factory() as db:
-            db.execute(stmt, rows)
+            db.execute(_save_upsert_sql(), rows)
             db.commit()
+
+    async def save_async(
+        self, updates: Mapping[str, str], *, actor_user_id: str | None = None
+    ) -> None:
+        """Async peer of ``save``.
+
+        Same persistable-key validation, same encryption-on-write, same
+        single-statement upsert. ``ValueError`` for non-persistable
+        keys is raised before any IO, matching the sync path.
+        """
+        if not updates:
+            return
+        rows = _build_save_rows(updates, self._kek, actor_user_id=actor_user_id)
+        factory = self._resolve_async_factory()
+        async with factory() as db:
+            await db.execute(_save_upsert_sql(), rows)
+            await db.commit()
 
     def delete(self, keys: Iterable[str]) -> None:
         keys_list = list(keys)
         if not keys_list:
             return
         with self._session_factory() as db:
-            db.execute(
-                text("DELETE FROM app_settings WHERE key = ANY(:keys)"),
-                {"keys": keys_list},
-            )
+            db.execute(_delete_sql(), {"keys": keys_list})
             db.commit()
 
+    async def delete_async(self, keys: Iterable[str]) -> None:
+        """Async peer of ``delete``."""
+        keys_list = list(keys)
+        if not keys_list:
+            return
+        factory = self._resolve_async_factory()
+        async with factory() as db:
+            await db.execute(_delete_sql(), {"keys": keys_list})
+            await db.commit()
+
     def _encryption_context(self) -> _encryption.EncryptionContext:
-        return {"table": self._CONTEXT_TABLE, "column": self._CONTEXT_COLUMN}
+        # Kept for backward-compat with any subclass / external caller
+        # that may have referenced the instance method directly. The
+        # module-level ``_encryption_context()`` is the source of truth
+        # for both sync and async paths.
+        return _encryption_context()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_db_settings_store_async.py
+++ b/tests/test_db_settings_store_async.py
@@ -1,0 +1,272 @@
+"""Tests for the async API of ``DbSettingsStore`` (issue #1175).
+
+Mirrors the DB-store half of ``tests/test_config_store.py`` for the
+``*_async`` peers added in the dual-API rollout. All tests opt into the
+per-test ``async_db`` fixture (see ``tests/conftest.py``) so writes are
+rolled back at teardown. Follows the IdempotencyStore async pilot
+(``tests/test_idempotency_pruning_async.py``, #1199) and the per-store
+conversions in #1200, #1201, #1203.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from backend.app.config_store import (
+    ConfigStoreError,
+    DbSettingsStore,
+)
+from backend.app.security.encryption import LocalKEKProvider, is_envelope
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _kek_provider() -> LocalKEKProvider:
+    """Deterministic provider for round-trip tests."""
+    return LocalKEKProvider(key_material=b"x" * 32)
+
+
+@pytest_asyncio.fixture()
+async def _db_store(
+    _kek_provider: LocalKEKProvider,
+    async_db: async_sessionmaker,
+) -> AsyncGenerator[DbSettingsStore]:
+    """Construct a store wired to the per-test sync and async factories.
+
+    The autouse ``_isolate_stores`` fixture rebinds ``SessionLocal`` to
+    a per-test connection in a rolled-back transaction. The ``async_db``
+    fixture rebinds ``_async_session_factory`` for the async path.
+    Passing the rebound async factory explicitly (rather than relying
+    on the deferred ``AsyncSessionLocal`` lookup) makes the test wiring
+    obvious at the call site.
+    """
+    import backend.app.database as _db_module
+
+    yield DbSettingsStore(
+        _db_module.SessionLocal,
+        _kek_provider,
+        async_session_factory=async_db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip parity with the sync API
+# ---------------------------------------------------------------------------
+
+
+async def test_async_save_and_load_round_trips(_db_store: DbSettingsStore) -> None:
+    """``save_async`` then ``load_async`` returns the exact value.
+
+    Mirrors the load-bearing sync round-trip test: the integration
+    guard against a future read/write split landing on the async path.
+    """
+    await _db_store.save_async(
+        {
+            "llm_provider": "anthropic",
+            "llm_model": "claude-sonnet-4-6",
+            "telegram_bot_token": "real-secret-token",
+        }
+    )
+    loaded = await _db_store.load_async()
+    assert loaded["llm_provider"] == "anthropic"
+    assert loaded["llm_model"] == "claude-sonnet-4-6"
+    # Decryption happened transparently on the async path too.
+    assert loaded["telegram_bot_token"] == "real-secret-token"
+
+
+async def test_async_secrets_are_envelope_encrypted_at_rest(
+    _db_store: DbSettingsStore,
+    async_db: async_sessionmaker,
+) -> None:
+    """The on-disk bytes are an envelope, not plaintext, when written async.
+
+    Belt-and-suspenders: catches a regression where someone wires up
+    ``save_async`` and forgets to route through the shared
+    ``_build_save_rows`` helper that handles secret encryption.
+    """
+    await _db_store.save_async({"telegram_bot_token": "real-secret-token"})
+
+    async with async_db() as db:
+        row = (
+            await db.execute(
+                text("SELECT value, is_secret FROM app_settings WHERE key='telegram_bot_token'")
+            )
+        ).one()
+    raw_value, is_secret_flag = row
+    assert is_secret_flag is True
+    assert "real-secret-token" not in raw_value
+    assert is_envelope(raw_value)
+
+
+async def test_async_non_secret_stored_verbatim(
+    _db_store: DbSettingsStore,
+    async_db: async_sessionmaker,
+) -> None:
+    """Non-secret values pass through unencrypted on the async path."""
+    await _db_store.save_async({"llm_provider": "anthropic"})
+    async with async_db() as db:
+        row = (
+            await db.execute(
+                text("SELECT value, is_secret FROM app_settings WHERE key='llm_provider'")
+            )
+        ).one()
+    assert row[0] == "anthropic"
+    assert row[1] is False
+
+
+async def test_async_save_rejects_non_persistable_keys(_db_store: DbSettingsStore) -> None:
+    """``save_async`` raises ``ValueError`` before any IO for unknown keys.
+
+    Same failure mode as ``save``: the sync path raises before opening
+    a session; the async path must too. Uses the shared
+    ``_build_save_rows`` helper, which validates up front.
+    """
+    with pytest.raises(ValueError, match="not a persistable setting"):
+        await _db_store.save_async({"definitely_not_a_setting": "x"})
+
+
+async def test_async_save_upserts(_db_store: DbSettingsStore) -> None:
+    """Saving the same key twice updates the value, doesn't error on dup PK."""
+    await _db_store.save_async({"llm_provider": "anthropic"})
+    await _db_store.save_async({"llm_provider": "openai"})
+    loaded = await _db_store.load_async()
+    assert loaded["llm_provider"] == "openai"
+
+
+async def test_async_delete_removes_rows(_db_store: DbSettingsStore) -> None:
+    """``delete_async`` removes the named keys from the table."""
+    await _db_store.save_async({"llm_provider": "anthropic", "llm_model": "sonnet"})
+    await _db_store.delete_async(["llm_model"])
+    loaded = await _db_store.load_async()
+    assert "llm_provider" in loaded
+    assert "llm_model" not in loaded
+
+
+async def test_async_save_empty_is_noop(_db_store: DbSettingsStore) -> None:
+    """An empty ``updates`` dict short-circuits before opening a session."""
+    await _db_store.save_async({})
+    assert await _db_store.load_async() == {}
+
+
+async def test_async_delete_empty_is_noop(_db_store: DbSettingsStore) -> None:
+    """``delete_async`` with no keys is a no-op (no SQL emitted)."""
+    await _db_store.save_async({"llm_provider": "anthropic"})
+    await _db_store.delete_async([])
+    loaded = await _db_store.load_async()
+    assert loaded["llm_provider"] == "anthropic"
+
+
+async def test_async_save_records_actor(
+    _db_store: DbSettingsStore,
+    async_db: async_sessionmaker,
+) -> None:
+    """``actor_user_id`` is recorded against the row by the async path too."""
+    from backend.app.models import User
+
+    async with async_db() as db:
+        user = User(
+            user_id="async-actor-user-store",
+            channel_identifier="async-actor-tel",
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        actor_id = user.id
+
+    await _db_store.save_async({"llm_provider": "anthropic"}, actor_user_id=actor_id)
+
+    async with async_db() as db:
+        row = (
+            await db.execute(
+                text("SELECT updated_by_user_id FROM app_settings WHERE key='llm_provider'")
+            )
+        ).one()
+    assert row[0] == actor_id
+
+
+async def test_async_load_returns_empty_for_empty_value(_db_store: DbSettingsStore) -> None:
+    """Empty stored values short-circuit to "" without a decrypt call.
+
+    Mirrors the sync ``load`` path so a row with ``value=""`` (the
+    column's server default, e.g. after a schema migration that
+    inserted blank rows) does not blow up trying to decrypt it as an
+    envelope.
+    """
+    # Save a non-secret with empty value, then read it back.
+    await _db_store.save_async({"llm_provider": ""})
+    loaded = await _db_store.load_async()
+    assert loaded["llm_provider"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-test isolation canary (proves the async fixture rolls back)
+# ---------------------------------------------------------------------------
+
+
+async def test_async_isolation_rolls_back_between_tests_part_a(
+    _db_store: DbSettingsStore,
+) -> None:
+    """Half 1 of a paired check that the async fixture rolls back.
+
+    Writes a row; the paired test below must not see it.
+    """
+    await _db_store.save_async({"llm_provider": "iso-canary-anthropic"})
+    loaded = await _db_store.load_async()
+    assert loaded["llm_provider"] == "iso-canary-anthropic"
+
+
+async def test_async_isolation_rolls_back_between_tests_part_b(
+    _db_store: DbSettingsStore,
+) -> None:
+    """Half 2: confirms the previous test's row was rolled back."""
+    loaded = await _db_store.load_async()
+    assert "llm_provider" not in loaded
+
+
+# ---------------------------------------------------------------------------
+# Backend-failure path on the async API
+# ---------------------------------------------------------------------------
+
+
+async def test_async_load_raises_on_missing_table(
+    _kek_provider: LocalKEKProvider,
+) -> None:
+    """``load_async`` wraps backend failure in ``ConfigStoreError``.
+
+    Mirrors the sync ``test_db_store_load_raises_on_missing_table``:
+    the contract is "raise loudly, don't silently return ``{}``", and
+    the async path must hold the same line.
+    """
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    # Point the store at a database URL that cannot resolve a
+    # connection (TCP refused). The first ``execute`` will raise; the
+    # store wraps it in ``ConfigStoreError``.
+    bad_engine = create_async_engine(
+        "postgresql+asyncpg://clawbolt:clawbolt@127.0.0.1:1/does_not_exist"
+    )
+    bad_factory: async_sessionmaker = async_sessionmaker(
+        bind=bad_engine,
+        autoflush=False,
+        expire_on_commit=False,
+    )
+    try:
+        store = DbSettingsStore(
+            session_factory=lambda: (_ for _ in ()).throw(  # never used in this test
+                AssertionError("sync path should not be touched here")
+            ),
+            kek_provider=_kek_provider,
+            async_session_factory=bad_factory,
+        )
+        with pytest.raises(ConfigStoreError):
+            await store.load_async()
+    finally:
+        await bad_engine.dispose()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds `load_async`, `save_async`, and `delete_async` to `DbSettingsStore` (`backend/app/config_store.py`) so async callers do not fall back to a sync DB call from async context, the failure mode that the epic in #1139 is closing.

`DbSettingsStore` was missed in the original 8-store inventory but is structurally identical: encrypted KV persistence, called from both request handlers and agent paths. Without an async API any async caller that reads or writes a setting would block the event loop on the sync `Session.execute` path.

Follows the IdempotencyStore pilot pattern (#1199) and the per-store conversions in #1200, #1201, #1203:

- Sync method bodies are unchanged in observable behavior.
- Both sync and async paths share validation, encryption, and SQL construction via pure module-level helpers (`_load_select_sql`, `_save_upsert_sql`, `_delete_sql` returning `TextClause`; `_build_save_rows` for persistable-key validation + secret encryption; `_decode_load_rows` for per-row decrypt + `ConfigStoreError` wrapping). No `Any` on builders.
- The constructor gains an optional `async_session_factory` parameter; when omitted the async methods resolve `AsyncSessionLocal` lazily so a store instantiated at import time does not capture a stale factory before the async engine has booted.
- New tests in `tests/test_db_settings_store_async.py` cover round-trip, encryption-at-rest, non-secret passthrough, persistable-key validation, upsert, delete, empty-input no-ops, audit-actor recording, and the backend-failure path. Includes the iso-canary pair (`_part_a` / `_part_b`) to verify per-test rollback through the `async_db` fixture.

### Encrypted-column anomaly check

`AppSetting.value` is plain `Text` (encryption is explicit via `_encryption.encrypt` / `_encryption.decrypt`), not `EncryptedString`. There is no SQL-side concatenation over an encrypted column in this store, so the `history_text` bug fixed in #1200 does not have an analog here. Flagging explicitly per the issue acceptance criteria.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests (n/a)

Additional checks run locally:
- `uv run ty check --python .venv backend/ tests/ alembic/` passes
- `SQLALCHEMY_WARN_20=1 uv run pytest -W error::sqlalchemy.exc.LegacyAPIWarning -W error::sqlalchemy.exc.MovedIn20Warning tests/test_db_settings_store_async.py` passes (no legacy or pre-2.0 SQLAlchemy warnings on the new path)

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

PR drafted by Claude (Opus 4.7, 1M context) via back-and-forth with @njbrake. The pattern, scope, and acceptance criteria are his; the prose and code are Claude's.

Closes #1175
Part of #1139