### PR TITLE
fix(security): raise EncryptionError on corrupt envelopes

### DIFF
--- a/backend/app/security/encryption.py
+++ b/backend/app/security/encryption.py
@@ -35,6 +35,25 @@ _logger = logging.getLogger(__name__)
 ENVELOPE_PREFIX = "clw1"
 
 
+class EncryptionError(Exception):
+    """Raised when an envelope cannot be parsed or decrypted.
+
+    Wraps the lower-level failure modes (malformed structure, bad
+    base64, ``InvalidToken`` from Fernet, ``UnicodeDecodeError`` on the
+    plaintext) under a single public type so callers can catch one
+    exception and decide whether to degrade gracefully or surface to
+    the user. The original cause is preserved via ``__cause__`` (i.e.
+    ``raise EncryptionError(...) from exc``) so logs and tracebacks
+    keep enough detail to diagnose corruption.
+
+    Issue #1223: previously corrupt envelopes raised ``ValueError`` for
+    structural problems and ``InvalidToken`` for cryptographic ones,
+    making it tempting for callers to ``except Exception`` and silently
+    return empty/partial data. The dedicated type makes the contract
+    explicit.
+    """
+
+
 class EncryptionContext(TypedDict, total=False):
     """Per-row context passed to wrap/unwrap.
 
@@ -137,12 +156,30 @@ def encrypt(plaintext: str, provider: KEKProvider, context: EncryptionContext) -
 def decrypt(envelope: str, provider: KEKProvider, context: EncryptionContext) -> str:
     """Decrypt a serialized envelope back to plaintext.
 
