### PR TITLE
feat(agent): admin-triggered context compaction

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -166,6 +166,7 @@ async def compact_session(
     trimmed_messages: list[AgentMessage],
     max_message_seq: int | None = None,
     event_id: int | None = None,
+    admin_note: str | None = None,
 ) -> tuple[str, int | None]:
     """Consolidate messages into an updated MEMORY.md via LLM rewrite.
 
@@ -185,6 +186,13 @@ async def compact_session(
             trim watermark. When ``None`` (e.g. test invocations or any
             future caller that has not pre-inserted), a new completed row
             is inserted.
+        admin_note: Optional steering note prepended to the conversation
+            block as ``[admin note: ...]`` so the compaction LLM can be
+            biased about how to read the conversation. Used by the admin
+            "compact now" path to flag e.g. "the agent made factual errors
+            about its own capabilities; do not preserve those as facts".
+            Has no effect on the trim-driven hot path, which leaves it
+            unset.
 
     Returns:
         A tuple of (memory_update, max_message_seq) where memory_update is the
@@ -200,6 +208,9 @@ async def compact_session(
     conversation_text = _format_messages_for_compaction(trimmed_messages)
     if not conversation_text.strip():
         return "", None
+
+    if admin_note:
+        conversation_text = f"[admin note: {admin_note}]\n\n{conversation_text}"
 
     # Telemetry: compaction is a routine operation for active users (every
     # ~27 days at 15k tokens/day, more often for power users). Capturing

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -299,6 +299,63 @@ def _expand_outbound_with_tools(
     return messages
 
 
+def _stored_messages_to_agent_messages(messages: list[Any]) -> list[AgentMessage]:
+    """Convert ``StoredMessage`` rows to typed ``AgentMessage`` objects.
+
+    Mirrors the conversion logic of ``load_conversation_history`` so any
+    caller operating on a custom slice (e.g. the admin compact-now path)
+    sees the same shape the LLM would normally receive: tool interactions
+    expanded, approval prompts and orphan approval replies dropped.
+
+    Stateful across the loop because dropping an approval prompt also
+    requires dropping the user's "yes/no" reply that immediately follows
+    it. ``last_was_approval_prompt`` carries that flag forward.
+    """
+    history: list[AgentMessage] = []
+    last_was_approval_prompt = False
+    for msg in messages:
+        # Prefer processed context (includes media descriptions) over raw body
+        content = msg.processed_context if msg.processed_context else msg.body
+        if msg.direction == MessageDirection.INBOUND:
+            # Rapid-fire attachment-only messages can be batched so the
+            # placeholder row is persisted with no body and no processed
+            # context. Keeping that blank row in history teaches the LLM
+            # that the previous user turn was "silent", which can produce
+            # stray clarification text on the next real message.
+            if not (content or "").strip():
+                last_was_approval_prompt = False
+                continue
+            # Drop the user's approval reply ("Yes", "Always", ...) when it
+            # immediately follows a (now-filtered) approval prompt. Without
+            # this, the orphan reply floats in history with no antecedent
+            # and risks confusing the LLM. We only filter the strict
+            # fast-path keyword set so a stray "Yes" in normal conversation
+            # is preserved.
+            if last_was_approval_prompt and _parse_approval_response(content) is not None:
+                last_was_approval_prompt = False
+                continue
+            last_was_approval_prompt = False
+            history.append(UserMessage(content=content, seq=msg.seq))
+        else:
+            # Check for stored tool interactions
+            tool_interactions = _parse_tool_interactions(msg.tool_interactions_json)
+            if tool_interactions:
+                history.extend(_expand_outbound_with_tools(tool_interactions, content, seq=msg.seq))
+                last_was_approval_prompt = False
+            elif _is_approval_prompt(content):
+                # Skip approval prompts (real ones persisted by older code,
+                # plus any LLM-generated fake prompts that mimic the format).
+                # Persisted prompts in past turns trained the LLM to produce
+                # them as prose instead of calling tools, creating an
+                # infinite-loop UX bug. Filtering at load time heals
+                # already-poisoned sessions without a DB migration.
+                last_was_approval_prompt = True
+            else:
+                history.append(AssistantMessage(content=content, seq=msg.seq))
+                last_was_approval_prompt = False
+    return history
+
+
 async def load_conversation_history(
     session: SessionState,
     limit: int = DEFAULT_HISTORY_LIMIT,
@@ -334,54 +391,10 @@ async def load_conversation_history(
     else:
         messages = []
 
-    history: list[AgentMessage] = []
-    tool_interaction_count = 0
-    last_was_approval_prompt = False
-    for msg in messages:
-        # Prefer processed context (includes media descriptions) over raw body
-        content = msg.processed_context if msg.processed_context else msg.body
-        if msg.direction == MessageDirection.INBOUND:
-            # Rapid-fire attachment-only messages can be batched so the
-            # placeholder row is persisted with no body and no processed
-            # context. Keeping that blank row in history teaches the LLM
-            # that the previous user turn was "silent", which can produce
-            # stray clarification text on the next real message.
-            if not (content or "").strip():
-                last_was_approval_prompt = False
-                continue
-            # Drop the user's approval reply ("Yes", "Always", ...) when it
-            # immediately follows a (now-filtered) approval prompt. Without
-            # this, the orphan reply floats in history with no antecedent
-            # and risks confusing the LLM. We only filter the strict
-            # fast-path keyword set so a stray "Yes" in normal conversation
-            # is preserved.
-            if last_was_approval_prompt and _parse_approval_response(content) is not None:
-                last_was_approval_prompt = False
-                continue
-            last_was_approval_prompt = False
-            history.append(UserMessage(content=content, seq=msg.seq))
-        else:
-            # Check for stored tool interactions
-            tool_interactions = _parse_tool_interactions(msg.tool_interactions_json)
-            if tool_interactions:
-                tool_interaction_count += len(tool_interactions)
-                history.extend(_expand_outbound_with_tools(tool_interactions, content, seq=msg.seq))
-                last_was_approval_prompt = False
-            elif _is_approval_prompt(content):
-                # Skip approval prompts (real ones persisted by older code,
-                # plus any LLM-generated fake prompts that mimic the format).
-                # Persisted prompts in past turns trained the LLM to produce
-                # them as prose instead of calling tools, creating an
-                # infinite-loop UX bug. Filtering at load time heals
-                # already-poisoned sessions without a DB migration.
-                last_was_approval_prompt = True
-            else:
-                history.append(AssistantMessage(content=content, seq=msg.seq))
-                last_was_approval_prompt = False
+    history = _stored_messages_to_agent_messages(messages)
     logger.debug(
-        "Loaded %d history messages (%d with tool interactions) for session %s",
+        "Loaded %d history messages for session %s",
         len(history),
-        tool_interaction_count,
         session.session_id,
     )
     return history
@@ -395,3 +408,155 @@ async def get_or_create_conversation(user_id: str) -> tuple[SessionState, bool]:
     where ``is_new`` is True only on the very first message for a user.
     """
     return await get_session_store(user_id).get_or_create_session()
