### PR TITLE
feat(stores): add async API to 4 stores in stores.py

### DIFF
--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -110,8 +110,63 @@ _MEDIA_UPDATABLE_FIELDS: frozenset[str] = frozenset(
 )
 
 
+# Builders shared by sync and async heartbeat methods (issue #1154).
+# Same dual-API pattern as the IdempotencyStore pilot in #1199: pure
+# ``select(...)`` builders so the two paths stay in lockstep without a
+# class hierarchy.
+def _heartbeat_user_select(user_id: str) -> Select[tuple[User]]:
+    """Builder shared by ``read_heartbeat_md`` / ``write_heartbeat_md`` peers."""
+    return select(User).filter_by(id=user_id)
+
+
+def _heartbeat_daily_count_select(
+    user_id: str,
+    today_start: datetime.datetime,
+    tomorrow_start: datetime.datetime,
+) -> Select[tuple[int]]:
+    """Builder shared by ``get_daily_count`` / ``get_daily_count_async``."""
+    return select(func.count(HeartbeatLog.id)).where(
+        HeartbeatLog.user_id == user_id,
+        HeartbeatLog.created_at >= today_start,
+        HeartbeatLog.created_at < tomorrow_start,
+        HeartbeatLog.action_type.notin_(("skip", "cleanup")),
+    )
+
+
+def _recent_heartbeat_logs_select(
+    user_id: str, since: datetime.datetime
+) -> Select[tuple[HeartbeatLog]]:
+    """Builder shared by ``get_recent_logs`` / ``get_recent_logs_async``."""
+    return (
+        select(HeartbeatLog)
+        .where(
+            HeartbeatLog.user_id == user_id,
+            HeartbeatLog.created_at >= since,
+        )
+        .order_by(HeartbeatLog.created_at)
+    )
+
+
+def _today_window_utc() -> tuple[datetime.datetime, datetime.datetime]:
+    """Compute today's [start, end) window in UTC for daily heartbeat counts."""
+    today = datetime.datetime.now(datetime.UTC).date()
+    today_start = datetime.datetime.combine(today, datetime.time.min, tzinfo=datetime.UTC)
+    tomorrow_start = today_start + datetime.timedelta(days=1)
+    return today_start, tomorrow_start
+
+
 class HeartbeatStore:
-    """Database-backed heartbeat storage using User.heartbeat_text and HeartbeatLog ORM models."""
+    """Database-backed heartbeat storage using User.heartbeat_text and HeartbeatLog ORM models.
+
+    Dual-API store (issue #1154). Each public method has an ``*_async``
+    peer with identical semantics; the two share query construction via
+    the ``_heartbeat_user_select`` / ``_heartbeat_daily_count_select`` /
+    ``_recent_heartbeat_logs_select`` builders above. Existing sync
+    callers (the heartbeat scheduler tick that runs outside the event
+    loop) keep working unchanged while OSS-internal hot paths migrate
+    to the async peers. Follows the IdempotencyStore pilot pattern
+    from PR #1199.
+    """
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
@@ -120,20 +175,39 @@ class HeartbeatStore:
         """Read freeform heartbeat markdown from User.heartbeat_text."""
         db = SessionLocal()
         try:
-            user = db.execute(select(User).filter_by(id=self.user_id)).scalar_one_or_none()
+            user = db.execute(_heartbeat_user_select(self.user_id)).scalar_one_or_none()
             if user is not None and user.heartbeat_text:
                 return user.heartbeat_text
             return ""
         finally:
             db.close()
 
+    async def read_heartbeat_md_async(self) -> str:
+        """Async peer of ``read_heartbeat_md``."""
+        db = AsyncSessionLocal()
+        try:
+            user = (await db.execute(_heartbeat_user_select(self.user_id))).scalar_one_or_none()
+            if user is not None and user.heartbeat_text:
+                return user.heartbeat_text
+            return ""
+        finally:
+            await db.close()
+
     async def write_heartbeat_md(self, text: str) -> None:
         """Write freeform heartbeat markdown to User.heartbeat_text."""
         with db_session() as db:
-            user = db.execute(select(User).filter_by(id=self.user_id)).scalar_one_or_none()
+            user = db.execute(_heartbeat_user_select(self.user_id)).scalar_one_or_none()
             if user is not None:
                 user.heartbeat_text = text
                 db.commit()
