### PR TITLE
feat(integrations): AppFolio Vendor Portal invoices, compliance, estimates (PR3)

### DIFF
--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -77,6 +77,12 @@ class ToolName:
     APPFOLIO_ADD_NOTE = "appfolio_add_note"
     APPFOLIO_UPDATE_NOTE = "appfolio_update_note"
     APPFOLIO_MESSAGE_TENANT = "appfolio_message_tenant"
+    APPFOLIO_CREATE_INVOICE = "appfolio_create_invoice"
+    APPFOLIO_UPLOAD_INVOICE_PDF = "appfolio_upload_invoice_pdf"
+    APPFOLIO_UPLOAD_COMPLIANCE_DOC = "appfolio_upload_compliance_doc"
+    APPFOLIO_GET_ESTIMATE = "appfolio_get_estimate"
+    APPFOLIO_UPDATE_ESTIMATE = "appfolio_update_estimate"
+    APPFOLIO_UPDATE_PROFILE = "appfolio_update_profile"
 
     # Supplier pricing
     SUPPLIER_SEARCH_PRODUCTS = "supplier_search_products"

--- a/backend/app/integrations/appfolio_vendor/SKILL.md
+++ b/backend/app/integrations/appfolio_vendor/SKILL.md
@@ -1,8 +1,9 @@
 # AppFolio Vendor Portal
 
-Read and write the user's AppFolio Vendor Portal: work orders, notes
-with photos, scheduling, status updates, tenant messaging, payments,
-and profile. Invoice creation ships in a follow-up.
+Full read/write access to the user's AppFolio Vendor Portal: work
+orders, notes with photos, scheduling, status updates, tenant
+messaging, invoices (line items or PDF), compliance docs, estimates,
+payments, and profile.
 
 ## Tools
 
@@ -23,13 +24,21 @@ and profile. Invoice creation ships in a follow-up.
 | appfolio_message_tenant | SMS the tenant via AppFolio's proxy | Ask |
 | appfolio_list_payments | Payments AppFolio has issued | Auto |
 | appfolio_get_profile | Connected vendor profile | Auto |
+| appfolio_update_profile | Update profile fields | Ask |
+| appfolio_create_invoice | Build a line-itemized invoice with photos | Ask |
+| appfolio_upload_invoice_pdf | Upload a pre-built invoice PDF | Ask |
+| appfolio_upload_compliance_doc | Upload W-9, COI, license, etc. | Ask |
+| appfolio_get_estimate | Get an estimate's details | Auto |
+| appfolio_update_estimate | Update an estimate's amount or description | Ask |
 
-## Photos
+## Photos and documents
 
-`appfolio_add_note` and `appfolio_update_note` accept a `media_refs`
-list. Each entry is either an `original_url` from a sent image in the
-conversation or a media handle (e.g. `media_xxxx`) returned by
-`analyze_photo`. AppFolio receives the photos inline with the note.
+`appfolio_add_note`, `appfolio_update_note`, `appfolio_create_invoice`,
+`appfolio_upload_invoice_pdf`, and `appfolio_upload_compliance_doc`
+all accept media references. Each entry is either an `original_url`
+from a sent image or a media handle (e.g. `media_xxxx`) returned by
+`analyze_photo`. AppFolio receives them inline as base64 in the JSON
+body.
 
 ## Connecting
 

