### PR TITLE
refactor(stores): finish removing sync store APIs (except IdempotencyStore)

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -204,12 +204,12 @@ async def compact_session(
     _input_chars = sum(len(m.content or "") for m in trimmed_messages if hasattr(m, "content"))
 
     memory_store = get_memory_store(user_id)
-    current_memory = memory_store.read_memory()
-    current_user_profile = memory_store.read_user()
-    current_soul = memory_store.read_soul()
-    current_history = memory_store.read_history()
+    current_memory = await memory_store.read_memory_async()
+    current_user_profile = await memory_store.read_user_async()
+    current_soul = await memory_store.read_soul_async()
+    current_history = await memory_store.read_history_async()
     heartbeat_store = HeartbeatStore(user_id)
-    current_heartbeat = heartbeat_store.read_heartbeat_md()
+    current_heartbeat = await heartbeat_store.read_heartbeat_md_async()
 
     user_prompt_parts = [
         "<current_memory>",
@@ -257,7 +257,7 @@ async def compact_session(
         logger.exception("Compaction LLM call failed for user %s", user_id)
         return "", None
 
-    log_llm_usage(user_id, model, response, purpose="compaction", provider=provider)
+    await log_llm_usage(user_id, model, response, purpose="compaction", provider=provider)
 
     raw_content = get_response_text(response)
     result = _parse_compaction_response(raw_content)
@@ -269,7 +269,7 @@ async def compact_session(
 
     # Write updated MEMORY.md if the LLM produced content
     if result.memory_update:
-        memory_store.write_memory(result.memory_update)
+        await memory_store.write_memory_async(result.memory_update)
         logger.info("Compaction rewrote MEMORY.md for user %s", user_id)
 
     # Append summary to HISTORY.md if the LLM produced one
@@ -287,12 +287,12 @@ async def compact_session(
 
     # Write updated USER.md if the LLM detected new profile info
     if result.user_profile_update:
-        memory_store.write_user(result.user_profile_update)
+        await memory_store.write_user_async(result.user_profile_update)
         logger.info("Compaction updated USER.md for user %s", user_id)
 
     # Write updated SOUL.md if the LLM detected personality changes
     if result.soul_update:
-        memory_store.write_soul(result.soul_update)
+        await memory_store.write_soul_async(result.soul_update)
         logger.info("Compaction updated SOUL.md for user %s", user_id)
 
     # Single structured summary line. Fields are space-separated key=value

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1037,7 +1037,7 @@ class ClawboltAgent:
                 messages, tool_schemas, max_tokens=max_tokens
             )
             purpose = "agent_main" if _round == 0 else "agent_followup"
-            log_llm_usage(
+            await log_llm_usage(
                 self.user.id,
                 self._llm_model_override or settings.llm_model,
                 response,

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -404,7 +404,9 @@ async def evaluate_heartbeat_need(
     agent.
     """
     session_store = get_session_store(user.id)
-    recent = session_store.get_recent_messages(count=settings.heartbeat_recent_messages_count)
+    recent = await session_store.get_recent_messages_async(
+        count=settings.heartbeat_recent_messages_count
+    )
     recent_lines: list[str] = []
     for m in recent:
         label = "User" if m.direction == MessageDirection.INBOUND else "Assistant"
@@ -425,7 +427,7 @@ async def evaluate_heartbeat_need(
     recent_text = "\n".join(recent_lines) or "(no recent messages)"
 
     heartbeat_store = HeartbeatStore(user.id)
-    heartbeat_md = heartbeat_store.read_heartbeat_md()
+    heartbeat_md = await heartbeat_store.read_heartbeat_md_async()
 
     # Fetch recent heartbeat send history so the LLM knows when it last
     # messaged this user and can avoid duplicates or missed sends.
@@ -485,7 +487,7 @@ async def evaluate_heartbeat_need(
     if response is None:
         raise RuntimeError("Heartbeat LLM retry loop exited without response")
 
-    log_llm_usage(user.id, model, response, "heartbeat_decision", provider=provider)
+    await log_llm_usage(user.id, model, response, "heartbeat_decision", provider=provider)
     decision = _parse_decision_response(response)
     if response.usage:
         decision.input_tokens = response.usage.input_tokens or 0
@@ -874,7 +876,7 @@ async def run_heartbeat_for_user(
     # ``read_heartbeat_md``, which is also called by compaction and the
     # heartbeat tools where the raw text is the right return.
     heartbeat_store = HeartbeatStore(user.id)
-    heartbeat_text = heartbeat_store.read_heartbeat_md()
+    heartbeat_text = await heartbeat_store.read_heartbeat_md_async()
     if not _has_actionable_heartbeat_content(heartbeat_text):
         logger.debug("Heartbeat skip user %s: no heartbeat items configured", user.id)
         return None

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -392,7 +392,9 @@ async def _dispatch_to_pipeline(
                         # messages persisted by a previous pipeline that
                         # was holding the lock (e.g. tool interactions
                         # from an interrupted approval).
-                        fresh_session = get_session_store(user_id).load_session(session.session_id)
+                        fresh_session = await get_session_store(user_id).load_session_async(
+                            session.session_id
+                        )
                         if fresh_session is not None:
                             session = fresh_session
                         await handle_inbound_message(

--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -15,27 +15,24 @@ from sqlalchemy import Select, Update, select, update
 from backend.app.agent.store_cache import StoreCache
 from backend.app.database import (
     AsyncSessionLocal,
-    SessionLocal,
-    db_session,
     db_session_async,
 )
 from backend.app.models import MemoryDocument, User
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
-    from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Pure typed builders shared by sync and async paths.
+# Pure typed builders shared by every async store method.
 #
-# Mirrors the IdempotencyStore pilot (issue #1150 / PR #1199): each
-# public sync method has an ``*_async`` peer; both forward through the
-# same ``select(...) / update(...)`` builders so the two paths cannot
-# drift. Builders return concretely-typed SQLAlchemy core constructs;
-# no ``Any`` so ``ty`` can verify call sites end-to-end.
+# Originally introduced as the dual sync/async pilot from issue #1150 /
+# PR #1199; the sync surface has since been removed (issue #1160 final
+# pass). Builders stay because they keep query construction in one place
+# and return concretely-typed SQLAlchemy core constructs that ``ty`` can
+# verify end-to-end without ``Any``.
 # ---------------------------------------------------------------------------
 
 
@@ -50,21 +47,21 @@ def _user_select(user_id: str) -> Select[tuple[User]]:
 
 
 def _doc_select_for_update(user_id: str) -> Select[tuple[MemoryDocument]]:
-    """Builder for the locked read used by ``append_history*``.
+    """Builder for the locked read used by ``append_history``.
 
     ``MemoryDocument.history_text`` is an ``EncryptedString`` column,
     so we cannot append ciphertext on the SQL side: each row carries
     its own DEK and the envelope format is not concat-friendly.
-    Instead, both sync and async append paths SELECT the row under
-    ``FOR UPDATE``, decrypt automatically on read, concatenate in
-    Python, and write the full new plaintext back. The row-level lock
-    serializes concurrent appenders so neither side loses its update.
+    Instead, the append path SELECTs the row under ``FOR UPDATE``,
+    decrypts automatically on read, concatenates in Python, and writes
+    the full new plaintext back. The row-level lock serializes
+    concurrent appenders so neither side loses its update.
     """
     return select(MemoryDocument).filter_by(user_id=user_id).with_for_update()
 
 
 def _append_history_update(doc_id: int, full_new_text: str) -> Update:
-    """Build the UPDATE used by both sync and async ``append_history`` paths.
+    """Build the UPDATE used by the ``append_history`` path.
 
     The caller has already read the current ``history_text`` under a
     row-level lock, decrypted it, appended the new entry in Python, and
@@ -82,8 +79,8 @@ def _append_history_update(doc_id: int, full_new_text: str) -> Update:
 def _strip_section_prefix(raw: str, prefix: str) -> str:
     """Strip an optional leading ``# Soul`` / ``# User`` header.
 
-    Pulled out of the read methods so sync and async produce the same
-    string for the same DB content.
+    Pulled out of the read methods so the public API and any tests
+    that read the column directly produce the same string.
     """
     raw = raw.strip()
     if raw.startswith(prefix):
@@ -94,13 +91,10 @@ def _strip_section_prefix(raw: str, prefix: str) -> str:
 class MemoryStore:
     """Database-backed memory storage using MemoryDocument ORM model.
 
-    Dual-API store (issue #1153, part of #1139). Each public sync
-    method has an ``*_async`` peer with identical semantics. The two
-    paths share query construction via the module-level builders
-    above; only the session acquisition and ``await`` placement
-    differ. Sync callers (CLI, premium, legacy paths) keep working
-    unchanged while OSS-internal callers migrate to the async API one
-    site at a time. Follows the IdempotencyStore pilot from PR #1199.
+    Async-only API after the issue #1160 final pass. The dual sync/async
+    surface from issue #1153 (PR #1199 pilot) has been collapsed: only the
+    ``*_async`` peers remain. Premium and OSS callers all reach for the
+    async API directly.
     """
 
     def __init__(self, user_id: str) -> None:
@@ -108,17 +102,8 @@ class MemoryStore:
 
     # -- internal helpers --------------------------------------------------
 
-    def _get_or_create_doc(self, db: Session) -> MemoryDocument:
-        """Get or create the MemoryDocument row for this user."""
-        doc = db.execute(_doc_select(self.user_id)).scalar_one_or_none()
-        if doc is None:
-            doc = MemoryDocument(user_id=self.user_id, memory_text="", history_text="")
-            db.add(doc)
-            db.flush()
-        return doc
-
     async def _get_or_create_doc_async(self, db: AsyncSession) -> MemoryDocument:
-        """Async peer of ``_get_or_create_doc``."""
+        """Get or create the MemoryDocument row for this user."""
         doc = (await db.execute(_doc_select(self.user_id))).scalar_one_or_none()
         if doc is None:
             doc = MemoryDocument(user_id=self.user_id, memory_text="", history_text="")
@@ -128,19 +113,8 @@ class MemoryStore:
 
     # -- memory text -------------------------------------------------------
 
-    def read_memory(self) -> str:
-        """Read memory text (equivalent of MEMORY.md)."""
-        db = SessionLocal()
-        try:
-            doc = db.execute(_doc_select(self.user_id)).scalar_one_or_none()
-            if doc is None:
-                return ""
-            return (doc.memory_text or "").strip()
-        finally:
-            db.close()
-
     async def read_memory_async(self) -> str:
-        """Async peer of ``read_memory``."""
+        """Read memory text (equivalent of MEMORY.md)."""
         db = AsyncSessionLocal()
         try:
             doc = (await db.execute(_doc_select(self.user_id))).scalar_one_or_none()
@@ -150,15 +124,8 @@ class MemoryStore:
         finally:
             await db.close()
 
-    def write_memory(self, content: str) -> None:
-        """Write memory text (full rewrite, equivalent of MEMORY.md)."""
-        with db_session() as db:
-            doc = self._get_or_create_doc(db)
-            doc.memory_text = content.rstrip() + "\n"
-            db.commit()
-
     async def write_memory_async(self, content: str) -> None:
-        """Async peer of ``write_memory``."""
+        """Write memory text (full rewrite, equivalent of MEMORY.md)."""
         async with db_session_async() as db:
             doc = await self._get_or_create_doc_async(db)
             doc.memory_text = content.rstrip() + "\n"
@@ -166,19 +133,8 @@ class MemoryStore:
 
     # -- history text ------------------------------------------------------
 
-    def read_history(self) -> str:
-        """Read history text (equivalent of HISTORY.md)."""
-        db = SessionLocal()
-        try:
-            doc = db.execute(_doc_select(self.user_id)).scalar_one_or_none()
-            if doc is None:
-                return ""
-            return (doc.history_text or "").strip()
-        finally:
-            db.close()
-
     async def read_history_async(self) -> str:
-        """Async peer of ``read_history``."""
+        """Read history text (equivalent of HISTORY.md)."""
         db = AsyncSessionLocal()
         try:
             doc = (await db.execute(_doc_select(self.user_id))).scalar_one_or_none()
@@ -194,31 +150,9 @@ class MemoryStore:
         Reads the current row under ``SELECT ... FOR UPDATE`` to
         serialize concurrent appenders, decrypts and concatenates in
         Python, then rewrites the column with the full plaintext.
-        SQL-side concatenation is not viable because
-        ``history_text`` is an ``EncryptedString`` column whose
-        envelope format is not concat-safe.
-        """
-        suffix = entry + "\n"
-        with db_session() as db:
-            doc = db.execute(_doc_select_for_update(self.user_id)).scalar_one_or_none()
-            if doc is None:
-                db.add(
-                    MemoryDocument(
-                        user_id=self.user_id,
-                        memory_text="",
-                        history_text=suffix,
-                    )
-                )
-            else:
-                full_new_text = (doc.history_text or "") + suffix
-                db.execute(_append_history_update(doc.id, full_new_text))
-            db.commit()
-
-    async def append_history_async(self, entry: str) -> None:
-        """Async peer of ``append_history``.
-
-        Same lock-and-rewrite contract as the sync path; only the
-        session acquisition and ``await`` placement differ.
+        SQL-side concatenation is not viable because ``history_text``
+        is an ``EncryptedString`` column whose envelope format is not
+        concat-safe.
         """
         suffix = entry + "\n"
         async with db_session_async() as db:
@@ -236,21 +170,14 @@ class MemoryStore:
                 await db.execute(_append_history_update(doc.id, full_new_text))
             await db.commit()
 
+    async def append_history_async(self, entry: str) -> None:
+        """Deprecated alias of :meth:`append_history`."""
+        await self.append_history(entry)
+
     # -- soul text ---------------------------------------------------------
 
-    def read_soul(self) -> str:
-        """Read soul text from User model."""
-        db = SessionLocal()
-        try:
-            user = db.execute(_user_select(self.user_id)).scalar_one_or_none()
-            if user is None:
-                return ""
-            return _strip_section_prefix(user.soul_text or "", "# Soul")
-        finally:
-            db.close()
-
     async def read_soul_async(self) -> str:
-        """Async peer of ``read_soul``."""
+        """Read soul text from User model."""
         db = AsyncSessionLocal()
         try:
             user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
@@ -260,16 +187,8 @@ class MemoryStore:
         finally:
             await db.close()
 
-    def write_soul(self, content: str) -> None:
-        """Write soul text to User model."""
-        with db_session() as db:
-            user = db.execute(_user_select(self.user_id)).scalar_one_or_none()
-            if user is not None:
-                user.soul_text = f"# Soul\n\n{content}\n"
-                db.commit()
-
     async def write_soul_async(self, content: str) -> None:
-        """Async peer of ``write_soul``."""
+        """Write soul text to User model."""
         async with db_session_async() as db:
             user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
             if user is not None:
@@ -278,19 +197,8 @@ class MemoryStore:
 
     # -- user text ---------------------------------------------------------
 
-    def read_user(self) -> str:
-        """Read user text from User model."""
-        db = SessionLocal()
-        try:
-            user = db.execute(_user_select(self.user_id)).scalar_one_or_none()
-            if user is None:
-                return ""
-            return _strip_section_prefix(user.user_text or "", "# User")
-        finally:
-            db.close()
-
     async def read_user_async(self) -> str:
-        """Async peer of ``read_user``."""
+        """Read user text from User model."""
         db = AsyncSessionLocal()
         try:
             user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
@@ -300,16 +208,8 @@ class MemoryStore:
         finally:
             await db.close()
 
-    def write_user(self, content: str) -> None:
-        """Write user text to User model."""
-        with db_session() as db:
-            user = db.execute(_user_select(self.user_id)).scalar_one_or_none()
-            if user is not None:
-                user.user_text = f"# User\n\n{content}\n"
-                db.commit()
-
     async def write_user_async(self, content: str) -> None:
-        """Async peer of ``write_user``."""
+        """Write user text to User model."""
         async with db_session_async() as db:
             user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
             if user is not None:
@@ -318,12 +218,8 @@ class MemoryStore:
 
     # -- composite helpers -------------------------------------------------
 
-    async def build_memory_context(self) -> str:
-        """Build memory context for injection into the agent prompt."""
-        return self.read_memory()
-
     async def build_memory_context_async(self) -> str:
-        """Async peer of ``build_memory_context``."""
+        """Build memory context for injection into the agent prompt."""
         return await self.read_memory_async()
 
 
@@ -356,16 +252,16 @@ def reset_memory_stores() -> None:
 async def build_memory_context(user_id: str) -> str:
     """Build memory context text for injection into the agent prompt."""
     store = get_memory_store(user_id)
-    return await store.build_memory_context()
+    return await store.build_memory_context_async()
 
 
-def read_memory(user_id: str) -> str:
+async def read_memory(user_id: str) -> str:
     """Read raw MEMORY.md content for a user."""
     store = get_memory_store(user_id)
-    return store.read_memory()
+    return await store.read_memory_async()
 
 
-def write_memory(user_id: str, content: str) -> None:
+async def write_memory(user_id: str, content: str) -> None:
     """Write raw MEMORY.md content for a user."""
     store = get_memory_store(user_id)
-    store.write_memory(content)
+    await store.write_memory_async(content)

--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -39,8 +39,6 @@ from backend.app.agent.store_cache import StoreCache
 from backend.app.config import settings
 from backend.app.database import (
     AsyncSessionLocal,
-    SessionLocal,
-    db_session,
     db_session_async,
 )
 from backend.app.models import ChatSession, Message
@@ -216,11 +214,11 @@ _MESSAGE_UPDATABLE_FIELDS: frozenset[str] = frozenset(
 class SessionStore:
     """Database-backed session storage using ChatSession and Message ORM models.
 
-    Dual-API store (issue #1152). Each public sync method has an
-    ``*_async`` peer with identical semantics; query construction is
-    factored into the module-level builder helpers above so the two
-    paths stay in lockstep. Sync callers keep working unchanged while
-    OSS-internal callers migrate to the async API one site at a time.
+    Async-only API after the issue #1160 final pass. The dual-API surface
+    from issue #1152 has been collapsed: only the async implementations
+    remain. The bare-name methods now delegate to their ``*_async`` peers
+    to keep the public surface stable for any out-of-tree caller; OSS and
+    premium have all migrated to the suffixed names.
     """
 
     def __init__(self, user_id: str) -> None:
@@ -230,22 +228,8 @@ class SessionStore:
     # load_session
     # ------------------------------------------------------------------
 
-    def load_session(self, session_id: str) -> SessionState | None:
-        """Load a session by its string session_id."""
-        db = SessionLocal()
-        try:
-            cs = db.execute(
-                _select_session_by_session_id(session_id, self.user_id)
-            ).scalar_one_or_none()
-            if cs is None:
-                return None
-            messages = list(db.execute(_select_messages_for_session(cs.id)).scalars().all())
-            return _session_to_state(cs, messages)
-        finally:
-            db.close()
-
     async def load_session_async(self, session_id: str) -> SessionState | None:
-        """Async peer of ``load_session``."""
+        """Load a session by its string session_id."""
         db = AsyncSessionLocal()
         try:
             cs = (
@@ -262,21 +246,8 @@ class SessionStore:
     # list_sessions
     # ------------------------------------------------------------------
 
-    async def list_sessions(self) -> list[SessionState]:
-        """Return all sessions with their messages for this user."""
-        db = SessionLocal()
-        try:
-            sessions = db.execute(_select_all_sessions_for_user(self.user_id)).scalars().all()
-            result = []
-            for cs in sessions:
-                messages = list(db.execute(_select_messages_for_session(cs.id)).scalars().all())
-                result.append(_session_to_state(cs, messages))
-            return result
-        finally:
-            db.close()
-
     async def list_sessions_async(self) -> list[SessionState]:
-        """Async peer of ``list_sessions``."""
+        """Return all sessions with their messages for this user."""
         db = AsyncSessionLocal()
         try:
             sessions = (
@@ -292,11 +263,19 @@ class SessionStore:
         finally:
             await db.close()
 
+    async def list_sessions(self) -> list[SessionState]:
+        """Deprecated alias of :meth:`list_sessions_async`."""
+        return await self.list_sessions_async()
+
     # ------------------------------------------------------------------
     # get_or_create_session  (advisory-lock site)
     # ------------------------------------------------------------------
 
     async def get_or_create_session(self) -> tuple[SessionState, bool]:
+        """Deprecated alias of :meth:`get_or_create_session_async`."""
+        return await self.get_or_create_session_async()
+
+    async def get_or_create_session_async(self) -> tuple[SessionState, bool]:
         """Get the user's session, creating it on first call.
 
         Each user has a single persistent session, enforced by the
@@ -308,66 +287,6 @@ class SessionStore:
         otherwise race the INSERT and one would lose to the unique
         constraint. We serialize with a transaction-scoped advisory lock
         keyed on user_id so the runner-up sees the winner's row instead.
-        """
-        db = SessionLocal()
-        try:
-            db.execute(
-                _advisory_lock_sql(),
-                {"k": _advisory_lock_key(self.user_id)},
-            )
-            cs = db.execute(_select_session_by_user(self.user_id)).scalar_one_or_none()
-            if cs is not None:
-                now = datetime.datetime.now(datetime.UTC)
-                cs.last_message_at = now
-                db.commit()
-                messages = list(db.execute(_select_messages_for_session(cs.id)).scalars().all())
-                return _session_to_state(cs, messages), False
-
-            # Create new session with unique ID. Use timestamp + short UUID suffix
-            # to keep IDs readable while avoiding races.
-            now = datetime.datetime.now(datetime.UTC)
-            ts = int(now.timestamp())
-            short_uid = uuid.uuid4().hex[:8]
-            session_id = f"{self.user_id}_{ts}_{short_uid}"
-
-            cs = ChatSession(
-                session_id=session_id,
-                user_id=self.user_id,
-                channel="",
-                created_at=now,
-                last_message_at=now,
-            )
-            db.add(cs)
-            try:
-                db.commit()
-            except IntegrityError:
-                db.rollback()
-                # Either a session_id collision (extremely unlikely) or
-                # the user_id UNIQUE lost a race despite the advisory
-                # lock. Reload and return the winner's row.
-                cs = db.execute(_select_session_by_user(self.user_id)).scalar_one_or_none()
-                if cs is not None:
-                    messages = list(db.execute(_select_messages_for_session(cs.id)).scalars().all())
-                    return _session_to_state(cs, messages), False
-                # No conflicting row found; retry with a fresh session_id.
-                short_uid = uuid.uuid4().hex[:8]
-                session_id = f"{self.user_id}_{ts}_{short_uid}"
-                cs = ChatSession(
-                    session_id=session_id,
-                    user_id=self.user_id,
-                    channel="",
-                    created_at=now,
-                    last_message_at=now,
-                )
-                db.add(cs)
-                db.commit()
-            db.refresh(cs)
-            return _session_to_state(cs, []), True
-        finally:
-            db.close()
-
-    async def get_or_create_session_async(self) -> tuple[SessionState, bool]:
-        """Async peer of ``get_or_create_session``.
 
         Preserves the ``pg_advisory_xact_lock`` semantics: the lock is
         acquired inside an autobegun transaction and released only on
@@ -444,70 +363,17 @@ class SessionStore:
         tool_interactions_json: str = "",
         channel: str = "",
     ) -> StoredMessage:
-        """Insert a message into the database and update the in-memory session."""
-        with db_session() as db:
-            cs = db.execute(
-                _select_session_by_session_id(session.session_id, self.user_id)
-            ).scalar_one_or_none()
-            if cs is None:
-                # Auto-create the session row (supports in-memory-only SessionState
-                # objects created outside of get_or_create_session).
-                now = datetime.datetime.now(datetime.UTC)
-                cs = ChatSession(
-                    session_id=session.session_id,
-                    user_id=session.user_id,
-                    channel=channel or session.channel,
-                    created_at=now,
-                    last_message_at=now,
-                )
-                db.add(cs)
-                db.flush()
-
-            # Lock the session row to serialize concurrent message inserts,
-            # then calculate next seq. FOR UPDATE cannot be used with aggregates
-            # in PostgreSQL, so we lock the parent row instead.
-            db.execute(_select_session_for_update(cs.id)).scalar_one_or_none()
-            max_seq: int = db.execute(_select_max_seq(cs.id)).scalar() or 0
-            seq = max_seq + 1
-            now = datetime.datetime.now(datetime.UTC)
-
-            msg = Message(
-                session_id=cs.id,
-                seq=seq,
-                direction=direction,
-                body=body,
-                processed_context=processed_context,
-                tool_interactions_json=tool_interactions_json,
-                external_message_id=external_message_id,
-                media_urls_json=media_urls_json,
-                timestamp=now,
-            )
-            db.add(msg)
-
-            # Update session metadata
-            cs.last_message_at = now
-            if channel:
-                cs.channel = channel
-
-            db.commit()
-
-            # Update in-memory state
-            stored = StoredMessage(
-                direction=direction,
-                body=body,
-                processed_context=processed_context,
-                tool_interactions_json=tool_interactions_json,
-                external_message_id=external_message_id,
-                media_urls_json=media_urls_json,
-                timestamp=now.isoformat(),
-                seq=seq,
-            )
-            session.messages.append(stored)
-            session.last_message_at = now.isoformat()
-            if channel:
-                session.channel = channel
-
-            return stored
+        """Deprecated alias of :meth:`add_message_async`."""
+        return await self.add_message_async(
+            session,
+            direction,
+            body,
+            external_message_id=external_message_id,
+            media_urls_json=media_urls_json,
+            processed_context=processed_context,
+            tool_interactions_json=tool_interactions_json,
+            channel=channel,
+        )
 
     async def add_message_async(
         self,
@@ -520,7 +386,7 @@ class SessionStore:
         tool_interactions_json: str = "",
         channel: str = "",
     ) -> StoredMessage:
-        """Async peer of ``add_message``."""
+        """Insert a message into the database and update the in-memory session."""
         async with db_session_async() as db:
             cs = (
                 await db.execute(_select_session_by_session_id(session.session_id, self.user_id))
@@ -593,50 +459,17 @@ class SessionStore:
         tool_interactions_json: str = "",
         channel: str = "",
     ) -> StoredMessage:
-        """Insert a message using only the session_id (no SessionState needed).
-
-        Useful when the caller does not have a live ``SessionState`` object,
-        e.g. persisting an approval prompt from the agent loop.
-        """
-        with db_session() as db:
-            cs = db.execute(
-                _select_session_by_session_id(session_id, self.user_id)
-            ).scalar_one_or_none()
-            if cs is None:
-                raise ValueError(f"Session {session_id!r} not found for user {self.user_id!r}")
-
-            db.execute(_select_session_for_update(cs.id)).scalar_one_or_none()
-            max_seq: int = db.execute(_select_max_seq(cs.id)).scalar() or 0
-            seq = max_seq + 1
-            now = datetime.datetime.now(datetime.UTC)
-
-            msg = Message(
-                session_id=cs.id,
-                seq=seq,
-                direction=direction,
-                body=body,
-                processed_context=processed_context,
-                tool_interactions_json=tool_interactions_json,
-                external_message_id=external_message_id,
-                media_urls_json=media_urls_json,
-                timestamp=now,
-            )
-            db.add(msg)
-            cs.last_message_at = now
-            if channel:
-                cs.channel = channel
-            db.commit()
-
-            return StoredMessage(
-                direction=direction,
-                body=body,
-                processed_context=processed_context,
-                tool_interactions_json=tool_interactions_json,
-                external_message_id=external_message_id,
-                media_urls_json=media_urls_json,
-                timestamp=now.isoformat(),
-                seq=seq,
-            )
+        """Deprecated alias of :meth:`add_message_by_session_id_async`."""
+        return await self.add_message_by_session_id_async(
+            session_id,
+            direction,
+            body,
+            external_message_id=external_message_id,
+            media_urls_json=media_urls_json,
+            processed_context=processed_context,
+            tool_interactions_json=tool_interactions_json,
+            channel=channel,
+        )
 
     async def add_message_by_session_id_async(
         self,
@@ -649,7 +482,11 @@ class SessionStore:
         tool_interactions_json: str = "",
         channel: str = "",
     ) -> StoredMessage:
-        """Async peer of ``add_message_by_session_id``."""
+        """Insert a message using only the session_id (no SessionState needed).
+
+        Useful when the caller does not have a live ``SessionState`` object,
+        e.g. persisting an approval prompt from the agent loop.
+        """
         async with db_session_async() as db:
             cs = (
                 await db.execute(_select_session_by_session_id(session_id, self.user_id))
@@ -700,30 +537,8 @@ class SessionStore:
         seq: int,
         **updates: Any,
     ) -> None:
-        """Update a message by seq number."""
-        with db_session() as db:
-            cs = db.execute(
-                _select_session_by_session_id(session.session_id, self.user_id)
-            ).scalar_one_or_none()
-            if cs is None:
-                return
-
-            msg = db.execute(_select_message_by_seq(cs.id, seq)).scalar_one_or_none()
-            if msg is None:
-                return
-
-            for key, value in updates.items():
-                if key in _MESSAGE_UPDATABLE_FIELDS:
-                    setattr(msg, key, value)
-            db.commit()
-
-            # Update in-memory
-            for m in session.messages:
-                if m.seq == seq:
-                    for k, v in updates.items():
-                        if k in _MESSAGE_UPDATABLE_FIELDS and hasattr(m, k):
-                            setattr(m, k, v)
-                    break
+        """Deprecated alias of :meth:`update_message_async`."""
+        await self.update_message_async(session, seq, **updates)
 
     async def update_message_async(
         self,
@@ -731,7 +546,7 @@ class SessionStore:
         seq: int,
         **updates: Any,
     ) -> None:
-        """Async peer of ``update_message``."""
+        """Update a message by seq number."""
         async with db_session_async() as db:
             cs = (
                 await db.execute(_select_session_by_session_id(session.session_id, self.user_id))
@@ -760,22 +575,13 @@ class SessionStore:
     # ------------------------------------------------------------------
 
     async def update_initial_system_prompt(self, session: SessionState, system_prompt: str) -> None:
-        """Store the system prompt on the session if not already set."""
-        if session.initial_system_prompt:
-            return
-        with db_session() as db:
-            cs = db.execute(
-                _select_session_by_session_id(session.session_id, self.user_id)
-            ).scalar_one_or_none()
-            if cs is not None and not cs.initial_system_prompt:
-                cs.initial_system_prompt = system_prompt
-                db.commit()
-            session.initial_system_prompt = system_prompt
+        """Deprecated alias of :meth:`update_initial_system_prompt_async`."""
+        await self.update_initial_system_prompt_async(session, system_prompt)
 
     async def update_initial_system_prompt_async(
         self, session: SessionState, system_prompt: str
     ) -> None:
-        """Async peer of ``update_initial_system_prompt``."""
+        """Store the system prompt on the session if not already set."""
         if session.initial_system_prompt:
             return
         async with db_session_async() as db:
@@ -791,26 +597,11 @@ class SessionStore:
     # delete_message
     # ------------------------------------------------------------------
 
-    def delete_message(self, session_id: str, seq: int) -> bool:
+    async def delete_message_async(self, session_id: str, seq: int) -> bool:
         """Delete a single message by seq number from a session.
 
         Returns True if a message was deleted, False if not found.
         """
-        with db_session() as db:
-            cs = db.execute(
-                _select_session_by_session_id(session_id, self.user_id)
-            ).scalar_one_or_none()
-            if cs is None:
-                return False
-            count: int = cast(
-                "CursorResult[object]",
-                db.execute(_delete_message_by_seq(cs.id, seq)),
-            ).rowcount
-            db.commit()
-            return count > 0
-
-    async def delete_message_async(self, session_id: str, seq: int) -> bool:
-        """Async peer of ``delete_message``."""
         async with db_session_async() as db:
             cs = (
                 await db.execute(_select_session_by_session_id(session_id, self.user_id))
@@ -826,26 +617,11 @@ class SessionStore:
     # delete_messages_by_seqs
     # ------------------------------------------------------------------
 
-    def delete_messages_by_seqs(self, session_id: str, seqs: list[int]) -> int:
+    async def delete_messages_by_seqs_async(self, session_id: str, seqs: list[int]) -> int:
         """Delete specific messages by seq numbers from a session.
 
         Returns the number of messages actually deleted.
         """
-        with db_session() as db:
-            cs = db.execute(
-                _select_session_by_session_id(session_id, self.user_id)
-            ).scalar_one_or_none()
-            if cs is None:
-                return 0
-            count: int = cast(
-                "CursorResult[object]",
-                db.execute(_delete_messages_by_seqs(cs.id, seqs)),
-            ).rowcount
-            db.commit()
-            return count
-
-    async def delete_messages_by_seqs_async(self, session_id: str, seqs: list[int]) -> int:
-        """Async peer of ``delete_messages_by_seqs``."""
         async with db_session_async() as db:
             cs = (
                 await db.execute(_select_session_by_session_id(session_id, self.user_id))
@@ -861,28 +637,12 @@ class SessionStore:
     # delete_messages
     # ------------------------------------------------------------------
 
-    def delete_messages(self, session_id: str) -> int:
+    async def delete_messages_async(self, session_id: str) -> int:
         """Delete all messages from a session and clear its initial system prompt.
 
         Returns the number of messages deleted. The session row itself is
         preserved so the conversation can continue with an empty history.
         """
-        with db_session() as db:
-            cs = db.execute(
-                _select_session_by_session_id(session_id, self.user_id)
-            ).scalar_one_or_none()
-            if cs is None:
-                return 0
-            count: int = cast(
-                "CursorResult[object]",
-                db.execute(_delete_all_messages_for_session(cs.id)),
-            ).rowcount
-            cs.initial_system_prompt = ""
-            db.commit()
-            return count
-
-    async def delete_messages_async(self, session_id: str) -> int:
-        """Async peer of ``delete_messages``."""
         async with db_session_async() as db:
             cs = (
                 await db.execute(_select_session_by_session_id(session_id, self.user_id))
@@ -899,67 +659,32 @@ class SessionStore:
     # last-timestamp helpers
     # ------------------------------------------------------------------
 
-    def _get_last_timestamp(self, direction: str) -> datetime.datetime | None:
-        """Get the most recent message timestamp in the given direction."""
-        db = SessionLocal()
-        try:
-            return db.execute(_select_last_timestamp(self.user_id, direction)).scalar()
-        finally:
-            db.close()
-
     async def _get_last_timestamp_async(self, direction: str) -> datetime.datetime | None:
-        """Async peer of ``_get_last_timestamp``."""
+        """Get the most recent message timestamp in the given direction."""
         db = AsyncSessionLocal()
         try:
             return (await db.execute(_select_last_timestamp(self.user_id, direction))).scalar()
         finally:
             await db.close()
 
-    def get_last_inbound_timestamp(self) -> datetime.datetime | None:
-        """Get the most recent inbound message timestamp."""
-        return self._get_last_timestamp("inbound")
-
     async def get_last_inbound_timestamp_async(self) -> datetime.datetime | None:
-        """Async peer of ``get_last_inbound_timestamp``."""
+        """Get the most recent inbound message timestamp."""
         return await self._get_last_timestamp_async("inbound")
 
-    def get_last_outbound_timestamp(self) -> datetime.datetime | None:
-        """Get the most recent outbound message timestamp."""
-        return self._get_last_timestamp("outbound")
-
     async def get_last_outbound_timestamp_async(self) -> datetime.datetime | None:
-        """Async peer of ``get_last_outbound_timestamp``."""
+        """Get the most recent outbound message timestamp."""
         return await self._get_last_timestamp_async("outbound")
 
     # ------------------------------------------------------------------
     # recent-message collectors
     # ------------------------------------------------------------------
 
-    def _collect_messages(
-        self,
-        count: int | None = None,
-        exclude_session_id: str | None = None,
-    ) -> list[StoredMessage]:
-        """Collect the most recent messages, optionally excluding a session."""
-        resolved = count if count is not None else settings.heartbeat_recent_messages_count
-        db = SessionLocal()
-        try:
-            messages = list(
-                db.execute(_select_recent_messages(self.user_id, resolved, exclude_session_id))
-                .scalars()
-                .all()
-            )
-            # Return in chronological order
-            return [_msg_to_stored(m) for m in reversed(messages)]
-        finally:
-            db.close()
-
     async def _collect_messages_async(
         self,
         count: int | None = None,
         exclude_session_id: str | None = None,
     ) -> list[StoredMessage]:
-        """Async peer of ``_collect_messages``."""
+        """Collect the most recent messages, optionally excluding a session."""
         resolved = count if count is not None else settings.heartbeat_recent_messages_count
         db = AsyncSessionLocal()
         try:
@@ -972,32 +697,21 @@ class SessionStore:
                 .scalars()
                 .all()
             )
+            # Return in chronological order
             return [_msg_to_stored(m) for m in reversed(messages)]
         finally:
             await db.close()
 
-    def get_recent_messages(self, count: int | None = None) -> list[StoredMessage]:
-        """Get the most recent messages across all sessions."""
-        return self._collect_messages(count)
-
     async def get_recent_messages_async(self, count: int | None = None) -> list[StoredMessage]:
-        """Async peer of ``get_recent_messages``."""
+        """Get the most recent messages across all sessions."""
         return await self._collect_messages_async(count)
-
-    def get_other_session_messages(
-        self,
-        exclude_session_id: str,
-        count: int | None = None,
-    ) -> list[StoredMessage]:
-        """Get recent messages from sessions other than *exclude_session_id*."""
-        return self._collect_messages(count, exclude_session_id)
 
     async def get_other_session_messages_async(
         self,
         exclude_session_id: str,
         count: int | None = None,
     ) -> list[StoredMessage]:
-        """Async peer of ``get_other_session_messages``."""
+        """Get recent messages from sessions other than *exclude_session_id*."""
         return await self._collect_messages_async(count, exclude_session_id)
 
 

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -158,32 +158,17 @@ def _today_window_utc() -> tuple[datetime.datetime, datetime.datetime]:
 class HeartbeatStore:
     """Database-backed heartbeat storage using User.heartbeat_text and HeartbeatLog ORM models.
 
-    Async-only API for the methods originally introduced by issue #1154
-    (collapsed in #1160). ``read_heartbeat_md`` retains its sync ``def``
-    signature: premium callers (data export, audit) invoke it from sync
-    code paths and converting them requires premium-side changes.
+    Async-only API after the issue #1160 final pass. The sync
+    ``read_heartbeat_md`` method introduced as a transition shim in
+    issue #1154 has been removed; all OSS and premium callers use
+    :meth:`read_heartbeat_md_async`.
     """
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
 
-    def read_heartbeat_md(self) -> str:
-        """Read freeform heartbeat markdown from User.heartbeat_text.
-
-        Sync-only; premium calls this from sync export/audit paths.
-        Async callers should use :meth:`read_heartbeat_md_async`.
-        """
-        db = SessionLocal()
-        try:
-            user = db.execute(_heartbeat_user_select(self.user_id)).scalar_one_or_none()
-            if user is not None and user.heartbeat_text:
-                return user.heartbeat_text
-            return ""
-        finally:
-            db.close()
-
     async def read_heartbeat_md_async(self) -> str:
-        """Async peer of :meth:`read_heartbeat_md`."""
+        """Read freeform heartbeat markdown from User.heartbeat_text."""
         db = AsyncSessionLocal()
         try:
             user = (await db.execute(_heartbeat_user_select(self.user_id))).scalar_one_or_none()
@@ -541,12 +526,15 @@ class IdempotencyStore:
     Uses the IdempotencyKey ORM model. No user_id scoping -- external_id
     is globally unique.
 
-    Pilot for the dual-API rollout (issue #1150). The sync surface is
-    retained because the webhook entry path runs from a sync TestClient
-    worker thread that cannot share an asyncpg connection with the
-    fixture loop; converting it requires test-infra changes outside the
-    scope of #1160. The ``_async`` peers are the canonical surface for
-    new code.
+    The last sync hold-out after the issue #1160 final pass. Every
+    other store's sync surface has been removed, but the webhook entry
+    path runs from a sync ``TestClient`` worker thread that cannot
+    share an asyncpg connection with the fixture's async loop, so
+    ``has_seen``, ``try_mark_seen``, and ``_prune`` keep their sync
+    bodies until the test infrastructure can drive that path through
+    an async client. The ``_async`` peers are the canonical surface
+    for new code; the sync methods stay only for that one TestClient
+    seam.
     """
 
     def has_seen(self, external_id: str) -> bool:
@@ -734,19 +722,16 @@ def _build_llm_usage_log(
 class LLMUsageStore:
     """Database-backed LLM usage logging using LLMUsageLog ORM model.
 
-    Dual-API store (issue #1156). The async peer matters for the
-    request hot path: premium reads from this table for quota
-    enforcement, and the sync write was a known event-loop blocking
-    risk. Sync and async paths share the ``_build_llm_usage_log``
-    helper so cost computation and the unpriced-model warning behave
-    identically. Follows the IdempotencyStore pilot pattern from
-    PR #1199.
+    Async-only API after the issue #1160 final pass. The sync ``log``
+    method has been removed; ``services.llm_usage.log_llm_usage`` is
+    the canonical async entry point and threads cost computation
+    plus the unpriced-model warning through ``_build_llm_usage_log``.
     """
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
 
-    def log(
+    async def log_async(
         self,
         model: str,
         prompt_tokens: int,
@@ -768,31 +753,6 @@ class LLMUsageStore:
         ``cost=0.000000`` and a once-per-process warning so we notice when
         our pricing data is stale.
         """
-        entry = _build_llm_usage_log(
-            user_id=self.user_id,
-            model=model,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            purpose=purpose,
-            provider=provider,
-            cache_creation_input_tokens=cache_creation_input_tokens,
-            cache_read_input_tokens=cache_read_input_tokens,
-        )
-        with db_session() as db:
-            db.add(entry)
-            db.commit()
-
-    async def log_async(
-        self,
-        model: str,
-        prompt_tokens: int,
-        completion_tokens: int,
-        purpose: str,
-        provider: str = "",
-        cache_creation_input_tokens: int | None = None,
-        cache_read_input_tokens: int | None = None,
-    ) -> None:
-        """Async peer of ``log``."""
         entry = _build_llm_usage_log(
             user_id=self.user_id,
             model=model,

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -198,7 +198,7 @@ def build_time_user_context(user: User) -> str:
     )
 
 
-def build_cross_session_context(
+async def build_cross_session_context(
     user_id: str,
     current_session_id: str,
     count: int | None = None,
@@ -210,7 +210,7 @@ def build_cross_session_context(
     continuity when the user switches channels.
     """
     store = get_session_store(user_id)
-    messages = store.get_other_session_messages(current_session_id, count=count)
+    messages = await store.get_other_session_messages_async(current_session_id, count=count)
     if not messages:
         return ""
     lines: list[str] = []
@@ -266,7 +266,7 @@ async def build_agent_system_prompt(
     builder.add_section("Your Memory", memory, dynamic=True)
 
     if current_session_id:
-        cross = build_cross_session_context(user.id, current_session_id)
+        cross = await build_cross_session_context(user.id, current_session_id)
         if cross:
             builder.add_section("Recent Activity (other channel)", cross, dynamic=True)
 

--- a/backend/app/agent/tools/heartbeat_tools.py
+++ b/backend/app/agent/tools/heartbeat_tools.py
@@ -32,7 +32,7 @@ def create_heartbeat_tools(user_id: str) -> list[Tool]:
     async def get_heartbeat() -> ToolResult:
         """Read the user's heartbeat notes."""
         store = HeartbeatStore(user_id)
-        text = store.read_heartbeat_md()
+        text = await store.read_heartbeat_md_async()
         if not text:
             return ToolResult(content="No heartbeat notes set.")
         return ToolResult(content=text)
@@ -43,7 +43,7 @@ def create_heartbeat_tools(user_id: str) -> list[Tool]:
         Reads the current content first so the result shows what changed.
         """
         store = HeartbeatStore(user_id)
-        previous = store.read_heartbeat_md()
+        previous = await store.read_heartbeat_md_async()
         await store.write_heartbeat_md(text)
         if previous:
             return ToolResult(content=f"Heartbeat notes updated.\n\nPrevious content:\n{previous}")

--- a/backend/app/routers/user_memory.py
+++ b/backend/app/routers/user_memory.py
@@ -16,7 +16,7 @@ async def get_memory(
 ) -> MemoryResponse:
     """Return the raw MEMORY.md content."""
     store = get_memory_store(current_user.id)
-    return MemoryResponse(content=store.read_memory())
+    return MemoryResponse(content=await store.read_memory_async())
 
 
 @router.put("/user/memory", response_model=MemoryResponse)
@@ -26,5 +26,5 @@ async def update_memory(
 ) -> MemoryResponse:
     """Overwrite MEMORY.md with new content."""
     store = get_memory_store(current_user.id)
-    store.write_memory(body.content)
-    return MemoryResponse(content=store.read_memory())
+    await store.write_memory_async(body.content)
+    return MemoryResponse(content=await store.read_memory_async())

--- a/backend/app/services/llm_usage.py
+++ b/backend/app/services/llm_usage.py
@@ -16,7 +16,7 @@ from backend.app.agent.stores import LLMUsageStore
 logger = logging.getLogger(__name__)
 
 
-def log_llm_usage(
+async def log_llm_usage(
     user_id: str,
     model: str,
     response: MessageResponse,
@@ -41,7 +41,7 @@ def log_llm_usage(
 
     try:
         store = LLMUsageStore(user_id)
-        store.log(
+        await store.log_async(
             model,
             prompt_tokens,
             completion_tokens,

--- a/tests/integration/test_dashboard_telegram.py
+++ b/tests/integration/test_dashboard_telegram.py
@@ -120,16 +120,31 @@ def _create_session(
 
 
 def _seed_memory(user: User) -> None:
-    """Write memory text for the given user."""
-    from backend.app.agent.memory_db import get_memory_store
+    """Write memory text for the given user via direct ORM write.
 
-    store = get_memory_store(user.id)
-    store.write_memory(
+    The MemoryStore API is async-only now; sync helpers seed the
+    row directly to avoid spinning up an event loop here.
+    """
+    from backend.app.database import SessionLocal
+    from backend.app.models import MemoryDocument
+
+    text = (
         "# Long-term Memory\n\n"
         "## Business\n"
         "- hourly_rate: 95 (confidence: 1.0)\n"
-        "- specialty: panel upgrades (confidence: 0.9)"
+        "- specialty: panel upgrades (confidence: 0.9)\n"
     )
+    db = SessionLocal()
+    try:
+        doc = db.query(MemoryDocument).filter_by(user_id=user.id).one_or_none()
+        if doc is None:
+            doc = MemoryDocument(user_id=user.id, memory_text=text, history_text="")
+            db.add(doc)
+        else:
+            doc.memory_text = text
+        db.commit()
+    finally:
+        db.close()
 
 
 class TestDashboardSeesTelegramData:

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1540,7 +1540,7 @@ class TestIngestionIntercept:
         from unittest.mock import MagicMock
 
         mock_store = MagicMock()
-        mock_store.load_session.return_value = fresh_session
+        mock_store.load_session_async = AsyncMock(return_value=fresh_session)
 
         mock_handle = AsyncMock()
 
@@ -1563,7 +1563,7 @@ class TestIngestionIntercept:
             )
 
         # Session store should have been called to reload
-        mock_store.load_session.assert_called_once_with("test-sess")
+        mock_store.load_session_async.assert_called_once_with("test-sess")
 
         # handle_inbound_message should have received the fresh session
         mock_handle.assert_called_once()

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -226,7 +226,7 @@ async def test_compact_session_rewrites_memory(test_user: UserData) -> None:
 
     # Verify MEMORY.md was written
     store = get_memory_store(test_user.id)
-    content = store.read_memory()
+    content = await store.read_memory_async()
     assert "Deck: $45/sqft" in content
 
     # Verify LLM was called with the system prompt
@@ -243,8 +243,8 @@ async def test_compact_session_includes_current_memory_and_user(
 ) -> None:
     """compact_session should pass current MEMORY.md and USER.md to the LLM."""
     store = get_memory_store(test_user.id)
-    store.write_memory("## Existing\n- Old fact: still relevant")
-    store.write_user("- Name: Nathan\n- Trade: General contractor")
+    await store.write_memory_async("## Existing\n- Old fact: still relevant")
+    await store.write_user_async("- Name: Nathan\n- Trade: General contractor")
 
     mock_response = make_text_response(
         json.dumps({"memory_update": "## Existing\n- Old fact: still relevant", "summary": ""})
@@ -278,8 +278,10 @@ async def test_compact_session_user_profile_in_separate_xml_section(
     """Regression test for #823: user profile must be in a distinct <user_profile>
     section so the LLM does not merge it into memory_update."""
     store = get_memory_store(test_user.id)
-    store.write_memory("## Clients\n- Bob: 555-0100")
-    store.write_user("- Name: Nathan\n- Trade: General contractor\n- Location: Portland")
+    await store.write_memory_async("## Clients\n- Bob: 555-0100")
+    await store.write_user_async(
+        "- Name: Nathan\n- Trade: General contractor\n- Location: Portland"
+    )
 
     mock_response = make_text_response(
         json.dumps({"memory_update": "## Clients\n- Bob: 555-0100", "summary": ""})
@@ -325,8 +327,8 @@ async def test_compact_session_includes_soul_and_heartbeat(
 ) -> None:
     """compact_session should pass soul and heartbeat text to the LLM in XML tags."""
     store = get_memory_store(test_user.id)
-    store.write_memory("## Clients\n- Alice: 555-0100")
-    store.write_soul("You are a friendly assistant for trades professionals.")
+    await store.write_memory_async("## Clients\n- Alice: 555-0100")
+    await store.write_soul_async("You are a friendly assistant for trades professionals.")
 
     heartbeat_store = HeartbeatStore(test_user.id)
     await heartbeat_store.write_heartbeat_md("- Follow up with Bob about the deck estimate")
@@ -359,8 +361,8 @@ async def test_compact_session_soul_in_separate_xml_section(
 ) -> None:
     """Regression: soul content must be in <soul>, not in <current_memory>."""
     store = get_memory_store(test_user.id)
-    store.write_memory("## Clients\n- Bob: 555-0100")
-    store.write_soul("You are a helpful construction assistant.")
+    await store.write_memory_async("## Clients\n- Bob: 555-0100")
+    await store.write_soul_async("You are a helpful construction assistant.")
 
     mock_response = make_text_response(
         json.dumps({"memory_update": "## Clients\n- Bob: 555-0100", "summary": ""})
@@ -394,7 +396,7 @@ async def test_compact_session_heartbeat_in_separate_xml_section(
 ) -> None:
     """Regression: heartbeat content must be in <heartbeat>, not in <current_memory>."""
     store = get_memory_store(test_user.id)
-    store.write_memory("## Facts\n- Rate: $50/hr")
+    await store.write_memory_async("## Facts\n- Rate: $50/hr")
 
     heartbeat_store = HeartbeatStore(test_user.id)
     await heartbeat_store.write_heartbeat_md("- Call supplier about lumber delivery")
@@ -474,7 +476,7 @@ async def test_compact_session_returns_max_message_seq(test_user: UserData) -> N
 async def test_compact_session_writes_user_profile(test_user: UserData) -> None:
     """compact_session should write USER.md when LLM returns user_profile_update."""
     store = get_memory_store(test_user.id)
-    store.write_user("- Name: Nathan\n- Trade: General contractor")
+    await store.write_user_async("- Name: Nathan\n- Trade: General contractor")
 
     llm_response_content = json.dumps(
         {
@@ -494,7 +496,7 @@ async def test_compact_session_writes_user_profile(test_user: UserData) -> None:
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
         await compact_session(test_user.id, messages)
 
-    updated_profile = store.read_user()
+    updated_profile = await store.read_user_async()
     assert "Day rate: $500" in updated_profile
     assert "Nathan" in updated_profile
     assert "General contractor" in updated_profile
@@ -504,7 +506,7 @@ async def test_compact_session_writes_user_profile(test_user: UserData) -> None:
 async def test_compact_session_writes_soul(test_user: UserData) -> None:
     """compact_session should write SOUL.md when LLM returns soul_update."""
     store = get_memory_store(test_user.id)
-    store.write_soul("You are a friendly assistant.")
+    await store.write_soul_async("You are a friendly assistant.")
 
     llm_response_content = json.dumps(
         {
@@ -524,7 +526,7 @@ async def test_compact_session_writes_soul(test_user: UserData) -> None:
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
         await compact_session(test_user.id, messages)
 
-    updated_soul = store.read_soul()
+    updated_soul = await store.read_soul_async()
     assert "direct, no-nonsense" in updated_soul
     assert "Skip the pleasantries" in updated_soul
 
@@ -533,8 +535,8 @@ async def test_compact_session_writes_soul(test_user: UserData) -> None:
 async def test_compact_session_skips_empty_profile_and_soul(test_user: UserData) -> None:
     """compact_session should not write USER.md or SOUL.md when updates are empty."""
     store = get_memory_store(test_user.id)
-    store.write_user("- Name: Nathan")
-    store.write_soul("You are helpful.")
+    await store.write_user_async("- Name: Nathan")
+    await store.write_soul_async("You are helpful.")
 
     llm_response_content = json.dumps(
         {
@@ -555,10 +557,10 @@ async def test_compact_session_skips_empty_profile_and_soul(test_user: UserData)
         await compact_session(test_user.id, messages)
 
     # Profile and soul should be unchanged
-    assert store.read_user() == "- Name: Nathan"
-    assert store.read_soul() == "You are helpful."
+    assert await store.read_user_async() == "- Name: Nathan"
+    assert await store.read_soul_async() == "You are helpful."
     # Memory should be updated
-    assert "Bob: 555-0100" in store.read_memory()
+    assert "Bob: 555-0100" in await store.read_memory_async()
 
 
 @pytest.mark.asyncio()
@@ -943,7 +945,7 @@ async def test_trigger_compaction_for_dropped_fires_background_task(
         await asyncio.sleep(0.2)
 
     store = get_memory_store(test_user.id)
-    content = store.read_memory()
+    content = await store.read_memory_async()
     assert "fact: from_trim" in content
 
 
@@ -1006,7 +1008,7 @@ async def test_compact_session_appends_history(test_user: UserData) -> None:
     assert "Rate: $100/hr" in memory_update
 
     memory_store = get_memory_store(test_user.id)
-    history_content = memory_store.read_history()
+    history_content = await memory_store.read_history_async()
     assert history_content  # non-empty
     assert "User set hourly rate to $100" in history_content
     assert "[TIMESTAMP]" not in history_content
@@ -1028,7 +1030,7 @@ async def test_compact_session_no_summary_skips_history(test_user: UserData) -> 
         await compact_session(test_user.id, messages, max_message_seq=2)
 
     memory_store = get_memory_store(test_user.id)
-    assert memory_store.read_history() == ""
+    assert await memory_store.read_history_async() == ""
 
 
 @pytest.mark.asyncio()
@@ -1285,7 +1287,7 @@ async def test_load_conversation_history_respects_last_trim_seq(test_user: User)
     finally:
         db.close()
 
-    session = get_session_store(test_user.id).load_session(cs.session_id)
+    session = await get_session_store(test_user.id).load_session_async(cs.session_id)
     assert session is not None
     history = await load_conversation_history(session)
 
@@ -1302,7 +1304,7 @@ async def test_load_conversation_history_respects_last_trim_seq(test_user: User)
 async def test_load_conversation_history_null_watermark_no_filter(test_user: User) -> None:
     """NULL watermark (default) is the back-compat behavior: no filtering."""
     cs = _seed_session_with_messages(test_user, message_count=10)
-    session = get_session_store(test_user.id).load_session(cs.session_id)
+    session = await get_session_store(test_user.id).load_session_async(cs.session_id)
     assert session is not None
     assert session.last_trim_seq is None
 
@@ -1435,7 +1437,7 @@ async def test_compact_session_with_event_id_updates_existing_row(
 
     # Seed memory before so the LLM-driven write produces a diff.
     memory_store = get_memory_store(test_user.id)
-    memory_store.write_memory("# Old MEMORY\n- nothing here yet")
+    await memory_store.write_memory_async("# Old MEMORY\n- nothing here yet")
 
     llm_response = json.dumps(
         {"memory_update": "# New MEMORY\n- learned something", "summary": "[TIMESTAMP] s"}

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -551,11 +551,11 @@ class TestEvaluateHeartbeatNeed:
         mock_settings.heartbeat_recent_messages_count = 5
 
         mock_session_store = MagicMock()
-        mock_session_store.get_recent_messages.return_value = []
+        mock_session_store.get_recent_messages_async = AsyncMock(return_value=[])
         mock_get_session_store.return_value = mock_session_store
 
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="")
         mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -898,7 +898,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="Nothing actionable"
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_hb_store_cls.return_value = mock_hb_store
 
@@ -922,7 +922,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="Nothing actionable right now"
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -980,7 +980,7 @@ class TestRunHeartbeatForUser:
         mock_get_session_store.return_value = mock_session_store
 
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1075,7 +1075,7 @@ class TestRunHeartbeatForUser:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1150,7 +1150,7 @@ class TestRunHeartbeatForUser:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1189,7 +1189,7 @@ class TestRunHeartbeatForUser:
         )
         mock_execute.return_value = None
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- Check something"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- Check something")
         mock_heartbeat_store_cls.return_value = mock_hb_store
         result = await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
         assert result is not None
@@ -1243,7 +1243,7 @@ class TestRunHeartbeatForUser:
             ],
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- (something)"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- (something)")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1285,7 +1285,7 @@ class TestRunHeartbeatForUser:
         mock_eval.return_value = HeartbeatDecision(action="run", tasks="Do a thing", reasoning="r")
         mock_execute.return_value = None
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- thing"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- thing")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1319,7 +1319,7 @@ class TestRunHeartbeatForUser:
         mock_execute.return_value = AgentResponse(reply_text="Here is an update.")
         mock_bus.publish_outbound = AsyncMock(side_effect=Exception("Bus down"))
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- Check something"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- Check something")
         mock_heartbeat_store_cls.return_value = mock_hb_store
         result = await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
         # Should still return the action, just not record a message
@@ -1344,7 +1344,7 @@ class TestRunHeartbeatForUser:
             action="skip", tasks="", reasoning="nothing to do"
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1379,7 +1379,7 @@ class TestRunHeartbeatForUser:
             action="run", tasks="", reasoning="empty tasks for some reason"
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1412,7 +1412,7 @@ class TestRunHeartbeatForUser:
         mock_eval.return_value = HeartbeatDecision(action="run", tasks="something", reasoning="run")
         mock_execute.return_value = None
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- something"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- something")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1462,7 +1462,7 @@ class TestRunHeartbeatForUser:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- check stuff"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- check stuff")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1522,7 +1522,7 @@ class TestHeartbeatUsageHooks:
             output_tokens=30,
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1581,7 +1581,7 @@ class TestHeartbeatUsageHooks:
         mock_session_store.add_message = AsyncMock()
         mock_get_session_store.return_value = mock_session_store
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -1614,7 +1614,7 @@ class TestHeartbeatUsageHooks:
             output_tokens=5,
         )
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -3031,11 +3031,11 @@ class TestEvaluateHeartbeatNeedPassesHistory:
         mock_settings.reasoning_effort = ""
 
         mock_session_store = MagicMock()
-        mock_session_store.get_recent_messages.return_value = []
+        mock_session_store.get_recent_messages_async = AsyncMock(return_value=[])
         mock_get_session_store.return_value = mock_session_store
 
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="")
         mock_hb_store.get_recent_logs = AsyncMock(
             return_value=[
                 HeartbeatLogEntry(
@@ -3087,11 +3087,11 @@ class TestEvaluateHeartbeatNeedPassesHistory:
         mock_settings.reasoning_effort = ""
 
         mock_session_store = MagicMock()
-        mock_session_store.get_recent_messages.return_value = []
+        mock_session_store.get_recent_messages_async = AsyncMock(return_value=[])
         mock_get_session_store.return_value = mock_session_store
 
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="")
         mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -3143,11 +3143,11 @@ class TestRecentMessagesIncludeTimestamps:
             timestamp=datetime.datetime(2026, 3, 23, 12, 30, tzinfo=datetime.UTC).isoformat(),
         )
         mock_session_store = MagicMock()
-        mock_session_store.get_recent_messages.return_value = [msg]
+        mock_session_store.get_recent_messages_async = AsyncMock(return_value=[msg])
         mock_get_session_store.return_value = mock_session_store
 
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="")
         mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -3196,11 +3196,11 @@ class TestRecentMessagesIncludeTimestamps:
             timestamp="",
         )
         mock_session_store = MagicMock()
-        mock_session_store.get_recent_messages.return_value = [msg]
+        mock_session_store.get_recent_messages_async = AsyncMock(return_value=[msg])
         mock_get_session_store.return_value = mock_session_store
 
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="")
         mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -3320,7 +3320,7 @@ class TestSkipEmptyHeartbeatText:
         """When heartbeat_text is empty, skip without calling the LLM."""
         mock_count.return_value = 0
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = ""
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="")
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
         result = await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
@@ -3341,7 +3341,7 @@ class TestSkipEmptyHeartbeatText:
         """Whitespace-only heartbeat text is treated as empty."""
         mock_count.return_value = 0
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "   \n  \n  "
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="   \n  \n  ")
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
         result = await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
@@ -3363,7 +3363,9 @@ class TestSkipEmptyHeartbeatText:
         mock_count.return_value = 0
         mock_eval.return_value = HeartbeatDecision(action="skip", tasks="", reasoning="Nothing due")
         mock_hb_store = MagicMock()
-        mock_hb_store.read_heartbeat_md.return_value = "- Check weather for outdoor jobs"
+        mock_hb_store.read_heartbeat_md_async = AsyncMock(
+            return_value="- Check weather for outdoor jobs"
+        )
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -3884,7 +3886,7 @@ async def test_heartbeat_skips_manual_delivery_when_agent_sent_reply(user: User)
         mock_get_ss.return_value = mock_ss
 
         mock_hb = MagicMock()
-        mock_hb.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb.log_heartbeat = AsyncMock()
         mock_hb_cls.return_value = mock_hb
 
@@ -3945,7 +3947,7 @@ async def test_heartbeat_logs_when_sent_reply_but_empty_reply_text(user: User) -
         mock_get_ss.return_value = mock_ss
 
         mock_hb = MagicMock()
-        mock_hb.read_heartbeat_md.return_value = "- At 3pm: check the queue"
+        mock_hb.read_heartbeat_md_async = AsyncMock(return_value="- At 3pm: check the queue")
         mock_hb.log_heartbeat = AsyncMock()
         mock_hb_cls.return_value = mock_hb
 

--- a/tests/test_heartbeat_tools.py
+++ b/tests/test_heartbeat_tools.py
@@ -44,7 +44,7 @@ async def test_update_heartbeat_writes_text(test_user: User) -> None:
 
     # Verify via store
     store = HeartbeatStore(test_user.id)
-    text = store.read_heartbeat_md()
+    text = await store.read_heartbeat_md_async()
     assert "Daily site check" in text
     assert "Review inbox" in text
 
@@ -60,7 +60,7 @@ async def test_update_heartbeat_clears_with_empty_text(test_user: User) -> None:
     result = await update_hb(text="")
     assert "updated" in result.content.lower()
 
-    text = store.read_heartbeat_md()
+    text = await store.read_heartbeat_md_async()
     assert text == ""
 
 

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -53,11 +53,12 @@ def _read_usage_entries(user_id: str) -> list[dict[str, object]]:
         db.close()
 
 
-def test_log_llm_usage_saves(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_log_llm_usage_saves(test_user: User) -> None:
     """log_llm_usage should persist token counts to the usage log."""
     response = _make_response_with_usage(prompt_tokens=200, completion_tokens=80, total_tokens=280)
 
-    log_llm_usage(test_user.id, "test-model", response, "agent_main")
+    await log_llm_usage(test_user.id, "test-model", response, "agent_main")
 
     entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1
@@ -69,11 +70,12 @@ def test_log_llm_usage_saves(test_user: User) -> None:
     assert entries[0]["purpose"] == "agent_main"
 
 
-def test_log_llm_usage_zero_tokens(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_log_llm_usage_zero_tokens(test_user: User) -> None:
     """log_llm_usage should handle zero token counts gracefully."""
     response = _make_response_with_usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
 
-    log_llm_usage(test_user.id, "test-model", response, "heartbeat")
+    await log_llm_usage(test_user.id, "test-model", response, "heartbeat")
 
     entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1
@@ -82,18 +84,20 @@ def test_log_llm_usage_zero_tokens(test_user: User) -> None:
     assert entries[0]["total_tokens"] == 0
 
 
-def test_log_llm_usage_computes_total(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_log_llm_usage_computes_total(test_user: User) -> None:
     """log_llm_usage should compute total_tokens as prompt + completion."""
     response = _make_response_with_usage(prompt_tokens=100, completion_tokens=50, total_tokens=0)
 
-    log_llm_usage(test_user.id, "test-model", response, "agent_main")
+    await log_llm_usage(test_user.id, "test-model", response, "agent_main")
 
     entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1
     assert entries[0]["total_tokens"] == 150
 
 
-def test_log_llm_usage_multiple_entries(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_log_llm_usage_multiple_entries(test_user: User) -> None:
     """Multiple log_llm_usage calls should create separate entries."""
     for i in range(3):
         response = _make_response_with_usage(
@@ -101,7 +105,7 @@ def test_log_llm_usage_multiple_entries(test_user: User) -> None:
             completion_tokens=50 * (i + 1),
             total_tokens=150 * (i + 1),
         )
-        log_llm_usage(test_user.id, "test-model", response, f"purpose_{i}")
+        await log_llm_usage(test_user.id, "test-model", response, f"purpose_{i}")
 
     entries = _read_usage_entries(test_user.id)
     assert len(entries) == 3
@@ -110,11 +114,12 @@ def test_log_llm_usage_multiple_entries(test_user: User) -> None:
     assert entries[2]["purpose"] == "purpose_2"
 
 
-def test_log_llm_usage_different_models(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_log_llm_usage_different_models(test_user: User) -> None:
     """log_llm_usage should correctly record different model names."""
     for model_name in ["model-a", "model-b", "model-c"]:
         response = _make_response_with_usage()
-        log_llm_usage(test_user.id, model_name, response, "agent_main")
+        await log_llm_usage(test_user.id, model_name, response, "agent_main")
 
     entries = _read_usage_entries(test_user.id)
     models = {r["model"] for r in entries}
@@ -150,13 +155,14 @@ async def test_agent_process_message_logs_usage(
 # ---------------------------------------------------------------------------
 
 
-def test_log_llm_usage_cache_tokens_stored(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_log_llm_usage_cache_tokens_stored(test_user: User) -> None:
     """log_llm_usage should persist cache token fields when present."""
     response = _make_response_with_usage(prompt_tokens=500, completion_tokens=100)
     response.usage.cache_creation_input_tokens = 200
     response.usage.cache_read_input_tokens = 300
 
-    log_llm_usage(test_user.id, "test-model", response, "agent_main")
+    await log_llm_usage(test_user.id, "test-model", response, "agent_main")
 
     entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1
@@ -164,11 +170,12 @@ def test_log_llm_usage_cache_tokens_stored(test_user: User) -> None:
     assert entries[0]["cache_read_input_tokens"] == 300
 
 
-def test_log_llm_usage_cache_tokens_null_when_absent(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_log_llm_usage_cache_tokens_null_when_absent(test_user: User) -> None:
     """Cache token fields should be NULL when not set on the response."""
     response = _make_response_with_usage(prompt_tokens=100, completion_tokens=50)
 
-    log_llm_usage(test_user.id, "test-model", response, "agent_main")
+    await log_llm_usage(test_user.id, "test-model", response, "agent_main")
 
     entries = _read_usage_entries(test_user.id)
     assert len(entries) == 1

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -12,24 +12,24 @@ from backend.app.models import User
 @pytest.mark.asyncio()
 async def test_write_and_read_memory(test_user: User) -> None:
     """write_memory / read_memory should round-trip freeform content."""
-    write_memory(test_user.id, "## Pricing\n- Deck: $45/sqft")
-    content = read_memory(test_user.id)
+    await write_memory(test_user.id, "## Pricing\n- Deck: $45/sqft")
+    content = await read_memory(test_user.id)
     assert "Deck: $45/sqft" in content
 
 
 @pytest.mark.asyncio()
 async def test_read_memory_empty(test_user: User) -> None:
     """read_memory returns empty string when no MEMORY.md exists."""
-    content = read_memory(test_user.id)
+    content = await read_memory(test_user.id)
     assert content == ""
 
 
 @pytest.mark.asyncio()
 async def test_write_memory_overwrites(test_user: User) -> None:
     """write_memory should fully replace the file."""
-    write_memory(test_user.id, "old content")
-    write_memory(test_user.id, "new content")
-    content = read_memory(test_user.id)
+    await write_memory(test_user.id, "old content")
+    await write_memory(test_user.id, "new content")
+    content = await read_memory(test_user.id)
     assert "new content" in content
     assert "old content" not in content
 
@@ -38,7 +38,7 @@ async def test_write_memory_overwrites(test_user: User) -> None:
 async def test_build_memory_context_with_memory(test_user: User) -> None:
     """build_memory_context should include memory text."""
     store = get_memory_store(test_user.id)
-    store.write_memory("## Pricing\n- Deck: $35/sqft")
+    await store.write_memory_async("## Pricing\n- Deck: $35/sqft")
 
     context = await build_memory_context(test_user.id)
     assert "$35/sqft" in context
@@ -68,7 +68,7 @@ async def test_append_history_multi_append_round_trips(test_user: User) -> None:
     await store.append_history("second entry")
     await store.append_history("third entry")
 
-    history = store.read_history()
+    history = await store.read_history_async()
     # ``read_history`` strips trailing whitespace, so the final entry's
     # newline is gone but the inter-entry newlines remain.
     assert history == "first entry\nsecond entry\nthird entry"
@@ -87,4 +87,4 @@ async def test_append_history_after_seed_round_trips(test_user: User) -> None:
     await store.append_history("seed")
     await store.append_history("follow-up")
 
-    assert store.read_history() == "seed\nfollow-up"
+    assert await store.read_history_async() == "seed\nfollow-up"

--- a/tests/test_memory_endpoints.py
+++ b/tests/test_memory_endpoints.py
@@ -2,14 +2,29 @@
 
 from fastapi.testclient import TestClient
 
-from backend.app.agent.memory_db import get_memory_store
-from backend.app.models import User
+from backend.app.database import SessionLocal
+from backend.app.models import MemoryDocument, User
 
 
 def _seed_memory(user: User) -> None:
-    """Create memory with test data."""
-    store = get_memory_store(user.id)
-    store.write_memory("## Pricing\n- Deck: $45/sqft\n- Fence: $20/ft")
+    """Create memory with test data via direct ORM write.
+
+    The MemoryStore API is async-only now (issue #1160 follow-up); sync
+    test helpers seed the row directly so they can run from inside a
+    sync ``TestClient`` test without spinning up an event loop.
+    """
+    db = SessionLocal()
+    try:
+        doc = db.query(MemoryDocument).filter_by(user_id=user.id).one_or_none()
+        text = "## Pricing\n- Deck: $45/sqft\n- Fence: $20/ft\n"
+        if doc is None:
+            doc = MemoryDocument(user_id=user.id, memory_text=text, history_text="")
+            db.add(doc)
+        else:
+            doc.memory_text = text
+        db.commit()
+    finally:
+        db.close()
 
 
 def test_get_memory_empty(client: TestClient) -> None:

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -733,7 +733,7 @@ class TestBatchApproval:
 
         # The approval prompt must NOT appear in session history.
         store = get_session_store(test_user.id)
-        session = store.load_session(session_id)
+        session = await store.load_session_async(session_id)
         assert session is not None
         outbound_msgs = [m for m in session.messages if m.direction == "outbound"]
         assert not any("reply with one of" in m.body.lower() for m in outbound_msgs), (

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -12,7 +12,7 @@ async def test_build_memory_context_includes_memory_content(
 ) -> None:
     """build_memory_context should include MEMORY.md content."""
     store = get_memory_store(test_user.id)
-    store.write_memory("## Pricing\n- Hourly rate: $75/hour for general work")
+    await store.write_memory_async("## Pricing\n- Hourly rate: $75/hour for general work")
 
     context = await build_memory_context(test_user.id)
     assert "$75/hour" in context

--- a/tests/test_session_debug_info.py
+++ b/tests/test_session_debug_info.py
@@ -65,7 +65,7 @@ async def test_system_prompt_stored_on_first_message(test_user: User) -> None:
 
     # Verify it was persisted
     store = get_session_store(test_user.id)
-    loaded = store.load_session("prompt-sess-1")
+    loaded = await store.load_session_async("prompt-sess-1")
     assert loaded is not None
     assert loaded.initial_system_prompt == "You are a helpful assistant."
 
@@ -79,7 +79,7 @@ async def test_system_prompt_not_overwritten(test_user: User) -> None:
     )
 
     store = get_session_store(test_user.id)
-    session = store.load_session("prompt-sess-2")
+    session = await store.load_session_async("prompt-sess-2")
     assert session is not None
 
     ctx = PipelineContext(
@@ -91,7 +91,7 @@ async def test_system_prompt_not_overwritten(test_user: User) -> None:
     )
     await persist_system_prompt_step(ctx)
 
-    loaded = store.load_session("prompt-sess-2")
+    loaded = await store.load_session_async("prompt-sess-2")
     assert loaded is not None
     assert loaded.initial_system_prompt == "Original prompt"
 

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -524,20 +524,37 @@ def test_delete_conversation_history(client: TestClient, test_user: User) -> Non
 
 def test_delete_conversation_history_preserves_memory(client: TestClient, test_user: User) -> None:
     """Memory documents are not affected by conversation history deletion."""
-    from backend.app.agent.memory_db import get_memory_store
+    from backend.app.database import SessionLocal
+    from backend.app.models import MemoryDocument
 
     _create_session(
         test_user,
         [{"direction": "inbound", "body": "Hi", "timestamp": "2025-01-15T10:01:00", "seq": 1}],
     )
-    mem_store = get_memory_store(test_user.id)
-    mem_store.write_memory("# Test Memory\nImportant fact.")
+    # Seed memory directly via ORM. ``MemoryStore`` is async-only after
+    # the #1160 follow-up; sync ``TestClient`` tests bypass the store
+    # rather than spin up an event loop just to seed a row.
+    db = SessionLocal()
+    try:
+        doc = MemoryDocument(
+            user_id=test_user.id,
+            memory_text="# Test Memory\nImportant fact.\n",
+            history_text="",
+        )
+        db.add(doc)
+        db.commit()
+    finally:
+        db.close()
 
     resp = client.delete("/api/user/conversation/messages")
     assert resp.status_code == 200
 
-    content = mem_store.read_memory()
-    assert "Important fact." in content
+    db = SessionLocal()
+    try:
+        doc = db.query(MemoryDocument).filter_by(user_id=test_user.id).one()
+        assert "Important fact." in (doc.memory_text or "")
+    finally:
+        db.close()
 
 
 def test_delete_conversation_history_no_conversation(client: TestClient, test_user: User) -> None:

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -463,12 +463,15 @@ class TestBuildTimeUserContext:
 
 
 class TestCrossSessionContext:
-    def test_returns_empty_when_no_other_sessions(
+    @pytest.mark.asyncio()
+    async def test_returns_empty_when_no_other_sessions(
         self,
         test_user: "User",
     ) -> None:
         """Should return empty string when no other sessions exist."""
-        result = build_cross_session_context(test_user.id, current_session_id="nonexistent_999")
+        result = await build_cross_session_context(
+            test_user.id, current_session_id="nonexistent_999"
+        )
         assert result == ""
 
     @pytest.mark.asyncio()
@@ -486,7 +489,7 @@ class TestCrossSessionContext:
         await store.add_message(session_a, "inbound", "Hello from Telegram")
         await store.add_message(session_a, "outbound", "Hi! How can I help?")
 
-        result = build_cross_session_context(
+        result = await build_cross_session_context(
             test_user.id, current_session_id="different_session_999"
         )
         assert "Hello from Telegram" in result
@@ -508,7 +511,9 @@ class TestCrossSessionContext:
         await store.add_message(session_a, "inbound", "Message in session A")
 
         # When querying with session A's own ID, nothing should appear
-        result = build_cross_session_context(test_user.id, current_session_id=session_a.session_id)
+        result = await build_cross_session_context(
+            test_user.id, current_session_id=session_a.session_id
+        )
         assert result == ""
 
     @pytest.mark.asyncio()
@@ -524,7 +529,7 @@ class TestCrossSessionContext:
         long_body = "x" * 300
         await store.add_message(session_a, "inbound", long_body)
 
-        result = build_cross_session_context(test_user.id, current_session_id="other_999")
+        result = await build_cross_session_context(test_user.id, current_session_id="other_999")
         assert "..." in result
         # Should be truncated to ~200 chars + "..."
         assert "x" * 201 not in result

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -382,11 +382,11 @@ async def test_heartbeat_sends_typing_indicator_before_llm_call(
     mock_settings.heartbeat_recent_messages_count = 5
 
     mock_session_store = MagicMock()
-    mock_session_store.get_recent_messages.return_value = []
+    mock_session_store.get_recent_messages_async = AsyncMock(return_value=[])
     mock_get_session_store.return_value = mock_session_store
 
     mock_hb_store = MagicMock()
-    mock_hb_store.read_heartbeat_md.return_value = ""
+    mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="")
     mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
     mock_heartbeat_store_cls.return_value = mock_hb_store
 
@@ -453,11 +453,11 @@ async def test_heartbeat_works_without_channel(
     mock_settings.heartbeat_recent_messages_count = 5
 
     mock_session_store = MagicMock()
-    mock_session_store.get_recent_messages.return_value = []
+    mock_session_store.get_recent_messages_async = AsyncMock(return_value=[])
     mock_get_session_store.return_value = mock_session_store
 
     mock_hb_store = MagicMock()
-    mock_hb_store.read_heartbeat_md.return_value = ""
+    mock_hb_store.read_heartbeat_md_async = AsyncMock(return_value="")
     mock_hb_store.get_recent_logs = AsyncMock(return_value=[])
     mock_heartbeat_store_cls.return_value = mock_hb_store
 


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Premium #438 just merged so premium uses only async OSS store APIs. This PR is the final cleanup of the OSS-side async-DB epic: convert the remaining OSS-internal sync callers to async and remove the now-unused sync method bodies from the OSS store classes.

### Per-store outcome

- **MemoryStore**: removed sync `read_memory`, `write_memory`, `read_history`, `read_soul`, `write_soul`, `read_user`, `write_user`, and the sync `_get_or_create_doc` helper. The module-level `read_memory` / `write_memory` / `build_memory_context` functions are now `async def`.
- **SessionStore**: removed the truly-sync `load_session`, `delete_message`, `delete_messages`, `delete_messages_by_seqs`, `_get_last_timestamp`, `get_last_inbound_timestamp`, `get_last_outbound_timestamp`, `_collect_messages`, `get_recent_messages`, `get_other_session_messages`. The fake-async methods (`get_or_create_session`, `add_message`, `add_message_by_session_id`, `update_message`, `update_initial_system_prompt`, `list_sessions`) had `async def` signatures but synchronous bodies that were silently blocking the event loop; their bodies now delegate to the `*_async` peers.
- **HeartbeatStore**: removed sync `read_heartbeat_md`. Only `read_heartbeat_md_async` remains.
- **LLMUsageStore**: removed sync `log`. `services.llm_usage.log_llm_usage` is now `async def` and threads cost computation through `_build_llm_usage_log` exactly as before.
- **IdempotencyStore**: kept sync `has_seen` / `try_mark_seen` / `_prune`. The webhook entry path runs from a sync `TestClient` worker thread that cannot share an asyncpg connection with the fixture's async loop; converting that path requires test-infra changes outside the scope of this PR. The class docstring now flags it as the last sync hold-out.

### OSS callers updated

- `agent/compaction.py` reads / writes memory and heartbeat via the async peers; the LLM usage call awaits `log_llm_usage`.
- `routers/user_memory.py` reads / writes memory via the async peers.
- `agent/core.py` and `agent/heartbeat.py` await `log_llm_usage`.
- `agent/heartbeat.py` reads heartbeat markdown and recent messages via the async peers.
- `agent/ingestion.py` calls `load_session_async`.
- `agent/system_prompt.py` exposes `build_cross_session_context` as `async def` and uses `get_other_session_messages_async`.
- `agent/tools/heartbeat_tools.py` reads heartbeat markdown via the async peer.

### Test updates

- All affected test files now `await` the async store APIs.
- Mocks of removed sync methods (`read_heartbeat_md`, `load_session`, `get_recent_messages`) are rewritten as `AsyncMock` of the async peer.
- A handful of sync `TestClient` tests that seeded `MemoryDocument` rows via the (now-removed) sync `MemoryStore.write_memory` write the rows directly via the ORM; spinning up an event loop just to seed a row is overkill.

### Cross-validation against premium

Cloned premium against this OSS branch and ran the full premium test suite:

- **OSS tests**: 2371 passed, 1 skipped, 13 deselected, 3 xfailed.
- **Premium tests (against this OSS)**: 556 passed, 4 skipped, 2 fail.

Both premium failures are in premium *test* code that still reaches into the removed sync surface:

- `tests/test_data_export.py::test_export_includes_memories` calls `mem_store.write_memory(...)` directly.
- `tests/test_heartbeat_usage_tracking.py::test_heartbeat_run_updates_usage_quota` sets `mock_hb_store.read_heartbeat_md.return_value` on a `MagicMock`.

Premium production code is fully on the async surface; only those two premium tests need touching. They will land in a follow-up premium PR.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (N/A: refactor)
- [x] Bug fixes include regression tests (N/A: refactor)

## AI Usage
- [x] AI-assisted (Claude drafted the conversion and authored this PR body via back-and-forth with @njbrake)
- [ ] No AI used

Closes #1160.
Part of #1139.