### PR TITLE
refactor: convert remaining production sync DB sites to async

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -378,7 +378,7 @@ async def compact_session(
     # or INSERT a fresh completed row (legacy/test paths). A DB hiccup
     # here must not lose the compacted memory we just wrote upstream.
     try:
-        _persist_compaction_event(
+        await _persist_compaction_event(
             event_id=event_id,
             user_id=user_id,
             trimmed_count=_trimmed_count,
@@ -442,7 +442,7 @@ def _build_snapshot_pairs(
     return pairs
 
 
-def _persist_compaction_event(
+async def _persist_compaction_event(
     *,
     event_id: int | None,
     user_id: str,
@@ -472,12 +472,14 @@ def _persist_compaction_event(
     """
     from sqlalchemy import select
 
-    from backend.app.database import SessionLocal
+    from backend.app.database import db_session_async
     from backend.app.models import CompactionEvent
 
-    with SessionLocal() as db:
+    async with db_session_async() as db:
         if event_id is not None:
-            event = db.execute(select(CompactionEvent).filter_by(id=event_id)).scalar_one_or_none()
+            event = (
+                await db.execute(select(CompactionEvent).filter_by(id=event_id))
+            ).scalar_one_or_none()
             if event is None:
                 logger.warning(
                     "Compaction event id=%d not found for user %s; "
@@ -522,4 +524,4 @@ def _persist_compaction_event(
                     **llm_call,
                 )
             )
-        db.commit()
+        await db.commit()

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -21,7 +21,7 @@ from backend.app.agent.messages import (
 )
 from backend.app.agent.session_db import get_session_store
 from backend.app.config import settings
-from backend.app.database import db_session
+from backend.app.database import db_session_async
 from backend.app.enums import MessageDirection
 from backend.app.models import ChatSession, CompactionEvent
 
@@ -108,7 +108,7 @@ def _seqs_from_dropped(dropped: list[AgentMessage]) -> list[int]:
     return seqs
 
 
-def trigger_compaction_for_dropped(
+async def trigger_compaction_for_dropped(
     user_id: str,
     dropped_messages: list[AgentMessage],
 ) -> None:
@@ -148,10 +148,10 @@ def trigger_compaction_for_dropped(
     max_seq = max(dropped_seqs)
     triggered_at = datetime.datetime.now(datetime.UTC)
 
-    # Phase 1: synchronous insert + watermark advance, in one transaction.
+    # Phase 1: insert + watermark advance, in one transaction.
     event_id: int
     try:
-        with db_session() as db:
+        async with db_session_async() as db:
             event = CompactionEvent(
                 user_id=user_id,
                 triggered_at=triggered_at,
@@ -161,16 +161,18 @@ def trigger_compaction_for_dropped(
                 trimmed_count=len(dropped_messages),
             )
             db.add(event)
-            db.flush()
+            await db.flush()
             assert event.id is not None, "flush() must populate the autoincrement id"
             event_id = event.id
 
-            cs = db.execute(select(ChatSession).filter_by(user_id=user_id)).scalar_one_or_none()
+            cs = (
+                await db.execute(select(ChatSession).filter_by(user_id=user_id))
+            ).scalar_one_or_none()
             if cs is not None:
                 current = cs.last_trim_seq or 0
                 if max_seq > current:
                     cs.last_trim_seq = max_seq
-            db.commit()
+            await db.commit()
     except Exception:
         logger.exception(
             "Failed to record pending compaction event for user %s; "

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1076,7 +1076,7 @@ class ClawboltAgent:
                 if all_dropped:
                     from backend.app.agent.context import trigger_compaction_for_dropped
 
-                    trigger_compaction_for_dropped(self.user.id, all_dropped)
+                    await trigger_compaction_for_dropped(self.user.id, all_dropped)
 
                 total_duration = (time.monotonic() - agent_start_time) * 1000
                 await self._emit(

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime
 from typing import cast
 
 from sqlalchemy import CursorResult, delete, select, update
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.agent.approval import (
     ApprovalDecision,
@@ -34,7 +34,7 @@ from backend.app.agent.router import handle_inbound_message
 from backend.app.agent.session_db import get_session_store
 from backend.app.agent.user_db import provision_user
 from backend.app.config import settings
-from backend.app.database import SessionLocal
+from backend.app.database import db_session_async
 from backend.app.enums import MessageDirection
 from backend.app.logging_utils import mask_pii
 from backend.app.media.download import DownloadedMedia
@@ -61,23 +61,20 @@ class InboundMessage:
     request_id: str = ""
 
 
-def _check_channel_route_enabled(user_id: str, channel: str) -> bool | None:
+async def _check_channel_route_enabled(user_id: str, channel: str) -> bool | None:
     """Check whether a channel route is enabled for a user.
 
     Returns True if the route exists and is enabled, False if it exists
     and is disabled, or None if no route exists (backward compat: treat
     as enabled).
     """
-    db = SessionLocal()
-    try:
-        route = db.execute(
-            select(ChannelRoute).filter_by(user_id=user_id, channel=channel)
+    async with db_session_async() as db:
+        route = (
+            await db.execute(select(ChannelRoute).filter_by(user_id=user_id, channel=channel))
         ).scalar_one_or_none()
         if route is None:
             return None
         return route.enabled
-    finally:
-        db.close()
 
 
 async def _send_early_typing_indicator(channel: str, chat_id: str) -> None:
@@ -137,7 +134,9 @@ async def _send_error_fallback(
         logger.exception("Failed to send error fallback to user %s", user_id)
 
 
-def _stamp_route_last_inbound(db: Session, user_id: str, channel: str, sender_id: str) -> None:
+async def _stamp_route_last_inbound(
+    db: AsyncSession, user_id: str, channel: str, sender_id: str
+) -> None:
     """Mark the resolved ChannelRoute as having received an inbound.
 
     The channel picker UI flips to "Verified" when this field is non-null,
@@ -145,7 +144,7 @@ def _stamp_route_last_inbound(db: Session, user_id: str, channel: str, sender_id
     delivers messages. Called on every inbound resolution so the stamp
     always reflects the most recent successful delivery.
     """
-    db.execute(
+    await db.execute(
         update(ChannelRoute)
         .where(
             ChannelRoute.user_id == user_id,
@@ -183,14 +182,15 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
     from sqlalchemy.exc import IntegrityError
 
     logger.debug("_get_or_create_user: channel=%s sender_id=%s", channel, mask_pii(sender_id))
-    db = SessionLocal()
-    try:
+    async with db_session_async() as db:
         # Look up by channel route
-        route = db.execute(
-            select(ChannelRoute).filter_by(channel=channel, channel_identifier=sender_id)
+        route = (
+            await db.execute(
+                select(ChannelRoute).filter_by(channel=channel, channel_identifier=sender_id)
+            )
         ).scalar_one_or_none()
         if route:
-            user = db.execute(select(User).filter_by(id=route.user_id)).scalar_one_or_none()
+            user = (await db.execute(select(User).filter_by(id=route.user_id))).scalar_one_or_none()
             if user is not None:
                 # Track the most recently used channel so heartbeat and other
                 # proactive messages are delivered to the right place.
@@ -204,7 +204,7 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
                 # dispatcher always picks up the current address.
                 deleted = cast(
                     "CursorResult[object]",
-                    db.execute(
+                    await db.execute(
                         delete(ChannelRoute).where(
                             ChannelRoute.user_id == user.id,
                             ChannelRoute.channel == channel,
@@ -220,9 +220,9 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
                         channel,
                         user.id,
                     )
-                _stamp_route_last_inbound(db, user.id, channel, sender_id)
-                db.commit()
-                db.refresh(user)
+                await _stamp_route_last_inbound(db, user.id, channel, sender_id)
+                await db.commit()
+                await db.refresh(user)
                 logger.debug("_get_or_create_user: found via channel route -> user %s", user.id)
                 db.expunge(user)
                 return user
@@ -231,14 +231,14 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
         # every channel are visible in the dashboard.  Skip this in
         # multi-tenant (premium) mode to avoid linking a new sender's
         # messages to an existing user's account.
-        all_users = db.execute(select(User)).scalars().all()
+        all_users = (await db.execute(select(User))).scalars().all()
         if len(all_users) == 1 and not settings.premium_plugin:
             user = all_users[0]
             logger.debug("_get_or_create_user: single-tenant reuse -> user %s", user.id)
             # Remove stale routes for this user+channel before adding the new one.
             # This prevents the outbound dispatcher from picking up an old
             # identifier (e.g. a UUID handle instead of a real phone number).
-            db.execute(
+            await db.execute(
                 delete(ChannelRoute).where(
                     ChannelRoute.user_id == user.id,
                     ChannelRoute.channel == channel,
@@ -248,28 +248,28 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
             db.add(ChannelRoute(user_id=user.id, channel=channel, channel_identifier=sender_id))
             user.channel_identifier = sender_id
             user.preferred_channel = channel
-            db.flush()
-            _stamp_route_last_inbound(db, user.id, channel, sender_id)
-            db.commit()
-            db.refresh(user)
+            await db.flush()
+            await _stamp_route_last_inbound(db, user.id, channel, sender_id)
+            await db.commit()
+            await db.refresh(user)
             db.expunge(user)
             return user
 
         # In premium mode the webchat sends sender_id = user.id (the PK).
         # Link the existing user to this channel instead of creating a
         # duplicate account.
-        existing = db.execute(select(User).filter_by(id=sender_id)).scalar_one_or_none()
+        existing = (await db.execute(select(User).filter_by(id=sender_id))).scalar_one_or_none()
         if existing is not None:
             logger.debug(
                 "_get_or_create_user: sender_id matches existing PK -> user %s",
                 existing.id,
             )
             db.add(ChannelRoute(user_id=existing.id, channel=channel, channel_identifier=sender_id))
-            provision_user(existing, db)
-            db.flush()
-            _stamp_route_last_inbound(db, existing.id, channel, sender_id)
-            db.commit()
-            db.refresh(existing)
+            await provision_user(existing, db)
+            await db.flush()
+            await _stamp_route_last_inbound(db, existing.id, channel, sender_id)
+            await db.commit()
+            await db.refresh(existing)
             db.expunge(existing)
             return existing
 
@@ -281,13 +281,13 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
                 preferred_channel=channel,
             )
             db.add(user)
-            db.flush()
+            await db.flush()
             db.add(ChannelRoute(user_id=user.id, channel=channel, channel_identifier=sender_id))
-            db.flush()
-            provision_user(user, db)
-            _stamp_route_last_inbound(db, user.id, channel, sender_id)
-            db.commit()
-            db.refresh(user)
+            await db.flush()
+            await provision_user(user, db)
+            await _stamp_route_last_inbound(db, user.id, channel, sender_id)
+            await db.commit()
+            await db.refresh(user)
             logger.debug(
                 "_get_or_create_user: created new user %s (user_id=%s)",
                 user.id,
@@ -296,31 +296,33 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
             db.expunge(user)
             return user
         except IntegrityError:
-            db.rollback()
+            await db.rollback()
             logger.debug(
                 "_get_or_create_user: IntegrityError race, re-querying for %s/%s",
                 channel,
                 sender_id,
             )
             # Concurrent insert won the race; re-query
-            route = db.execute(
-                select(ChannelRoute).filter_by(channel=channel, channel_identifier=sender_id)
+            route = (
+                await db.execute(
+                    select(ChannelRoute).filter_by(channel=channel, channel_identifier=sender_id)
+                )
             ).scalar_one_or_none()
             if route:
-                user = db.execute(select(User).filter_by(id=route.user_id)).scalar_one_or_none()
+                user = (
+                    await db.execute(select(User).filter_by(id=route.user_id))
+                ).scalar_one_or_none()
                 if user is not None:
                     db.expunge(user)
                     return user
             # Fallback: look up by user_id
-            user = db.execute(
-                select(User).filter_by(user_id=f"{channel}_{sender_id}")
+            user = (
+                await db.execute(select(User).filter_by(user_id=f"{channel}_{sender_id}"))
             ).scalar_one_or_none()
             if user is not None:
                 db.expunge(user)
                 return user
             raise
-    finally:
-        db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -378,6 +380,12 @@ async def _dispatch_to_pipeline(
                 async with user_locks.acquire(user_id):
                     interrupt_task.cancel()
                     try:
+                        # Defensive User reload: use the sync session here
+                        # so the in-loop hot path stays mockable and fast.
+                        # The block runs once per pipeline invocation and
+                        # only writes to the in-memory ``user`` variable.
+                        from backend.app.database import SessionLocal
+
                         db = SessionLocal()
                         try:
                             fresh = db.execute(
@@ -661,48 +669,49 @@ async def _handle_report_command(
         # ``session.session_id`` (the UUID string); we resolve to the
         # integer ``ChatSession.id`` here for the FK on
         # ``reported_conversations``.
-        db = SessionLocal()
         try:
-            cs_row = db.execute(
-                select(ChatSession).where(ChatSession.session_id == session.session_id)
-            ).scalar_one_or_none()
-            if cs_row is None:
-                logger.error(
-                    "/report: session %s not in DB; skipping persistence",
-                    session.session_id,
-                )
-            else:
-                latest_seq = db.execute(
-                    select(Message.seq)
-                    .where(Message.session_id == cs_row.id)
-                    .order_by(Message.seq.desc())
-                    .limit(1)
-                ).scalar()
-                anchor_seq = int(latest_seq) if latest_seq is not None else None
-                row = ReportedConversation(
-                    user_id=user.id,
-                    session_id=cs_row.id,
-                    anchor_seq=anchor_seq,
-                    reason=reason,
-                )
-                db.add(row)
-                db.commit()
-                logger.info(
-                    "/report filed by user %s for session %s (anchor_seq=%s, reason_len=%d)",
-                    user.id,
-                    session.session_id,
-                    anchor_seq,
-                    len(reason),
-                )
+            async with db_session_async() as db:
+                cs_row = (
+                    await db.execute(
+                        select(ChatSession).where(ChatSession.session_id == session.session_id)
+                    )
+                ).scalar_one_or_none()
+                if cs_row is None:
+                    logger.error(
+                        "/report: session %s not in DB; skipping persistence",
+                        session.session_id,
+                    )
+                else:
+                    latest_seq = (
+                        await db.execute(
+                            select(Message.seq)
+                            .where(Message.session_id == cs_row.id)
+                            .order_by(Message.seq.desc())
+                            .limit(1)
+                        )
+                    ).scalar()
+                    anchor_seq = int(latest_seq) if latest_seq is not None else None
+                    row = ReportedConversation(
+                        user_id=user.id,
+                        session_id=cs_row.id,
+                        anchor_seq=anchor_seq,
+                        reason=reason,
+                    )
+                    db.add(row)
+                    await db.commit()
+                    logger.info(
+                        "/report filed by user %s for session %s (anchor_seq=%s, reason_len=%d)",
+                        user.id,
+                        session.session_id,
+                        anchor_seq,
+                        len(reason),
+                    )
         except Exception:
             logger.exception(
                 "/report: failed to persist row for user %s session %s",
                 user.id,
                 session.session_id,
             )
-            db.rollback()
-        finally:
-            db.close()
     finally:
         await message_bus.publish_outbound(
             OutboundMessage(
@@ -738,7 +747,7 @@ async def process_inbound_from_bus(
     )
 
     # -- Check if channel is disabled for this user --
-    route_enabled = _check_channel_route_enabled(user.id, inbound.channel)
+    route_enabled = await _check_channel_route_enabled(user.id, inbound.channel)
     if route_enabled is False:
         from backend.app.bus import OutboundMessage, message_bus
 

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -19,14 +19,13 @@ from sqlalchemy.exc import IntegrityError
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
-    from sqlalchemy.orm import Session
 
 from backend.app.agent.dto import (
     HeartbeatLogEntry,
     MediaData,
     ToolConfigEntry,
 )
-from backend.app.database import AsyncSessionLocal, SessionLocal, db_session, db_session_async
+from backend.app.database import AsyncSessionLocal, db_session_async
 from backend.app.models import (
     HeartbeatLog,
     IdempotencyKey,
@@ -526,27 +525,14 @@ class IdempotencyStore:
     Uses the IdempotencyKey ORM model. No user_id scoping -- external_id
     is globally unique.
 
-    The last sync hold-out after the issue #1160 final pass. Every
-    other store's sync surface has been removed, but the webhook entry
-    path runs from a sync ``TestClient`` worker thread that cannot
-    share an asyncpg connection with the fixture's async loop, so
-    ``has_seen``, ``try_mark_seen``, and ``_prune`` keep their sync
-    bodies until the test infrastructure can drive that path through
-    an async client. The ``_async`` peers are the canonical surface
-    for new code; the sync methods stay only for that one TestClient
-    seam.
+    Async-only as of issue #1160. The webhook entry path is async, the
+    test fixtures drive it through ``httpx.AsyncClient`` so the route
+    runs on the same event loop as the test's async DB connection.
+    ``*_async`` aliases are kept as thin wrappers for any out-of-tree
+    caller still on the suffix.
     """
 
-    def has_seen(self, external_id: str) -> bool:
-        """Check if an external message ID has been seen."""
-        db = SessionLocal()
-        try:
-            row = db.execute(_seen_select(external_id)).scalar_one_or_none()
-            return row is not None
-        finally:
-            db.close()
-
-    async def has_seen_async(self, external_id: str) -> bool:
+    async def has_seen(self, external_id: str) -> bool:
         """Check if an external message ID has been seen."""
         db = AsyncSessionLocal()
         try:
@@ -555,37 +541,18 @@ class IdempotencyStore:
         finally:
             await db.close()
 
-    def try_mark_seen(self, external_id: str) -> bool:
+    async def has_seen_async(self, external_id: str) -> bool:
+        """Deprecated alias of :meth:`has_seen`."""
+        return await self.has_seen(external_id)
+
+    async def try_mark_seen(self, external_id: str) -> bool:
         """Atomically insert an IdempotencyKey row and return whether it was new.
 
         Returns ``True`` if the row was newly inserted (first time seen),
-        ``False`` if it already existed (duplicate). This replaces the
-        separate has_seen + mark_seen pattern to eliminate the TOCTOU race.
-        """
-        with db_session() as db:
-            key = IdempotencyKey(external_id=external_id)
-            db.add(key)
-            try:
-                db.commit()
-            except IntegrityError:
-                db.rollback()
-                return False
-
-            # Prune in the same session; insert is already committed
-            try:
-                self._prune(db)
-            except Exception:
-                db.rollback()
-                logger.warning("IdempotencyStore prune failed", exc_info=True)
-        return True
-
-    async def try_mark_seen_async(self, external_id: str) -> bool:
-        """Async peer of :meth:`try_mark_seen`.
-
-        Same TOCTOU-free contract: the unique-constraint violation on
-        ``external_id`` is the source of truth for "already seen". A
-        prune failure is logged and swallowed so a transient prune
-        error never makes a duplicate webhook re-fire.
+        ``False`` if it already existed (duplicate). The unique-constraint
+        violation on ``external_id`` is the source of truth for "already
+        seen". A prune failure is logged and swallowed so a transient
+        prune error never makes a duplicate webhook re-fire.
         """
         async with db_session_async() as db:
             key = IdempotencyKey(external_id=external_id)
@@ -597,18 +564,22 @@ class IdempotencyStore:
                 return False
 
             try:
-                await self._prune_async(db)
+                await self._prune(db)
             except Exception:
                 await db.rollback()
                 logger.warning("IdempotencyStore prune failed", exc_info=True)
         return True
 
-    def _prune(self, db: Session | None = None) -> None:
+    async def try_mark_seen_async(self, external_id: str) -> bool:
+        """Deprecated alias of :meth:`try_mark_seen`."""
+        return await self.try_mark_seen(external_id)
+
+    async def _prune(self, db: AsyncSession | None = None) -> None:
         """Remove the oldest rows when the table exceeds ``_SEEN_MAX``.
 
         When *db* is provided the caller's session is reused, avoiding
-        an extra connection checkout.  When called without a session
-        (e.g. from tests) a fresh session is created automatically.
+        an extra connection checkout.  When called without a session a
+        fresh session is created automatically.
 
         Keeps the newest rows by ``id`` (autoincrement, so allocation
         order is monotonic even if commit order isn't -- fine for dedup).
@@ -616,20 +587,8 @@ class IdempotencyStore:
         app-generated timestamps can drift across workers.
         """
         if db is None:
-            with db_session() as db:
-                self._prune(db)
-            return
-        count = db.scalar(_count_select()) or 0
-        if count <= _SEEN_MAX:
-            return
-        db.execute(_prune_delete())
-        db.commit()
-
-    async def _prune_async(self, db: AsyncSession | None = None) -> None:
-        """Async peer of :meth:`_prune`. Same semantics, awaitable."""
-        if db is None:
             async with db_session_async() as fresh:
-                await self._prune_async(fresh)
+                await self._prune(fresh)
             return
         count = (await db.scalar(_count_select())) or 0
         if count <= _SEEN_MAX:
@@ -642,14 +601,11 @@ class IdempotencyStore:
 
         Prefer :meth:`try_mark_seen` for atomic check-and-insert.
         """
-        self.try_mark_seen(external_id)
+        await self.try_mark_seen(external_id)
 
     async def mark_seen_async(self, external_id: str) -> None:
-        """Async peer of :meth:`mark_seen`.
-
-        Prefer :meth:`try_mark_seen_async` for atomic check-and-insert.
-        """
-        await self.try_mark_seen_async(external_id)
+        """Deprecated alias of :meth:`mark_seen`."""
+        await self.try_mark_seen(external_id)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/user_db.py
+++ b/backend/app/agent/user_db.py
@@ -19,17 +19,18 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.agent.dto import UserData
 from backend.app.agent.prompts import load_prompt
 from backend.app.config import settings
-from backend.app.database import AsyncSessionLocal, SessionLocal, db_session_async
+from backend.app.database import AsyncSessionLocal, db_session_async
 from backend.app.models import User
 
 logger = logging.getLogger(__name__)
 
 
-def provision_user(user: User, db: object | None = None) -> None:
+async def provision_user(user: User, db: AsyncSession | None = None) -> None:
     """Provision a new user: seed DB defaults and create the data directory.
 
     Seeds soul_text and user_text DB columns with default templates if
@@ -42,33 +43,13 @@ def provision_user(user: User, db: object | None = None) -> None:
     are currently empty and only writes BOOTSTRAP.md if missing and the
     user is not already onboarded.
     """
-    from sqlalchemy.orm import Session as SASession
-
     # Seed DB text columns with default templates
     seeded: list[str] = []
-    own_session = db is None
-    if own_session:
-        db = SessionLocal()
-    assert isinstance(db, SASession)
-    try:
-        # Re-query within this session to ensure we can write
-        db_user = db.execute(select(User).filter_by(id=user.id)).scalar_one_or_none()
-        if db_user is not None:
-            if not db_user.soul_text:
-                db_user.soul_text = f"# Soul\n\n{load_prompt('default_soul')}\n"
-                seeded.append("soul_text")
-            if not db_user.user_text:
-                db_user.user_text = f"# User\n\n{load_prompt('default_user')}\n"
-                seeded.append("user_text")
-            if seeded:
-                db.commit()
-                db.refresh(db_user)
-                # Update the in-memory user object so callers see the seeded values
-                user.soul_text = db_user.soul_text
-                user.user_text = db_user.user_text
-    finally:
-        if own_session:
-            db.close()
+    if db is None:
+        async with db_session_async() as own_db:
+            await _seed_user_text(own_db, user, seeded)
+    else:
+        await _seed_user_text(db, user, seeded)
 
     # On-disk: BOOTSTRAP.md + data directory structure
     user_dir = Path(settings.data_dir) / str(user.id)
@@ -89,6 +70,29 @@ def provision_user(user: User, db: object | None = None) -> None:
         user.onboarding_complete,
         user_dir,
     )
+
+
+async def _seed_user_text(db: AsyncSession, user: User, seeded: list[str]) -> None:
+    """Re-query the User row in *db* and seed empty text columns with defaults.
+
+    Mutates *seeded* in place so the caller can include the field list in
+    its log line. Updates *user* (the in-memory object) to reflect the
+    seeded values for callers that hold on to it.
+    """
+    db_user = (await db.execute(select(User).filter_by(id=user.id))).scalar_one_or_none()
+    if db_user is None:
+        return
+    if not db_user.soul_text:
+        db_user.soul_text = f"# Soul\n\n{load_prompt('default_soul')}\n"
+        seeded.append("soul_text")
+    if not db_user.user_text:
+        db_user.user_text = f"# User\n\n{load_prompt('default_user')}\n"
+        seeded.append("user_text")
+    if seeded:
+        await db.commit()
+        await db.refresh(db_user)
+        user.soul_text = db_user.soul_text
+        user.user_text = db_user.user_text
 
 
 def _user_to_dto(user: User) -> UserData:

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -24,9 +24,9 @@ async def get_current_user(db: AsyncSession = Depends(get_async_db)) -> User:
     db.add(user)
     await db.commit()
     await db.refresh(user)
-    # ``provision_user`` is the sync seed-and-bootstrap path. The user row
-    # is committed above so it is visible to a fresh sync session; passing
-    # ``db=None`` lets ``provision_user`` open its own ``SessionLocal()``
-    # rather than trying to share the AsyncSession.
-    provision_user(user)
+    # The user row is committed above so it is visible to a fresh
+    # AsyncSession; passing ``db=None`` lets ``provision_user`` open its
+    # own ``db_session_async()`` rather than reusing the dependency's
+    # session.
+    await provision_user(user)
     return user

--- a/backend/app/auth/scoping.py
+++ b/backend/app/auth/scoping.py
@@ -1,18 +1,18 @@
 from fastapi import Depends, HTTPException
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.app.database import get_db
+from backend.app.database import get_async_db
 from backend.app.models import User
 
 
 async def get_scoped_user(
     current_user: User,
     target_id: str,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> User:
     """Get a user by ID, scoped to the current user. Returns 404 on mismatch."""
-    target = db.execute(select(User).where(User.id == str(target_id))).scalar_one_or_none()
+    target = (await db.execute(select(User).where(User.id == str(target_id)))).scalar_one_or_none()
     if not target or target.user_id != current_user.user_id:
         raise HTTPException(status_code=404, detail="User not found")
     return target

--- a/backend/app/channels/base.py
+++ b/backend/app/channels/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
@@ -22,8 +22,10 @@ logger = logging.getLogger(__name__)
 
 # Type for the pluggable allowlist override. The callback receives
 # (channel_name, sender_id) and returns True/False. When set, channels
-# delegate to this instead of their static allowlist.
-IsAllowedOverride = Callable[[str, str], bool]
+# delegate to this instead of their static allowlist. Async so the
+# implementation can use the async DB stack without blocking the event
+# loop on a sync session.
+IsAllowedOverride = Callable[[str, str], Awaitable[bool]]
 
 # Module-level override set by premium during plugin initialization.
 _is_allowed_override: IsAllowedOverride | None = None
@@ -75,10 +77,10 @@ class BaseChannel(ABC):
         """Return a FastAPI ``APIRouter`` that handles inbound webhooks."""
 
     @abstractmethod
-    def is_allowed(self, sender_id: str, username: str) -> bool:
+    async def is_allowed(self, sender_id: str, username: str) -> bool:
         """Return ``True`` if the sender passes the channel's allowlist."""
 
-    def _check_premium_route(self, sender_id: str) -> bool | None:
+    async def _check_premium_route(self, sender_id: str) -> bool | None:
         """Check if a plugin-level allowlist override handles this sender.
 
         Returns ``True``/``False`` if an override is registered (e.g. premium
@@ -88,15 +90,15 @@ class BaseChannel(ABC):
         override = _is_allowed_override
         if override is None:
             return None
-        return override(self.name, sender_id)
+        return await override(self.name, sender_id)
 
-    def _check_static_allowlist(self, setting_value: str, sender_id: str) -> bool:
+    async def _check_static_allowlist(self, setting_value: str, sender_id: str) -> bool:
         """Check premium route first, then fall back to a static allowlist setting.
 
         Consolidates the common pattern used by Telegram, BlueBubbles, and Linq:
         premium override -> empty denies all -> ``"*"`` allows all -> exact match.
         """
-        premium = self._check_premium_route(sender_id)
+        premium = await self._check_premium_route(sender_id)
         if premium is not None:
             return premium
         allowed = setting_value.strip()
@@ -184,7 +186,7 @@ async def handle_webhook_inbound(
     if inbound is None:
         return JSONResponse(content={"ok": True})
 
-    if not channel.is_allowed(inbound.sender_id, inbound.sender_username or ""):
+    if not await channel.is_allowed(inbound.sender_id, inbound.sender_username or ""):
         logger.debug(
             "%s: sender not in allowlist, ignoring",
             channel.name,
@@ -200,7 +202,7 @@ async def handle_webhook_inbound(
 
     if inbound.external_message_id:
         idempotency = get_idempotency_store()
-        if not idempotency.try_mark_seen(inbound.external_message_id):
+        if not await idempotency.try_mark_seen(inbound.external_message_id):
             logger.info(
                 "%s: duplicate webhook for %s, skipping",
                 channel.name,

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -327,7 +327,7 @@ class BlueBubblesChannel(BaseChannel):
 
     # -- Inbound ---------------------------------------------------------------
 
-    def is_allowed(self, sender_id: str, username: str) -> bool:
+    async def is_allowed(self, sender_id: str, username: str) -> bool:
         """Return True if the sender passes the BlueBubbles allowlist.
 
         In premium mode, approval is based on whether a ``ChannelRoute``
@@ -335,7 +335,7 @@ class BlueBubblesChannel(BaseChannel):
         or email) is checked against ``settings.bluebubbles_allowed_numbers``:
         empty denies all, ``"*"`` allows all, or a specific value must match.
         """
-        return self._check_static_allowlist(settings.bluebubbles_allowed_numbers, sender_id)
+        return await self._check_static_allowlist(settings.bluebubbles_allowed_numbers, sender_id)
 
     @staticmethod
     def parse_webhook(payload: BBWebhookPayload) -> InboundMessage | None:

--- a/backend/app/channels/linq.py
+++ b/backend/app/channels/linq.py
@@ -250,7 +250,7 @@ class LinqChannel(BaseChannel):
         ).hexdigest()
         return hmac.compare_digest(expected, signature)
 
-    def is_allowed(self, sender_id: str, username: str) -> bool:
+    async def is_allowed(self, sender_id: str, username: str) -> bool:
         """Return True if the sender passes the Linq allowlist.
 
         In premium mode, approval is based on whether a ``ChannelRoute``
@@ -258,7 +258,7 @@ class LinqChannel(BaseChannel):
         number) is checked against ``settings.linq_allowed_numbers``:
         empty denies all, ``"*"`` allows all, or a specific number must match.
         """
-        return self._check_static_allowlist(settings.linq_allowed_numbers, sender_id)
+        return await self._check_static_allowlist(settings.linq_allowed_numbers, sender_id)
 
     @staticmethod
     def _guess_mime(url: str) -> str:

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -316,7 +316,7 @@ class TelegramChannel(BaseChannel):
             )
         return media
 
-    def is_allowed(self, sender_id: str, username: str) -> bool:
+    async def is_allowed(self, sender_id: str, username: str) -> bool:
         """Return ``True`` if the sender passes the Telegram allowlist gate.
 
         In premium mode, approval is based on whether a ``ChannelRoute``
@@ -324,7 +324,7 @@ class TelegramChannel(BaseChannel):
         is used: empty rejects all, ``"*"`` allows all, or a specific
         chat ID must match.
         """
-        return self._check_static_allowlist(settings.telegram_allowed_chat_id, sender_id)
+        return await self._check_static_allowlist(settings.telegram_allowed_chat_id, sender_id)
 
     @staticmethod
     def parse_update(update: TelegramUpdate) -> InboundMessage | None:

--- a/backend/app/channels/webchat.py
+++ b/backend/app/channels/webchat.py
@@ -195,7 +195,7 @@ class WebChatChannel(BaseChannel):
 
         return router
 
-    def is_allowed(self, sender_id: str, username: str) -> bool:
+    async def is_allowed(self, sender_id: str, username: str) -> bool:
         return True
 
     async def send_text(self, to: str, body: str) -> str:

--- a/backend/app/config_store.py
+++ b/backend/app/config_store.py
@@ -33,7 +33,6 @@ from typing import Any, Protocol
 
 from sqlalchemy import Row, text
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import TextClause
 
 from backend.app.config import (
@@ -148,7 +147,7 @@ class ConfigStoreError(RuntimeError):
 class SettingsStore(Protocol):
     """Persistent backend for runtime-configurable settings."""
 
-    def load(self) -> dict[str, str]:
+    async def load(self) -> dict[str, str]:
         """Return all persisted settings.
 
         An empty dict means the backend is reachable but has no rows.
@@ -158,7 +157,7 @@ class SettingsStore(Protocol):
         """
         ...
 
-    def save(self, updates: Mapping[str, str], *, actor_user_id: str | None = None) -> None:
+    async def save(self, updates: Mapping[str, str], *, actor_user_id: str | None = None) -> None:
         """Atomically merge *updates* into persisted state.
 
         ``actor_user_id`` is recorded against each updated row so the
@@ -167,7 +166,7 @@ class SettingsStore(Protocol):
         """
         ...
 
-    def delete(self, keys: Iterable[str]) -> None:
+    async def delete(self, keys: Iterable[str]) -> None:
         """Remove keys, reverting them to env or Pydantic default."""
         ...
 
@@ -294,21 +293,11 @@ class DbSettingsStore:
     the configured ``KEKProvider`` before insertion. Decryption happens
     on read. Non-secret keys are stored verbatim.
 
-    Uses ``SessionLocal`` so writes share the same connection pool (and
-    in tests, the same bound transaction) as the rest of the app. That
-    keeps FK references like ``updated_by_user_id`` consistent with
-    rows the route handler just inserted in the same request.
-
-    Dual-API store (issue #1175). Each public method has an ``*_async``
-    peer with identical semantics; the two share validation, encryption,
-    and SQL construction via the module-level ``_build_save_rows`` /
-    ``_decode_load_rows`` / ``_load_select_sql`` / ``_save_upsert_sql`` /
-    ``_delete_sql`` helpers above. Sync callers (lifespan boot, admin
-    routes still on sync) keep working unchanged while async callers
-    can opt into the ``*_async`` peers without falling back to a sync
-    DB call from async context. Follows the IdempotencyStore pilot
-    pattern (#1199) and mirrors the per-store conversions in #1200,
-    #1201, #1203.
+    Async-only as of issue #1160. The store resolves
+    ``AsyncSessionLocal`` lazily so a store instantiated at import time
+    picks up test rebinding of the ``async_db`` fixture's session
+    factory. ``*_async`` aliases are kept as thin wrappers in case
+    out-of-tree callers still reference the suffix.
     """
 
     _CONTEXT_TABLE = "app_settings"
@@ -316,34 +305,27 @@ class DbSettingsStore:
 
     def __init__(
         self,
-        session_factory: Callable[[], Session],
         kek_provider: KEKProvider,
         async_session_factory: Callable[[], AsyncSession] | None = None,
     ) -> None:
-        """Construct a store bound to the given session factories.
+        """Construct a store bound to *async_session_factory*.
 
-        ``session_factory`` is the existing sync factory. The optional
-        ``async_session_factory`` is used by the ``*_async`` methods.
-        When omitted, the async methods resolve the singleton
-        ``AsyncSessionLocal`` factory at call time. Tests that drive
-        the async API through a per-test transaction can pass the
-        rebound ``async_sessionmaker`` from the ``async_db`` fixture
-        explicitly, mirroring how sync tests pass ``SessionLocal``
-        rebound by the autouse ``_isolate_stores`` fixture.
+        When the factory is ``None`` (the production default), each
+        call resolves the singleton ``AsyncSessionLocal`` at call time
+        so test fixtures rebinding ``_async_session_factory`` are
+        picked up. Tests that drive the API through a per-test
+        transaction can pass the rebound ``async_sessionmaker`` from
+        the ``async_db`` fixture explicitly.
         """
-        self._session_factory = session_factory
         self._kek = kek_provider
         self._async_session_factory = async_session_factory
 
-    def _resolve_async_factory(self) -> Callable[[], AsyncSession]:
+    def _resolve_factory(self) -> Callable[[], AsyncSession]:
         """Return the async session factory to use for this call.
 
         Deferred lookup: the constructor default is ``None`` so that a
         store instantiated before the async engine has booted (e.g. at
-        import time) doesn't capture a stale factory. The first
-        ``*_async`` call resolves the factory from
-        ``backend.app.database`` (which honors test rebinding of the
-        module-level ``_async_session_factory``).
+        import time) doesn't capture a stale factory.
         """
         if self._async_session_factory is not None:
             return self._async_session_factory
@@ -354,18 +336,8 @@ class DbSettingsStore:
 
         return AsyncSessionLocal
 
-    def load(self) -> dict[str, str]:
-        try:
-            with self._session_factory() as db:
-                rows = db.execute(_load_select_sql()).all()
-        except Exception as exc:
-            raise ConfigStoreError(f"Failed to query app_settings: {exc}") from exc
-
-        return _decode_load_rows(rows, self._kek)
-
-    async def load_async(self) -> dict[str, str]:
-        """Async peer of ``load``."""
-        factory = self._resolve_async_factory()
+    async def load(self) -> dict[str, str]:
+        factory = self._resolve_factory()
         try:
             async with factory() as db:
                 rows = (await db.execute(_load_select_sql())).all()
@@ -374,54 +346,42 @@ class DbSettingsStore:
 
         return _decode_load_rows(rows, self._kek)
 
-    def save(self, updates: Mapping[str, str], *, actor_user_id: str | None = None) -> None:
+    async def load_async(self) -> dict[str, str]:
+        """Deprecated alias of :meth:`load`."""
+        return await self.load()
+
+    async def save(self, updates: Mapping[str, str], *, actor_user_id: str | None = None) -> None:
         if not updates:
             return
         rows = _build_save_rows(updates, self._kek, actor_user_id=actor_user_id)
-        with self._session_factory() as db:
-            db.execute(_save_upsert_sql(), rows)
-            db.commit()
-
-    async def save_async(
-        self, updates: Mapping[str, str], *, actor_user_id: str | None = None
-    ) -> None:
-        """Async peer of ``save``.
-
-        Same persistable-key validation, same encryption-on-write, same
-        single-statement upsert. ``ValueError`` for non-persistable
-        keys is raised before any IO, matching the sync path.
-        """
-        if not updates:
-            return
-        rows = _build_save_rows(updates, self._kek, actor_user_id=actor_user_id)
-        factory = self._resolve_async_factory()
+        factory = self._resolve_factory()
         async with factory() as db:
             await db.execute(_save_upsert_sql(), rows)
             await db.commit()
 
-    def delete(self, keys: Iterable[str]) -> None:
-        keys_list = list(keys)
-        if not keys_list:
-            return
-        with self._session_factory() as db:
-            db.execute(_delete_sql(), {"keys": keys_list})
-            db.commit()
+    async def save_async(
+        self, updates: Mapping[str, str], *, actor_user_id: str | None = None
+    ) -> None:
+        """Deprecated alias of :meth:`save`."""
+        await self.save(updates, actor_user_id=actor_user_id)
 
-    async def delete_async(self, keys: Iterable[str]) -> None:
-        """Async peer of ``delete``."""
+    async def delete(self, keys: Iterable[str]) -> None:
         keys_list = list(keys)
         if not keys_list:
             return
-        factory = self._resolve_async_factory()
+        factory = self._resolve_factory()
         async with factory() as db:
             await db.execute(_delete_sql(), {"keys": keys_list})
             await db.commit()
 
+    async def delete_async(self, keys: Iterable[str]) -> None:
+        """Deprecated alias of :meth:`delete`."""
+        await self.delete(keys)
+
     def _encryption_context(self) -> _encryption.EncryptionContext:
         # Kept for backward-compat with any subclass / external caller
         # that may have referenced the instance method directly. The
-        # module-level ``_encryption_context()`` is the source of truth
-        # for both sync and async paths.
+        # module-level ``_encryption_context()`` is the source of truth.
         return _encryption_context()
 
 
@@ -446,7 +406,7 @@ class JsonFileSettingsStore:
         self._path = path
         self._allow_missing = allow_missing
 
-    def load(self) -> dict[str, str]:
+    async def load(self) -> dict[str, str]:
         if not self._path.is_file():
             if self._allow_missing:
                 return {}
@@ -463,7 +423,7 @@ class JsonFileSettingsStore:
             raise ConfigStoreError(f"{self._path} is not a JSON object at the top level")
         return {k: str(v) for k, v in data.items()}
 
-    def save(self, updates: Mapping[str, str], *, actor_user_id: str | None = None) -> None:
+    async def save(self, updates: Mapping[str, str], *, actor_user_id: str | None = None) -> None:
         del actor_user_id  # JSON file has no audit column
         if not updates:
             return
@@ -477,7 +437,7 @@ class JsonFileSettingsStore:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
 
-    def delete(self, keys: Iterable[str]) -> None:
+    async def delete(self, keys: Iterable[str]) -> None:
         keys_list = list(keys)
         if not keys_list or not self._path.is_file():
             return
@@ -525,14 +485,11 @@ def get_settings_store() -> SettingsStore:
     if backend == "file":
         _store = JsonFileSettingsStore(_config_json_path())
     elif backend == "db":
-        import backend.app.database as _db_module
         from backend.app.auth.loader import get_kek_provider
 
-        # Use SessionLocal (a bound sessionmaker) so writes ride the
-        # same connection pool the rest of the app uses, and so tests
-        # that bind SessionLocal to a rolled-back transaction also
-        # roll back our writes.
-        _store = DbSettingsStore(_db_module.SessionLocal, get_kek_provider())
+        # Async session factory is resolved lazily on each call so test
+        # rebinding of ``_async_session_factory`` is picked up.
+        _store = DbSettingsStore(get_kek_provider())
     else:
         raise ConfigStoreError(
             f"Unknown SETTINGS_STORE value: {backend!r} (expected 'db' or 'file')"
@@ -546,7 +503,7 @@ def reset_settings_store() -> None:
     _store = None
 
 
-def import_legacy_config_json(store: SettingsStore) -> dict[str, str]:
+async def import_legacy_config_json(store: SettingsStore) -> dict[str, str]:
     """One-shot import of legacy ``data/config.json`` into the store.
 
     Idempotent: a no-op if the store already has any persistable rows
@@ -561,7 +518,7 @@ def import_legacy_config_json(store: SettingsStore) -> dict[str, str]:
         return {}
 
     try:
-        current = store.load()
+        current = await store.load()
     except ConfigStoreError:
         # Store unreachable. Don't import; let the caller surface the
         # underlying failure.
@@ -590,7 +547,7 @@ def import_legacy_config_json(store: SettingsStore) -> dict[str, str]:
     if not to_import:
         return {}
 
-    store.save(to_import)
+    await store.save(to_import)
     logger.info(
         "Imported %d setting(s) from legacy %s into the settings store: %s",
         len(to_import),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ from backend.app.config_store import (
     get_settings_store,
     import_legacy_config_json,
 )
-from backend.app.database import db_session_async, get_engine
+from backend.app.database import db_session_async, get_async_engine
 from backend.app.logging_utils import mask_pii
 from backend.app.models import ChannelRoute, User
 from backend.app.routers import (
@@ -178,15 +178,15 @@ async def _verify_llm_settings() -> None:
             )
 
 
-def _verify_database() -> None:
+async def _verify_database() -> None:
     """Verify database connectivity at startup.
 
     Creates the engine and runs a simple SELECT 1 to surface connection
     errors early rather than at first user request.
     """
-    engine = get_engine()
-    with engine.connect() as conn:
-        conn.execute(text("SELECT 1"))
+    engine = get_async_engine()
+    async with engine.connect() as conn:
+        await conn.execute(text("SELECT 1"))
     logger.info("Database connection verified: %s", engine.url)
 
 
@@ -198,13 +198,13 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     # missing migration, decryption failure) so a misconfigured
     # production environment fails the lifespan loudly rather than
     # booting with empty defaults and crashing 30 lines deeper.
-    _verify_database()
+    await _verify_database()
     store = get_settings_store()
     # One-shot migration from the legacy data/config.json into the DB
     # store. No-op once the table has any persistable rows, so safe to
     # leave in place across releases.
-    import_legacy_config_json(store)
-    persisted = store.load()
+    await import_legacy_config_json(store)
+    persisted = await store.load()
     applied = apply_to_settings(persisted)
     if applied:
         logger.info(

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -226,7 +226,7 @@ async def update_channel_config(
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    get_settings_store().save(updates, actor_user_id=current_user.id)
+    await get_settings_store().save(updates, actor_user_id=current_user.id)
 
     reset_channel_clients(updates)
 
@@ -426,7 +426,7 @@ async def update_model_config(
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    get_settings_store().save(updates, actor_user_id=current_user.id)
+    await get_settings_store().save(updates, actor_user_id=current_user.id)
     return _build_model_config_response()
 
 
@@ -484,7 +484,7 @@ async def update_storage_config(
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    get_settings_store().save(updates, actor_user_id=current_user.id)
+    await get_settings_store().save(updates, actor_user_id=current_user.id)
     return _build_storage_config_response()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@ from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
+from httpx import ASGITransport
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -484,12 +486,16 @@ def _stub_unknown_sender_reply() -> Generator[AsyncMock]:
     unknown_sender_module.reset_unknown_sender_cache()
 
 
-@pytest.fixture()
-def linq_client(test_user: User) -> Generator[TestClient]:
+@pytest_asyncio.fixture()
+async def linq_client(test_user: User) -> AsyncGenerator[httpx.AsyncClient]:
     """FastAPI test client with Linq channel available.
 
     The Linq channel is always registered at module level in main.py.
     This fixture patches settings to allow all numbers and disable HMAC.
+
+    Uses ``httpx.AsyncClient`` over ``ASGITransport`` so the FastAPI request
+    runs on the same event loop as the async DB fixtures, allowing webhook
+    handlers to share the per-test asyncpg session.
     """
 
     def _override_get_current_user() -> User:
@@ -515,17 +521,23 @@ def linq_client(test_user: User) -> Generator[TestClient]:
         patch("backend.app.channels.telegram.settings.telegram_allowed_chat_id", "*"),
         patch("backend.app.channels.telegram.settings.telegram_bot_token", ""),
         patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
-        TestClient(app) as c,
     ):
-        yield c
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as c:
+            yield c
     app.dependency_overrides.clear()
 
 
-@pytest.fixture()
-def bluebubbles_client(test_user: User) -> Generator[TestClient]:
+@pytest_asyncio.fixture()
+async def bluebubbles_client(test_user: User) -> AsyncGenerator[httpx.AsyncClient]:
     """FastAPI test client with BlueBubbles channel available.
 
     Patches settings to allow all numbers and disable password validation.
+
+    Uses ``httpx.AsyncClient`` over ``ASGITransport`` so the FastAPI request
+    runs on the same event loop as the async DB fixtures, allowing webhook
+    handlers to share the per-test asyncpg session.
     """
 
     def _override_get_current_user() -> User:
@@ -553,9 +565,11 @@ def bluebubbles_client(test_user: User) -> Generator[TestClient]:
         patch("backend.app.channels.linq.settings.linq_allowed_numbers", "*"),
         patch("backend.app.channels.linq.settings.linq_webhook_signing_secret", ""),
         patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
-        TestClient(app) as c,
     ):
-        yield c
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as c:
+            yield c
     app.dependency_overrides.clear()
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -106,13 +106,10 @@ async def test_scoping_returns_404_for_wrong_user() -> None:
         db.close()
 
     # User 1 should not be able to access user 2
-    db = _db_module.SessionLocal()
-    try:
+    async with _db_module.AsyncSessionLocal() as db:
         with pytest.raises(HTTPException) as exc_info:
             await get_scoped_user(user1, user2.id, db)
         assert exc_info.value.status_code == 404
-    finally:
-        db.close()
 
 
 @pytest.mark.asyncio()
@@ -128,9 +125,6 @@ async def test_scoping_returns_user_for_correct_user() -> None:
     finally:
         db.close()
 
-    db = _db_module.SessionLocal()
-    try:
+    async with _db_module.AsyncSessionLocal() as db:
         result = await get_scoped_user(user, user.id, db)
         assert result.id == user.id
-    finally:
-        db.close()

--- a/tests/test_bluebubbles_backfill.py
+++ b/tests/test_bluebubbles_backfill.py
@@ -20,7 +20,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from fastapi.testclient import TestClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -214,7 +213,7 @@ async def test_already_seen_messages_are_deduped(
 
 @pytest.mark.asyncio
 async def test_webhook_processed_message_is_not_replayed_after_restart(
-    bluebubbles_client: TestClient,
+    bluebubbles_client: httpx.AsyncClient,
     async_db: object,
 ) -> None:
     """End-to-end production scenario: the live webhook delivered a message,
@@ -254,7 +253,7 @@ async def test_webhook_processed_message_is_not_replayed_after_restart(
         # Step 1: live webhook delivers the message via the running app.
         # Goes through the real router -> handle_webhook_inbound ->
         # IdempotencyStore.try_mark_seen, which commits the seen-row.
-        webhook_resp = bluebubbles_client.post(
+        webhook_resp = await bluebubbles_client.post(
             f"/api/webhooks/bluebubbles?token={token}", json=webhook_payload
         )
         assert webhook_resp.status_code == 200

--- a/tests/test_bluebubbles_channel.py
+++ b/tests/test_bluebubbles_channel.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from fastapi.testclient import TestClient
 
 from backend.app.channels.bluebubbles import BlueBubblesChannel, _derive_webhook_token
 from tests.mocks.bluebubbles import make_bluebubbles_webhook_payload
@@ -22,8 +21,8 @@ _PATCH_BUS_PUBLISH = "backend.app.bus.message_bus.publish_inbound"
 # ---------------------------------------------------------------------------
 
 
-def _post_webhook(
-    client: TestClient,
+async def _post_webhook(
+    client: httpx.AsyncClient,
     payload: dict,
     token: str = "",
     password: str = "",
@@ -34,7 +33,7 @@ def _post_webhook(
         url = f"{url}?token={token}"
     elif password:
         url = f"{url}?password={password}"
-    return client.post(url, json=payload)
+    return await client.post(url, json=payload)
 
 
 # ---------------------------------------------------------------------------
@@ -42,20 +41,20 @@ def _post_webhook(
 # ---------------------------------------------------------------------------
 
 
-def test_inbound_webhook_returns_200(bluebubbles_client: TestClient) -> None:
+async def test_inbound_webhook_returns_200(bluebubbles_client: httpx.AsyncClient) -> None:
     """Valid webhook payload should return 200 with ok:true."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock):
         payload = make_bluebubbles_webhook_payload(text="Hello")
-        resp = _post_webhook(bluebubbles_client, payload)
+        resp = await _post_webhook(bluebubbles_client, payload)
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
 
 
-def test_inbound_webhook_publishes_text(bluebubbles_client: TestClient) -> None:
+async def test_inbound_webhook_publishes_text(bluebubbles_client: httpx.AsyncClient) -> None:
     """Inbound text message should be published to the bus."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         payload = make_bluebubbles_webhook_payload(sender="+15559876543", text="Need a quote")
-        _post_webhook(bluebubbles_client, payload)
+        await _post_webhook(bluebubbles_client, payload)
 
     mock_pub.assert_called_once()
     inbound = mock_pub.call_args[0][0]
@@ -64,7 +63,7 @@ def test_inbound_webhook_publishes_text(bluebubbles_client: TestClient) -> None:
     assert inbound.text == "Need a quote"
 
 
-def test_inbound_webhook_publishes_media(bluebubbles_client: TestClient) -> None:
+async def test_inbound_webhook_publishes_media(bluebubbles_client: httpx.AsyncClient) -> None:
     """Media messages should include media_refs in the published InboundMessage."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         payload = make_bluebubbles_webhook_payload(
@@ -78,7 +77,7 @@ def test_inbound_webhook_publishes_media(bluebubbles_client: TestClient) -> None
                 }
             ],
         )
-        _post_webhook(bluebubbles_client, payload)
+        await _post_webhook(bluebubbles_client, payload)
 
     mock_pub.assert_called_once()
     inbound = mock_pub.call_args[0][0]
@@ -88,30 +87,30 @@ def test_inbound_webhook_publishes_media(bluebubbles_client: TestClient) -> None
     assert inbound.media_refs[0][1] == "image/jpeg"
 
 
-def test_is_from_me_ignored(bluebubbles_client: TestClient) -> None:
+async def test_is_from_me_ignored(bluebubbles_client: httpx.AsyncClient) -> None:
     """Messages sent by the Mac (isFromMe=True) should be ignored."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         payload = make_bluebubbles_webhook_payload(text="Echo", is_from_me=True)
-        resp = _post_webhook(bluebubbles_client, payload)
+        resp = await _post_webhook(bluebubbles_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
 
 
-def test_non_new_message_event_ignored(bluebubbles_client: TestClient) -> None:
+async def test_non_new_message_event_ignored(bluebubbles_client: httpx.AsyncClient) -> None:
     """Non-new-message events should return 200 without publishing."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         for event in ("typing-indicator", "chat-read-status-changed", "updated-message"):
             payload = make_bluebubbles_webhook_payload(text="Hi", event_type=event)
-            resp = _post_webhook(bluebubbles_client, payload)
+            resp = await _post_webhook(bluebubbles_client, payload)
             assert resp.status_code == 200
 
     mock_pub.assert_not_called()
 
 
-def test_invalid_json_returns_200(bluebubbles_client: TestClient) -> None:
+async def test_invalid_json_returns_200(bluebubbles_client: httpx.AsyncClient) -> None:
     """Invalid JSON body should return 200 without crashing."""
-    resp = bluebubbles_client.post(
+    resp = await bluebubbles_client.post(
         "/api/webhooks/bluebubbles",
         content=b"not valid json",
         headers={"Content-Type": "application/json"},
@@ -120,17 +119,17 @@ def test_invalid_json_returns_200(bluebubbles_client: TestClient) -> None:
     assert resp.json() == {"ok": True}
 
 
-def test_duplicate_message_skipped(bluebubbles_client: TestClient) -> None:
+async def test_duplicate_message_skipped(bluebubbles_client: httpx.AsyncClient) -> None:
     """Duplicate webhook calls should not publish to bus twice."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         payload = make_bluebubbles_webhook_payload(text="First", message_guid="dup-msg-001")
-        _post_webhook(bluebubbles_client, payload)
-        _post_webhook(bluebubbles_client, payload)
+        await _post_webhook(bluebubbles_client, payload)
+        await _post_webhook(bluebubbles_client, payload)
 
     mock_pub.assert_called_once()
 
 
-def test_invalid_token_does_not_publish(bluebubbles_client: TestClient) -> None:
+async def test_invalid_token_does_not_publish(bluebubbles_client: httpx.AsyncClient) -> None:
     """Invalid webhook token should return 200 but not publish to bus."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
@@ -140,13 +139,13 @@ def test_invalid_token_does_not_publish(bluebubbles_client: TestClient) -> None:
         ),
     ):
         payload = make_bluebubbles_webhook_payload(text="Hi")
-        resp = _post_webhook(bluebubbles_client, payload, token="wrong-token")
+        resp = await _post_webhook(bluebubbles_client, payload, token="wrong-token")
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
 
 
-def test_correct_token_publishes(bluebubbles_client: TestClient) -> None:
+async def test_correct_token_publishes(bluebubbles_client: httpx.AsyncClient) -> None:
     """Correct derived webhook token should publish to bus."""
     password = "correct-password"
     with (
@@ -158,13 +157,13 @@ def test_correct_token_publishes(bluebubbles_client: TestClient) -> None:
     ):
         payload = make_bluebubbles_webhook_payload(text="Hi")
         token = _derive_webhook_token(password)
-        resp = _post_webhook(bluebubbles_client, payload, token=token)
+        resp = await _post_webhook(bluebubbles_client, payload, token=token)
 
     assert resp.status_code == 200
     mock_pub.assert_called_once()
 
 
-def test_correct_password_param_publishes(bluebubbles_client: TestClient) -> None:
+async def test_correct_password_param_publishes(bluebubbles_client: httpx.AsyncClient) -> None:
     """Webhook with correct raw ?password= should also pass auth and publish."""
     password = "correct-password"
     with (
@@ -175,13 +174,13 @@ def test_correct_password_param_publishes(bluebubbles_client: TestClient) -> Non
         ),
     ):
         payload = make_bluebubbles_webhook_payload(text="Hi via password")
-        resp = _post_webhook(bluebubbles_client, payload, password=password)
+        resp = await _post_webhook(bluebubbles_client, payload, password=password)
 
     assert resp.status_code == 200
     mock_pub.assert_called_once()
 
 
-def test_wrong_password_param_does_not_publish(bluebubbles_client: TestClient) -> None:
+async def test_wrong_password_param_does_not_publish(bluebubbles_client: httpx.AsyncClient) -> None:
     """Webhook with incorrect raw ?password= should not publish."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
@@ -191,7 +190,7 @@ def test_wrong_password_param_does_not_publish(bluebubbles_client: TestClient) -
         ),
     ):
         payload = make_bluebubbles_webhook_payload(text="Hi")
-        resp = _post_webhook(bluebubbles_client, payload, password="wrong-password")
+        resp = await _post_webhook(bluebubbles_client, payload, password="wrong-password")
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
@@ -210,33 +209,33 @@ def test_raw_password_never_in_webhook_url() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_allowlist_empty_denies_all(bluebubbles_client: TestClient) -> None:
+async def test_allowlist_empty_denies_all(bluebubbles_client: httpx.AsyncClient) -> None:
     """Empty allowlist should deny all senders."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", ""),
     ):
         payload = make_bluebubbles_webhook_payload(sender="+15551234567", text="Hi")
-        resp = _post_webhook(bluebubbles_client, payload)
+        resp = await _post_webhook(bluebubbles_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
 
 
-def test_allowlist_wildcard_allows_all(bluebubbles_client: TestClient) -> None:
+async def test_allowlist_wildcard_allows_all(bluebubbles_client: httpx.AsyncClient) -> None:
     """Setting allowed_numbers to '*' should allow all senders."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"),
     ):
         payload = make_bluebubbles_webhook_payload(sender="+15559999999", text="Hi")
-        resp = _post_webhook(bluebubbles_client, payload)
+        resp = await _post_webhook(bluebubbles_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_called_once()
 
 
-def test_allowlist_matching_number_allows(bluebubbles_client: TestClient) -> None:
+async def test_allowlist_matching_number_allows(bluebubbles_client: httpx.AsyncClient) -> None:
     """Matching E.164 number should be allowed."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
@@ -246,13 +245,13 @@ def test_allowlist_matching_number_allows(bluebubbles_client: TestClient) -> Non
         ),
     ):
         payload = make_bluebubbles_webhook_payload(sender="+15551234567", text="Hi")
-        resp = _post_webhook(bluebubbles_client, payload)
+        resp = await _post_webhook(bluebubbles_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_called_once()
 
 
-def test_allowlist_non_matching_number_denies(bluebubbles_client: TestClient) -> None:
+async def test_allowlist_non_matching_number_denies(bluebubbles_client: httpx.AsyncClient) -> None:
     """Non-matching phone number should be denied."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
@@ -262,7 +261,7 @@ def test_allowlist_non_matching_number_denies(bluebubbles_client: TestClient) ->
         ),
     ):
         payload = make_bluebubbles_webhook_payload(sender="+15559999999", text="Hi")
-        resp = _post_webhook(bluebubbles_client, payload)
+        resp = await _post_webhook(bluebubbles_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
@@ -273,34 +272,34 @@ def test_allowlist_non_matching_number_denies(bluebubbles_client: TestClient) ->
 # ---------------------------------------------------------------------------
 
 
-def test_is_allowed_empty_denies() -> None:
+async def test_is_allowed_empty_denies() -> None:
     channel = BlueBubblesChannel()
     with patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", ""):
-        assert channel.is_allowed("+15551234567", "") is False
+        assert await channel.is_allowed("+15551234567", "") is False
 
 
-def test_is_allowed_wildcard_allows() -> None:
+async def test_is_allowed_wildcard_allows() -> None:
     channel = BlueBubblesChannel()
     with patch("backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "*"):
-        assert channel.is_allowed("+15551234567", "") is True
+        assert await channel.is_allowed("+15551234567", "") is True
 
 
-def test_is_allowed_matching_number() -> None:
+async def test_is_allowed_matching_number() -> None:
     channel = BlueBubblesChannel()
     with patch(
         "backend.app.channels.bluebubbles.settings.bluebubbles_allowed_numbers", "+15551234567"
     ):
-        assert channel.is_allowed("+15551234567", "") is True
-        assert channel.is_allowed("+15559999999", "") is False
+        assert await channel.is_allowed("+15551234567", "") is True
+        assert await channel.is_allowed("+15559999999", "") is False
 
 
-def test_is_allowed_premium_override() -> None:
+async def test_is_allowed_premium_override() -> None:
     """When premium override is set, it should take precedence."""
     channel = BlueBubblesChannel()
-    with patch.object(channel, "_check_premium_route", return_value=True):
-        assert channel.is_allowed("+15551234567", "") is True
-    with patch.object(channel, "_check_premium_route", return_value=False):
-        assert channel.is_allowed("+15551234567", "") is False
+    with patch.object(channel, "_check_premium_route", AsyncMock(return_value=True)):
+        assert await channel.is_allowed("+15551234567", "") is True
+    with patch.object(channel, "_check_premium_route", AsyncMock(return_value=False)):
+        assert await channel.is_allowed("+15551234567", "") is False
 
 
 # ---------------------------------------------------------------------------
@@ -741,7 +740,7 @@ async def test_download_media() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_webhook_populates_chat_cache(bluebubbles_client: TestClient) -> None:
+async def test_webhook_populates_chat_cache(bluebubbles_client: httpx.AsyncClient) -> None:
     """Inbound webhook should populate the chat cache for outbound use."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock):
         payload = make_bluebubbles_webhook_payload(
@@ -749,7 +748,7 @@ def test_webhook_populates_chat_cache(bluebubbles_client: TestClient) -> None:
             text="Hello",
             chat_guid="iMessage;-;+15551234567",
         )
-        _post_webhook(bluebubbles_client, payload)
+        await _post_webhook(bluebubbles_client, payload)
 
     from backend.app.channels import get_channel
 

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -1,7 +1,7 @@
 """Tests for channel config GET/PUT endpoints."""
 
 from collections.abc import Iterator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -35,11 +35,15 @@ def _stub_store() -> Iterator[MagicMock]:
     mutation, not actual persistence. The mock captures ``save`` calls
     so individual tests can assert on them when relevant.
     """
+    store = MagicMock()
+    store.save = AsyncMock()
+    store.delete = AsyncMock()
+    store.load = AsyncMock(return_value={})
     with patch(
         "backend.app.routers.user_profile.get_settings_store",
-        return_value=MagicMock(),
-    ) as factory:
-        yield factory.return_value
+        return_value=store,
+    ):
+        yield store
 
 
 def test_get_channel_config_token_set(client: TestClient, _set_bot_token: None) -> None:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -37,7 +37,7 @@ class _StubChannel(BaseChannel):
     def get_router(self) -> APIRouter:
         return APIRouter()
 
-    def is_allowed(self, sender_id: str, username: str) -> bool:
+    async def is_allowed(self, sender_id: str, username: str) -> bool:
         return True
 
     async def send_text(self, to: str, body: str) -> str:

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -941,7 +941,7 @@ async def test_trigger_compaction_for_dropped_fires_background_task(
     )
 
     with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
-        trigger_compaction_for_dropped(test_user.id, dropped)
+        await trigger_compaction_for_dropped(test_user.id, dropped)
         await asyncio.sleep(0.2)
 
     store = get_memory_store(test_user.id)
@@ -957,7 +957,7 @@ async def test_trigger_compaction_for_dropped_skips_empty(
     from backend.app.agent.context import trigger_compaction_for_dropped
 
     with patch("backend.app.agent.compaction.amessages") as mock_llm:
-        trigger_compaction_for_dropped(test_user.id, [])
+        await trigger_compaction_for_dropped(test_user.id, [])
         await asyncio.sleep(0.1)
 
     mock_llm.assert_not_called()
@@ -977,7 +977,7 @@ async def test_trigger_compaction_for_dropped_skips_when_disabled(
         patch("backend.app.agent.compaction.amessages") as mock_llm,
     ):
         mock_settings.compaction_enabled = False
-        trigger_compaction_for_dropped(test_user.id, dropped)
+        await trigger_compaction_for_dropped(test_user.id, dropped)
         await asyncio.sleep(0.1)
 
     mock_llm.assert_not_called()
@@ -1328,7 +1328,7 @@ async def test_trigger_compaction_for_dropped_no_seqs_skips(test_user: User) -> 
     in_memory_only: list[AgentMessage] = [
         UserMessage(content="placeholder"),  # seq=None
     ]
-    trigger_compaction_for_dropped(test_user.id, in_memory_only)
+    await trigger_compaction_for_dropped(test_user.id, in_memory_only)
     db = _db_module.SessionLocal()
     try:
         rows = db.query(CompactionEvent).filter_by(user_id=test_user.id).count()
@@ -1356,7 +1356,7 @@ async def test_trigger_compaction_for_dropped_inserts_pending_and_advances_water
         "backend.app.agent.context.compact_session",
         new=AsyncMock(return_value=("", 5)),
     ):
-        trigger_compaction_for_dropped(test_user.id, dropped)
+        await trigger_compaction_for_dropped(test_user.id, dropped)
         # Yield to let the (mocked) background task run.
         await asyncio.sleep(0)
 
@@ -1393,7 +1393,7 @@ async def test_watermark_event_seq_invariant_after_compaction(test_user: User) -
         "backend.app.agent.context.compact_session",
         new=AsyncMock(return_value=("", 8)),
     ):
-        trigger_compaction_for_dropped(test_user.id, dropped)
+        await trigger_compaction_for_dropped(test_user.id, dropped)
         await asyncio.sleep(0)
 
     db = _db_module.SessionLocal()

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -12,12 +12,11 @@ admin-UI-saves-survive-restart contract.
 from __future__ import annotations
 
 import json
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import Engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from backend.app.config import settings
 from backend.app.config_store import (
@@ -139,14 +138,14 @@ def test_apply_to_settings_empty_env_var_does_not_block_store_value() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_json_file_store_loads_existing_file(tmp_path: Path) -> None:
+async def test_json_file_store_loads_existing_file(tmp_path: Path) -> None:
     path = tmp_path / "config.json"
     path.write_text(json.dumps({"llm_provider": "anthropic", "llm_model": "sonnet"}))
     store = JsonFileSettingsStore(path)
-    assert store.load() == {"llm_provider": "anthropic", "llm_model": "sonnet"}
+    assert await store.load() == {"llm_provider": "anthropic", "llm_model": "sonnet"}
 
 
-def test_json_file_store_missing_file_is_loud_by_default(tmp_path: Path) -> None:
+async def test_json_file_store_missing_file_is_loud_by_default(tmp_path: Path) -> None:
     """Missing file raises ``ConfigStoreError`` instead of returning {}.
 
     This is the regression guard for the production bug that motivated
@@ -156,32 +155,32 @@ def test_json_file_store_missing_file_is_loud_by_default(tmp_path: Path) -> None
     """
     store = JsonFileSettingsStore(tmp_path / "missing.json")
     with pytest.raises(ConfigStoreError, match="does not exist"):
-        store.load()
+        await store.load()
 
 
-def test_json_file_store_allow_missing_returns_empty(tmp_path: Path) -> None:
+async def test_json_file_store_allow_missing_returns_empty(tmp_path: Path) -> None:
     """First-boot opt-in: ``allow_missing=True`` returns {}."""
     store = JsonFileSettingsStore(tmp_path / "missing.json", allow_missing=True)
-    assert store.load() == {}
+    assert await store.load() == {}
 
 
-def test_json_file_store_save_creates_and_merges(tmp_path: Path) -> None:
+async def test_json_file_store_save_creates_and_merges(tmp_path: Path) -> None:
     path = tmp_path / "data" / "config.json"
     store = JsonFileSettingsStore(path)
-    store.save({"llm_provider": "anthropic"})
+    await store.save({"llm_provider": "anthropic"})
     assert json.loads(path.read_text()) == {"llm_provider": "anthropic"}
-    store.save({"llm_model": "sonnet"})
+    await store.save({"llm_model": "sonnet"})
     assert json.loads(path.read_text()) == {
         "llm_provider": "anthropic",
         "llm_model": "sonnet",
     }
 
 
-def test_json_file_store_delete_removes_keys(tmp_path: Path) -> None:
+async def test_json_file_store_delete_removes_keys(tmp_path: Path) -> None:
     path = tmp_path / "config.json"
     store = JsonFileSettingsStore(path)
-    store.save({"llm_provider": "x", "llm_model": "y"})
-    store.delete(["llm_model"])
+    await store.save({"llm_provider": "x", "llm_model": "y"})
+    await store.delete(["llm_model"])
     assert json.loads(path.read_text()) == {"llm_provider": "x"}
 
 
@@ -197,39 +196,32 @@ def _kek_provider() -> LocalKEKProvider:
 
 
 @pytest.fixture()
-def _db_store(_kek_provider: LocalKEKProvider) -> Generator[DbSettingsStore]:
-    """Construct a store bound to the active ``SessionLocal``.
-
-    The autouse ``_isolate_stores`` fixture rebinds ``SessionLocal`` to
-    a per-test connection in a rolled-back transaction; using it here
-    means our writes auto-clean between tests.
-    """
-    import backend.app.database as _db_module
-
-    yield DbSettingsStore(_db_module.SessionLocal, _kek_provider)
+def _db_store(_kek_provider: LocalKEKProvider) -> DbSettingsStore:
+    """Construct a store that resolves the test-scoped async session factory."""
+    return DbSettingsStore(_kek_provider)
 
 
-def test_db_store_save_and_load_round_trips(_db_store: DbSettingsStore) -> None:
+async def test_db_store_save_and_load_round_trips(_db_store: DbSettingsStore) -> None:
     """Save then load returns the exact value for both secret and non-secret keys.
 
     This is the integration guard the previous DB-backed attempt was
     missing: it proves the read and write halves agree end-to-end.
     """
-    _db_store.save(
+    await _db_store.save(
         {
             "llm_provider": "anthropic",
             "llm_model": "claude-sonnet-4-6",
             "telegram_bot_token": "real-secret-token",
         }
     )
-    loaded = _db_store.load()
+    loaded = await _db_store.load()
     assert loaded["llm_provider"] == "anthropic"
     assert loaded["llm_model"] == "claude-sonnet-4-6"
     # Decryption happened transparently.
     assert loaded["telegram_bot_token"] == "real-secret-token"
 
 
-def test_db_store_int_setting_round_trips_through_text_column(
+async def test_db_store_int_setting_round_trips_through_text_column(
     _db_store: DbSettingsStore,
 ) -> None:
     """Integer persistable settings round-trip cleanly through the TEXT
@@ -252,9 +244,9 @@ def test_db_store_int_setting_round_trips_through_text_column(
     """
     original = settings.llm_max_tokens_agent
     try:
-        _db_store.save({"llm_max_tokens_agent": "4096"})
+        await _db_store.save({"llm_max_tokens_agent": "4096"})
         # Stored verbatim as TEXT, not transparently re-typed by the store.
-        assert _db_store.load()["llm_max_tokens_agent"] == "4096"
+        assert (await _db_store.load())["llm_max_tokens_agent"] == "4096"
 
         # Boot path: load from store, apply to settings. ``apply_to_settings``
         # skips keys that have a non-empty matching env var, so clear the
@@ -263,7 +255,7 @@ def test_db_store_int_setting_round_trips_through_text_column(
             import os
 
             os.environ.pop("LLM_MAX_TOKENS_AGENT", None)
-            applied = apply_to_settings(_db_store.load())
+            applied = apply_to_settings(await _db_store.load())
         assert applied["llm_max_tokens_agent"] == "4096"
         # The live singleton holds the typed int, not the raw string.
         assert settings.llm_max_tokens_agent == 4096
@@ -272,7 +264,7 @@ def test_db_store_int_setting_round_trips_through_text_column(
         settings.llm_max_tokens_agent = original
 
 
-def test_db_store_secrets_are_envelope_encrypted_at_rest(
+async def test_db_store_secrets_are_envelope_encrypted_at_rest(
     _db_store: DbSettingsStore,
 ) -> None:
     """Verify the on-disk bytes are an envelope, not plaintext.
@@ -282,13 +274,15 @@ def test_db_store_secrets_are_envelope_encrypted_at_rest(
     """
     from sqlalchemy import text
 
-    import backend.app.database as _db_module
+    from backend.app.database import db_session_async
 
-    _db_store.save({"telegram_bot_token": "real-secret-token"})
+    await _db_store.save({"telegram_bot_token": "real-secret-token"})
 
-    with _db_module.SessionLocal() as db:
-        row = db.execute(
-            text("SELECT value, is_secret FROM app_settings WHERE key='telegram_bot_token'")
+    async with db_session_async() as db:
+        row = (
+            await db.execute(
+                text("SELECT value, is_secret FROM app_settings WHERE key='telegram_bot_token'")
+            )
         ).one()
     raw_value, is_secret_flag = row
     assert is_secret_flag is True
@@ -296,83 +290,95 @@ def test_db_store_secrets_are_envelope_encrypted_at_rest(
     assert is_envelope(raw_value)
 
 
-def test_db_store_non_secret_stored_verbatim(
+async def test_db_store_non_secret_stored_verbatim(
     _db_store: DbSettingsStore,
 ) -> None:
     from sqlalchemy import text
 
-    import backend.app.database as _db_module
+    from backend.app.database import db_session_async
 
-    _db_store.save({"llm_provider": "anthropic"})
-    with _db_module.SessionLocal() as db:
-        row = db.execute(
-            text("SELECT value, is_secret FROM app_settings WHERE key='llm_provider'")
+    await _db_store.save({"llm_provider": "anthropic"})
+    async with db_session_async() as db:
+        row = (
+            await db.execute(
+                text("SELECT value, is_secret FROM app_settings WHERE key='llm_provider'")
+            )
         ).one()
     assert row[0] == "anthropic"
     assert row[1] is False
 
 
-def test_db_store_save_rejects_non_persistable_keys(_db_store: DbSettingsStore) -> None:
+async def test_db_store_save_rejects_non_persistable_keys(_db_store: DbSettingsStore) -> None:
     with pytest.raises(ValueError, match="not a persistable setting"):
-        _db_store.save({"definitely_not_a_setting": "x"})
+        await _db_store.save({"definitely_not_a_setting": "x"})
 
 
-def test_db_store_save_upserts(_db_store: DbSettingsStore) -> None:
+async def test_db_store_save_upserts(_db_store: DbSettingsStore) -> None:
     """Saving the same key twice updates the value, doesn't error on dup PK."""
-    _db_store.save({"llm_provider": "anthropic"})
-    _db_store.save({"llm_provider": "openai"})
-    assert _db_store.load()["llm_provider"] == "openai"
+    await _db_store.save({"llm_provider": "anthropic"})
+    await _db_store.save({"llm_provider": "openai"})
+    assert (await _db_store.load())["llm_provider"] == "openai"
 
 
-def test_db_store_delete_removes_rows(_db_store: DbSettingsStore) -> None:
-    _db_store.save({"llm_provider": "anthropic", "llm_model": "sonnet"})
-    _db_store.delete(["llm_model"])
-    loaded = _db_store.load()
+async def test_db_store_delete_removes_rows(_db_store: DbSettingsStore) -> None:
+    await _db_store.save({"llm_provider": "anthropic", "llm_model": "sonnet"})
+    await _db_store.delete(["llm_model"])
+    loaded = await _db_store.load()
     assert "llm_provider" in loaded
     assert "llm_model" not in loaded
 
 
-def test_db_store_load_raises_on_missing_table(
-    _kek_provider: LocalKEKProvider, _pg_engine: Engine
+async def test_db_store_load_raises_on_missing_table(
+    _kek_provider: LocalKEKProvider, _pg_async_engine_session: AsyncEngine
 ) -> None:
     """Backend-failure path raises ``ConfigStoreError``, not silently returns {}."""
     from sqlalchemy import text
-    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.ext.asyncio import async_sessionmaker
 
     from backend.app.database import Base
 
-    # Drop the table outside the autouse rollback so the store sees the
+    # Drop the table outside the autouse TRUNCATE so the store sees the
     # absence; recreate at the end so other tests aren't poisoned.
-    with _pg_engine.begin() as conn:
-        conn.execute(text("DROP TABLE IF EXISTS app_settings CASCADE"))
+    async with _pg_async_engine_session.begin() as conn:
+        await conn.execute(text("DROP TABLE IF EXISTS app_settings CASCADE"))
     try:
         store = DbSettingsStore(
-            sessionmaker(bind=_pg_engine, autocommit=False, autoflush=False),
             _kek_provider,
+            async_session_factory=async_sessionmaker(
+                bind=_pg_async_engine_session, autoflush=False, expire_on_commit=False
+            ),
         )
         with pytest.raises(ConfigStoreError):
-            store.load()
+            await store.load()
     finally:
-        Base.metadata.tables["app_settings"].create(_pg_engine, checkfirst=True)
+        async with _pg_async_engine_session.begin() as conn:
+            await conn.run_sync(
+                lambda sync_conn: Base.metadata.tables["app_settings"].create(
+                    sync_conn, checkfirst=True
+                )
+            )
 
 
-def test_db_store_save_records_actor(_db_store: DbSettingsStore) -> None:
+async def test_db_store_save_records_actor(_db_store: DbSettingsStore) -> None:
     """``actor_user_id`` is recorded against the row for audit clarity."""
     from sqlalchemy import text
 
-    import backend.app.database as _db_module
+    from backend.app.database import db_session_async
     from backend.app.models import User
 
-    with _db_module.SessionLocal() as db:
+    async with db_session_async() as db:
         user = User(user_id="actor-user-store", channel_identifier="actor-tel")
         db.add(user)
-        db.commit()
+        await db.commit()
+        await db.refresh(user)
         actor_id = user.id
 
-    _db_store.save({"llm_provider": "anthropic"}, actor_user_id=actor_id)
+    await _db_store.save({"llm_provider": "anthropic"}, actor_user_id=actor_id)
 
-    with _db_module.SessionLocal() as db:
-        row = db.execute(
-            text("SELECT updated_by_user_id FROM app_settings WHERE key='llm_provider'")
+    async with db_session_async() as db:
+        row = (
+            await db.execute(
+                text("SELECT updated_by_user_id FROM app_settings WHERE key='llm_provider'")
+            )
         ).one()
     assert row[0] == actor_id

--- a/tests/test_db_settings_store_async.py
+++ b/tests/test_db_settings_store_async.py
@@ -39,22 +39,14 @@ async def _db_store(
     _kek_provider: LocalKEKProvider,
     async_db: async_sessionmaker,
 ) -> AsyncGenerator[DbSettingsStore]:
-    """Construct a store wired to the per-test sync and async factories.
+    """Construct a store wired to the per-test async session factory.
 
-    The autouse ``_isolate_stores`` fixture rebinds ``SessionLocal`` to
-    a per-test connection in a rolled-back transaction. The ``async_db``
-    fixture rebinds ``_async_session_factory`` for the async path.
-    Passing the rebound async factory explicitly (rather than relying
-    on the deferred ``AsyncSessionLocal`` lookup) makes the test wiring
-    obvious at the call site.
+    The ``async_db`` fixture rebinds ``_async_session_factory`` for the
+    async path. Passing the rebound factory explicitly (rather than
+    relying on the deferred ``AsyncSessionLocal`` lookup) makes the
+    test wiring obvious at the call site.
     """
-    import backend.app.database as _db_module
-
-    yield DbSettingsStore(
-        _db_module.SessionLocal,
-        _kek_provider,
-        async_session_factory=async_db,
-    )
+    yield DbSettingsStore(_kek_provider, async_session_factory=async_db)
 
 
 # ---------------------------------------------------------------------------
@@ -260,9 +252,6 @@ async def test_async_load_raises_on_missing_table(
     )
     try:
         store = DbSettingsStore(
-            session_factory=lambda: (_ for _ in ()).throw(  # never used in this test
-                AssertionError("sync path should not be touched here")
-            ),
             kek_provider=_kek_provider,
             async_session_factory=bad_factory,
         )

--- a/tests/test_idempotency_pruning.py
+++ b/tests/test_idempotency_pruning.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
 
 from backend.app.agent.stores import IdempotencyStore
-from backend.app.database import SessionLocal
+from backend.app.database import db_session_async
 from backend.app.models import IdempotencyKey
 
 # ---------------------------------------------------------------------------
@@ -13,22 +15,17 @@ from backend.app.models import IdempotencyKey
 # ---------------------------------------------------------------------------
 
 
-def _row_count() -> int:
+async def _row_count() -> int:
     """Return the total number of IdempotencyKey rows in the database."""
-    db = SessionLocal()
-    try:
-        return db.query(IdempotencyKey).count()
-    finally:
-        db.close()
+    async with db_session_async() as db:
+        return len((await db.execute(select(IdempotencyKey))).scalars().all())
 
 
-def _surviving_ids() -> set[str]:
+async def _surviving_ids() -> set[str]:
     """Return the set of external_id values still present in the table."""
-    db = SessionLocal()
-    try:
-        return {row.external_id for row in db.query(IdempotencyKey).all()}
-    finally:
-        db.close()
+    async with db_session_async() as db:
+        rows = (await db.execute(select(IdempotencyKey))).scalars().all()
+        return {row.external_id for row in rows}
 
 
 # ---------------------------------------------------------------------------
@@ -36,164 +33,167 @@ def _surviving_ids() -> set[str]:
 # ---------------------------------------------------------------------------
 
 
-def test_prune_removes_oldest_keeps_newest() -> None:
+async def test_prune_removes_oldest_keeps_newest() -> None:
     """_prune() deletes the oldest rows and keeps the newest up to the cap."""
     store = IdempotencyStore()
     small_max = 10
 
     with patch("backend.app.agent.stores._SEEN_MAX", small_max):
         for i in range(small_max + 5):
-            assert store.try_mark_seen(f"ext-{i}") is True
+            assert await store.try_mark_seen(f"ext-{i}") is True
 
     # The oldest 5 should have been pruned, newest 10 should survive.
     for i in range(5):
-        assert not store.has_seen(f"ext-{i}"), f"ext-{i} should have been pruned"
+        assert not await store.has_seen(f"ext-{i}"), f"ext-{i} should have been pruned"
     for i in range(5, small_max + 5):
-        assert store.has_seen(f"ext-{i}"), f"ext-{i} should still exist"
+        assert await store.has_seen(f"ext-{i}"), f"ext-{i} should still exist"
 
 
-def test_prune_deterministic_on_every_insert() -> None:
+async def test_prune_deterministic_on_every_insert() -> None:
     """Pruning fires on every insert, enforcing a hard cap."""
     store = IdempotencyStore()
     small_max = 20
 
     with patch("backend.app.agent.stores._SEEN_MAX", small_max):
         for i in range(small_max + 50):
-            store.try_mark_seen(f"det-{i}")
+            await store.try_mark_seen(f"det-{i}")
 
     # Table must never exceed small_max after pruning runs.
-    assert _row_count() == small_max
+    assert await _row_count() == small_max
 
     # The surviving rows must be the most recent ones.
-    surviving = _surviving_ids()
+    surviving = await _surviving_ids()
     for i in range(small_max + 50 - small_max, small_max + 50):
         assert f"det-{i}" in surviving, f"det-{i} should have survived"
 
 
-def test_prune_noop_at_exact_max() -> None:
+async def test_prune_noop_at_exact_max() -> None:
     """_prune() is a no-op when row count equals exactly _SEEN_MAX."""
     store = IdempotencyStore()
     small_max = 10
 
     with patch("backend.app.agent.stores._SEEN_MAX", small_max):
         for i in range(small_max):
-            store.try_mark_seen(f"exact-{i}")
-        store._prune()
+            await store.try_mark_seen(f"exact-{i}")
+        await store._prune()
 
-    assert _row_count() == small_max
+    assert await _row_count() == small_max
     for i in range(small_max):
-        assert store.has_seen(f"exact-{i}")
+        assert await store.has_seen(f"exact-{i}")
 
 
-def test_prune_noop_when_below_max() -> None:
+async def test_prune_noop_when_below_max() -> None:
     """_prune() is a no-op when row count is below _SEEN_MAX."""
     store = IdempotencyStore()
     for i in range(5):
-        store.try_mark_seen(f"below-{i}")
+        await store.try_mark_seen(f"below-{i}")
 
-    store._prune()
+    await store._prune()
 
-    assert _row_count() == 5
+    assert await _row_count() == 5
     for i in range(5):
-        assert store.has_seen(f"below-{i}")
+        assert await store.has_seen(f"below-{i}")
 
 
-def test_prune_on_empty_table() -> None:
+async def test_prune_on_empty_table() -> None:
     """_prune() on an empty table does not raise."""
     store = IdempotencyStore()
-    store._prune()
-    assert _row_count() == 0
+    await store._prune()
+    assert await _row_count() == 0
 
 
-def test_prune_with_seen_max_one() -> None:
+async def test_prune_with_seen_max_one() -> None:
     """_SEEN_MAX = 1 keeps only the latest row."""
     store = IdempotencyStore()
 
     with patch("backend.app.agent.stores._SEEN_MAX", 1):
-        store.try_mark_seen("first")
-        store.try_mark_seen("second")
-        store.try_mark_seen("third")
+        await store.try_mark_seen("first")
+        await store.try_mark_seen("second")
+        await store.try_mark_seen("third")
 
-    assert _row_count() == 1
-    assert store.has_seen("third")
-    assert not store.has_seen("first")
-    assert not store.has_seen("second")
+    assert await _row_count() == 1
+    assert await store.has_seen("third")
+    assert not await store.has_seen("first")
+    assert not await store.has_seen("second")
 
 
-def test_duplicate_returns_false() -> None:
+async def test_duplicate_returns_false() -> None:
     """Duplicate external_id returns False."""
     store = IdempotencyStore()
-    assert store.try_mark_seen("dup-1") is True
-    assert store.try_mark_seen("dup-1") is False
+    assert await store.try_mark_seen("dup-1") is True
+    assert await store.try_mark_seen("dup-1") is False
 
 
-def test_prune_exception_does_not_block_return() -> None:
+async def test_prune_exception_does_not_block_return() -> None:
     """If _prune() raises, try_mark_seen() still returns True and the key is persisted."""
     store = IdempotencyStore()
 
-    with patch.object(store, "_prune", side_effect=RuntimeError("db exploded")):
-        result = store.try_mark_seen("safe-1")
+    with patch.object(store, "_prune", AsyncMock(side_effect=RuntimeError("db exploded"))):
+        result = await store.try_mark_seen("safe-1")
 
     assert result is True
-    assert store.has_seen("safe-1")
+    assert await store.has_seen("safe-1")
 
 
-def test_repeated_prune_does_not_over_delete() -> None:
+async def test_repeated_prune_does_not_over_delete() -> None:
     """Multiple _prune() calls never reduce the table below _SEEN_MAX."""
     store = IdempotencyStore()
     small_max = 5
 
     with patch("backend.app.agent.stores._SEEN_MAX", small_max):
         # Insert without pruning to set up the table.
-        with patch.object(store, "_prune"):
+        with patch.object(store, "_prune", AsyncMock()):
             for i in range(small_max + 3):
-                store.try_mark_seen(f"conc-{i}")
+                await store.try_mark_seen(f"conc-{i}")
 
-        assert _row_count() == small_max + 3
+        assert await _row_count() == small_max + 3
 
         # Multiple sequential prunes must converge: first prune deletes
         # overflow, subsequent prunes are no-ops.
-        store._prune()
-        store._prune()
-        store._prune()
+        await store._prune()
+        await store._prune()
+        await store._prune()
 
     # Must not have over-deleted below small_max.
-    assert _row_count() == small_max
+    assert await _row_count() == small_max
 
     # The newest rows must survive.
-    surviving = _surviving_ids()
+    surviving = await _surviving_ids()
     for i in range(3, small_max + 3):
         assert f"conc-{i}" in surviving
 
 
-def test_prune_is_self_correcting_after_external_delete() -> None:
+async def test_prune_is_self_correcting_after_external_delete() -> None:
     """If rows disappear between COUNT and DELETE, prune still converges."""
     store = IdempotencyStore()
     small_max = 5
 
     with patch("backend.app.agent.stores._SEEN_MAX", small_max):
         # Insert enough rows to trigger overflow.
-        with patch.object(store, "_prune"):
+        with patch.object(store, "_prune", AsyncMock()):
             for i in range(small_max + 6):
-                store.try_mark_seen(f"ext-del-{i}")
+                await store.try_mark_seen(f"ext-del-{i}")
 
-        assert _row_count() == small_max + 6
+        assert await _row_count() == small_max + 6
 
         # Simulate another worker pruning some rows before our prune.
-        from backend.app.database import SessionLocal as SL
-
-        db = SL()
-        try:
-            oldest = db.query(IdempotencyKey).order_by(IdempotencyKey.id.asc()).limit(3).all()
+        async with db_session_async() as db:
+            oldest = (
+                (
+                    await db.execute(
+                        select(IdempotencyKey).order_by(IdempotencyKey.id.asc()).limit(3)
+                    )
+                )
+                .scalars()
+                .all()
+            )
             for row in oldest:
-                db.delete(row)
-            db.commit()
-        finally:
-            db.close()
+                await db.delete(row)
+            await db.commit()
 
-        assert _row_count() == small_max + 3
+        assert await _row_count() == small_max + 3
 
         # Our prune should still leave exactly small_max, not fewer.
-        store._prune()
+        await store._prune()
 
-    assert _row_count() == small_max
+    assert await _row_count() == small_max

--- a/tests/test_idempotency_pruning_async.py
+++ b/tests/test_idempotency_pruning_async.py
@@ -87,7 +87,7 @@ async def test_async_prune_noop_at_exact_max(
     with patch("backend.app.agent.stores._SEEN_MAX", small_max):
         for i in range(small_max):
             await store.try_mark_seen_async(f"exact-{i}")
-        await store._prune_async()
+        await store._prune()
 
     assert await _row_count(async_db) == small_max
     for i in range(small_max):
@@ -102,7 +102,7 @@ async def test_async_prune_noop_when_below_max(
     for i in range(5):
         await store.try_mark_seen_async(f"below-{i}")
 
-    await store._prune_async()
+    await store._prune()
 
     assert await _row_count(async_db) == 5
     for i in range(5):
@@ -114,7 +114,7 @@ async def test_async_prune_on_empty_table(
 ) -> None:
     """``_prune_async`` on an empty table does not raise."""
     store = IdempotencyStore()
-    await store._prune_async()
+    await store._prune()
     assert await _row_count(async_db) == 0
 
 
@@ -152,7 +152,7 @@ async def test_async_prune_exception_does_not_block_return(
 
     with patch.object(
         store,
-        "_prune_async",
+        "_prune",
         new=AsyncMock(side_effect=RuntimeError("db exploded")),
     ):
         result = await store.try_mark_seen_async("safe-1")

--- a/tests/test_linq_channel.py
+++ b/tests/test_linq_channel.py
@@ -10,7 +10,6 @@ import time
 from unittest.mock import AsyncMock, patch
 
 import httpx
-from fastapi.testclient import TestClient
 
 from backend.app.channels.linq import LinqChannel
 from tests.mocks.linq import (
@@ -27,8 +26,8 @@ _PATCH_BUS_PUBLISH = "backend.app.bus.message_bus.publish_inbound"
 # ---------------------------------------------------------------------------
 
 
-def _post_webhook(
-    client: TestClient,
+async def _post_webhook(
+    client: httpx.AsyncClient,
     payload: dict,
     signing_secret: str = "",
     timestamp: int | None = None,
@@ -39,7 +38,7 @@ def _post_webhook(
         headers = make_linq_webhook_headers(body, signing_secret, timestamp)
     else:
         headers = {"Content-Type": "application/json"}
-    return client.post("/api/webhooks/linq", content=body, headers=headers)
+    return await client.post("/api/webhooks/linq", content=body, headers=headers)
 
 
 # ---------------------------------------------------------------------------
@@ -47,20 +46,20 @@ def _post_webhook(
 # ---------------------------------------------------------------------------
 
 
-def test_inbound_webhook_returns_200(linq_client: TestClient) -> None:
+async def test_inbound_webhook_returns_200(linq_client: httpx.AsyncClient) -> None:
     """Valid webhook payload should return 200 with ok:true."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock):
         payload = make_linq_webhook_payload(text="Hello")
-        resp = _post_webhook(linq_client, payload)
+        resp = await _post_webhook(linq_client, payload)
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
 
 
-def test_inbound_webhook_publishes_text(linq_client: TestClient) -> None:
+async def test_inbound_webhook_publishes_text(linq_client: httpx.AsyncClient) -> None:
     """Inbound text message should be published to the bus."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         payload = make_linq_webhook_payload(sender="+15559876543", text="Need a quote")
-        _post_webhook(linq_client, payload)
+        await _post_webhook(linq_client, payload)
 
     mock_pub.assert_called_once()
     inbound = mock_pub.call_args[0][0]
@@ -69,14 +68,14 @@ def test_inbound_webhook_publishes_text(linq_client: TestClient) -> None:
     assert inbound.text == "Need a quote"
 
 
-def test_inbound_webhook_publishes_media(linq_client: TestClient) -> None:
+async def test_inbound_webhook_publishes_media(linq_client: httpx.AsyncClient) -> None:
     """Media messages should include media_refs in the published InboundMessage."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         payload = make_linq_webhook_payload(
             text="Check this out",
             media_url="https://cdn.linqapp.com/media/photo.jpg",
         )
-        _post_webhook(linq_client, payload)
+        await _post_webhook(linq_client, payload)
 
     mock_pub.assert_called_once()
     inbound = mock_pub.call_args[0][0]
@@ -86,7 +85,7 @@ def test_inbound_webhook_publishes_media(linq_client: TestClient) -> None:
     assert inbound.media_refs[0][1] == "image/jpeg"
 
 
-def test_non_utf8_body_does_not_crash(linq_client: TestClient) -> None:
+async def test_non_utf8_body_does_not_crash(linq_client: httpx.AsyncClient) -> None:
     """Non-UTF-8 webhook body should return 200 without crashing (not raise UnicodeDecodeError)."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
@@ -101,14 +100,14 @@ def test_non_utf8_body_does_not_crash(linq_client: TestClient) -> None:
             "X-Webhook-Timestamp": str(int(time.time())),
             "Content-Type": "application/json",
         }
-        resp = linq_client.post("/api/webhooks/linq", content=raw_body, headers=headers)
+        resp = await linq_client.post("/api/webhooks/linq", content=raw_body, headers=headers)
 
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
     mock_pub.assert_not_called()
 
 
-def test_invalid_hmac_does_not_publish(linq_client: TestClient) -> None:
+async def test_invalid_hmac_does_not_publish(linq_client: httpx.AsyncClient) -> None:
     """Invalid HMAC signature should return 200 but not publish to bus."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
@@ -124,13 +123,13 @@ def test_invalid_hmac_does_not_publish(linq_client: TestClient) -> None:
             "X-Webhook-Timestamp": str(int(time.time())),
             "Content-Type": "application/json",
         }
-        resp = linq_client.post("/api/webhooks/linq", content=body, headers=headers)
+        resp = await linq_client.post("/api/webhooks/linq", content=body, headers=headers)
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
 
 
-def test_stale_timestamp_does_not_publish(linq_client: TestClient) -> None:
+async def test_stale_timestamp_does_not_publish(linq_client: httpx.AsyncClient) -> None:
     """Stale timestamp (replay attack) should return 200 but not publish."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
@@ -141,7 +140,7 @@ def test_stale_timestamp_does_not_publish(linq_client: TestClient) -> None:
     ):
         payload = make_linq_webhook_payload(text="Hi")
         stale_ts = int(time.time()) - 600  # 10 minutes ago
-        resp = _post_webhook(
+        resp = await _post_webhook(
             linq_client, payload, signing_secret=LINQ_TEST_SIGNING_SECRET, timestamp=stale_ts
         )
 
@@ -149,7 +148,7 @@ def test_stale_timestamp_does_not_publish(linq_client: TestClient) -> None:
     mock_pub.assert_not_called()
 
 
-def test_valid_hmac_publishes(linq_client: TestClient) -> None:
+async def test_valid_hmac_publishes(linq_client: httpx.AsyncClient) -> None:
     """Valid HMAC signature should publish to bus."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
@@ -159,36 +158,36 @@ def test_valid_hmac_publishes(linq_client: TestClient) -> None:
         ),
     ):
         payload = make_linq_webhook_payload(text="Hi")
-        resp = _post_webhook(linq_client, payload, signing_secret=LINQ_TEST_SIGNING_SECRET)
+        resp = await _post_webhook(linq_client, payload, signing_secret=LINQ_TEST_SIGNING_SECRET)
 
     assert resp.status_code == 200
     mock_pub.assert_called_once()
 
 
-def test_duplicate_message_skipped(linq_client: TestClient) -> None:
+async def test_duplicate_message_skipped(linq_client: httpx.AsyncClient) -> None:
     """Duplicate webhook calls should not publish to bus twice."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         payload = make_linq_webhook_payload(text="First", message_id="dup-msg-001")
-        _post_webhook(linq_client, payload)
-        _post_webhook(linq_client, payload)
+        await _post_webhook(linq_client, payload)
+        await _post_webhook(linq_client, payload)
 
     mock_pub.assert_called_once()
 
 
-def test_non_message_received_event_ignored(linq_client: TestClient) -> None:
+async def test_non_message_received_event_ignored(linq_client: httpx.AsyncClient) -> None:
     """Non-message.received events should return 200 without publishing."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         for event in ("message.delivered", "message.read", "message.failed"):
             payload = make_linq_webhook_payload(text="Hi", event=event)
-            resp = _post_webhook(linq_client, payload)
+            resp = await _post_webhook(linq_client, payload)
             assert resp.status_code == 200
 
     mock_pub.assert_not_called()
 
 
-def test_invalid_json_returns_200(linq_client: TestClient) -> None:
+async def test_invalid_json_returns_200(linq_client: httpx.AsyncClient) -> None:
     """Invalid JSON body should return 200 without crashing."""
-    resp = linq_client.post(
+    resp = await linq_client.post(
         "/api/webhooks/linq",
         content=b"not valid json",
         headers={"Content-Type": "application/json"},
@@ -197,11 +196,11 @@ def test_invalid_json_returns_200(linq_client: TestClient) -> None:
     assert resp.json() == {"ok": True}
 
 
-def test_outbound_direction_ignored(linq_client: TestClient) -> None:
+async def test_outbound_direction_ignored(linq_client: httpx.AsyncClient) -> None:
     """Outbound messages should be ignored."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
         payload = make_linq_webhook_payload(text="Echo", direction="outbound")
-        resp = _post_webhook(linq_client, payload)
+        resp = await _post_webhook(linq_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
@@ -212,53 +211,53 @@ def test_outbound_direction_ignored(linq_client: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_allowlist_empty_denies_all(linq_client: TestClient) -> None:
+async def test_allowlist_empty_denies_all(linq_client: httpx.AsyncClient) -> None:
     """Empty allowlist should deny all phone numbers."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch("backend.app.channels.linq.settings.linq_allowed_numbers", ""),
     ):
         payload = make_linq_webhook_payload(sender="+15551234567", text="Hi")
-        resp = _post_webhook(linq_client, payload)
+        resp = await _post_webhook(linq_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
 
 
-def test_allowlist_wildcard_allows_all(linq_client: TestClient) -> None:
+async def test_allowlist_wildcard_allows_all(linq_client: httpx.AsyncClient) -> None:
     """Setting allowed_numbers to '*' should allow all phone numbers."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch("backend.app.channels.linq.settings.linq_allowed_numbers", "*"),
     ):
         payload = make_linq_webhook_payload(sender="+15559999999", text="Hi")
-        resp = _post_webhook(linq_client, payload)
+        resp = await _post_webhook(linq_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_called_once()
 
 
-def test_allowlist_matching_number_allows(linq_client: TestClient) -> None:
+async def test_allowlist_matching_number_allows(linq_client: httpx.AsyncClient) -> None:
     """Matching E.164 number should be allowed."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch("backend.app.channels.linq.settings.linq_allowed_numbers", "+15551234567"),
     ):
         payload = make_linq_webhook_payload(sender="+15551234567", text="Hi")
-        resp = _post_webhook(linq_client, payload)
+        resp = await _post_webhook(linq_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_called_once()
 
 
-def test_allowlist_non_matching_number_denies(linq_client: TestClient) -> None:
+async def test_allowlist_non_matching_number_denies(linq_client: httpx.AsyncClient) -> None:
     """Non-matching phone number should be denied."""
     with (
         patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
         patch("backend.app.channels.linq.settings.linq_allowed_numbers", "+15551234567"),
     ):
         payload = make_linq_webhook_payload(sender="+15559999999", text="Hi")
-        resp = _post_webhook(linq_client, payload)
+        resp = await _post_webhook(linq_client, payload)
 
     assert resp.status_code == 200
     mock_pub.assert_not_called()
@@ -288,23 +287,23 @@ def test_verify_signature_rejects_non_utf8_body() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_is_allowed_empty_denies() -> None:
+async def test_is_allowed_empty_denies() -> None:
     channel = LinqChannel()
     with patch("backend.app.channels.linq.settings.linq_allowed_numbers", ""):
-        assert channel.is_allowed("+15551234567", "") is False
+        assert await channel.is_allowed("+15551234567", "") is False
 
 
-def test_is_allowed_wildcard_allows() -> None:
+async def test_is_allowed_wildcard_allows() -> None:
     channel = LinqChannel()
     with patch("backend.app.channels.linq.settings.linq_allowed_numbers", "*"):
-        assert channel.is_allowed("+15551234567", "") is True
+        assert await channel.is_allowed("+15551234567", "") is True
 
 
-def test_is_allowed_matching_number() -> None:
+async def test_is_allowed_matching_number() -> None:
     channel = LinqChannel()
     with patch("backend.app.channels.linq.settings.linq_allowed_numbers", "+15551234567"):
-        assert channel.is_allowed("+15551234567", "") is True
-        assert channel.is_allowed("+15559999999", "") is False
+        assert await channel.is_allowed("+15551234567", "") is True
+        assert await channel.is_allowed("+15559999999", "") is False
 
 
 # ---------------------------------------------------------------------------
@@ -406,7 +405,7 @@ async def test_download_media_from_cdn() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_webhook_populates_chat_cache(linq_client: TestClient) -> None:
+async def test_webhook_populates_chat_cache(linq_client: httpx.AsyncClient) -> None:
     """Inbound webhook should populate the chat cache for outbound use."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock):
         payload = make_linq_webhook_payload(
@@ -414,7 +413,7 @@ def test_webhook_populates_chat_cache(linq_client: TestClient) -> None:
             text="Hello",
             chat_id="webhook-chat-uuid",
         )
-        _post_webhook(linq_client, payload)
+        await _post_webhook(linq_client, payload)
 
     # Get the LinqChannel instance from the app
     from backend.app.channels import get_channel

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -122,22 +122,21 @@ def test_is_onboarding_needed_respects_flag() -> None:
     assert is_onboarding_needed(user) is False
 
 
-def test_provision_user_creates_bootstrap_and_seeds_db() -> None:
+async def test_provision_user_creates_bootstrap_and_seeds_db() -> None:
     """provision_user should seed DB text columns and create BOOTSTRAP.md."""
     from backend.app.agent.user_db import provision_user
-    from backend.app.database import SessionLocal
+    from backend.app.database import db_session_async
 
-    db = SessionLocal()
-    try:
+    async with db_session_async() as db:
         user = User(id="provision-test", user_id="provision-user")
         db.add(user)
-        db.commit()
-        db.refresh(user)
+        await db.commit()
+        await db.refresh(user)
 
-        provision_user(user, db)
+        await provision_user(user, db)
 
         # DB columns should be seeded (except heartbeat, which waits for onboarding)
-        db.refresh(user)
+        await db.refresh(user)
         assert user.soul_text
         assert user.user_text
         assert not user.heartbeat_text
@@ -146,29 +145,24 @@ def test_provision_user_creates_bootstrap_and_seeds_db() -> None:
         user_dir = Path(settings.data_dir) / str(user.id)
         assert (user_dir / "BOOTSTRAP.md").exists()
         assert is_onboarding_needed(user) is True
-    finally:
-        db.close()
 
 
-def test_provision_skips_bootstrap_when_onboarding_complete() -> None:
+async def test_provision_skips_bootstrap_when_onboarding_complete() -> None:
     """provision_user should not create BOOTSTRAP.md for onboarded users."""
     from backend.app.agent.user_db import provision_user
-    from backend.app.database import SessionLocal
+    from backend.app.database import db_session_async
 
-    db = SessionLocal()
-    try:
+    async with db_session_async() as db:
         user = User(id="provision-complete", user_id="done-user", onboarding_complete=True)
         db.add(user)
-        db.commit()
-        db.refresh(user)
+        await db.commit()
+        await db.refresh(user)
 
-        provision_user(user, db)
+        await provision_user(user, db)
 
         user_dir = Path(settings.data_dir) / str(user.id)
         assert not (user_dir / "BOOTSTRAP.md").exists()
         assert is_onboarding_needed(user) is False
-    finally:
-        db.close()
 
 
 def test_is_onboarding_needed_bootstrap_deleted_selfheals() -> None:

--- a/tests/test_premium_channel_auth.py
+++ b/tests/test_premium_channel_auth.py
@@ -5,16 +5,17 @@ When an ``is_allowed`` override is registered (e.g. by the premium plugin),
 reject those that do not, bypassing the static allowlist entirely.
 """
 
-from collections.abc import Generator
+from collections.abc import AsyncGenerator
 from unittest.mock import patch
 
-import pytest
+import pytest_asyncio
+from sqlalchemy import select
 
 from backend.app.channels.base import set_is_allowed_override
 from backend.app.channels.linq import LinqChannel
 from backend.app.channels.telegram import TelegramChannel
 from backend.app.config import settings
-from backend.app.database import SessionLocal, db_session
+from backend.app.database import db_session_async
 from backend.app.models import ChannelRoute, User
 
 # ---------------------------------------------------------------------------
@@ -22,16 +23,15 @@ from backend.app.models import ChannelRoute, User
 # ---------------------------------------------------------------------------
 
 
-def _create_user_with_route(channel: str, identifier: str) -> str:
+async def _create_user_with_route(channel: str, identifier: str) -> str:
     """Create a User + ChannelRoute in the test DB. Returns user_id."""
     import uuid
 
-    db = SessionLocal()
-    try:
-        user_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+    async with db_session_async() as db:
         user = User(id=user_id, user_id=f"premium-{user_id[:8]}")
         db.add(user)
-        db.flush()
+        await db.flush()
         db.add(
             ChannelRoute(
                 user_id=user_id,
@@ -39,25 +39,23 @@ def _create_user_with_route(channel: str, identifier: str) -> str:
                 channel_identifier=identifier,
             )
         )
-        db.commit()
-        return user_id
-    finally:
-        db.close()
+        await db.commit()
+    return user_id
 
 
-def _route_based_override(channel_name: str, sender_id: str) -> bool:
+async def _route_based_override(channel_name: str, sender_id: str) -> bool:
     """Test override that checks ChannelRoute, matching premium behavior."""
-    with db_session() as db:
+    async with db_session_async() as db:
         route = (
-            db.query(ChannelRoute)
-            .filter_by(channel=channel_name, channel_identifier=sender_id)
-            .first()
-        )
+            await db.execute(
+                select(ChannelRoute).filter_by(channel=channel_name, channel_identifier=sender_id)
+            )
+        ).scalar_one_or_none()
         return route is not None
 
 
-@pytest.fixture()
-def _premium_override() -> Generator[None]:
+@pytest_asyncio.fixture()
+async def _premium_override() -> AsyncGenerator[None]:
     """Register the route-based override for the duration of the test."""
     set_is_allowed_override(_route_based_override)
     yield
@@ -69,28 +67,28 @@ def _premium_override() -> Generator[None]:
 # ---------------------------------------------------------------------------
 
 
-def test_check_premium_route_returns_none_without_override() -> None:
+async def test_check_premium_route_returns_none_without_override() -> None:
     """_check_premium_route returns None when no override is registered."""
     set_is_allowed_override(None)  # type: ignore[arg-type]
     channel = TelegramChannel(bot_token="fake")
-    assert channel._check_premium_route("12345") is None
+    assert await channel._check_premium_route("12345") is None
 
 
-def test_check_premium_route_returns_true_when_route_exists(
+async def test_check_premium_route_returns_true_when_route_exists(
     _premium_override: None,
 ) -> None:
     """_check_premium_route returns True when a matching ChannelRoute exists."""
-    _create_user_with_route("telegram", "12345")
+    await _create_user_with_route("telegram", "12345")
     channel = TelegramChannel(bot_token="fake")
-    assert channel._check_premium_route("12345") is True
+    assert await channel._check_premium_route("12345") is True
 
 
-def test_check_premium_route_returns_false_when_no_route(
+async def test_check_premium_route_returns_false_when_no_route(
     _premium_override: None,
 ) -> None:
     """_check_premium_route returns False when no matching ChannelRoute exists."""
     channel = TelegramChannel(bot_token="fake")
-    assert channel._check_premium_route("99999") is False
+    assert await channel._check_premium_route("99999") is False
 
 
 # ---------------------------------------------------------------------------
@@ -98,34 +96,34 @@ def test_check_premium_route_returns_false_when_no_route(
 # ---------------------------------------------------------------------------
 
 
-def test_telegram_premium_allows_routed_sender(_premium_override: None) -> None:
+async def test_telegram_premium_allows_routed_sender(_premium_override: None) -> None:
     """Telegram is_allowed returns True for a sender with a ChannelRoute."""
-    _create_user_with_route("telegram", "111222333")
+    await _create_user_with_route("telegram", "111222333")
     channel = TelegramChannel(bot_token="fake")
-    assert channel.is_allowed("111222333", "testuser") is True
+    assert await channel.is_allowed("111222333", "testuser") is True
 
 
-def test_telegram_premium_rejects_unrouted_sender(_premium_override: None) -> None:
+async def test_telegram_premium_rejects_unrouted_sender(_premium_override: None) -> None:
     """Telegram is_allowed returns False for a sender without a ChannelRoute."""
     channel = TelegramChannel(bot_token="fake")
-    assert channel.is_allowed("999888777", "stranger") is False
+    assert await channel.is_allowed("999888777", "stranger") is False
 
 
-def test_telegram_premium_ignores_static_allowlist(_premium_override: None) -> None:
+async def test_telegram_premium_ignores_static_allowlist(_premium_override: None) -> None:
     """With an override registered, the static allowlist setting is not consulted."""
     channel = TelegramChannel(bot_token="fake")
     with patch.object(settings, "telegram_allowed_chat_id", "*"):
         # Even though static allowlist is "*", sender without route is rejected
-        assert channel.is_allowed("444555666", "") is False
+        assert await channel.is_allowed("444555666", "") is False
 
 
-def test_telegram_oss_falls_through_to_static_allowlist() -> None:
+async def test_telegram_oss_falls_through_to_static_allowlist() -> None:
     """Without an override (OSS mode), the static allowlist is used as before."""
     set_is_allowed_override(None)  # type: ignore[arg-type]
     channel = TelegramChannel(bot_token="fake")
     with patch.object(settings, "telegram_allowed_chat_id", "12345"):
-        assert channel.is_allowed("12345", "") is True
-        assert channel.is_allowed("99999", "") is False
+        assert await channel.is_allowed("12345", "") is True
+        assert await channel.is_allowed("99999", "") is False
 
 
 # ---------------------------------------------------------------------------
@@ -133,34 +131,34 @@ def test_telegram_oss_falls_through_to_static_allowlist() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_linq_premium_allows_routed_sender(_premium_override: None) -> None:
+async def test_linq_premium_allows_routed_sender(_premium_override: None) -> None:
     """Linq is_allowed returns True for a sender with a ChannelRoute."""
-    _create_user_with_route("linq", "+15551234567")
+    await _create_user_with_route("linq", "+15551234567")
     channel = LinqChannel()
-    assert channel.is_allowed("+15551234567", "") is True
+    assert await channel.is_allowed("+15551234567", "") is True
 
 
-def test_linq_premium_rejects_unrouted_sender(_premium_override: None) -> None:
+async def test_linq_premium_rejects_unrouted_sender(_premium_override: None) -> None:
     """Linq is_allowed returns False for a sender without a ChannelRoute."""
     channel = LinqChannel()
-    assert channel.is_allowed("+15559999999", "") is False
+    assert await channel.is_allowed("+15559999999", "") is False
 
 
-def test_linq_premium_ignores_static_allowlist(_premium_override: None) -> None:
+async def test_linq_premium_ignores_static_allowlist(_premium_override: None) -> None:
     """With an override registered, the static allowlist setting is not consulted."""
     channel = LinqChannel()
     with patch.object(settings, "linq_allowed_numbers", "*"):
         # Even though static allowlist is "*", sender without route is rejected
-        assert channel.is_allowed("+15550000000", "") is False
+        assert await channel.is_allowed("+15550000000", "") is False
 
 
-def test_linq_oss_falls_through_to_static_allowlist() -> None:
+async def test_linq_oss_falls_through_to_static_allowlist() -> None:
     """Without an override (OSS mode), the static allowlist is used as before."""
     set_is_allowed_override(None)  # type: ignore[arg-type]
     channel = LinqChannel()
     with patch.object(settings, "linq_allowed_numbers", "+15551234567"):
-        assert channel.is_allowed("+15551234567", "") is True
-        assert channel.is_allowed("+15559999999", "") is False
+        assert await channel.is_allowed("+15551234567", "") is True
+        assert await channel.is_allowed("+15559999999", "") is False
 
 
 # ---------------------------------------------------------------------------
@@ -168,8 +166,8 @@ def test_linq_oss_falls_through_to_static_allowlist() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_premium_route_scoped_to_channel(_premium_override: None) -> None:
+async def test_premium_route_scoped_to_channel(_premium_override: None) -> None:
     """A ChannelRoute for 'telegram' should not authorize the same ID on 'linq'."""
-    _create_user_with_route("telegram", "+15551234567")
+    await _create_user_with_route("telegram", "+15551234567")
     linq = LinqChannel()
-    assert linq.is_allowed("+15551234567", "") is False
+    assert await linq.is_allowed("+15551234567", "") is False

--- a/tests/test_unknown_sender.py
+++ b/tests/test_unknown_sender.py
@@ -34,7 +34,7 @@ class _RecordingChannel(BaseChannel):
     def get_router(self) -> APIRouter:
         return APIRouter()
 
-    def is_allowed(self, sender_id: str, username: str) -> bool:
+    async def is_allowed(self, sender_id: str, username: str) -> bool:
         return False
 
     async def send_text(self, to: str, body: str) -> str:


### PR DESCRIPTION
## Description

Closes the last sync DB call sites that production code reaches from async context. Every callable on the inbound and admin hot paths now runs against the async engine.

The sync engine itself remains in ``database.py`` because ~30 OSS test files still set up state via ``SessionLocal``; deleting the engine is tracked as #1234.

### Production code

- ``backend/app/channels``: ``IsAllowedOverride`` typed as ``Callable[..., Awaitable[bool]]``; ``BaseChannel.is_allowed`` / ``_check_premium_route`` / ``_check_static_allowlist`` async; each channel impl (telegram, bluebubbles, linq, webchat) and ``handle_webhook_inbound`` updated.
- ``backend/app/agent/user_db::provision_user`` async (factored ``_seed_user_text`` helper). Callers in ``auth/dependencies.py`` and ``agent/ingestion.py`` await it.
- ``backend/app/auth/scoping::get_scoped_user`` takes ``AsyncSession`` via ``Depends(get_async_db)``.
- ``backend/app/agent/ingestion``: 5 sync DB sites converted (``_check_channel_route_enabled``, ``_stamp_route_last_inbound``, the body of ``_get_or_create_user``, fresh-User reload inside ``_dispatch_to_pipeline``, /report persistence in ``_handle_report_command``).
- ``backend/app/agent/context::trigger_compaction_for_dropped`` async; the two ``agent/core::process_message`` call sites await it.
- ``backend/app/agent/compaction::_persist_compaction_event`` async.
- ``backend/app/agent/stores::IdempotencyStore`` collapsed to async-only. ``has_seen``, ``try_mark_seen``, ``_prune``, ``mark_seen`` are now ``async def``; ``*_async`` aliases kept as thin wrappers. This closes the documented test-infra blocker.
- ``backend/app/channels/base`` webhook dispatcher awaits ``idempotency.try_mark_seen``.
- ``backend/app/config_store``: ``SettingsStore`` Protocol async-only; ``DbSettingsStore`` constructor drops the sync ``session_factory`` argument; ``JsonFileSettingsStore`` methods async; ``import_legacy_config_json`` async.
- ``backend/app/main``: ``_verify_database`` async over ``get_async_engine``; lifespan awaits ``store.load`` and the legacy import.
- ``backend/app/routers/user_profile``: 3 ``get_settings_store().save(...)`` call sites awaited.

### Tests

Routed to the async DB stack:
- ``tests/test_premium_channel_auth``, ``tests/test_idempotency_pruning``, ``tests/test_idempotency_pruning_async``, ``tests/test_config_store``, ``tests/test_db_settings_store_async``, ``tests/test_channel_config``, ``tests/test_bluebubbles_backfill``, ``tests/test_channels``, ``tests/test_unknown_sender``, ``tests/test_onboarding``, ``tests/test_compaction``, ``tests/test_auth``.
- ``tests/conftest``: ``linq_client`` and ``bluebubbles_client`` fixtures yield ``httpx.AsyncClient`` over ``ASGITransport``.
- ``tests/test_linq_channel`` / ``tests/test_bluebubbles_channel``: webhook tests are ``async def`` against ``httpx.AsyncClient``.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (``uv run pytest``): **2371 passed, 1 skipped, 13 deselected, 3 xfailed, 5 warnings in 230s**
- [x] Lint passes (``ruff check backend/ tests/`` and ``ruff format --check backend/ tests/``)
- [x] Type checking passes (``ty check --python .venv backend/``)
- [x] New tests added for new functionality (existing tests routed through async DB)
- [x] Bug fixes include regression tests (n/a, refactor)

## AI Usage
- [x] AI-assisted (drafted with Claude)
- [ ] No AI used

## Premium follow-up

Premium will pair with this in a separate PR: ``check_premium_route`` becomes async, and the ``asyncio.to_thread`` bridges in ``oauth_flow._provision_user_sync`` and ``services/llm_resolver.py`` are removed. ``OSS_REF`` bumps past this commit.

## Drop sync engine entirely

Tracked as #1234. The test-infra rewrite required to actually delete the sync engine surface from ``database.py`` and ``pyproject.toml`` needs ~30 test files converted in lockstep with the conftest fixture; that earns its own focused review pass.