### PR TITLE
fix(integrations): correct AppFolio connection state and capability summary

### DIFF
--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -302,15 +302,26 @@ async def _handle_status(
     return ToolResult(content="\n".join(lines))
 
 
+def _hidden_factories_paired_with(target: str) -> list[str]:
+    """Return any backing factory names that should follow ``target``'s
+    enable/disable state. Hidden factories never appear directly in user-
+    facing listings, so toggling them only happens via cascade from the
+    user-facing factory they back.
+    """
+    return [hidden for hidden, paired in _HIDDEN_CORE_FACTORIES.items() if paired == target]
+
+
 async def _handle_enable(
     user_id: str,
     target: str,
     registry: ToolRegistry,
 ) -> ToolResult:
     """Enable a tool group."""
-    if target not in registry.factory_names:
+    if target not in registry.factory_names or target in _HIDDEN_CORE_FACTORIES:
         available = [
-            n for n in sorted(registry.factory_names) if n not in registry.core_factory_names
+            n
+            for n in sorted(registry.factory_names)
+            if n not in registry.core_factory_names and n not in _HIDDEN_CORE_FACTORIES
         ]
         return ToolResult(
             content=(
@@ -329,6 +340,8 @@ async def _handle_enable(
 
     store = ToolConfigStore(user_id)
     await store.set_enabled(target, enabled=True)
+    for hidden in _hidden_factories_paired_with(target):
+        await store.set_enabled(hidden, enabled=True)
 
     display = _DISPLAY_NAMES.get(target, target)
     logger.info("User %s enabled tool group '%s' via chat", user_id, target)
@@ -343,9 +356,11 @@ async def _handle_disable(
     registry: ToolRegistry,
 ) -> ToolResult:
     """Disable a tool group."""
-    if target not in registry.factory_names:
+    if target not in registry.factory_names or target in _HIDDEN_CORE_FACTORIES:
         available = [
-            n for n in sorted(registry.factory_names) if n not in registry.core_factory_names
+            n
+            for n in sorted(registry.factory_names)
+            if n not in registry.core_factory_names and n not in _HIDDEN_CORE_FACTORIES
         ]
         return ToolResult(
             content=(
@@ -366,6 +381,8 @@ async def _handle_disable(
 
     store = ToolConfigStore(user_id)
     await store.set_enabled(target, enabled=False)
+    for hidden in _hidden_factories_paired_with(target):
+        await store.set_enabled(hidden, enabled=False)
 
     display = _DISPLAY_NAMES.get(target, target)
     logger.info("User %s disabled tool group '%s' via chat", user_id, target)
@@ -376,6 +393,15 @@ async def _handle_disable(
 
 async def _handle_connect(user_id: str, target: str) -> ToolResult:
     """Generate an OAuth authorization URL for an integration."""
+    # Hidden backing factories are never directly addressable by users; the
+    # connect flow goes through the user-facing factory they back.
+    if target in _HIDDEN_CORE_FACTORIES:
+        return ToolResult(
+            content=f"Unknown tool group '{target}'.",
+            is_error=True,
+            error_kind=ToolErrorKind.NOT_FOUND,
+        )
+
     # Magic-link integrations have their own connect flow (paste-a-token)
     # and don't fit the OAuth URL model.
     if target in _MAGIC_LINK_INTEGRATIONS:
@@ -426,6 +452,13 @@ async def _handle_connect(user_id: str, target: str) -> ToolResult:
 
 async def _handle_disconnect(user_id: str, target: str) -> ToolResult:
     """Remove OAuth tokens for an integration."""
+    if target in _HIDDEN_CORE_FACTORIES:
+        return ToolResult(
+            content=f"Unknown tool group '{target}'.",
+            is_error=True,
+            error_kind=ToolErrorKind.NOT_FOUND,
+        )
+
     if target in _MAGIC_LINK_INTEGRATIONS:
         return await _handle_magic_link_disconnect(user_id, target)
 

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -52,6 +52,17 @@ _TOOL_OAUTH_MAP: dict[str, str] = {
 # discovery surface for "connect <integration>".
 _MAGIC_LINK_INTEGRATIONS: set[str] = {"appfolio_vendor"}
 
+# Core factories that back a user-facing integration but should not surface
+# in ``manage_integration`` listings or be enable/disable-able on their own.
+# These are visibility-paired with another factory: when the user-facing
+# integration is disabled, the backing factory follows. ``appfolio_auth``
+# holds the magic-link connect tools that must stay on the schema even when
+# ``appfolio_vendor`` reports "not connected"; from the user's perspective
+# both are one integration.
+_HIDDEN_CORE_FACTORIES: dict[str, str] = {
+    "appfolio_auth": "appfolio_vendor",
+}
+
 
 _warned_missing_display_names: set[str] = set()
 
@@ -246,6 +257,8 @@ async def _handle_status(
     integration_lines: list[str] = []
 
     for name in sorted(registry.factory_names):
+        if name in _HIDDEN_CORE_FACTORIES:
+            continue
         factory = registry._factories.get(name)
         if factory is None:
             continue

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -1,20 +1,23 @@
-"""AppFolio Vendor Portal tool registration and factory.
+"""AppFolio Vendor Portal tool registration and factories.
 
 Picked up by the registry's ``ensure_tool_modules_imported`` scan; the
-``_register()`` call at the bottom installs the integration into the
-default tool registry at module-import time.
+``_register()`` call at the bottom installs two factories at module-import
+time:
 
-Two registration concerns:
+* ``appfolio_auth`` (core, always on the schema): the magic-link connect
+  tools (``appfolio_connect``, ``appfolio_complete_2fa``). These must
+  stay reachable even when the user has no credential, since pasting
+  the token *is* the connect path.
+* ``appfolio_vendor`` (specialist, gated on connection state): the data
+  tools (work orders, notes, invoices, payments, etc.). When the user
+  is not yet connected, ``_appfolio_vendor_auth_check`` returns a reason
+  string so the registry surfaces it under "Not connected" rather than
+  letting the LLM believe AppFolio is ready to use.
 
-1. The auth tools (``appfolio_connect``, ``appfolio_complete_2fa``) must
-   stay on the LLM schema even when the user has no credential, so the
-   factory always returns them and ``auth_check`` returns ``None``
-   unconditionally. The registry's ``auth_check`` contract is binary:
-   any non-None return value strips the entire factory's tools from
-   the schema, which would also hide the connect tool, leaving the
-   user with no in-product way to authenticate.
-2. The data tools (work orders, payments, profile) require a loaded
-   credential and so live in the factory body, hidden until connected.
+This split closes a prod bug where the agent confidently told users
+"AppFolio is connected" before they had connected, because a single
+combined factory had to keep ``auth_check`` returning ``None``
+unconditionally to keep the connect tool on the schema.
 """
 
 from __future__ import annotations
@@ -22,6 +25,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from backend.app.agent.stores import ToolConfigStore
 from backend.app.agent.tools.base import Tool
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
@@ -46,22 +50,38 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_INTEGRATION = "appfolio_vendor"
+_AUTH_FACTORY = "appfolio_auth"
+_DATA_FACTORY = "appfolio_vendor"
 
 
-async def _appfolio_factory(ctx: ToolContext) -> list[Tool]:
-    """Assemble AppFolio tools for the given user.
+async def _appfolio_auth_factory(ctx: ToolContext) -> list[Tool]:
+    """Assemble just the magic-link auth tools for AppFolio.
 
-    Always returns the two auth tools so the user can connect from a
-    fresh state. Data tools are appended only when a usable credential
-    is on file.
+    Returns the connect + 2FA tools so the user can authenticate from a
+    fresh state. Registered as a core factory so the schema contract is
+    independent of credential state. Mirrors the user-facing ``appfolio_vendor``
+    factory's enabled state: if the user has disabled AppFolio, the auth
+    tools disappear too.
     """
-    user_id = ctx.user.id
-    tools: list[Tool] = list(build_auth_tools(user_id))
-    cred = await load_credential(user_id)
+    disabled = await ToolConfigStore(ctx.user.id).get_disabled_tool_names()
+    if _DATA_FACTORY in disabled:
+        return []
+    return list(build_auth_tools(ctx.user.id))
+
+
+async def _appfolio_vendor_factory(ctx: ToolContext) -> list[Tool]:
+    """Assemble the AppFolio data tools for an authenticated user.
+
+    Callers should not invoke this when the user has no credential; the
+    registry guards via ``_appfolio_vendor_auth_check`` and skips factory
+    creation in that case. The defensive ``return []`` covers the rare
+    race where the credential disappears between auth check and create.
+    """
+    cred = await load_credential(ctx.user.id)
     if cred is None or not cred.jwt:
-        return tools
+        return []
     service = build_service(cred, api_base=settings.appfolio_vendor_api_base)
+    tools: list[Tool] = []
     tools.extend(build_work_order_tools(service))
     tools.extend(build_work_order_write_tools(service))
     tools.extend(build_note_tools(service, ctx))
@@ -74,34 +94,36 @@ async def _appfolio_factory(ctx: ToolContext) -> list[Tool]:
     return tools
 
 
-async def _appfolio_auth_check(ctx: ToolContext) -> str | None:
-    """Always return ``None`` so the auth tools stay on the schema.
+async def _appfolio_vendor_auth_check(ctx: ToolContext) -> str | None:
+    """Return ``None`` when the user has a usable AppFolio credential.
 
-    The registry's ``auth_check`` contract is binary: a non-None return
-    pulls *every* tool the factory builds out of the LLM schema. For
-    OAuth integrations that is fine because the registry surfaces a
-    connect URL through ``manage_integration``. AppFolio uses magic-link
-    auth, so the only way to connect is for the agent to call
-    ``appfolio_connect`` with a user-pasted token. If that tool is not
-    in the schema, no connect path exists. We always return ``None``
-    and let the factory body decide which tools to expose based on
-    credential state.
+    When no credential is on file, returns a reason string so the
+    registry surfaces ``appfolio_vendor`` under "Not connected" in the
+    LLM's capability list. The LLM then knows it must guide the user
+    through the magic-link flow before claiming AppFolio access.
+
+    The connect tool itself lives in the separate ``appfolio_auth``
+    factory (core, always available), so this auth_check returning a
+    reason does not strip the connect path from the schema.
     """
-    _ = ctx
-    return None
+    cred = await load_credential(ctx.user.id)
+    if cred is not None and cred.jwt:
+        return None
+    return (
+        "AppFolio Vendor Portal is not connected. Use "
+        "manage_integration(action='connect', target='appfolio_vendor') "
+        "for the magic-link recipe, then call appfolio_connect with the "
+        "URL the user pastes."
+    )
 
 
 def _register() -> None:
     from backend.app.agent.tools.registry import SubToolInfo, default_registry
 
     default_registry.register(
-        _INTEGRATION,
-        _appfolio_factory,
-        core=False,
-        summary=(
-            "Manage AppFolio Vendor Portal: view work orders, search,"
-            " check payments, and read your vendor profile"
-        ),
+        _AUTH_FACTORY,
+        _appfolio_auth_factory,
+        core=True,
         sub_tools=[
             SubToolInfo(
                 ToolName.APPFOLIO_CONNECT,
@@ -113,6 +135,21 @@ def _register() -> None:
                 "Submit AppFolio 2FA code",
                 default_permission="always",
             ),
+        ],
+    )
+
+    default_registry.register(
+        _DATA_FACTORY,
+        _appfolio_vendor_factory,
+        core=False,
+        summary=(
+            "AppFolio Vendor Portal: view, search, and act on work orders "
+            "(accept, schedule, update status, add notes with photos), "
+            "message tenants, create or upload invoices, upload compliance "
+            "documents (W-9, COI, license), update estimates and profile, "
+            "and check payments"
+        ),
+        sub_tools=[
             SubToolInfo(
                 ToolName.APPFOLIO_LIST_WORK_ORDERS,
                 "List AppFolio work orders by status",
@@ -209,7 +246,7 @@ def _register() -> None:
                 default_permission="ask",
             ),
         ],
-        auth_check=_appfolio_auth_check,
+        auth_check=_appfolio_vendor_auth_check,
     )
 
 

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from backend.app.agent.stores import ToolConfigStore
 from backend.app.agent.tools.base import Tool
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
@@ -59,13 +58,12 @@ async def _appfolio_auth_factory(ctx: ToolContext) -> list[Tool]:
 
     Returns the connect + 2FA tools so the user can authenticate from a
     fresh state. Registered as a core factory so the schema contract is
-    independent of credential state. Mirrors the user-facing ``appfolio_vendor``
-    factory's enabled state: if the user has disabled AppFolio, the auth
-    tools disappear too.
+    independent of credential state. Disabling the user-facing
+    ``appfolio_vendor`` integration cascades through ``manage_integration``
+    to also flip ``appfolio_auth`` in ``ToolConfigStore``, so the registry's
+    ``excluded_factories`` mechanism in ``tool_assembly`` removes both
+    factories together without a per-turn DB query in this factory body.
     """
-    disabled = await ToolConfigStore(ctx.user.id).get_disabled_tool_names()
-    if _DATA_FACTORY in disabled:
-        return []
     return list(build_auth_tools(ctx.user.id))
 
 
@@ -75,10 +73,17 @@ async def _appfolio_vendor_factory(ctx: ToolContext) -> list[Tool]:
     Callers should not invoke this when the user has no credential; the
     registry guards via ``_appfolio_vendor_auth_check`` and skips factory
     creation in that case. The defensive ``return []`` covers the rare
-    race where the credential disappears between auth check and create.
+    race where the credential disappears between auth check and create
+    (e.g. the user disconnected mid-turn). We log a warning so the race
+    is observable rather than silent.
     """
     cred = await load_credential(ctx.user.id)
     if cred is None or not cred.jwt:
+        logger.warning(
+            "AppFolio credential missing during factory creation for user %s "
+            "despite passing auth_check; user may have disconnected mid-turn",
+            ctx.user.id,
+        )
         return []
     service = build_service(cred, api_base=settings.appfolio_vendor_api_base)
     tools: list[Tool] = []

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from backend.app.agent.approval import ApprovalStore, PermissionLevel, get_approval_store
 from backend.app.agent.dto import SubToolEntry, ToolConfigEntry, UserData
 from backend.app.agent.stores import ToolConfigStore
+from backend.app.agent.tools.integration_tools import _HIDDEN_CORE_FACTORIES
 from backend.app.agent.tools.registry import (
     default_registry,
     ensure_tool_modules_imported,
@@ -116,6 +117,10 @@ async def _build_tool_list(
     )
     entries: list[ToolConfigEntry] = []
     for name in sorted(default_registry.factory_names):
+        # Hidden backing factories (e.g. ``appfolio_auth``) are part of a
+        # user-facing integration's plumbing, not a separate dashboard row.
+        if name in _HIDDEN_CORE_FACTORIES:
+            continue
         is_core = name in _CORE_FACTORIES
         meta = _FACTORY_META.get(name)
 

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -967,11 +967,14 @@ async def test_access_failure_does_not_log_magic_link(caplog: Any) -> None:
 async def test_auth_tools_always_in_schema_when_disconnected() -> None:
     """``appfolio_connect`` must stay reachable when the user has no credential.
 
-    The registry's ``auth_check`` contract is binary: any non-None return
-    value strips the entire factory's tools from the LLM schema. Magic-link
-    integrations need the auth tool on the schema regardless of connection
-    state, since pasting the token *is* the connect path. Regression for
-    the dev.clawbolt.ai bug where the agent had no way to start the flow.
+    Magic-link integrations need the auth tool on the schema regardless
+    of connection state, since pasting the token *is* the connect path.
+    The auth tools live in a separate core factory (``appfolio_auth``) so
+    the data factory's auth_check can correctly report "not connected"
+    without stripping the connect path. Regression for the prod bug where
+    the agent confidently told users "AppFolio is connected" before they
+    had connected, and for the original dev.clawbolt.ai bug where the
+    agent had no way to start the connect flow.
     """
     from backend.app.agent.tools.names import ToolName
     from backend.app.agent.tools.registry import (
@@ -986,21 +989,117 @@ async def test_auth_tools_always_in_schema_when_disconnected() -> None:
     user = User(id="appfolio-disconnected-user", user_id="test")
     ctx = ToolContext(user=user)
 
-    # auth_check must be None-returning unconditionally.
-    factory = default_registry._factories["appfolio_vendor"]
-    assert factory.auth_check is not None
-    assert await factory.auth_check(ctx) is None
+    # The data factory's auth_check returns a reason when not connected,
+    # so the registry will surface ``appfolio_vendor`` under "Not
+    # connected" in list_capabilities and the LLM will know it must
+    # connect first before claiming AppFolio access.
+    data_factory = default_registry._factories["appfolio_vendor"]
+    assert data_factory.auth_check is not None
+    with patch(
+        "backend.app.integrations.appfolio_vendor.factory.load_credential",
+        new=AsyncMock(return_value=None),
+    ):
+        reason = await data_factory.auth_check(ctx)
+    assert reason is not None
+    assert "not connected" in reason.lower()
 
-    # And the materialized factory output must include the auth tools.
-    from backend.app.integrations.appfolio_vendor.factory import _appfolio_factory
+    # The auth factory is separate, core, and always materializes the
+    # connect tools so the LLM has a way to drive the magic-link flow.
+    from backend.app.integrations.appfolio_vendor.factory import (
+        _appfolio_auth_factory,
+        _appfolio_vendor_factory,
+    )
+
+    auth_tools = await _appfolio_auth_factory(ctx)
+    auth_names = {t.name for t in auth_tools}
+    assert ToolName.APPFOLIO_CONNECT in auth_names
+    assert ToolName.APPFOLIO_COMPLETE_2FA in auth_names
+
+    # The data factory returns nothing when the credential is missing.
+    with patch(
+        "backend.app.integrations.appfolio_vendor.factory.load_credential",
+        new=AsyncMock(return_value=None),
+    ):
+        data_tools = await _appfolio_vendor_factory(ctx)
+    data_names = {t.name for t in data_tools}
+    assert ToolName.APPFOLIO_LIST_WORK_ORDERS not in data_names
+    assert ToolName.APPFOLIO_CONNECT not in data_names
+
+
+@pytest.mark.asyncio()
+async def test_unconnected_user_sees_appfolio_in_unauthenticated_list() -> None:
+    """When the user has no AppFolio credential, ``list_capabilities`` must
+    show ``appfolio_vendor`` under "Not connected", not in the available
+    specialists list. Regression for the prod bug where the agent told a
+    first-time user "Yeah, AppFolio is connected" before the user had
+    pasted any magic link, because the registry treated AppFolio as a
+    ready specialist regardless of credential state.
+    """
+    from backend.app.agent.tools.registry import (
+        ToolContext,
+        default_registry,
+        ensure_tool_modules_imported,
+    )
+    from backend.app.models import User
+
+    ensure_tool_modules_imported()
+
+    user = User(id="appfolio-unconnected", user_id="test")
+    ctx = ToolContext(user=user)
 
     with patch(
         "backend.app.integrations.appfolio_vendor.factory.load_credential",
         new=AsyncMock(return_value=None),
     ):
-        tools = await _appfolio_factory(ctx)
-    names = {t.name for t in tools}
-    assert ToolName.APPFOLIO_CONNECT in names
-    assert ToolName.APPFOLIO_COMPLETE_2FA in names
-    # Data tools should still be hidden until a credential is on file.
-    assert ToolName.APPFOLIO_LIST_WORK_ORDERS not in names
+        ready = await default_registry.get_available_specialist_summaries(ctx)
+        unauth = await default_registry.get_unauthenticated_specialists(ctx)
+
+    assert "appfolio_vendor" not in ready, (
+        "appfolio_vendor must NOT appear as a ready specialist for an "
+        "unconnected user; it should be in the unauthenticated list so "
+        "the LLM knows to guide the user through connecting first."
+    )
+    assert "appfolio_vendor" in unauth
+    assert "not connected" in unauth["appfolio_vendor"].lower()
+
+
+@pytest.mark.asyncio()
+async def test_connected_user_sees_appfolio_in_specialist_summaries() -> None:
+    """The complementary case: when the user has a usable credential,
+    ``appfolio_vendor`` must show up as a ready specialist. The summary
+    should mention write capabilities (notes, photos, invoices) so the
+    LLM knows it can act on work orders, not just read them.
+    """
+    from backend.app.agent.tools.registry import (
+        ToolContext,
+        default_registry,
+        ensure_tool_modules_imported,
+    )
+    from backend.app.models import User
+
+    ensure_tool_modules_imported()
+
+    user = User(id="appfolio-connected", user_id="test")
+    ctx = ToolContext(user=user)
+
+    cred = AppFolioCredential(
+        user_id=user.id,
+        jwt="eyJ.fake.jwt",
+        fingerprint="abc123",
+        customer_ids=["cust-1"],
+        extra={},
+    )
+    with patch(
+        "backend.app.integrations.appfolio_vendor.factory.load_credential",
+        new=AsyncMock(return_value=cred),
+    ):
+        ready = await default_registry.get_available_specialist_summaries(ctx)
+        unauth = await default_registry.get_unauthenticated_specialists(ctx)
+
+    assert "appfolio_vendor" in ready
+    assert "appfolio_vendor" not in unauth
+    summary = ready["appfolio_vendor"].lower()
+    # Read-only language alone caused the agent to refuse writes in prod
+    # ("AppFolio is read-only on my end..."). The summary must surface
+    # write capabilities so the LLM knows the full surface area.
+    assert "note" in summary or "invoice" in summary or "schedule" in summary

--- a/tests/test_integration_tools.py
+++ b/tests/test_integration_tools.py
@@ -575,3 +575,74 @@ async def test_appfolio_usage_hint_mentions_magic_link(test_user: User) -> None:
     hint = tool.usage_hint.lower()
     assert "appfolio" in hint
     assert "magic-link" in hint or "magic link" in hint
+
+
+# ---------------------------------------------------------------------------
+# Hidden backing factories (``appfolio_auth``)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_status_omits_hidden_appfolio_auth_factory(test_user: User) -> None:
+    """``manage_integration(status)`` must not surface the backing
+    ``appfolio_auth`` factory; users see only ``appfolio_vendor`` as the
+    AppFolio integration.
+    """
+    with patch(
+        "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await _call(test_user, "status")
+    assert "appfolio_auth" not in result.content
+
+
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("action", ["enable", "disable", "connect", "disconnect"])
+async def test_hidden_factory_rejected_from_all_actions(test_user: User, action: str) -> None:
+    """All ``manage_integration`` actions must reject the backing
+    ``appfolio_auth`` factory as ``Unknown tool group``. The LLM never has
+    a reason to address it directly; this is defense in depth in case it
+    tries.
+    """
+    result = await _call(test_user, action, "appfolio_auth")
+    assert result.is_error
+    assert "Unknown tool group" in result.content
+    assert "appfolio_auth" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_disable_appfolio_vendor_cascades_to_appfolio_auth(
+    test_user: User,
+) -> None:
+    """Disabling ``appfolio_vendor`` must also flip ``appfolio_auth`` so
+    the registry's ``excluded_factories`` mechanism removes both
+    factories together. Without the cascade, the auth tools would stay
+    on the LLM's schema even though the user disabled the integration.
+    """
+    store = ToolConfigStore(test_user.id)
+
+    result = await _call(test_user, "disable", "appfolio_vendor")
+    assert not result.is_error
+
+    disabled = await store.get_disabled_tool_names()
+    assert "appfolio_vendor" in disabled
+    assert "appfolio_auth" in disabled
+
+
+@pytest.mark.asyncio()
+async def test_enable_appfolio_vendor_cascades_to_appfolio_auth(
+    test_user: User,
+) -> None:
+    """The complementary cascade: re-enabling ``appfolio_vendor`` must
+    also re-enable ``appfolio_auth`` so the connect flow works again.
+    """
+    store = ToolConfigStore(test_user.id)
+    await store.set_enabled("appfolio_vendor", enabled=False)
+    await store.set_enabled("appfolio_auth", enabled=False)
+
+    result = await _call(test_user, "enable", "appfolio_vendor")
+    assert not result.is_error
+
+    disabled = await store.get_disabled_tool_names()
+    assert "appfolio_vendor" not in disabled
+    assert "appfolio_auth" not in disabled


### PR DESCRIPTION
## Description

In prod the agent told a first-time user `Yeah, AppFolio is connected` before they had connected, and refused to do writes (`AppFolio is read-only on my end`) even after they had connected. Two root causes, both fixed here.

### 1. False "connected" claim

`_appfolio_auth_check` returned `None` unconditionally so the `appfolio_connect` tool would stay reachable through the binary `auth_check` contract. Side effect: the registry treated `appfolio_vendor` as a ready specialist regardless of credential state, and the LLM read that as `I have AppFolio access`.

Fix: split the integration into two factories.

- **`appfolio_auth`** (core, always on the schema): the magic-link `appfolio_connect` and `appfolio_complete_2fa` tools. Mirrors the user-facing `appfolio_vendor` enabled state so disabling the integration also hides them.
- **`appfolio_vendor`** (specialist, gated): the data tools. Its `auth_check` now returns a `not connected` reason when no credential is on file, so `list_capabilities` surfaces it under `Not connected (user must authenticate before use)` with the existing `Do NOT attempt to activate these` guidance.

### 2. Read-only summary text

The static specialist summary listed only read operations: `view work orders, search, check payments, and read your vendor profile`. The LLM parroted that back as the integration's full surface area when a connected user asked it to add a note. Rewrote the summary to enumerate the write surface area: accept/schedule/update work orders, add notes with photos, message tenants, create or upload invoices, upload compliance documents, update estimates and profile, check payments.

### Misc

Adds `_HIDDEN_CORE_FACTORIES` in `integration_tools` so the backing `appfolio_auth` factory does not appear as its own entry in `manage_integration(action='status')`. From the user's perspective both factories are one integration.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

New/updated tests:
- Updated `test_auth_tools_always_in_schema_when_disconnected` for the new factory split.
- Added `test_unconnected_user_sees_appfolio_in_unauthenticated_list` locking in that the LLM is told `not connected` rather than treating AppFolio as ready.
- Added `test_connected_user_sees_appfolio_in_specialist_summaries` asserting the summary mentions write capabilities so the LLM knows the full surface area.

## AI Usage
- [x] AI-assisted: Claude (Opus 4.7) drafted the diagnosis, factory split, and tests through back-and-forth with @njbrake.