--- a/backend/app/integrations/appfolio_vendor/compliance.py
+++ b/backend/app/integrations/appfolio_vendor/compliance.py
@@ -1,0 +1,84 @@
+"""Compliance document upload tool for AppFolio Vendor Portal.
+
+PMs ask vendors to upload W-9s, certificates of insurance, and licenses.
+AppFolio's compliance endpoint takes a singular ``file`` field rather
+than a list, so this tool resolves exactly one media reference.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.media_resolver import resolve_staged_files
+from backend.app.integrations.appfolio_vendor.params import (
+    AppFolioUploadComplianceDocParams,
+)
+from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+def build_compliance_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[Tool]:
+    """Return the AppFolio compliance-document tools."""
+
+    async def appfolio_upload_compliance_doc(
+        customer_id: str, compliance_type: str, media_ref: str
+    ) -> ToolResult:
+        files_or_err = await resolve_staged_files(ctx, [media_ref])
+        if isinstance(files_or_err, ToolResult):
+            return files_or_err
+        if not files_or_err:
+            return ToolResult(
+                content="Could not resolve the document reference to a file.",
+                is_error=True,
+                error_kind=ToolErrorKind.NOT_FOUND,
+            )
+        file = files_or_err[0]
+        try:
+            await service.upload_compliance_document(
+                customer_id=customer_id,
+                compliance_type=compliance_type,
+                file=file,
+            )
+        except Exception as exc:
+            return service_error_to_tool_result("uploading compliance document", exc)
+
+        return ToolResult(
+            content=(f"Uploaded {compliance_type} document for customer {customer_id}."),
+            receipt=ToolReceipt(
+                action="Uploaded AppFolio compliance document",
+                target=f"customer {customer_id} ({compliance_type})",
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.APPFOLIO_UPLOAD_COMPLIANCE_DOC,
+            description=(
+                "Upload a compliance document (W-9, COI, license) for a"
+                " specific AppFolio property manager."
+            ),
+            function=appfolio_upload_compliance_doc,
+            params_model=AppFolioUploadComplianceDocParams,
+            usage_hint=(
+                "Confirm the compliance type (e.g. 'w9', 'general_liability')"
+                " with the user before uploading. AppFolio scopes the doc to"
+                " one customer at a time."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Upload {args.get('compliance_type', '?')} document"
+                    f" for AppFolio customer {args.get('customer_id', '?')}"
+                ),
+            ),
+        ),
+    ]

--- a/backend/app/integrations/appfolio_vendor/estimates.py
+++ b/backend/app/integrations/appfolio_vendor/estimates.py
@@ -1,0 +1,119 @@
+"""Estimate tools for AppFolio Vendor Portal."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.params import (
+    AppFolioGetEstimateParams,
+    AppFolioUpdateEstimateParams,
+)
+from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
+
+logger = logging.getLogger(__name__)
+
+
+def _fmt_estimate(payload: Any) -> str:
+    """Render the JSON:API estimate envelope into a compact summary."""
+    if not isinstance(payload, dict):
+        return "AppFolio returned an unexpected estimate shape."
+    data = payload.get("data") if "data" in payload else payload
+    if not isinstance(data, dict):
+        return "AppFolio returned no estimate data."
+    attrs = data.get("attributes") if isinstance(data.get("attributes"), dict) else data
+    estimate_id = data.get("id") or data.get("estimate_id") or "?"
+    amount = attrs.get("amount") or attrs.get("total") or ""
+    description = attrs.get("description") or ""
+    status = attrs.get("status") or ""
+    lines = [f"Estimate {estimate_id}"]
+    if status:
+        lines.append(f"  Status: {status}")
+    if amount:
+        lines.append(f"  Amount: {amount}")
+    if description:
+        lines.append(f"  Description: {description}")
+    attachments = payload.get("included") if isinstance(payload, dict) else None
+    if isinstance(attachments, list):
+        photos = [a for a in attachments if isinstance(a, dict)]
+        if photos:
+            lines.append(f"  Attachments: {len(photos)}")
+    return "\n".join(lines)
+
+
+def build_estimate_tools(service: AppFolioVendorService) -> list[Tool]:
+    """Return the AppFolio estimate tools."""
+
+    async def appfolio_get_estimate(estimate_id: str) -> ToolResult:
+        try:
+            payload = await service.get_estimate(estimate_id)
+        except Exception as exc:
+            return service_error_to_tool_result("fetching estimate", exc)
+        if not payload:
+            return ToolResult(
+                content=f"Estimate {estimate_id} not found.",
+                is_error=True,
+                error_kind=ToolErrorKind.NOT_FOUND,
+            )
+        return ToolResult(content=_fmt_estimate(payload))
+
+    async def appfolio_update_estimate(
+        estimate_id: str,
+        amount: float | None = None,
+        description: str = "",
+        notes: str = "",
+    ) -> ToolResult:
+        attributes: dict[str, Any] = {}
+        if amount is not None:
+            attributes["amount"] = amount
+        if description:
+            attributes["description"] = description
+        if notes:
+            attributes["notes"] = notes
+        if not attributes:
+            return ToolResult(
+                content="At least one of amount, description, or notes must be provided.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        try:
+            await service.update_estimate(estimate_id, attributes=attributes)
+        except Exception as exc:
+            return service_error_to_tool_result("updating estimate", exc)
+        return ToolResult(
+            content=f"Updated estimate {estimate_id}: {sorted(attributes.keys())}.",
+            receipt=ToolReceipt(
+                action="Updated AppFolio estimate",
+                target=f"estimate {estimate_id}",
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.APPFOLIO_GET_ESTIMATE,
+            description="Get an AppFolio estimate (with attachments).",
+            function=appfolio_get_estimate,
+            params_model=AppFolioGetEstimateParams,
+            usage_hint="Use when the user references a specific estimate by ID.",
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_UPDATE_ESTIMATE,
+            description="Update an AppFolio estimate's amount, description, or notes.",
+            function=appfolio_update_estimate,
+            params_model=AppFolioUpdateEstimateParams,
+            usage_hint=(
+                "Confirm the new amount with the user before submitting;"
+                " property managers see this estimate before approval."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Update AppFolio estimate {args.get('estimate_id', '?')}"
+                ),
+            ),
+        ),
+    ]

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -27,7 +27,10 @@ from backend.app.integrations.appfolio_vendor.auth import (
     load_credential,
 )
 from backend.app.integrations.appfolio_vendor.auth_tools import build_auth_tools
+from backend.app.integrations.appfolio_vendor.compliance import build_compliance_tools
 from backend.app.integrations.appfolio_vendor.conversations import build_conversation_tools
+from backend.app.integrations.appfolio_vendor.estimates import build_estimate_tools
+from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
 from backend.app.integrations.appfolio_vendor.notes import build_note_tools
 from backend.app.integrations.appfolio_vendor.payments import build_payment_tools
 from backend.app.integrations.appfolio_vendor.profile import build_profile_tools
@@ -65,6 +68,9 @@ async def _appfolio_factory(ctx: ToolContext) -> list[Tool]:
     tools.extend(build_conversation_tools(service))
     tools.extend(build_payment_tools(service))
     tools.extend(build_profile_tools(service))
+    tools.extend(build_invoice_tools(service, ctx))
+    tools.extend(build_compliance_tools(service, ctx))
+    tools.extend(build_estimate_tools(service))
     return tools
 
 
@@ -172,6 +178,36 @@ def _register() -> None:
             SubToolInfo(
                 ToolName.APPFOLIO_MESSAGE_TENANT,
                 "Send an SMS to the tenant on an AppFolio work order",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_CREATE_INVOICE,
+                "Build a line-itemized AppFolio invoice with optional photos",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UPLOAD_INVOICE_PDF,
+                "Upload a pre-built invoice PDF to AppFolio",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UPLOAD_COMPLIANCE_DOC,
+                "Upload a compliance document (W-9, COI, license)",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_GET_ESTIMATE,
+                "Get an AppFolio estimate's details",
+                default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UPDATE_ESTIMATE,
+                "Update an AppFolio estimate amount or description",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UPDATE_PROFILE,
+                "Update AppFolio profile fields (name, phone, company)",
                 default_permission="ask",
             ),
         ],

