### PR TITLE
fix(integrations): make AppFolio reachable from manage_integration

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -436,9 +436,21 @@ class ApprovalGate:
             timeout = float(settings.approval_timeout_seconds)
 
         pending = PendingApproval(tool_name=tool_name, description=description)
-        self._pending[user_id] = pending
-        await _persist_pending_row(user_id, tool_name, description, channel, chat_id)
+        # Persist the audit row + orphan-detection row BEFORE registering
+        # in ``_pending``. ``resolve()`` consults ``_pending`` and bails
+        # when the entry is absent, so a concurrent ``resolve`` (e.g. the
+        # ``_interrupt_stale_approval`` poll in ingestion that fires
+        # ``INTERRUPTED`` when a second message arrives for the same user)
+        # cannot run until both writes are committed. Without this
+        # ordering, the await on either DB call yields the event loop,
+        # the poll task fires, ``resolve`` inserts the ``decided`` row,
+        # and the still-pending ``requested`` insert lands afterward,
+        # giving an out-of-order audit log (and a possibly orphaned
+        # ``pending_approvals`` row when the DELETE in resolve sees no
+        # row under READ COMMITTED).
         await _log_approval_event(user_id, "requested", tool_name, description, channel, chat_id)
+        await _persist_pending_row(user_id, tool_name, description, channel, chat_id)
+        self._pending[user_id] = pending
 
         if prompt is None:
             prompt = format_approval_message(tool_name, description)

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from backend.app.agent.stores import ToolConfigStore
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor import auth as appfolio_auth
 from backend.app.services.oauth import get_oauth_config, list_oauth_integrations, oauth_service
 
 if TYPE_CHECKING:
@@ -34,6 +35,7 @@ _DISPLAY_NAMES: dict[str, str] = {
     "calendar": "Google Calendar",
     "companycam": "CompanyCam",
     "supplier_pricing": "Home Depot pricing",
+    "appfolio_vendor": "AppFolio Vendor Portal",
 }
 
 # Map tool group names to their OAuth integration names.
@@ -43,6 +45,12 @@ _TOOL_OAUTH_MAP: dict[str, str] = {
     "companycam": "companycam",
     "file": "google_drive",
 }
+
+# Tool groups that use magic-link / paste-token auth instead of OAuth. These
+# do not show up in ``list_oauth_integrations()`` but should still be
+# manageable through ``manage_integration`` so the agent has a single
+# discovery surface for "connect <integration>".
+_MAGIC_LINK_INTEGRATIONS: set[str] = {"appfolio_vendor"}
 
 
 class ManageIntegrationParams(BaseModel):
@@ -123,6 +131,8 @@ def create_integration_tools(ctx: ToolContext) -> list[Tool]:
                 "Call with action='connect' and target='google_calendar', "
                 "'google_drive', or 'quickbooks' to generate an OAuth link "
                 "the user can tap to connect. "
+                "For 'appfolio_vendor' you'll get magic-link instructions instead "
+                "of a URL; follow them and then call appfolio_connect directly. "
                 "Call with action='enable'/'disable' and target=group_name to toggle tools."
             ),
             # Enable/disable and connect/disconnect mutate the per-user
