### PR TITLE
refactor(db): convert advisory-lock paths to async

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -33,7 +33,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from backend.app.bus import OutboundMessage
 from backend.app.config import settings
-from backend.app.database import SessionLocal, db_session
+from backend.app.database import SessionLocal, db_session, db_session_async
 from backend.app.models import ApprovalEvent, PendingApprovalRow, UserPermissionSet
 
 logger = logging.getLogger(__name__)
@@ -42,6 +42,15 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # ApprovalStore helpers
 # ---------------------------------------------------------------------------
+
+
+def _user_permissions_lock_key(user_id: str) -> str:
+    """Stable string key for the per-user permissions advisory lock.
+
+    Shared between sync and async callers so the two paths contend on
+    the same key.
+    """
+    return f"user_permissions:{user_id}"
 
 
 def _lock_user_permissions(db: Any, user_id: str) -> None:
@@ -54,7 +63,24 @@ def _lock_user_permissions(db: Any, user_id: str) -> None:
     """
     db.execute(
         text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
-        {"k": f"user_permissions:{user_id}"},
+        {"k": _user_permissions_lock_key(user_id)},
+    )
+
+
+async def _lock_user_permissions_async(db: Any, user_id: str) -> None:
+    """Async peer of ``_lock_user_permissions``.
+
+    Same ``pg_advisory_xact_lock`` semantics: the lock is bound to the
+    surrounding transaction and released only on COMMIT / ROLLBACK of
+    that transaction. ``db`` is an ``AsyncSession`` (or any handle that
+    awaits ``execute(...)``); the caller must hold the lock and the
+    matching read+write inside a single ``async with db.begin()`` /
+    ``async with db_session_async()`` block so the autobegun
+    transaction owns the lock.
+    """
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+        {"k": _user_permissions_lock_key(user_id)},
     )
 
 
@@ -71,6 +97,15 @@ def _parse_row_data(row: UserPermissionSet | None) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         return default
     return parsed
+
+
+def _select_user_permissions(user_id: str) -> Any:
+    """Select the ``UserPermissionSet`` row for one user.
+
+    Shared between sync and async paths so the query shape stays in
+    lockstep across the dual-API surface.
+    """
+    return select(UserPermissionSet).filter_by(user_id=user_id)
 
 
 # ---------------------------------------------------------------------------
@@ -212,9 +247,13 @@ class ApprovalStore:
 
     def _load(self, user_id: str) -> dict[str, Any]:
         with db_session() as db:
-            row = db.execute(
-                select(UserPermissionSet).filter_by(user_id=user_id)
-            ).scalar_one_or_none()
+            row = db.execute(_select_user_permissions(user_id)).scalar_one_or_none()
+            return _parse_row_data(row)
+
+    async def _load_async(self, user_id: str) -> dict[str, Any]:
+        """Async peer of ``_load``."""
+        async with db_session_async() as db:
+            row = (await db.execute(_select_user_permissions(user_id))).scalar_one_or_none()
             return _parse_row_data(row)
 
     def _save(self, user_id: str, data: dict[str, Any]) -> None:
@@ -225,14 +264,31 @@ class ApprovalStore:
         payload = json.dumps(data, indent=2, default=str)
         with db_session() as db:
             _lock_user_permissions(db, user_id)
-            row = db.execute(
-                select(UserPermissionSet).filter_by(user_id=user_id)
-            ).scalar_one_or_none()
+            row = db.execute(_select_user_permissions(user_id)).scalar_one_or_none()
             if row is None:
                 db.add(UserPermissionSet(user_id=user_id, data=payload))
             else:
                 row.data = payload
             db.commit()
+
+    async def _save_async(self, user_id: str, data: dict[str, Any]) -> None:
+        """Async peer of ``_save``.
+
+        Acquires the per-user ``pg_advisory_xact_lock`` on the same
+        AsyncSession that performs the read+write. The lock and the
+        DML share one autobegun transaction, so the lock is released
+        only when ``await db.commit()`` (handled by
+        ``db_session_async``) ends that transaction.
+        """
+        payload = json.dumps(data, indent=2, default=str)
+        async with db_session_async() as db:
+            await _lock_user_permissions_async(db, user_id)
+            row = (await db.execute(_select_user_permissions(user_id))).scalar_one_or_none()
+            if row is None:
+                db.add(UserPermissionSet(user_id=user_id, data=payload))
+            else:
+                row.data = payload
+            await db.commit()
 
     def load_user_permissions(self, user_id: str) -> dict[str, Any]:
         """Load the raw permission data for a user.
@@ -241,6 +297,10 @@ class ApprovalStore:
         repeated file reads.
         """
         return self._load(user_id)
+
+    async def load_user_permissions_async(self, user_id: str) -> dict[str, Any]:
+        """Async peer of ``load_user_permissions``."""
+        return await self._load_async(user_id)
 
     @staticmethod
     def resolve_permission(
@@ -283,6 +343,17 @@ class ApprovalStore:
         data = self._load(user_id)
         return self.resolve_permission(data, tool_name, resource, default)
 
+    async def check_permission_async(
+        self,
+        user_id: str,
+        tool_name: str,
+        resource: str | None = None,
+        default: PermissionLevel = PermissionLevel.ASK,
+    ) -> PermissionLevel:
+        """Async peer of ``check_permission``."""
+        data = await self._load_async(user_id)
+        return self.resolve_permission(data, tool_name, resource, default)
+
     def generate_defaults(self, user_id: str) -> dict[str, Any]:
         """Build a complete permissions dict with all tools at their default levels."""
         from backend.app.agent.tools.registry import (
@@ -310,9 +381,26 @@ class ApprovalStore:
             self._save(user_id, data)
         return data
 
+    async def ensure_complete_async(self, user_id: str) -> dict[str, Any]:
+        """Async peer of ``ensure_complete``."""
+        data = await self._load_async(user_id)
+        defaults = self.generate_defaults(user_id)
+        changed = False
+        for tool_name, default_level in defaults["tools"].items():
+            if tool_name not in data.get("tools", {}):
+                data.setdefault("tools", {})[tool_name] = default_level
+                changed = True
+        if changed:
+            await self._save_async(user_id, data)
+        return data
+
     def reset_permissions(self, user_id: str) -> None:
         """Reset all permissions to defaults."""
         self._save(user_id, self.generate_defaults(user_id))
+
+    async def reset_permissions_async(self, user_id: str) -> None:
+        """Async peer of ``reset_permissions``."""
+        await self._save_async(user_id, self.generate_defaults(user_id))
 
     def set_permission(
         self,
@@ -335,9 +423,7 @@ class ApprovalStore:
         """
         with db_session() as db:
             _lock_user_permissions(db, user_id)
-            row = db.execute(
-                select(UserPermissionSet).filter_by(user_id=user_id)
-            ).scalar_one_or_none()
+            row = db.execute(_select_user_permissions(user_id)).scalar_one_or_none()
             data = _parse_row_data(row)
 
             # ensure_complete-style backfill: fill missing tool defaults.
@@ -356,6 +442,45 @@ class ApprovalStore:
             else:
                 row.data = payload
             db.commit()
+
+    async def set_permission_async(
+        self,
+        user_id: str,
+        tool_name: str,
+        level: PermissionLevel,
+        resource: str | None = None,
+    ) -> None:
+        """Async peer of ``set_permission``.
+
+        Same lost-update guard as the sync path: lock + read +
+        backfill-merge + write all happen inside one autobegun async
+        transaction so the lock is released only after the write
+        commits. ``db_session_async`` calls ``await db.commit()``
+        implicitly via its context manager exit only on success;
+        rollback on exception drops the lock too. Either way the
+        transaction-scoped lock cannot leak past this method.
+        """
+        async with db_session_async() as db:
+            await _lock_user_permissions_async(db, user_id)
+            row = (await db.execute(_select_user_permissions(user_id))).scalar_one_or_none()
+            data = _parse_row_data(row)
+
+            # ensure_complete-style backfill: fill missing tool defaults.
+            defaults = self.generate_defaults(user_id)
+            for tname, default_level in defaults["tools"].items():
+                data.setdefault("tools", {}).setdefault(tname, default_level)
+
+            if resource is not None:
+                data.setdefault("resources", {}).setdefault(tool_name, {})[resource] = str(level)
+            else:
+                data.setdefault("tools", {})[tool_name] = str(level)
+
+            payload = json.dumps(data, indent=2, default=str)
+            if row is None:
+                db.add(UserPermissionSet(user_id=user_id, data=payload))
+            else:
+                row.data = payload
+            await db.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/inbound_recovery.py
+++ b/backend/app/agent/inbound_recovery.py
@@ -55,17 +55,18 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from sqlalchemy import and_, exists, select, text
+from sqlalchemy import Select, and_, exists, select, text
 
