### PR TITLE
refactor(agent): convert remaining OSS-internal sync DB callers to async

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -261,7 +261,7 @@ class ClawboltAgent:
             except Exception:
                 logger.debug("Failed to send typing indicator to %s", mask_pii(self._chat_id))
 
-    def _get_tool_permission(
+    async def _get_tool_permission(
         self,
         tool_obj: Tool,
         validated_args: dict[str, Any],
@@ -282,7 +282,7 @@ class ClawboltAgent:
             resource = policy.resource_extractor(validated_args)
 
         store = get_approval_store()
-        level = store.check_permission(
+        level = await store.check_permission_async(
             self.user.id, tool_obj.name, resource=resource, default=policy.default_level
         )
 
@@ -762,7 +762,7 @@ class ClawboltAgent:
 
         for entry in pre_validated:
             _i, tool_obj, v_args = entry
-            level, resource, description = self._get_tool_permission(tool_obj, v_args)
+            level, resource, description = await self._get_tool_permission(tool_obj, v_args)
             if level == PermissionLevel.ALWAYS:
                 auto_entries.append(entry)
             elif level == PermissionLevel.DENY:
@@ -854,7 +854,7 @@ class ClawboltAgent:
                     approved_entries.append(entry)
                     if decision == ApprovalDecision.ALWAYS_ALLOW:
                         try:
-                            store.set_permission(
+                            await store.set_permission_async(
                                 self.user.id, tool_obj.name, PermissionLevel.ALWAYS, resource
                             )
                         except Exception:
@@ -892,7 +892,7 @@ class ClawboltAgent:
                 else:  # DENIED / ALWAYS_DENY
                     if decision == ApprovalDecision.ALWAYS_DENY:
                         try:
-                            store.set_permission(
+                            await store.set_permission_async(
                                 self.user.id, tool_obj.name, PermissionLevel.DENY, resource
                             )
                         except Exception:

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -26,7 +26,8 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from any_llm import RateLimitError, amessages
 from any_llm.types.messages import MessageResponse
 from pydantic import BaseModel, Field, ValidationError
-from sqlalchemy import select
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from backend.app.agent.context import get_or_create_conversation
@@ -44,7 +45,7 @@ from backend.app.agent.tools.names import ToolName
 from backend.app.bus import OutboundMessage, message_bus
 from backend.app.channels import get_channel
 from backend.app.config import settings
-from backend.app.database import SessionLocal
+from backend.app.database import AsyncSessionLocal
 from backend.app.enums import MessageDirection
 from backend.app.logging_utils import mask_pii
 from backend.app.models import ChannelRoute, User
@@ -773,12 +774,12 @@ def _is_atx_heading(stripped_line: str) -> bool:
     return i == len(stripped_line) or stripped_line[i] in (" ", "\t")
 
 
-def _user_messaged_within(user_id: str, minutes: int) -> bool:
+async def _user_messaged_within(user_id: str, minutes: int) -> bool:
     """Return True if the user sent an inbound message in the last *minutes*.
 
     Backs the heartbeat quiet-period gate. Used to skip the heartbeat
     LLM call for users in an active conversation, where the scheduler
-    would otherwise tick → LLM call → "skip" decision once per interval
+    would otherwise tick -> LLM call -> "skip" decision once per interval
     until the user goes quiet. Cheap point lookup against the indexed
     ``messages`` table (filtered to the user's sessions).
 
@@ -789,20 +790,20 @@ def _user_messaged_within(user_id: str, minutes: int) -> bool:
     from backend.app.models import ChatSession, Message
 
     cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=minutes)
-    db = SessionLocal()
+    db = AsyncSessionLocal()
     try:
-        latest = db.execute(
+        latest = await db.scalar(
             select(Message.timestamp)
             .join(ChatSession, ChatSession.id == Message.session_id)
             .where(ChatSession.user_id == user_id, Message.direction == "inbound")
             .order_by(Message.timestamp.desc())
             .limit(1)
-        ).scalar()
+        )
     except Exception:
         logger.exception("Failed to check recent-message gate for user %s", user_id)
         return False
     finally:
-        db.close()
+        await db.close()
     return latest is not None and latest >= cutoff
 
 
@@ -850,7 +851,7 @@ async def run_heartbeat_for_user(
     # LLM call every tick that adds nothing the user will see. Cheap DB
     # lookup, runs after the in-memory gates and before the LLM call.
     quiet_minutes = settings.heartbeat_user_quiet_period_minutes
-    if quiet_minutes > 0 and _user_messaged_within(user.id, quiet_minutes):
+    if quiet_minutes > 0 and await _user_messaged_within(user.id, quiet_minutes):
         logger.debug(
             "Heartbeat skip user %s: messaged within last %d min",
             user.id,
@@ -1046,6 +1047,33 @@ async def run_heartbeat_for_user(
 _NON_PUSHABLE_CHANNELS: frozenset[str] = frozenset({"webchat"})
 
 
+def _heartbeat_route_select(user: User) -> Select[tuple[ChannelRoute]]:
+    """Pure builder shared by sync and async ``resolve_heartbeat_route`` peers."""
+    return select(ChannelRoute).where(
+        ChannelRoute.user_id == user.id,
+        ChannelRoute.enabled.is_(True),
+        ChannelRoute.channel.notin_(list(_NON_PUSHABLE_CHANNELS)),
+    )
+
+
+def _check_route_is_registered(user: User, route: ChannelRoute) -> tuple[str, ChannelRoute] | None:
+    """Verify the channel is registered in this process and return the result tuple.
+
+    Pure helper shared between the sync and async ``resolve_heartbeat_route``
+    peers so the post-query branching cannot drift.
+    """
+    try:
+        get_channel(route.channel)
+    except KeyError:
+        logger.debug(
+            "Heartbeat skipped for user %s: channel %s not registered",
+            user.id,
+            route.channel,
+        )
+        return None
+    return route.channel, route
+
+
 def resolve_heartbeat_route(
     user: User,
     db: Session,
@@ -1060,13 +1088,7 @@ def resolve_heartbeat_route(
     that flip ``enabled`` are responsible for keeping ``User.preferred_channel``
     in sync.
     """
-    route = db.execute(
-        select(ChannelRoute).where(
-            ChannelRoute.user_id == user.id,
-            ChannelRoute.enabled.is_(True),
-            ChannelRoute.channel.notin_(list(_NON_PUSHABLE_CHANNELS)),
-        )
-    ).scalar_one_or_none()
+    route = db.execute(_heartbeat_route_select(user)).scalar_one_or_none()
 
     if route is None:
         logger.debug(
@@ -1075,18 +1097,27 @@ def resolve_heartbeat_route(
         )
         return None
 
-    # Verify the channel is actually registered in this process.
-    try:
-        get_channel(route.channel)
-    except KeyError:
+    return _check_route_is_registered(user, route)
+
+
+async def resolve_heartbeat_route_async(
+    user: User,
+    db: AsyncSession,
+) -> tuple[str, ChannelRoute] | None:
+    """Async peer of :func:`resolve_heartbeat_route`.
+
+    Same shape and semantics as the sync version; only the IO is async.
+    """
+    route = (await db.execute(_heartbeat_route_select(user))).scalar_one_or_none()
+
+    if route is None:
         logger.debug(
-            "Heartbeat skipped for user %s: channel %s not registered",
+            "Heartbeat skipped for user %s: no pushable route configured",
             user.id,
-            route.channel,
         )
         return None
 
-    return route.channel, route
+    return _check_route_is_registered(user, route)
 
 
 # ---------------------------------------------------------------------------
@@ -1196,13 +1227,15 @@ class HeartbeatScheduler:
 
     async def tick(self) -> None:
         """Single heartbeat pass: evaluate due users concurrently."""
-        db = SessionLocal()
+        db = AsyncSessionLocal()
         try:
-            users = (
-                db.execute(
-                    select(User).where(
-                        User.onboarding_complete.is_(True),
-                        User.is_active.is_(True),
+            users = list(
+                (
+                    await db.execute(
+                        select(User).where(
+                            User.onboarding_complete.is_(True),
+                            User.is_active.is_(True),
+                        )
                     )
                 )
                 .scalars()
@@ -1211,7 +1244,7 @@ class HeartbeatScheduler:
             for u in users:
                 db.expunge(u)
         finally:
-            db.close()
+            await db.close()
 
         if not users:
             return
@@ -1234,11 +1267,11 @@ class HeartbeatScheduler:
             """Process a single user."""
             async with semaphore:
                 try:
-                    db = SessionLocal()
+                    db = AsyncSessionLocal()
                     try:
-                        result = resolve_heartbeat_route(user, db)
+                        result = await resolve_heartbeat_route_async(user, db)
                     finally:
-                        db.close()
+                        await db.close()
 
                     if result is None:
                         return

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -268,7 +268,7 @@ async def run_agent(
     # Ensure PERMISSIONS.json exists with all tools backfilled so the
     # agent can read/edit it and the approval store resolves from it.
 
-    get_approval_store().ensure_complete(user.id)
+    await get_approval_store().ensure_complete_async(user.id)
 
     # Shared mutable set so the list_capabilities tool closure and the
     # agent loop both see the same activation state.  This prevents the
@@ -353,7 +353,7 @@ async def run_agent(
         )
         store = get_approval_store()
         for tool_name in _onboarding_auto_tools:
-            store.set_permission(user.id, tool_name, PermissionLevel.ALWAYS)
+            await store.set_permission_async(user.id, tool_name, PermissionLevel.ALWAYS)
 
     logger.debug(
         "Agent initialized for user %s, message seq=%d with %d core tools, "

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -24,7 +24,7 @@ from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTags
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
-from backend.app.database import SessionLocal
+from backend.app.database import AsyncSessionLocal, db_session_async
 from backend.app.models import MemoryDocument, User
 
 if TYPE_CHECKING:
@@ -137,37 +137,25 @@ def _resolve_path(user_id: str, relative_path: str) -> tuple[Path, str | None]:
     return resolved, None
 
 
-def _db_read_sync(user_id: str, column: str) -> str:
-    """Read a DB-backed virtual file column (synchronous)."""
-    db = SessionLocal()
+async def _db_read(user_id: str, column: str) -> str:
+    """Read a DB-backed virtual file column."""
+    db = AsyncSessionLocal()
     try:
-        user = db.execute(select(User).filter_by(id=user_id)).scalar_one_or_none()
+        user = (await db.execute(select(User).filter_by(id=user_id))).scalar_one_or_none()
         if user is None:
             return ""
         return getattr(user, column, "") or ""
     finally:
-        db.close()
-
-
-async def _db_read(user_id: str, column: str) -> str:
-    """Read a DB-backed virtual file column."""
-    return await asyncio.to_thread(_db_read_sync, user_id, column)
-
-
-def _db_write_sync(user_id: str, column: str, content: str) -> None:
-    """Write a DB-backed virtual file column (synchronous)."""
-    from backend.app.database import db_session
-
-    with db_session() as db:
-        user = db.execute(select(User).filter_by(id=user_id)).scalar_one_or_none()
-        if user is not None:
-            setattr(user, column, content)
-            db.commit()
+        await db.close()
 
 
 async def _db_write(user_id: str, column: str, content: str) -> None:
     """Write a DB-backed virtual file column."""
-    await asyncio.to_thread(_db_write_sync, user_id, column, content)
+    async with db_session_async() as db:
+        user = (await db.execute(select(User).filter_by(id=user_id))).scalar_one_or_none()
+        if user is not None:
+            setattr(user, column, content)
+            await db.commit()
 
 
 def _canonical_name(relative_path: str) -> str | None:
@@ -203,40 +191,32 @@ def _memory_doc_column(relative_path: str) -> str | None:
     return _MEMORY_DOC_COLUMN[name]
 
 
-def _memory_doc_read_sync(user_id: str, column: str) -> str:
-    """Read a MemoryDocument column (synchronous)."""
-    db = SessionLocal()
+async def _memory_doc_read(user_id: str, column: str) -> str:
+    """Read a MemoryDocument column."""
+    db = AsyncSessionLocal()
     try:
-        doc = db.execute(select(MemoryDocument).filter_by(user_id=user_id)).scalar_one_or_none()
+        doc = (
+            await db.execute(select(MemoryDocument).filter_by(user_id=user_id))
+        ).scalar_one_or_none()
         if doc is None:
             return ""
         return getattr(doc, column, "") or ""
     finally:
-        db.close()
-
-
-async def _memory_doc_read(user_id: str, column: str) -> str:
-    """Read a MemoryDocument column."""
-    return await asyncio.to_thread(_memory_doc_read_sync, user_id, column)
-
-
-def _memory_doc_write_sync(user_id: str, column: str, content: str) -> None:
-    """Write a MemoryDocument column (synchronous)."""
-    from backend.app.database import db_session
-
-    with db_session() as db:
-        doc = db.execute(select(MemoryDocument).filter_by(user_id=user_id)).scalar_one_or_none()
-        if doc is None:
-            doc = MemoryDocument(user_id=user_id, memory_text="", history_text="")
-            db.add(doc)
-            db.flush()
-        setattr(doc, column, content)
-        db.commit()
+        await db.close()
 
 
 async def _memory_doc_write(user_id: str, column: str, content: str) -> None:
     """Write a MemoryDocument column."""
-    await asyncio.to_thread(_memory_doc_write_sync, user_id, column, content)
+    async with db_session_async() as db:
+        doc = (
+            await db.execute(select(MemoryDocument).filter_by(user_id=user_id))
+        ).scalar_one_or_none()
+        if doc is None:
+            doc = MemoryDocument(user_id=user_id, memory_text="", history_text="")
+            db.add(doc)
+            await db.flush()
+        setattr(doc, column, content)
+        await db.commit()
 
 
 def _is_permissions_path(relative_path: str) -> bool:
@@ -256,24 +236,22 @@ def _is_permissions_path(relative_path: str) -> bool:
     return not ("/" in stripped or relative_path.startswith(".."))
 
 
-def _permissions_read_sync(user_id: str) -> str:
+async def _permissions_read(user_id: str) -> str:
     from backend.app.models import UserPermissionSet
 
-    db = SessionLocal()
+    db = AsyncSessionLocal()
     try:
-        row = db.execute(select(UserPermissionSet).filter_by(user_id=user_id)).scalar_one_or_none()
+        row = (
+            await db.execute(select(UserPermissionSet).filter_by(user_id=user_id))
+        ).scalar_one_or_none()
         if row is None:
             return ""
         return row.data or ""
     finally:
-        db.close()
+        await db.close()
 
 
-async def _permissions_read(user_id: str) -> str:
-    return await asyncio.to_thread(_permissions_read_sync, user_id)
-
-
-def _permissions_write_sync(user_id: str, content: str) -> None:
+async def _permissions_write(user_id: str, content: str) -> None:
     """Persist PERMISSIONS.json content, normalizing to indented JSON.
 
     Stable pretty-printing matters: ApprovalStore pretty-prints on every
@@ -287,8 +265,7 @@ def _permissions_write_sync(user_id: str, content: str) -> None:
     """
     import json as _json
 
-    from backend.app.agent.approval import _lock_user_permissions
-    from backend.app.database import db_session
+    from backend.app.agent.approval import _lock_user_permissions_async
     from backend.app.models import UserPermissionSet
 
     try:
@@ -298,21 +275,19 @@ def _permissions_write_sync(user_id: str, content: str) -> None:
     else:
         payload = _json.dumps(parsed, indent=2, default=str)
 
-    with db_session() as db:
-        _lock_user_permissions(db, user_id)
-        row = db.execute(select(UserPermissionSet).filter_by(user_id=user_id)).scalar_one_or_none()
+    async with db_session_async() as db:
+        await _lock_user_permissions_async(db, user_id)
+        row = (
+            await db.execute(select(UserPermissionSet).filter_by(user_id=user_id))
+        ).scalar_one_or_none()
         if row is None:
             db.add(UserPermissionSet(user_id=user_id, data=payload))
         else:
             row.data = payload
-        db.commit()
+        await db.commit()
 
 
-async def _permissions_write(user_id: str, content: str) -> None:
-    await asyncio.to_thread(_permissions_write_sync, user_id, content)
-
-
-def _permissions_edit_sync(user_id: str, old_text: str, new_text: str) -> tuple[bool, str]:
+async def _permissions_edit(user_id: str, old_text: str, new_text: str) -> tuple[bool, str]:
     """Atomic text replace on PERMISSIONS.json.
 
     Returns ``(ok, detail)``: ``ok=True`` with ``detail=""`` on success,
@@ -323,13 +298,14 @@ def _permissions_edit_sync(user_id: str, old_text: str, new_text: str) -> tuple[
     """
     import json as _json
 
-    from backend.app.agent.approval import _lock_user_permissions
-    from backend.app.database import db_session
+    from backend.app.agent.approval import _lock_user_permissions_async
     from backend.app.models import UserPermissionSet
 
-    with db_session() as db:
-        _lock_user_permissions(db, user_id)
-        row = db.execute(select(UserPermissionSet).filter_by(user_id=user_id)).scalar_one_or_none()
+    async with db_session_async() as db:
+        await _lock_user_permissions_async(db, user_id)
+        row = (
+            await db.execute(select(UserPermissionSet).filter_by(user_id=user_id))
+        ).scalar_one_or_none()
         current = (row.data if row is not None else "") or ""
 
         if old_text not in current:
@@ -349,12 +325,8 @@ def _permissions_edit_sync(user_id: str, old_text: str, new_text: str) -> tuple[
             db.add(UserPermissionSet(user_id=user_id, data=payload))
         else:
             row.data = payload
-        db.commit()
+        await db.commit()
     return (True, "")
-
-
-async def _permissions_edit(user_id: str, old_text: str, new_text: str) -> tuple[bool, str]:
-    return await asyncio.to_thread(_permissions_edit_sync, user_id, old_text, new_text)
 
 
 def create_workspace_tools(user_id: str) -> list[Tool]:

--- a/backend/app/query_helpers.py
+++ b/backend/app/query_helpers.py
@@ -4,6 +4,7 @@ from typing import TypeVar
 
 from fastapi import HTTPException
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 T = TypeVar("T")
@@ -22,6 +23,24 @@ def get_or_404(
         user = get_or_404(db, User, detail="User not found", id=user_id)
     """
     row = db.execute(select(model).filter_by(**filters)).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail=detail)
+    return row
+
+
+async def get_or_404_async(
+    db: AsyncSession,
+    model: type[T],
+    detail: str = "Not found",
+    **filters: object,
+) -> T:
+    """Async peer of :func:`get_or_404`.
+
+    Usage::
+
+        user = await get_or_404_async(db, User, detail="User not found", id=user_id)
+    """
+    row = (await db.execute(select(model).filter_by(**filters))).scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail=detail)
     return row

--- a/backend/app/routers/user_permissions.py
+++ b/backend/app/routers/user_permissions.py
@@ -18,7 +18,7 @@ async def get_permissions(
 ) -> PermissionsResponse:
     """Return the current PERMISSIONS.json content."""
     store = get_approval_store()
-    data = store.ensure_complete(current_user.id)
+    data = await store.ensure_complete_async(current_user.id)
     return PermissionsResponse(content=json.dumps(data, indent=2))
 
 
@@ -39,7 +39,7 @@ async def update_permissions(
     _validate_permissions_shape(data)
 
     store = get_approval_store()
-    store._save(current_user.id, data)
+    await store._save_async(current_user.id, data)
     return PermissionsResponse(content=json.dumps(data, indent=2))
 
 

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -6,10 +6,10 @@ from typing import cast
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import CursorResult, delete, select, update
 from sqlalchemy import func as sa_func
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.auth.dependencies import get_current_user
-from backend.app.channel_state import realign_preferred_channel
+from backend.app.channel_state import realign_preferred_channel_async
 from backend.app.channels import is_bluebubbles_configured, reset_channel_clients
 from backend.app.config import (
     resolve_imessage_backend,
@@ -20,9 +20,9 @@ from backend.app.config_store import (
     get_settings_store,
     strip_unchanged_secrets,
 )
-from backend.app.database import get_db
+from backend.app.database import get_async_db
 from backend.app.models import ChannelRoute, HeartbeatLog, LLMUsageLog, User
-from backend.app.query_helpers import get_or_404
+from backend.app.query_helpers import get_or_404_async
 from backend.app.schemas import (
     ChannelConfigResponse,
     ChannelConfigUpdate,
@@ -87,7 +87,7 @@ async def get_profile(
 async def update_profile(
     body: UserProfileUpdate,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> UserProfileResponse:
     """Partial update of the current user's profile."""
     updates = body.model_dump(exclude_unset=True)
@@ -95,12 +95,12 @@ async def update_profile(
         raise HTTPException(status_code=400, detail="No fields to update")
 
     # Re-query user in the current session to avoid detached instance issues
-    user = get_or_404(db, User, detail="User not found", id=current_user.id)
+    user = await get_or_404_async(db, User, detail="User not found", id=current_user.id)
 
     for key, value in updates.items():
         setattr(user, key, value)
-    db.commit()
-    db.refresh(user)
+    await db.commit()
+    await db.refresh(user)
     return _profile_response(user)
 
 
@@ -146,7 +146,7 @@ async def get_data_sharing_consent(
 async def update_data_sharing_consent(
     body: DataSharingConsentRequest,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> DataSharingConsentResponse:
     """Toggle the current user's data sharing consent.
 
@@ -156,11 +156,11 @@ async def update_data_sharing_consent(
     which is the cheaper guarantee to keep correct: a one-shot accidental
     double-PUT can't drift the timestamp.
     """
-    user = get_or_404(db, User, detail="User not found", id=current_user.id)
+    user = await get_or_404_async(db, User, detail="User not found", id=current_user.id)
     user.data_sharing_consent = body.consent
     user.data_sharing_consent_at = _data_sharing_consent_now()
-    db.commit()
-    db.refresh(user)
+    await db.commit()
+    await db.refresh(user)
     return DataSharingConsentResponse(
         data_sharing_consent=user.data_sharing_consent,
         data_sharing_consent_at=(
@@ -236,14 +236,16 @@ async def update_channel_config(
 @router.get("/user/channels/routes", response_model=ChannelRouteListResponse)
 async def get_channel_routes(
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> ChannelRouteListResponse:
     """Return the current user's channel routes with enabled status."""
     routes = (
-        db.execute(
-            select(ChannelRoute)
-            .where(ChannelRoute.user_id == current_user.id)
-            .order_by(ChannelRoute.created_at)
+        (
+            await db.execute(
+                select(ChannelRoute)
+                .where(ChannelRoute.user_id == current_user.id)
+                .order_by(ChannelRoute.created_at)
+            )
         )
         .scalars()
         .all()
@@ -267,7 +269,7 @@ async def update_channel_route(
     channel: str,
     body: ChannelRouteUpdate,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> ChannelRouteResponse:
     """Toggle enabled status for a channel route.
 
@@ -292,11 +294,11 @@ async def update_channel_route(
         raise HTTPException(status_code=404, detail=f"Unknown channel: {channel}") from exc
 
     # Re-query user in the current session to avoid detached instance issues
-    user = get_or_404(db, User, detail="User not found", id=current_user.id)
+    user = await get_or_404_async(db, User, detail="User not found", id=current_user.id)
 
     if body.enabled:
         # Single-channel enforcement: disable all other non-webchat routes
-        db.execute(
+        await db.execute(
             update(ChannelRoute)
             .where(
                 ChannelRoute.user_id == user.id,
@@ -306,8 +308,8 @@ async def update_channel_route(
             .values(enabled=False)
         )
 
-    route = db.execute(
-        select(ChannelRoute).filter_by(user_id=user.id, channel=channel)
+    route = (
+        await db.execute(select(ChannelRoute).filter_by(user_id=user.id, channel=channel))
     ).scalar_one_or_none()
     if route is None and user.channel_identifier:
         route = ChannelRoute(
@@ -323,11 +325,11 @@ async def update_channel_route(
     if body.enabled:
         user.preferred_channel = channel
     else:
-        realign_preferred_channel(db, user)
+        await realign_preferred_channel_async(db, user)
 
-    db.commit()
+    await db.commit()
     if route is not None:
-        db.refresh(route)
+        await db.refresh(route)
         return ChannelRouteResponse(
             channel=route.channel,
             channel_identifier=route.channel_identifier,
@@ -521,22 +523,23 @@ async def list_provider_models(
 async def get_heartbeat_logs(
     limit: int = Query(50, ge=1, le=200),
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> HeartbeatLogListResponse:
     """List heartbeat logs for the current user, most recent first."""
     total: int = (
-        db.execute(
+        await db.scalar(
             select(sa_func.count(HeartbeatLog.id)).where(HeartbeatLog.user_id == current_user.id)
-        ).scalar()
-        or 0
-    )
+        )
+    ) or 0
 
     logs = (
-        db.execute(
-            select(HeartbeatLog)
-            .where(HeartbeatLog.user_id == current_user.id)
-            .order_by(HeartbeatLog.created_at.desc())
-            .limit(limit)
+        (
+            await db.execute(
+                select(HeartbeatLog)
+                .where(HeartbeatLog.user_id == current_user.id)
+                .order_by(HeartbeatLog.created_at.desc())
+                .limit(limit)
+            )
         )
         .scalars()
         .all()
@@ -563,18 +566,18 @@ async def get_heartbeat_logs(
 @router.delete("/user/heartbeat-logs", response_model=DeleteHeartbeatLogsResponse)
 async def delete_heartbeat_logs(
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> DeleteHeartbeatLogsResponse:
     """Delete all heartbeat logs for the current user."""
     deleted: int = cast(
         "CursorResult[object]",
-        db.execute(
+        await db.execute(
             delete(HeartbeatLog)
             .where(HeartbeatLog.user_id == current_user.id)
             .execution_options(synchronize_session="fetch")
         ),
     ).rowcount
-    db.commit()
+    await db.commit()
     return DeleteHeartbeatLogsResponse(status="deleted", deleted=deleted)
 
 
@@ -587,27 +590,31 @@ async def delete_heartbeat_logs(
 async def get_llm_usage(
     days: int = Query(30, ge=1, le=365),
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> LLMUsageSummary:
     """Aggregate LLM usage for the current user over the last N days."""
     since = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=days)
 
-    rows = db.execute(
-        select(
-            LLMUsageLog.purpose,
-            sa_func.count(LLMUsageLog.id).label("call_count"),
-            sa_func.coalesce(sa_func.sum(LLMUsageLog.input_tokens), 0).label("total_input_tokens"),
-            sa_func.coalesce(sa_func.sum(LLMUsageLog.output_tokens), 0).label(
-                "total_output_tokens"
-            ),
-            sa_func.coalesce(sa_func.sum(LLMUsageLog.total_tokens), 0).label("total_tokens"),
-            sa_func.coalesce(sa_func.sum(LLMUsageLog.cost), 0).label("total_cost"),
+    rows = (
+        await db.execute(
+            select(
+                LLMUsageLog.purpose,
+                sa_func.count(LLMUsageLog.id).label("call_count"),
+                sa_func.coalesce(sa_func.sum(LLMUsageLog.input_tokens), 0).label(
+                    "total_input_tokens"
+                ),
+                sa_func.coalesce(sa_func.sum(LLMUsageLog.output_tokens), 0).label(
+                    "total_output_tokens"
+                ),
+                sa_func.coalesce(sa_func.sum(LLMUsageLog.total_tokens), 0).label("total_tokens"),
+                sa_func.coalesce(sa_func.sum(LLMUsageLog.cost), 0).label("total_cost"),
+            )
+            .where(
+                LLMUsageLog.user_id == current_user.id,
+                LLMUsageLog.created_at >= since,
+            )
+            .group_by(LLMUsageLog.purpose)
         )
-        .where(
-            LLMUsageLog.user_id == current_user.id,
-            LLMUsageLog.created_at >= since,
-        )
-        .group_by(LLMUsageLog.purpose)
     ).all()
 
     by_purpose = [

--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -21,7 +21,7 @@ from backend.app.agent.system_prompt import build_agent_system_prompt
 from backend.app.agent.tool_assembly import build_initial_turn_tools
 from backend.app.agent.tool_summary import append_receipts
 from backend.app.auth.dependencies import get_current_user
-from backend.app.database import SessionLocal
+from backend.app.database import AsyncSessionLocal
 from backend.app.models import ChatSession, User
 from backend.app.schemas import (
     BatchDeleteRequest,
@@ -35,14 +35,14 @@ from backend.app.schemas import (
 router = APIRouter()
 
 
-def _user_session_id(user_id: str) -> str | None:
+async def _user_session_id(user_id: str) -> str | None:
     """Return the user's session_id, or None if they have no conversation yet."""
-    db = SessionLocal()
+    db = AsyncSessionLocal()
     try:
-        cs = db.execute(select(ChatSession).filter_by(user_id=user_id)).scalar_one_or_none()
+        cs = (await db.execute(select(ChatSession).filter_by(user_id=user_id))).scalar_one_or_none()
         return cs.session_id if cs is not None else None
     finally:
-        db.close()
+        await db.close()
 
 
 def _empty_conversation(user_id: str) -> SessionDetailResponse:
@@ -68,12 +68,12 @@ async def get_conversation(
     The session row is created by the agent pipeline on the first
     inbound message, not by this endpoint.
     """
-    session_id = _user_session_id(current_user.id)
+    session_id = await _user_session_id(current_user.id)
     if session_id is None:
         return _empty_conversation(current_user.id)
 
     store = get_session_store(current_user.id)
-    session = store.load_session(session_id)
+    session = await store.load_session_async(session_id)
     if session is None:
         # Race: session row was deleted between the queries above.
         return _empty_conversation(current_user.id)
@@ -150,11 +150,11 @@ async def get_conversation_system_prompt(
       out of onboarding mode while this preview still reports
       ``is_onboarding=true`` based on the in-memory heuristic.
     """
-    session_id = _user_session_id(current_user.id)
+    session_id = await _user_session_id(current_user.id)
     if session_id is None:
         raise HTTPException(status_code=404, detail="No conversation yet")
     store = get_session_store(current_user.id)
-    session = store.load_session(session_id)
+    session = await store.load_session_async(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="No conversation yet")
 
@@ -194,12 +194,12 @@ async def delete_messages_batch(
     current_user: User = Depends(get_current_user),
 ) -> DeleteMessagesResponse:
     """Delete specific messages from the user's conversation by sequence number."""
-    session_id = _user_session_id(current_user.id)
+    session_id = await _user_session_id(current_user.id)
     if session_id is None:
         raise HTTPException(status_code=404, detail="No conversation yet")
     store = get_session_store(current_user.id)
     async with user_locks.acquire(current_user.id):
-        deleted = store.delete_messages_by_seqs(session_id, body.seqs)
+        deleted = await store.delete_messages_by_seqs_async(session_id, body.seqs)
     return DeleteMessagesResponse(status="deleted", messages_deleted=deleted)
 
 
@@ -212,12 +212,12 @@ async def delete_single_message(
     current_user: User = Depends(get_current_user),
 ) -> DeleteMessageResponse:
     """Delete a single message from the user's conversation by sequence number."""
-    session_id = _user_session_id(current_user.id)
+    session_id = await _user_session_id(current_user.id)
     if session_id is None:
         raise HTTPException(status_code=404, detail="No conversation yet")
     store = get_session_store(current_user.id)
     async with user_locks.acquire(current_user.id):
-        deleted = store.delete_message(session_id, seq)
+        deleted = await store.delete_message_async(session_id, seq)
         if not deleted:
             raise HTTPException(status_code=404, detail="Message not found")
     return DeleteMessageResponse(status="deleted", seq=seq)
@@ -235,10 +235,10 @@ async def delete_conversation_history(
     Resets the initial system prompt so the conversation continues with
     a clean slate while retaining compacted memory.
     """
-    session_id = _user_session_id(current_user.id)
+    session_id = await _user_session_id(current_user.id)
     if session_id is None:
         raise HTTPException(status_code=404, detail="No conversation yet")
     store = get_session_store(current_user.id)
     async with user_locks.acquire(current_user.id):
-        deleted = store.delete_messages(session_id)
+        deleted = await store.delete_messages_async(session_id)
     return DeleteMessagesResponse(status="deleted", messages_deleted=deleted)

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -86,7 +86,7 @@ _FACTORY_META: dict[str, _FactoryMeta] = {
 }
 
 
-def _build_tool_list(
+async def _build_tool_list(
     disabled_names: set[str],
     disabled_sub_tools_map: dict[str, list[str]] | None = None,
     user_id: str | None = None,
@@ -107,7 +107,9 @@ def _build_tool_list(
     # Load permission data once to avoid repeated file reads per sub-tool.
     approval_store = get_approval_store() if user_id else None
     perm_data = (
-        approval_store.load_user_permissions(user_id) if approval_store and user_id else None
+        await approval_store.load_user_permissions_async(user_id)
+        if approval_store and user_id
+        else None
     )
     entries: list[ToolConfigEntry] = []
     for name in sorted(default_registry.factory_names):
@@ -220,7 +222,7 @@ async def get_tool_config(
     saved = await store.load()
     disabled_names = {e.name for e in saved if not e.enabled}
     disabled_sub_map = {e.name: e.disabled_sub_tools for e in saved if e.disabled_sub_tools}
-    entries = _build_tool_list(disabled_names, disabled_sub_map, user_id=current_user.id)
+    entries = await _build_tool_list(disabled_names, disabled_sub_map, user_id=current_user.id)
     auth_issues = _get_auth_status(current_user)
     return ToolConfigResponse(tools=[_entry_to_response(e, auth_issues) for e in entries])
 
@@ -275,7 +277,7 @@ async def update_tool_config(
                 disabled_sub_map.pop(name, None)
 
     # Build and save the full config
-    entries = _build_tool_list(disabled_names, disabled_sub_map, user_id=current_user.id)
+    entries = await _build_tool_list(disabled_names, disabled_sub_map, user_id=current_user.id)
     await store.save(entries)
 
     auth_issues = _get_auth_status(current_user)

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1687,10 +1687,10 @@ def _seed_message(
 
 
 class TestUserMessagedWithinIntegration:
-    def test_returns_false_when_no_messages(self, user: User) -> None:
-        assert _user_messaged_within(user.id, minutes=5) is False
+    async def test_returns_false_when_no_messages(self, user: User) -> None:
+        assert await _user_messaged_within(user.id, minutes=5) is False
 
-    def test_returns_true_for_recent_inbound(self, user: User) -> None:
+    async def test_returns_true_for_recent_inbound(self, user: User) -> None:
         now = datetime.datetime.now(datetime.UTC)
         db = _db_module.SessionLocal()
         try:
@@ -1702,9 +1702,9 @@ class TestUserMessagedWithinIntegration:
             )
         finally:
             db.close()
-        assert _user_messaged_within(user.id, minutes=5) is True
+        assert await _user_messaged_within(user.id, minutes=5) is True
 
-    def test_returns_false_for_old_inbound(self, user: User) -> None:
+    async def test_returns_false_for_old_inbound(self, user: User) -> None:
         now = datetime.datetime.now(datetime.UTC)
         db = _db_module.SessionLocal()
         try:
@@ -1716,9 +1716,9 @@ class TestUserMessagedWithinIntegration:
             )
         finally:
             db.close()
-        assert _user_messaged_within(user.id, minutes=5) is False
+        assert await _user_messaged_within(user.id, minutes=5) is False
 
-    def test_ignores_outbound_messages(self, user: User) -> None:
+    async def test_ignores_outbound_messages(self, user: User) -> None:
         """Outbound (assistant-authored) messages must not satisfy the gate.
 
         The gate exists to detect that the *user* is mid-conversation,
@@ -1737,9 +1737,9 @@ class TestUserMessagedWithinIntegration:
             )
         finally:
             db.close()
-        assert _user_messaged_within(user.id, minutes=5) is False
+        assert await _user_messaged_within(user.id, minutes=5) is False
 
-    def test_other_users_messages_do_not_leak(self, user: User) -> None:
+    async def test_other_users_messages_do_not_leak(self, user: User) -> None:
         """A different user's recent inbound must not trigger this user's gate."""
         other_db = _db_module.SessionLocal()
         try:
@@ -1767,7 +1767,7 @@ class TestUserMessagedWithinIntegration:
             )
         finally:
             db.close()
-        assert _user_messaged_within(user.id, minutes=5) is False
+        assert await _user_messaged_within(user.id, minutes=5) is False
 
 
 # ---------------------------------------------------------------------------
@@ -2224,7 +2224,11 @@ class TestHeartbeatScheduler:
         ) -> None:
             captured_sql.append(statement)
 
-        engine = _db_module.get_engine()
+        # tick() runs against the async engine, so attach the listener to
+        # its underlying sync engine. SQLAlchemy core events fire on the
+        # sync_engine of an AsyncEngine; listening on the async engine
+        # itself (or the sync engine) would miss the SQL emitted here.
+        engine = _db_module.get_async_engine().sync_engine
         event.listen(engine, "before_cursor_execute", _capture)
         try:
             scheduler = HeartbeatScheduler()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Continues the dual-API rollout (epic #1139, follow-up to the store conversions in #1189-#1206). Each converted site now calls the async peer of an existing dual-API method, swaps the `Session` annotation to `AsyncSession`, and threads `await` through the call chain. No new sync surface added; no observable behavior changes.

### Files / functions converted

- `backend/app/agent/tools/workspace_tools.py`: collapsed `_db_read`, `_db_write`, `_memory_doc_read`, `_memory_doc_write`, `_permissions_read`, `_permissions_write`, `_permissions_edit`. Removed the `asyncio.to_thread` plus sync helper sandwich and replaced with native async DB access. Now uses `_lock_user_permissions_async` for the PERMISSIONS.json critical section.
- `backend/app/agent/router.py` (`run_agent`): `ensure_complete` becomes `ensure_complete_async`, `set_permission` becomes `set_permission_async` for the onboarding auto-allow path.
- `backend/app/agent/core.py` (`_execute_tool_round`): `_get_tool_permission` is now `async`. Calls `check_permission_async` and `set_permission_async` for both ALWAYS_ALLOW and ALWAYS_DENY persistence.
- `backend/app/agent/heartbeat.py`: added `resolve_heartbeat_route_async` (mirrors the sync peer via a shared `_heartbeat_route_select` builder and a shared `_check_route_is_registered` post-query helper). `tick()` and `_user_messaged_within` now use `AsyncSessionLocal`. `_user_messaged_within` is async and awaited from `run_heartbeat_for_user`.
- `backend/app/routers/user_permissions.py`: GET uses `ensure_complete_async`; PUT uses `_save_async`.
- `backend/app/routers/user_profile.py`: every route that took `db: Session = Depends(get_db)` now uses `AsyncSession = Depends(get_async_db)`. Calls converted: `update_profile`, `update_data_sharing_consent`, `get_channel_routes`, `update_channel_route` (with `realign_preferred_channel_async`), `get_heartbeat_logs`, `delete_heartbeat_logs`, `get_llm_usage`.
- `backend/app/routers/user_sessions.py`: `_user_session_id` is async; all five route handlers use the async peers (`load_session_async`, `delete_message_async`, `delete_messages_by_seqs_async`, `delete_messages_async`).
- `backend/app/routers/user_tools.py`: `_build_tool_list` is async, calls `load_user_permissions_async`. Both routes await the new signature.
- `backend/app/query_helpers.py`: added `get_or_404_async` peer for the new async router code paths.

### Sites deferred (follow-up)

- `backend/app/services/oauth.py` (5 sites: `save_token`, `load_token`, `_load_token_uncached`, `delete_token`, `is_connected`, plus the inline session inside `_get_valid_token` refresh path). The OAuth refresh logic mixes sync session-scoped advisory locks with async HTTP, and the `_load_token_uncached` plus `save_token` rotation runs inside a session-pinned advisory critical section (`_try_acquire_advisory_lock_sync`). Converting these requires adding async peer methods plus a careful re-think of the lock-pin invariants. Better in its own focused PR.
- `backend/app/agent/approval.py` sync surface (`_load`, `_save`, `set_permission`, `ensure_complete`, ...). Kept because tests and the OSS to premium boundary still call them. Premium's incremental migration will drive removal in #1160.
- `backend/app/agent/ingestion.py` (4 sites). Mixes sync `MessageBatcher` callbacks with persistence and `idempotency` writes; deserves a focused conversion that audits the message-bus ordering invariants.
- `backend/app/agent/context.py` `trigger_compaction_for_dropped`. Called from a sync agent-loop callback; conversion needs the surrounding loop to also become async.
- `backend/app/agent/compaction.py` (1 site). Inside `compact_session` background task; benign sync write that warrants its own pass alongside the trim watermark logic.
- `backend/app/auth/dependencies.py` `provision_user`. Auth path; deserves dedicated review.
- `backend/app/auth/scoping.py` `get_scoped_user`. Used directly by tests with sync sessions; converting requires updating the test pattern.
- `backend/app/agent/heartbeat.py` `resolve_heartbeat_route` (kept). Async peer added; sync version retained for tests in `test_single_channel.py` and `test_channel_routes.py` that drive the helper with a sync `db`.
- `backend/app/channel_state.py` `realign_preferred_channel` (kept; async peer existed before this PR and is now used by the converted route).

### Sync-by-design (unrelated to async migration)

- Alembic migrations under `alembic/versions/`.
- CLI scripts under `scripts/`.
- Sync hook contract in `HeartbeatUsageHook` (per #1219).

## Type
- [x] Refactor

## Checklist
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] Type check passes (`ty check --python .venv backend/`, 14 pre-existing diagnostics; identical count before and after this diff)
- [ ] Tests pass (`uv run pytest -v`), not run locally; CI will validate.
- [x] No new sync DB surface added
- [x] Every converted site uses an existing async peer or a new pure builder

Closes #1159
Part of #1139

## AI Usage
- [x] AI-assisted (Claude Code agent ran the conversion under @njbrake's direction; commit message and PR body drafted by Claude.)