@@ -166,6 +176,9 @@ async def _handle_status(
                     status_parts.append("connected" if connected else "not connected")
                 else:
                     status_parts.append("not configured by admin")
+            elif name in _MAGIC_LINK_INTEGRATIONS:
+                connected = await _is_magic_link_connected(name, user_id)
+                status_parts.append("connected" if connected else "not connected")
 
             integration_lines.append(f"- {name}: {display} ({', '.join(status_parts)})")
 
@@ -259,6 +272,11 @@ async def _handle_disable(
 
 async def _handle_connect(user_id: str, target: str) -> ToolResult:
     """Generate an OAuth authorization URL for an integration."""
+    # Magic-link integrations have their own connect flow (paste-a-token)
+    # and don't fit the OAuth URL model.
+    if target in _MAGIC_LINK_INTEGRATIONS:
+        return await _handle_magic_link_connect(user_id, target)
+
     # Check if target is a tool group name that maps to an OAuth integration
     oauth_name = _TOOL_OAUTH_MAP.get(target, target)
 
@@ -304,6 +322,9 @@ async def _handle_connect(user_id: str, target: str) -> ToolResult:
 
 async def _handle_disconnect(user_id: str, target: str) -> ToolResult:
     """Remove OAuth tokens for an integration."""
+    if target in _MAGIC_LINK_INTEGRATIONS:
+        return await _handle_magic_link_disconnect(user_id, target)
+
     oauth_name = _TOOL_OAUTH_MAP.get(target, target)
 
     if oauth_name not in list_oauth_integrations():
@@ -332,6 +353,82 @@ async def _handle_disconnect(user_id: str, target: str) -> ToolResult:
             f"Disconnected {display}. "
             "The tools are still enabled but won't work until you reconnect."
         ),
+    )
+
+
+async def _is_magic_link_connected(target: str, user_id: str) -> bool:
+    """Dispatch ``is_connected`` lookup for magic-link integrations."""
+    if target == "appfolio_vendor":
+        return await appfolio_auth.is_connected(user_id)
+    return False
+
+
+async def _handle_magic_link_connect(user_id: str, target: str) -> ToolResult:
+    """Return paste-token instructions for a magic-link integration.
+
+    These integrations cannot be connected with a single URL: the user
+    has to request a magic link from the vendor's web UI and paste it
+    back. We return that recipe so the agent can guide the user, then
+    rely on the integration's own auth tool (e.g. ``appfolio_connect``)
+    to finish the flow.
+    """
+    if target == "appfolio_vendor":
+        if await appfolio_auth.is_connected(user_id):
+            return ToolResult(
+                content=(
+                    "AppFolio Vendor Portal is already connected. "
+                    "Use action='disconnect' first to reconnect."
+                ),
+            )
+        logger.info(
+            "User %s requested magic-link connect instructions for '%s' via chat",
+            user_id,
+            target,
+        )
+        return ToolResult(
+            content=(
+                "AppFolio Vendor Portal uses magic-link auth (no OAuth URL). "
+                "Walk the user through these steps: "
+                "(1) open vendor.appfolio.com on their phone or laptop, "
+                "(2) enter their email and request a sign-in link, "
+                "(3) when the email arrives, copy the full link and paste "
+                "it back to you. Then call appfolio_connect with the "
+                "pasted text. If AppFolio asks for a 2FA code, ask the "
+                "user for it and call appfolio_complete_2fa."
+            ),
+        )
+    return ToolResult(
+        content=f"No magic-link connect flow registered for '{target}'.",
+        is_error=True,
+        error_kind=ToolErrorKind.VALIDATION,
+    )
+
+
+async def _handle_magic_link_disconnect(user_id: str, target: str) -> ToolResult:
+    """Clear stored credentials for a magic-link integration."""
+    if target == "appfolio_vendor":
+        if not await appfolio_auth.is_connected(user_id):
+            return ToolResult(
+                content="AppFolio Vendor Portal is not currently connected.",
+                is_error=True,
+                error_kind=ToolErrorKind.NOT_FOUND,
+            )
+        await appfolio_auth.clear_credential(user_id)
+        logger.info(
+            "User %s disconnected magic-link integration '%s' via chat",
+            user_id,
+            target,
+        )
+        return ToolResult(
+            content=(
+                "Disconnected AppFolio Vendor Portal. "
+                "The tools are still enabled but won't work until you reconnect."
+            ),
+        )
+    return ToolResult(
+        content=f"No magic-link disconnect flow registered for '{target}'.",
+        is_error=True,
+        error_kind=ToolErrorKind.VALIDATION,
     )
 
 

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -6,10 +6,13 @@ default tool registry at module-import time.
 
 Two registration concerns:
 
-1. The auth tools (``appfolio_connect``, ``appfolio_complete_2fa``) need
-   to be available *before* the user has a credential, so they are
-   surfaced via ``auth_check`` returning a connect prompt rather than
-   an empty tool list.
+1. The auth tools (``appfolio_connect``, ``appfolio_complete_2fa``) must
+   stay on the LLM schema even when the user has no credential, so the
+   factory always returns them and ``auth_check`` returns ``None``
+   unconditionally. The registry's ``auth_check`` contract is binary:
+   any non-None return value strips the entire factory's tools from
+   the schema, which would also hide the connect tool, leaving the
+   user with no in-product way to authenticate.
 2. The data tools (work orders, payments, profile) require a loaded
    credential and so live in the factory body, hidden until connected.
 """
@@ -22,10 +25,7 @@ from typing import TYPE_CHECKING
 from backend.app.agent.tools.base import Tool
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
-from backend.app.integrations.appfolio_vendor.auth import (
-    is_connected,
-    load_credential,
-)
+from backend.app.integrations.appfolio_vendor.auth import load_credential
 from backend.app.integrations.appfolio_vendor.auth_tools import build_auth_tools
 from backend.app.integrations.appfolio_vendor.compliance import build_compliance_tools
 from backend.app.integrations.appfolio_vendor.conversations import build_conversation_tools
@@ -75,22 +75,20 @@ async def _appfolio_factory(ctx: ToolContext) -> list[Tool]:
 
 
 async def _appfolio_auth_check(ctx: ToolContext) -> str | None:
-    """Hide AppFolio behind a connect prompt until the user is connected.
+    """Always return ``None`` so the auth tools stay on the schema.
 
-    Returns ``None`` (tools available) once a credential is on file. A
-    string return surfaces the connect instructions to the agent and
-    keeps the data tools out of the LLM schema until then.
+    The registry's ``auth_check`` contract is binary: a non-None return
+    pulls *every* tool the factory builds out of the LLM schema. For
+    OAuth integrations that is fine because the registry surfaces a
+    connect URL through ``manage_integration``. AppFolio uses magic-link
+    auth, so the only way to connect is for the agent to call
+    ``appfolio_connect`` with a user-pasted token. If that tool is not
+    in the schema, no connect path exists. We always return ``None``
+    and let the factory body decide which tools to expose based on
+    credential state.
     """
