### PR TITLE
refactor(channel_state): add realign_preferred_channel_async peer

### DIFF
--- a/backend/app/channel_state.py
+++ b/backend/app/channel_state.py
@@ -8,10 +8,39 @@ those write paths, so the helper lives here for both to import.
 
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from backend.app.models import ChannelRoute, User
+
+
+def _preferred_match_select(user: User) -> Select[tuple[ChannelRoute]]:
+    """Builder shared by sync and async realign paths.
+
+    Selects the route that already matches ``user.preferred_channel`` and
+    is enabled and not webchat. A non-null result means realignment is a
+    no-op.
+    """
+    return select(ChannelRoute).where(
+        ChannelRoute.user_id == user.id,
+        ChannelRoute.channel == user.preferred_channel,
+        ChannelRoute.enabled.is_(True),
+        ChannelRoute.channel != "webchat",
+    )
+
+
+def _fallback_select(user: User) -> Select[tuple[ChannelRoute]]:
+    """Builder shared by sync and async realign paths.
+
+    Selects any enabled non-webchat route, used when the current
+    ``preferred_channel`` no longer points at one.
+    """
+    return select(ChannelRoute).where(
+        ChannelRoute.user_id == user.id,
+        ChannelRoute.enabled.is_(True),
+        ChannelRoute.channel != "webchat",
+    )
 
 
 def realign_preferred_channel(db: Session, user: User) -> None:
@@ -29,22 +58,25 @@ def realign_preferred_channel(db: Session, user: User) -> None:
     transaction would still appear enabled here.
     """
     db.flush()
-    existing = db.execute(
-        select(ChannelRoute).where(
-            ChannelRoute.user_id == user.id,
-            ChannelRoute.channel == user.preferred_channel,
-            ChannelRoute.enabled.is_(True),
-            ChannelRoute.channel != "webchat",
-        )
-    ).scalar_one_or_none()
+    existing = db.execute(_preferred_match_select(user)).scalar_one_or_none()
     if existing is not None:
         return
-    fallback = db.execute(
-        select(ChannelRoute).where(
-            ChannelRoute.user_id == user.id,
-            ChannelRoute.enabled.is_(True),
-            ChannelRoute.channel != "webchat",
-        )
-    ).scalar_one_or_none()
+    fallback = db.execute(_fallback_select(user)).scalar_one_or_none()
+    if fallback is not None:
+        user.preferred_channel = fallback.channel
+
+
+async def realign_preferred_channel_async(db: AsyncSession, user: User) -> None:
+    """Async peer of :func:`realign_preferred_channel`.
+
+    Same semantics; mirrors the dual-API store pattern (issue #1150) so
+    async write paths in OSS and premium can call the helper without
+    blocking on a sync session.
+    """
+    await db.flush()
+    existing = (await db.execute(_preferred_match_select(user))).scalar_one_or_none()
+    if existing is not None:
+        return
+    fallback = (await db.execute(_fallback_select(user))).scalar_one_or_none()
     if fallback is not None:
         user.preferred_channel = fallback.channel

--- a/tests/test_channel_state.py
+++ b/tests/test_channel_state.py
@@ -2,8 +2,14 @@
 
 import uuid
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
 import backend.app.database as _db_module
-from backend.app.channel_state import realign_preferred_channel
+from backend.app.channel_state import (
+    realign_preferred_channel,
+    realign_preferred_channel_async,
+)
 from backend.app.models import ChannelRoute, User
 
 
@@ -114,3 +120,96 @@ def test_flushes_pending_disable() -> None:
         assert user.preferred_channel == "linq"
     finally:
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# Async peer (mirrors the sync cases above)
+# ---------------------------------------------------------------------------
+
+
+async def _make_user_async(
+    async_db: async_sessionmaker,
+    preferred_channel: str = "telegram",
+) -> str:
+    async with async_db() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id=f"test-{uuid.uuid4().hex[:8]}",
+            channel_identifier="",
+            preferred_channel=preferred_channel,
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.commit()
+        return str(user.id)
+
+
+async def test_async_noop_when_preferred_matches_enabled(
+    async_db: async_sessionmaker,
+) -> None:
+    uid = await _make_user_async(async_db, preferred_channel="telegram")
+    async with async_db() as db:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=True)
+        )
+        await db.commit()
+        user = (await db.execute(select(User).where(User.id == uid))).scalar_one()
+        await realign_preferred_channel_async(db, user)
+        await db.commit()
+        assert user.preferred_channel == "telegram"
+
+
+async def test_async_repoints_when_preferred_stale(async_db: async_sessionmaker) -> None:
+    uid = await _make_user_async(async_db, preferred_channel="telegram")
+    async with async_db() as db:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=False)
+        )
+        db.add(
+            ChannelRoute(
+                user_id=uid,
+                channel="linq",
+                channel_identifier="+15551234567",
+                enabled=True,
+            )
+        )
+        await db.commit()
+        user = (await db.execute(select(User).where(User.id == uid))).scalar_one()
+        await realign_preferred_channel_async(db, user)
+        await db.commit()
+        assert user.preferred_channel == "linq"
+
+
+async def test_async_flushes_pending_disable(async_db: async_sessionmaker) -> None:
+    """async_sessionmaker has autoflush=False (matching SessionLocal). A
+    route disabled in-session but not yet committed must still be treated
+    as disabled by the helper.
+    """
+    uid = await _make_user_async(async_db, preferred_channel="telegram")
+    async with async_db() as db:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=True)
+        )
+        db.add(
+            ChannelRoute(
+                user_id=uid,
+                channel="linq",
+                channel_identifier="+15551234567",
+                enabled=True,
+            )
+        )
+        await db.commit()
+
+        telegram_route = (
+            await db.execute(
+                select(ChannelRoute).where(
+                    ChannelRoute.user_id == uid,
+                    ChannelRoute.channel == "telegram",
+                )
+            )
+        ).scalar_one()
+        telegram_route.enabled = False
+        user = (await db.execute(select(User).where(User.id == uid))).scalar_one()
+        await realign_preferred_channel_async(db, user)
+        await db.commit()
+        assert user.preferred_channel == "linq"


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds `realign_preferred_channel_async` alongside the existing sync `realign_preferred_channel` so async write paths in OSS and premium can preserve the `preferred_channel` invariant without falling back to a sync session.

Internal logic is factored into two pure typed builders (`_preferred_match_select`, `_fallback_select`) shared between sync and async paths, matching the dual-API store pattern from #1199. Sync `realign_preferred_channel` is minimally refactored to call the same builders; observable behavior is unchanged.

Three paired async test cases mirror the existing sync cases: noop when preferred matches enabled, repoint when preferred is stale, flush-pending-disable.

This unblocks premium #391 (channels_router async pilot in mozilla-ai/clawbolt-premium#421) and is the first cross-repo paired conversion for OSS Phase C.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v tests/test_channel_state.py`)
- [x] Lint passes (`ruff check backend/ tests/ alembic/`)
- [x] Format passes (`ruff format --check backend/ tests/ alembic/`)
- [x] Type checking passes (`ty check`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests (n/a)

## AI Usage
- [x] AI-assisted (drafted by Claude as part of the channels_router pilot work for premium #391; the OSS-side helper landed first as a paired prereq)

Part of #1139.