+
+
+class AdminCompactionResult(BaseModel):
+    """Outcome of an admin-triggered context compaction."""
+
+    compacted_message_count: int
+    new_watermark: int | None
+    memory_updated: bool
+    event_id: int | None
+
+
+async def admin_compact_visible_messages(
+    user_id: str,
+    keep_recent: int = 0,
+    admin_note: str | None = None,
+) -> AdminCompactionResult:
+    """Synchronously compact every message currently visible to the agent.
+
+    Companion to :func:`trigger_compaction_for_dropped`, but driven by an
+    admin (not by the trim path) so the LLM-facing context can be reset
+    when the conversation has been poisoned, e.g. by a now-fixed bug
+    that taught the agent a wrong fact about its own capabilities.
+
+    Resolves "everything visible" the same way ``load_conversation_history``
+    does: messages with ``seq > sessions.last_trim_seq``, excluding orphan
+    approval prompts/replies, with tool interactions expanded. The last
+    *keep_recent* visible turns are preserved on the schema so the agent
+    still has immediate context if the admin wants to surgically clear
+    older noise without dropping a pending request.
+
+    Phase 1 (synchronous, one transaction) inserts a pending
+    ``CompactionEvent`` and advances ``sessions.last_trim_seq`` to the max
+    seq of the to-compact set, mirroring ``trigger_compaction_for_dropped``
+    so the next inbound's history loader already filters them.
+
+    Phase 2 (synchronous, awaited) calls :func:`compact_session` with the
+    optional admin note prepended to the conversation block. Unlike the
+    trim-driven path, we await the LLM call here so the admin endpoint
+    can return a real result and surface failures.
+    """
+    if keep_recent < 0:
+        raise ValueError("keep_recent must be non-negative")
+
+    if not settings.compaction_enabled:
+        return AdminCompactionResult(
+            compacted_message_count=0,
+            new_watermark=None,
+            memory_updated=False,
+            event_id=None,
+        )
+
+    store = get_session_store(user_id)
+    state, _ = await store.get_or_create_session()
+
+    watermark = state.last_trim_seq or 0
+    above = [m for m in state.messages if m.seq > watermark]
+    if keep_recent > 0:
+        to_compact_stored = above[:-keep_recent] if keep_recent <= len(above) else []
+    else:
+        to_compact_stored = list(above)
+
+    if not to_compact_stored:
+        return AdminCompactionResult(
+            compacted_message_count=0,
+            new_watermark=state.last_trim_seq,
+            memory_updated=False,
+            event_id=None,
+        )
+
+    agent_messages = _stored_messages_to_agent_messages(to_compact_stored)
+    if not agent_messages:
+        # All visible rows were filtered (e.g. only approval prompts).
+        # Still advance the watermark so they stop reaching the LLM, but
+        # skip the LLM call since there is nothing to extract facts from.
+        max_seq = to_compact_stored[-1].seq
+        await _advance_trim_watermark_only(user_id, max_seq)
+        return AdminCompactionResult(
+            compacted_message_count=0,
+            new_watermark=max_seq,
+            memory_updated=False,
+            event_id=None,
+        )
+
+    # Mirror ``_seqs_from_dropped``: only ``UserMessage`` /
+    # ``AssistantMessage`` carry ``seq``; tool-result and system messages
+    # do not. ``getattr`` with isinstance narrows for the type checker.
+    seqs = [getattr(m, "seq", None) for m in agent_messages]
+    seqs = [s for s in seqs if isinstance(s, int)]
+    if not seqs:
+        return AdminCompactionResult(
+            compacted_message_count=0,
+            new_watermark=state.last_trim_seq,
+            memory_updated=False,
+            event_id=None,
+        )
+    min_seq = min(seqs)
+    max_seq = max(seqs)
+    triggered_at = datetime.datetime.now(datetime.UTC)
+
+    event_id: int
+    async with db_session_async() as db:
+        event = CompactionEvent(
+            user_id=user_id,
+            triggered_at=triggered_at,
+            status="pending",
+            min_message_seq=min_seq,
+            max_message_seq=max_seq,
+            trimmed_count=len(agent_messages),
+        )
+        db.add(event)
+        await db.flush()
+        assert event.id is not None, "flush() must populate the autoincrement id"
+        event_id = event.id
+
+        cs = (await db.execute(select(ChatSession).filter_by(user_id=user_id))).scalar_one_or_none()
+        if cs is not None:
+            current = cs.last_trim_seq or 0
+            if max_seq > current:
+                cs.last_trim_seq = max_seq
+        await db.commit()
+
+    memory_update, _ = await compact_session(
+        user_id,
+        agent_messages,
+        max_message_seq=max_seq,
+        event_id=event_id,
+        admin_note=admin_note,
+    )
+
+    return AdminCompactionResult(
+        compacted_message_count=len(agent_messages),
+        new_watermark=max_seq,
+        memory_updated=bool(memory_update),
+        event_id=event_id,
+    )
+
+
+async def _advance_trim_watermark_only(user_id: str, max_seq: int) -> None:
+    """Advance ``sessions.last_trim_seq`` without inserting a compaction event.
+
+    Used when an admin compaction would drop only filtered rows (e.g.
+    nothing but approval prompts). There is nothing to extract facts
+    from, so the LLM call is skipped, but the watermark still advances
+    so the rows stop reaching the LLM.
+    """
+    async with db_session_async() as db:
+        cs = (await db.execute(select(ChatSession).filter_by(user_id=user_id))).scalar_one_or_none()
+        if cs is not None:
+            current = cs.last_trim_seq or 0
+            if max_seq > current:
+                cs.last_trim_seq = max_seq
+        await db.commit()

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from backend.app.agent.compaction import (
     compact_session,
 )
 from backend.app.agent.context import (
+    admin_compact_visible_messages,
     load_conversation_history,
     trigger_compaction_for_dropped,
 )
