### PR TITLE
feat(agent): add LLM request observer hook

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import logging
 import time
+from datetime import UTC
 from typing import Any, cast
 
 from any_llm import amessages
@@ -21,6 +22,11 @@ from any_llm.types.messages import MessageResponse
 from backend.app.agent.llm_parsing import get_response_text
 from backend.app.agent.memory_db import get_memory_store
 from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
+from backend.app.agent.observer import (
+    PURPOSE_COMPACTION,
+    LLMRequestPayload,
+    emit_llm_request,
+)
 from backend.app.agent.prompts import load_prompt
 from backend.app.agent.stores import HeartbeatStore
 from backend.app.config import settings
@@ -239,18 +245,42 @@ async def compact_session(
     messages: list[dict[str, Any]] = [
         {"role": "user", "content": "\n".join(user_prompt_parts)},
     ]
+    compaction_system = prepare_system_with_caching(COMPACTION_SYSTEM_PROMPT)
+    compaction_thinking = reasoning_effort_to_thinking(settings.reasoning_effort)
 
     try:
+        await emit_llm_request(
+            LLMRequestPayload(
+                schema_version=1,
+                purpose=PURPOSE_COMPACTION,
+                user_id=user_id,
+                session_id=None,
+                request_id=None,
+                model=model,
+                provider=provider,
+                max_tokens=settings.compaction_max_tokens,
+                thinking=compaction_thinking,
+                system=compaction_system,
+                messages=messages,
+                tools=None,
+                # Compaction operates on a synthetic prompt rebuilt from
+                # MEMORY/USER/SOUL/HEARTBEAT plus the trimmed conversation
+                # text, not on a session-aware message history. The
+                # era-marker field has no meaning here.
+                min_message_seq_in_prompt=None,
+                started_at=datetime.datetime.now(UTC),
+            )
+        )
         response = cast(
             MessageResponse,
             await amessages(
                 model=model,
                 provider=provider,
                 api_base=settings.llm_api_base,
-                system=prepare_system_with_caching(COMPACTION_SYSTEM_PROMPT),
+                system=compaction_system,
                 messages=messages,
                 max_tokens=settings.compaction_max_tokens,
-                thinking=reasoning_effort_to_thinking(settings.reasoning_effort),
+                thinking=compaction_thinking,
             ),
         )
     except Exception:

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -5,6 +5,7 @@ import re
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any, cast
 
 from any_llm import (
@@ -43,6 +44,11 @@ from backend.app.agent.messages import (
     ToolResultMessage,
     UserMessage,
     messages_to_messages_api,
+)
+from backend.app.agent.observer import (
+    LLMRequestPayload,
+    compute_min_message_seq,
+    emit_llm_request,
 )
 from backend.app.agent.system_prompt import build_agent_system_prompt, build_time_user_context
 from backend.app.agent.tool_errors import (
@@ -468,6 +474,23 @@ class ClawboltAgent:
             tool_count,
             effective_max_tokens,
         )
+        await emit_llm_request(
+            LLMRequestPayload(
+                schema_version=1,
+                user_id=self.user.id,
+                session_id=self._session_id or None,
+                request_id=self._request_id or None,
+                model=effective_model,
+                provider=effective_provider,
+                max_tokens=effective_max_tokens,
+                thinking=thinking,
+                system=system,
+                messages=msg_dicts,
+                tools=tool_schemas,
+                min_message_seq_in_prompt=compute_min_message_seq(messages),
+                started_at=datetime.now(UTC),
+            )
+        )
         for attempt in range(LLM_MAX_RETRIES):
             try:
                 return cast(
@@ -510,6 +533,23 @@ class ClawboltAgent:
                     prepare_system_with_caching(retry_system_str)
                     if retry_system_str is not None
                     else None
+                )
+                await emit_llm_request(
+                    LLMRequestPayload(
+                        schema_version=1,
+                        user_id=self.user.id,
+                        session_id=self._session_id or None,
+                        request_id=self._request_id or None,
+                        model=effective_model,
+                        provider=effective_provider,
+                        max_tokens=effective_max_tokens,
+                        thinking=thinking,
+                        system=system,
+                        messages=trimmed_dicts,
+                        tools=tool_schemas,
+                        min_message_seq_in_prompt=compute_min_message_seq(trim_result.messages),
+                        started_at=datetime.now(UTC),
+                    )
                 )
                 return cast(
                     MessageResponse,

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -46,6 +46,8 @@ from backend.app.agent.messages import (
     messages_to_messages_api,
 )
 from backend.app.agent.observer import (
+    PURPOSE_AGENT_FOLLOWUP,
+    PURPOSE_AGENT_MAIN,
     LLMRequestPayload,
     compute_min_message_seq,
     emit_llm_request,
@@ -477,6 +479,7 @@ class ClawboltAgent:
         await emit_llm_request(
             LLMRequestPayload(
                 schema_version=1,
+                purpose=PURPOSE_AGENT_MAIN,
                 user_id=self.user.id,
                 session_id=self._session_id or None,
                 request_id=self._request_id or None,
@@ -537,6 +540,7 @@ class ClawboltAgent:
                 await emit_llm_request(
                     LLMRequestPayload(
                         schema_version=1,
+                        purpose=PURPOSE_AGENT_FOLLOWUP,
                         user_id=self.user.id,
                         session_id=self._session_id or None,
                         request_id=self._request_id or None,

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -33,6 +33,11 @@ from sqlalchemy.orm import Session
 from backend.app.agent.context import get_or_create_conversation
 from backend.app.agent.dto import HeartbeatLogEntry
 from backend.app.agent.llm_parsing import get_response_text, parse_tool_calls
+from backend.app.agent.observer import (
+    PURPOSE_HEARTBEAT_DECISION,
+    LLMRequestPayload,
+    emit_llm_request,
+)
 from backend.app.agent.session_db import get_session_store
 from backend.app.agent.stores import HeartbeatStore
 from backend.app.agent.system_prompt import (
@@ -449,6 +454,38 @@ async def evaluate_heartbeat_need(
     time_context = build_time_user_context(user)
     max_retries = settings.llm_max_retries
     response: MessageResponse | None = None
+    heartbeat_system = prepare_system_with_caching(prompt)
+    heartbeat_messages: list[dict[str, Any]] = [
+        {
+            "role": "user",
+            "content": (
+                f"{time_context}\n\n"
+                "Review the context above and decide whether any tasks need attention."
+            ),
+        },
+    ]
+    heartbeat_tools = [HEARTBEAT_DECISION_TOOL]
+    heartbeat_thinking = reasoning_effort_to_thinking(settings.reasoning_effort)
+    await emit_llm_request(
+        LLMRequestPayload(
+            schema_version=1,
+            purpose=PURPOSE_HEARTBEAT_DECISION,
+            user_id=user.id,
+            session_id=None,
+            request_id=None,
+            model=model,
+            provider=provider,
+            max_tokens=settings.llm_max_tokens_heartbeat,
+            thinking=heartbeat_thinking,
+            system=heartbeat_system,
+            messages=heartbeat_messages,
+            tools=heartbeat_tools,
+            # Heartbeat sends a synthetic single-message prompt -- there
+            # is no session history to derive an era marker from.
+            min_message_seq_in_prompt=None,
+            started_at=datetime.datetime.now(datetime.UTC),
+        )
+    )
     for attempt in range(max_retries):
         try:
             response = cast(
@@ -457,19 +494,11 @@ async def evaluate_heartbeat_need(
                     model=model,
                     provider=provider,
                     api_base=settings.llm_api_base,
-                    system=prepare_system_with_caching(prompt),
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": (
-                                f"{time_context}\n\n"
-                                "Review the context above and decide whether any tasks need attention."
-                            ),
-                        },
-                    ],
-                    tools=[HEARTBEAT_DECISION_TOOL],
+                    system=heartbeat_system,
+                    messages=heartbeat_messages,
+                    tools=heartbeat_tools,
                     max_tokens=settings.llm_max_tokens_heartbeat,
-                    thinking=reasoning_effort_to_thinking(settings.reasoning_effort),
+                    thinking=heartbeat_thinking,
                 ),
             )
             break

--- a/backend/app/agent/observer.py
+++ b/backend/app/agent/observer.py
@@ -1,13 +1,13 @@
-"""Observer hook for LLM requests assembled by the agent loop.
+"""Observer hook for LLM requests dispatched by the agent layer.
 
 Mirrors the module-level setter pattern used by ``set_pipeline_override``
 in ``backend.app.agent.router``. Premium (or other plugins) can register
-a single async callback that receives a versioned record of every LLM
-request just before it is dispatched, for telemetry / token-efficiency
-analysis purposes.
+a single async callback that receives a versioned snapshot of every LLM
+request the agent layer dispatches (main agent loop, compaction,
+heartbeat decision), for telemetry and token-efficiency analysis.
 
 The observer runs inline with the LLM call but its exceptions are caught
-and logged, so it never crashes the agent loop. Observers should return
+and logged, so it never crashes the caller. Observers should return
 quickly (e.g. by enqueueing work onto a background task) to avoid adding
 latency to the user-facing response.
 """
@@ -27,6 +27,15 @@ from backend.app.agent.messages import (
 logger = logging.getLogger(__name__)
 
 
+# Stable strings for ``LLMRequestPayload.purpose``. Match
+# ``LLMUsageLog.purpose`` values so observers can correlate against the
+# usage-log table without translation.
+PURPOSE_AGENT_MAIN = "agent_main"
+PURPOSE_AGENT_FOLLOWUP = "agent_followup"  # post-trim retry of the main agent call
+PURPOSE_COMPACTION = "compaction"
+PURPOSE_HEARTBEAT_DECISION = "heartbeat_decision"
+
+
 @dataclass(frozen=True)
 class LLMRequestPayload:
     """Versioned snapshot of an LLM request dispatched to observers.
@@ -34,9 +43,28 @@ class LLMRequestPayload:
     Observers should read fields by name and tolerate unknown ones via
     ``getattr(payload, "field", default)`` so newer OSS builds remain
     compatible with older observer implementations.
+
+    The dataclass is ``frozen=True`` to prevent field rebinding, but the
+    ``messages`` and ``tools`` lists ARE THE SAME OBJECTS that get passed
+    into ``amessages`` immediately after the observer returns. Observers
+    must not mutate them or they will corrupt the in-flight LLM call.
+    Treat the payload as read-only; if an observer needs a mutable copy,
+    take a deep copy itself.
+
+    ``min_message_seq_in_prompt`` is the era marker for agent-loop calls:
+    the lowest persisted ``seq`` across user/assistant messages currently
+    in the prompt. Compaction trims older messages, which raises this
+    value on the next request, so observers can detect compaction-driven
+    trimming without querying ``compaction_events``. Synthetic messages
+    (e.g. summary placeholders injected by ``trim_messages``) are not
+    persisted and have ``seq=None``; they are intentionally skipped, so
+    the field reflects "lowest persisted seq still visible to the model"
+    rather than a complete inventory of the prompt. For non-agent-loop
+    purposes (compaction, heartbeat) the value is ``None``.
     """
 
     schema_version: int
+    purpose: str
     user_id: str
     session_id: str | None
     request_id: str | None
@@ -47,10 +75,6 @@ class LLMRequestPayload:
     system: str | list[dict[str, Any]] | None
     messages: list[dict[str, Any]]
     tools: list[dict[str, Any]] | None
-    # Lowest persisted ``seq`` across user/assistant messages currently in
-    # the prompt. Compaction trims older messages, which raises this value
-    # on the next request -- observers use it as an "era marker" without
-    # needing to query ``compaction_events`` themselves.
     min_message_seq_in_prompt: int | None
     started_at: datetime
 
@@ -65,6 +89,10 @@ def set_llm_request_observer(observer: LLMRequestObserver | None) -> None:
 
     Pass ``None`` to clear. Premium calls this at module import time,
     similar to ``set_pipeline_override``.
+
+    The observer must be safe to invoke concurrently from multiple agent
+    loops (one per active user) and from the compaction / heartbeat
+    schedulers. The OSS side does no locking around the dispatch.
     """
     global _observer
     _observer = observer
@@ -78,10 +106,15 @@ def get_llm_request_observer() -> LLMRequestObserver | None:
 def compute_min_message_seq(messages: list[AgentMessage]) -> int | None:
     """Return the lowest persisted ``seq`` across user/assistant messages.
 
-    ``ToolResultMessage`` and ``SystemMessage`` are excluded -- only
-    user/assistant turns carry an independent ``seq``. Returns ``None``
-    when no message has a persisted seq (e.g. brand-new conversation
-    with only in-memory entries).
+    Used by the main agent loop to populate the era-marker field on
+    ``LLMRequestPayload``. ``ToolResultMessage`` and ``SystemMessage`` are
+    excluded -- only user/assistant turns carry an independent ``seq``.
+    Synthetic messages with ``seq=None`` (the live inbound, summary
+    placeholders from ``trim_messages``) are intentionally skipped: they
+    are not persisted and would otherwise mask era boundaries.
+
+    Returns ``None`` when no persisted message remains in the prompt
+    (e.g. brand-new conversation with only the live inbound).
     """
     seqs = [
         m.seq
@@ -95,7 +128,9 @@ async def emit_llm_request(payload: LLMRequestPayload) -> None:
     """Dispatch ``payload`` to the registered observer, swallowing errors.
 
     No-op when no observer is registered. Errors raised by the observer
-    are logged and discarded so they never crash ``_call_llm_with_retry``.
+    are logged and discarded so they never crash the caller. The observer
+    remains registered after a failure: a transient issue does not
+    deregister it.
     """
     observer = _observer
     if observer is None:
@@ -103,4 +138,4 @@ async def emit_llm_request(payload: LLMRequestPayload) -> None:
     try:
         await observer(payload)
     except Exception:
-        logger.exception("LLM request observer raised; continuing")
+        logger.exception("LLM request observer raised; payload dropped")

--- a/backend/app/agent/observer.py
+++ b/backend/app/agent/observer.py
@@ -1,0 +1,106 @@
+"""Observer hook for LLM requests assembled by the agent loop.
+
+Mirrors the module-level setter pattern used by ``set_pipeline_override``
+in ``backend.app.agent.router``. Premium (or other plugins) can register
+a single async callback that receives a versioned record of every LLM
+request just before it is dispatched, for telemetry / token-efficiency
+analysis purposes.
+
+The observer runs inline with the LLM call but its exceptions are caught
+and logged, so it never crashes the agent loop. Observers should return
+quickly (e.g. by enqueueing work onto a background task) to avoid adding
+latency to the user-facing response.
+"""
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from backend.app.agent.messages import (
+    AgentMessage,
+    AssistantMessage,
+    UserMessage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LLMRequestPayload:
+    """Versioned snapshot of an LLM request dispatched to observers.
+
+    Observers should read fields by name and tolerate unknown ones via
+    ``getattr(payload, "field", default)`` so newer OSS builds remain
+    compatible with older observer implementations.
+    """
+
+    schema_version: int
+    user_id: str
+    session_id: str | None
+    request_id: str | None
+    model: str
+    provider: str
+    max_tokens: int
+    thinking: dict[str, Any] | None
+    system: str | list[dict[str, Any]] | None
+    messages: list[dict[str, Any]]
+    tools: list[dict[str, Any]] | None
+    # Lowest persisted ``seq`` across user/assistant messages currently in
+    # the prompt. Compaction trims older messages, which raises this value
+    # on the next request -- observers use it as an "era marker" without
+    # needing to query ``compaction_events`` themselves.
+    min_message_seq_in_prompt: int | None
+    started_at: datetime
+
+
+LLMRequestObserver = Callable[[LLMRequestPayload], Awaitable[None]]
+
+_observer: LLMRequestObserver | None = None
+
+
+def set_llm_request_observer(observer: LLMRequestObserver | None) -> None:
+    """Register the (single) observer that receives each LLM request.
+
+    Pass ``None`` to clear. Premium calls this at module import time,
+    similar to ``set_pipeline_override``.
+    """
+    global _observer
+    _observer = observer
+
+
+def get_llm_request_observer() -> LLMRequestObserver | None:
+    """Return the registered observer, or ``None`` if none is set."""
+    return _observer
+
+
+def compute_min_message_seq(messages: list[AgentMessage]) -> int | None:
+    """Return the lowest persisted ``seq`` across user/assistant messages.
+
+    ``ToolResultMessage`` and ``SystemMessage`` are excluded -- only
+    user/assistant turns carry an independent ``seq``. Returns ``None``
+    when no message has a persisted seq (e.g. brand-new conversation
+    with only in-memory entries).
+    """
+    seqs = [
+        m.seq
+        for m in messages
+        if isinstance(m, (UserMessage, AssistantMessage)) and m.seq is not None
+    ]
+    return min(seqs) if seqs else None
+
+
+async def emit_llm_request(payload: LLMRequestPayload) -> None:
+    """Dispatch ``payload`` to the registered observer, swallowing errors.
+
+    No-op when no observer is registered. Errors raised by the observer
+    are logged and discarded so they never crash ``_call_llm_with_retry``.
+    """
+    observer = _observer
+    if observer is None:
+        return
+    try:
+        await observer(payload)
+    except Exception:
+        logger.exception("LLM request observer raised; continuing")

--- a/tests/test_llm_observer.py
+++ b/tests/test_llm_observer.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from any_llm import ContextLengthExceededError
 
 from backend.app.agent.core import ClawboltAgent
 from backend.app.agent.messages import (
@@ -17,6 +18,8 @@ from backend.app.agent.messages import (
     UserMessage,
 )
 from backend.app.agent.observer import (
+    PURPOSE_AGENT_FOLLOWUP,
+    PURPOSE_AGENT_MAIN,
     LLMRequestPayload,
     compute_min_message_seq,
     emit_llm_request,
@@ -39,6 +42,7 @@ def _reset_observer() -> Iterator[None]:
 def _make_payload() -> LLMRequestPayload:
     return LLMRequestPayload(
         schema_version=1,
+        purpose=PURPOSE_AGENT_MAIN,
         user_id="user-1",
         session_id="sess-1",
         request_id="req-1",
@@ -52,6 +56,12 @@ def _make_payload() -> LLMRequestPayload:
         min_message_seq_in_prompt=42,
         started_at=datetime.now(UTC),
     )
+
+
+def test_payload_schema_version_is_one() -> None:
+    """Pin the schema version. Bumping it is a coordinated change with
+    every observer implementation; this guard keeps the bump deliberate."""
+    assert _make_payload().schema_version == 1
 
 
 def test_default_observer_is_none() -> None:
@@ -102,6 +112,10 @@ async def test_emit_swallows_observer_exception(
         await emit_llm_request(_make_payload())
 
     assert any("observer raised" in rec.message for rec in caplog.records)
+    # And the broken observer is still registered: a transient failure
+    # does not deregister the callback, so subsequent payloads continue
+    # to fire and (potentially) succeed.
+    assert get_llm_request_observer() is boom
 
 
 def test_compute_min_message_seq_returns_lowest_persisted_seq() -> None:
@@ -173,11 +187,99 @@ async def test_observer_fires_from_agent_loop(
     assert received, "observer was not invoked"
     payload = received[0]
     assert payload.schema_version == 1
+    assert payload.purpose == PURPOSE_AGENT_MAIN
     assert payload.user_id == test_user.id
     assert payload.session_id == "sess-int"
     assert payload.request_id == "req-int"
     assert payload.messages, "messages should be non-empty when LLM is dispatched"
     assert isinstance(payload.started_at, datetime)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_observer_fires_again_after_context_length_trim_retry(
+    mock_amessages: MagicMock,
+    test_user: User,
+) -> None:
+    """When the first LLM call raises ``ContextLengthExceededError`` the
+    agent trims history and retries. The retry sends a different (smaller)
+    payload, so the observer must fire a second time with
+    ``purpose=PURPOSE_AGENT_FOLLOWUP``. Without this, premium would never
+    capture the post-trim shape that actually went over the wire."""
+    mock_amessages.side_effect = [
+        ContextLengthExceededError("too big"),
+        make_text_response("ok after trim"),
+    ]
+
+    received: list[LLMRequestPayload] = []
+
+    async def obs(payload: LLMRequestPayload) -> None:
+        received.append(payload)
+
+    set_llm_request_observer(obs)
+    try:
+        agent = ClawboltAgent(user=test_user)
+        await agent.process_message("hello there")
+    finally:
+        set_llm_request_observer(None)
+
+    purposes = [p.purpose for p in received]
+    assert PURPOSE_AGENT_MAIN in purposes
+    assert PURPOSE_AGENT_FOLLOWUP in purposes
+    # The follow-up payload's messages list reflects the trimmed history,
+    # so it should be a different object from (and not necessarily the
+    # same length as) the main payload.
+    main = next(p for p in received if p.purpose == PURPOSE_AGENT_MAIN)
+    followup = next(p for p in received if p.purpose == PURPOSE_AGENT_FOLLOWUP)
+    assert main.messages is not followup.messages
+
+
+# ---------------------------------------------------------------------------
+# Integration: observer fires from compaction and heartbeat dispatch sites
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.compaction.amessages")
+async def test_observer_fires_from_compaction(
+    mock_amessages: MagicMock,
+    test_user: User,
+) -> None:
+    """``compact_session`` dispatches an LLM call too, and observers that
+    care about token-efficiency analysis want it: compaction is precisely
+    where context-window weight gets compressed. The observer must fire
+    with ``purpose='compaction'``."""
+    import json
+
+    from backend.app.agent.compaction import compact_session
+    from backend.app.agent.messages import UserMessage as AgentUserMessage
+
+    mock_amessages.return_value = make_text_response(
+        json.dumps({"memory_update": "ok", "summary": ""})
+    )
+
+    received: list[LLMRequestPayload] = []
+
+    async def obs(payload: LLMRequestPayload) -> None:
+        received.append(payload)
+
+    set_llm_request_observer(obs)
+    try:
+        await compact_session(
+            test_user.id,
+            [AgentUserMessage(content="hi", seq=1)],
+        )
+    finally:
+        set_llm_request_observer(None)
+
+    assert any(p.purpose == "compaction" for p in received)
+    payload = next(p for p in received if p.purpose == "compaction")
+    assert payload.user_id == test_user.id
+    assert payload.session_id is None
+    # Compaction sends a synthetic prompt; the era-marker field has no
+    # meaning here and must be None so observers don't conflate it with
+    # an agent-loop era.
+    assert payload.min_message_seq_in_prompt is None
 
 
 @pytest.mark.asyncio()

--- a/tests/test_llm_observer.py
+++ b/tests/test_llm_observer.py
@@ -1,0 +1,206 @@
+"""Unit and integration tests for the LLM request observer hook."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.messages import (
+    AssistantMessage,
+    SystemMessage,
+    ToolResultMessage,
+    UserMessage,
+)
+from backend.app.agent.observer import (
+    LLMRequestPayload,
+    compute_min_message_seq,
+    emit_llm_request,
+    get_llm_request_observer,
+    set_llm_request_observer,
+)
+from backend.app.models import User
+from tests.mocks.llm import make_text_response
+
+
+@pytest.fixture(autouse=True)
+def _reset_observer() -> Iterator[None]:
+    """Clear any registered observer between tests so module-level state does
+    not leak across cases."""
+    set_llm_request_observer(None)
+    yield
+    set_llm_request_observer(None)
+
+
+def _make_payload() -> LLMRequestPayload:
+    return LLMRequestPayload(
+        schema_version=1,
+        user_id="user-1",
+        session_id="sess-1",
+        request_id="req-1",
+        model="claude-test",
+        provider="anthropic",
+        max_tokens=1024,
+        thinking=None,
+        system="hello",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        min_message_seq_in_prompt=42,
+        started_at=datetime.now(UTC),
+    )
+
+
+def test_default_observer_is_none() -> None:
+    assert get_llm_request_observer() is None
+
+
+def test_set_and_get_observer() -> None:
+    async def obs(_: LLMRequestPayload) -> None:
+        return None
+
+    set_llm_request_observer(obs)
+    assert get_llm_request_observer() is obs
+
+    set_llm_request_observer(None)
+    assert get_llm_request_observer() is None
+
+
+@pytest.mark.asyncio()
+async def test_emit_calls_registered_observer() -> None:
+    received: list[LLMRequestPayload] = []
+
+    async def obs(payload: LLMRequestPayload) -> None:
+        received.append(payload)
+
+    set_llm_request_observer(obs)
+    payload = _make_payload()
+    await emit_llm_request(payload)
+
+    assert received == [payload]
+
+
+@pytest.mark.asyncio()
+async def test_emit_is_noop_when_no_observer() -> None:
+    # Should not raise.
+    await emit_llm_request(_make_payload())
+
+
+@pytest.mark.asyncio()
+async def test_emit_swallows_observer_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def boom(_: LLMRequestPayload) -> None:
+        raise RuntimeError("observer blew up")
+
+    set_llm_request_observer(boom)
+    with caplog.at_level(logging.ERROR, logger="backend.app.agent.observer"):
+        # Must not raise -- agent loop survives observer failure.
+        await emit_llm_request(_make_payload())
+
+    assert any("observer raised" in rec.message for rec in caplog.records)
+
+
+def test_compute_min_message_seq_returns_lowest_persisted_seq() -> None:
+    msgs = [
+        SystemMessage(content="sys"),
+        UserMessage(content="hi", seq=5),
+        AssistantMessage(content="hello", seq=6),
+        UserMessage(content="more", seq=7),
+    ]
+    assert compute_min_message_seq(msgs) == 5
+
+
+def test_compute_min_message_seq_ignores_tool_results_and_system() -> None:
+    msgs = [
+        SystemMessage(content="sys"),
+        UserMessage(content="hi", seq=10),
+        AssistantMessage(content="ok", seq=11),
+        ToolResultMessage(tool_call_id="t1", content="result"),
+    ]
+    # ToolResultMessage / SystemMessage should be ignored.
+    assert compute_min_message_seq(msgs) == 10
+
+
+def test_compute_min_message_seq_returns_none_when_no_persisted_seqs() -> None:
+    msgs = [
+        UserMessage(content="hi"),  # seq defaults to None
+        AssistantMessage(content="hello"),  # seq defaults to None
+    ]
+    assert compute_min_message_seq(msgs) is None
+
+
+def test_compute_min_message_seq_skips_none_seqs() -> None:
+    msgs = [
+        UserMessage(content="hi"),  # seq=None -> skipped
+        UserMessage(content="next", seq=3),
+        AssistantMessage(content="resp", seq=4),
+    ]
+    assert compute_min_message_seq(msgs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration: observer fires from inside _call_llm_with_retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_observer_fires_from_agent_loop(
+    mock_amessages: MagicMock,
+    test_user: User,
+) -> None:
+    """Registering an observer causes it to be invoked with each LLM request
+    dispatched by the agent loop, with the user/session identifiers from the
+    surrounding agent populated."""
+    mock_amessages.return_value = make_text_response("ok")
+
+    received: list[LLMRequestPayload] = []
+
+    async def obs(payload: LLMRequestPayload) -> None:
+        received.append(payload)
+
+    set_llm_request_observer(obs)
+    try:
+        agent = ClawboltAgent(user=test_user, session_id="sess-int", request_id="req-int")
+        await agent.process_message("hello there")
+    finally:
+        set_llm_request_observer(None)
+
+    assert received, "observer was not invoked"
+    payload = received[0]
+    assert payload.schema_version == 1
+    assert payload.user_id == test_user.id
+    assert payload.session_id == "sess-int"
+    assert payload.request_id == "req-int"
+    assert payload.messages, "messages should be non-empty when LLM is dispatched"
+    assert isinstance(payload.started_at, datetime)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_observer_exception_does_not_crash_agent_loop(
+    mock_amessages: MagicMock,
+    test_user: User,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An observer that raises must be caught: the agent loop continues and
+    ``process_message`` succeeds."""
+    mock_amessages.return_value = make_text_response("ok")
+
+    async def boom(_: LLMRequestPayload) -> None:
+        raise RuntimeError("observer blew up")
+
+    set_llm_request_observer(boom)
+    try:
+        with caplog.at_level(logging.ERROR, logger="backend.app.agent.observer"):
+            agent = ClawboltAgent(user=test_user)
+            # Must not raise.
+            await agent.process_message("still ok")
+    finally:
+        set_llm_request_observer(None)
+
+    assert any("observer raised" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Description

Add a module-level observer hook that lets plugins (premium) receive a versioned snapshot of every LLM request the agent layer dispatches, just before transmission. Mirrors the existing `set_pipeline_override` / `set_is_allowed_override` pattern so OSS stays agnostic about how observers consume the payload.

The motivating use case is per-tenant token-efficiency analysis: today `LLMUsageLog` records aggregate token counts per call but never the assembled payload, so we can't break down "where did my 80k input tokens go." Premium will register an observer that captures payloads to a bounded per-user table for offline analysis (separate premium PR).

## What changes

- **New module `backend/app/agent/observer.py`**: defines `LLMRequestPayload` (frozen dataclass with `schema_version: int` and a `purpose` field), `set_llm_request_observer(observer)`, `get_llm_request_observer()`, and `emit_llm_request(payload)`. The observer is called inline (`await`-ed) but its exceptions are caught and logged so it cannot stall the caller.
- **Hook fires from all agent-layer LLM dispatch sites**:
  - `backend/app/agent/core.py::_call_llm_with_retry` (initial dispatch, purpose=`agent_main`; post-trim retry, purpose=`agent_followup`).
  - `backend/app/agent/compaction.py::compact_session` (purpose=`compaction`).
  - `backend/app/agent/heartbeat.py` heartbeat decision call (purpose=`heartbeat_decision`).
  - The `purpose` strings match `LLMUsageLog.purpose` values so observers can correlate against the existing usage-log table.
- The hook does NOT fire for rate-limit retries that re-send the same body (no new payload to capture).
- **`tests/test_llm_observer.py`**: 14 tests covering the observer module in isolation, schema-version pinning, integration with the agent loop including the post-trim retry path, observer-exception isolation (and the registered callback surviving a failure), and integration from compaction.

## Era marker for downstream observers

The payload includes `min_message_seq_in_prompt` (the lowest persisted `seq` across user/assistant messages currently in the prompt). When this value rises between captures, the observer can infer that compaction trimmed older messages. This avoids forcing observers to query `compaction_events` themselves to detect era boundaries. For non-agent-loop purposes (compaction, heartbeat) the field is `None` and the docstring explains why.

## Important contract for observers

The dataclass is `frozen=True` to prevent field rebinding, but the `messages` and `tools` lists are the same objects passed to `amessages` immediately after the observer returns. **Observers must treat the payload as read-only** -- mutating these lists corrupts the in-flight LLM call. Documented prominently in the `LLMRequestPayload` docstring.

The observer must also be safe to invoke concurrently from multiple agent loops, the compaction scheduler, and the heartbeat scheduler. The OSS side does no locking around the dispatch.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v` — full OSS suite green locally, 2398 passed)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] Type check passes (`ty check --python .venv backend/ tests/ alembic/`)
- [x] New tests added for new functionality

## AI Usage
- [x] AI-assisted (Claude Code drafted the implementation and tests after a planning conversation; reviewed by njbrake)