-    if await is_connected(ctx.user.id):
-        return None
-    return (
-        "AppFolio Vendor Portal is not connected. Tell the user to:"
-        " (1) open vendor.appfolio.com and request a magic link,"
-        " (2) paste the full link from the email back to you,"
-        " (3) you call appfolio_connect with that link."
-        " If AppFolio asks for a 2FA code, ask the user for it and"
-        " call appfolio_complete_2fa."
-    )
+    _ = ctx
+    return None
 
 
 def _register() -> None:

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -964,3 +964,51 @@ async def test_access_failure_does_not_log_magic_link(caplog: Any) -> None:
     # Status and response body should still be in the log so we can debug.
     assert "400" in caplog.text
     assert "expired" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Factory + registry wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_auth_tools_always_in_schema_when_disconnected() -> None:
+    """``appfolio_connect`` must stay reachable when the user has no credential.
+
+    The registry's ``auth_check`` contract is binary: any non-None return
+    value strips the entire factory's tools from the LLM schema. Magic-link
+    integrations need the auth tool on the schema regardless of connection
+    state, since pasting the token *is* the connect path. Regression for
+    the dev.clawbolt.ai bug where the agent had no way to start the flow.
+    """
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.agent.tools.registry import (
+        ToolContext,
+        default_registry,
+        ensure_tool_modules_imported,
+    )
+    from backend.app.models import User
+
+    ensure_tool_modules_imported()
+
+    user = User(id="appfolio-disconnected-user", user_id="test")
+    ctx = ToolContext(user=user)
+
+    # auth_check must be None-returning unconditionally.
+    factory = default_registry._factories["appfolio_vendor"]
+    assert factory.auth_check is not None
+    assert await factory.auth_check(ctx) is None
+
+    # And the materialized factory output must include the auth tools.
+    from backend.app.integrations.appfolio_vendor.factory import _appfolio_factory
+
+    with patch(
+        "backend.app.integrations.appfolio_vendor.factory.load_credential",
+        new=AsyncMock(return_value=None),
+    ):
+        tools = await _appfolio_factory(ctx)
+    names = {t.name for t in tools}
+    assert ToolName.APPFOLIO_CONNECT in names
+    assert ToolName.APPFOLIO_COMPLETE_2FA in names
+    # Data tools should still be hidden until a credential is on file.
+    assert ToolName.APPFOLIO_LIST_WORK_ORDERS not in names

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -38,6 +38,23 @@ from tests.mocks.llm import make_text_response, make_tool_call_response
 # ---------------------------------------------------------------------------
 
 