@@ -1578,3 +1580,241 @@ async def test_compact_session_truncates_oversized_prompt(
         record = json.loads(ev.prompt_text)
         assert record["truncated"] is True
         assert record["size_bytes"] >= 60_000
+
+
+# ---------------------------------------------------------------------------
+# admin_compact_visible_messages: admin-triggered context reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_admin_compact_visible_messages_compacts_everything_above_watermark(
+    test_user: User,
+) -> None:
+    """The admin path must compact every visible message and advance the
+    watermark to the latest seq. Regression scaffold for the prod issue
+    where the agent's poisoned in-context turns needed to be cleared
+    without dropping durable user-supplied facts.
+    """
+    cs = await _seed_session_with_messages(test_user, message_count=10)
+    # Pre-seed a partial watermark so we exercise the "above watermark"
+    # filter, not just "everything in the session".
+    async with db_session_async() as db:
+        cs_ref = (await db.execute(select(ChatSession).filter_by(id=cs.id))).scalar_one_or_none()
+        assert cs_ref is not None
+        cs_ref.last_trim_seq = 3
+        await db.commit()
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_compact(*args: Any, **kwargs: Any) -> tuple[str, int | None]:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return ("## Notes\n- compacted", kwargs.get("max_message_seq"))
+
+    with patch("backend.app.agent.context.compact_session", new=_fake_compact):
+        result = await admin_compact_visible_messages(test_user.id)
+
+    assert result.compacted_message_count == 7  # seqs 4..10
+    assert result.new_watermark == 10
+    assert result.memory_updated is True
+    assert result.event_id is not None
+
+    # compact_session was called with messages whose seqs are 4..10.
+    passed_messages = captured["args"][1]
+    seqs = [m.seq for m in passed_messages if isinstance(m.seq, int)]
+    assert seqs == list(range(4, 11))
+    assert captured["kwargs"]["admin_note"] is None
+
+    # Watermark advanced and a CompactionEvent row was inserted.
+    async with db_session_async() as db:
+        cs_ref = (await db.execute(select(ChatSession).filter_by(id=cs.id))).scalar_one_or_none()
+        assert cs_ref is not None
+        assert cs_ref.last_trim_seq == 10
+        events = (
+            (await db.execute(select(CompactionEvent).filter_by(user_id=test_user.id)))
+            .scalars()
+            .all()
+        )
+        assert len(events) == 1
+        assert events[0].min_message_seq == 4
+        assert events[0].max_message_seq == 10
+        assert events[0].trimmed_count == 7
+
+
+@pytest.mark.asyncio()
+async def test_admin_compact_visible_messages_keeps_recent_tail(test_user: User) -> None:
+    """``keep_recent`` must preserve the tail so the agent retains an
+    immediate request even when older context is being cleared.
+    """
+    await _seed_session_with_messages(test_user, message_count=10)
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_compact(*args: Any, **kwargs: Any) -> tuple[str, int | None]:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return ("", kwargs.get("max_message_seq"))
+
+    with patch("backend.app.agent.context.compact_session", new=_fake_compact):
+        result = await admin_compact_visible_messages(test_user.id, keep_recent=3)
+
+    # 10 visible (no prior watermark), keep last 3 → compact seqs 1..7.
+    assert result.compacted_message_count == 7
+    assert result.new_watermark == 7
+
+    passed_messages = captured["args"][1]
+    seqs = [m.seq for m in passed_messages if isinstance(m.seq, int)]
+    assert seqs == list(range(1, 8))
+
+
+@pytest.mark.asyncio()
+async def test_admin_compact_visible_messages_admin_note_flows_through(
+    test_user: User,
+) -> None:
+    """The admin-supplied steering note must reach ``compact_session`` so
+    the LLM can be biased about how to read the conversation.
+    """
+    await _seed_session_with_messages(test_user, message_count=4)
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_compact(*args: Any, **kwargs: Any) -> tuple[str, int | None]:
+        captured["kwargs"] = kwargs
+        return ("", kwargs.get("max_message_seq"))
+
+    with patch("backend.app.agent.context.compact_session", new=_fake_compact):
+        await admin_compact_visible_messages(
+            test_user.id,
+            admin_note="ignore prior agent self-claims about AppFolio",
+        )
+
+    assert captured["kwargs"]["admin_note"] == "ignore prior agent self-claims about AppFolio"
+
+
+@pytest.mark.asyncio()
+async def test_admin_compact_visible_messages_no_visible_returns_zero(
+    test_user: User,
+) -> None:
+    """When the watermark already covers every message, the admin call
+    must be a no-op (no LLM call, no event row, watermark unchanged).
+    """
+    cs = await _seed_session_with_messages(test_user, message_count=5)
+    async with db_session_async() as db:
+        cs_ref = (await db.execute(select(ChatSession).filter_by(id=cs.id))).scalar_one_or_none()
+        assert cs_ref is not None
+        cs_ref.last_trim_seq = 5
+        await db.commit()
+
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("", None)),
+    ) as mock_compact:
+        result = await admin_compact_visible_messages(test_user.id)
+
+    mock_compact.assert_not_awaited()
+    assert result.compacted_message_count == 0
+    assert result.new_watermark == 5
+    assert result.memory_updated is False
+    assert result.event_id is None
+
+    async with db_session_async() as db:
+        events = (
+            (await db.execute(select(CompactionEvent).filter_by(user_id=test_user.id)))
+            .scalars()
+            .all()
+        )
+        assert events == []
+
+
+@pytest.mark.asyncio()
+async def test_admin_compact_visible_messages_skips_when_disabled(test_user: User) -> None:
+    """When ``compaction_enabled`` is off, the admin path must be a no-op."""
+    await _seed_session_with_messages(test_user, message_count=5)
+
+    with (
+        patch.object(settings, "compaction_enabled", False),
+        patch(
+            "backend.app.agent.context.compact_session",
+            new=AsyncMock(return_value=("", None)),
+        ) as mock_compact,
+    ):
+        result = await admin_compact_visible_messages(test_user.id)
+
+    mock_compact.assert_not_awaited()
+    assert result.compacted_message_count == 0
+    assert result.event_id is None
+
+
+@pytest.mark.asyncio()
+async def test_admin_compact_visible_messages_keep_recent_larger_than_visible(
+    test_user: User,
+) -> None:
+    """``keep_recent`` greater than visible count is a degenerate no-op
+    (nothing left to compact). Watermark and stores untouched.
+    """
+    await _seed_session_with_messages(test_user, message_count=3)
+
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("", None)),
+    ) as mock_compact:
+        result = await admin_compact_visible_messages(test_user.id, keep_recent=10)
+
+    mock_compact.assert_not_awaited()
+    assert result.compacted_message_count == 0
+
+
+@pytest.mark.asyncio()
+async def test_admin_compact_visible_messages_rejects_negative_keep_recent(
+    test_user: User,
+) -> None:
+    """Negative ``keep_recent`` is a programming error and must raise."""
+    with pytest.raises(ValueError):
+        await admin_compact_visible_messages(test_user.id, keep_recent=-1)
+
+
+# ---------------------------------------------------------------------------
+# compact_session: admin_note steering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_admin_note_prepended_to_conversation(
+    test_user: User,
+) -> None:
+    """``admin_note`` must land inside ``<conversation>`` as ``[admin note: ...]``
+    so the compaction LLM sees it alongside the messages.
+    """
+    mock_response = make_text_response(json.dumps({"memory_update": "## empty\n", "summary": ""}))
+    messages: list[AgentMessage] = [UserMessage(content="Hello", seq=1)]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response) as mock_llm:
+        await compact_session(
+            test_user.id,
+            messages,
+            admin_note="ignore prior agent self-claims",
+        )
+
+    user_content = mock_llm.call_args.kwargs["messages"][0]["content"]
+    assert "[admin note: ignore prior agent self-claims]" in user_content
+    # The admin note lives inside <conversation>, not as a sibling tag.
+    conv_start = user_content.index("<conversation>")
+    conv_end = user_content.index("</conversation>")
+    assert "[admin note:" in user_content[conv_start:conv_end]
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_no_admin_note_no_prefix(test_user: User) -> None:
+    """Without an admin note the conversation block must not contain
+    ``[admin note:``. Locks in that the trim-driven hot path (which never
+    sets the parameter) is unaffected by this change.
+    """
+    mock_response = make_text_response(json.dumps({"memory_update": "", "summary": ""}))
+    messages: list[AgentMessage] = [UserMessage(content="Hello", seq=1)]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response) as mock_llm:
+        await compact_session(test_user.id, messages)
+
+    user_content = mock_llm.call_args.kwargs["messages"][0]["content"]
+    assert "[admin note:" not in user_content


