### PR TITLE
refactor(boot): convert health probe + lifespan to async DB

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ from backend.app.config_store import (
     get_settings_store,
     import_legacy_config_json,
 )
-from backend.app.database import SessionLocal, get_engine
+from backend.app.database import db_session_async, get_engine
 from backend.app.logging_utils import mask_pii
 from backend.app.models import ChannelRoute, User
 from backend.app.routers import (
@@ -65,7 +65,7 @@ register_channel(LinqChannel())
 register_channel(BlueBubblesChannel())
 
 
-def _enforce_single_channel() -> None:
+async def _enforce_single_channel() -> None:
     """One-time: disable non-preferred routes for existing multi-channel users.
 
     After the single-channel refactor, each user should have at most one
@@ -77,12 +77,13 @@ def _enforce_single_channel() -> None:
     consumers (heartbeat, reauth notifications) consistent without needing
     read-time drift-sync.
     """
-    db = SessionLocal()
-    try:
-        users = db.execute(select(User)).scalars().all()
+    async with db_session_async() as db:
+        users = (await db.execute(select(User))).scalars().all()
         fixed = 0
         for user in users:
-            routes = db.execute(select(ChannelRoute).filter_by(user_id=user.id)).scalars().all()
+            routes = (
+                (await db.execute(select(ChannelRoute).filter_by(user_id=user.id))).scalars().all()
+            )
             enabled_messaging = [r for r in routes if r.enabled and r.channel != "webchat"]
             if len(enabled_messaging) > 1:
                 preferred_match = next(
@@ -101,13 +102,11 @@ def _enforce_single_channel() -> None:
                     user.preferred_channel = keeper.channel
                 fixed += 1
         if fixed:
-            db.commit()
+            await db.commit()
             logger.info(
                 "Single-channel enforcement: fixed %d user(s) with multiple enabled channels",
                 fixed,
             )
-    finally:
-        db.close()
 
 
 async def _verify_llm_settings() -> None:
@@ -222,7 +221,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     # env_file directive; this call covers bare-host / local-dev setups.
     load_dotenv()
 
-    _enforce_single_channel()
+    await _enforce_single_channel()
     validate_imessage_backend()
     validate_personal_storage_backend()
     log_config_warnings()

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -3,7 +3,7 @@ import logging
 from fastapi import APIRouter
 from sqlalchemy import text
 
-from backend.app.database import SessionLocal
+from backend.app.database import AsyncSessionLocal
 from backend.app.schemas import HealthResponse
 
 logger = logging.getLogger(__name__)
@@ -15,18 +15,17 @@ async def health_check() -> HealthResponse:
     """Full health check: process is up AND can reach the database.
 
     Use for ops dashboards and richer monitoring. NOT recommended as the
-    deployment platform's healthcheck path: a sync DB call from an async
-    handler can block the event loop, and during an incident a healthcheck
-    that waits on the same DB can pile up alongside whatever already broke.
-    Use ``/health/live`` for that.
+    deployment platform's healthcheck path: during an incident a
+    healthcheck that waits on the same DB can pile up alongside whatever
+    already broke. Use ``/health/live`` for that.
     """
     db_status = "ok"
     try:
-        db = SessionLocal()
+        db = AsyncSessionLocal()
         try:
-            db.execute(text("SELECT 1"))
+            await db.execute(text("SELECT 1"))
         finally:
-            db.close()
+            await db.close()
     except Exception:
         logger.exception("Health check: database unreachable")
         db_status = "error"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8,7 +8,7 @@
     "/api/health": {
       "get": {
         "summary": "Health Check",
-        "description": "Full health check: process is up AND can reach the database.\n\nUse for ops dashboards and richer monitoring. NOT recommended as the\ndeployment platform's healthcheck path: a sync DB call from an async\nhandler can block the event loop, and during an incident a healthcheck\nthat waits on the same DB can pile up alongside whatever already broke.\nUse ``/health/live`` for that.",
+        "description": "Full health check: process is up AND can reach the database.\n\nUse for ops dashboards and richer monitoring. NOT recommended as the\ndeployment platform's healthcheck path: during an incident a\nhealthcheck that waits on the same DB can pile up alongside whatever\nalready broke. Use ``/health/live`` for that.",
         "operationId": "health_check_api_health_get",
         "responses": {
           "200": {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -16,10 +16,9 @@ export interface paths {
          * @description Full health check: process is up AND can reach the database.
          *
          *     Use for ops dashboards and richer monitoring. NOT recommended as the
-         *     deployment platform's healthcheck path: a sync DB call from an async
-         *     handler can block the event loop, and during an incident a healthcheck
-         *     that waits on the same DB can pile up alongside whatever already broke.
-         *     Use ``/health/live`` for that.
+         *     deployment platform's healthcheck path: during an incident a
+         *     healthcheck that waits on the same DB can pile up alongside whatever
+         *     already broke. Use ``/health/live`` for that.
          */
         get: operations["health_check_api_health_get"];
         put?: never;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -462,7 +462,7 @@ def linq_client(test_user: User) -> Generator[TestClient]:
 
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
-        patch("backend.app.main._enforce_single_channel"),
+        patch("backend.app.main._enforce_single_channel", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.channels.linq.settings.linq_allowed_numbers", "*"),
         patch("backend.app.channels.linq.settings.linq_webhook_signing_secret", ""),
@@ -498,7 +498,7 @@ def bluebubbles_client(test_user: User) -> Generator[TestClient]:
 
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
-        patch("backend.app.main._enforce_single_channel"),
+        patch("backend.app.main._enforce_single_channel", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"),
         patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", ""),
@@ -524,7 +524,7 @@ def client(test_user: User) -> Generator[TestClient]:
     app.dependency_overrides[get_current_user] = _override_get_current_user
     with (
         patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
-        patch("backend.app.main._enforce_single_channel"),
+        patch("backend.app.main._enforce_single_channel", new_callable=AsyncMock),
         patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
         # Default allowlist to "*" (allow all) so tests are not blocked.
         # Individual allowlist tests override these values.

--- a/tests/test_single_channel.py
+++ b/tests/test_single_channel.py
@@ -7,6 +7,9 @@ unknown channel rejection) and startup migration.
 
 import uuid
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
 import backend.app.database as _db_module
 from backend.app.agent.heartbeat import resolve_heartbeat_route
 from backend.app.agent.ingestion import _get_or_create_user
@@ -46,6 +49,42 @@ def _create_user_with_routes(
     finally:
         db.close()
     return uid
+
+
+async def _create_user_with_routes_async(
+    async_db: async_sessionmaker,
+    routes: list[tuple[str, str, bool]],
+    preferred_channel: str = "telegram",
+) -> str:
+    """Async peer of ``_create_user_with_routes``.
+
+    Writes through the per-test async connection so rows are visible to
+    ``_enforce_single_channel`` (which uses ``db_session_async()``) under
+    the same outer transaction. The cross-API caveat in AGENTS.md
+    prevents the sync helper above from being used for async-native
+    tests.
+    """
+    async with async_db() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id=f"test-{uuid.uuid4().hex[:8]}",
+            channel_identifier=routes[0][1] if routes else "",
+            preferred_channel=preferred_channel,
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.flush()
+        for channel, identifier, enabled in routes:
+            db.add(
+                ChannelRoute(
+                    user_id=user.id,
+                    channel=channel,
+                    channel_identifier=identifier,
+                    enabled=enabled,
+                )
+            )
+        await db.commit()
+        return str(user.id)
 
 
 class TestAutoDisableOnEnable:
@@ -412,12 +451,20 @@ class TestHeartbeatRouting:
 
 
 class TestStartupMigration:
-    """_enforce_single_channel fixes users with multiple enabled routes."""
+    """_enforce_single_channel fixes users with multiple enabled routes.
 
-    def test_disables_non_preferred_routes(self) -> None:
+    These tests opt in to the ``async_db`` fixture: setup writes go
+    through the per-test async connection so the rows are visible to
+    ``_enforce_single_channel`` (which uses ``db_session_async()``)
+    under the same outer transaction. Mixing sync setup with the async
+    helper would hit the cross-API caveat documented in AGENTS.md.
+    """
+
+    async def test_disables_non_preferred_routes(self, async_db: async_sessionmaker) -> None:
         from backend.app.main import _enforce_single_channel
 
-        uid = _create_user_with_routes(
+        uid = await _create_user_with_routes_async(
+            async_db,
             [
                 ("telegram", "mig-111", True),
                 ("linq", "+15551234567", True),
@@ -426,21 +473,19 @@ class TestStartupMigration:
             preferred_channel="telegram",
         )
 
-        _enforce_single_channel()
+        await _enforce_single_channel()
 
-        db = _db_module.SessionLocal()
-        try:
-            routes = db.query(ChannelRoute).filter_by(user_id=uid).all()
+        async with async_db() as db:
+            routes = (await db.execute(select(ChannelRoute).filter_by(user_id=uid))).scalars().all()
             enabled = [r for r in routes if r.enabled and r.channel != "webchat"]
             assert len(enabled) == 1
             assert enabled[0].channel == "telegram"
-        finally:
-            db.close()
 
-    def test_preserves_webchat_route(self) -> None:
+    async def test_preserves_webchat_route(self, async_db: async_sessionmaker) -> None:
         from backend.app.main import _enforce_single_channel
 
-        uid = _create_user_with_routes(
+        uid = await _create_user_with_routes_async(
+            async_db,
             [
                 ("telegram", "mig-222", True),
                 ("linq", "+15552222222", True),
@@ -449,8 +494,7 @@ class TestStartupMigration:
         )
 
         # Add webchat route separately
-        db = _db_module.SessionLocal()
-        try:
+        async with async_db() as db:
             db.add(
                 ChannelRoute(
                     user_id=uid,
@@ -459,41 +503,38 @@ class TestStartupMigration:
                     enabled=True,
                 )
             )
-            db.commit()
-        finally:
-            db.close()
+            await db.commit()
 
-        _enforce_single_channel()
+        await _enforce_single_channel()
 
-        db = _db_module.SessionLocal()
-        try:
-            webchat = db.query(ChannelRoute).filter_by(user_id=uid, channel="webchat").first()
+        async with async_db() as db:
+            webchat = (
+                await db.execute(select(ChannelRoute).filter_by(user_id=uid, channel="webchat"))
+            ).scalar_one_or_none()
             assert webchat is not None
             assert webchat.enabled is True
-        finally:
-            db.close()
 
-    def test_no_change_when_single_channel(self) -> None:
+    async def test_no_change_when_single_channel(self, async_db: async_sessionmaker) -> None:
         from backend.app.main import _enforce_single_channel
 
-        uid = _create_user_with_routes(
+        uid = await _create_user_with_routes_async(
+            async_db,
             [
                 ("telegram", "mig-333", True),
             ],
             preferred_channel="telegram",
         )
 
-        _enforce_single_channel()
+        await _enforce_single_channel()
 
-        db = _db_module.SessionLocal()
-        try:
-            route = db.query(ChannelRoute).filter_by(user_id=uid, channel="telegram").first()
+        async with async_db() as db:
+            route = (
+                await db.execute(select(ChannelRoute).filter_by(user_id=uid, channel="telegram"))
+            ).scalar_one_or_none()
             assert route is not None
             assert route.enabled is True
-        finally:
-            db.close()
 
-    def test_realigns_preferred_when_stale(self) -> None:
+    async def test_realigns_preferred_when_stale(self, async_db: async_sessionmaker) -> None:
         """preferred_channel is repointed to an enabled route when stale.
 
         Multi-channel users whose ``preferred_channel`` points at a channel
@@ -502,7 +543,8 @@ class TestStartupMigration:
         """
         from backend.app.main import _enforce_single_channel
 
-        uid = _create_user_with_routes(
+        uid = await _create_user_with_routes_async(
+            async_db,
             [
                 ("linq", "+15551111111", True),
                 ("bluebubbles", "+15552222222", True),
@@ -510,26 +552,27 @@ class TestStartupMigration:
             preferred_channel="telegram",
         )
 
-        _enforce_single_channel()
+        await _enforce_single_channel()
 
-        db = _db_module.SessionLocal()
-        try:
-            user = db.query(User).filter_by(id=uid).first()
+        async with async_db() as db:
+            user = (await db.execute(select(User).filter_by(id=uid))).scalar_one_or_none()
             assert user is not None
             assert user.preferred_channel in {"linq", "bluebubbles"}
             enabled = (
-                db.query(ChannelRoute)
-                .filter(
-                    ChannelRoute.user_id == uid,
-                    ChannelRoute.enabled.is_(True),
-                    ChannelRoute.channel != "webchat",
+                (
+                    await db.execute(
+                        select(ChannelRoute).where(
+                            ChannelRoute.user_id == uid,
+                            ChannelRoute.enabled.is_(True),
+                            ChannelRoute.channel != "webchat",
+                        )
+                    )
                 )
+                .scalars()
                 .all()
             )
             assert len(enabled) == 1
             assert enabled[0].channel == user.preferred_channel
-        finally:
-            db.close()
 
 
 class TestPatchDisableSyncsPreferred:


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Boot slice of #1178. Re-opened against main after #1210 (auth conversion) merged; the prior PR #1215 was auto-closed when its base branch was deleted.

Converts:
- backend/app/routers/health.py readiness probe (1 site): SessionLocal() to AsyncSessionLocal() with await
- backend/app/main.py _enforce_single_channel lifespan helper (4 sites): async def with db_session_async(), awaits on execute and commit; lifespan caller awaits the now-async helper

Tests:
- conftest patches for _enforce_single_channel switched to AsyncMock
- TestStartupMigration tests in tests/test_single_channel.py opt into async_db so setup writes flow through the per-test async connection

Sync coexistence: none needed; both sites are only invoked from async contexts.

DoD: 2344 pytest pass, ruff/format/ty clean.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass
- [x] Lint passes
- [x] Type checking passes
- [x] New tests added (TestStartupMigration migrated to async_db)

## AI Usage
- [x] AI-assisted

Addresses health + lifespan boot slice of #1178. Agent module slice in #1214; calendar slice in flight.
Part of #1139.

Supersedes #1215 (auto-closed when its base branch was deleted on the #1210 merge).