-    Raises ``ValueError`` for malformed envelopes and propagates
-    ``InvalidToken`` if the underlying Fernet operations fail.
+    Raises ``EncryptionError`` for any corruption mode: malformed
+    envelope structure, a wrapped DEK that fails to unwrap, a
+    ciphertext that fails Fernet authentication, or plaintext that
+    isn't valid UTF-8. The original exception is chained via
+    ``__cause__`` so callers that log the failure get the underlying
+    detail without having to enumerate cryptographic exception types.
+
+    Fail-loud is intentional (issue #1223). Earlier code paths that
+    caught ``Exception`` and returned ``""`` turned a corrupted row
+    into silently-empty data downstream; the multi-append memory bug
+    in #1200 was the visible symptom.
     """
     kek_id, wrapped, ciphertext = _parse(envelope)
-    dek = provider.unwrap(kek_id, wrapped, context=context)
-    return Fernet(dek).decrypt(ciphertext.encode()).decode()
+    try:
+        dek = provider.unwrap(kek_id, wrapped, context=context)
+        return Fernet(dek).decrypt(ciphertext.encode()).decode()
+    except InvalidToken as exc:
+        raise EncryptionError(
+            f"Envelope failed authenticated decryption (kek_id={kek_id!r}): {exc}"
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise EncryptionError(
+            f"Decrypted plaintext is not valid UTF-8 (kek_id={kek_id!r}): {exc}"
+        ) from exc
 
 
 def is_envelope(value: str) -> bool:
@@ -168,14 +205,22 @@ def _serialize(kek_id: str, wrapped: bytes, ciphertext: str) -> str:
 
 
 def _parse(envelope: str) -> tuple[str, bytes, str]:
+    """Split a serialized envelope into ``(kek_id, wrapped_dek, ciphertext)``.
+
+    Raises ``EncryptionError`` (not ``ValueError``) on any structural
+    problem. Issue #1223: callers must not silently treat corrupt
+    envelopes as empty/partial data, so this surfaces a dedicated
+    exception type that's easy to catch deliberately and impossible to
+    catch by accident under a broad ``except ValueError``.
+    """
     parts = envelope.split(".", 3)
     if len(parts) != 4 or parts[0] != ENVELOPE_PREFIX:
-        raise ValueError(f"Malformed envelope (prefix/parts): {envelope[:32]!r}")
+        raise EncryptionError(f"Malformed envelope (prefix/parts): {envelope[:32]!r}")
     _, kek_id, wrapped_b64, ciphertext = parts
     try:
         wrapped = base64.urlsafe_b64decode(wrapped_b64.encode())
     except (ValueError, binascii.Error) as exc:
-        raise ValueError(f"Malformed envelope (wrapped DEK): {exc}") from exc
+        raise EncryptionError(f"Malformed envelope (wrapped DEK): {exc}") from exc
     return kek_id, wrapped, ciphertext
 
 
@@ -183,6 +228,7 @@ def _parse(envelope: str) -> tuple[str, bytes, str]:
 __all__ = [
     "ENVELOPE_PREFIX",
     "EncryptionContext",
+    "EncryptionError",
     "InvalidToken",
     "KEKProvider",
     "LocalKEKProvider",

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -36,6 +36,7 @@ from backend.app.models import ChatSession, Message, OAuthToken, User
 from backend.app.security.encryption import (
     ENVELOPE_PREFIX,
     EncryptionContext,
+    EncryptionError,
     KEKProvider,
     LocalKEKProvider,
     decrypt,
@@ -177,10 +178,61 @@ def test_recording_provider_threads_context_end_to_end() -> None:
 
 
 def test_malformed_envelope_raises(local_provider: LocalKEKProvider) -> None:
-    with pytest.raises(ValueError, match="Malformed envelope"):
+    """Structural corruption surfaces as ``EncryptionError``, not the
+    generic ``ValueError`` used pre-#1223. The dedicated type lets
+    callers catch decryption problems deliberately without snagging
+    unrelated programming errors that happen to use ``ValueError``.
+    """
+    with pytest.raises(EncryptionError, match="Malformed envelope"):
         decrypt("not-an-envelope", local_provider, {})
-    with pytest.raises(ValueError, match="Malformed envelope"):
+    with pytest.raises(EncryptionError, match="Malformed envelope"):
         decrypt("clw1.local.only-three-parts", local_provider, {})
+
+
+def test_corrupt_envelope_ciphertext_raises_encryption_error(
+    local_provider: LocalKEKProvider,
+) -> None:
+    """A structurally valid envelope whose ciphertext was tampered with
+    must raise ``EncryptionError``, not silently return empty/partial
+    data. Issue #1223: the multi-append memory bug (#1200) leaned on
+    silent-empty decrypts to mask its real symptom.
+
+    Three corruption modes are exercised:
+    1. Bad base64 in the wrapped DEK (caught by ``_parse``).
+    2. A wrapped DEK that base64-decodes but isn't a valid Fernet
+       token (``InvalidToken`` from ``provider.unwrap``).
+    3. A flipped byte inside an otherwise valid ciphertext segment
+       (``InvalidToken`` from the inner Fernet decrypt).
+
+    All three paths must raise ``EncryptionError`` and chain the
+    underlying cause via ``__cause__`` so logs keep the original
+    diagnostic text.
+    """
+    # 1. Bad base64 in the wrapped DEK position.
+    with pytest.raises(EncryptionError, match="Malformed envelope"):
+        decrypt("clw1.local.!!!not-base64!!!.something", local_provider, {})
+
+    # Build a real envelope, then corrupt pieces of it.
+    good_envelope = encrypt("super secret", local_provider, {"table": "t", "column": "c"})
+    parts = good_envelope.split(".", 3)
+    assert len(parts) == 4
+    prefix, kek_id, wrapped_b64, ciphertext = parts
+
+    # 2. Wrapped DEK is valid base64 but not a real Fernet token.
+    bogus_wrapped = base64.urlsafe_b64encode(b"\x00" * 64).decode()
+    bad_wrap_envelope = ".".join([prefix, kek_id, bogus_wrapped, ciphertext])
+    with pytest.raises(EncryptionError, match="failed authenticated decryption") as wrap_info:
+        decrypt(bad_wrap_envelope, local_provider, {"table": "t", "column": "c"})
+    assert wrap_info.value.__cause__ is not None  # original cause preserved
+
+    # 3. Flip a byte inside the inner Fernet ciphertext. Decoding the
+    # wrapped DEK still works; the inner Fernet.decrypt raises
+    # InvalidToken which decrypt() must wrap as EncryptionError.
+    flipped = ciphertext[:-1] + ("A" if ciphertext[-1] != "A" else "B")
+    flipped_envelope = ".".join([prefix, kek_id, wrapped_b64, flipped])
+    with pytest.raises(EncryptionError, match="failed authenticated decryption") as inner_info:
+        decrypt(flipped_envelope, local_provider, {"table": "t", "column": "c"})
+    assert inner_info.value.__cause__ is not None
 
 
 def test_kek_id_with_dot_is_rejected(local_provider: LocalKEKProvider) -> None:


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Define a dedicated `EncryptionError` exception in `backend/app/security/encryption.py` and surface it from `_parse` and `decrypt` for every corruption mode: malformed envelope structure, bad base64 in the wrapped DEK, `InvalidToken` from the KEK unwrap step, `InvalidToken` from the inner Fernet decrypt, and non-UTF-8 plaintext. Original causes are preserved via `__cause__` (`raise EncryptionError(...) from exc`) so logs and tracebacks keep the underlying detail.

Pre-#1223 the structural path raised `ValueError` and the cryptographic path raised `InvalidToken`. Two different exception types from one logical operation made it tempting to write `except Exception` and silently return empty/partial data. The multi-append memory bug surfaced by #1200 was the visible symptom of that pattern. A dedicated type makes the contract explicit and easy to handle deliberately.

### Caller audit

- `config_store._decode_load_rows` catches `Exception` and re-raises as `ConfigStoreError`. Still works, now wraps `EncryptionError` instead of mixed `ValueError`/`InvalidToken`.
- `EncryptedString.process_result_value` lets the exception propagate up to the SQLAlchemy ORM read path. Now propagates `EncryptionError` instead of `ValueError`/`InvalidToken`. No code path caught either type specifically, so behavior at the boundary is unchanged: a corrupt row still fails the read loudly.

### Tests

- Updated `test_malformed_envelope_raises` to expect `EncryptionError` (was `ValueError`).
- New `test_corrupt_envelope_ciphertext_raises_encryption_error` exercises three corruption modes: bad base64 in the wrapped DEK position (caught by `_parse`), a wrapped DEK that base64-decodes to garbage (`InvalidToken` from `provider.unwrap`), and a flipped byte inside an otherwise valid inner ciphertext (`InvalidToken` from the inner Fernet decrypt). Each must raise `EncryptionError` and chain the original cause.

Closes #1223
Part of #1139

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (targeted: 4 encryption tests including the new regression)
- [x] Lint passes (`ruff check`, `ruff format --check`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 drafted the implementation and PR text via back-and-forth with @njbrake)