### PR DESCRIPTION
## Description

Adds `admin_compact_visible_messages` so an admin can synchronously compact every message currently visible to the agent (`seq > sessions.last_trim_seq`), advance the watermark, and write a `CompactionEvent` audit row.

The motivation is poisoned-context recovery. When an OSS bug taught the agent a wrong fact about its own capabilities, the existing options were the chat UI's `delete conversation history` (which drops the user's durable facts) or letting the trim path eventually compact the bad turns out (which only fires once the context window is about to overflow). This admin entry point closes that gap by reusing `compact_session` over a custom message slice, so durable facts are preserved while the bad in-context turns are summarized and removed from future LLM input.

### Highlights

- `keep_recent` preserves the tail so an admin can clear stale noise without dropping the user's most recent pending request.
- `admin_note` is a steering hint prepended inside `<conversation>` as `[admin note: ...]` so the compaction LLM can be biased about how to read the messages (e.g. `ignore prior agent self-claims about AppFolio capabilities`). The trim hot path leaves it unset.
- Conversion of `StoredMessage` rows to `AgentMessage` objects is factored into `_stored_messages_to_agent_messages`, called by both `load_conversation_history` (existing behavior unchanged) and the new admin path so they see the same approval-prompt filtering and tool-interaction expansion.
- Phase-1 (insert pending event + advance watermark in one transaction) mirrors `trigger_compaction_for_dropped` so the next inbound's history loader already filters the compacted range.
- Phase-2 (the LLM call) is awaited synchronously so the admin endpoint can return a real success/failure result rather than fire-and-forget.

A premium admin endpoint that calls this helper, plus an admin UI button for it, will land in a follow-up premium PR.

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v` — 2408 passed)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (9 new in `tests/test_compaction.py`)
- [ ] Bug fixes include regression tests (not a bug fix)

## AI Usage
- [x] AI-assisted: Claude (Opus 4.7) drafted the helper, factored the conversion split, and wrote the tests through back-and-forth with @njbrake.
