### PR TITLE
refactor(agent): make HeartbeatUsageHook awaitable

### DIFF
--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -19,7 +19,7 @@ import json
 import logging
 import random
 import re
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -699,22 +699,25 @@ async def get_daily_heartbeat_count(user_id: str) -> int:
 # Post-heartbeat usage hooks
 # ---------------------------------------------------------------------------
 
-HeartbeatUsageHook = Callable[[str, int, int, bool], None]
+HeartbeatUsageHook = Callable[[str, int, int, bool], Awaitable[None]]
 
 _heartbeat_usage_hooks: list[HeartbeatUsageHook] = []
 
 
 def register_heartbeat_usage_hook(hook: HeartbeatUsageHook) -> None:
-    """Register a callback invoked after each heartbeat LLM run.
+    """Register an async callback invoked after each heartbeat LLM run.
 
     Called with ``(user_id, input_tokens, output_tokens, sent_reply)`` once
     Phase 1 (plus any Phase 2) has completed. Premium layers subscribe to
     this hook to reflect heartbeat LLM spend in per-tenant usage counters.
+
+    Hooks must be ``async def`` so they can use the async DB stack without
+    blocking the heartbeat event loop on a sync session.
     """
     _heartbeat_usage_hooks.append(hook)
 
 
-def _dispatch_heartbeat_usage(
+async def _dispatch_heartbeat_usage(
     user_id: str,
     input_tokens: int,
     output_tokens: int,
@@ -723,7 +726,7 @@ def _dispatch_heartbeat_usage(
     """Fire all registered usage hooks, isolating failures per hook."""
     for hook in _heartbeat_usage_hooks:
         try:
-            hook(user_id, input_tokens, output_tokens, sent_reply)
+            await hook(user_id, input_tokens, output_tokens, sent_reply)
         except Exception:
             logger.exception("heartbeat usage hook failed for user %s", user_id)
 
@@ -1031,7 +1034,9 @@ async def run_heartbeat_for_user(
         )
     finally:
         if total_input_tokens or total_output_tokens:
-            _dispatch_heartbeat_usage(user.id, total_input_tokens, total_output_tokens, sent_reply)
+            await _dispatch_heartbeat_usage(
+                user.id, total_input_tokens, total_output_tokens, sent_reply
+            )
         # The heartbeat fires a typing indicator before Phase 1. If we exit
         # without delivering a reply (skip, empty tasks, no Phase 2 output,
         # or exception), the indicator is orphaned. Cancel it explicitly so

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1528,7 +1528,7 @@ class TestHeartbeatUsageHooks:
 
         calls: list[tuple[str, int, int, bool]] = []
 
-        def _hook(user_id: str, in_tok: int, out_tok: int, sent: bool) -> None:
+        async def _hook(user_id: str, in_tok: int, out_tok: int, sent: bool) -> None:
             calls.append((user_id, in_tok, out_tok, sent))
 
         register_heartbeat_usage_hook(_hook)
@@ -1586,7 +1586,11 @@ class TestHeartbeatUsageHooks:
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
         calls: list[tuple[str, int, int, bool]] = []
-        register_heartbeat_usage_hook(lambda uid, i, o, s: calls.append((uid, i, o, s)))
+
+        async def _hook(uid: str, i: int, o: int, s: bool) -> None:
+            calls.append((uid, i, o, s))
+
+        register_heartbeat_usage_hook(_hook)
 
         await run_heartbeat_for_user(user, "telegram", "+15559990000", 5)
 
@@ -1618,7 +1622,7 @@ class TestHeartbeatUsageHooks:
         mock_hb_store.log_heartbeat = AsyncMock()
         mock_heartbeat_store_cls.return_value = mock_hb_store
 
-        def _boom(*_args: object) -> None:
+        async def _boom(*_args: object) -> None:
             raise RuntimeError("hook exploded")
 
         register_heartbeat_usage_hook(_boom)
@@ -1631,7 +1635,11 @@ class TestHeartbeatUsageHooks:
     async def test_hook_not_called_when_no_llm_ran(self, clear_heartbeat_hooks: object) -> None:
         """Early-return paths (not onboarded, rate-limited, etc.) skip the hook."""
         calls: list[tuple[str, int, int, bool]] = []
-        register_heartbeat_usage_hook(lambda uid, i, o, s: calls.append((uid, i, o, s)))
+
+        async def _hook(uid: str, i: int, o: int, s: bool) -> None:
+            calls.append((uid, i, o, s))
+
+        register_heartbeat_usage_hook(_hook)
 
         u = User(id="99", user_id="hb-early", phone="+15550000099", onboarding_complete=False)
         await run_heartbeat_for_user(u, "telegram", u.phone, 5)


### PR DESCRIPTION
Closes #1219.

## Description

Hook signature changes from `Callable[..., None]` to `Callable[..., Awaitable[None]]` so subscribers can use the async DB stack from inside the now-async heartbeat tick without blocking the event loop on a sync session. `_dispatch_heartbeat_usage` becomes async and awaits each registered hook (per-hook exception isolation preserved). The single call site at the end of `run_heartbeat_for_user` awaits dispatch. OSS unit tests in `TestHeartbeatUsageHooks` register `async def` hooks instead of sync `def` / lambdas.

Premium's `track_heartbeat_usage` is the only registered hook today. It currently holds a sync `db_session()` from inside the heartbeat hot path. With this PR, premium can switch to the async DB stack in a paired premium PR that bumps `OSS_REF` past this commit.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- `tests/test_heartbeat.py::TestHeartbeatUsageHooks` 4/4
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (existing OSS hook tests updated to async)
- [x] Bug fixes include regression tests (n/a, refactor)

## AI Usage
- [x] AI-assisted (drafted with Claude)
- [ ] No AI used