### PR TITLE
fix(frontend): drop photo access hint from get started page

### DIFF
--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -285,7 +285,6 @@ export default function GetStartedPage() {
                     subtitle="Send an iMessage to this address to get started."
                     qrSize={120}
                   />
-                  <PhotoAccessHint />
                 </div>
               ) : selectedChannel === 'bluebubbles' && bbConfigured && bbAddress ? (
                 <div className="mt-2 grid gap-2">
@@ -294,7 +293,6 @@ export default function GetStartedPage() {
                     subtitle="Send an iMessage to this address to get started."
                     qrSize={120}
                   />
-                  <PhotoAccessHint />
                 </div>
               ) : (
                 <p className="text-sm text-muted-foreground mt-1">
@@ -615,7 +613,6 @@ function MobileImessageFlow({
             <p className="text-center text-sm font-mono">{imessageNumber}</p>
           </>
         )}
-        <PhotoAccessHint />
       </Card>
     );
   }
@@ -722,7 +719,6 @@ function MobileTelegramFlow({
         {telegramBotInfo?.bot_username && (
           <p className="text-center text-sm font-mono">@{telegramBotInfo.bot_username}</p>
         )}
-        <PhotoAccessHint />
       </Card>
     );
   }
@@ -767,14 +763,6 @@ function MobileTelegramFlow({
 // ---------------------------------------------------------------------------
 // Shared bits
 // ---------------------------------------------------------------------------
-
-function PhotoAccessHint() {
-  return (
-    <p className="text-xs text-muted-foreground italic">
-      Clawbolt only sees photos you send it. It can't browse your camera roll.
-    </p>
-  );
-}
 
 function ChannelRadioItem({
   value,


### PR DESCRIPTION
## Description
Removes the italic note "Clawbolt only sees photos you send it. It can't browse your camera roll." from the Get Started page. This message added noise on a page meant to get users moving quickly.

Removed all four call sites of `<PhotoAccessHint />` (linq, bluebubbles, mobile iMessage flow, mobile Telegram flow) plus the now-unused `PhotoAccessHint` helper.

Fixes #1264

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

Note: this is a pure UI string removal in a presentational component with no behavioral logic. The existing 23 `GetStartedPage` tests continue to pass. Backend tests/lint are unaffected by this frontend-only change. The one failing vitest case (`ToolsPage.test.tsx`) is pre-existing on `main` and unrelated.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Drafted with Claude Code via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's.