### PR TITLE
test: stabilize approval persistence checks

### DIFF
--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -430,28 +430,37 @@ class TestApprovalGate:
         from backend.app.models import PendingApprovalRow
 
         gate = ApprovalGate()
-        mock_publish = AsyncMock()
+        prompt_sent = asyncio.Event()
+        release_publish = asyncio.Event()
 
-        async def _observe_and_resolve() -> None:
-            await asyncio.sleep(0.01)
-            async with db_session_async() as db:
-                row = await db.get(PendingApprovalRow, test_user.id)
-                assert row is not None, "row should exist while approval is in flight"
-                assert row.tool_name == "write_file"
-                assert row.channel == "telegram"
-            await gate.resolve(test_user.id, ApprovalDecision.APPROVED)
+        async def _publish(_msg: OutboundMessage) -> None:
+            # request_approval() only calls publish_outbound after the
+            # pending_approvals row has been persisted.
+            prompt_sent.set()
+            await release_publish.wait()
 
-        task = asyncio.create_task(_observe_and_resolve())
-        decision = await gate.request_approval(
-            user_id=test_user.id,
-            tool_name="write_file",
-            description="write a file",
-            publish_outbound=mock_publish,
-            channel="telegram",
-            chat_id="chat_1",
-            timeout=5.0,
+        request_task = asyncio.create_task(
+            gate.request_approval(
+                user_id=test_user.id,
+                tool_name="write_file",
+                description="write a file",
+                publish_outbound=_publish,
+                channel="telegram",
+                chat_id="chat_1",
+                timeout=5.0,
+            )
         )
-        await task
+        await asyncio.wait_for(prompt_sent.wait(), timeout=1.0)
+
+        async with db_session_async() as db:
+            row = await db.get(PendingApprovalRow, test_user.id)
+            assert row is not None, "row should exist while approval is in flight"
+            assert row.tool_name == "write_file"
+            assert row.channel == "telegram"
+
+        release_publish.set()
+        await gate.resolve(test_user.id, ApprovalDecision.APPROVED)
+        decision = await asyncio.wait_for(request_task, timeout=1.0)
         assert decision == ApprovalDecision.APPROVED
 
         async with db_session_async() as db:
@@ -593,32 +602,43 @@ class TestApprovalGate:
         from backend.app.models import PendingApprovalRow
 
         gate = ApprovalGate()
-        mock_publish = AsyncMock()
-        woke_after_delete = asyncio.Event()
+        prompt_sent = asyncio.Event()
+        release_publish = asyncio.Event()
 
-        async def _resolve_and_check() -> None:
-            await asyncio.sleep(0.01)
-            await gate.resolve(test_user.id, ApprovalDecision.APPROVED)
-            # Immediately after resolve returns, the DB row must already be
-            # gone, without waiting for request_approval's trailing cleanup.
-            async with db_session_async() as db:
-                assert await db.get(PendingApprovalRow, test_user.id) is None, (
-                    "resolve() must delete the row before waking the waiter"
-                )
-            woke_after_delete.set()
+        async def _publish(_msg: OutboundMessage) -> None:
+            prompt_sent.set()
+            await release_publish.wait()
 
-        task = asyncio.create_task(_resolve_and_check())
-        await gate.request_approval(
-            user_id=test_user.id,
-            tool_name="write_file",
-            description="write",
-            publish_outbound=mock_publish,
-            channel="telegram",
-            chat_id="chat_1",
-            timeout=5.0,
+        request_task = asyncio.create_task(
+            gate.request_approval(
+                user_id=test_user.id,
+                tool_name="write_file",
+                description="write",
+                publish_outbound=_publish,
+                channel="telegram",
+                chat_id="chat_1",
+                timeout=5.0,
+            )
         )
-        await task
-        assert woke_after_delete.is_set()
+        await asyncio.wait_for(prompt_sent.wait(), timeout=1.0)
+
+        async with db_session_async() as db:
+            assert await db.get(PendingApprovalRow, test_user.id) is not None, (
+                "row must exist before resolve deletes it"
+            )
+
+        release_publish.set()
+        await gate.resolve(test_user.id, ApprovalDecision.APPROVED)
+
+        # Immediately after resolve returns, the DB row must already be
+        # gone, without waiting for request_approval's trailing cleanup.
+        async with db_session_async() as db:
+            assert await db.get(PendingApprovalRow, test_user.id) is None, (
+                "resolve() must delete the row before waking the waiter"
+            )
+
+        decision = await asyncio.wait_for(request_task, timeout=1.0)
+        assert decision == ApprovalDecision.APPROVED
 
     @pytest.mark.asyncio()
     async def test_persist_pending_row_upsert_is_idempotent(self, test_user: User) -> None:


### PR DESCRIPTION
## Description
Stabilizes the flaky approval persistence tests that are failing OSS `main` CI.

The two affected tests were using short `asyncio.sleep(...)` delays and assuming the pending approval row would already be visible from a second session. On GitHub Actions that timing was not stable, so the observer sometimes never saw the row and the request timed out instead.

This change replaces the sleep-based sequencing with explicit async events tied to `publish_outbound`, which is the point where `request_approval()` has already persisted the row. It applies the same synchronization pattern to the neighboring resolve-before-wake assertion.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Used Codex to inspect the failing GitHub Actions log, localize the flaky test race, patch the synchronization logic, and run validation.
