### PR TITLE
refactor(boot): convert health probe + lifespan to async DB

### DIFF
--- a/backend/app/channel_state.py
+++ b/backend/app/channel_state.py
@@ -8,10 +8,39 @@ those write paths, so the helper lives here for both to import.
 
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from backend.app.models import ChannelRoute, User
+
+
+def _preferred_match_select(user: User) -> Select[tuple[ChannelRoute]]:
+    """Builder shared by sync and async realign paths.
+
+    Selects the route that already matches ``user.preferred_channel`` and
+    is enabled and not webchat. A non-null result means realignment is a
+    no-op.
+    """
+    return select(ChannelRoute).where(
+        ChannelRoute.user_id == user.id,
+        ChannelRoute.channel == user.preferred_channel,
+        ChannelRoute.enabled.is_(True),
+        ChannelRoute.channel != "webchat",
+    )
+
+
+def _fallback_select(user: User) -> Select[tuple[ChannelRoute]]:
+    """Builder shared by sync and async realign paths.
+
+    Selects any enabled non-webchat route, used when the current
+    ``preferred_channel`` no longer points at one.
+    """
+    return select(ChannelRoute).where(
+        ChannelRoute.user_id == user.id,
+        ChannelRoute.enabled.is_(True),
+        ChannelRoute.channel != "webchat",
+    )
 
 
 def realign_preferred_channel(db: Session, user: User) -> None:
@@ -29,22 +58,25 @@ def realign_preferred_channel(db: Session, user: User) -> None:
     transaction would still appear enabled here.
     """
     db.flush()
-    existing = db.execute(
-        select(ChannelRoute).where(
-            ChannelRoute.user_id == user.id,
-            ChannelRoute.channel == user.preferred_channel,
-            ChannelRoute.enabled.is_(True),
-            ChannelRoute.channel != "webchat",
-        )
-    ).scalar_one_or_none()
+    existing = db.execute(_preferred_match_select(user)).scalar_one_or_none()
     if existing is not None:
         return
-    fallback = db.execute(
-        select(ChannelRoute).where(
-            ChannelRoute.user_id == user.id,
-            ChannelRoute.enabled.is_(True),
-            ChannelRoute.channel != "webchat",
-        )
-    ).scalar_one_or_none()
+    fallback = db.execute(_fallback_select(user)).scalar_one_or_none()
+    if fallback is not None:
+        user.preferred_channel = fallback.channel
+
+
+async def realign_preferred_channel_async(db: AsyncSession, user: User) -> None:
+    """Async peer of :func:`realign_preferred_channel`.
+
+    Same semantics; mirrors the dual-API store pattern (issue #1150) so
+    async write paths in OSS and premium can call the helper without
+    blocking on a sync session.
+    """
+    await db.flush()
+    existing = (await db.execute(_preferred_match_select(user))).scalar_one_or_none()
+    if existing is not None:
+        return
+    fallback = (await db.execute(_fallback_select(user))).scalar_one_or_none()
     if fallback is not None:
         user.preferred_channel = fallback.channel

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ from backend.app.config_store import (
     get_settings_store,
     import_legacy_config_json,
 )
-from backend.app.database import SessionLocal, get_engine
+from backend.app.database import db_session_async, get_engine
 from backend.app.logging_utils import mask_pii
 from backend.app.models import ChannelRoute, User
 from backend.app.routers import (
@@ -65,7 +65,7 @@ register_channel(LinqChannel())
 register_channel(BlueBubblesChannel())
 
 
-def _enforce_single_channel() -> None:
+async def _enforce_single_channel() -> None:
     """One-time: disable non-preferred routes for existing multi-channel users.
 
     After the single-channel refactor, each user should have at most one
@@ -77,12 +77,13 @@ def _enforce_single_channel() -> None:
     consumers (heartbeat, reauth notifications) consistent without needing
     read-time drift-sync.
     """
-    db = SessionLocal()
-    try:
-        users = db.execute(select(User)).scalars().all()
+    async with db_session_async() as db:
+        users = (await db.execute(select(User))).scalars().all()
         fixed = 0
         for user in users:
-            routes = db.execute(select(ChannelRoute).filter_by(user_id=user.id)).scalars().all()
+            routes = (
+                (await db.execute(select(ChannelRoute).filter_by(user_id=user.id))).scalars().all()
+            )
             enabled_messaging = [r for r in routes if r.enabled and r.channel != "webchat"]
             if len(enabled_messaging) > 1:
                 preferred_match = next(
@@ -101,13 +102,11 @@ def _enforce_single_channel() -> None:
                     user.preferred_channel = keeper.channel
                 fixed += 1
         if fixed:
-            db.commit()
+            await db.commit()
             logger.info(
                 "Single-channel enforcement: fixed %d user(s) with multiple enabled channels",
                 fixed,
             )
-    finally:
-        db.close()
 
 
 async def _verify_llm_settings() -> None:
@@ -222,7 +221,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     # env_file directive; this call covers bare-host / local-dev setups.
     load_dotenv()
 
-    _enforce_single_channel()
+    await _enforce_single_channel()
     validate_imessage_backend()
     validate_personal_storage_backend()
     log_config_warnings()

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -3,7 +3,7 @@ import logging
 from fastapi import APIRouter
 from sqlalchemy import text
 
-from backend.app.database import SessionLocal
+from backend.app.database import AsyncSessionLocal
 from backend.app.schemas import HealthResponse
 
 logger = logging.getLogger(__name__)
@@ -15,18 +15,17 @@ async def health_check() -> HealthResponse:
     """Full health check: process is up AND can reach the database.
 
     Use for ops dashboards and richer monitoring. NOT recommended as the
-    deployment platform's healthcheck path: a sync DB call from an async
-    handler can block the event loop, and during an incident a healthcheck
-    that waits on the same DB can pile up alongside whatever already broke.
-    Use ``/health/live`` for that.
+    deployment platform's healthcheck path: during an incident a
+    healthcheck that waits on the same DB can pile up alongside whatever
+    already broke. Use ``/health/live`` for that.
     """
     db_status = "ok"
     try:
-        db = SessionLocal()
+        db = AsyncSessionLocal()
         try:
-            db.execute(text("SELECT 1"))
+            await db.execute(text("SELECT 1"))
         finally:
-            db.close()
+            await db.close()
     except Exception:
         logger.exception("Health check: database unreachable")
         db_status = "error"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -462,7 +462,7 @@ def linq_client(test_user: User) -> Generator[TestClient]:
 
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
-        patch("backend.app.main._enforce_single_channel"),
+        patch("backend.app.main._enforce_single_channel", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.channels.linq.settings.linq_allowed_numbers", "*"),
         patch("backend.app.channels.linq.settings.linq_webhook_signing_secret", ""),
@@ -498,7 +498,7 @@ def bluebubbles_client(test_user: User) -> Generator[TestClient]:
 
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
-        patch("backend.app.main._enforce_single_channel"),
+        patch("backend.app.main._enforce_single_channel", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"),
         patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", ""),
@@ -524,7 +524,7 @@ def client(test_user: User) -> Generator[TestClient]:
     app.dependency_overrides[get_current_user] = _override_get_current_user
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
-        patch("backend.app.main._enforce_single_channel"),
+        patch("backend.app.main._enforce_single_channel", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         # Default allowlist to "*" (allow all) so tests are not blocked.
         # Individual allowlist tests override these values.

--- a/tests/test_channel_state.py
+++ b/tests/test_channel_state.py
@@ -2,8 +2,14 @@
 
 import uuid
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
 import backend.app.database as _db_module
-from backend.app.channel_state import realign_preferred_channel
+from backend.app.channel_state import (
+    realign_preferred_channel,
+    realign_preferred_channel_async,
+)
 from backend.app.models import ChannelRoute, User
 
 
@@ -114,3 +120,96 @@ def test_flushes_pending_disable() -> None:
         assert user.preferred_channel == "linq"
     finally:
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# Async peer (mirrors the sync cases above)
+# ---------------------------------------------------------------------------
+
+
+async def _make_user_async(
+    async_db: async_sessionmaker,
+    preferred_channel: str = "telegram",
+) -> str:
+    async with async_db() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id=f"test-{uuid.uuid4().hex[:8]}",
+            channel_identifier="",
+            preferred_channel=preferred_channel,
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.commit()
+        return str(user.id)
+
+
+async def test_async_noop_when_preferred_matches_enabled(
+    async_db: async_sessionmaker,
+) -> None:
+    uid = await _make_user_async(async_db, preferred_channel="telegram")
+    async with async_db() as db:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=True)
+        )
+        await db.commit()
+        user = (await db.execute(select(User).where(User.id == uid))).scalar_one()
+        await realign_preferred_channel_async(db, user)
+        await db.commit()
+        assert user.preferred_channel == "telegram"
+
+
+async def test_async_repoints_when_preferred_stale(async_db: async_sessionmaker) -> None:
+    uid = await _make_user_async(async_db, preferred_channel="telegram")
+    async with async_db() as db:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=False)
+        )
+        db.add(
+            ChannelRoute(
+                user_id=uid,
+                channel="linq",
+                channel_identifier="+15551234567",
+                enabled=True,
+            )
+        )
+        await db.commit()
+        user = (await db.execute(select(User).where(User.id == uid))).scalar_one()
+        await realign_preferred_channel_async(db, user)
+        await db.commit()
+        assert user.preferred_channel == "linq"
+
+
+async def test_async_flushes_pending_disable(async_db: async_sessionmaker) -> None:
+    """async_sessionmaker has autoflush=False (matching SessionLocal). A
+    route disabled in-session but not yet committed must still be treated
+    as disabled by the helper.
+    """
+    uid = await _make_user_async(async_db, preferred_channel="telegram")
+    async with async_db() as db:
+        db.add(
+            ChannelRoute(user_id=uid, channel="telegram", channel_identifier="111", enabled=True)
+        )
+        db.add(
+            ChannelRoute(
+                user_id=uid,
+                channel="linq",
+                channel_identifier="+15551234567",
+                enabled=True,
+            )
+        )
+        await db.commit()
+
+        telegram_route = (
+            await db.execute(
+                select(ChannelRoute).where(
+                    ChannelRoute.user_id == uid,
+                    ChannelRoute.channel == "telegram",
+                )
+            )
+        ).scalar_one()
+        telegram_route.enabled = False
+        user = (await db.execute(select(User).where(User.id == uid))).scalar_one()
+        await realign_preferred_channel_async(db, user)
+        await db.commit()
+        assert user.preferred_channel == "linq"

--- a/tests/test_single_channel.py
+++ b/tests/test_single_channel.py
@@ -7,6 +7,9 @@ unknown channel rejection) and startup migration.
 
 import uuid
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
 import backend.app.database as _db_module
 from backend.app.agent.heartbeat import resolve_heartbeat_route
 from backend.app.agent.ingestion import _get_or_create_user
@@ -46,6 +49,42 @@ def _create_user_with_routes(
     finally:
         db.close()
     return uid
+
+
+async def _create_user_with_routes_async(
+    async_db: async_sessionmaker,
+    routes: list[tuple[str, str, bool]],
+    preferred_channel: str = "telegram",
+) -> str:
+    """Async peer of ``_create_user_with_routes``.
+
+    Writes through the per-test async connection so rows are visible to
+    ``_enforce_single_channel`` (which uses ``db_session_async()``) under
+    the same outer transaction. The cross-API caveat in AGENTS.md
+    prevents the sync helper above from being used for async-native
+    tests.
+    """
+    async with async_db() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id=f"test-{uuid.uuid4().hex[:8]}",
+            channel_identifier=routes[0][1] if routes else "",
+            preferred_channel=preferred_channel,
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.flush()
+        for channel, identifier, enabled in routes:
+            db.add(
+                ChannelRoute(
+                    user_id=user.id,
+                    channel=channel,
+                    channel_identifier=identifier,
+                    enabled=enabled,
+                )
+            )
+        await db.commit()
+        return str(user.id)
 
 
 class TestAutoDisableOnEnable:
@@ -412,12 +451,20 @@ class TestHeartbeatRouting:
 
 
 class TestStartupMigration:
-    """_enforce_single_channel fixes users with multiple enabled routes."""
+    """_enforce_single_channel fixes users with multiple enabled routes.
 
-    def test_disables_non_preferred_routes(self) -> None:
+    These tests opt in to the ``async_db`` fixture: setup writes go
+    through the per-test async connection so the rows are visible to
+    ``_enforce_single_channel`` (which uses ``db_session_async()``)
+    under the same outer transaction. Mixing sync setup with the async
+    helper would hit the cross-API caveat documented in AGENTS.md.
+    """
+
+    async def test_disables_non_preferred_routes(self, async_db: async_sessionmaker) -> None:
         from backend.app.main import _enforce_single_channel
 
-        uid = _create_user_with_routes(
+        uid = await _create_user_with_routes_async(
+            async_db,
             [
                 ("telegram", "mig-111", True),
                 ("linq", "+15551234567", True),
@@ -426,21 +473,19 @@ class TestStartupMigration:
             preferred_channel="telegram",
         )
 
-        _enforce_single_channel()
+        await _enforce_single_channel()
 
-        db = _db_module.SessionLocal()
-        try:
-            routes = db.query(ChannelRoute).filter_by(user_id=uid).all()
+        async with async_db() as db:
+            routes = (await db.execute(select(ChannelRoute).filter_by(user_id=uid))).scalars().all()
             enabled = [r for r in routes if r.enabled and r.channel != "webchat"]
             assert len(enabled) == 1
             assert enabled[0].channel == "telegram"
-        finally:
-            db.close()
 
-    def test_preserves_webchat_route(self) -> None:
+    async def test_preserves_webchat_route(self, async_db: async_sessionmaker) -> None:
         from backend.app.main import _enforce_single_channel
 
-        uid = _create_user_with_routes(
+        uid = await _create_user_with_routes_async(
+            async_db,
             [
                 ("telegram", "mig-222", True),
                 ("linq", "+15552222222", True),
@@ -449,8 +494,7 @@ class TestStartupMigration:
         )
 
         # Add webchat route separately
-        db = _db_module.SessionLocal()
-        try:
+        async with async_db() as db:
             db.add(
                 ChannelRoute(
                     user_id=uid,
@@ -459,41 +503,38 @@ class TestStartupMigration:
                     enabled=True,
                 )
             )
-            db.commit()
-        finally:
-            db.close()
+            await db.commit()
 
-        _enforce_single_channel()
+        await _enforce_single_channel()
 
-        db = _db_module.SessionLocal()
-        try:
-            webchat = db.query(ChannelRoute).filter_by(user_id=uid, channel="webchat").first()
+        async with async_db() as db:
+            webchat = (
+                await db.execute(select(ChannelRoute).filter_by(user_id=uid, channel="webchat"))
+            ).scalar_one_or_none()
             assert webchat is not None
             assert webchat.enabled is True
-        finally:
-            db.close()
 
-    def test_no_change_when_single_channel(self) -> None:
+    async def test_no_change_when_single_channel(self, async_db: async_sessionmaker) -> None:
         from backend.app.main import _enforce_single_channel
 
-        uid = _create_user_with_routes(
+        uid = await _create_user_with_routes_async(
+            async_db,
             [
                 ("telegram", "mig-333", True),
             ],
             preferred_channel="telegram",
         )
 
-        _enforce_single_channel()
+        await _enforce_single_channel()
 
-        db = _db_module.SessionLocal()
-        try:
-            route = db.query(ChannelRoute).filter_by(user_id=uid, channel="telegram").first()
+        async with async_db() as db:
+            route = (
+                await db.execute(select(ChannelRoute).filter_by(user_id=uid, channel="telegram"))
+            ).scalar_one_or_none()
             assert route is not None
             assert route.enabled is True
-        finally:
-            db.close()
 
-    def test_realigns_preferred_when_stale(self) -> None:
+    async def test_realigns_preferred_when_stale(self, async_db: async_sessionmaker) -> None:
         """preferred_channel is repointed to an enabled route when stale.
 
         Multi-channel users whose ``preferred_channel`` points at a channel
@@ -502,7 +543,8 @@ class TestStartupMigration:
         """
         from backend.app.main import _enforce_single_channel
 
-        uid = _create_user_with_routes(
+        uid = await _create_user_with_routes_async(
+            async_db,
             [
                 ("linq", "+15551111111", True),
                 ("bluebubbles", "+15552222222", True),
@@ -510,26 +552,27 @@ class TestStartupMigration:
             preferred_channel="telegram",
         )
 
-        _enforce_single_channel()
+        await _enforce_single_channel()
 
-        db = _db_module.SessionLocal()
-        try:
-            user = db.query(User).filter_by(id=uid).first()
+        async with async_db() as db:
+            user = (await db.execute(select(User).filter_by(id=uid))).scalar_one_or_none()
             assert user is not None
             assert user.preferred_channel in {"linq", "bluebubbles"}
             enabled = (
-                db.query(ChannelRoute)
-                .filter(
-                    ChannelRoute.user_id == uid,
-                    ChannelRoute.enabled.is_(True),
-                    ChannelRoute.channel != "webchat",
+                (
+                    await db.execute(
+                        select(ChannelRoute).where(
+                            ChannelRoute.user_id == uid,
+                            ChannelRoute.enabled.is_(True),
+                            ChannelRoute.channel != "webchat",
+                        )
+                    )
                 )
+                .scalars()
                 .all()
             )
             assert len(enabled) == 1
             assert enabled[0].channel == user.preferred_channel
-        finally:
-            db.close()
 
 
 class TestPatchDisableSyncsPreferred:


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Two boot-path call sites move off the sync session:

- `health_check` (`/api/health`) now opens an `AsyncSession` and awaits `SELECT 1`. The stale "sync DB call from an async handler can block the event loop" caveat in the docstring goes away; the "do not use as the platform healthcheck" guidance remains because a deep DB hit is still a poor liveness signal.
- `_enforce_single_channel` becomes `async def` and uses `db_session_async()`. The lifespan handler awaits it. SQL shape and ordering are preserved so the cleanup invariant is unchanged.

Per the issue body, the lifespan handler is the lowest-priority item in the bundle: a regression there is bounded to startup time, not steady-state event-loop blocking. Convert for consistency.

Test changes:
- The startup-migration tests in `tests/test_single_channel.py` opt in to `async_db` so setup writes go through the per-test async connection (cross-API caveat from AGENTS.md).
- conftest's three `_enforce_single_channel` patches switch to `AsyncMock` so the lifespan's `await` resolves cleanly.

Addresses health + lifespan boot slice of #1178; agent-module and calendar slices follow in separate PRs.

Part of #1139.

This PR is stacked on top of #1210; the engine-rebinding fixture from that PR is required for the converted `/api/health` route to talk to the test DB rather than the production engine. GitHub will retarget this PR to `main` once #1210 merges.

## Type
- [x] Refactor

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 drafted the diff and tests via back-and-forth with @njbrake; reasoning and decisions are his.)
- [ ] No AI used