### PR TITLE
feat(integrations): AppFolio Vendor Portal write tools (PR2)

### DIFF
--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -69,6 +69,14 @@ class ToolName:
     APPFOLIO_GET_WORK_ORDER = "appfolio_get_work_order"
     APPFOLIO_LIST_PAYMENTS = "appfolio_list_payments"
     APPFOLIO_GET_PROFILE = "appfolio_get_profile"
+    APPFOLIO_ACCEPT_WORK_ORDER = "appfolio_accept_work_order"
+    APPFOLIO_SCHEDULE_WORK_ORDER = "appfolio_schedule_work_order"
+    APPFOLIO_UPDATE_WORK_ORDER_STATUS = "appfolio_update_work_order_status"
+    APPFOLIO_UNDO_WORK_ORDER_STATUS = "appfolio_undo_work_order_status"
+    APPFOLIO_LIST_NOTES = "appfolio_list_notes"
+    APPFOLIO_ADD_NOTE = "appfolio_add_note"
+    APPFOLIO_UPDATE_NOTE = "appfolio_update_note"
+    APPFOLIO_MESSAGE_TENANT = "appfolio_message_tenant"
 
     # Supplier pricing
     SUPPLIER_SEARCH_PRODUCTS = "supplier_search_products"

--- a/backend/app/integrations/appfolio_vendor/SKILL.md
+++ b/backend/app/integrations/appfolio_vendor/SKILL.md
@@ -1,8 +1,8 @@
 # AppFolio Vendor Portal
 
-Read-only access to the user's AppFolio Vendor Portal: work orders,
-payments AppFolio has issued, and vendor profile. Write tools (notes,
-invoices, photos) ship in a follow-up.
+Read and write the user's AppFolio Vendor Portal: work orders, notes
+with photos, scheduling, status updates, tenant messaging, payments,
+and profile. Invoice creation ships in a follow-up.
 
 ## Tools
 
@@ -13,8 +13,23 @@ invoices, photos) ship in a follow-up.
 | appfolio_list_work_orders | List work orders, filter by status | Auto |
 | appfolio_search_work_orders | Search by address, number, or text | Auto |
 | appfolio_get_work_order | One work order's details | Auto |
+| appfolio_accept_work_order | Accept a work order assignment | Ask |
+| appfolio_schedule_work_order | Set the scheduled visit time | Ask |
+| appfolio_update_work_order_status | Update the status code | Ask |
+| appfolio_undo_work_order_status | Revert a recent status change | Ask |
+| appfolio_list_notes | List notes on a work order | Auto |
+| appfolio_add_note | Add a note (with optional photos) | Ask |
+| appfolio_update_note | Edit an existing note | Ask |
+| appfolio_message_tenant | SMS the tenant via AppFolio's proxy | Ask |
 | appfolio_list_payments | Payments AppFolio has issued | Auto |
 | appfolio_get_profile | Connected vendor profile | Auto |
+
+## Photos
+
+`appfolio_add_note` and `appfolio_update_note` accept a `media_refs`
+list. Each entry is either an `original_url` from a sent image in the
+conversation or a media handle (e.g. `media_xxxx`) returned by
+`analyze_photo`. AppFolio receives the photos inline with the note.
 
 ## Connecting
 