--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -1,0 +1,193 @@
+"""Invoice tools for AppFolio Vendor Portal.
+
+Two write paths share one endpoint:
+
+* ``appfolio_create_invoice`` — line-itemized invoice built inside the
+  portal. Supports inline photo attachments via ``media_refs``.
+* ``appfolio_upload_invoice_pdf`` — single invoice constructed from one
+  or more pre-built PDFs the user already has.
+
+Both bodies POST to ``/maintenance/api/invoices``; AppFolio
+disambiguates by the presence of ``lineItems`` vs ``files`` only.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.media_resolver import resolve_staged_files
+from backend.app.integrations.appfolio_vendor.params import (
+    AppFolioCreateInvoiceParams,
+    AppFolioInvoiceLineItem,
+    AppFolioUploadInvoicePdfParams,
+)
+from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+def _line_items_total(items: list[AppFolioInvoiceLineItem]) -> float:
+    return sum(item.quantity * item.rate for item in items)
+
+
+def _line_items_to_payload(items: list[AppFolioInvoiceLineItem]) -> list[dict[str, Any]]:
+    return [{"description": i.description, "quantity": i.quantity, "rate": i.rate} for i in items]
+
+
+def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[Tool]:
+    """Return the AppFolio invoice tools."""
+
+    async def appfolio_create_invoice(
+        customer_id: str,
+        work_order_id: str,
+        line_items: list[dict[str, Any]],
+        invoice_number: str = "",
+        due_date: str = "",
+        media_refs: list[str] | None = None,
+    ) -> ToolResult:
+        # Pydantic-coerce raw dicts the LLM emits into the typed shape.
+        try:
+            typed_items = [AppFolioInvoiceLineItem.model_validate(li) for li in line_items]
+        except Exception as exc:
+            return ToolResult(
+                content=f"Could not parse line items: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint=(
+                    "Each line item needs description (str), quantity (number), and rate (number)."
+                ),
+            )
+        if not typed_items:
+            return ToolResult(
+                content="At least one line item is required.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        files_or_err = await resolve_staged_files(ctx, media_refs or [])
+        if isinstance(files_or_err, ToolResult):
+            return files_or_err
+        files = files_or_err
+        try:
+            result = await service.create_invoice(
+                customer_id=customer_id,
+                work_order_id=work_order_id,
+                line_items=_line_items_to_payload(typed_items),
+                invoice_number=invoice_number,
+                due_date=due_date,
+                files=files or None,
+            )
+        except Exception as exc:
+            return service_error_to_tool_result("creating invoice", exc)
+
+        invoice_id = ""
+        if isinstance(result, dict):
+            invoice_id = str(result.get("id") or result.get("invoice", {}).get("id") or "")
+        total = _line_items_total(typed_items)
+        photo_phrase = f" with {len(files)} attachment(s)" if files else ""
+        return ToolResult(
+            content=(
+                f"Created invoice on work order {work_order_id} for ${total:.2f}"
+                f" ({len(typed_items)} line item(s)){photo_phrase}"
+                + (f" (invoice id {invoice_id})." if invoice_id else ".")
+            ),
+            receipt=ToolReceipt(
+                action="Created AppFolio invoice",
+                target=f"#{work_order_id} ${total:.2f}{photo_phrase}",
+            ),
+        )
+
+    async def appfolio_upload_invoice_pdf(
+        customer_id: str,
+        work_order_id: str,
+        media_refs: list[str],
+    ) -> ToolResult:
+        if not media_refs:
+            return ToolResult(
+                content="At least one PDF or photo reference is required.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        files_or_err = await resolve_staged_files(ctx, media_refs)
+        if isinstance(files_or_err, ToolResult):
+            return files_or_err
+        files = files_or_err
+        if not files:
+            return ToolResult(
+                content="No usable files resolved from the provided references.",
+                is_error=True,
+                error_kind=ToolErrorKind.NOT_FOUND,
+            )
+        try:
+            result = await service.upload_invoice_pdf(
+                customer_id=customer_id,
+                work_order_id=work_order_id,
+                files=files,
+            )
+        except Exception as exc:
+            return service_error_to_tool_result("uploading invoice", exc)
+
+        invoice_id = ""
+        if isinstance(result, dict):
+            invoice_id = str(result.get("id") or "")
+        return ToolResult(
+            content=(
+                f"Uploaded {len(files)} file(s) as an invoice on work order"
+                f" {work_order_id}" + (f" (invoice id {invoice_id})." if invoice_id else ".")
+            ),
+            receipt=ToolReceipt(
+                action="Uploaded AppFolio invoice",
+                target=f"#{work_order_id} ({len(files)} file)",
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.APPFOLIO_CREATE_INVOICE,
+            description=(
+                "Build a line-itemized invoice on an AppFolio work order"
+                " (with optional photo attachments)."
+            ),
+            function=appfolio_create_invoice,
+            params_model=AppFolioCreateInvoiceParams,
+            usage_hint=(
+                "Confirm each line item's description, quantity, and rate with"
+                " the user before submitting; this is a billing action."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Create invoice on AppFolio work order"
+                    f" #{args.get('work_order_id', '?')}"
+                    f" ({len(args.get('line_items') or [])} line item(s))"
+                ),
+            ),
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_UPLOAD_INVOICE_PDF,
+            description=(
+                "Upload one or more pre-built PDFs as an invoice on an AppFolio work order."
+            ),
+            function=appfolio_upload_invoice_pdf,
+            params_model=AppFolioUploadInvoicePdfParams,
+            usage_hint=(
+                "Use when the user has already prepared an invoice document."
+                " For line-item entry, use appfolio_create_invoice instead."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Upload invoice PDF to AppFolio work order"
+                    f" #{args.get('work_order_id', '?')}"
+                    f" ({len(args.get('media_refs') or [])} file)"
+                ),
+            ),
+        ),
+    ]

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -176,3 +176,102 @@ class AppFolioMessageTenantParams(BaseModel):
     message: str = Field(
         description="SMS body to send to the tenant via AppFolio's proxy.",
     )
+
+
+class AppFolioInvoiceLineItem(BaseModel):
+    description: str = Field(description="Line-item description (e.g. 'Labor: 4hr').")
+    quantity: float = Field(default=1.0, description="Quantity (decimal supported).")
+    rate: float = Field(description="Per-unit rate in dollars.")
+
+
+class AppFolioCreateInvoiceParams(BaseModel):
+    customer_id: str = Field(
+        description="AppFolio customer (property manager) ID for this invoice.",
+    )
+    work_order_id: str = Field(description="Work order ID this invoice bills against.")
+    line_items: list[AppFolioInvoiceLineItem] = Field(
+        description=(
+            "List of line items for the invoice. Each entry has description, quantity, and rate."
+        ),
+    )
+    invoice_number: str = Field(
+        default="",
+        description="Optional vendor-side invoice number to print on the document.",
+    )
+    due_date: str = Field(
+        default="",
+        description="Optional due date in ISO YYYY-MM-DD format.",
+    )
+    media_refs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional photo or document references from the conversation"
+            " to attach as supporting evidence (same shape as appfolio_add_note)."
+        ),
+    )
+
+
+class AppFolioUploadInvoicePdfParams(BaseModel):
+    customer_id: str = Field(
+        description="AppFolio customer (property manager) ID for this invoice.",
+    )
+    work_order_id: str = Field(description="Work order ID this invoice bills against.")
+    media_refs: list[str] = Field(
+        description=(
+            "Photo or PDF references from the conversation. Each entry is"
+            " an original_url or a media handle. AppFolio uploads them as"
+            " a single invoice document."
+        ),
+    )
+
+
+class AppFolioUploadComplianceDocParams(BaseModel):
+    customer_id: str = Field(
+        description="AppFolio customer (property manager) ID requesting the doc.",
+    )
+    compliance_type: str = Field(
+        description=(
+            "AppFolio compliance category. Common values: 'w9',"
+            " 'general_liability', 'workers_compensation', 'license'."
+            " Confirm with the user when uncertain."
+        ),
+    )
+    media_ref: str = Field(
+        description=(
+            "Single document reference from the conversation: an original_url"
+            " or a media handle. AppFolio expects exactly one file per upload."
+        ),
+    )
+
+
+class AppFolioGetEstimateParams(BaseModel):
+    estimate_id: str = Field(description="AppFolio estimate ID.")
+
+
+class AppFolioUpdateEstimateParams(BaseModel):
+    estimate_id: str = Field(description="AppFolio estimate ID to update.")
+    amount: float | None = Field(
+        default=None,
+        description="Updated total amount in dollars. Omit to leave unchanged.",
+    )
+    description: str = Field(
+        default="",
+        description="Updated estimate description. Empty leaves it unchanged.",
+    )
+    notes: str = Field(
+        default="",
+        description="Optional vendor notes for the property manager.",
+    )
+
+
+class AppFolioUpdateProfileParams(BaseModel):
+    first_name: str = Field(default="", description="New first name (empty to leave unchanged).")
+    last_name: str = Field(default="", description="New last name (empty to leave unchanged).")
+    phone_number: str = Field(
+        default="",
+        description="New phone number, E.164 preferred (empty to leave unchanged).",
+    )
+    company_name: str = Field(
+        default="",
+        description="New company name (empty to leave unchanged).",
+    )

--- a/backend/app/integrations/appfolio_vendor/profile.py
+++ b/backend/app/integrations/appfolio_vendor/profile.py
@@ -1,18 +1,19 @@
-"""Profile read tool for AppFolio Vendor Portal."""
+"""Profile read and update tools for AppFolio Vendor Portal."""
 
 from __future__ import annotations
 
 import logging
 from typing import Any
 
-from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
-from backend.app.integrations.appfolio_vendor.params import AppFolioGetProfileParams
-from backend.app.integrations.appfolio_vendor.service import (
-    AppFolioError,
-    AppFolioVendorService,
-    AuthExpiredError,
+from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.params import (
+    AppFolioGetProfileParams,
+    AppFolioUpdateProfileParams,
 )
+from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
 
 logger = logging.getLogger(__name__)
 
@@ -59,26 +60,8 @@ def build_profile_tools(service: AppFolioVendorService) -> list[Tool]:
     async def appfolio_get_profile() -> ToolResult:
         try:
             payload = await service.get_profile()
-        except AuthExpiredError:
-            return ToolResult(
-                content="AppFolio session expired while fetching profile.",
-                is_error=True,
-                error_kind=ToolErrorKind.AUTH,
-                hint=("Tell the user to request a fresh magic link and re-run appfolio_connect."),
-            )
-        except AppFolioError as exc:
-            return ToolResult(
-                content=f"AppFolio profile lookup failed: {exc}",
-                is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
-            )
         except Exception as exc:
-            logger.exception("AppFolio profile fetch unexpected failure")
-            return ToolResult(
-                content=f"Unexpected profile error: {exc}",
-                is_error=True,
-                error_kind=ToolErrorKind.INTERNAL,
-            )
+            return service_error_to_tool_result("fetching profile", exc)
 
         if not isinstance(payload, dict) or not payload:
             return ToolResult(
@@ -87,6 +70,45 @@ def build_profile_tools(service: AppFolioVendorService) -> list[Tool]:
                 error_kind=ToolErrorKind.NOT_FOUND,
             )
         return ToolResult(content=_fmt_profile(payload))
+
+    async def appfolio_update_profile(
+        first_name: str = "",
+        last_name: str = "",
+        phone_number: str = "",
+        company_name: str = "",
+    ) -> ToolResult:
+        if not (first_name or last_name or phone_number or company_name):
+            return ToolResult(
+                content="At least one profile field must be provided.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        try:
+            await service.update_profile(
+                first_name=first_name or None,
+                last_name=last_name or None,
+                phone_number=phone_number or None,
+                company_name=company_name or None,
+            )
+        except Exception as exc:
+            return service_error_to_tool_result("updating profile", exc)
+        changed = [
+            f
+            for f, v in [
+                ("first_name", first_name),
+                ("last_name", last_name),
+                ("phone_number", phone_number),
+                ("company_name", company_name),
+            ]
+            if v
+        ]
+        return ToolResult(
+            content=f"Updated AppFolio profile: {', '.join(changed)}.",
+            receipt=ToolReceipt(
+                action="Updated AppFolio profile",
+                target=", ".join(changed),
+            ),
+        )
 
     return [
         Tool(
@@ -99,6 +121,25 @@ def build_profile_tools(service: AppFolioVendorService) -> list[Tool]:
             usage_hint=(
                 "Use to confirm which AppFolio account is connected, or to"
                 " answer 'who am I logged in as'."
+            ),
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_UPDATE_PROFILE,
+            description="Update fields on the AppFolio vendor profile: name, phone, company.",
+            function=appfolio_update_profile,
+            params_model=AppFolioUpdateProfileParams,
+            usage_hint=(
+                "Pass only the fields the user wants changed; empty strings"
+                " leave that field as-is. Confirm changes with the user first."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    "Update AppFolio profile: "
+                    + ", ".join(
+                        f"{k}={v!r}" for k, v in (args or {}).items() if isinstance(v, str) and v
+                    )
+                ),
             ),
         ),
     ]

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -76,6 +76,62 @@ def _encode_files(files: list[FileUpload]) -> list[dict[str, str]]:
     ]
 
 
+_LOG_BODY_PREVIEW_LIMIT = 1500
+"""Cap on response/request body length surfaced in error logs and the
+:class:`AppFolioError` message. Long enough to capture a JSON validation
+error in full; short enough to keep individual log lines manageable."""
+
+
+def _summarize_body_for_log(body: Any) -> Any:
+    """Replace base64-encoded file payloads with size markers for log output.
+
+    AppFolio note/invoice bodies inline photo bytes as base64 strings,
+    which dwarf the rest of the JSON and bury the actual API contract
+    we're trying to debug. Replace each ``file_base64`` string with a
+    ``<base64 N bytes>`` marker; leave everything else intact.
+    """
+    if isinstance(body, dict):
+        return {k: _summarize_body_for_log(v) for k, v in body.items()}
+    if isinstance(body, list):
+        return [_summarize_body_for_log(v) for v in body]
+    if isinstance(body, str) and len(body) > 200:
+        return f"<{len(body)} char string>"
+    return body
+
+
+def _summarize_file_entry(entry: Any) -> Any:
+    """Replace a ``{file_base64, name}`` dict's payload with a size marker."""
+    if not isinstance(entry, dict):
+        return entry
+    summarized: dict[str, Any] = {}
+    for k, v in entry.items():
+        if k == "file_base64" and isinstance(v, str):
+            summarized[k] = f"<{len(v)} chars base64>"
+        else:
+            summarized[k] = v
+    return summarized
+
+
+def _summarize_files_field(body: Any) -> Any:
+    """Specialize the generic summarizer for AppFolio's file payload shapes.
+
+    Handles both the plural form (``files: [{file_base64, name}, ...]``,
+    used by notes and invoices) and the singular form (``file: {file_base64,
+    name}``, used by compliance uploads).
+    """
+    if not isinstance(body, dict):
+        return _summarize_body_for_log(body)
+    out: dict[str, Any] = {}
+    for k, v in body.items():
+        if k == "files" and isinstance(v, list):
+            out[k] = [_summarize_file_entry(e) for e in v]
+        elif k == "file" and isinstance(v, dict):
+            out[k] = _summarize_file_entry(v)
+        else:
+            out[k] = _summarize_body_for_log(v)
+    return out
+
+
 class AppFolioVendorService:
     """Async REST client bound to one user's credential.
 
@@ -127,23 +183,70 @@ class AppFolioVendorService:
         json_body: Any = None,
     ) -> Any:
         url = self._full_url(path)
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            resp = await client.request(
+        body_for_log = _summarize_files_field(json_body) if json_body is not None else None
+        logger.debug(
+            "AppFolio request: %s %s params=%r body=%r",
+            method,
+            path,
+            params,
+            body_for_log,
+        )
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.request(
+                    method,
+                    url,
+                    headers=self._headers(),
+                    params=params,
+                    json=json_body,
+                )
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "AppFolio %s %s network failure: %s | params=%r body=%r",
                 method,
-                url,
-                headers=self._headers(),
-                params=params,
-                json=json_body,
+                path,
+                exc,
+                params,
+                body_for_log,
             )
+            raise AppFolioError(f"AppFolio {method} {path} network failure: {exc}") from exc
+
         if resp.status_code == 401:
             login_url = ""
             with contextlib.suppress(Exception):
                 login_url = resp.json().get("login_url") or ""
+            logger.warning(
+                "AppFolio %s %s rejected the JWT (401) | login_url=%r"
+                " | params=%r body=%r response=%s",
+                method,
+                path,
+                login_url,
+                params,
+                body_for_log,
+                resp.text[:_LOG_BODY_PREVIEW_LIMIT],
+            )
             raise AuthExpiredError(login_url=login_url)
         if resp.status_code >= 400:
-            raise AppFolioError(
-                f"AppFolio {method} {path} failed: {resp.status_code} {resp.text[:300]}"
+            response_text = resp.text[:_LOG_BODY_PREVIEW_LIMIT]
+            logger.warning(
+                "AppFolio %s %s failed: status=%d | params=%r body=%r response=%s",
+                method,
+                path,
+                resp.status_code,
+                params,
+                body_for_log,
+                response_text,
             )
+            raise AppFolioError(
+                f"AppFolio {method} {path} failed: {resp.status_code} {response_text}"
+            )
+        logger.debug(
+            "AppFolio %s %s ok (%d, %d bytes)",
+            method,
+            path,
+            resp.status_code,
+            len(resp.content or b""),
+        )
         if not resp.content:
             return None
         ctype = resp.headers.get("content-type", "")
@@ -333,6 +436,152 @@ class AppFolioVendorService:
             },
         )
 
+    # ------------------------------------------------------------------
+    # Domain helpers (PR3: invoices, compliance, estimates, profile)
+    # ------------------------------------------------------------------
+
+    async def create_invoice(
+        self,
+        *,
+        customer_id: str,
+        work_order_id: str,
+        line_items: list[dict[str, Any]],
+        invoice_number: str = "",
+        due_date: str = "",
+        files: list[FileUpload] | None = None,
+    ) -> Any:
+        """Create a line-itemized invoice tied to a work order.
+
+        ``line_items`` should be a list of ``{description, quantity, rate}``
+        entries (or whichever shape AppFolio's UI emits — confirmed
+        post-smoke-test). Optional ``files`` attach photos or supporting
+        docs inline as base64. ``invoice_number`` and ``due_date``
+        (ISO YYYY-MM-DD) are passed through when present.
+        """
+        body: dict[str, Any] = {
+            "customerId": customer_id,
+            "workOrderId": work_order_id,
+            "lineItems": line_items,
+        }
+        if invoice_number:
+            body["invoiceNumber"] = invoice_number
+        if due_date:
+            body["dueDate"] = due_date
+        if files:
+            body["files"] = _encode_files(files)
+        return await self.post("/maintenance/api/invoices", json_body=body)
+
+    async def upload_invoice_pdf(
+        self,
+        *,
+        customer_id: str,
+        work_order_id: str,
+        files: list[FileUpload],
+    ) -> Any:
+        """Upload one or more pre-built invoice PDFs as a single AppFolio invoice.
+
+        AppFolio reuses the ``/maintenance/api/invoices`` endpoint for
+        both shapes; the absence of ``lineItems`` plus presence of
+        ``files`` switches it to the "uploaded PDF" mode.
+        """
+        if not files:
+            raise ValueError("upload_invoice_pdf requires at least one file")
+        return await self.post(
+            "/maintenance/api/invoices",
+            json_body={
+                "customerId": customer_id,
+                "workOrderId": work_order_id,
+                "files": _encode_files(files),
+            },
+        )
+
+    async def upload_compliance_document(
+        self,
+        *,
+        customer_id: str,
+        compliance_type: str,
+        file: FileUpload,
+    ) -> Any:
+        """Upload a compliance doc (W-9, COI, license) for one customer.
+
+        Note the singular ``file`` field; AppFolio's compliance endpoint
+        does not take an array.
+        """
+        return await self.post(
+            "/maintenance/api/compliance_documents",
+            json_body={
+                "customerId": customer_id,
+                "complianceType": compliance_type,
+                "file": {
+                    "name": file.name,
+                    "file_base64": base64.b64encode(file.data).decode("ascii"),
+                },
+            },
+        )
+
+    async def get_estimate(self, estimate_id: str) -> Any:
+        return await self.get(
+            f"/api/estimates/{estimate_id}",
+            params={"include": "attachments"},
+        )
+
+    async def update_estimate(
+        self,
+        estimate_id: str,
+        *,
+        attributes: dict[str, Any],
+    ) -> Any:
+        """PATCH an estimate's attributes via JSON:API envelope.
+
+        The frontend wraps the payload as ``{data: {id, type: "estimates",
+        attributes: ...}}``. We mirror that shape; the agent supplies just
+        the attributes dict.
+        """
+        return await self.patch(
+            f"/api/estimates/{estimate_id}",
+            json_body={
+                "data": {
+                    "id": estimate_id,
+                    "type": "estimates",
+                    "attributes": attributes,
+                }
+            },
+        )
+
+    async def update_profile(
+        self,
+        *,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        phone_number: str | None = None,
+        company_name: str | None = None,
+    ) -> Any:
+        """PATCH /profiles with whatever subset of fields the user wants changed.
+
+        Mirror the SPA shape (``user: {...}, company: {...}``) but only
+        include each sub-object when at least one of its fields is set,
+        so we don't send empty objects that AppFolio could read as
+        "clear these values".
+        """
+        user: dict[str, Any] = {}
+        if first_name is not None:
+            user["firstName"] = first_name
+        if last_name is not None:
+            user["lastName"] = last_name
+        if phone_number is not None:
+            user["phoneNumber"] = phone_number
+        company: dict[str, Any] = {}
+        if company_name is not None:
+            company["name"] = company_name
+        body: dict[str, Any] = {}
+        if user:
+            body["user"] = user
+        if company:
+            body["company"] = company
+        if not body:
+            raise ValueError("update_profile requires at least one field to change")
+        return await self.patch("/profiles", json_body=body)
+
 
 def build_service(
     credential: AppFolioCredential,
@@ -390,17 +639,29 @@ async def exchange_magic_link(
         "X-Vendor-Portal-Web-Client": _CLIENT_VERSION,
         "Authorization": f"Bearer {magic_link_token}",
     }
-    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
-        resp = await client.post(
-            url,
-            headers=headers,
-            params={"magic_link_token": magic_link_token},
-            json=body,
-        )
+    logger.debug("AppFolio /access exchange starting (token redacted)")
+    try:
+        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+            resp = await client.post(
+                url,
+                headers=headers,
+                params={"magic_link_token": magic_link_token},
+                json=body,
+            )
+    except httpx.HTTPError as exc:
+        logger.warning("AppFolio /access network failure: %s", exc)
+        raise AppFolioError(f"AppFolio /access network failure: {exc}") from exc
     if resp.status_code >= 400:
-        raise AppFolioError(
-            f"AppFolio /access exchange failed: {resp.status_code} {resp.text[:300]}"
+        response_text = resp.text[:_LOG_BODY_PREVIEW_LIMIT]
+        # nfo is the only loggable body field — fingerprint and the magic
+        # link token are credential material.
+        logger.warning(
+            "AppFolio /access exchange failed: status=%d nfo=%r response=%s",
+            resp.status_code,
+            (body.get("nfo") if isinstance(body, dict) else None),
+            response_text,
         )
+        raise AppFolioError(f"AppFolio /access exchange failed: {resp.status_code} {response_text}")
     payload: dict[str, Any] = resp.json() if resp.content else {}
     jwt = (
         payload.get("access_token")
@@ -452,10 +713,21 @@ async def submit_two_factor(
         "Authorization": f"Bearer {jwt}",
     }
     body = {"twoFactorToken": {"twoFactorToken": code}}
-    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
-        resp = await client.post(url, headers=headers, json=body)
+    logger.debug("AppFolio 2FA onboard starting (code redacted)")
+    try:
+        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+            resp = await client.post(url, headers=headers, json=body)
+    except httpx.HTTPError as exc:
+        logger.warning("AppFolio 2FA onboard network failure: %s", exc)
+        raise AppFolioError(f"AppFolio 2FA network failure: {exc}") from exc
     if resp.status_code >= 400:
-        raise AppFolioError(f"AppFolio 2FA onboard failed: {resp.status_code} {resp.text[:300]}")
+        response_text = resp.text[:_LOG_BODY_PREVIEW_LIMIT]
+        logger.warning(
+            "AppFolio 2FA onboard failed: status=%d response=%s",
+            resp.status_code,
+            response_text,
+        )
+        raise AppFolioError(f"AppFolio 2FA onboard failed: {resp.status_code} {response_text}")
     return resp.json() if resp.content else {}
 
 

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -164,13 +164,14 @@ def _mock_response(
     json_data: Any = None,
     status_code: int = 200,
     headers: dict[str, str] | None = None,
+    text: str = "stub error body",
 ) -> httpx.Response:
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = status_code
     resp.headers = headers or {"content-type": "application/json"}
     resp.content = b"{}" if json_data is None else b'{"x": 1}'
     resp.json.return_value = json_data if json_data is not None else {}
-    resp.text = "stub error body"
+    resp.text = text
     return resp
 
 
@@ -655,3 +656,311 @@ async def test_resolve_staged_files_empty_list_returns_empty_list() -> None:
     ctx.user.id = "u1"
     result = await resolve_staged_files(ctx, [])
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# PR3: invoices, compliance, estimates, profile update
+# ---------------------------------------------------------------------------
+
+
+def _patch_request(response: httpx.Response) -> Any:
+    client = AsyncMock()
+    client.request = AsyncMock(return_value=response)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm, client
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_serializes_line_items() -> None:
+    from backend.app.integrations.appfolio_vendor.service import FileUpload
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={"id": "inv-1"})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        cm, client = _patch_request(response)
+        cls.return_value = cm
+        await service.create_invoice(
+            customer_id="cust-1",
+            work_order_id="wo-1",
+            line_items=[
+                {"description": "Labor 4hr", "quantity": 4.0, "rate": 75.0},
+                {"description": "Materials", "quantity": 1.0, "rate": 120.0},
+            ],
+            invoice_number="INV-001",
+            due_date="2026-06-01",
+            files=[FileUpload(name="receipt.pdf", data=b"%PDF-fake")],
+        )
+    args, kwargs = client.request.call_args
+    assert args[0] == "POST"
+    payload = kwargs["json"]
+    assert payload["customerId"] == "cust-1"
+    assert payload["workOrderId"] == "wo-1"
+    assert payload["lineItems"][0]["description"] == "Labor 4hr"
+    assert payload["invoiceNumber"] == "INV-001"
+    assert payload["dueDate"] == "2026-06-01"
+    assert len(payload["files"]) == 1
+
+
+@pytest.mark.asyncio()
+async def test_upload_invoice_pdf_omits_line_items() -> None:
+    from backend.app.integrations.appfolio_vendor.service import FileUpload
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        cm, client = _patch_request(response)
+        cls.return_value = cm
+        await service.upload_invoice_pdf(
+            customer_id="cust-1",
+            work_order_id="wo-1",
+            files=[FileUpload(name="invoice.pdf", data=b"%PDF-fake")],
+        )
+    _, kwargs = client.request.call_args
+    payload = kwargs["json"]
+    assert "lineItems" not in payload
+    assert payload["customerId"] == "cust-1"
+    assert payload["workOrderId"] == "wo-1"
+    assert len(payload["files"]) == 1
+
+
+@pytest.mark.asyncio()
+async def test_upload_compliance_document_uses_singular_file() -> None:
+    from backend.app.integrations.appfolio_vendor.service import FileUpload
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        cm, client = _patch_request(response)
+        cls.return_value = cm
+        await service.upload_compliance_document(
+            customer_id="cust-1",
+            compliance_type="w9",
+            file=FileUpload(name="w9.pdf", data=b"%PDF-fake"),
+        )
+    _, kwargs = client.request.call_args
+    payload = kwargs["json"]
+    assert payload["customerId"] == "cust-1"
+    assert payload["complianceType"] == "w9"
+    assert isinstance(payload["file"], dict)
+    assert payload["file"]["name"] == "w9.pdf"
+    assert "files" not in payload
+
+
+@pytest.mark.asyncio()
+async def test_update_estimate_wraps_jsonapi_envelope() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        cm, client = _patch_request(response)
+        cls.return_value = cm
+        await service.update_estimate("est-7", attributes={"amount": 250.0})
+    args, kwargs = client.request.call_args
+    assert args[0] == "PATCH"
+    assert "/api/estimates/est-7" in args[1]
+    assert kwargs["json"] == {
+        "data": {"id": "est-7", "type": "estimates", "attributes": {"amount": 250.0}}
+    }
+
+
+@pytest.mark.asyncio()
+async def test_update_profile_includes_only_set_fields() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        cm, client = _patch_request(response)
+        cls.return_value = cm
+        await service.update_profile(phone_number="+15551234567")
+    _, kwargs = client.request.call_args
+    assert kwargs["json"] == {"user": {"phoneNumber": "+15551234567"}}
+
+
+@pytest.mark.asyncio()
+async def test_update_profile_rejects_empty_payload() -> None:
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    with pytest.raises(ValueError, match="at least one field"):
+        await service.update_profile()
+
+
+# ---------------------------------------------------------------------------
+# Tool-level validation paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_tool_rejects_empty_line_items() -> None:
+    """The tool should validate before any HTTP call."""
+    from backend.app.agent.tools.base import ToolErrorKind
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    tools = build_invoice_tools(service, ctx)
+    create = next(t for t in tools if t.name == "appfolio_create_invoice")
+    result = await create.function(customer_id="cust-1", work_order_id="wo-1", line_items=[])
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_tool_rejects_malformed_line_item() -> None:
+    """Per-item Pydantic errors surface as a validation ToolResult, not an exception."""
+    from backend.app.agent.tools.base import ToolErrorKind
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    tools = build_invoice_tools(service, ctx)
+    create = next(t for t in tools if t.name == "appfolio_create_invoice")
+    # Missing rate; quantity wrong type.
+    result = await create.function(
+        customer_id="cust-1",
+        work_order_id="wo-1",
+        line_items=[{"description": "labor", "quantity": "two"}],
+    )
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.VALIDATION
+
+
+# ---------------------------------------------------------------------------
+# Logging diagnostics — failure paths surface enough info to debug
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_4xx_failure_logs_request_body_and_response(caplog: Any) -> None:
+    import logging
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(
+        json_data={"errors": ["scheduledAt: must be in the future"]},
+        status_code=422,
+        text='{"errors":["scheduledAt: must be in the future"]}',
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="backend.app.integrations.appfolio_vendor.service"),
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+    ):
+        cm, _ = _patch_request(response)
+        cls.return_value = cm
+        with pytest.raises(AppFolioError) as exc_info:
+            await service.schedule_work_order("42", scheduled_at="2024-01-01T00:00:00")
+
+    # ToolResult-side message includes status + response body.
+    assert "422" in str(exc_info.value)
+    assert "scheduledAt" in str(exc_info.value)
+
+    # Log line includes everything a dev needs to diagnose.
+    record_text = "\n".join(r.message for r in caplog.records)
+    assert "POST" in record_text
+    assert "/maintenance/api/work_orders/42/schedule" in record_text
+    assert "scheduledAt" in record_text  # request body logged
+    assert "422" in record_text
+
+
+@pytest.mark.asyncio()
+async def test_4xx_log_summarizes_base64_files(caplog: Any) -> None:
+    import logging
+
+    from backend.app.integrations.appfolio_vendor.service import FileUpload
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    big_blob = b"\x00" * 250_000  # large payload
+    response = _mock_response(
+        json_data={"errors": ["bad"]},
+        status_code=400,
+        text='{"errors":["bad"]}',
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="backend.app.integrations.appfolio_vendor.service"),
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+    ):
+        cm, _ = _patch_request(response)
+        cls.return_value = cm
+        with pytest.raises(AppFolioError):
+            await service.add_work_order_note(
+                "42", body_text="here", files=[FileUpload(name="big.jpg", data=big_blob)]
+            )
+
+    # The base64 content of the photo should NOT appear in logs.
+    encoded = __import__("base64").b64encode(big_blob).decode()
+    assert encoded not in caplog.text
+    # But the file name and a length marker should.
+    assert "big.jpg" in caplog.text
+    assert "chars base64" in caplog.text  # marker token
+
+
+@pytest.mark.asyncio()
+async def test_4xx_log_summarizes_singular_file_compliance_upload(caplog: Any) -> None:
+    """Compliance uploads use singular ``file: {...}``; the marker still applies."""
+    import logging
+
+    from backend.app.integrations.appfolio_vendor.service import FileUpload
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    big_blob = b"\x00" * 250_000
+    response = _mock_response(
+        json_data={"errors": ["bad"]},
+        status_code=400,
+        text='{"errors":["bad"]}',
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="backend.app.integrations.appfolio_vendor.service"),
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+    ):
+        cm, _ = _patch_request(response)
+        cls.return_value = cm
+        with pytest.raises(AppFolioError):
+            await service.upload_compliance_document(
+                customer_id="cust-1",
+                compliance_type="w9",
+                file=FileUpload(name="w9.pdf", data=big_blob),
+            )
+
+    encoded = __import__("base64").b64encode(big_blob).decode()
+    assert encoded not in caplog.text
+    assert "w9.pdf" in caplog.text
+    assert "chars base64" in caplog.text
+
+
+@pytest.mark.asyncio()
+async def test_access_failure_does_not_log_magic_link(caplog: Any) -> None:
+    import logging
+
+    response = _mock_response(
+        json_data={"error": "expired"},
+        status_code=400,
+        text='{"error":"expired"}',
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="backend.app.integrations.appfolio_vendor.service"),
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+    ):
+        cls.return_value = _patch_async_client("post", response)
+        with pytest.raises(AppFolioError):
+            from backend.app.integrations.appfolio_vendor.service import (
+                exchange_magic_link,
+            )
+
+            await exchange_magic_link(
+                api_base="https://api.test",
+                magic_link_token="SUPER_SECRET_TOKEN",
+                fingerprint="FP_SECRET",
+            )
+
+    assert "SUPER_SECRET_TOKEN" not in caplog.text
+    assert "FP_SECRET" not in caplog.text
+    # Status and response body should still be in the log so we can debug.
+    assert "400" in caplog.text
+    assert "expired" in caplog.text


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Closes the AppFolio integration's write surface and adds the diagnostic logging Nathan asked for so we can debug API-shape mismatches against a real account.

**Stacks on #1249.** Set base to that PR; once #1249 merges, GitHub will auto-retarget this to `main`.

## Description

7 new tools (defaults shown):

* `appfolio_create_invoice` (ask) — line-itemized, optional photo attachments
* `appfolio_upload_invoice_pdf` (ask) — pre-built PDF invoice upload
* `appfolio_upload_compliance_doc` (ask) — W-9, COI, license, etc.
* `appfolio_get_estimate` (always)
* `appfolio_update_estimate` (ask) — JSON:API envelope
* `appfolio_update_profile` (ask) — name, phone, company

### Diagnostic logging

`service._request()` and the module-level auth functions now produce structured log lines aimed at the case where a real-account API call fails because we got the request shape wrong. Per failure we log:

* HTTP method, path, params
* The full request body (with base64 file payloads collapsed to `<N chars base64>` markers so logs stay readable)
* Up to 1500 chars of the response body (long enough to capture a full Rails-style validation error)
* Status code

Magic-link tokens, fingerprints, and 2FA codes are redacted from the auth-side logs but the status code and response body are preserved so we can still diagnose those failures.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass — 2400 passed, 1 skipped
- [x] Lint passes
- [x] Type checking passes
- [x] New tests added for new functionality (9 new tests)
- [x] Bug fixes include regression tests (n/a)

## AI Usage
- [x] AI-assisted: Claude Opus 4.7 implemented the write surface + logging via pair work with @njbrake.
- [ ] No AI used

## Notes for reviewers

* AppFolio reuses `/maintenance/api/invoices` for both the line-item and PDF-upload paths; the body shape distinguishes them. No second endpoint.
* `update_estimate` uses the JSON:API envelope (`{data: {id, type, attributes}}`) confirmed in the SPA bundle.
* Profile update body is the most likely thing to need adjustment after smoke testing — the SPA shape (`{user: {firstName, lastName, phoneNumber}, company: {name}}`) was inferred from a fragmentary call site. The new logging will show us exactly what shape AppFolio rejects if we got it wrong.