+async def _await_pending(gate: ApprovalGate, user_id: str, timeout: float = 2.0) -> None:
+    """Block until ``gate.has_pending(user_id)`` is True.
+
+    ``request_approval`` performs two DB writes (audit + orphan-detection
+    row) before flipping ``has_pending`` to True, so a fixed sleep in a
+    test can race ahead of registration when those commits take longer
+    than expected. Polling on the same predicate the production poll
+    task uses (``_interrupt_stale_approval`` in ``ingestion.py``) avoids
+    that flake without weakening the assertion the test is making.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not gate.has_pending(user_id):
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError(f"has_pending({user_id!r}) never became True within {timeout}s")
+        await asyncio.sleep(0.001)
+
+
 class _EchoParams(BaseModel):
     text: str
 
@@ -381,7 +398,7 @@ class TestApprovalGate:
         mock_publish = AsyncMock()
 
         async def _resolve_soon() -> None:
-            await asyncio.sleep(0.01)
+            await _await_pending(gate, "1")
             await gate.resolve("1", ApprovalDecision.APPROVED)
 
         task = asyncio.create_task(_resolve_soon())
@@ -725,7 +742,7 @@ class TestApprovalGate:
         mock_publish = AsyncMock()
 
         async def _check_and_resolve() -> None:
-            await asyncio.sleep(0.01)
+            await _await_pending(gate, "1")
             assert gate.has_pending("1")
             await gate.resolve("1", ApprovalDecision.DENIED)
 
@@ -1159,7 +1176,7 @@ class TestIngestionIntercept:
             )
 
         approval_task = asyncio.create_task(_start_approval())
-        await asyncio.sleep(0.01)
+        await _await_pending(gate, test_user.id)
         assert gate.has_pending(test_user.id)
 
         # Simulate inbound "yes" message
@@ -1199,7 +1216,7 @@ class TestIngestionIntercept:
             )
 
         approval_task = asyncio.create_task(_start_approval())
-        await asyncio.sleep(0.01)
+        await _await_pending(gate, test_user.id)
         assert gate.has_pending(test_user.id)
 
         inbound = InboundMessage(
@@ -1249,7 +1266,7 @@ class TestIngestionIntercept:
             )
 
         approval_task = asyncio.create_task(_start_approval())
-        await asyncio.sleep(0.01)
+        await _await_pending(gate, test_user.id)
 
         inbound = InboundMessage(
             channel="telegram",
@@ -1299,7 +1316,7 @@ class TestIngestionIntercept:
             )
 
         approval_task = asyncio.create_task(_start_approval())
-        await asyncio.sleep(0.01)
+        await _await_pending(gate, test_user.id)
         assert gate.has_pending(test_user.id)
 
         # "Yes to both" is not an exact match, but the LLM classifies it
@@ -1514,7 +1531,7 @@ class TestApprovalEvents:
         mock_publish = AsyncMock()
 
         async def _resolve_soon() -> None:
-            await asyncio.sleep(0.01)
+            await _await_pending(gate, test_user.id)
             await gate.resolve(test_user.id, ApprovalDecision.APPROVED)
 
         task = asyncio.create_task(_resolve_soon())
@@ -1600,7 +1617,7 @@ class TestApprovalEvents:
         mock_publish = AsyncMock()
 
         async def _interrupt_soon() -> None:
-            await asyncio.sleep(0.01)
+            await _await_pending(gate, test_user.id)
             await gate.resolve(test_user.id, ApprovalDecision.INTERRUPTED)
 
         task = asyncio.create_task(_interrupt_soon())

--- a/tests/test_integration_tools.py
+++ b/tests/test_integration_tools.py
@@ -397,3 +397,124 @@ async def test_set_enabled_updates_existing_row(test_user: User) -> None:
     await store.set_enabled("calendar", enabled=True)
     disabled = await store.get_disabled_tool_names()
     assert "calendar" not in disabled
+
+
+# ---------------------------------------------------------------------------
+# Magic-link integrations (AppFolio Vendor Portal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_status_lists_appfolio_with_connection_state(test_user: User) -> None:
+    """Status should surface AppFolio's magic-link connection state.
+
+    Regression for the dev.clawbolt.ai bug where the agent told the user
+    "AppFolio is listed as an integration but it's not set up yet on the
+    backend" because manage_integration only knew about OAuth.
+    """
+    with patch(
+        "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await _call(test_user, "status")
+    assert not result.is_error
+    assert "appfolio_vendor" in result.content
+    assert "AppFolio Vendor Portal" in result.content
+    assert "not connected" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_status_marks_appfolio_connected(test_user: User) -> None:
+    """When AppFolio has a credential, status should say 'connected'."""
+    with patch(
+        "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
+        new=AsyncMock(return_value=True),
+    ):
+        result = await _call(test_user, "status")
+    assert not result.is_error
+    # The line for appfolio_vendor must include 'connected' (and not the
+    # negated form).
+    appfolio_line = next(line for line in result.content.splitlines() if "appfolio_vendor" in line)
+    assert "connected" in appfolio_line
+    assert "not connected" not in appfolio_line
+
+
+@pytest.mark.asyncio()
+async def test_connect_appfolio_returns_magic_link_instructions(test_user: User) -> None:
+    """Connect with target='appfolio_vendor' should return paste-token instructions.
+
+    The agent-facing message must mention vendor.appfolio.com (so the
+    agent can guide the user to the right site) and appfolio_connect (so
+    the agent knows which tool finishes the flow).
+    """
+    with patch(
+        "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await _call(test_user, "connect", "appfolio_vendor")
+    assert not result.is_error
+    assert "vendor.appfolio.com" in result.content
+    assert "appfolio_connect" in result.content
+    # Should NOT claim AppFolio "does not use OAuth" or look like a rejection.
+    assert "does not use OAuth" not in result.content
+
+
+@pytest.mark.asyncio()
+async def test_connect_appfolio_when_already_connected(test_user: User) -> None:
+    """Connecting an already-connected AppFolio should report it, not re-prompt."""
+    with patch(
+        "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
+        new=AsyncMock(return_value=True),
+    ):
+        result = await _call(test_user, "connect", "appfolio_vendor")
+    assert not result.is_error
+    assert "already connected" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_disconnect_appfolio_clears_credential(test_user: User) -> None:
+    """Disconnecting AppFolio should call clear_credential."""
+    is_connected_mock = AsyncMock(return_value=True)
+    clear_mock = AsyncMock()
+    with (
+        patch(
+            "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
+            new=is_connected_mock,
+        ),
+        patch(
+            "backend.app.agent.tools.integration_tools.appfolio_auth.clear_credential",
+            new=clear_mock,
+        ),
+    ):
+        result = await _call(test_user, "disconnect", "appfolio_vendor")
+    assert not result.is_error
+    assert "Disconnected" in result.content
+    clear_mock.assert_awaited_once_with(test_user.id)
+
+
+@pytest.mark.asyncio()
+async def test_disconnect_appfolio_when_not_connected(test_user: User) -> None:
+    """Disconnecting AppFolio with no credential should return a NOT_FOUND error."""
+    with patch(
+        "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await _call(test_user, "disconnect", "appfolio_vendor")
+    assert result.is_error
+    assert "not currently connected" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_appfolio_usage_hint_mentions_magic_link(test_user: User) -> None:
+    """The usage_hint should tell the agent that AppFolio uses magic-link auth.
+
+    Without this guidance the agent would assume a connect URL is coming
+    back and either stall or pass the instructions through verbatim.
+    """
+    ctx = ToolContext(user=test_user)
+    tools = create_integration_tools(ctx)
+    tool = next(t for t in tools if t.name == ToolName.MANAGE_INTEGRATION)
+    assert tool.usage_hint is not None
+    hint = tool.usage_hint.lower()
+    assert "appfolio" in hint
+    assert "magic-link" in hint or "magic link" in hint


### PR DESCRIPTION
## Description

A user said \"connect appfolio\" in chat and got back \"AppFolio is listed as an integration but it's not set up yet on the backend, I can't generate a connection link for it.\" This PR fixes the discoverability bug behind that message.

Two compounding issues:

1. **Factory hid its own auth tools.** ``_appfolio_auth_check`` returned a connect-instructions string when no credential was on file. The registry's ``auth_check`` contract is binary: any non-None return strips every tool the factory builds, including ``appfolio_connect`` itself. So when the user wasn't connected, the only tool that *could* connect them was missing from the LLM schema.
2. **manage_integration only knew OAuth.** ``_handle_connect`` and ``_handle_disconnect`` checked ``list_oauth_integrations()``, so the magic-link integration fell through to \"appfolio_vendor does not use OAuth authentication\". The agent paraphrased that as \"not set up yet on the backend.\"

### Fix

- ``_appfolio_auth_check`` returns ``None`` unconditionally. The factory body still gates data tools (work orders, invoices, etc.) on ``load_credential``, so only the auth tools are exposed pre-connect.
- ``manage_integration`` learns about a small ``_MAGIC_LINK_INTEGRATIONS`` set (currently just ``appfolio_vendor``). Status reflects ``appfolio_auth.is_connected``, connect returns paste-token instructions and points at ``appfolio_connect``, and disconnect routes to ``clear_credential``.
- ``manage_integration``'s ``usage_hint`` mentions that AppFolio uses magic-link auth so the agent doesn't expect an OAuth URL back.

### Tests

- ``test_auth_tools_always_in_schema_when_disconnected``: factory's ``auth_check`` returns ``None`` and the materialized output includes ``appfolio_connect``/``appfolio_complete_2fa`` while keeping data tools hidden.
- New cases in ``test_integration_tools.py``: status surfaces AppFolio's connection state, connect returns the magic-link recipe (or \"already connected\"), disconnect calls ``clear_credential`` (or returns NOT_FOUND), and ``usage_hint`` mentions magic-link auth.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (``uv run pytest -v``)
- [x] Lint passes (``ruff check backend/ && ruff format --check backend/``)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude wrote the diff and tests under @njbrake's direction)