### PR TITLE
refactor(calendar): convert sync DB sites to async

### DIFF
--- a/backend/app/integrations/calendar/factory.py
+++ b/backend/app/integrations/calendar/factory.py
@@ -17,7 +17,7 @@ from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
-from backend.app.database import SessionLocal
+from backend.app.database import AsyncSessionLocal
 from backend.app.integrations.calendar.provider import (
     CalendarEventCreate,
     CalendarEventUpdate,
@@ -947,18 +947,20 @@ def _calendar_auth_check(ctx: ToolContext) -> str | None:
     )
 
 
-def _get_enabled_calendars(user_id: str) -> list[tuple[str, str, list[str], str]]:
+async def _get_enabled_calendars(user_id: str) -> list[tuple[str, str, list[str], str]]:
     """Load the user's enabled calendars from CalendarConfig.
 
     Returns a list of ``(calendar_id, display_name, disabled_tools, access_role)``
     tuples.  Write tools are automatically added to *disabled_tools* for
     calendars whose *access_role* is ``reader`` or ``freeBusyReader``.
     """
-    db = SessionLocal()
+    db = AsyncSessionLocal()
     try:
         configs = (
-            db.execute(
-                select(CalendarConfig).filter_by(user_id=user_id, provider="google_calendar")
+            (
+                await db.execute(
+                    select(CalendarConfig).filter_by(user_id=user_id, provider="google_calendar")
+                )
             )
             .scalars()
             .all()
@@ -990,12 +992,12 @@ def _get_enabled_calendars(user_id: str) -> list[tuple[str, str, list[str], str]
             )
             return result
     finally:
-        db.close()
+        await db.close()
     logger.debug("No calendar config for user %s, defaulting to primary", user_id)
     return [("primary", "Primary", [], "owner")]
 
 
-def _get_primary_calendar_id(user_id: str) -> str:
+async def _get_primary_calendar_id(user_id: str) -> str:
     """Return the calendar_id of the row marked is_primary, or empty string.
 
     Mirrors ``_get_enabled_calendars`` but pulls only the
@@ -1003,16 +1005,18 @@ def _get_primary_calendar_id(user_id: str) -> str:
     config at all (the literal ``"primary"`` magic alias is the implicit
     default in that case) or when no row is flagged primary.
     """
-    db = SessionLocal()
+    db = AsyncSessionLocal()
     try:
-        row = db.execute(
-            select(CalendarConfig).filter_by(
-                user_id=user_id, provider="google_calendar", is_primary=True
+        row = (
+            await db.execute(
+                select(CalendarConfig).filter_by(
+                    user_id=user_id, provider="google_calendar", is_primary=True
+                )
             )
         ).scalar_one_or_none()
         return row.calendar_id if row is not None else ""
     finally:
-        db.close()
+        await db.close()
 
 
 async def _calendar_factory(ctx: ToolContext) -> list[Tool]:
@@ -1030,8 +1034,8 @@ async def _calendar_factory(ctx: ToolContext) -> list[Tool]:
         token_expires_at=token.expires_at or 0.0,
         on_token_refresh=oauth_service.build_on_refresh_callback(ctx.user.id, "google_calendar"),
     )
-    enabled_calendars = _get_enabled_calendars(ctx.user.id)
-    primary_calendar_id = _get_primary_calendar_id(ctx.user.id)
+    enabled_calendars = await _get_enabled_calendars(ctx.user.id)
+    primary_calendar_id = await _get_primary_calendar_id(ctx.user.id)
     return create_calendar_tools(
         service,
         user_timezone=ctx.user.timezone,

--- a/backend/app/routers/user_calendar.py
+++ b/backend/app/routers/user_calendar.py
@@ -11,10 +11,11 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.auth.dependencies import get_current_user
 from backend.app.config import settings
-from backend.app.database import SessionLocal
+from backend.app.database import get_async_db
 from backend.app.integrations.calendar.factory import parse_disabled_tools
 from backend.app.integrations.calendar.service import GoogleCalendarService
 from backend.app.models import CalendarConfig, User
@@ -75,21 +76,20 @@ async def list_calendars(
 @router.get("/user/calendar/config", response_model=CalendarConfigResponse)
 async def get_calendar_config(
     current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
 ) -> CalendarConfigResponse:
     """Get all enabled calendars for the user."""
-    db = SessionLocal()
-    try:
-        configs = (
-            db.execute(
+    configs = (
+        (
+            await db.execute(
                 select(CalendarConfig).filter_by(
                     user_id=current_user.id, provider="google_calendar"
                 )
             )
-            .scalars()
-            .all()
         )
-    finally:
-        db.close()
+        .scalars()
+        .all()
+    )
 
     return CalendarConfigResponse(
         calendars=[
@@ -108,6 +108,7 @@ async def get_calendar_config(
 async def update_calendar_config(
     body: CalendarConfigUpdate,
     current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
 ) -> CalendarConfigResponse:
     """Replace all enabled calendars (delete existing, insert new).
 
@@ -136,43 +137,39 @@ async def update_calendar_config(
             "Failed to fetch calendarList for is_primary detection (user %s)", current_user.id
         )
 
-    db = SessionLocal()
-    try:
-        db.execute(
-            delete(CalendarConfig).where(
-                CalendarConfig.user_id == current_user.id,
-                CalendarConfig.provider == "google_calendar",
-            )
+    await db.execute(
+        delete(CalendarConfig).where(
+            CalendarConfig.user_id == current_user.id,
+            CalendarConfig.provider == "google_calendar",
         )
+    )
 
-        new_configs: list[CalendarConfig] = []
-        for entry in body.calendars:
-            config = CalendarConfig(
-                user_id=current_user.id,
-                provider="google_calendar",
-                calendar_id=entry.calendar_id,
-                display_name=entry.display_name,
-                disabled_tools=json.dumps(entry.disabled_tools) if entry.disabled_tools else "",
-                access_role=entry.access_role,
-                is_primary=bool(primary_id) and entry.calendar_id == primary_id,
-            )
-            db.add(config)
-            new_configs.append(config)
-
-        db.commit()
-        for c in new_configs:
-            db.refresh(c)
-
-        return CalendarConfigResponse(
-            calendars=[
-                CalendarConfigEntry(
-                    calendar_id=c.calendar_id,
-                    display_name=c.display_name,
-                    disabled_tools=parse_disabled_tools(c.disabled_tools),
-                    access_role=c.access_role or "",
-                )
-                for c in new_configs
-            ]
+    new_configs: list[CalendarConfig] = []
+    for entry in body.calendars:
+        config = CalendarConfig(
+            user_id=current_user.id,
+            provider="google_calendar",
+            calendar_id=entry.calendar_id,
+            display_name=entry.display_name,
+            disabled_tools=json.dumps(entry.disabled_tools) if entry.disabled_tools else "",
+            access_role=entry.access_role,
+            is_primary=bool(primary_id) and entry.calendar_id == primary_id,
         )
-    finally:
-        db.close()
+        db.add(config)
+        new_configs.append(config)
+
+    await db.commit()
+    for c in new_configs:
+        await db.refresh(c)
+
+    return CalendarConfigResponse(
+        calendars=[
+            CalendarConfigEntry(
+                calendar_id=c.calendar_id,
+                display_name=c.display_name,
+                disabled_tools=parse_disabled_tools(c.disabled_tools),
+                access_role=c.access_role or "",
+            )
+            for c in new_configs
+        ]
+    )

--- a/tests/test_calendar_tools.py
+++ b/tests/test_calendar_tools.py
@@ -110,7 +110,13 @@ async def test_factory_returns_6_tools_when_configured() -> None:
         patch("backend.app.integrations.calendar.factory.oauth_service") as mock_oauth,
         patch(
             "backend.app.integrations.calendar.factory._get_enabled_calendars",
+            new_callable=AsyncMock,
             return_value=[("primary", "Primary", [], "owner")],
+        ),
+        patch(
+            "backend.app.integrations.calendar.factory._get_primary_calendar_id",
+            new_callable=AsyncMock,
+            return_value="",
         ),
     ):
         mock_settings.google_calendar_client_id = "test-id"
@@ -986,10 +992,16 @@ async def test_factory_passes_enabled_calendars() -> None:
         ) as mock_create,
         patch(
             "backend.app.integrations.calendar.factory._get_enabled_calendars",
+            new_callable=AsyncMock,
             return_value=[
                 ("primary", "Personal", [], "owner"),
                 ("jobs@example.com", "Jobs", [ToolName.CALENDAR_CREATE_EVENT], "writer"),
             ],
+        ),
+        patch(
+            "backend.app.integrations.calendar.factory._get_primary_calendar_id",
+            new_callable=AsyncMock,
+            return_value="",
         ),
     ):
         mock_settings.google_calendar_client_id = "test-id"


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Calendar slice of the async DB conversion bundle in #1178. Switches the calendar router and the factory's CalendarConfig helpers off `SessionLocal` onto `AsyncSession`.

- `backend/app/routers/user_calendar.py` (~6 sites): `get_calendar_config` and `update_calendar_config` now take an `AsyncSession` via `Depends(get_async_db)` and use `await db.execute`, `await db.commit`, `await db.refresh`. The first router conversion in OSS to use `get_async_db`.
- `backend/app/integrations/calendar/factory.py` (~4 sites): `_get_enabled_calendars` and `_get_primary_calendar_id` converted outright. Both are module-private and the only caller, `_calendar_factory`, was already `async`, so no sync peer is needed. Sessions move to `AsyncSessionLocal()` with `await db.close()`.
- `tests/test_calendar_tools.py`: the two factory tests that patched `_get_enabled_calendars` now also patch `_get_primary_calendar_id` with `AsyncMock` so awaitable return values resolve correctly.

Part of #1139. Addresses the calendar slice of #1178; the agent-module and boot slices follow in separate PRs.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (calendar test files all green; full-suite pollution observed both on `main` and on this branch is unrelated)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] `ty check` passes
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude wrote the patches under @njbrake's direction; @njbrake reviewed before push.)
- [ ] No AI used