--- a/backend/app/integrations/appfolio_vendor/conversations.py
+++ b/backend/app/integrations/appfolio_vendor/conversations.py
@@ -1,0 +1,111 @@
+"""Tenant messaging tool for AppFolio Vendor Portal.
+
+AppFolio brokers SMS between vendor and tenant via an anonymized proxy
+number minted per work order. The flow is two API calls: ``get_proxy_number``
+to obtain (or refresh) the proxy, then a POST to
+``tenant_vendor_conversations`` with the message and that number. We
+hide that two-step behind a single tool.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.params import AppFolioMessageTenantParams
+from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_proxy_number(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    body: dict[str, Any] = payload
+    for key in ("phone_number", "proxy_number", "phoneNumber", "proxyNumber"):
+        value = body.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def build_conversation_tools(service: AppFolioVendorService) -> list[Tool]:
+    """Return the AppFolio tenant-messaging tool."""
+
+    async def appfolio_message_tenant(work_order_id: str, message: str) -> ToolResult:
+        text = message.strip()
+        if not text:
+            return ToolResult(
+                content="Message cannot be empty.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+
+        try:
+            proxy = await service.get_proxy_number(work_order_id)
+        except Exception as exc:
+            return service_error_to_tool_result("obtaining tenant proxy number", exc)
+
+        phone_number = _extract_proxy_number(proxy)
+        if not phone_number:
+            # Surface the actual response shape so we can adjust
+            # ``_extract_proxy_number`` if AppFolio ever returns a key
+            # we don't currently recognize.
+            logger.warning(
+                "AppFolio proxy_number response had no usable phone field"
+                " | work_order_id=%s response=%r",
+                work_order_id,
+                proxy,
+            )
+            return ToolResult(
+                content=(
+                    "AppFolio did not return a tenant proxy number for this"
+                    " work order. The tenant may have opted out of SMS or the"
+                    " work order may not have an associated tenant."
+                ),
+                is_error=True,
+                error_kind=ToolErrorKind.NOT_FOUND,
+            )
+
+        try:
+            await service.message_tenant(
+                work_order_id=work_order_id,
+                phone_number=phone_number,
+                message=text,
+            )
+        except Exception as exc:
+            return service_error_to_tool_result("sending tenant message", exc)
+
+        return ToolResult(
+            content=(f"Sent message to tenant on work order {work_order_id} via AppFolio proxy."),
+            receipt=ToolReceipt(
+                action="Sent AppFolio tenant SMS",
+                target=f"#{work_order_id}",
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.APPFOLIO_MESSAGE_TENANT,
+            description=(
+                "Send an SMS to the tenant on an AppFolio work order via"
+                " AppFolio's anonymized proxy number."
+            ),
+            function=appfolio_message_tenant,
+            params_model=AppFolioMessageTenantParams,
+            usage_hint=(
+                "Use for tenant communication tied to a work order. The vendor's"
+                " real number is never exposed."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Send tenant SMS on AppFolio work order #{args.get('work_order_id', '?')}"
+                ),
+            ),
+        ),
+    ]

--- a/backend/app/integrations/appfolio_vendor/errors.py
+++ b/backend/app/integrations/appfolio_vendor/errors.py
@@ -1,0 +1,53 @@
+"""Shared error-to-ToolResult translation for AppFolio tools.
+
+Every tool that calls into :class:`AppFolioVendorService` ends up
+funnelling the same exception types into ToolResult shapes. Centralize
+that mapping here so the auth-expired hint, the service-error wrapping,
+and the unexpected-error logging stay identical across tool modules.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from backend.app.agent.tools.base import ToolErrorKind, ToolResult
+from backend.app.integrations.appfolio_vendor.service import (
+    AppFolioError,
+    AuthExpiredError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_AUTH_EXPIRED_HINT = "Have the user request a fresh magic link and re-run appfolio_connect."
+
+
+def service_error_to_tool_result(method_label: str, exc: BaseException) -> ToolResult:
+    """Map an AppFolio service exception to a populated :class:`ToolResult`.
+
+    ``method_label`` is a short verb phrase ("scheduling work order",
+    "creating invoice") woven into the user-facing message. The function
+    handles the three exception classes the service layer can raise plus
+    the catch-all path; for the catch-all it logs an exception trace
+    so the failure is visible even when the agent only surfaces the
+    short ToolResult message to the user.
+    """
+    if isinstance(exc, AuthExpiredError):
+        return ToolResult(
+            content=f"AppFolio session expired while {method_label}.",
+            is_error=True,
+            error_kind=ToolErrorKind.AUTH,
+            hint=_AUTH_EXPIRED_HINT,
+        )
+    if isinstance(exc, AppFolioError):
+        return ToolResult(
+            content=f"AppFolio error while {method_label}: {exc}",
+            is_error=True,
+            error_kind=ToolErrorKind.SERVICE,
+        )
+    logger.exception("Unexpected AppFolio failure %s", method_label)
+    return ToolResult(
+        content=f"Unexpected error while {method_label}: {exc}",
+        is_error=True,
+        error_kind=ToolErrorKind.INTERNAL,
+    )

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -27,9 +27,14 @@ from backend.app.integrations.appfolio_vendor.auth import (
     load_credential,
 )
 from backend.app.integrations.appfolio_vendor.auth_tools import build_auth_tools
+from backend.app.integrations.appfolio_vendor.conversations import build_conversation_tools
+from backend.app.integrations.appfolio_vendor.notes import build_note_tools
 from backend.app.integrations.appfolio_vendor.payments import build_payment_tools
 from backend.app.integrations.appfolio_vendor.profile import build_profile_tools
 from backend.app.integrations.appfolio_vendor.service import build_service
+from backend.app.integrations.appfolio_vendor.work_order_writes import (
+    build_work_order_write_tools,
+)
 from backend.app.integrations.appfolio_vendor.work_orders import build_work_order_tools
 
 if TYPE_CHECKING:
@@ -55,6 +60,9 @@ async def _appfolio_factory(ctx: ToolContext) -> list[Tool]:
         return tools
     service = build_service(cred, api_base=settings.appfolio_vendor_api_base)
     tools.extend(build_work_order_tools(service))
+    tools.extend(build_work_order_write_tools(service))
+    tools.extend(build_note_tools(service, ctx))
+    tools.extend(build_conversation_tools(service))
     tools.extend(build_payment_tools(service))
     tools.extend(build_profile_tools(service))
     return tools
@@ -125,6 +133,46 @@ def _register() -> None:
                 ToolName.APPFOLIO_GET_PROFILE,
                 "Get the connected AppFolio profile",
                 default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_ACCEPT_WORK_ORDER,
+                "Accept an AppFolio work order assignment",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_SCHEDULE_WORK_ORDER,
+                "Schedule an AppFolio work order visit",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UPDATE_WORK_ORDER_STATUS,
+                "Update the status code on an AppFolio work order",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UNDO_WORK_ORDER_STATUS,
+                "Revert a recent AppFolio work order status change",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_LIST_NOTES,
+                "List notes on an AppFolio work order",
+                default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_ADD_NOTE,
+                "Add a note (with optional photos) to an AppFolio work order",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UPDATE_NOTE,
+                "Edit an existing AppFolio work-order note",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_MESSAGE_TENANT,
+                "Send an SMS to the tenant on an AppFolio work order",
+                default_permission="ask",
             ),
         ],
         auth_check=_appfolio_auth_check,

