### PR TITLE
chore: drop DROPBOX_ACCESS_TOKEN from legacy config warning

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -406,7 +406,6 @@ def log_config_warnings(s: Settings | None = None) -> list[str]:
     # them so upgraders notice their config is dead.
     for legacy_key in (
         "STORAGE_PROVIDER",
-        "DROPBOX_ACCESS_TOKEN",
         "GOOGLE_DRIVE_CREDENTIALS_JSON",
         "FILE_STORAGE_BASE_DIR",
     ):


### PR DESCRIPTION
## Description

`log_config_warnings()` flags four deprecated env vars when upgraders still have them set. With no remaining users on the deprecated `DROPBOX_ACCESS_TOKEN`, that entry is dead migration scaffolding. Drop it.

The other three legacy keys (`STORAGE_PROVIDER`, `GOOGLE_DRIVE_CREDENTIALS_JSON`, `FILE_STORAGE_BASE_DIR`) stay since they still help upgraders moving off deployment-level storage to per-user Drive OAuth.

## Type
- [x] Refactor

## Checklist
- [x] Tests pass (`uv run pytest tests/test_config_validation.py -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code, drafted via discussion with @njbrake)