-from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.dto import SessionState, StoredMessage
 from backend.app.agent.ingestion import _dispatch_to_pipeline
+from backend.app.agent.session_db import get_session_store
 from backend.app.config import settings
-from backend.app.database import SessionLocal
+from backend.app.database import AsyncSessionLocal, get_async_engine
 from backend.app.enums import MessageDirection
 from backend.app.models import ChatSession, Message, User
 
 if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
     from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -80,6 +81,37 @@ _RECOVERY_LOCK_KEY = "inbound_recovery:cleanup"
 # timer), and a parallel recovery would race it. 5 s comfortably covers
 # the 1.5 s batcher window plus pipeline acquisition latency.
 _FRESHNESS_FLOOR_SECONDS = 5
+
+
+def _orphaned_inbounds_select(
+    cutoff_utc: datetime.datetime,
+    freshness_floor_utc: datetime.datetime,
+) -> Select[tuple[Message, ChatSession]]:
+    """Pure builder for the orphan-inbound query.
+
+    Shared between sync and async recovery paths so the query shape and
+    filter semantics stay identical. See ``_find_orphaned_inbounds``
+    for the rationale on each filter.
+    """
+    OutboundAfter = Message.__table__.alias("ob")
+    has_outbound_after = exists().where(
+        and_(
+            OutboundAfter.c.session_id == Message.session_id,
+            OutboundAfter.c.seq > Message.seq,
+            OutboundAfter.c.direction == MessageDirection.OUTBOUND,
+        )
+    )
+    return (
+        select(Message, ChatSession)
+        .join(ChatSession, Message.session_id == ChatSession.id)
+        .where(
+            Message.direction == MessageDirection.INBOUND,
+            Message.timestamp >= cutoff_utc,
+            Message.timestamp <= freshness_floor_utc,
+            ~has_outbound_after,
+        )
+        .order_by(Message.timestamp.asc())
+    )
 
 
 def _find_orphaned_inbounds(
@@ -100,28 +132,62 @@ def _find_orphaned_inbounds(
     the sweep doesn't race the normal ingestion path on a brand-new
     inbound that arrived during the sweep itself.
     """
-    OutboundAfter = Message.__table__.alias("ob")
-    has_outbound_after = exists().where(
-        and_(
-            OutboundAfter.c.session_id == Message.session_id,
-            OutboundAfter.c.seq > Message.seq,
-            OutboundAfter.c.direction == MessageDirection.OUTBOUND,
-        )
-    )
-    rows = db.execute(
-        select(Message, ChatSession)
-        .join(ChatSession, Message.session_id == ChatSession.id)
-        .where(
-            Message.direction == MessageDirection.INBOUND,
-            Message.timestamp >= cutoff_utc,
-            Message.timestamp <= freshness_floor_utc,
-            ~has_outbound_after,
-        )
-        .order_by(Message.timestamp.asc())
-    ).all()
+    rows = db.execute(_orphaned_inbounds_select(cutoff_utc, freshness_floor_utc)).all()
     # Convert Row objects to plain tuples so callers don't need to know
     # the Row API.
     return [(row[0], row[1]) for row in rows]
+
+
+async def _find_orphaned_inbounds_async(
+    db: AsyncSession,
+    cutoff_utc: datetime.datetime,
+    freshness_floor_utc: datetime.datetime,
+) -> list[tuple[Message, ChatSession]]:
+    """Async peer of ``_find_orphaned_inbounds``."""
+    rows = (await db.execute(_orphaned_inbounds_select(cutoff_utc, freshness_floor_utc))).all()
+    return [(row[0], row[1]) for row in rows]
+
+
+def _select_user_by_id(user_id: str) -> Select[tuple[User]]:
+    """Pure builder for the per-orphan user lookup.
+
+    Shared between sync and async ``_build_dispatch_inputs`` peers so
+    they cannot drift on filter shape.
+    """
+    return select(User).filter_by(id=user_id)
+
+
+def _orphan_to_stored_and_state(
+    msg: Message,
+    chat_session: ChatSession,
+) -> tuple[StoredMessage, SessionState]:
+    """Pure mapping from an orphan ``Message`` row plus its
+    ``ChatSession`` to the (stored_message, session_state) the dispatch
+    pipeline expects.
+
+    No DB access; safe to share between sync and async peers.
+    """
+    stored = StoredMessage(
+        direction=msg.direction,
+        body=msg.body or "",
+        processed_context=msg.processed_context or "",
+        tool_interactions_json=msg.tool_interactions_json or "",
+        external_message_id=msg.external_message_id or "",
+        media_urls_json=msg.media_urls_json or "[]",
+        timestamp=msg.timestamp.isoformat() if msg.timestamp else "",
+        seq=msg.seq,
+    )
+    state = SessionState(
+        session_id=chat_session.session_id,
+        user_id=chat_session.user_id,
+        messages=[stored],
+        created_at=chat_session.created_at.isoformat() if chat_session.created_at else "",
+        last_message_at=(
+            chat_session.last_message_at.isoformat() if chat_session.last_message_at else ""
+        ),
+        channel=chat_session.channel or "",
+    )
+    return stored, state
 
 
 def _build_dispatch_inputs(
@@ -143,7 +209,7 @@ def _build_dispatch_inputs(
     Returns None when the user row is missing (extremely unlikely outside
     of a manual delete during the recovery window).
     """
-    user = db.execute(select(User).filter_by(id=chat_session.user_id)).scalar_one_or_none()
+    user = db.execute(_select_user_by_id(chat_session.user_id)).scalar_one_or_none()
     if user is None:
         logger.warning(
             "Skipping orphan recovery for message %d: user %s not found",
@@ -153,27 +219,27 @@ def _build_dispatch_inputs(
         return None
     db.expunge(user)
 
-    stored = StoredMessage(
-        direction=msg.direction,
-        body=msg.body or "",
-        processed_context=msg.processed_context or "",
-        tool_interactions_json=msg.tool_interactions_json or "",
-        external_message_id=msg.external_message_id or "",
-        media_urls_json=msg.media_urls_json or "[]",
-        timestamp=msg.timestamp.isoformat() if msg.timestamp else "",
-        seq=msg.seq,
-    )
+    stored, state = _orphan_to_stored_and_state(msg, chat_session)
+    return user, state, stored
 
-    state = SessionState(
-        session_id=chat_session.session_id,
-        user_id=chat_session.user_id,
-        messages=[stored],
-        created_at=chat_session.created_at.isoformat() if chat_session.created_at else "",
-        last_message_at=(
-            chat_session.last_message_at.isoformat() if chat_session.last_message_at else ""
-        ),
-        channel=chat_session.channel or "",
-    )
+
+async def _build_dispatch_inputs_async(
+    db: AsyncSession,
+    msg: Message,
+    chat_session: ChatSession,
+) -> tuple[User, SessionState, StoredMessage] | None:
+    """Async peer of ``_build_dispatch_inputs``."""
+    user = (await db.execute(_select_user_by_id(chat_session.user_id))).scalar_one_or_none()
+    if user is None:
+        logger.warning(
+            "Skipping orphan recovery for message %d: user %s not found",
+            msg.id,
+            chat_session.user_id,
+        )
+        return None
+    db.expunge(user)
+
+    stored, state = _orphan_to_stored_and_state(msg, chat_session)
     return user, state, stored
 
 
@@ -228,6 +294,53 @@ def _release_lock(db: Session) -> None:
         logger.exception("Failed to release inbound-recovery advisory lock")
 
 
+async def _try_acquire_lock_async(conn: AsyncConnection) -> bool:
+    """Async peer of ``_try_acquire_lock``.
+
+    ``conn`` MUST be an ``AsyncConnection`` (not an ``AsyncSession``):
+    ``AsyncSession.commit()`` returns the underlying connection to the
+    pool, which would let a peer task pick the same connection up and
+    re-enter the critical section (locks are reentrant per PG session).
+    The session-scoped advisory lock must stay pinned to one physical
+    connection from acquire through unlock. The
+    ``test_unlock_on_different_connection_is_a_no_op`` regression in
+    ``tests/test_inbound_recovery.py`` traps any future refactor that
+    breaks this coupling.
+    """
+    try:
+        result = await conn.execute(
+            text("SELECT pg_try_advisory_lock(hashtext(:k))"),
+            {"k": _RECOVERY_LOCK_KEY},
+        )
+        got_lock = result.scalar()
+        # Commit ends the implicit read transaction so we don't sit
+        # idle-in-transaction while we go off and do recovery work. On
+        # an AsyncConnection this does NOT return the connection to
+        # the pool, so the advisory lock stays attached.
+        await conn.commit()
+    except Exception:
+        logger.exception("Failed to acquire inbound-recovery advisory lock")
+        return False
+    return bool(got_lock)
+
+
+async def _release_lock_async(conn: AsyncConnection) -> None:
+    """Async peer of ``_release_lock``.
+
+    Must run on the same ``AsyncConnection`` that took the lock or
+    Postgres returns ``False`` and the unlock silently no-ops. See
+    ``_try_acquire_lock_async`` for the connection-coupling rationale.
+    """
+    try:
+        await conn.execute(
+            text("SELECT pg_advisory_unlock(hashtext(:k))"),
+            {"k": _RECOVERY_LOCK_KEY},
+        )
+        await conn.commit()
+    except Exception:
+        logger.exception("Failed to release inbound-recovery advisory lock")
+
+
 async def recover_orphan_inbound_messages() -> int:
     """Re-dispatch any inbound messages that look like they never ran.
 
@@ -235,6 +348,18 @@ async def recover_orphan_inbound_messages() -> int:
     messages re-dispatched, mostly for the startup log line. Best-effort:
     the sweep itself is wrapped in try/except by the caller so a recovery
     bug never blocks app startup.
+
+    The advisory lock and the per-orphan queries run on different
+    handles. The lock connection (``AsyncConnection`` from
+    ``get_async_engine``) is held across the whole sweep so the
+    session-scoped ``pg_try_advisory_lock`` / ``pg_advisory_unlock``
+    pair lands on the same physical Postgres session. The queries run
+    on a separate ``AsyncSession`` so its commits do not bounce the
+    lock connection. Pool sizing note: each in-flight recovery sweep
+    holds one async-pool connection for the duration of the sweep
+    (lock + dispatches), and ``_dispatch_to_pipeline`` itself may
+    acquire more connections for the agent loop. Operators sizing the
+    async pool should budget for this concurrency.
     """
     lookback_minutes = settings.inbound_recovery_lookback_minutes
     if lookback_minutes == 0:
@@ -245,77 +370,89 @@ async def recover_orphan_inbound_messages() -> int:
     cutoff = now - datetime.timedelta(minutes=lookback_minutes)
     freshness_floor = now - datetime.timedelta(seconds=_FRESHNESS_FLOOR_SECONDS)
 
-    db = SessionLocal()
+    lock_conn = await get_async_engine().connect()
     lock_acquired = False
     try:
-        if not _try_acquire_lock(db):
+        if not await _try_acquire_lock_async(lock_conn):
             logger.info("Another worker is running inbound recovery; skipping on this boot")
             return 0
         lock_acquired = True
 
-        rows = _find_orphaned_inbounds(db, cutoff, freshness_floor)
-        if not rows:
-            return 0
-
-        logger.info(
-            "Inbound recovery: found %d orphan(s) between %s and %s",
-            len(rows),
-            cutoff.isoformat(),
-            freshness_floor.isoformat(),
-        )
-
-        dispatched = 0
-        for msg, chat_session in rows:
-            inputs = _build_dispatch_inputs(db, msg, chat_session)
-            if inputs is None:
-                continue
-            user, state, stored = inputs
-            channel = chat_session.channel or ""
-            media_refs = _parse_media_refs(msg.media_urls_json or "")
-            try:
-                # Re-run the conversation lookup so the live session
-                # state reflects any messages persisted since the
-                # orphan was written. Falls back to the reconstructed
-                # state above if this raises.
-                refreshed_state, _ = await get_or_create_conversation(user.id)
-                state = refreshed_state if refreshed_state is not None else state
-            except Exception:
-                logger.exception(
-                    "get_or_create_conversation failed during inbound recovery for user %s",
-                    user.id,
-                )
+        # The query session is independent of the lock connection so its
+        # commit/close lifecycle does not disturb the advisory lock that
+        # ``lock_conn`` holds across the whole sweep.
+        db: AsyncSession = AsyncSessionLocal()
+        try:
+            rows = await _find_orphaned_inbounds_async(db, cutoff, freshness_floor)
+            if not rows:
+                return 0
 
             logger.info(
-                "Re-dispatching orphan inbound seq=%d session=%s user=%s",
-                msg.seq,
-                chat_session.session_id,
-                user.id,
+                "Inbound recovery: found %d orphan(s) between %s and %s",
+                len(rows),
+                cutoff.isoformat(),
+                freshness_floor.isoformat(),
             )
-            try:
-                await _dispatch_to_pipeline(
-                    user=user,
-                    session=state,
-                    message=stored,
-                    media_urls=media_refs,
-                    channel=channel,
-                    request_id="",
-                    downloaded_media=None,
-                    download_media=None,
-                )
-                dispatched += 1
-            except Exception:
-                logger.exception(
-                    "Failed to re-dispatch orphan inbound seq=%d (session %s, user %s)",
+
+            dispatched = 0
+            for msg, chat_session in rows:
+                inputs = await _build_dispatch_inputs_async(db, msg, chat_session)
+                if inputs is None:
+                    continue
+                user, state, stored = inputs
+                channel = chat_session.channel or ""
+                media_refs = _parse_media_refs(msg.media_urls_json or "")
+                try:
+                    # Re-run the conversation lookup so the live session
+                    # state reflects any messages persisted since the
+                    # orphan was written. Falls back to the reconstructed
+                    # state above if this raises. Use the async store
+                    # directly so the recovery sweep stays fully async
+                    # (the sync ``get_or_create_conversation`` would
+                    # block the event loop on the DB call).
+                    refreshed_state, _ = await get_session_store(
+                        user.id
+                    ).get_or_create_session_async()
+                    state = refreshed_state if refreshed_state is not None else state
+                except Exception:
+                    logger.exception(
+                        "get_or_create_session_async failed during inbound recovery for user %s",
+                        user.id,
+                    )
+
+                logger.info(
+                    "Re-dispatching orphan inbound seq=%d session=%s user=%s",
                     msg.seq,
                     chat_session.session_id,
                     user.id,
                 )
+                try:
+                    await _dispatch_to_pipeline(
+                        user=user,
+                        session=state,
+                        message=stored,
+                        media_urls=media_refs,
+                        channel=channel,
+                        request_id="",
+                        downloaded_media=None,
+                        download_media=None,
+                    )
+                    dispatched += 1
+                except Exception:
+                    logger.exception(
+                        "Failed to re-dispatch orphan inbound seq=%d (session %s, user %s)",
+                        msg.seq,
+                        chat_session.session_id,
+                        user.id,
+                    )
 
-        return dispatched
+            return dispatched
+        finally:
+            await db.close()
     finally:
         if lock_acquired:
-            _release_lock(db)
-        db.close()
+            await _release_lock_async(lock_conn)
+        await lock_conn.close()
 
 
 __all__ = [

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -25,7 +25,7 @@ from sqlalchemy import select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from backend.app.config import settings
-from backend.app.database import db_session, get_engine
+from backend.app.database import db_session, get_async_engine, get_engine
 
 logger = logging.getLogger(__name__)
 
@@ -57,27 +57,30 @@ async def _try_acquire_advisory_lock_async(conn: Any, lock_key: str) -> bool:
     ``await asyncio.sleep`` between polls so the event loop stays
     responsive during contention.
 
-    ``conn`` MUST be a SQLAlchemy ``Connection`` (or other handle whose
-    ``commit()`` does NOT return the underlying DBAPI connection to the
-    pool). Passing a ``Session`` would break the lock semantics: in
-    SQLAlchemy 2.0 ``Session.commit()`` releases the underlying
-    connection back to the pool, where a peer can pick it up and call
-    ``pg_try_advisory_lock`` on it (locks are reentrant per PG session),
-    causing both callers to enter the critical section. The advisory
-    lock must stay pinned to the same physical connection from acquire
-    through unlock; only ``Connection`` provides that pinning.
+    ``conn`` MUST be a SQLAlchemy ``AsyncConnection`` (or other handle
+    whose ``commit()`` does NOT return the underlying DBAPI connection
+    to the pool). Passing an ``AsyncSession`` would break the lock
+    semantics: in SQLAlchemy 2.0 ``AsyncSession.commit()`` releases the
+    underlying connection back to the pool, where a peer task can pick
+    it up and call ``pg_try_advisory_lock`` on it (locks are reentrant
+    per PG session), causing both callers to enter the critical
+    section. The advisory lock must stay pinned to the same physical
+    connection from acquire through unlock; only ``AsyncConnection``
+    provides that pinning.
     """
     deadline = time.monotonic() + _LOCK_MAX_WAIT_S
     while True:
-        acquired = conn.execute(
+        result = await conn.execute(
             text("SELECT pg_try_advisory_lock(hashtext(:k))"),
             {"k": lock_key},
-        ).scalar()
+        )
+        acquired = result.scalar()
         # Commit ends the implicit transaction so we don't sit
-        # idle-in-transaction between polls. On a Connection this does
-        # NOT return the connection to the pool, so the session-scoped
-        # advisory lock stays attached to this same connection.
-        conn.commit()
+        # idle-in-transaction between polls. On an AsyncConnection this
+        # does NOT return the connection to the pool, so the
+        # session-scoped advisory lock stays attached to this same
+        # connection.
+        await conn.commit()
         if acquired:
             return True
         if time.monotonic() >= deadline:
@@ -749,14 +752,16 @@ class OAuthService:
         )
         # The advisory lock is session-scoped (lives on the underlying
         # PG connection until released or the connection closes). We
-        # must hold it on a dedicated ``Connection`` rather than a
-        # ``Session``: ``Session.commit()`` returns the connection to
-        # the pool, where a peer coroutine can check it out and call
-        # ``pg_try_advisory_lock`` on it (locks are reentrant per PG
-        # session), letting both callers enter the critical section.
-        # The token read / write business logic still uses its own
-        # ``Session`` via ``_load_token_uncached`` and ``save_token``.
-        lock_conn = get_engine().connect()
+        # must hold it on a dedicated ``AsyncConnection`` rather than
+        # an ``AsyncSession``: ``AsyncSession.commit()`` returns the
+        # connection to the pool, where a peer coroutine can check it
+        # out and call ``pg_try_advisory_lock`` on it (locks are
+        # reentrant per PG session), letting both callers enter the
+        # critical section. The token read / write business logic still
+        # uses its own sync ``Session`` via ``_load_token_uncached``
+        # and ``save_token``; only the lock primitive runs on the async
+        # engine so the polling waits do not block the event loop.
+        lock_conn = await get_async_engine().connect()
         lock_key = _refresh_lock_key(user_id, integration)
         try:
             if not await _try_acquire_advisory_lock_async(lock_conn, lock_key):
@@ -850,11 +855,11 @@ class OAuthService:
                 return token
             finally:
                 try:
-                    lock_conn.execute(
+                    await lock_conn.execute(
                         text("SELECT pg_advisory_unlock(hashtext(:k))"),
                         {"k": lock_key},
                     )
-                    lock_conn.commit()
+                    await lock_conn.commit()
                 except Exception:
                     logger.exception(
                         "Failed to release OAuth refresh lock: user=%s integration=%s",
@@ -862,7 +867,7 @@ class OAuthService:
                         integration,
                     )
         finally:
-            lock_conn.close()
+            await lock_conn.close()
 
     async def get_valid_token(
         self,

--- a/tests/test_approval_async.py
+++ b/tests/test_approval_async.py
@@ -1,0 +1,284 @@
+"""Async tests for the ``ApprovalStore`` and the ``pg_advisory_xact_lock``
+serialization invariant on its async path.
+
+Mirrors ``tests/test_approval.py::TestApprovalLockSerialization`` (PR #1198)
+for the ``*_async`` peers added in the advisory-lock conversion (issue
+#1158). The matrix is the same: same-key serializes, different-key
+runs in parallel. Concurrency primitive: ``asyncio.gather`` with two
+``asyncio.Event`` handshakes per task. Each task opens its own
+``AsyncSession`` over a fresh connection from the per-test
+``_pg_async_engine`` so contention happens on the real Postgres lock,
+not on a shared connection.
+
+These tests do NOT use the ``async_db`` fixture: ``async_db`` rebinds
+the singleton factory to a single shared connection so test writes can
+be rolled back, which would defeat the parallelism check here. Each
+task instead opens its own connection from ``_pg_async_engine`` and
+runs in its own self-contained transaction that it commits before the
+test ends; no rows are inserted so nothing leaks past teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from backend.app.agent.approval import (
+    ApprovalStore,
+    PermissionLevel,
+    _lock_user_permissions_async,
+    _user_permissions_lock_key,
+)
+from backend.app.models import User
+
+# ---------------------------------------------------------------------------
+# Async parity for ApprovalStore public methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_set_permission_async_persists_and_reads_back(
+    async_test_user: User,
+) -> None:
+    """``set_permission_async`` must round-trip through
+    ``load_user_permissions_async`` so the agent loop and the dashboard
+    both see the same data via the async API."""
+    store = ApprovalStore()
+    await store.set_permission_async(async_test_user.id, "send_media_reply", PermissionLevel.DENY)
+    data = await store.load_user_permissions_async(async_test_user.id)
+    assert data["tools"]["send_media_reply"] == "deny"
+
+
+@pytest.mark.asyncio()
+async def test_ensure_complete_async_backfills_missing_tools(
+    async_test_user: User,
+) -> None:
+    """``ensure_complete_async`` should write the defaults dict on first
+    call and leave existing overrides untouched."""
+    store = ApprovalStore()
+    data = await store.ensure_complete_async(async_test_user.id)
+    assert "tools" in data
+    assert len(data["tools"]) > 0
+
+
+@pytest.mark.asyncio()
+async def test_check_permission_async_resolves_resource_then_tool(
+    async_test_user: User,
+) -> None:
+    """Resource-keyed entries take precedence over tool-keyed entries
+    in the async resolver, same as the sync resolver."""
+    store = ApprovalStore()
+    await store.set_permission_async(
+        async_test_user.id,
+        "web_fetch",
+        PermissionLevel.ALWAYS,
+        resource="example.com",
+    )
+    # Resource match wins.
+    level = await store.check_permission_async(
+        async_test_user.id, "web_fetch", resource="example.com"
+    )
+    assert level == PermissionLevel.ALWAYS
+    # Unrelated resource falls through to the default ASK.
+    level = await store.check_permission_async(
+        async_test_user.id, "web_fetch", resource="other.com"
+    )
+    assert level == PermissionLevel.ASK
+
+
+@pytest.mark.asyncio()
+async def test_reset_permissions_async_writes_defaults(
+    async_test_user: User,
+) -> None:
+    """``reset_permissions_async`` should clobber any prior overrides."""
+    store = ApprovalStore()
+    await store.set_permission_async(async_test_user.id, "send_media_reply", PermissionLevel.DENY)
+    await store.reset_permissions_async(async_test_user.id)
+    data = await store.load_user_permissions_async(async_test_user.id)
+    # Default for send_media_reply is not "deny" (the registry default
+    # depends on the tool's declaration). Asserting the override is
+    # gone is enough to prove reset wrote new data.
+    assert data["tools"].get("send_media_reply") != "deny"
+
+
+# ---------------------------------------------------------------------------
+# pg_advisory_xact_lock concurrency regression (async port of #1198)
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalLockSerializationAsync:
+    """Async port of
+    ``tests/test_approval.py::TestApprovalLockSerialization``.
+
+    Encodes the same matrix against ``_lock_user_permissions_async``:
+
+    * Same user_id: two tasks must serialize on the lock; the second
+      task must not acquire until the first commits.
+    * Different user_id: two tasks must run in parallel because the
+      hash-derived advisory keys do not collide.
+
+    A future refactor that accidentally weakens the lock (e.g. routing
+    acquire and the read-modify-write through different sessions, or
+    committing before the write) trips this test the same way the sync
+    sibling traps the same failure mode.
+    """
+
+    _HOLD_S = 0.4
+    _ACQUIRE_TIMEOUT_S = 5.0
+
+    async def _acquire_in_task(
+        self,
+        engine: AsyncEngine,
+        user_id: str,
+        ready: asyncio.Event,
+        release: asyncio.Event,
+        result: dict[str, float],
+        label: str,
+    ) -> None:
+        """Open a fresh ``AsyncSession``, take the lock on its autobegun
+        transaction, signal ``ready``, wait for ``release``, then commit.
+
+        Mirrors the sync sibling's ``_acquire_in_thread``. Each task gets
+        its own connection so contention runs through the real Postgres
+        lock and not through a shared connection's serialization.
+        """
+        async with AsyncSession(engine, expire_on_commit=False) as db:
+            await _lock_user_permissions_async(db, user_id)
+            result[f"{label}_acquired"] = time.monotonic()
+            ready.set()
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(release.wait(), timeout=self._ACQUIRE_TIMEOUT_S)
+            await db.commit()
+            result[f"{label}_committed"] = time.monotonic()
+
+    @pytest.mark.asyncio()
+    async def test_same_user_lock_serializes_concurrent_writers(
+        self,
+        _pg_async_engine: AsyncEngine,
+    ) -> None:
+        """Two tasks acquiring the lock for the same user must run
+        strictly one at a time. The second task must not acquire until
+        the first commits."""
+        user_id = f"approval-async-serial-{uuid.uuid4().hex[:8]}"
+        a_ready = asyncio.Event()
+        a_release = asyncio.Event()
+        b_ready = asyncio.Event()
+        b_release = asyncio.Event()
+        results: dict[str, float] = {}
+
+        task_a = asyncio.create_task(
+            self._acquire_in_task(_pg_async_engine, user_id, a_ready, a_release, results, "a")
+        )
+        await asyncio.wait_for(a_ready.wait(), timeout=self._ACQUIRE_TIMEOUT_S)
+
+        task_b = asyncio.create_task(
+            self._acquire_in_task(_pg_async_engine, user_id, b_ready, b_release, results, "b")
+        )
+
+        # While A still holds the lock, B must NOT acquire it.
+        try:
+            await asyncio.wait_for(b_ready.wait(), timeout=self._HOLD_S)
+            b_acquired_during_a = True
+        except TimeoutError:
+            b_acquired_during_a = False
+        assert not b_acquired_during_a, (
+            "task B acquired the lock before task A released it; "
+            "pg_advisory_xact_lock did not serialize same-user writers "
+            "on the async path"
+        )
+
+        # Release A; B should now proceed.
+        a_release.set()
+        await asyncio.wait_for(task_a, timeout=self._ACQUIRE_TIMEOUT_S)
+        await asyncio.wait_for(b_ready.wait(), timeout=self._ACQUIRE_TIMEOUT_S)
+
+        b_release.set()
+        await asyncio.wait_for(task_b, timeout=self._ACQUIRE_TIMEOUT_S)
+
+    @pytest.mark.asyncio()
+    async def test_different_users_do_not_contend(
+        self,
+        _pg_async_engine: AsyncEngine,
+    ) -> None:
+        """Different ``user_id`` values hash to different advisory-lock
+        keys so the second task must acquire while the first is still in
+        its critical section."""
+        user_a = f"approval-async-parallel-a-{uuid.uuid4().hex[:8]}"
+        user_c = f"approval-async-parallel-c-{uuid.uuid4().hex[:8]}"
+
+        a_ready = asyncio.Event()
+        a_release = asyncio.Event()
+        c_ready = asyncio.Event()
+        c_release = asyncio.Event()
+        results: dict[str, float] = {}
+
+        task_a = asyncio.create_task(
+            self._acquire_in_task(_pg_async_engine, user_a, a_ready, a_release, results, "a")
+        )
+        await asyncio.wait_for(a_ready.wait(), timeout=self._ACQUIRE_TIMEOUT_S)
+
+        task_c = asyncio.create_task(
+            self._acquire_in_task(_pg_async_engine, user_c, c_ready, c_release, results, "c")
+        )
+        await asyncio.wait_for(c_ready.wait(), timeout=self._ACQUIRE_TIMEOUT_S)
+
+        assert "a_committed" not in results, (
+            "task A committed before C acquired; the parallelism check "
+            "did not actually exercise overlapping critical sections"
+        )
+
+        c_release.set()
+        await asyncio.wait_for(task_c, timeout=self._ACQUIRE_TIMEOUT_S)
+        a_release.set()
+        await asyncio.wait_for(task_a, timeout=self._ACQUIRE_TIMEOUT_S)
+
+
+# ---------------------------------------------------------------------------
+# Lock-key parity
+# ---------------------------------------------------------------------------
+
+
+def test_user_permissions_lock_key_is_stable() -> None:
+    """The lock key must remain a stable function of ``user_id`` so the
+    sync and async paths contend on the same Postgres advisory key."""
+    key = _user_permissions_lock_key("user-abc")
+    assert key == "user_permissions:user-abc"
+
+
+# ---------------------------------------------------------------------------
+# Iso-canary pair (proves async rollback isolates between tests)
+# ---------------------------------------------------------------------------
+
+
+_ISO_CANARY_USER_ID = f"approval-async-iso-{uuid.uuid4().hex[:12]}"
+
+
+@pytest.mark.asyncio()
+async def test_async_isolation_rolls_back_between_tests_part_a(
+    async_test_user: User,
+) -> None:
+    """Write a permission row through the async API. ``part_b`` asserts
+    it disappeared after this test's transaction was rolled back."""
+    store = ApprovalStore()
+    await store.set_permission_async(async_test_user.id, "send_media_reply", PermissionLevel.DENY)
+    data = await store.load_user_permissions_async(async_test_user.id)
+    assert data["tools"]["send_media_reply"] == "deny"
+
+
+@pytest.mark.asyncio()
+async def test_async_isolation_rolls_back_between_tests_part_b(
+    async_test_user: User,
+) -> None:
+    """The override written in ``part_a`` must not be visible here. Two
+    different ``async_test_user`` rows ensure the assertion is on
+    user_id-keyed state, not row identity."""
+    store = ApprovalStore()
+    data = await store.load_user_permissions_async(async_test_user.id)
+    # Either no row exists or, after ensure_complete, the registry default
+    # for send_media_reply is whatever the registry says, not "deny".
+    assert data.get("tools", {}).get("send_media_reply") != "deny"

--- a/tests/test_inbound_recovery.py
+++ b/tests/test_inbound_recovery.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy import Engine, text
+from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy.orm import Session
 
 from backend.app.agent.inbound_recovery import (
@@ -36,6 +37,75 @@ from backend.app.config import settings
 from backend.app.database import SessionLocal
 from backend.app.enums import MessageDirection
 from backend.app.models import ChatSession, Message, User
+
+
+async def _make_user_async(factory: async_sessionmaker) -> User:
+    """Async peer of ``_make_user`` for end-to-end tests that exercise
+    ``recover_orphan_inbound_messages`` (which now runs on the async
+    DB engine; a sync write would land in a different connection and
+    not be visible to the async sweep)."""
+    async with factory() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id=f"recovery-test-{uuid.uuid4().hex[:8]}",
+            phone="+15555550101",
+            channel_identifier="+15555550101",
+            preferred_channel="bluebubbles",
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        db.expunge(user)
+    return user
+
+
+async def _make_session_async(
+    factory: async_sessionmaker, user: User, channel: str = "bluebubbles"
+) -> ChatSession:
+    """Async peer of ``_make_session``."""
+    async with factory() as db:
+        now = datetime.datetime.now(datetime.UTC)
+        cs = ChatSession(
+            session_id=f"sess-{uuid.uuid4().hex[:8]}",
+            user_id=user.id,
+            channel=channel,
+            created_at=now,
+            last_message_at=now,
+        )
+        db.add(cs)
+        await db.commit()
+        await db.refresh(cs)
+        db.expunge(cs)
+    return cs
+
+
+async def _add_message_async(
+    factory: async_sessionmaker,
+    cs: ChatSession,
+    direction: str,
+    seq: int,
+    body: str,
+    *,
+    minutes_ago: int = 0,
+) -> Message:
+    """Async peer of ``_add_message``."""
+    async with factory() as db:
+        ts = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=minutes_ago)
+        msg = Message(
+            session_id=cs.id,
+            seq=seq,
+            direction=direction,
+            body=body,
+            external_message_id=f"ext-{seq}",
+            media_urls_json="[]",
+            timestamp=ts,
+        )
+        db.add(msg)
+        await db.commit()
+        await db.refresh(msg)
+        db.expunge(msg)
+    return msg
 
 
 def _make_user(db: Session) -> User:
@@ -249,18 +319,25 @@ def test_parse_media_refs_handles_invalid_json() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_recover_dispatches_each_orphan() -> None:
+async def test_recover_dispatches_each_orphan(async_db: async_sessionmaker) -> None:
     """The recovery loop calls ``_dispatch_to_pipeline`` once per orphan
-    and returns the count of successes."""
-    db = SessionLocal()
-    try:
-        user = _make_user(db)
-        cs = _make_session(db, user)
-        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="one", minutes_ago=2)
-        _add_message(db, cs, MessageDirection.INBOUND, seq=2, body="two", minutes_ago=1)
-        expected_user_id = user.id
-    finally:
-        db.close()
+    and returns the count of successes.
+
+    Setup runs through the async fixture because
+    ``recover_orphan_inbound_messages`` now reads via an
+    ``AsyncSession``: a sync write committed on the per-test sync
+    transaction lives on a different connection and would not be
+    visible under READ COMMITTED. See AGENTS.md "Cross-API caveat".
+    """
+    user = await _make_user_async(async_db)
+    cs = await _make_session_async(async_db, user)
+    await _add_message_async(
+        async_db, cs, MessageDirection.INBOUND, seq=1, body="one", minutes_ago=2
+    )
+    await _add_message_async(
+        async_db, cs, MessageDirection.INBOUND, seq=2, body="two", minutes_ago=1
+    )
+    expected_user_id = user.id
 
     captured_user_ids: list[str] = []
     captured_bodies: list[str] = []
@@ -307,19 +384,21 @@ async def test_recover_short_circuits_when_lookback_zero() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_recover_continues_past_individual_dispatch_failure() -> None:
+async def test_recover_continues_past_individual_dispatch_failure(
+    async_db: async_sessionmaker,
+) -> None:
     """One failing dispatch must not abort the whole sweep; the other
     orphan should still be recovered. Caller wraps the whole thing in a
     try/except too, but per-row resilience is what lets us deploy this
     in front of an in-flight queue without an all-or-nothing failure."""
-    db = SessionLocal()
-    try:
-        user = _make_user(db)
-        cs = _make_session(db, user)
-        _add_message(db, cs, MessageDirection.INBOUND, seq=1, body="one", minutes_ago=2)
-        _add_message(db, cs, MessageDirection.INBOUND, seq=2, body="two", minutes_ago=1)
-    finally:
-        db.close()
+    user = await _make_user_async(async_db)
+    cs = await _make_session_async(async_db, user)
+    await _add_message_async(
+        async_db, cs, MessageDirection.INBOUND, seq=1, body="one", minutes_ago=2
+    )
+    await _add_message_async(
+        async_db, cs, MessageDirection.INBOUND, seq=2, body="two", minutes_ago=1
+    )
 
     call_count = {"n": 0}
 

--- a/tests/test_inbound_recovery.py
+++ b/tests/test_inbound_recovery.py
@@ -514,8 +514,8 @@ async def test_recovery_skips_when_another_worker_holds_the_lock() -> None:
 
     with (
         patch(
-            "backend.app.agent.inbound_recovery._try_acquire_lock",
-            return_value=False,
+            "backend.app.agent.inbound_recovery._try_acquire_lock_async",
+            new=AsyncMock(return_value=False),
         ),
         patch(
             "backend.app.agent.inbound_recovery._dispatch_to_pipeline",

--- a/tests/test_inbound_recovery_async.py
+++ b/tests/test_inbound_recovery_async.py
@@ -1,0 +1,239 @@
+"""Async tests for the inbound-recovery advisory-lock pair.
+
+Mirrors ``tests/test_inbound_recovery.py::TestInboundRecoveryLockSerialization``
+(PR #1206) for the async port added in issue #1158. The matrix is the
+same: only one of N contenders acquires when a holder owns the lock,
+and a contender succeeds after the holder releases.
+
+The most load-bearing assertion is
+``test_unlock_on_different_connection_is_a_no_op_async`` -- the async
+port of the same-connection-coupling regression. The async sweep opens
+a single ``AsyncConnection`` for the lock and routes both
+``_try_acquire_lock_async`` and ``_release_lock_async`` through that
+connection. If a future refactor splits acquire and release across
+different ``AsyncConnection`` handles (or accidentally routes one
+through an ``AsyncSession`` whose ``commit()`` returns the connection
+to the pool), the unlock silently no-ops and the lock leaks for the
+lifetime of the original connection. This test traps that the same
+way the sync sibling does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from backend.app.agent.inbound_recovery import (
+    _RECOVERY_LOCK_KEY,
+    _release_lock_async,
+    _try_acquire_lock_async,
+)
+
+
+class TestInboundRecoveryLockSerializationAsync:
+    """Async port of ``TestInboundRecoveryLockSerialization``.
+
+    Concurrency primitive: ``asyncio.Event`` and ``asyncio.gather``
+    coordinated tasks. Each task opens its own ``AsyncConnection`` from
+    the per-test ``_pg_async_engine`` so the contention runs through
+    the real Postgres lock, not through a shared connection.
+
+    These tests do NOT use the ``async_db`` fixture: ``async_db``
+    rebinds the singleton factory to a single shared connection so test
+    writes can be rolled back, which would defeat the parallelism check
+    here. Each task instead opens its own connection from
+    ``_pg_async_engine`` and closes it cleanly.
+    """
+
+    _N_CONTENDERS = 5
+    _TIMEOUT_S = 5.0
+
+    async def _try_lock_in_task(
+        self,
+        engine: AsyncEngine,
+        ready: asyncio.Event,
+        release: asyncio.Event,
+        result: dict[str, bool],
+    ) -> None:
+        """Acquire the recovery lock on a fresh ``AsyncConnection``,
+        hold it until signaled, then release it on the **same**
+        connection. Mirrors the sync ``_try_lock_in_thread``."""
+        connection = await engine.connect()
+        try:
+            acquired = await _try_acquire_lock_async(connection)
+            result["acquired"] = acquired
+            ready.set()
+            if not acquired:
+                return
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(release.wait(), timeout=self._TIMEOUT_S)
+            await _release_lock_async(connection)
+        finally:
+            await connection.close()
+
+    async def _race_contender(
+        self,
+        engine: AsyncEngine,
+        barrier_event: asyncio.Event,
+        results: list[bool],
+        results_lock: asyncio.Lock,
+    ) -> None:
+        """One of N contenders racing for the lock. Opens a fresh
+        ``AsyncConnection``, waits for the barrier event, then calls
+        the production ``_try_acquire_lock_async``. If acquired,
+        releases via ``_release_lock_async`` on the same connection."""
+        connection = await engine.connect()
+        try:
+            await barrier_event.wait()
+            acquired = await _try_acquire_lock_async(connection)
+            async with results_lock:
+                results.append(acquired)
+            if acquired:
+                await _release_lock_async(connection)
+        finally:
+            await connection.close()
+
+    @pytest.mark.asyncio()
+    async def test_only_one_of_n_concurrent_attempts_acquires_lock(
+        self,
+        _pg_async_engine: AsyncEngine,
+    ) -> None:
+        """N tasks racing for the recovery lock while a pre-acquired
+        holder owns it: zero contenders acquire. This is the core
+        no-duplicate-processing invariant."""
+        barrier_event = asyncio.Event()
+        results: list[bool] = []
+        results_lock = asyncio.Lock()
+
+        # Pre-acquire on a holder connection so every contender sees
+        # the lock as taken.
+        holder_conn = await _pg_async_engine.connect()
+        try:
+            held = await _try_acquire_lock_async(holder_conn)
+            assert held, "holder task failed to pre-acquire the lock"
+
+            tasks = [
+                asyncio.create_task(
+                    self._race_contender(_pg_async_engine, barrier_event, results, results_lock)
+                )
+                for _ in range(self._N_CONTENDERS)
+            ]
+
+            barrier_event.set()
+            await asyncio.wait_for(asyncio.gather(*tasks), timeout=self._TIMEOUT_S)
+        finally:
+            await _release_lock_async(holder_conn)
+            await holder_conn.close()
+
+        assert len(results) == self._N_CONTENDERS
+        assert results.count(True) == 0, (
+            f"expected zero contenders to acquire while holder held the lock, "
+            f"got {results.count(True)} of {self._N_CONTENDERS}; "
+            f"pg_try_advisory_lock did not exclude concurrent sessions on "
+            f"the async path"
+        )
+
+    @pytest.mark.asyncio()
+    async def test_contender_succeeds_after_holder_releases(
+        self,
+        _pg_async_engine: AsyncEngine,
+    ) -> None:
+        """While a holder task owns the lock, a contender's
+        ``pg_try_advisory_lock`` returns False. After the holder
+        releases, a fresh attempt on a new connection returns True."""
+        ready = asyncio.Event()
+        release = asyncio.Event()
+        holder_result: dict[str, bool] = {}
+
+        holder_task = asyncio.create_task(
+            self._try_lock_in_task(_pg_async_engine, ready, release, holder_result)
+        )
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=self._TIMEOUT_S)
+            assert holder_result.get("acquired") is True
+
+            contender_conn = await _pg_async_engine.connect()
+            try:
+                got = await _try_acquire_lock_async(contender_conn)
+                assert got is False, (
+                    "contender acquired the lock while holder owned it; "
+                    "pg_try_advisory_lock failed to exclude concurrent "
+                    "sessions on the async path"
+                )
+            finally:
+                await contender_conn.close()
+        finally:
+            release.set()
+            await asyncio.wait_for(holder_task, timeout=self._TIMEOUT_S)
+
+        post_conn = await _pg_async_engine.connect()
+        try:
+            got_after = await _try_acquire_lock_async(post_conn)
+            assert got_after is True, "lock was not released after holder task exited"
+            await _release_lock_async(post_conn)
+        finally:
+            await post_conn.close()
+
+    @pytest.mark.asyncio()
+    async def test_unlock_on_different_connection_is_a_no_op_async(
+        self,
+        _pg_async_engine: AsyncEngine,
+    ) -> None:
+        """Lock-release coupling check on the async path:
+        ``pg_advisory_unlock`` only releases a lock owned by the same
+        Postgres session. Calling it on a different ``AsyncConnection``
+        silently returns ``False`` and the lock stays held.
+
+        This is the invariant the issue body calls out for the async
+        conversion. If a future refactor accidentally routes
+        ``_release_lock_async`` through a different ``AsyncConnection``
+        than ``_try_acquire_lock_async`` (or routes either through an
+        ``AsyncSession`` whose ``commit()`` returns the connection to
+        the pool), the unlock becomes a silent no-op and the lock
+        leaks for the lifetime of the original connection. This test
+        encodes that coupling on the async side so a regression
+        surfaces immediately.
+        """
+        holder_conn = await _pg_async_engine.connect()
+        wrong_conn = await _pg_async_engine.connect()
+        observer_conn = await _pg_async_engine.connect()
+        try:
+            # Holder acquires.
+            held = await _try_acquire_lock_async(holder_conn)
+            assert held is True
+
+            # Try to release on a different connection. Postgres
+            # returns ``False`` here (lock not owned by this session).
+            # The release is silently ineffective.
+            unlocked_result = await wrong_conn.execute(
+                text("SELECT pg_advisory_unlock(hashtext(:k))"),
+                {"k": _RECOVERY_LOCK_KEY},
+            )
+            unlocked = bool(unlocked_result.scalar())
+            await wrong_conn.commit()
+            assert unlocked is False, (
+                "pg_advisory_unlock returned True on a non-owning connection; "
+                "Postgres semantics changed and this test needs updating"
+            )
+
+            # The lock is still held: a third connection cannot acquire.
+            still_held = await _try_acquire_lock_async(observer_conn)
+            assert still_held is False, (
+                "lock was released by an unlock on a different connection; "
+                "the async recovery code's same-connection coupling is broken"
+            )
+
+            # Releasing on the holder connection actually frees it.
+            await _release_lock_async(holder_conn)
+
+            now_free = await _try_acquire_lock_async(observer_conn)
+            assert now_free is True, "lock did not free after release on the owning connection"
+            await _release_lock_async(observer_conn)
+        finally:
+            await holder_conn.close()
+            await wrong_conn.close()
+            await observer_conn.close()

--- a/tests/test_oauth_refresh.py
+++ b/tests/test_oauth_refresh.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from sqlalchemy import Engine, text
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from backend.app.services.oauth import (
     _PERMANENT_OAUTH_ERROR_CODES,
@@ -492,14 +493,25 @@ class TestAdvisoryLockBounded:
             cur.execute("SELECT pg_advisory_lock(hashtext(%s))", (lock_key,))
             peer.commit()
 
-            db = _pg_engine.connect()
+            # The async helper now operates on an ``AsyncConnection`` so the
+            # event loop stays responsive during the bounded poll. We build
+            # one off the production async engine, which targets the same DB
+            # as ``_pg_engine`` (per ``settings.database_url``).
+            async_engine = create_async_engine(
+                _pg_engine.url.set(drivername="postgresql+asyncpg"),
+                pool_pre_ping=True,
+            )
             try:
-                with patch("backend.app.services.oauth._LOCK_MAX_WAIT_S", 0.3):
-                    start = time.monotonic()
-                    acquired = await _try_acquire_advisory_lock_async(db, lock_key)
-                    elapsed = time.monotonic() - start
+                db = await async_engine.connect()
+                try:
+                    with patch("backend.app.services.oauth._LOCK_MAX_WAIT_S", 0.3):
+                        start = time.monotonic()
+                        acquired = await _try_acquire_advisory_lock_async(db, lock_key)
+                        elapsed = time.monotonic() - start
+                finally:
+                    await db.close()
             finally:
-                db.close()
+                await async_engine.dispose()
 
             assert acquired is False
             # Bounded wait, not the multi-hour pg_advisory_lock freeze.
@@ -512,14 +524,21 @@ class TestAdvisoryLockBounded:
     @pytest.mark.asyncio()
     async def test_async_acquire_succeeds_when_lock_free(self, _pg_engine: Engine) -> None:
         lock_key = _refresh_lock_key("free-user", "google_calendar")
-        db = _pg_engine.connect()
+        async_engine = create_async_engine(
+            _pg_engine.url.set(drivername="postgresql+asyncpg"),
+            pool_pre_ping=True,
+        )
         try:
-            acquired = await _try_acquire_advisory_lock_async(db, lock_key)
-            assert acquired is True
-            db.execute(text("SELECT pg_advisory_unlock(hashtext(:k))"), {"k": lock_key})
-            db.commit()
+            db = await async_engine.connect()
+            try:
+                acquired = await _try_acquire_advisory_lock_async(db, lock_key)
+                assert acquired is True
+                await db.execute(text("SELECT pg_advisory_unlock(hashtext(:k))"), {"k": lock_key})
+                await db.commit()
+            finally:
+                await db.close()
         finally:
-            db.close()
+            await async_engine.dispose()
 
     def test_sync_acquire_returns_false_when_lock_held_by_peer(self, _pg_engine: Engine) -> None:
         lock_key = _refresh_lock_key("contended-user-sync", "quickbooks")
@@ -864,23 +883,24 @@ class TestRefreshTokenLockSerialization:
         self, _pg_engine: Engine
     ) -> None:
         """Same-connection coupling check: the lock helper guarantees
-        nothing if the caller passes a ``Session`` (whose ``commit()``
-        returns the underlying connection to the pool).
+        nothing if the caller passes an ``AsyncSession`` (whose
+        ``commit()`` returns the underlying connection to the pool).
 
         This is the production bug encoded as an invariant: the
-        production refresh path now passes ``engine.connect()`` (a
-        ``Connection``), and any future refactor that swaps it back to
-        ``SessionLocal()`` re-introduces the bug. Mirrors the
-        same-connection-coupling check in
+        production refresh path now passes ``async_engine.connect()``
+        (an ``AsyncConnection``), and any future refactor that swaps
+        it back to ``AsyncSessionLocal()`` re-introduces the bug.
+        Mirrors the same-connection-coupling check in
         ``test_inbound_recovery.py::test_unlock_on_different_connection_is_a_no_op``.
 
         Demonstrates the failure mode by calling the helper twice on
-        two ``Session`` instances bound to a shared engine: the second
-        ``pg_try_advisory_lock`` returns ``True`` even though the first
-        Session never explicitly released, because the underlying
-        connection was returned to the pool by the intervening commit.
+        two ``AsyncSession`` instances bound to a shared engine: the
+        second ``pg_try_advisory_lock`` returns ``True`` even though
+        the first session never explicitly released, because the
+        underlying connection was returned to the pool by the
+        intervening commit.
         """
-        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.ext.asyncio import async_sessionmaker
 
         lock_key = _refresh_lock_key("session-misuse-user", "google_calendar")
         # pool_size=2 + max_overflow=0 keeps the pool small enough that
@@ -888,15 +908,13 @@ class TestRefreshTokenLockSerialization:
         # recycled between the two sessions. The point of this test is
         # to encode the exact failure mode the production fix avoids,
         # so we keep the setup minimal and close to the bug.
-        from sqlalchemy import create_engine
-
-        small_engine = create_engine(
-            _pg_engine.url,
+        small_engine = create_async_engine(
+            _pg_engine.url.set(drivername="postgresql+asyncpg"),
             pool_size=2,
             max_overflow=0,
         )
         try:
-            factory = sessionmaker(bind=small_engine)
+            factory = async_sessionmaker(bind=small_engine, expire_on_commit=False)
             s1 = factory()
             s2 = factory()
             try:
@@ -910,21 +928,21 @@ class TestRefreshTokenLockSerialization:
                 acquired_2 = await _try_acquire_advisory_lock_async(s2, lock_key)
                 assert acquired_1 is True
                 assert acquired_2 is True, (
-                    "Postgres advisory lock semantics changed: a Session "
+                    "Postgres advisory lock semantics changed: an AsyncSession "
                     "returning its connection to the pool no longer lets a "
-                    "peer Session re-acquire. If this is now False, the "
+                    "peer session re-acquire. If this is now False, the "
                     "production fix may be unnecessary; investigate before "
                     "deleting it."
                 )
             finally:
                 # Best-effort cleanup. ``pg_advisory_unlock_all`` on a
                 # raw connection drops every lock held by that PG
-                # session regardless of which Session originally
+                # session regardless of which session originally
                 # acquired it.
-                with small_engine.connect() as cleanup:
-                    cleanup.execute(text("SELECT pg_advisory_unlock_all()"))
-                    cleanup.commit()
-                s1.close()
-                s2.close()
+                async with small_engine.connect() as cleanup:
+                    await cleanup.execute(text("SELECT pg_advisory_unlock_all()"))
+                    await cleanup.commit()
+                await s1.close()
+                await s2.close()
         finally:
-            small_engine.dispose()
+            await small_engine.dispose()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Convert the three advisory-lock paths called out in #1158 to the async DB engine so the locks no longer block the event loop on their poll waits or upstream HTTP calls. Approach is additive per AGENTS.md: every async path runs alongside the existing sync surface; sync method bodies are unchanged except for substituting shared pure builders.

### OAuth refresh (`backend/app/services/oauth.py`)
Swap the lock connection in `OAuthService.refresh_token` from sync `get_engine().connect()` to `await get_async_engine().connect()`, and update `_try_acquire_advisory_lock_async` to await `execute()` and `commit()` on the `AsyncConnection`. The session-scoped lock stays pinned to one `AsyncConnection` from acquire through unlock; the existing `httpx.AsyncClient` upstream call already awaits. The sync `_persist` callback in `build_on_refresh_callback` continues to use the sync helper because it is invoked from sync provider services.

### Approval gate (`backend/app/agent/approval.py`)
Add `_lock_user_permissions_async` (same `pg_advisory_xact_lock` semantics) plus `*_async` peers for `_load`, `_save`, `set_permission`, `ensure_complete`, `reset_permissions`, `check_permission`, and `load_user_permissions`. Each async path acquires the lock inside an autobegun async transaction so the lock and the read-modify-write share one transaction and `await db.commit()` releases it. The sync surface is unchanged.

### Inbound recovery (`backend/app/agent/inbound_recovery.py`)
Add `_try_acquire_lock_async` and `_release_lock_async` taking an `AsyncConnection`, plus async query peers (`_find_orphaned_inbounds_async`, `_build_dispatch_inputs_async`) that share pure SQL builders with the sync side. `recover_orphan_inbound_messages` now opens one `AsyncConnection` for the lock and holds it across the whole sweep inside `try/finally`; queries run on a separate `AsyncSession` so its commits do not bounce the lock connection. The conversation refresh call switches from the sync wrapper to `get_session_store(...).get_or_create_session_async()` so the recovery sweep stays fully async.

## Type
- [x] Refactor
- [x] Test

## Tests added

- `tests/test_approval_async.py`: async parity for the new peers plus the same-key serialize / different-key parallel matrix from #1198, ported to `asyncio.gather` against `_lock_user_permissions_async`.
- `tests/test_inbound_recovery_async.py`: async port of `TestInboundRecoveryLockSerialization`, including the same-connection-coupling regression `test_unlock_on_different_connection_is_a_no_op_async` so a future refactor that splits acquire and release across different `AsyncConnection` handles trips immediately.
- `tests/test_oauth_refresh.py`: update the bounded-acquire and primitive-misuse-witness tests to use `AsyncConnection` / `AsyncSession` against an async engine, encoding the same invariant on the async path.
- `tests/test_inbound_recovery.py`: route the end-to-end recovery tests through async setup helpers because the sweep now reads via an `AsyncSession` and a sync write committed on the per-test sync transaction is invisible under READ COMMITTED (cross-API caveat in AGENTS.md).
- `tests/conftest.py`: stash and clear the `_async_engine` / `_async_session_factory` singletons in `_isolate_stores` so tests that touch the production async engine build a fresh pool pinned to the current event loop instead of reusing a pool whose asyncpg connections came from a previous loop.

All five lock regression test classes pass on the converted code:
- `TestRefreshTokenLockSerialization` (3 tests)
- `TestApprovalLockSerialization` (2 tests)
- `TestInboundRecoveryLockSerialization` incl. `test_unlock_on_different_connection_is_a_no_op` (3 tests)
- `TestApprovalLockSerializationAsync` (2 tests)
- `TestInboundRecoveryLockSerializationAsync` incl. `test_unlock_on_different_connection_is_a_no_op_async` (3 tests)

## Pool sizing note

Each in-flight OAuth refresh holds one async-pool connection across the upstream POST (potentially seconds in the contended-lock case), and each inbound recovery sweep holds one async-pool connection across all dispatches. Operators sizing the async pool should budget for this concurrency. Default `pool_size=5` / `max_overflow=10` is fine for typical single-worker setups; multi-worker rolling restarts that all race the recovery sweep will see N-1 of them short-circuit on the bounded `pg_try_advisory_lock` and release their connection within milliseconds.

## Checklist
- [x] Tests pass (`uv run pytest -v`) for the converted paths and their regression test classes
- [x] Lint passes (`ruff check backend/ tests/ alembic/`)
- [x] Format passes (`ruff format --check backend/ tests/ alembic/`)
- [x] Type checking passes (`ty check --python .venv backend/ tests/ alembic/`)
- [x] New tests added for new functionality (async lock regression matrix in two new files)
- [x] Bug fixes include regression tests (the same-connection-coupling test for the async port lives in `test_inbound_recovery_async.py`)

## AI Usage
- [x] AI-assisted (drafted by Claude Code via back-and-forth with @njbrake; reasoning and decisions are his, prose is Claude's)

Closes #1158
Part of #1139