### PR TITLE
chore: scrub stale dropbox references from docs and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,7 @@ uv run pytest -v
 |------|------------------|
 | Telegram | Telegram Bot API calls |
 | LLM | any-llm `acompletion` calls |
-| Dropbox/Drive | Cloud storage operations |
-| Storage | `MockStorageBackend` for file operations |
+| Storage | `MockStorageBackend` for Google Drive operations |
 
 **Auth override:** The `get_current_user` dependency is overridden in tests to return a fixed test user, bypassing authentication.
 

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -223,7 +223,7 @@ def create_file_tools(
 
     Args:
         user: The user
-        storage: Storage backend (Dropbox, Google Drive, or mock)
+        storage: Storage backend (Google Drive or mock)
         pending_media: Dict of original_url -> file bytes available for upload.
             Includes bytes from the current message and any recent staged
             media bytes from prior turns (populated by ``_file_factory``).

--- a/frontend/src/docs-content/features/file-cataloging.md
+++ b/frontend/src/docs-content/features/file-cataloging.md
@@ -1,37 +1,52 @@
 # File Cataloging
 
-Clawbolt can automatically catalog job photos and documents to a cloud storage backend. Files are organized by client and type.
+Clawbolt can automatically catalog job photos and documents to **your own Google Drive**. Files are organized by client and type, under a top-level `Clawbolt` folder in your Drive.
 
-## Supported storage providers
+## How storage is enabled
 
-| Provider | Setup |
-|----------|-------|
-| **Local** | Works out of the box. Files saved to `data/storage/` on disk |
-| **Dropbox** | Requires API credentials. See [Storage Providers](https://github.com/mozilla-ai/clawbolt/blob/main/docs/self-host/storage.md) |
-| **Google Drive** | Requires OAuth credentials. See [Storage Providers](https://github.com/mozilla-ai/clawbolt/blob/main/docs/self-host/storage.md) |
+File storage is per-user and opt-in. To turn it on, ask the assistant to connect Drive (or use the integrations panel). The OAuth flow grants the `drive.file` scope, which means Clawbolt only sees files it created itself, not the rest of your Drive.
+
+Until you connect Drive, the file tools (`upload_to_storage`, `find_saved_files`, etc.) stay disabled. Other integrations like CompanyCam continue to work without Drive.
 
 ## File organization
 
-Files are organized into folders by type:
+Files land under your Drive's `Clawbolt` folder, organized by client and type:
 
 ```
-Job Photos/
-├── 2026-02-28/
-│   ├── site-front.jpg
-│   └── site-back.jpg
-└── 2026-03-01/
-    └── kitchen-demo.jpg
+Clawbolt/
+├── John Smith - 116 Virginia Ave/
+│   ├── photos/
+│   │   ├── kitchen-before_001.jpg
+│   │   └── kitchen-after_002.jpg
+│   ├── estimates/
+│   │   └── kitchen-remodel_001.pdf
+│   └── documents/
+│       └── signed-contract_001.pdf
+└── Unsorted/
+    └── 2026-02-28/
+        └── site-photo_001.jpg
 ```
+
+Files without a known client land under `Unsorted/<date>/` so nothing is lost when context is missing. The agent can move them later via `organize_file`.
 
 ## How it works
 
-When you send media, the agent uses the `upload_to_storage` and `organize_file` tools to:
+When you send media, the agent uses these tools:
 
-1. Upload the file to your configured storage backend
-2. Organize it into the appropriate folder structure
-3. Generate a shareable link (for Dropbox/Google Drive)
-4. Store the storage URL in the user's media manifest for future reference
+1. `upload_to_storage` uploads the file into the appropriate folder in your Drive.
+2. `organize_file` moves files between folders (e.g., out of `Unsorted/` into the right client folder).
+3. `find_saved_files` searches your saved files by client, filename, or saved description.
+4. `analyze_saved_file` runs vision analysis on a previously saved image without asking you to resend it.
 
-## Configuration
+Each upload is recorded in Clawbolt's media manifest with a stable id (`media-NNN`) so the agent can reference it across turns.
 
-Set the `STORAGE_PROVIDER` environment variable to choose your backend. See [Storage Providers](https://github.com/mozilla-ai/clawbolt/blob/main/docs/self-host/storage.md) for detailed setup instructions for each provider.
+## Operator setup (self-hosted only)
+
+If you're self-hosting Clawbolt, the operator must register an OAuth client and set:
+
+```
+GOOGLE_DRIVE_CLIENT_ID=...apps.googleusercontent.com
+GOOGLE_DRIVE_CLIENT_SECRET=...
+```
+
+See [Storage Providers](https://github.com/mozilla-ai/clawbolt/blob/main/docs/self-host/storage.md) for the full setup walkthrough.

--- a/frontend/src/docs-content/guide/photos.md
+++ b/frontend/src/docs-content/guide/photos.md
@@ -19,7 +19,7 @@ Great for before/after documentation, damage records, material identification, a
 
 ## Where photos are stored
 
-With cloud storage connected (Dropbox or Google Drive), photos are organized into folders by date:
+Once you connect Google Drive (via the integrations panel), photos are organized into folders by date inside your own Drive under a top-level Clawbolt folder:
 
 ```
 Job Photos/

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1807,7 +1807,7 @@ async def test_error_kind_service_produces_specific_hint(
 
     async def failing_service(**kwargs: object) -> ToolResult:
         return ToolResult(
-            content="Error: Dropbox API unavailable",
+            content="Error: Storage API unavailable",
             is_error=True,
             error_kind=ToolErrorKind.SERVICE,
         )


### PR DESCRIPTION
## Description

Follow-up cleanup to PR #1251 (per-user Drive storage). PR #1251 removed Dropbox as a runtime backend, but a few doc and comment references still mentioned it. This PR scrubs them so the codebase reads consistently with the per-user-Drive model.

### What changed

| File | Change |
|------|--------|
| `backend/app/agent/tools/file_tools.py` | Docstring no longer lists Dropbox as a supported backend |
| `tests/test_agent.py` | Rename generic SERVICE-error fixture string from "Dropbox API unavailable" to "Storage API unavailable" |
| `CONTRIBUTING.md` | Drop the Dropbox/Drive mock row from the test-mocks table; collapse to one MockStorageBackend row |
| `frontend/src/docs-content/guide/photos.md` | Replace the "Dropbox or Google Drive" framing with a per-user Drive connection note |
| `frontend/src/docs-content/features/file-cataloging.md` | Full rewrite to match the per-user OAuth model (no `STORAGE_PROVIDER`, no Local/Dropbox options, files land under `Clawbolt/` in the user's own Drive) |

The intentional reference to `DROPBOX_ACCESS_TOKEN` in the `log_config_warnings` deprecation loop stays so upgraders still see a warning when they boot with the old env var set.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest tests/test_agent.py -v` -- 86 passed)
- [x] Lint passes (`uv run ruff check backend/ tests/ alembic/`)
- [x] Type checking passes (`uv run ty check --python .venv backend/ tests/ alembic/`)
- [x] Frontend builds and typechecks (`npm run build`, `tsc --noEmit`)
- [x] No new functionality (pure doc/comment cleanup)

## AI Usage
- [x] AI-assisted (describe how)
  - Drafted by Claude (Opus 4.7) via back-and-forth with @njbrake after they asked for a final sweep of leftover dropbox references following the per-user Drive migration.
- [ ] No AI used