### PR TITLE
refactor(agent): convert ApprovalEventStore.list_for_user to async

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -1069,9 +1069,9 @@ class ApprovalEventStore:
             rows = (
                 (
                     await db.execute(
-                        stmt.order_by(
-                            ApprovalEvent.created_at.asc(), ApprovalEvent.id.asc()
-                        ).limit(limit)
+                        stmt.order_by(ApprovalEvent.created_at.asc(), ApprovalEvent.id.asc()).limit(
+                            limit
+                        )
                     )
                 )
                 .scalars()

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -1050,7 +1050,7 @@ class ApprovalEventStore:
     the premium repo.
     """
 
-    def list_for_user(
+    async def list_for_user(
         self,
         user_id: str,
         limit: int = 500,
@@ -1062,14 +1062,16 @@ class ApprovalEventStore:
         cannot OOM the response. ``since`` is an inclusive lower bound
         on ``created_at``; pass it to scope to a recent window.
         """
-        with db_session() as db:
+        async with db_session_async() as db:
             stmt = select(ApprovalEvent).where(ApprovalEvent.user_id == user_id)
             if since is not None:
                 stmt = stmt.where(ApprovalEvent.created_at >= since)
             rows = (
-                db.execute(
-                    stmt.order_by(ApprovalEvent.created_at.asc(), ApprovalEvent.id.asc()).limit(
-                        limit
+                (
+                    await db.execute(
+                        stmt.order_by(
+                            ApprovalEvent.created_at.asc(), ApprovalEvent.id.asc()
+                        ).limit(limit)
                     )
                 )
                 .scalars()

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1688,7 +1688,7 @@ class TestApprovalEvents:
         assert rows[1].decision == "approved"
 
         # Read-side store returns them in chronological order.
-        events = get_approval_event_store().list_for_user(test_user.id)
+        events = await get_approval_event_store().list_for_user(test_user.id)
         assert [e.event_type for e in events] == ["requested", "decided"]
         assert events[1].decision == "approved"
 
@@ -1829,10 +1829,10 @@ class TestApprovalEvents:
             db.commit()
 
         store = get_approval_event_store()
-        only_recent = store.list_for_user(
+        only_recent = await store.list_for_user(
             test_user.id, since=datetime.now(UTC) - timedelta(minutes=5)
         )
         assert [e.event_type for e in only_recent] == ["decided"]
 
-        capped = store.list_for_user(test_user.id, limit=1)
+        capped = await store.list_for_user(test_user.id, limit=1)
         assert len(capped) == 1


### PR DESCRIPTION
Closes #1225.

## Description

`ApprovalEventStore.list_for_user` becomes `async def`, reads via `db_session_async()`. OSS unit tests in `TestApprovalEvents` await the call.

This is the last sync DB call in `approval.py`. The premium caller (`admin_shared_data.list_shared_data_approval_events`) is an async route, so today the call blocks the event loop on a sync session. Converting the method removes that block; premium will switch to `await get_approval_event_store().list_for_user(...)` in a paired premium PR.

No deprecated `_async` alias added: the only callers are the OSS tests in this PR and the premium admin_shared_data caller, both of which are updated in lockstep.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) -- `tests/test_approval.py::TestApprovalEvents` 5/5
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (existing OSS test_approval suite updated to await)
- [x] Bug fixes include regression tests (n/a, refactor)

## AI Usage
- [x] AI-assisted (drafted with Claude)
- [ ] No AI used