+
+    async def write_heartbeat_md_async(self, text: str) -> None:
+        """Async peer of ``write_heartbeat_md``."""
+        async with db_session_async() as db:
+            user = (await db.execute(_heartbeat_user_select(self.user_id))).scalar_one_or_none()
+            if user is not None:
+                user.heartbeat_text = text
+                await db.commit()
 
     async def log_heartbeat(
         self,
@@ -157,6 +231,28 @@ class HeartbeatStore:
             db.add(log)
             db.commit()
 
+    async def log_heartbeat_async(
+        self,
+        *,
+        action_type: str = "send",
+        message_text: str = "",
+        channel: str = "",
+        reasoning: str = "",
+        tasks: str = "",
+    ) -> None:
+        """Async peer of ``log_heartbeat``."""
+        async with db_session_async() as db:
+            log = HeartbeatLog(
+                user_id=self.user_id,
+                action_type=action_type,
+                message_text=message_text,
+                channel=channel,
+                reasoning=reasoning,
+                tasks=tasks,
+            )
+            db.add(log)
+            await db.commit()
+
     async def get_daily_count(self) -> int:
         """Count HeartbeatLog entries for today (UTC) that consumed the nudge budget.
 
@@ -168,23 +264,30 @@ class HeartbeatStore:
         """
         db = SessionLocal()
         try:
-            today = datetime.datetime.now(datetime.UTC).date()
-            today_start = datetime.datetime.combine(today, datetime.time.min, tzinfo=datetime.UTC)
-            tomorrow_start = today_start + datetime.timedelta(days=1)
+            today_start, tomorrow_start = _today_window_utc()
             count: int = (
                 db.execute(
-                    select(func.count(HeartbeatLog.id)).where(
-                        HeartbeatLog.user_id == self.user_id,
-                        HeartbeatLog.created_at >= today_start,
-                        HeartbeatLog.created_at < tomorrow_start,
-                        HeartbeatLog.action_type.notin_(("skip", "cleanup")),
-                    )
+                    _heartbeat_daily_count_select(self.user_id, today_start, tomorrow_start)
                 ).scalar()
                 or 0
             )
             return count
         finally:
             db.close()
+
+    async def get_daily_count_async(self) -> int:
+        """Async peer of ``get_daily_count``."""
+        db = AsyncSessionLocal()
+        try:
+            today_start, tomorrow_start = _today_window_utc()
+            count: int = (
+                await db.scalar(
+                    _heartbeat_daily_count_select(self.user_id, today_start, tomorrow_start)
+                )
+            ) or 0
+            return count
+        finally:
+            await db.close()
 
     async def get_recent_logs(
         self,
@@ -193,21 +296,23 @@ class HeartbeatStore:
         """Select HeartbeatLog entries where created_at >= since."""
         db = SessionLocal()
         try:
-            logs = (
-                db.execute(
-                    select(HeartbeatLog)
-                    .where(
-                        HeartbeatLog.user_id == self.user_id,
-                        HeartbeatLog.created_at >= since,
-                    )
-                    .order_by(HeartbeatLog.created_at)
-                )
-                .scalars()
-                .all()
-            )
+            logs = db.execute(_recent_heartbeat_logs_select(self.user_id, since)).scalars().all()
             return [_heartbeat_log_to_dto(log) for log in logs]
         finally:
             db.close()
+
+    async def get_recent_logs_async(
+        self,
+        since: datetime.datetime,
+    ) -> list[HeartbeatLogEntry]:
+        """Async peer of ``get_recent_logs``."""
+        db = AsyncSessionLocal()
+        try:
+            result = await db.execute(_recent_heartbeat_logs_select(self.user_id, since))
+            logs = result.scalars().all()
+            return [_heartbeat_log_to_dto(log) for log in logs]
+        finally:
+            await db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -215,8 +320,88 @@ class HeartbeatStore:
 # ---------------------------------------------------------------------------
 
 
+# Builders shared by sync and async media methods (issue #1155). Pure
+# ``select(...)`` builders so the two paths stay in lockstep without a
+# class hierarchy. Same pattern as the IdempotencyStore pilot.
+def _media_list_select(user_id: str) -> Select[tuple[MediaFile]]:
+    """Builder shared by ``list_all`` / ``list_all_async``."""
+    return select(MediaFile).filter_by(user_id=user_id).order_by(MediaFile.created_at)
+
+
+def _media_existing_ids_select(user_id: str) -> Select[tuple[str]]:
+    """Builder shared by the ``create`` / ``create_async`` ID-allocation paths.
+
+    Locks the existing rows ``FOR UPDATE`` so two concurrent inserts do
+    not race to allocate the same ``media-NNN`` id.
+    """
+    return select(MediaFile.id).filter_by(user_id=user_id).with_for_update()
+
+
+def _media_by_id_select(user_id: str, media_id: str) -> Select[tuple[MediaFile]]:
+    """Builder shared by the ``update`` / ``update_async`` paths."""
+    return select(MediaFile).filter_by(id=media_id, user_id=user_id)
+
+
+def _media_by_url_select(user_id: str, original_url: str) -> Select[tuple[MediaFile]]:
+    """Builder shared by ``get_by_url`` / ``get_by_url_async``."""
+    return select(MediaFile).where(
+        MediaFile.user_id == user_id,
+        or_(
+            MediaFile.original_url == original_url,
+            MediaFile.storage_url == original_url,
+            MediaFile.storage_path == original_url,
+        ),
+    )
+
+
+def _media_count_by_prefix_select(user_id: str, prefix: str) -> Select[tuple[int]]:
+    """Builder shared by ``count_by_path_prefix`` / ``count_by_path_prefix_async``."""
+    return select(func.count(MediaFile.id)).where(
+        MediaFile.user_id == user_id,
+        MediaFile.storage_path.startswith(prefix),
+    )
+
+
+def _next_media_id(existing_ids: list[str]) -> str:
+    """Compute the next ``media-NNN`` id from the locked existing-id set.
+
+    Pure helper so ``create`` / ``create_async`` use identical
+    allocation semantics. The caller owns the lock and the surrounding
+    transaction.
+    """
+    max_num = 0
+    for mid in existing_ids:
+        if mid.startswith("media-"):
+            try:
+                num = int(mid[6:])
+                max_num = max(max_num, num)
+            except ValueError:
+                pass
+    return f"media-{max_num + 1:03d}"
+
+
+def _apply_media_updates(m: MediaFile, fields: dict[str, Any]) -> None:
+    """Apply allowlisted attribute updates to a MediaFile row in place.
+
+    Pure helper so ``update`` / ``update_async`` use identical
+    field-allowlist semantics. ``None`` values are skipped to match the
+    existing partial-update contract.
+    """
+    for key, value in fields.items():
+        if value is not None and key in _MEDIA_UPDATABLE_FIELDS:
+            setattr(m, key, value)
+
+
 class MediaStore:
-    """Database-backed media file storage using MediaFile ORM model."""
+    """Database-backed media file storage using MediaFile ORM model.
+
+    Dual-API store (issue #1155). Each public method has an ``*_async``
+    peer with identical semantics; the two share query construction via
+    the ``_media_list_select`` / ``_media_existing_ids_select`` /
+    ``_media_by_id_select`` / ``_media_by_url_select`` /
+    ``_media_count_by_prefix_select`` builders above. Follows the
+    IdempotencyStore pilot pattern from PR #1199.
+    """
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
@@ -225,16 +410,20 @@ class MediaStore:
         """Query all MediaFile rows, return as DTOs."""
         db = SessionLocal()
         try:
-            rows = (
-                db.execute(
-                    select(MediaFile).filter_by(user_id=self.user_id).order_by(MediaFile.created_at)
-                )
-                .scalars()
-                .all()
-            )
+            rows = db.execute(_media_list_select(self.user_id)).scalars().all()
             return [_media_to_dto(m) for m in rows]
         finally:
             db.close()
+
+    async def list_all_async(self) -> list[MediaData]:
+        """Async peer of ``list_all``."""
+        db = AsyncSessionLocal()
+        try:
+            result = await db.execute(_media_list_select(self.user_id))
+            rows = result.scalars().all()
+            return [_media_to_dto(m) for m in rows]
+        finally:
+            await db.close()
 
     async def create(
         self,
@@ -249,19 +438,9 @@ class MediaStore:
         with db_session() as db:
             # ID generation: "media-NNN" format -- lock rows to prevent races
             existing_ids = list(
-                db.execute(select(MediaFile.id).filter_by(user_id=self.user_id).with_for_update())
-                .scalars()
-                .all()
+                db.execute(_media_existing_ids_select(self.user_id)).scalars().all()
             )
-            max_num = 0
-            for mid in existing_ids:
-                if mid.startswith("media-"):
-                    try:
-                        num = int(mid[6:])
-                        max_num = max(max_num, num)
-                    except ValueError:
-                        pass
-            new_id = f"media-{max_num + 1:03d}"
+            new_id = _next_media_id(existing_ids)
 
             media = MediaFile(
                 id=new_id,
@@ -278,19 +457,56 @@ class MediaStore:
             db.refresh(media)
             return _media_to_dto(media)
 
+    async def create_async(
+        self,
+        original_url: str = "",
+        mime_type: str = "",
+        processed_text: str = "",
+        storage_url: str = "",
+        storage_path: str = "",
+        message_id: str | None = None,
+    ) -> MediaData:
+        """Async peer of ``create``."""
+        async with db_session_async() as db:
+            result = await db.execute(_media_existing_ids_select(self.user_id))
+            existing_ids = list(result.scalars().all())
+            new_id = _next_media_id(existing_ids)
+
+            media = MediaFile(
+                id=new_id,
+                user_id=self.user_id,
+                message_id=message_id or "",
+                original_url=original_url,
+                mime_type=mime_type,
+                processed_text=processed_text,
+                storage_url=storage_url,
+                storage_path=storage_path,
+            )
+            db.add(media)
+            await db.commit()
+            await db.refresh(media)
+            return _media_to_dto(media)
+
     async def update(self, media_id: str, **fields: Any) -> MediaData | None:
         """Update a MediaFile row by id."""
         with db_session() as db:
-            m = db.execute(
-                select(MediaFile).filter_by(id=media_id, user_id=self.user_id)
-            ).scalar_one_or_none()
+            m = db.execute(_media_by_id_select(self.user_id, media_id)).scalar_one_or_none()
             if m is None:
                 return None
-            for key, value in fields.items():
-                if value is not None and key in _MEDIA_UPDATABLE_FIELDS:
-                    setattr(m, key, value)
+            _apply_media_updates(m, fields)
             db.commit()
             db.refresh(m)
+            return _media_to_dto(m)
+
+    async def update_async(self, media_id: str, **fields: Any) -> MediaData | None:
+        """Async peer of ``update``."""
+        async with db_session_async() as db:
+            m = (await db.execute(_media_by_id_select(self.user_id, media_id))).scalar_one_or_none()
+            if m is None:
+                return None
+            _apply_media_updates(m, fields)
+            await db.commit()
+            await db.refresh(m)
             return _media_to_dto(m)
 
     async def get_by_url(self, original_url: str) -> MediaData | None:
@@ -307,36 +523,43 @@ class MediaStore:
             return None
         db = SessionLocal()
         try:
-            m = db.execute(
-                select(MediaFile).where(
-                    MediaFile.user_id == self.user_id,
-                    or_(
-                        MediaFile.original_url == original_url,
-                        MediaFile.storage_url == original_url,
-                        MediaFile.storage_path == original_url,
-                    ),
-                )
-            ).scalar_one_or_none()
+            m = db.execute(_media_by_url_select(self.user_id, original_url)).scalar_one_or_none()
             return _media_to_dto(m) if m else None
         finally:
             db.close()
+
+    async def get_by_url_async(self, original_url: str) -> MediaData | None:
+        """Async peer of ``get_by_url``."""
+        if not original_url:
+            return None
+        db = AsyncSessionLocal()
+        try:
+            m = (
+                await db.execute(_media_by_url_select(self.user_id, original_url))
+            ).scalar_one_or_none()
+            return _media_to_dto(m) if m else None
+        finally:
+            await db.close()
 
     async def count_by_path_prefix(self, prefix: str) -> int:
         """Count MediaFile rows where storage_path starts with prefix."""
         db = SessionLocal()
         try:
             count: int = (
-                db.execute(
-                    select(func.count(MediaFile.id)).where(
-                        MediaFile.user_id == self.user_id,
-                        MediaFile.storage_path.startswith(prefix),
-                    )
-                ).scalar()
-                or 0
+                db.execute(_media_count_by_prefix_select(self.user_id, prefix)).scalar() or 0
             )
             return count
         finally:
             db.close()
+
+    async def count_by_path_prefix_async(self, prefix: str) -> int:
+        """Async peer of ``count_by_path_prefix``."""
+        db = AsyncSessionLocal()
+        try:
+            count: int = (await db.scalar(_media_count_by_prefix_select(self.user_id, prefix))) or 0
+            return count
+        finally:
+            await db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -521,8 +744,71 @@ class IdempotencyStore:
 _warned_unpriced_models: set[tuple[str, str]] = set()
 
 
+def _build_llm_usage_log(
+    *,
+    user_id: str,
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    purpose: str,
+    provider: str,
+    cache_creation_input_tokens: int | None,
+    cache_read_input_tokens: int | None,
+) -> LLMUsageLog:
+    """Compute cost, emit the unpriced-model warning, and build an LLMUsageLog row.
+
+    Pure helper shared by ``LLMUsageStore.log`` and ``log_async`` so the
+    two paths use identical pricing semantics, identical warning
+    suppression, and identical column population. Does not touch the
+    database; the caller owns the session and the surrounding commit.
+    """
+    cost = compute_cost(
+        model,
+        provider=provider,
+        input_tokens=prompt_tokens,
+        output_tokens=completion_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+    )
+    if (
+        not is_known_model(model, provider=provider)
+        and (prompt_tokens or completion_tokens)
+        and (provider, model) not in _warned_unpriced_models
+    ):
+        _warned_unpriced_models.add((provider, model))
+        logger.warning(
+            "genai-prices does not know provider=%r model=%r; logging "
+            "usage with cost=0. Bump the genai-prices dependency to "
+            "pick up new model pricing.",
+            provider,
+            model,
+        )
+
+    return LLMUsageLog(
+        user_id=user_id,
+        provider=provider,
+        model=model,
+        input_tokens=prompt_tokens,
+        output_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        cost=cost,
+        purpose=purpose,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+    )
+
+
 class LLMUsageStore:
-    """Database-backed LLM usage logging using LLMUsageLog ORM model."""
+    """Database-backed LLM usage logging using LLMUsageLog ORM model.
+
+    Dual-API store (issue #1156). The async peer matters for the
+    request hot path: premium reads from this table for quota
+    enforcement, and the sync write was a known event-loop blocking
+    risk. Sync and async paths share the ``_build_llm_usage_log``
+    helper so cost computation and the unpriced-model warning behave
+    identically. Follows the IdempotencyStore pilot pattern from
+    PR #1199.
+    """
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
@@ -549,43 +835,44 @@ class LLMUsageStore:
         ``cost=0.000000`` and a once-per-process warning so we notice when
         our pricing data is stale.
         """
-        cost = compute_cost(
-            model,
+        entry = _build_llm_usage_log(
+            user_id=self.user_id,
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            purpose=purpose,
             provider=provider,
-            input_tokens=prompt_tokens,
-            output_tokens=completion_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
         )
-        if (
-            not is_known_model(model, provider=provider)
-            and (prompt_tokens or completion_tokens)
-            and (provider, model) not in _warned_unpriced_models
-        ):
-            _warned_unpriced_models.add((provider, model))
-            logger.warning(
-                "genai-prices does not know provider=%r model=%r; logging "
-                "usage with cost=0. Bump the genai-prices dependency to "
-                "pick up new model pricing.",
-                provider,
-                model,
-            )
-
         with db_session() as db:
-            entry = LLMUsageLog(
-                user_id=self.user_id,
-                provider=provider,
-                model=model,
-                input_tokens=prompt_tokens,
-                output_tokens=completion_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
-                cost=cost,
-                purpose=purpose,
-                cache_creation_input_tokens=cache_creation_input_tokens,
-                cache_read_input_tokens=cache_read_input_tokens,
-            )
             db.add(entry)
             db.commit()
+
+    async def log_async(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        purpose: str,
+        provider: str = "",
+        cache_creation_input_tokens: int | None = None,
+        cache_read_input_tokens: int | None = None,
+    ) -> None:
+        """Async peer of ``log``."""
+        entry = _build_llm_usage_log(
+            user_id=self.user_id,
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            purpose=purpose,
+            provider=provider,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+        )
+        async with db_session_async() as db:
+            db.add(entry)
+            await db.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -593,8 +880,83 @@ class LLMUsageStore:
 # ---------------------------------------------------------------------------
 
 
+# Builders shared by sync and async tool-config methods (issue #1157).
+# Pure ``select(...) / delete(...)`` builders so the two paths stay in
+# lockstep without a class hierarchy. Same pattern as the
+# IdempotencyStore pilot.
+def _tool_config_load_select(user_id: str) -> Select[tuple[ToolConfig]]:
+    """Builder shared by ``load`` / ``load_async``."""
+    return (
+        select(ToolConfig)
+        .filter_by(user_id=user_id)
+        .order_by(ToolConfig.domain_group_order, ToolConfig.name)
+    )
+
+
+def _tool_config_delete_for_user(user_id: str) -> Delete[tuple[ToolConfig]]:
+    """Builder shared by the ``save`` / ``save_async`` replace-all paths."""
+    return delete(ToolConfig).where(ToolConfig.user_id == user_id)
+
+
+def _tool_config_disabled_names_select(user_id: str) -> Select[tuple[str]]:
+    """Builder shared by ``get_disabled_tool_names`` / ``_async``."""
+    return select(ToolConfig.name).filter_by(user_id=user_id, enabled=False)
+
+
+def _tool_config_by_name_select(user_id: str, name: str) -> Select[tuple[ToolConfig]]:
+    """Builder shared by the ``set_enabled`` / ``set_enabled_async`` paths."""
+    return select(ToolConfig).filter_by(user_id=user_id, name=name)
+
+
+def _tool_config_disabled_sub_tools_select(user_id: str) -> Select[tuple[str]]:
+    """Builder shared by ``get_disabled_sub_tool_names`` / ``_async``."""
+    return (
+        select(ToolConfig.disabled_sub_tools)
+        .filter_by(user_id=user_id)
+        .where(ToolConfig.disabled_sub_tools != "")
+    )
+
+
+def _build_tool_config(user_id: str, entry: ToolConfigEntry) -> ToolConfig:
+    """Construct a ToolConfig ORM row from a DTO. Pure helper shared by save paths."""
+    disabled_sub = json.dumps(entry.disabled_sub_tools) if entry.disabled_sub_tools else ""
+    return ToolConfig(
+        user_id=user_id,
+        name=entry.name,
+        description=entry.description,
+        category=entry.category,
+        domain_group=entry.domain_group,
+        domain_group_order=entry.domain_group_order,
+        enabled=entry.enabled,
+        disabled_sub_tools=disabled_sub,
+    )
+
+
+def _new_disabled_tool_config(user_id: str, name: str, enabled: bool) -> ToolConfig:
+    """Construct a placeholder ToolConfig row for ``set_enabled`` when none exists."""
+    return ToolConfig(
+        user_id=user_id,
+        name=name,
+        description="",
+        category="domain",
+        domain_group="",
+        domain_group_order=0,
+        enabled=enabled,
+        disabled_sub_tools="",
+    )
+
+
 class ToolConfigStore:
-    """Database-backed tool configuration using ToolConfig ORM model."""
+    """Database-backed tool configuration using ToolConfig ORM model.
+
+    Dual-API store (issue #1157). Each public method has an ``*_async``
+    peer with identical semantics; the two share query construction via
+    the ``_tool_config_load_select`` / ``_tool_config_delete_for_user`` /
+    ``_tool_config_disabled_names_select`` /
+    ``_tool_config_by_name_select`` /
+    ``_tool_config_disabled_sub_tools_select`` builders above. Follows
+    the IdempotencyStore pilot pattern from PR #1199.
+    """
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
@@ -603,54 +965,60 @@ class ToolConfigStore:
         """Query all ToolConfig rows for this user, return as DTOs."""
         db = SessionLocal()
         try:
-            rows = (
-                db.execute(
-                    select(ToolConfig)
-                    .filter_by(user_id=self.user_id)
-                    .order_by(ToolConfig.domain_group_order, ToolConfig.name)
-                )
-                .scalars()
-                .all()
-            )
+            rows = db.execute(_tool_config_load_select(self.user_id)).scalars().all()
             return [_tool_config_to_dto(tc) for tc in rows]
         finally:
             db.close()
+
+    async def load_async(self) -> list[ToolConfigEntry]:
+        """Async peer of ``load``."""
+        db = AsyncSessionLocal()
+        try:
+            result = await db.execute(_tool_config_load_select(self.user_id))
+            rows = result.scalars().all()
+            return [_tool_config_to_dto(tc) for tc in rows]
+        finally:
+            await db.close()
 
     async def save(self, entries: list[ToolConfigEntry]) -> list[ToolConfigEntry]:
         """Replace all ToolConfig rows for this user with new entries."""
         with db_session() as db:
             # Delete existing rows for this user
-            db.execute(delete(ToolConfig).where(ToolConfig.user_id == self.user_id))
+            db.execute(_tool_config_delete_for_user(self.user_id))
 
             # Insert new rows
             for entry in entries:
-                disabled_sub = (
-                    json.dumps(entry.disabled_sub_tools) if entry.disabled_sub_tools else ""
-                )
-                tc = ToolConfig(
-                    user_id=self.user_id,
-                    name=entry.name,
-                    description=entry.description,
-                    category=entry.category,
-                    domain_group=entry.domain_group,
-                    domain_group_order=entry.domain_group_order,
-                    enabled=entry.enabled,
-                    disabled_sub_tools=disabled_sub,
-                )
-                db.add(tc)
+                db.add(_build_tool_config(self.user_id, entry))
             db.commit()
+            return entries
+
+    async def save_async(self, entries: list[ToolConfigEntry]) -> list[ToolConfigEntry]:
+        """Async peer of ``save``."""
+        async with db_session_async() as db:
+            await db.execute(_tool_config_delete_for_user(self.user_id))
+
+            for entry in entries:
+                db.add(_build_tool_config(self.user_id, entry))
+            await db.commit()
             return entries
 
     async def get_disabled_tool_names(self) -> set[str]:
         """Return the set of tool group names that are disabled."""
         db = SessionLocal()
         try:
-            rows = db.execute(
-                select(ToolConfig.name).filter_by(user_id=self.user_id, enabled=False)
-            ).all()
+            rows = db.execute(_tool_config_disabled_names_select(self.user_id)).all()
             return {row[0] for row in rows}
         finally:
             db.close()
+
+    async def get_disabled_tool_names_async(self) -> set[str]:
+        """Async peer of ``get_disabled_tool_names``."""
+        db = AsyncSessionLocal()
+        try:
+            result = await db.execute(_tool_config_disabled_names_select(self.user_id))
+            return {row[0] for row in result.all()}
+        finally:
+            await db.close()
 
     async def set_enabled(self, name: str, enabled: bool) -> None:
         """Set a single tool group's enabled state.
@@ -661,40 +1029,49 @@ class ToolConfigStore:
         """
         with db_session() as db:
             existing = db.execute(
-                select(ToolConfig).filter_by(user_id=self.user_id, name=name)
+                _tool_config_by_name_select(self.user_id, name)
             ).scalar_one_or_none()
             if existing:
                 existing.enabled = enabled
             else:
-                db.add(
-                    ToolConfig(
-                        user_id=self.user_id,
-                        name=name,
-                        description="",
-                        category="domain",
-                        domain_group="",
-                        domain_group_order=0,
-                        enabled=enabled,
-                        disabled_sub_tools="",
-                    )
-                )
+                db.add(_new_disabled_tool_config(self.user_id, name, enabled))
             db.commit()
+
+    async def set_enabled_async(self, name: str, enabled: bool) -> None:
+        """Async peer of ``set_enabled``."""
+        async with db_session_async() as db:
+            existing = (
+                await db.execute(_tool_config_by_name_select(self.user_id, name))
+            ).scalar_one_or_none()
+            if existing:
+                existing.enabled = enabled
+            else:
+                db.add(_new_disabled_tool_config(self.user_id, name, enabled))
+            await db.commit()
 
     async def get_disabled_sub_tool_names(self) -> set[str]:
         """Return the union of all disabled sub-tool names across all groups."""
         db = SessionLocal()
         try:
-            rows = db.execute(
-                select(ToolConfig.disabled_sub_tools)
-                .filter_by(user_id=self.user_id)
-                .where(ToolConfig.disabled_sub_tools != "")
-            ).all()
+            rows = db.execute(_tool_config_disabled_sub_tools_select(self.user_id)).all()
             result: set[str] = set()
             for (raw,) in rows:
                 result.update(_parse_disabled_sub_tools(raw))
             return result
         finally:
             db.close()
+
+    async def get_disabled_sub_tool_names_async(self) -> set[str]:
+        """Async peer of ``get_disabled_sub_tool_names``."""
+        db = AsyncSessionLocal()
+        try:
+            db_result = await db.execute(_tool_config_disabled_sub_tools_select(self.user_id))
+            result: set[str] = set()
+            for (raw,) in db_result.all():
+                result.update(_parse_disabled_sub_tools(raw))
+            return result
+        finally:
+            await db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat_store_async.py
+++ b/tests/test_heartbeat_store_async.py
@@ -1,0 +1,254 @@
+"""Tests for the async API of ``HeartbeatStore`` (issue #1154).
+
+Mirrors the sync ``HeartbeatStore`` surface for the ``*_async`` peers
+added in the dual-API rollout. All tests opt into the per-test
+``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
+back at teardown. Follows the IdempotencyStore pilot pattern from
+PR #1199.
+
+User-row setup runs through the shared ``async_test_user`` fixture in
+``tests/conftest.py``; that fixture routes the insert through the
+async connection because the sync ``test_user`` fixture opens its own
+per-test transaction on a separate connection and rows committed there
+are invisible to the async store under READ COMMITTED.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from backend.app.agent.stores import HeartbeatStore
+from backend.app.models import HeartbeatLog, User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _row_count(factory: async_sessionmaker, user_id: str) -> int:
+    """Return the number of HeartbeatLog rows for the given user."""
+    async with factory() as db:
+        return (
+            await db.scalar(
+                select(func.count(HeartbeatLog.id)).where(HeartbeatLog.user_id == user_id)
+            )
+        ) or 0
+
+
+# ---------------------------------------------------------------------------
+# read_heartbeat_md_async / write_heartbeat_md_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_read_heartbeat_md_empty_when_unset(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``read_heartbeat_md_async`` returns ``""`` when the user row has no text."""
+    store = HeartbeatStore(async_test_user.id)
+    assert await store.read_heartbeat_md_async() == ""
+
+
+async def test_async_write_then_read_heartbeat_md_round_trip(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """An async write is visible via an async read in the same test."""
+    store = HeartbeatStore(async_test_user.id)
+    await store.write_heartbeat_md_async("- next: call back the customer")
+
+    content = await store.read_heartbeat_md_async()
+    assert "call back the customer" in content
+
+
+async def test_async_write_heartbeat_md_overwrites(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``write_heartbeat_md_async`` fully replaces the existing text."""
+    store = HeartbeatStore(async_test_user.id)
+    await store.write_heartbeat_md_async("old")
+    await store.write_heartbeat_md_async("new")
+
+    assert await store.read_heartbeat_md_async() == "new"
+
+
+async def test_async_write_heartbeat_md_no_user_is_noop(
+    async_db: async_sessionmaker,
+) -> None:
+    """``write_heartbeat_md_async`` silently no-ops when the user row is missing."""
+    store = HeartbeatStore("does-not-exist")
+    await store.write_heartbeat_md_async("anything")
+    # And the read just returns empty string.
+    assert await store.read_heartbeat_md_async() == ""
+
+
+# ---------------------------------------------------------------------------
+# log_heartbeat_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_log_heartbeat_inserts_row(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``log_heartbeat_async`` inserts a HeartbeatLog row visible via an async read."""
+    store = HeartbeatStore(async_test_user.id)
+    before = await _row_count(async_db, async_test_user.id)
+
+    await store.log_heartbeat_async(
+        action_type="send",
+        message_text="ping",
+        channel="telegram",
+        reasoning="just because",
+        tasks="",
+    )
+
+    assert await _row_count(async_db, async_test_user.id) == before + 1
+
+
+async def test_async_log_heartbeat_defaults_match_sync(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Default keyword arguments match the sync surface (``action_type='send'``)."""
+    store = HeartbeatStore(async_test_user.id)
+    await store.log_heartbeat_async()
+
+    async with async_db() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(HeartbeatLog).where(HeartbeatLog.user_id == async_test_user.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    assert rows[0].action_type == "send"
+
+
+# ---------------------------------------------------------------------------
+# get_daily_count_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_get_daily_count_excludes_skip_and_cleanup(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_daily_count_async`` excludes ``skip`` and ``cleanup`` rows.
+
+    Mirrors the sync method: only nudges that consumed budget count.
+    """
+    store = HeartbeatStore(async_test_user.id)
+    await store.log_heartbeat_async(action_type="send")
+    await store.log_heartbeat_async(action_type="send")
+    await store.log_heartbeat_async(action_type="skip")
+    await store.log_heartbeat_async(action_type="cleanup")
+
+    assert await store.get_daily_count_async() == 2
+
+
+async def test_async_get_daily_count_zero_when_empty(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_daily_count_async`` returns 0 when no log rows exist for the user."""
+    store = HeartbeatStore(async_test_user.id)
+    assert await store.get_daily_count_async() == 0
+
+
+# ---------------------------------------------------------------------------
+# get_recent_logs_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_get_recent_logs_orders_by_created_at(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_recent_logs_async`` returns rows ordered by ``created_at`` ascending."""
+    store = HeartbeatStore(async_test_user.id)
+    await store.log_heartbeat_async(message_text="first")
+    await store.log_heartbeat_async(message_text="second")
+    await store.log_heartbeat_async(message_text="third")
+
+    since = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
+    logs = await store.get_recent_logs_async(since)
+
+    assert [log.message_text for log in logs] == ["first", "second", "third"]
+
+
+async def test_async_get_recent_logs_filters_by_since(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_recent_logs_async`` skips rows older than ``since``."""
+    store = HeartbeatStore(async_test_user.id)
+    await store.log_heartbeat_async(message_text="present")
+
+    future = datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1)
+    logs = await store.get_recent_logs_async(future)
+
+    assert logs == []
+
+
+async def test_async_get_recent_logs_returns_dtos_with_isoformat_timestamps(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """The async path returns ``HeartbeatLogEntry`` DTOs, not ORM rows."""
+    store = HeartbeatStore(async_test_user.id)
+    await store.log_heartbeat_async(message_text="dto check")
+
+    since = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
+    logs = await store.get_recent_logs_async(since)
+
+    assert len(logs) == 1
+    # The DTO converts created_at to an ISO string.
+    assert isinstance(logs[0].created_at, str)
+    assert "T" in logs[0].created_at
+
+
+# ---------------------------------------------------------------------------
+# Sync/async parity: an async write should be readable via the async path
+# ---------------------------------------------------------------------------
+
+
+async def test_async_writer_visible_via_async_read(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``write_heartbeat_md_async`` is visible through ``read_heartbeat_md_async``."""
+    store = HeartbeatStore(async_test_user.id)
+    await store.write_heartbeat_md_async("- check the truck oil")
+    assert "truck oil" in await store.read_heartbeat_md_async()
+
+
+# ---------------------------------------------------------------------------
+# Per-test isolation canary (mirrors test_idempotency_pruning_async.py)
+# ---------------------------------------------------------------------------
+
+
+async def test_async_isolation_rolls_back_between_tests_part_a(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Half 1: write a row; the paired test below must not see it."""
+    store = HeartbeatStore(async_test_user.id)
+    await store.log_heartbeat_async(message_text="iso-canary")
+    assert await store.get_daily_count_async() == 1
+
+
+async def test_async_isolation_rolls_back_between_tests_part_b(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Half 2: confirms the previous test's row was rolled back."""
+    store = HeartbeatStore(async_test_user.id)
+    assert await store.get_daily_count_async() == 0

--- a/tests/test_llm_usage_store_async.py
+++ b/tests/test_llm_usage_store_async.py
@@ -1,0 +1,231 @@
+"""Tests for the async API of ``LLMUsageStore`` (issue #1156).
+
+Mirrors the sync ``LLMUsageStore.log`` for the ``log_async`` peer
+added in the dual-API rollout. All tests opt into the per-test
+``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
+back at teardown. Follows the IdempotencyStore pilot pattern from
+PR #1199.
+
+This store matters for the request hot path: premium reads from
+``llm_usage_logs`` for quota enforcement, and the sync write was a
+known event-loop blocking risk.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from backend.app.agent.stores import LLMUsageStore
+from backend.app.models import LLMUsageLog, User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _row_count(factory: async_sessionmaker, user_id: str) -> int:
+    """Return the number of LLMUsageLog rows for the given user."""
+    async with factory() as db:
+        return (
+            await db.scalar(
+                select(func.count(LLMUsageLog.id)).where(LLMUsageLog.user_id == user_id)
+            )
+        ) or 0
+
+
+async def _fetch_one(factory: async_sessionmaker, user_id: str) -> LLMUsageLog:
+    """Return the single LLMUsageLog row for the given user."""
+    async with factory() as db:
+        return (
+            (await db.execute(select(LLMUsageLog).where(LLMUsageLog.user_id == user_id)))
+            .scalars()
+            .one()
+        )
+
+
+# ---------------------------------------------------------------------------
+# log_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_log_inserts_row(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``log_async`` inserts a single row visible via an async read."""
+    store = LLMUsageStore(async_test_user.id)
+    before = await _row_count(async_db, async_test_user.id)
+
+    await store.log_async(
+        model="claude-sonnet-4-5",
+        prompt_tokens=100,
+        completion_tokens=50,
+        purpose="agent",
+        provider="anthropic",
+    )
+
+    assert await _row_count(async_db, async_test_user.id) == before + 1
+
+
+async def test_async_log_persists_token_and_cost_columns(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``log_async`` populates the same columns as the sync ``log``.
+
+    Maps prompt_tokens -> input_tokens, completion_tokens -> output_tokens.
+    """
+    store = LLMUsageStore(async_test_user.id)
+    await store.log_async(
+        model="claude-sonnet-4-5",
+        prompt_tokens=100,
+        completion_tokens=50,
+        purpose="agent",
+        provider="anthropic",
+    )
+
+    row = await _fetch_one(async_db, async_test_user.id)
+    assert row.model == "claude-sonnet-4-5"
+    assert row.provider == "anthropic"
+    assert row.input_tokens == 100
+    assert row.output_tokens == 50
+    assert row.total_tokens == 150
+    assert row.purpose == "agent"
+    # Cost is computed via genai-prices; just assert the column was populated
+    # with a non-negative numeric value.
+    assert row.cost is not None
+    assert float(row.cost) >= 0
+
+
+async def test_async_log_persists_cache_token_columns(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``log_async`` writes through optional cache token columns."""
+    store = LLMUsageStore(async_test_user.id)
+    await store.log_async(
+        model="claude-sonnet-4-5",
+        prompt_tokens=10,
+        completion_tokens=5,
+        purpose="agent",
+        provider="anthropic",
+        cache_creation_input_tokens=42,
+        cache_read_input_tokens=7,
+    )
+
+    row = await _fetch_one(async_db, async_test_user.id)
+    assert row.cache_creation_input_tokens == 42
+    assert row.cache_read_input_tokens == 7
+
+
+async def test_async_log_unknown_model_does_not_raise(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """An unknown (provider, model) combo logs a once-per-process warning, no raise.
+
+    Mirrors the sync method's contract: cost falls through as 0 and the
+    insert still happens.
+    """
+    store = LLMUsageStore(async_test_user.id)
+    await store.log_async(
+        model="totally-made-up-model-name",
+        prompt_tokens=10,
+        completion_tokens=5,
+        purpose="agent",
+        provider="totally-made-up-provider",
+    )
+
+    row = await _fetch_one(async_db, async_test_user.id)
+    assert row.model == "totally-made-up-model-name"
+    assert row.provider == "totally-made-up-provider"
+    assert row.input_tokens == 10
+    assert row.output_tokens == 5
+
+
+async def test_async_log_zero_tokens_persisted(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Zero-token logs still insert a row (matches sync)."""
+    store = LLMUsageStore(async_test_user.id)
+    await store.log_async(
+        model="claude-sonnet-4-5",
+        prompt_tokens=0,
+        completion_tokens=0,
+        purpose="ping",
+        provider="anthropic",
+    )
+
+    row = await _fetch_one(async_db, async_test_user.id)
+    assert row.input_tokens == 0
+    assert row.output_tokens == 0
+    assert row.total_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Sync/async parity: an async log is queryable via the same SQL the
+# sync code uses for quota checks.
+# ---------------------------------------------------------------------------
+
+
+async def test_async_log_visible_via_async_select(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """A simple aggregate over the async-written rows returns the expected sum."""
+    store = LLMUsageStore(async_test_user.id)
+    await store.log_async(
+        model="claude-sonnet-4-5",
+        prompt_tokens=100,
+        completion_tokens=200,
+        purpose="agent",
+        provider="anthropic",
+    )
+    await store.log_async(
+        model="claude-sonnet-4-5",
+        prompt_tokens=50,
+        completion_tokens=10,
+        purpose="agent",
+        provider="anthropic",
+    )
+
+    async with async_db() as db:
+        total = await db.scalar(
+            select(func.sum(LLMUsageLog.total_tokens)).where(
+                LLMUsageLog.user_id == async_test_user.id
+            )
+        )
+
+    # 100 + 200 + 50 + 10 = 360
+    assert total == 360
+
+
+# ---------------------------------------------------------------------------
+# Per-test isolation canary
+# ---------------------------------------------------------------------------
+
+
+async def test_async_isolation_rolls_back_between_tests_part_a(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Half 1: insert a usage row; the paired test below must not see it."""
+    store = LLMUsageStore(async_test_user.id)
+    await store.log_async(
+        model="claude-sonnet-4-5",
+        prompt_tokens=1,
+        completion_tokens=1,
+        purpose="agent",
+        provider="anthropic",
+    )
+    assert await _row_count(async_db, async_test_user.id) == 1
+
+
+async def test_async_isolation_rolls_back_between_tests_part_b(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Half 2: confirms the previous test's row was rolled back."""
+    assert await _row_count(async_db, async_test_user.id) == 0

--- a/tests/test_media_store_async.py
+++ b/tests/test_media_store_async.py
@@ -1,0 +1,290 @@
+"""Tests for the async API of ``MediaStore`` (issue #1155).
+
+Mirrors the sync ``MediaStore`` surface for the ``*_async`` peers
+added in the dual-API rollout. All tests opt into the per-test
+``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
+back at teardown. Follows the IdempotencyStore pilot pattern from
+PR #1199.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from backend.app.agent.stores import MediaStore
+from backend.app.models import MediaFile, User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _row_count(factory: async_sessionmaker, user_id: str) -> int:
+    """Return the number of MediaFile rows for the given user."""
+    async with factory() as db:
+        return (
+            await db.scalar(select(func.count(MediaFile.id)).where(MediaFile.user_id == user_id))
+        ) or 0
+
+
+# ---------------------------------------------------------------------------
+# create_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_create_inserts_row_and_allocates_id(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``create_async`` inserts a row and returns a DTO with an allocated id."""
+    store = MediaStore(async_test_user.id)
+    before = await _row_count(async_db, async_test_user.id)
+
+    created = await store.create_async(
+        original_url="bb_abcd",
+        mime_type="image/jpeg",
+        storage_path="/photos/2026",
+    )
+
+    assert created.id == "media-001"
+    assert created.original_url == "bb_abcd"
+    assert created.mime_type == "image/jpeg"
+    assert created.storage_path == "/photos/2026"
+    assert await _row_count(async_db, async_test_user.id) == before + 1
+
+
+async def test_async_create_increments_id_per_user(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Successive ``create_async`` calls allocate ``media-001``, ``media-002``, ..."""
+    store = MediaStore(async_test_user.id)
+    a = await store.create_async(original_url="bb_a")
+    b = await store.create_async(original_url="bb_b")
+    c = await store.create_async(original_url="bb_c")
+
+    assert [a.id, b.id, c.id] == ["media-001", "media-002", "media-003"]
+
+
+async def test_async_create_defaults_message_id_to_empty_string(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``message_id=None`` should round-trip as ``""`` (matches sync)."""
+    store = MediaStore(async_test_user.id)
+    created = await store.create_async(message_id=None)
+    assert created.message_id == ""
+
+
+# ---------------------------------------------------------------------------
+# list_all_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_list_all_orders_by_created_at(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``list_all_async`` returns DTOs ordered by ``created_at`` ascending."""
+    store = MediaStore(async_test_user.id)
+    a = await store.create_async(original_url="bb_a")
+    b = await store.create_async(original_url="bb_b")
+    c = await store.create_async(original_url="bb_c")
+
+    rows = await store.list_all_async()
+
+    ids = [r.id for r in rows]
+    assert ids == [a.id, b.id, c.id]
+
+
+async def test_async_list_all_empty_for_no_rows(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``list_all_async`` returns ``[]`` when no rows exist."""
+    store = MediaStore(async_test_user.id)
+    assert await store.list_all_async() == []
+
+
+# ---------------------------------------------------------------------------
+# update_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_update_writes_allowed_fields(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``update_async`` writes through allowlisted fields."""
+    store = MediaStore(async_test_user.id)
+    created = await store.create_async(original_url="bb_a")
+
+    updated = await store.update_async(
+        created.id,
+        processed_text="hello world",
+        storage_url="file:///tmp/a.jpg",
+        storage_path="/uploads/a.jpg",
+    )
+
+    assert updated is not None
+    assert updated.processed_text == "hello world"
+    assert updated.storage_url == "file:///tmp/a.jpg"
+    assert updated.storage_path == "/uploads/a.jpg"
+
+
+async def test_async_update_skips_none_values(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``update_async`` skips fields whose value is ``None`` (matches sync)."""
+    store = MediaStore(async_test_user.id)
+    created = await store.create_async(original_url="bb_a", processed_text="initial")
+
+    updated = await store.update_async(
+        created.id,
+        processed_text=None,
+        storage_url="file:///tmp/x",
+    )
+
+    assert updated is not None
+    assert updated.processed_text == "initial"
+    assert updated.storage_url == "file:///tmp/x"
+
+
+async def test_async_update_ignores_disallowed_fields(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``update_async`` silently drops fields outside the allowlist."""
+    store = MediaStore(async_test_user.id)
+    created = await store.create_async(original_url="bb_a")
+
+    updated = await store.update_async(
+        created.id,
+        original_url="should-not-change",
+        processed_text="ok",
+    )
+
+    assert updated is not None
+    assert updated.original_url == "bb_a"
+    assert updated.processed_text == "ok"
+
+
+async def test_async_update_returns_none_for_missing(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``update_async`` returns ``None`` when no row matches."""
+    store = MediaStore(async_test_user.id)
+    assert await store.update_async("media-999", processed_text="x") is None
+
+
+# ---------------------------------------------------------------------------
+# get_by_url_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_get_by_url_matches_original_url(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_by_url_async`` matches by ``original_url``."""
+    store = MediaStore(async_test_user.id)
+    created = await store.create_async(original_url="bb_xyz")
+
+    fetched = await store.get_by_url_async("bb_xyz")
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_async_get_by_url_matches_storage_url(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_by_url_async`` also matches by ``storage_url`` (LLM round-trip path)."""
+    store = MediaStore(async_test_user.id)
+    created = await store.create_async(original_url="bb_xyz", storage_url="file:///tmp/photo.jpg")
+
+    fetched = await store.get_by_url_async("file:///tmp/photo.jpg")
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_async_get_by_url_matches_storage_path(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_by_url_async`` also matches by ``storage_path``."""
+    store = MediaStore(async_test_user.id)
+    created = await store.create_async(original_url="bb_xyz", storage_path="/uploads/2026")
+
+    fetched = await store.get_by_url_async("/uploads/2026")
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_async_get_by_url_returns_none_for_empty(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_by_url_async`` returns ``None`` for an empty url (matches sync)."""
+    store = MediaStore(async_test_user.id)
+    assert await store.get_by_url_async("") is None
+
+
+async def test_async_get_by_url_returns_none_for_unknown(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_by_url_async`` returns ``None`` for an unknown url."""
+    store = MediaStore(async_test_user.id)
+    assert await store.get_by_url_async("nope") is None
+
+
+# ---------------------------------------------------------------------------
+# count_by_path_prefix_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_count_by_path_prefix_counts_matching(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``count_by_path_prefix_async`` counts rows whose ``storage_path`` starts with the prefix."""
+    store = MediaStore(async_test_user.id)
+    await store.create_async(storage_path="/photos/2026/jan/a.jpg")
+    await store.create_async(storage_path="/photos/2026/feb/b.jpg")
+    await store.create_async(storage_path="/docs/c.pdf")
+
+    assert await store.count_by_path_prefix_async("/photos/") == 2
+    assert await store.count_by_path_prefix_async("/docs/") == 1
+    assert await store.count_by_path_prefix_async("/missing/") == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-test isolation canary
+# ---------------------------------------------------------------------------
+
+
+async def test_async_isolation_rolls_back_between_tests_part_a(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Half 1: insert a row; the paired test below must not see it."""
+    store = MediaStore(async_test_user.id)
+    await store.create_async(original_url="iso-canary")
+    rows = await store.list_all_async()
+    assert any(r.original_url == "iso-canary" for r in rows)
+
+
+async def test_async_isolation_rolls_back_between_tests_part_b(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Half 2: confirms the previous test's row was rolled back."""
+    store = MediaStore(async_test_user.id)
+    assert await store.list_all_async() == []

--- a/tests/test_tool_config_store_async.py
+++ b/tests/test_tool_config_store_async.py
@@ -1,0 +1,271 @@
+"""Tests for the async API of ``ToolConfigStore`` (issue #1157).
+
+Mirrors the sync ``ToolConfigStore`` surface for the ``*_async`` peers
+added in the dual-API rollout. All tests opt into the per-test
+``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
+back at teardown. Follows the IdempotencyStore pilot pattern from
+PR #1199.
+"""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from backend.app.agent.dto import ToolConfigEntry
+from backend.app.agent.stores import ToolConfigStore
+from backend.app.models import ToolConfig, User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _row_count(factory: async_sessionmaker, user_id: str) -> int:
+    """Return the number of ToolConfig rows for the given user."""
+    async with factory() as db:
+        return (
+            await db.scalar(select(func.count(ToolConfig.id)).where(ToolConfig.user_id == user_id))
+        ) or 0
+
+
+def _entry(
+    name: str,
+    *,
+    enabled: bool = True,
+    domain_group: str = "core",
+    domain_group_order: int = 0,
+    disabled_sub_tools: list[str] | None = None,
+) -> ToolConfigEntry:
+    """Build a ``ToolConfigEntry`` for tests with sensible defaults."""
+    return ToolConfigEntry(
+        name=name,
+        description=f"{name} description",
+        category="domain",
+        domain_group=domain_group,
+        domain_group_order=domain_group_order,
+        enabled=enabled,
+        disabled_sub_tools=disabled_sub_tools or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_async / save_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_save_then_load_round_trip(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``save_async`` writes rows that ``load_async`` returns as DTOs."""
+    store = ToolConfigStore(async_test_user.id)
+    entries = [_entry("workspace"), _entry("calendar", enabled=False)]
+
+    returned = await store.save_async(entries)
+
+    assert returned == entries
+    loaded = await store.load_async()
+    by_name = {e.name: e for e in loaded}
+    assert by_name["workspace"].enabled is True
+    assert by_name["calendar"].enabled is False
+
+
+async def test_async_save_replaces_existing_rows(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``save_async`` replaces the full set; a second save with fewer rows shrinks the table."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async([_entry("workspace"), _entry("calendar"), _entry("billing")])
+    assert await _row_count(async_db, async_test_user.id) == 3
+
+    await store.save_async([_entry("workspace")])
+    assert await _row_count(async_db, async_test_user.id) == 1
+
+    loaded = await store.load_async()
+    assert [e.name for e in loaded] == ["workspace"]
+
+
+async def test_async_save_persists_disabled_sub_tools_as_json(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``save_async`` JSON-encodes ``disabled_sub_tools`` (matches sync)."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async([_entry("workspace", disabled_sub_tools=["delete_file", "rename_file"])])
+
+    async with async_db() as db:
+        raw = (
+            await db.execute(
+                select(ToolConfig.disabled_sub_tools).where(
+                    ToolConfig.user_id == async_test_user.id, ToolConfig.name == "workspace"
+                )
+            )
+        ).scalar_one()
+    assert json.loads(raw) == ["delete_file", "rename_file"]
+
+
+async def test_async_save_empty_list_clears_rows(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``save_async([])`` deletes all rows for the user."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async([_entry("workspace"), _entry("calendar")])
+    assert await _row_count(async_db, async_test_user.id) == 2
+
+    await store.save_async([])
+    assert await _row_count(async_db, async_test_user.id) == 0
+
+
+async def test_async_load_orders_by_domain_group_order_then_name(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``load_async`` orders by ``(domain_group_order, name)`` ascending."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async(
+        [
+            _entry("zeta", domain_group_order=2),
+            _entry("alpha", domain_group_order=1),
+            _entry("beta", domain_group_order=1),
+        ]
+    )
+
+    loaded = await store.load_async()
+    assert [e.name for e in loaded] == ["alpha", "beta", "zeta"]
+
+
+async def test_async_load_empty_returns_empty_list(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``load_async`` returns ``[]`` when no rows exist."""
+    store = ToolConfigStore(async_test_user.id)
+    assert await store.load_async() == []
+
+
+# ---------------------------------------------------------------------------
+# get_disabled_tool_names_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_get_disabled_tool_names(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_disabled_tool_names_async`` returns names of tools with ``enabled=False``."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async(
+        [
+            _entry("workspace", enabled=True),
+            _entry("calendar", enabled=False),
+            _entry("billing", enabled=False),
+        ]
+    )
+
+    disabled = await store.get_disabled_tool_names_async()
+    assert disabled == {"calendar", "billing"}
+
+
+async def test_async_get_disabled_tool_names_empty(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_disabled_tool_names_async`` returns ``set()`` when nothing is disabled."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async([_entry("workspace", enabled=True)])
+    assert await store.get_disabled_tool_names_async() == set()
+
+
+# ---------------------------------------------------------------------------
+# set_enabled_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_set_enabled_creates_row_for_unknown_name(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``set_enabled_async`` inserts a placeholder row when none exists."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.set_enabled_async("brand-new-tool", False)
+
+    disabled = await store.get_disabled_tool_names_async()
+    assert "brand-new-tool" in disabled
+
+
+async def test_async_set_enabled_updates_existing_row(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``set_enabled_async`` flips an existing row's ``enabled`` flag in place."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async([_entry("calendar", enabled=True)])
+    assert await store.get_disabled_tool_names_async() == set()
+
+    await store.set_enabled_async("calendar", False)
+
+    assert "calendar" in await store.get_disabled_tool_names_async()
+    # No duplicate row inserted.
+    assert await _row_count(async_db, async_test_user.id) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_disabled_sub_tool_names_async
+# ---------------------------------------------------------------------------
+
+
+async def test_async_get_disabled_sub_tool_names_unions_across_groups(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``get_disabled_sub_tool_names_async`` unions sub-tool names across all groups."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async(
+        [
+            _entry("workspace", disabled_sub_tools=["delete_file", "rename_file"]),
+            _entry("calendar", disabled_sub_tools=["delete_event"]),
+            _entry("billing", disabled_sub_tools=[]),
+        ]
+    )
+
+    disabled_subs = await store.get_disabled_sub_tool_names_async()
+    assert disabled_subs == {"delete_file", "rename_file", "delete_event"}
+
+
+async def test_async_get_disabled_sub_tool_names_empty(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Returns ``set()`` when no group declares any disabled sub-tools."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async([_entry("workspace")])
+    assert await store.get_disabled_sub_tool_names_async() == set()
+
+
+# ---------------------------------------------------------------------------
+# Per-test isolation canary
+# ---------------------------------------------------------------------------
+
+
+async def test_async_isolation_rolls_back_between_tests_part_a(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Half 1: insert a row; the paired test below must not see it."""
+    store = ToolConfigStore(async_test_user.id)
+    await store.save_async([_entry("iso-canary")])
+    assert await _row_count(async_db, async_test_user.id) == 1
+
+
+async def test_async_isolation_rolls_back_between_tests_part_b(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """Half 2: confirms the previous test's row was rolled back."""
+    store = ToolConfigStore(async_test_user.id)
+    assert await store.load_async() == []


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds `*_async` peers to four stores in `backend/app/agent/stores.py`:

- `HeartbeatStore` (#1154)
- `MediaStore` (#1155)
- `LLMUsageStore` (#1156)
- `ToolConfigStore` (#1157)

Closes #1154
Closes #1155
Closes #1156
Closes #1157

Part of #1139.

### Why one PR for four issues

All four issues target the same file (`backend/app/agent/stores.py`). Splitting them into four separate PRs would create a four-way merge conflict storm on the imports section, the module-level builder block, and the class bodies. The conversion is mechanical and follows the well-established pilot pattern from PR #1199 (IdempotencyStore) plus PRs #1200, #1201, #1203 (Memory, User, Session). One review, one merge, identical pattern across all four stores. Mirrors the precedent set by PR #1199 itself, which combined #1148 + #1150.

### Pattern

For each store, sync methods keep their plain names; new `_async` methods are added with identical semantics. Both paths share pure module-level builders that return typed `Select` / `Delete` objects, so query shape stays in lockstep without a class hierarchy. The `LLMUsageStore.log` cost-computation logic is extracted into `_build_llm_usage_log` so the sync and async paths share identical pricing semantics and identical once-per-process unpriced-model warning suppression.

Sync method bodies are only modified where extracting a builder reduces duplication. No observable sync behavior changes: same return types, same exception classes, same query shapes, same ID-allocation `FOR UPDATE` lock, same partial-update `None`-skipping contract.

### HeartbeatStore (#1154)

New async peers: `read_heartbeat_md_async`, `write_heartbeat_md_async`, `log_heartbeat_async`, `get_daily_count_async`, `get_recent_logs_async`.

Builders extracted: `_heartbeat_user_select`, `_heartbeat_daily_count_select`, `_recent_heartbeat_logs_select`. Helper: `_today_window_utc` (so sync and async compute the same `[today_start, tomorrow_start)` window in UTC).

Tests: `tests/test_heartbeat_store_async.py` (14 tests, includes iso-canary pair).

### MediaStore (#1155)

New async peers: `list_all_async`, `create_async`, `update_async`, `get_by_url_async`, `count_by_path_prefix_async`.

Builders extracted: `_media_list_select`, `_media_existing_ids_select` (preserves the `with_for_update()` lock used in `create`), `_media_by_id_select`, `_media_by_url_select`, `_media_count_by_prefix_select`. Helpers: `_next_media_id` (the `media-NNN` allocator) and `_apply_media_updates` (allowlist + `None`-skip).

Tests: `tests/test_media_store_async.py` (17 tests, includes iso-canary pair).

### LLMUsageStore (#1156)

New async peer: `log_async`.

Helper extracted: `_build_llm_usage_log` does the cost computation, the unpriced-model warning, and ORM row construction; both sync and async call it. This matters for the request hot path: premium reads from `llm_usage_logs` for quota enforcement, and the sync write was a known event-loop blocking risk.

Tests: `tests/test_llm_usage_store_async.py` (8 tests, includes iso-canary pair, covers the cache-token columns and the unknown-model fall-through).

### ToolConfigStore (#1157)

New async peers: `load_async`, `save_async`, `get_disabled_tool_names_async`, `set_enabled_async`, `get_disabled_sub_tool_names_async`.

Builders extracted: `_tool_config_load_select`, `_tool_config_delete_for_user`, `_tool_config_disabled_names_select`, `_tool_config_by_name_select`, `_tool_config_disabled_sub_tools_select`. Helpers: `_build_tool_config` (DTO -> ORM) and `_new_disabled_tool_config` (the placeholder row `set_enabled` writes when no row exists yet).

Tests: `tests/test_tool_config_store_async.py` (14 tests, includes iso-canary pair, covers `disabled_sub_tools` JSON round-trip).

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests (n/a, feature)

Strict warning sweep also clean:

```
SQLALCHEMY_WARN_20=1 uv run pytest \
  -W "error::sqlalchemy.exc.LegacyAPIWarning" \
  -W "error::sqlalchemy.exc.MovedIn20Warning" \
  tests/test_heartbeat_store_async.py \
  tests/test_media_store_async.py \
  tests/test_llm_usage_store_async.py \
  tests/test_tool_config_store_async.py
# 53 passed, 0 warnings
```

Full suite: 2336 passed.

## AI Usage
- [x] AI-assisted (Claude wrote the diff and tests via back-and-forth with @njbrake; the conversion pattern was established in PRs #1199, #1200, #1201, #1203)
- [ ] No AI used