--- a/backend/app/integrations/appfolio_vendor/media_resolver.py
+++ b/backend/app/integrations/appfolio_vendor/media_resolver.py
@@ -1,0 +1,124 @@
+"""Resolve staged photos into AppFolio's base64 file payload shape.
+
+AppFolio's notes and invoice endpoints accept JSON-inlined files via
+``files: [{file_base64, name}]`` rather than multipart upload. The
+agent receives photos through the OSS staging pipeline (current
+message ``downloaded_media``, then the in-memory media staging cache,
+then the persistent ``MediaStore``). This module hides that lookup
+behind one entry point so each write tool only needs to accept a list
+of media references.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from backend.app.agent.tools.base import ToolErrorKind, ToolResult
+from backend.app.integrations.appfolio_vendor.service import FileUpload
+from backend.app.media.download import generate_filename
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_staged_files(
+    ctx: ToolContext,
+    media_refs: list[str],
+) -> list[FileUpload] | ToolResult:
+    """Resolve each ``media_ref`` to bytes and return a list of FileUpload.
+
+    Inputs are LLM-supplied references: either an ``original_url`` from
+    the conversation or a media handle (``media_abZtYWFs``) returned by
+    the ``analyze_photo`` flow. Each ref is checked against, in order:
+
+    1. The current turn's ``ctx.downloaded_media``.
+    2. The ``media_staging`` cache (may have evicted older photos).
+    3. The persistent ``MediaStore`` (saved to storage).
+
+    Returns a list of :class:`FileUpload` on success, or a populated
+    :class:`ToolResult` with ``is_error=True`` when at least one ref
+    cannot be resolved. Tools should bubble the error verbatim so the
+    agent gets a deterministic "no photo found" message instead of a
+    half-attached payload.
+
+    An empty ``media_refs`` returns an empty list — tools that want a
+    no-photo path should branch on the input rather than the output.
+    """
+    if not media_refs:
+        return []
+
+    # Lazy imports keep the test surface narrow and break what would
+    # otherwise be a circular dependency through ``backend.app.agent``.
+    from backend.app.agent import media_staging
+    from backend.app.agent.stores import MediaStore
+
+    media_store = MediaStore(ctx.user.id)
+    staged_cache = media_staging.get_all_for_user(ctx.user.id)
+
+    resolved: list[FileUpload] = []
+    missing: list[str] = []
+
+    for raw_ref in media_refs:
+        ref = raw_ref.strip()
+        if not ref:
+            continue
+        original_url = ref
+        file_bytes: bytes = b""
+        mime_type = "image/jpeg"
+
+        # 0. Resolve a media handle to (original_url, bytes).
+        handle = media_staging.resolve_media_ref(ctx.user.id, ref)
+        if handle is not None:
+            original_url, file_bytes, mime_type = handle
+
+        # 1. Current message's downloaded_media.
+        if not file_bytes:
+            for media in ctx.downloaded_media:
+                if media.original_url != original_url:
+                    continue
+                file_bytes = media.content
+                mime_type = media.mime_type or mime_type
+                break
+
+        # 2. Media staging cache.
+        if not file_bytes and original_url in staged_cache:
+            file_bytes = staged_cache[original_url]
+
+        # 3. Persistent MediaStore.
+        if not file_bytes:
+            stored = await media_store.get_by_url(original_url)
+            if stored is not None:
+                mime_type = stored.mime_type or mime_type
+                storage_url = stored.storage_url or ""
+                if storage_url.startswith("file://"):
+                    local_path = Path(storage_url.removeprefix("file://"))
+                    if local_path.is_file():
+                        file_bytes = await asyncio.to_thread(local_path.read_bytes)
+
+        if not file_bytes:
+            missing.append(ref)
+            continue
+
+        resolved.append(
+            FileUpload(
+                name=generate_filename(mime_type),
+                data=file_bytes,
+            )
+        )
+
+    if missing:
+        return ToolResult(
+            content=(
+                "Could not resolve "
+                + ", ".join(repr(m) for m in missing)
+                + " to staged media. Ask the user to resend the photo(s)."
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.NOT_FOUND,
+        )
+    return resolved

--- a/backend/app/integrations/appfolio_vendor/notes.py
+++ b/backend/app/integrations/appfolio_vendor/notes.py
@@ -1,0 +1,178 @@
+"""Note tools for AppFolio work orders, including photo attachments.
+
+Notes are the vendor's primary write surface inside a work order:
+status updates, "arrived on site", "needs another visit", with photos
+attached as base64 entries in the JSON body. Both add and update flow
+through the shared :mod:`media_resolver` so the agent can reference
+photos by ``original_url`` or by handle.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.media_resolver import resolve_staged_files
+from backend.app.integrations.appfolio_vendor.params import (
+    AppFolioAddNoteParams,
+    AppFolioListNotesParams,
+    AppFolioUpdateNoteParams,
+)
+from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_notes(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [n for n in payload if isinstance(n, dict)]
+    if isinstance(payload, dict):
+        for key in ("notes", "data", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [n for n in value if isinstance(n, dict)]
+    return []
+
+
+def build_note_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[Tool]:
+    """Return the AppFolio work-order note tools."""
+
+    async def appfolio_list_notes(work_order_id: str) -> ToolResult:
+        try:
+            payload = await service.list_work_order_notes(work_order_id)
+        except Exception as exc:
+            return service_error_to_tool_result("listing notes", exc)
+        notes = _normalize_notes(payload)
+        if not notes:
+            return ToolResult(content=f"No notes on work order {work_order_id}.")
+        lines = [f"{len(notes)} note(s) on work order {work_order_id}:"]
+        for n in notes[:30]:
+            note_id = n.get("id") or "?"
+            created = n.get("created_at") or n.get("createdAt") or ""
+            text = (n.get("body") or "").strip().replace("\n", " ")[:160]
+            lines.append(f"- ID: {note_id} | {created} | {text}")
+        return ToolResult(content="\n".join(lines))
+
+    async def appfolio_add_note(
+        work_order_id: str,
+        body: str,
+        media_refs: list[str],
+    ) -> ToolResult:
+        text = body.strip()
+        if not text:
+            return ToolResult(
+                content="Note body cannot be empty.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        files_or_err = await resolve_staged_files(ctx, media_refs)
+        if isinstance(files_or_err, ToolResult):
+            return files_or_err
+        files = files_or_err
+        try:
+            result = await service.add_work_order_note(
+                work_order_id, body_text=text, files=files or None
+            )
+        except Exception as exc:
+            return service_error_to_tool_result("adding note", exc)
+        note_id = ""
+        if isinstance(result, dict):
+            note_id = str(result.get("id") or result.get("note", {}).get("id") or "")
+        photo_count = len(files)
+        photo_phrase = f" with {photo_count} photo(s)" if photo_count else ""
+        return ToolResult(
+            content=(
+                f"Added note{photo_phrase} to work order {work_order_id}"
+                + (f" (note id {note_id})." if note_id else ".")
+            ),
+            receipt=ToolReceipt(
+                action="Added AppFolio work order note",
+                target=f"#{work_order_id}{photo_phrase}",
+            ),
+        )
+
+    async def appfolio_update_note(
+        work_order_id: str,
+        note_id: str,
+        body: str,
+        media_refs: list[str],
+    ) -> ToolResult:
+        text = body.strip()
+        if not text:
+            return ToolResult(
+                content="Note body cannot be empty.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        files_or_err = await resolve_staged_files(ctx, media_refs)
+        if isinstance(files_or_err, ToolResult):
+            return files_or_err
+        files = files_or_err
+        try:
+            await service.update_work_order_note(
+                work_order_id, note_id, body_text=text, files=files or None
+            )
+        except Exception as exc:
+            return service_error_to_tool_result("updating note", exc)
+        photo_count = len(files)
+        photo_phrase = f", added {photo_count} photo(s)" if photo_count else ""
+        return ToolResult(
+            content=f"Updated note {note_id}{photo_phrase}.",
+            receipt=ToolReceipt(
+                action="Updated AppFolio work order note",
+                target=f"#{work_order_id} note {note_id}{photo_phrase}",
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.APPFOLIO_LIST_NOTES,
+            description="List notes on an AppFolio work order.",
+            function=appfolio_list_notes,
+            params_model=AppFolioListNotesParams,
+            usage_hint="Use to see prior status updates and photos before adding a new one.",
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_ADD_NOTE,
+            description=("Add a note (text + optional photos) to an AppFolio work order."),
+            function=appfolio_add_note,
+            params_model=AppFolioAddNoteParams,
+            usage_hint=(
+                "Pass photos by their original_url from the conversation or by"
+                " media handle from analyze_photo. Notes are visible to the PM."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    "Add a note to AppFolio work order"
+                    f" #{args.get('work_order_id', '?')}"
+                    + (
+                        f" with {len(args.get('media_refs') or [])} photo(s)"
+                        if args.get("media_refs")
+                        else ""
+                    )
+                ),
+            ),
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_UPDATE_NOTE,
+            description="Edit an existing AppFolio work-order note.",
+            function=appfolio_update_note,
+            params_model=AppFolioUpdateNoteParams,
+            usage_hint="Only use when the user wants to fix the text or attach more photos.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Update AppFolio note {args.get('note_id', '?')}"
+                    f" on work order #{args.get('work_order_id', '?')}"
+                ),
+            ),
+        ),
+    ]

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -85,3 +85,94 @@ class AppFolioListPaymentsParams(BaseModel):
 
 class AppFolioGetProfileParams(BaseModel):
     """Empty param model — ``get_profile`` takes no arguments."""
+
+
+class AppFolioAcceptWorkOrderParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID to accept.")
+    notes: str = Field(
+        default="",
+        description="Optional acceptance notes the property manager will see.",
+    )
+
+
+class AppFolioScheduleWorkOrderParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID to schedule.")
+    scheduled_at: str = Field(
+        description=(
+            "When the visit will start, as an ISO 8601 timestamp (e.g."
+            " '2026-05-08T14:00:00-04:00'). Use the user's timezone."
+        ),
+    )
+    duration_minutes: int = Field(
+        default=0,
+        description="Estimated visit duration in minutes (0 to omit).",
+    )
+    notes: str = Field(
+        default="",
+        description="Optional scheduling notes for the tenant or PM.",
+    )
+
+
+class AppFolioUpdateWorkOrderStatusParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID to update.")
+    status_code: int = Field(
+        description=(
+            "Numeric status code AppFolio expects. Common values:"
+            " 0=new, 4=in progress, 8=completed."
+            " Confirm with the user when uncertain rather than guessing."
+        ),
+    )
+
+
+class AppFolioUndoWorkOrderStatusParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID.")
+    previous_status: str = Field(
+        description=(
+            "The status the work order should revert to. Pass the prior"
+            " status code or label as returned by appfolio_get_work_order."
+        ),
+    )
+
+
+class AppFolioListNotesParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID.")
+
+
+class AppFolioAddNoteParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID to add a note to.")
+    body: str = Field(description="Note text. Visible to the property manager.")
+    media_refs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional list of photo references from the conversation."
+            " Each entry is either an original_url from a sent image or a"
+            " media handle (e.g. 'media_xxxx') returned by analyze_photo."
+            " Photos are uploaded to AppFolio inline with the note."
+        ),
+    )
+
+
+class AppFolioUpdateNoteParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID.")
+    note_id: str = Field(description="AppFolio note ID to edit.")
+    body: str = Field(description="Replacement note text.")
+    media_refs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional list of photo references to attach, same shape as"
+            " appfolio_add_note. Existing attachments are preserved."
+        ),
+    )
+
+
+class AppFolioMessageTenantParams(BaseModel):
+    work_order_id: str = Field(
+        description=(
+            "AppFolio work order ID. AppFolio mints an anonymized proxy"
+            " number per work order, so the message routes to the right"
+            " tenant without exposing the vendor's real phone number."
+        ),
+    )
+    message: str = Field(
+        description="SMS body to send to the tenant via AppFolio's proxy.",
+    )

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -219,6 +219,120 @@ class AppFolioVendorService:
     async def get_profile(self) -> Any:
         return await self.get("/profiles/me", params={"viewed": "true"})
 
