### PR TITLE
docs(agents): document async-only DB pattern in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,77 @@ Key store modules:
 
 File storage for uploads uses the local filesystem under `data/` (configurable via `DATA_DIR`).
 
+## Database access (sync + async dual-API)
+
+OSS is mid-migration from sync DB sessions to async (epic #1139). Every store currently exposes both a sync and an async surface so internal callers can convert one site at a time and external consumers (premium, CLI, Alembic) keep working unchanged. The pattern below is the contract that landed in PRs #1189, #1198, #1199, #1200, #1201, #1202, #1203, #1204, #1205, #1206. New stores and new methods MUST follow it; the sync surface will be removed in #1160 only after premium migration completes.
+
+### Dual-API contract
+
+- Sync methods keep their plain names (`load`, `get_by_id`, `create`, ...).
+- Async peers add an `_async` suffix (`load_async`, `get_by_id_async`, ...).
+- Sync method bodies must not change observable behavior when an async peer is added. Refactor only as far as extracting shared pure builders. Do not change return types, exception classes, query shapes, ordering, or locking.
+- Do not preemptively delete sync APIs. Removal lands in #1160 once premium converts.
+- Do not accept an externally-managed session as a parameter on the `_async` methods. Mismatch with the sync API contract; not how callers use the methods.
+
+### Shared logic via pure builders
+
+Sync and async methods share query construction through module-level builders that return concretely-typed SQLAlchemy core constructs. No `Any`, no session dependency. Canonical pilot: `_seen_select`, `_count_select`, `_prune_delete` in `backend/app/agent/stores.py:578-600` (IdempotencyStore). Same shape across `HeartbeatStore`, `MediaStore`, `LLMUsageStore`, `ToolConfigStore`, `MemoryStore`, `UserStore`, `SessionStore`, `DbSettingsStore`.
+
+Non-SQL helpers that both paths need (allowlist setters like `_apply_media_updates`, time-window helpers like `_today_window_utc`) follow the same rule: pure, module-level, no session.
+
+```python
+def _seen_select(external_id: str) -> Select[tuple[IdempotencyKey]]:
+    return select(IdempotencyKey).filter_by(external_id=external_id)
+```
+
+### Async session lifecycle
+
+Both factories live in `backend/app/database.py`. Async pool tuning matches the sync pool (`pool_recycle`, `pool_pre_ping`, statement timeout), and the async session factory ships with `expire_on_commit=False` so attribute access after commit does not trigger `MissingGreenlet`.
+
+- READ-only async methods: `db = AsyncSessionLocal()` + `try / finally await db.close()`. Lighter weight, no rollback wrapper. Reference `IdempotencyStore.has_seen_async` in `backend/app/agent/stores.py:628-635`.
+- WRITE async methods: `async with db_session_async() as db: ...`. Auto-rollback on exception, auto-close. Reference `IdempotencyStore.try_mark_seen_async` in `backend/app/agent/stores.py:661-683`.
+
+### Common SQLAlchemy 2.0 patterns
+
+These are the patterns that survive the sync-to-async port. PR #1190 already converted all `db.query()` call sites; do not reintroduce the 1.x Query API in new code.
+
+- Read: `db.execute(select(X).where(...)).scalar_one_or_none()` works on both `Session` and `AsyncSession` (with `await` on the async side). For a scalar count use `db.scalar(select(func.count(...)))`.
+- DML rowcount: at runtime `db.execute(update/delete).rowcount` returns `int`, but the stubs say `Result`. Cast to access cleanly: `cast("CursorResult[object]", db.execute(...)).rowcount`. Reference `SessionStore.delete_message` in `backend/app/agent/session_db.py:794-823`.
+- Bulk DML `synchronize_session`: the kwarg moved off `update()`/`delete()` constructors. Use `.execution_options(synchronize_session="fetch")` on the executable, and preserve the original value when migrating call sites. Reference `_append_history_update` in `backend/app/agent/memory_db.py:66-79`.
+- Row-level lock: `db.execute(select(M).filter_by(id=x).with_for_update()).scalar_one_or_none()`.
+- `.scalars().all()` returns `Sequence[T]`, not `list[T]`. Wrap with `list(...)` only when the consumer is typed for `list`.
+
+### Encrypted columns: do not concat on the SQL side
+
+`EncryptedString` columns (e.g. `MemoryDocument.history_text`, `OAuthToken.access_token`) handle envelope encryption automatically on bind/unbind. SQL-side string concat (`Model.col || new_text`) operates on ciphertext and silently corrupts the row. Bug fixed in #1200.
+
+Correct pattern: SELECT FOR UPDATE the row, decrypt-in-Python via attribute access, append in Python, UPDATE with the full new plaintext. Reference `_doc_select_for_update` and `_append_history_update` plus their callers in `backend/app/agent/memory_db.py:52-237`. The row-level lock serializes concurrent appenders so neither side loses its update.
+
+### Advisory locks
+
+Use `pg_advisory_xact_lock` whenever possible: the lock is bound to the surrounding transaction and released automatically on COMMIT or ROLLBACK. Both sync and async paths simply execute the lock SQL inside their session and let the existing commit drop it. Reference `_advisory_lock_sql` in `backend/app/agent/session_db.py:100-111` (SessionStore) and `_lock_user_permissions` in `backend/app/agent/approval.py`.
+
+Session-scoped advisory locks (`pg_advisory_lock` / `pg_try_advisory_lock`) are different: the unlock MUST run on the **same** connection that took the lock. SQLAlchemy `Session.commit()` returns the underlying DBAPI connection to the pool, so a follow-up `pg_advisory_unlock` call on a fresh `SessionLocal()` runs on a different connection and is a silent no-op (Postgres returns `False`, the helper logs nothing). Recovery code in `backend/app/agent/inbound_recovery.py` and OAuth refresh in `backend/app/services/oauth.py` rely on the same-connection coupling. The regression test in `tests/test_inbound_recovery.py:715` (`test_unlock_on_different_connection_is_a_no_op`) pins this invariant for the future async port.
+
+Concurrency tests for advisory locks: spin per-thread `engine.connect()` (sync) or per-task `AsyncSession(engine, ...)` connections so the lock primitive is actually exercised, not the connection serialization. Coordinate via `threading.Event` (sync) or `asyncio.Event` (async). Do not assert on `time.monotonic()` deltas across threads or tasks; sub-millisecond races make the comparisons flake (lesson from #1202). Reference `tests/test_approval.py:216-385` (`TestApprovalLockSerialization`) and `tests/test_inbound_recovery.py:457-790` (`TestInboundRecoveryLockSerialization`).
+
+### Test fixture: async DB isolation
+
+The `async_db` fixture in `tests/conftest.py:171-211` runs each async test inside a per-test `AsyncConnection` with a wrapping transaction; it rebinds `backend.app.database._async_session_factory` so store calls to `AsyncSessionLocal()` and `db_session_async()` pick up the test connection. Two non-obvious choices documented in the design comment block above the fixture (lines 119-168):
+
+- **Function-scoped engine.** asyncpg connections bind to the event loop they were created on; pytest-asyncio rotates loops between tests by default. A session-scoped async engine surfaces as `RuntimeError: Future attached to a different loop` on the second test. We pay one engine setup per async test in exchange for not having to widen the loop scope across the whole suite.
+- **`join_transaction_mode="create_savepoint"`, not `conditional_savepoint`.** The sync analog uses `conditional_savepoint` because psycopg2 keeps the outer transaction alive when only the savepoint aborts on `IntegrityError`. Under asyncpg the outer transaction silently detaches in the same scenario, which surfaces as "the row I just committed disappeared after a duplicate-insert error in a later session". `create_savepoint` forces every session into its own SAVEPOINT and keeps the contract consistent across drivers.
+
+The shared `async_test_user` fixture (`tests/conftest.py:248-280`) inserts a test user through the async connection, expunges it, and yields. Use it from any async store test; do not redefine.
+
+End every async test file with an iso-canary pair to prove rollback isolation. The `_part_a` test writes a fixed-id row; the `_part_b` test asserts the row is gone. Reference `test_async_isolation_rolls_back_between_tests_part_a` and `_part_b` in `tests/test_idempotency_pruning_async.py`.
+
+Cross-API caveat: the sync per-test transaction (`_isolate_stores`) and the async per-test transaction (`async_db`) live on independent connections. Under READ COMMITTED, a sync write committed from one is not visible to an async read in the same test. Pure-async store tests are fine; mixed-API tests must drive their setup through the matching API.
+
+### Premium
+
+Premium imports OSS via the editable `../clawbolt` path. The dual-API surface lets premium migrate call sites incrementally without lockstep merges. Premium ships its own `async_db` fixture that mirrors the OSS one but rebinds the OSS module attributes (`_oss_db_module._async_engine`, `_async_session_factory`); see premium #390 when it lands. The sync removal in #1160 is gated on premium completing its store conversions.
+
 ## Backwards Compatibility
 
 Until this project has its first production release, you do not need to be concerned about backwards compatible changes.


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds a new top-level section to `AGENTS.md` titled **Database access (sync + async dual-API)** that codifies the contract established by the async-DB migration wave (#1189, #1198-#1206). The audience is contributors who already know SQLAlchemy and need a single place to learn how new stores and new methods should be shaped during the migration window.

The section sits between **Storage** and **Backwards Compatibility**, where the existing AGENTS.md outline naturally calls for it.

Subsections, in order:
- the dual-API contract (`*` plus `*_async` peers; sync surface frozen until #1160)
- shared logic via pure typed builders (links to the IdempotencyStore pilot)
- async session lifecycle (READ-only vs WRITE; `AsyncSessionLocal()` vs `db_session_async()`)
- common SQLAlchemy 2.0 patterns (rowcount cast, `synchronize_session` placement, `with_for_update`, `db.query()` already extinct)
- encrypted columns: do not concat on the SQL side (the `MemoryDocument.history_text` bug fixed in #1200)
- advisory locks: transaction-scoped vs session-scoped, the same-connection coupling invariant, concurrency test patterns
- the `async_db` fixture's two non-obvious choices (function-scoped engine, `create_savepoint` mode) plus the iso-canary pair pattern and the cross-API caveat
- premium's incremental-migration relationship via the editable path

Every subsection links to the canonical example in the codebase (file plus line range) so readers can follow up.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- no-op for docs-only
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality -- N/A (docs-only)
- [x] Bug fixes include regression tests -- N/A (docs-only)

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake; reasoning and decisions are his, prose is Claude's)
- [ ] No AI used

Closes #1161
Part of #1139