### PR TITLE
fix: skip blank batched inbound placeholders in history

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -341,6 +341,14 @@ async def load_conversation_history(
         # Prefer processed context (includes media descriptions) over raw body
         content = msg.processed_context if msg.processed_context else msg.body
         if msg.direction == MessageDirection.INBOUND:
+            # Rapid-fire attachment-only messages can be batched so the
+            # placeholder row is persisted with no body and no processed
+            # context. Keeping that blank row in history teaches the LLM
+            # that the previous user turn was "silent", which can produce
+            # stray clarification text on the next real message.
+            if not (content or "").strip():
+                last_was_approval_prompt = False
+                continue
             # Drop the user's approval reply ("Yes", "Always", ...) when it
             # immediately follows a (now-filtered) approval prompt. Without
             # this, the orphan reply floats in history with no antecedent

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -105,6 +105,53 @@ async def test_load_history_prefers_processed_context(
 
 
 @pytest.mark.asyncio()
+async def test_load_history_skips_blank_inbound_placeholder_rows(
+    conversation: SessionState,
+) -> None:
+    """Blank inbounds from batched attachment-only turns should not reach the LLM."""
+    conversation.messages.append(StoredMessage(direction="inbound", body="", seq=1))
+    conversation.messages.append(
+        StoredMessage(
+            direction="inbound",
+            body="Save this receipt for later",
+            processed_context=(
+                "[Text message]: 'Save this receipt for later'\n\n"
+                "[Photo 1, handle=media_test123]: "
+                "(staged, call analyze_photo(handle='media_test123') if you need a description)"
+            ),
+            seq=2,
+        )
+    )
+
+    history = await load_conversation_history(conversation)
+    assert history == []
+
+
+@pytest.mark.asyncio()
+async def test_load_history_keeps_processed_attachment_only_turns(
+    conversation: SessionState,
+) -> None:
+    """A processed photo-only turn still carries useful context and must survive."""
+    conversation.messages.append(
+        StoredMessage(
+            direction="inbound",
+            body="",
+            processed_context=(
+                "[Photo 1, handle=media_test123]: "
+                "(staged, call analyze_photo(handle='media_test123') if you need a description)"
+            ),
+            seq=1,
+        )
+    )
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=2))
+
+    history = await load_conversation_history(conversation)
+    assert len(history) == 1
+    assert isinstance(history[0], UserMessage)
+    assert "Photo 1" in (history[0].content or "")
+
+
+@pytest.mark.asyncio()
 async def test_load_history_empty_conversation(
     conversation: SessionState,
 ) -> None:


### PR DESCRIPTION
## Description
Fixes a conversation-history edge case where rapid-fire attachment-only inbound rows with no text could remain in reconstructed LLM history after batching. When a user sent a photo and then quickly followed with actionable text, the model could produce a mixed reply that both asked what to do with the photo and completed the requested action.

This change skips truly blank inbound placeholder rows while preserving attachment-only turns that contain processed context, and adds regression coverage for both cases.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (used to investigate the production symptom, identify the OSS history reconstruction bug, draft the patch, and run verification)
- [ ] No AI used