+    # ------------------------------------------------------------------
+    # Domain helpers (PR2: write surface)
+    # ------------------------------------------------------------------
+
+    async def accept_work_order(
+        self,
+        work_order_id: str,
+        *,
+        body: dict[str, Any] | None = None,
+    ) -> Any:
+        return await self.post(
+            f"/maintenance/api/work_orders/{work_order_id}/accept",
+            params={"ref": "vendor_portal"},
+            json_body=body,
+        )
+
+    async def schedule_work_order(
+        self,
+        work_order_id: str,
+        *,
+        scheduled_at: str,
+        duration_minutes: int | None = None,
+        notes: str = "",
+    ) -> Any:
+        """POST a schedule onto a work order.
+
+        Body shape mirrors the SPA: a flat dict whose keys are camelCase.
+        ``scheduled_at`` should be an ISO 8601 string with timezone (or
+        local with offset) so AppFolio can render it correctly back to
+        the property manager.
+        """
+        body: dict[str, Any] = {"scheduledAt": scheduled_at}
+        if duration_minutes is not None:
+            body["durationMinutes"] = duration_minutes
+        if notes:
+            body["notes"] = notes
+        return await self.post(
+            f"/maintenance/api/work_orders/{work_order_id}/schedule",
+            json_body=body,
+        )
+
+    async def update_work_order_status(self, work_order_id: str, *, status_code: int) -> Any:
+        return await self.patch(
+            f"/maintenance/api/work_orders/{work_order_id}",
+            json_body={"workOrder": {"statusCode": status_code}},
+        )
+
+    async def undo_work_order_status(
+        self, work_order_id: str, *, previous_status: int | str
+    ) -> Any:
+        return await self.patch(
+            f"/maintenance/api/work_orders/{work_order_id}/undo_status",
+            json_body={"workOrder": {"status": previous_status}},
+        )
+
+    async def list_work_order_notes(self, work_order_id: str) -> Any:
+        return await self.get(f"/maintenance/api/work_orders/{work_order_id}/notes")
+
+    async def add_work_order_note(
+        self,
+        work_order_id: str,
+        *,
+        body_text: str,
+        files: list[FileUpload] | None = None,
+    ) -> Any:
+        body: dict[str, Any] = {"note": {"body": body_text}}
+        if files:
+            body["files"] = _encode_files(files)
+        return await self.post(
+            f"/maintenance/api/work_orders/{work_order_id}/notes",
+            json_body=body,
+        )
+
+    async def update_work_order_note(
+        self,
+        work_order_id: str,
+        note_id: str,
+        *,
+        body_text: str,
+        files: list[FileUpload] | None = None,
+    ) -> Any:
+        body: dict[str, Any] = {"note": {"body": body_text}}
+        if files:
+            body["files"] = _encode_files(files)
+        return await self.patch(
+            f"/maintenance/api/work_orders/{work_order_id}/notes/{note_id}",
+            json_body=body,
+        )
+
+    async def get_proxy_number(self, work_order_id: str) -> Any:
+        """Fetch AppFolio's anonymized proxy phone number for the tenant.
+
+        Vendors message tenants via a proxy number AppFolio mints per
+        work order. Calling this endpoint creates (or returns) the
+        number; the SMS itself goes through ``message_tenant`` below.
+        """
+        return await self.get(f"/maintenance/api/work_orders/{work_order_id}/get_proxy_number")
+
+    async def message_tenant(
+        self,
+        *,
+        work_order_id: str,
+        phone_number: str,
+        message: str,
+    ) -> Any:
+        return await self.post(
+            "/maintenance/api/tenant_vendor_conversations",
+            json_body={
+                "work_order_id": work_order_id,
+                "phone_number": phone_number,
+                "message": message,
+            },
+        )
+
 
 def build_service(
     credential: AppFolioCredential,

--- a/backend/app/integrations/appfolio_vendor/work_order_writes.py
+++ b/backend/app/integrations/appfolio_vendor/work_order_writes.py
@@ -1,0 +1,167 @@
+"""Write tools for AppFolio work orders.
+
+Accept, schedule, status update, and undo. Notes (with photo upload)
+live in :mod:`notes`; tenant messaging lives in :mod:`conversations`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.params import (
+    AppFolioAcceptWorkOrderParams,
+    AppFolioScheduleWorkOrderParams,
+    AppFolioUndoWorkOrderStatusParams,
+    AppFolioUpdateWorkOrderStatusParams,
+)
+from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
+
+logger = logging.getLogger(__name__)
+
+
+def build_work_order_write_tools(service: AppFolioVendorService) -> list[Tool]:
+    """Return the work-order write Tool instances."""
+
+    async def appfolio_accept_work_order(work_order_id: str, notes: str = "") -> ToolResult:
+        # When the user supplies no notes, send no body at all rather than
+        # an empty dict; mirrors the SPA which only POSTs a body when the
+        # user filled in the optional notes field.
+        body = {"notes": notes} if notes else None
+        try:
+            await service.accept_work_order(work_order_id, body=body)
+        except Exception as exc:
+            return service_error_to_tool_result("accepting work order", exc)
+        return ToolResult(
+            content=f"Accepted work order {work_order_id}.",
+            receipt=ToolReceipt(
+                action="Accepted AppFolio work order",
+                target=f"#{work_order_id}",
+            ),
+        )
+
+    async def appfolio_schedule_work_order(
+        work_order_id: str,
+        scheduled_at: str,
+        duration_minutes: int = 0,
+        notes: str = "",
+    ) -> ToolResult:
+        try:
+            await service.schedule_work_order(
+                work_order_id,
+                scheduled_at=scheduled_at,
+                duration_minutes=duration_minutes or None,
+                notes=notes,
+            )
+        except Exception as exc:
+            return service_error_to_tool_result("scheduling work order", exc)
+        return ToolResult(
+            content=f"Scheduled work order {work_order_id} for {scheduled_at}.",
+            receipt=ToolReceipt(
+                action="Scheduled AppFolio work order",
+                target=f"#{work_order_id} at {scheduled_at}",
+            ),
+        )
+
+    async def appfolio_update_work_order_status(work_order_id: str, status_code: int) -> ToolResult:
+        try:
+            await service.update_work_order_status(work_order_id, status_code=status_code)
+        except Exception as exc:
+            return service_error_to_tool_result("updating work order status", exc)
+        return ToolResult(
+            content=f"Updated work order {work_order_id} status to {status_code}.",
+            receipt=ToolReceipt(
+                action="Updated AppFolio work order status",
+                target=f"#{work_order_id} → {status_code}",
+            ),
+        )
+
+    async def appfolio_undo_work_order_status(
+        work_order_id: str, previous_status: str
+    ) -> ToolResult:
+        # AppFolio accepts either the int code or the string label; pass
+        # whichever the agent supplied through unchanged so the API-side
+        # validation is the canonical check rather than us guessing.
+        try:
+            await service.undo_work_order_status(work_order_id, previous_status=previous_status)
+        except Exception as exc:
+            return service_error_to_tool_result("undoing work order status", exc)
+        return ToolResult(
+            content=(f"Reverted work order {work_order_id} status to {previous_status}."),
+            receipt=ToolReceipt(
+                action="Reverted AppFolio work order status",
+                target=f"#{work_order_id} → {previous_status}",
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.APPFOLIO_ACCEPT_WORK_ORDER,
+            description="Accept an AppFolio work order assignment.",
+            function=appfolio_accept_work_order,
+            params_model=AppFolioAcceptWorkOrderParams,
+            usage_hint=(
+                "Use when the user agrees to take a job. Optional notes are"
+                " visible to the property manager."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Accept AppFolio work order #{args.get('work_order_id', '?')}"
+                ),
+            ),
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_SCHEDULE_WORK_ORDER,
+            description="Set the scheduled visit time on an AppFolio work order.",
+            function=appfolio_schedule_work_order,
+            params_model=AppFolioScheduleWorkOrderParams,
+            usage_hint=(
+                "Confirm the date, time, and timezone with the user before"
+                " calling. AppFolio sends the tenant a 24-hour reminder."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Schedule AppFolio work order #{args.get('work_order_id', '?')}"
+                    f" for {args.get('scheduled_at', '?')}"
+                ),
+            ),
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_UPDATE_WORK_ORDER_STATUS,
+            description="Update the status code on an AppFolio work order.",
+            function=appfolio_update_work_order_status,
+            params_model=AppFolioUpdateWorkOrderStatusParams,
+            usage_hint=(
+                "Use to mark a job in-progress, completed, or back to needs-action."
+                " Confirm the target status with the user when uncertain."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Update AppFolio work order #{args.get('work_order_id', '?')}"
+                    f" status to {args.get('status_code', '?')}"
+                ),
+            ),
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_UNDO_WORK_ORDER_STATUS,
+            description="Revert a recent status change on an AppFolio work order.",
+            function=appfolio_undo_work_order_status,
+            params_model=AppFolioUndoWorkOrderStatusParams,
+            usage_hint=(
+                "Use only when the user explicitly asks to undo a status change they just made."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Revert AppFolio work order #{args.get('work_order_id', '?')}"
+                    f" status to {args.get('previous_status', '?')}"
+                ),
+            ),
+        ),
+    ]

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -405,3 +405,253 @@ def test_list_work_orders_params_defaults() -> None:
     assert p.include_completed is False
     assert p.include_estimates is True
     assert p.customer_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Write surface (PR2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_accept_work_order_passes_ref_param() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.accept_work_order("42", body={"notes": "got it"})
+    args, kwargs = client.request.call_args
+    assert args[0] == "POST"
+    assert "/maintenance/api/work_orders/42/accept" in args[1]
+    assert kwargs["params"] == {"ref": "vendor_portal"}
+    assert kwargs["json"] == {"notes": "got it"}
+
+
+@pytest.mark.asyncio()
+async def test_schedule_work_order_omits_unset_fields() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.schedule_work_order("42", scheduled_at="2026-05-08T14:00:00-04:00")
+    _, kwargs = client.request.call_args
+    assert kwargs["json"] == {"scheduledAt": "2026-05-08T14:00:00-04:00"}
+
+
+@pytest.mark.asyncio()
+async def test_schedule_work_order_includes_optional_fields() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.schedule_work_order(
+            "42",
+            scheduled_at="2026-05-08T14:00:00",
+            duration_minutes=90,
+            notes="bring ladder",
+        )
+    _, kwargs = client.request.call_args
+    assert kwargs["json"] == {
+        "scheduledAt": "2026-05-08T14:00:00",
+        "durationMinutes": 90,
+        "notes": "bring ladder",
+    }
+
+
+@pytest.mark.asyncio()
+async def test_update_status_uses_camelcase_envelope() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.update_work_order_status("42", status_code=8)
+    args, kwargs = client.request.call_args
+    assert args[0] == "PATCH"
+    assert kwargs["json"] == {"workOrder": {"statusCode": 8}}
+
+
+@pytest.mark.asyncio()
+async def test_add_note_inlines_base64_files() -> None:
+    from backend.app.integrations.appfolio_vendor.service import FileUpload
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={"id": "999"})
+    files = [FileUpload(name="kitchen.jpg", data=b"\x89PNGfake")]
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.add_work_order_note("42", body_text="arrived", files=files)
+    _, kwargs = client.request.call_args
+    payload = kwargs["json"]
+    assert payload["note"] == {"body": "arrived"}
+    assert len(payload["files"]) == 1
+    entry = payload["files"][0]
+    assert entry["name"] == "kitchen.jpg"
+    # base64 of b"\x89PNGfake"
+    import base64
+
+    assert entry["file_base64"] == base64.b64encode(b"\x89PNGfake").decode("ascii")
+
+
+@pytest.mark.asyncio()
+async def test_add_note_omits_files_key_when_empty() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={"id": "999"})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.add_work_order_note("42", body_text="status")
+    _, kwargs = client.request.call_args
+    assert kwargs["json"] == {"note": {"body": "status"}}
+
+
+@pytest.mark.asyncio()
+async def test_message_tenant_two_step_flow() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    proxy_resp = _mock_response(json_data={"phone_number": "+15551234567"})
+    msg_resp = _mock_response(json_data={"ok": True})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        # service.get_proxy_number then service.message_tenant
+        client.request = AsyncMock(side_effect=[proxy_resp, msg_resp])
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        proxy = await service.get_proxy_number("42")
+        await service.message_tenant(
+            work_order_id="42",
+            phone_number=proxy["phone_number"],
+            message="on my way",
+        )
+    assert client.request.call_count == 2
+    second_args, second_kwargs = client.request.call_args_list[1]
+    assert second_args[0] == "POST"
+    assert second_args[1].endswith("/tenant_vendor_conversations")
+    assert second_kwargs["json"] == {
+        "work_order_id": "42",
+        "phone_number": "+15551234567",
+        "message": "on my way",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Media resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_resolve_staged_files_pulls_from_downloaded_media() -> None:
+    from backend.app.integrations.appfolio_vendor.media_resolver import (
+        resolve_staged_files,
+    )
+    from backend.app.media.download import DownloadedMedia
+
+    media = DownloadedMedia(
+        content=b"\xff\xd8fakejpg",
+        mime_type="image/jpeg",
+        original_url="https://example.com/photo1.jpg",
+        filename="photo1.jpg",
+    )
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = [media]
+
+    with (
+        patch(
+            "backend.app.agent.media_staging.resolve_media_ref",
+            return_value=None,
+        ),
+        patch(
+            "backend.app.agent.media_staging.get_all_for_user",
+            return_value={},
+        ),
+        patch("backend.app.agent.stores.MediaStore") as ms_cls,
+    ):
+        store = AsyncMock()
+        store.get_by_url = AsyncMock(return_value=None)
+        ms_cls.return_value = store
+
+        result = await resolve_staged_files(ctx, ["https://example.com/photo1.jpg"])
+
+    from backend.app.integrations.appfolio_vendor.service import FileUpload
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    first = result[0]
+    assert isinstance(first, FileUpload)
+    assert first.data == b"\xff\xd8fakejpg"
+    assert first.name.endswith(".jpg")
+
+
+@pytest.mark.asyncio()
+async def test_resolve_staged_files_returns_error_for_missing_ref() -> None:
+    from backend.app.integrations.appfolio_vendor.media_resolver import (
+        resolve_staged_files,
+    )
+
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    with (
+        patch(
+            "backend.app.agent.media_staging.resolve_media_ref",
+            return_value=None,
+        ),
+        patch(
+            "backend.app.agent.media_staging.get_all_for_user",
+            return_value={},
+        ),
+        patch("backend.app.agent.stores.MediaStore") as ms_cls,
+    ):
+        store = AsyncMock()
+        store.get_by_url = AsyncMock(return_value=None)
+        ms_cls.return_value = store
+
+        result = await resolve_staged_files(ctx, ["https://example.com/missing.jpg"])
+
+    # Returns ToolResult on error rather than raising.
+    from backend.app.agent.tools.base import ToolResult as _TR
+
+    assert isinstance(result, _TR)
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio()
+async def test_resolve_staged_files_empty_list_returns_empty_list() -> None:
+    from backend.app.integrations.appfolio_vendor.media_resolver import (
+        resolve_staged_files,
+    )
+
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    result = await resolve_staged_files(ctx, [])
+    assert result == []


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Builds on #1247 (read surface) with the work-order write surface and tenant messaging. Invoice creation + compliance docs follow in PR3.

## Description

Eight new tools (defaults shown):

* `appfolio_accept_work_order` (ask)
* `appfolio_schedule_work_order` (ask)
* `appfolio_update_work_order_status` (ask)
* `appfolio_undo_work_order_status` (ask)
* `appfolio_list_notes` (always)
* `appfolio_add_note` (ask) — supports inline photo upload
* `appfolio_update_note` (ask) — supports inline photo upload
* `appfolio_message_tenant` (ask) — two-step proxy + post under the hood

All writes default to `ask` per @njbrake's direction.

### Photo handling

New `media_resolver` module resolves LLM-supplied media references (`original_url` from the conversation, or a `media_xxxx` handle from `analyze_photo`) through three lookup tiers (current `downloaded_media`, `media_staging` cache, persistent `MediaStore`) and produces `FileUpload` entries. The service base64-encodes them inline into AppFolio's JSON body shape (`files: [{file_base64, name}]`). When any reference is unresolvable, the resolver returns a populated `ToolResult` so the agent gets a deterministic "no photo found" message instead of a half-attached payload.

### Tenant messaging flow

`appfolio_message_tenant` hides AppFolio's two-call dance: `get_proxy_number` to mint (or fetch) the anonymized number, then a POST to `tenant_vendor_conversations` with the message body. The vendor's real number is never exposed.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass — 2391 passed, 1 skipped (10 new tests in `test_appfolio_vendor.py`)
- [x] Lint passes
- [x] Type checking passes
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests (n/a)

## AI Usage
- [x] AI-assisted: Claude Opus 4.7 implemented the write surface, photo pipeline, and tests via pair work with @njbrake.
- [ ] No AI used

## Notes for reviewers

* Schedule body shape (`scheduledAt` + optional `durationMinutes` and `notes`) is a best guess from the SPA bundle. The schedule tool is the most likely thing to need adjustment after a real-account smoke test.
* `update_work_order_status` exposes `status_code` as a raw int and documents 0/4/8 as the common values. The status code mapping is partially inferred and may need tightening once we observe real responses.
* The `undo_work_order_status` tool passes `previous_status` through unchanged so AppFolio's API-side validation is the canonical check rather than us guessing label vs. int.