### PR TITLE
feat(integrations): add Gmail integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,14 @@ LLM_MODEL=
 # GOOGLE_CALENDAR_CLIENT_ID=
 # GOOGLE_CALENDAR_CLIENT_SECRET=
 
+# Gmail
+# Set client_id and client_secret to enable the Gmail integration. Use a
+# separate Google OAuth client from Calendar/Drive so the gmail.readonly
+# and gmail.send scopes can be approved independently. Users connect via
+# manage_integration(action='connect', target='gmail').
+# GMAIL_CLIENT_ID=
+# GMAIL_CLIENT_SECRET=
+
 # CompanyCam OAuth 2.0
 # Register your app at https://docs.companycam.com/docs/oauth
 # COMPANYCAM_CLIENT_ID=

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -33,6 +33,7 @@ _DISPLAY_NAMES: dict[str, str] = {
     "heartbeat": "Heartbeat",
     "quickbooks": "QuickBooks Online",
     "calendar": "Google Calendar",
+    "gmail": "Gmail",
     "companycam": "CompanyCam",
     "supplier_pricing": "Home Depot pricing",
     "appfolio_vendor": "AppFolio Vendor Portal",
@@ -44,6 +45,7 @@ _TOOL_OAUTH_MAP: dict[str, str] = {
     "quickbooks": "quickbooks",
     "companycam": "companycam",
     "file": "google_drive",
+    "gmail": "gmail",
 }
 
 # Tool groups that use magic-link / paste-token auth instead of OAuth. These

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -36,6 +36,12 @@ class ToolName:
     QB_UPDATE = "qb_update"
     QB_SEND = "qb_send"
 
+    # Gmail
+    GMAIL_SEARCH = "gmail_search"
+    GMAIL_GET_MESSAGE = "gmail_get_message"
+    GMAIL_LIST_RECENT = "gmail_list_recent"
+    GMAIL_SEND = "gmail_send"
+
     # Calendar
     CALENDAR_LIST_CALENDARS = "calendar_list_calendars"
     CALENDAR_LIST_EVENTS = "calendar_list_events"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -177,6 +177,15 @@ class Settings(BaseSettings):
     google_calendar_client_id: str = ""
     google_calendar_client_secret: str = ""
 
+    # Gmail: per-user Gmail API access via OAuth. The deployment supplies the
+    # OAuth client credentials; each user grants the ``gmail.readonly`` and
+    # ``gmail.send`` scopes through
+    # ``manage_integration(action='connect', target='gmail')``. Read access
+    # lets the agent search and fetch the user's own messages; send access
+    # lets it compose new messages or thread replies on the user's behalf.
+    gmail_client_id: str = ""
+    gmail_client_secret: str = ""
+
     # CompanyCam OAuth 2.0
     companycam_client_id: str = ""
     companycam_client_secret: str = ""

--- a/backend/app/integrations/gmail/__init__.py
+++ b/backend/app/integrations/gmail/__init__.py
@@ -1,0 +1,13 @@
+"""Gmail integration: search, read, and send messages on the user's behalf.
+
+The integration uses Gmail's REST API with two OAuth scopes:
+
+* ``gmail.readonly`` for ``messages.list`` and ``messages.get``
+* ``gmail.send`` for composing new mail and threaded replies
+
+The factory registers four agent tools (``gmail_search``, ``gmail_get_message``,
+``gmail_list_recent``, ``gmail_send``) all defaulting to ``ask`` permission so
+the user is prompted before any mailbox access or outbound message.
+"""
+
+from backend.app.integrations.gmail import factory  # noqa: F401  (registers tools)

--- a/backend/app/integrations/gmail/__init__.py
+++ b/backend/app/integrations/gmail/__init__.py
@@ -9,5 +9,3 @@ The factory registers four agent tools (``gmail_search``, ``gmail_get_message``,
 ``gmail_list_recent``, ``gmail_send``) all defaulting to ``ask`` permission so
 the user is prompted before any mailbox access or outbound message.
 """
-
-from backend.app.integrations.gmail import factory  # noqa: F401  (registers tools)

--- a/backend/app/integrations/gmail/factory.py
+++ b/backend/app/integrations/gmail/factory.py
@@ -207,7 +207,7 @@ def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
 def create_gmail_tools(service: GmailService) -> list[Tool]:
     """Create Gmail tools bound to a service instance."""
 
-    async def gmail_search(query: str, max_results: int = 10) -> ToolResult:
+    async def _run_search(query: str, max_results: int, empty_msg: str) -> ToolResult:
         try:
             results = await service.search_messages(query, max_results)
         except httpx.TimeoutException:
@@ -227,11 +227,14 @@ def create_gmail_tools(service: GmailService) -> list[Tool]:
             )
 
         if not results:
-            return ToolResult(content=f"No messages match '{query}'.")
+            return ToolResult(content=empty_msg)
         lines = [f"Found {len(results)} message(s):"]
         for s in results:
             lines.append(f"- {_format_summary(s)}")
         return ToolResult(content="\n".join(lines))
+
+    async def gmail_search(query: str, max_results: int = 10) -> ToolResult:
+        return await _run_search(query, max_results, f"No messages match '{query}'.")
 
     async def gmail_get_message(message_id: str) -> ToolResult:
         try:
@@ -256,7 +259,7 @@ def create_gmail_tools(service: GmailService) -> list[Tool]:
     async def gmail_list_recent(max_results: int = 10) -> ToolResult:
         # Empty query lists in reverse-chronological order, matching the
         # Gmail web UI's default inbox view.
-        return await gmail_search("", max_results)
+        return await _run_search("", max_results, "Inbox is empty.")
 
     async def gmail_send(
         to: list[str],

--- a/backend/app/integrations/gmail/factory.py
+++ b/backend/app/integrations/gmail/factory.py
@@ -1,0 +1,472 @@
+"""Gmail tools for the agent.
+
+Registers four tools (``gmail_search``, ``gmail_get_message``,
+``gmail_list_recent``, ``gmail_send``). All four default to ``ask`` permission
+because reading mail and sending mail are both privacy-sensitive: the user
+should explicitly allow each operation rather than letting the LLM act
+autonomously on their inbox.
+
+The factory mirrors ``calendar/factory.py`` and lives off the same shared
+``oauth_service`` token store. The ``auth_check`` returns ``None`` (i.e. the
+integration is hidden entirely) when the deployment has not configured the
+Gmail OAuth client, matching the Calendar pattern.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+
+import httpx
+from pydantic import BaseModel, Field
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.config import settings
+from backend.app.integrations.gmail.service import (
+    GmailMessage,
+    GmailMessageSummary,
+    GmailService,
+)
+from backend.app.services.oauth import oauth_service
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Param models
+# ---------------------------------------------------------------------------
+
+
+class GmailSearchParams(BaseModel):
+    """Parameters for the gmail_search tool."""
+
+    query: str = Field(
+        description=(
+            "Gmail search query, using Gmail's native syntax. Examples: "
+            "'from:noreply@appfolio.com newer_than:1d', 'subject:invoice', "
+            "'is:unread', 'has:attachment'."
+        ),
+    )
+    max_results: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Number of messages to return (1-50). Default 10.",
+    )
+
+
+class GmailGetMessageParams(BaseModel):
+    """Parameters for the gmail_get_message tool."""
+
+    message_id: str = Field(
+        description="The Gmail message ID returned by gmail_search or gmail_list_recent.",
+    )
+
+
+class GmailListRecentParams(BaseModel):
+    """Parameters for the gmail_list_recent tool."""
+
+    max_results: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Number of recent messages to return (1-50). Default 10.",
+    )
+
+
+class GmailSendParams(BaseModel):
+    """Parameters for the gmail_send tool."""
+
+    to: list[str] = Field(
+        description=(
+            "Recipient email addresses (one or more). Each entry may be a "
+            "bare address ('jane@example.com') or a name+address pair "
+            "('Jane Doe <jane@example.com>')."
+        ),
+    )
+    subject: str = Field(description="Subject line of the email.")
+    body: str = Field(description="Plain-text body of the email.")
+    reply_to_message_id: str = Field(
+        default="",
+        description=(
+            "Optional Gmail message ID to reply to. When set, the new message "
+            "is threaded onto the original conversation and the In-Reply-To / "
+            "References headers are populated automatically. Leave empty to "
+            "send a brand-new message."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_summary(s: GmailMessageSummary) -> str:
+    parts = [s.sender or "(unknown sender)"]
+    if s.subject:
+        parts.append(s.subject)
+    else:
+        parts.append("(no subject)")
+    if s.date:
+        parts.append(s.date)
+    if s.snippet:
+        snippet = s.snippet[:140]
+        if len(s.snippet) > 140:
+            snippet += "..."
+        parts.append(snippet)
+    parts.append(f"[id: {s.id}]")
+    return " | ".join(parts)
+
+
+def _format_message(m: GmailMessage) -> str:
+    lines = [
+        f"From: {m.sender or '(unknown)'}",
+        f"To: {', '.join(m.recipients) or '(none)'}",
+    ]
+    if m.cc:
+        lines.append(f"Cc: {', '.join(m.cc)}")
+    lines.append(f"Subject: {m.subject or '(no subject)'}")
+    if m.date:
+        lines.append(f"Date: {m.date}")
+    lines.append(f"Message ID: {m.id}")
+    if m.thread_id and m.thread_id != m.id:
+        lines.append(f"Thread ID: {m.thread_id}")
+    if m.links:
+        lines.append("Links found in body:")
+        for url in m.links:
+            lines.append(f"  - {url}")
+    lines.append("")
+    lines.append("Body:")
+    lines.append(m.body or "(empty body)")
+    return "\n".join(lines)
+
+
+def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
+    status = exc.response.status_code
+    body = ""
+    with contextlib.suppress(Exception):
+        body = exc.response.text[:500]
+    logger.warning(
+        "Gmail HTTP %d during %s: url=%s body=%s",
+        status,
+        action,
+        str(exc.request.url) if exc.request else "unknown",
+        body,
+    )
+    if status == 401:
+        return ToolResult(
+            content="Gmail disconnected. Please reconnect Gmail in Settings.",
+            is_error=True,
+            error_kind=ToolErrorKind.SERVICE,
+        )
+    if status == 403:
+        return ToolResult(
+            content=(
+                f"Permission denied while trying to {action}. "
+                "The Gmail integration may be missing the required scope; "
+                "disconnect and reconnect Gmail to grant the missing permissions."
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.VALIDATION,
+        )
+    if status == 404:
+        return ToolResult(
+            content=(
+                f"Not found while trying to {action}. The message may have been "
+                "deleted or the ID is wrong."
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.NOT_FOUND,
+        )
+    if status == 429:
+        return ToolResult(
+            content="Gmail rate limited. Try again shortly.",
+            is_error=True,
+            error_kind=ToolErrorKind.SERVICE,
+            hint="Wait a moment before retrying Gmail operations.",
+        )
+    return ToolResult(
+        content=f"Gmail service error ({status}) while trying to {action}.",
+        is_error=True,
+        error_kind=ToolErrorKind.SERVICE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool creation
+# ---------------------------------------------------------------------------
+
+
+def create_gmail_tools(service: GmailService) -> list[Tool]:
+    """Create Gmail tools bound to a service instance."""
+
+    async def gmail_search(query: str, max_results: int = 10) -> ToolResult:
+        try:
+            results = await service.search_messages(query, max_results)
+        except httpx.TimeoutException:
+            return ToolResult(
+                content="Gmail unavailable (timeout). Try again shortly.",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+        except httpx.HTTPStatusError as exc:
+            return _handle_http_error(exc, "search messages")
+        except Exception as exc:
+            logger.exception("Gmail search failed")
+            return ToolResult(
+                content=f"Gmail error: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+        if not results:
+            return ToolResult(content=f"No messages match '{query}'.")
+        lines = [f"Found {len(results)} message(s):"]
+        for s in results:
+            lines.append(f"- {_format_summary(s)}")
+        return ToolResult(content="\n".join(lines))
+
+    async def gmail_get_message(message_id: str) -> ToolResult:
+        try:
+            msg = await service.get_message(message_id)
+        except httpx.TimeoutException:
+            return ToolResult(
+                content="Gmail unavailable (timeout). Try again shortly.",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+        except httpx.HTTPStatusError as exc:
+            return _handle_http_error(exc, f"get message {message_id}")
+        except Exception as exc:
+            logger.exception("Gmail get_message failed")
+            return ToolResult(
+                content=f"Gmail error: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+        return ToolResult(content=_format_message(msg))
+
+    async def gmail_list_recent(max_results: int = 10) -> ToolResult:
+        # Empty query lists in reverse-chronological order, matching the
+        # Gmail web UI's default inbox view.
+        return await gmail_search("", max_results)
+
+    async def gmail_send(
+        to: list[str],
+        subject: str,
+        body: str,
+        reply_to_message_id: str = "",
+    ) -> ToolResult:
+        if not to:
+            return ToolResult(
+                content="At least one recipient address is required.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        try:
+            result = await service.send_message(
+                to=to,
+                subject=subject,
+                body=body,
+                reply_to_message_id=reply_to_message_id,
+            )
+        except httpx.TimeoutException:
+            return ToolResult(
+                content="Gmail unavailable (timeout). Try again shortly.",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+        except httpx.HTTPStatusError as exc:
+            return _handle_http_error(exc, "send message")
+        except ValueError as exc:
+            return ToolResult(content=str(exc), is_error=True, error_kind=ToolErrorKind.VALIDATION)
+        except Exception as exc:
+            logger.exception("Gmail send failed")
+            return ToolResult(
+                content=f"Gmail error: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+            )
+
+        # Receipt strings get rendered to the user, so keep them short.
+        receipt_target = f"reply to {reply_to_message_id}" if reply_to_message_id else ", ".join(to)
+        return ToolResult(
+            content=f"Message sent (id={result.id}, thread={result.thread_id}).",
+            receipt=ToolReceipt(
+                action="Sent email via Gmail",
+                target=receipt_target,
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.GMAIL_SEARCH,
+            description=(
+                "Search the user's Gmail inbox using Gmail's native query "
+                "syntax (e.g. 'from:noreply@appfolio.com', 'subject:invoice', "
+                "'is:unread', 'newer_than:7d'). Returns a list of message "
+                "summaries (sender, subject, date, snippet, id)."
+            ),
+            function=gmail_search,
+            params_model=GmailSearchParams,
+            usage_hint=(
+                "Use this when the user wants to find a specific email or "
+                "set of emails. Combine multiple Gmail operators in a single "
+                "query for precise results. Always confirm before opening "
+                "anything sensitive."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: f"Search Gmail for: {args.get('query', '')}",
+            ),
+        ),
+        Tool(
+            name=ToolName.GMAIL_GET_MESSAGE,
+            description=(
+                "Fetch the full body of a single Gmail message by its ID. "
+                "Returns headers, the plain-text body, and a deduplicated "
+                "list of URLs found in the body."
+            ),
+            function=gmail_get_message,
+            params_model=GmailGetMessageParams,
+            usage_hint=(
+                "Use after gmail_search or gmail_list_recent to read the "
+                "contents of a specific message. The 'links' list is the "
+                "fastest way to extract a magic link or unsubscribe URL."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: f"Read Gmail message {args.get('message_id', '')}",
+            ),
+        ),
+        Tool(
+            name=ToolName.GMAIL_LIST_RECENT,
+            description=(
+                "List the most recent messages in the user's Gmail inbox. "
+                "Returns the same summary shape as gmail_search."
+            ),
+            function=gmail_list_recent,
+            params_model=GmailListRecentParams,
+            usage_hint=(
+                "Use when the user asks 'what's in my inbox' or wants a "
+                "general overview without a specific search query."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"List the {args.get('max_results', 10)} most recent Gmail messages"
+                ),
+            ),
+        ),
+        Tool(
+            name=ToolName.GMAIL_SEND,
+            description=(
+                "Send an email from the user's Gmail account. Pass "
+                "reply_to_message_id to thread the new message onto an "
+                "existing conversation (the original headers and threadId "
+                "are wired up for you)."
+            ),
+            function=gmail_send,
+            params_model=GmailSendParams,
+            usage_hint=(
+                "Use when the user explicitly asks you to send or reply to "
+                "an email. Confirm recipients, subject, and body in chat "
+                "before calling this tool. Always default to plain text."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    "Reply via Gmail"
+                    if args.get("reply_to_message_id")
+                    else f"Send Gmail to {', '.join(args.get('to', []) or [])}"
+                ),
+            ),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Factory and registration
+# ---------------------------------------------------------------------------
+
+
+async def _gmail_auth_check(ctx: ToolContext) -> str | None:
+    """Return ``None`` when Gmail is ready or not configured at all.
+
+    Matches the calendar pattern: if the operator has not provided
+    ``GMAIL_CLIENT_ID`` / ``GMAIL_CLIENT_SECRET`` this returns ``None`` so
+    the integration stays completely hidden from the agent. When the
+    operator HAS configured Gmail but the user has not connected, we return
+    a reason string so the registry surfaces "not connected" cleanly.
+    """
+    if not settings.gmail_client_id or not settings.gmail_client_secret:
+        return None
+    token = await oauth_service.load_token(ctx.user.id, "gmail")
+    if token is not None and token.access_token:
+        return None
+    return (
+        "Gmail is not connected. "
+        "Use manage_integration(action='connect', target='gmail') "
+        "to generate a connection link for the user."
+    )
+
+
+async def _gmail_factory(ctx: ToolContext) -> list[Tool]:
+    if not settings.gmail_client_id or not settings.gmail_client_secret:
+        return []
+    token = await oauth_service.get_valid_token(ctx.user.id, "gmail")
+    if token is None or not token.access_token:
+        return []
+    service = GmailService(
+        access_token=token.access_token,
+        refresh_token=token.refresh_token,
+        client_id=settings.gmail_client_id,
+        client_secret=settings.gmail_client_secret,
+        token_expires_at=token.expires_at or 0.0,
+        on_token_refresh=oauth_service.build_on_refresh_callback(ctx.user.id, "gmail"),
+    )
+    return create_gmail_tools(service)
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import SubToolInfo, default_registry
+
+    default_registry.register(
+        "gmail",
+        _gmail_factory,
+        core=False,
+        summary=("Search, read, and send Gmail messages on the user's behalf"),
+        sub_tools=[
+            SubToolInfo(
+                ToolName.GMAIL_SEARCH,
+                "Search the inbox using Gmail's native query syntax",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.GMAIL_GET_MESSAGE,
+                "Read the full body of a single Gmail message",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.GMAIL_LIST_RECENT,
+                "List the most recent messages in the inbox",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.GMAIL_SEND,
+                "Send an email or threaded reply from the user's Gmail",
+                default_permission="ask",
+            ),
+        ],
+        auth_check=_gmail_auth_check,
+    )
+
+
+_register()

--- a/backend/app/integrations/gmail/service.py
+++ b/backend/app/integrations/gmail/service.py
@@ -381,17 +381,22 @@ def _decode_part_data(part: dict[str, Any]) -> str:
 _TAG_RE = re.compile(r"<[^>]+>")
 _WS_RE = re.compile(r"[ \t]+")
 _NL_RE = re.compile(r"\n{3,}")
+# Match the whole opening anchor tag (not just the href attribute) so the URL
+# can be placed OUTSIDE the tag boundaries before the generic tag stripper
+# runs; otherwise the hoisted URL would land inside ``<a ... URL >`` and be
+# eaten by ``_TAG_RE``.
+_ANCHOR_OPEN_RE = re.compile(r"""<a\b[^>]*?href\s*=\s*['"]([^'"\s>]+)['"][^>]*>""", re.IGNORECASE)
 
 
 def _strip_tags(html: str) -> str:
     """Best-effort HTML to text conversion.
 
-    Not a real renderer: this is a regex strip plus whitespace squash, which
-    is good enough for extracting URLs and reading short transactional emails
-    (the only Gmail bodies the agent needs to reason about today). For
-    anything richer we'd swap in BeautifulSoup; not worth the dependency yet.
+    Anchor ``href`` URLs are surfaced inline before the tags get stripped, so
+    a magic-link email rendered as ``<a href="https://x">click</a>`` still
+    leaves the URL in the body for ``_extract_links`` to pick up.
     """
-    text = _TAG_RE.sub(" ", html)
+    hoisted = _ANCHOR_OPEN_RE.sub(r" \1 ", html)
+    text = _TAG_RE.sub(" ", hoisted)
     text = _WS_RE.sub(" ", text)
     text = _NL_RE.sub("\n\n", text)
     return text.strip()

--- a/backend/app/integrations/gmail/service.py
+++ b/backend/app/integrations/gmail/service.py
@@ -1,0 +1,448 @@
+"""Gmail REST API client using httpx.
+
+Mirrors the shape of ``calendar/service.py``: an httpx-based client with a
+proactive token refresh, reactive 401 retry, and a refresh callback so the
+``oauth_service`` can persist rotated tokens.
+
+Why a hand-rolled client and not ``google-api-python-client``: the rest of
+this codebase is httpx-based, the surface area we need from Gmail is tiny
+(three reads + one write), and the official client drags in synchronous
+discovery-document fetches we'd have to wrap to keep ``async``.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import re
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from email.message import EmailMessage
+from email.utils import formatdate, make_msgid
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+# Refresh 5 minutes before expiry. Matches the calendar service so the two
+# integrations behave identically when both are in use.
+_REFRESH_BUFFER_SECONDS = 300
+
+# Cap the body slice we surface to the LLM so a marketing newsletter doesn't
+# eat the context window. Callers asking for "the magic link" only need the
+# first chunk; full retrieval of long bodies is intentionally out of scope.
+_MAX_BODY_CHARS = 16_000
+
+# A Gmail search returning thousands of message IDs would be useless to the
+# LLM and expensive to fetch. Hard ceiling at the API's per-page max of 500.
+_MAX_RESULTS_CEILING = 500
+
+_URL_RE = re.compile(r"https?://[^\s<>\"')]+")
+
+
+@dataclass
+class GmailMessageSummary:
+    """Lightweight summary returned by search / list-recent."""
+
+    id: str
+    thread_id: str
+    sender: str
+    subject: str
+    date: str
+    snippet: str
+
+
+@dataclass
+class GmailMessage:
+    """Full message returned by ``get_message``.
+
+    ``links`` is a deduplicated list of every URL the body contains, in
+    first-seen order. The Gmail API returns the body either as plain text
+    or as HTML depending on the part; we prefer ``text/plain`` and fall
+    back to a stripped-tags rendering of ``text/html`` so the agent always
+    has something readable to work with.
+    """
+
+    id: str
+    thread_id: str
+    sender: str
+    recipients: list[str]
+    cc: list[str]
+    subject: str
+    date: str
+    body: str
+    links: list[str] = field(default_factory=list)
+    rfc822_message_id: str = ""
+
+
+@dataclass
+class GmailSendResult:
+    """Outcome of a successful send."""
+
+    id: str
+    thread_id: str
+
+
+class GmailService:
+    """Gmail API client bound to one user's tokens."""
+
+    def __init__(
+        self,
+        access_token: str,
+        refresh_token: str,
+        client_id: str,
+        client_secret: str,
+        on_token_refresh: Callable[[str, str, float], Awaitable[None]] | None = None,
+        token_expires_at: float = 0.0,
+        sender_email: str = "",
+    ) -> None:
+        self._access_token = access_token
+        self._refresh_token = refresh_token
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._on_token_refresh = on_token_refresh
+        self._token_expires_at = token_expires_at
+        # Resolved lazily on first ``send_message`` call so we don't pay
+        # the round-trip on read-only flows. ``getProfile`` is the only
+        # Gmail endpoint that returns the authenticated user's address;
+        # the OAuth ``id_token`` is not in scope here.
+        self._sender_email = sender_email
+
+    @property
+    def provider_name(self) -> str:
+        return "gmail"
+
+    # -- Token refresh --------------------------------------------------------
+
+    async def _refresh_access_token(self, client: httpx.AsyncClient) -> None:
+        logger.info("Refreshing Gmail access token")
+        resp = await client.post(
+            GOOGLE_TOKEN_URL,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": self._refresh_token,
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        self._access_token = data["access_token"]
+        if "refresh_token" in data:
+            self._refresh_token = data["refresh_token"]
+        if "expires_in" in data:
+            self._token_expires_at = time.time() + data["expires_in"]
+        if self._on_token_refresh:
+            await self._on_token_refresh(
+                self._access_token, self._refresh_token, self._token_expires_at
+            )
+
+    async def _ensure_valid_token(self, client: httpx.AsyncClient) -> None:
+        if self._token_expires_at <= 0:
+            return
+        if time.time() >= (self._token_expires_at - _REFRESH_BUFFER_SECONDS):
+            await self._refresh_access_token(client)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> dict[str, Any] | None:
+        url = f"{GMAIL_API_BASE}{path}"
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            await self._ensure_valid_token(client)
+            headers["Authorization"] = f"Bearer {self._access_token}"
+            resp = await client.request(method, url, headers=headers, json=json, params=params)
+            if resp.status_code == 401:
+                await self._refresh_access_token(client)
+                headers["Authorization"] = f"Bearer {self._access_token}"
+                resp = await client.request(method, url, headers=headers, json=json, params=params)
+            resp.raise_for_status()
+            if resp.status_code == 204 or not resp.content:
+                return None
+            return resp.json()
+
+    # -- Public API -----------------------------------------------------------
+
+    async def get_profile(self) -> dict[str, Any]:
+        """Return ``users.me.getProfile`` (caches ``emailAddress`` for sends)."""
+        data = await self._request("GET", "/users/me/profile") or {}
+        if not self._sender_email:
+            self._sender_email = data.get("emailAddress", "")
+        return data
+
+    async def search_messages(
+        self,
+        query: str,
+        max_results: int,
+    ) -> list[GmailMessageSummary]:
+        """Run a Gmail search; returns light summaries for each hit.
+
+        Gmail's ``messages.list`` only returns IDs, so we follow up with a
+        ``metadata`` fetch per ID. We cap *max_results* at
+        ``_MAX_RESULTS_CEILING`` so the agent can't accidentally hammer the
+        API with a 10000-row query.
+        """
+        capped = max(1, min(int(max_results), _MAX_RESULTS_CEILING))
+        params: dict[str, str] = {"maxResults": str(capped)}
+        if query:
+            params["q"] = query
+        listing = await self._request("GET", "/users/me/messages", params=params) or {}
+        ids = [item.get("id", "") for item in listing.get("messages", []) if item.get("id")]
+
+        summaries: list[GmailMessageSummary] = []
+        for msg_id in ids:
+            try:
+                summaries.append(await self._get_message_summary(msg_id))
+            except httpx.HTTPStatusError as exc:
+                # A single 404 (message deleted between list and get) shouldn't
+                # nuke the whole response. Log + skip; the LLM still sees the rest.
+                logger.warning(
+                    "Skipping Gmail message %s during search: %s",
+                    msg_id,
+                    exc.response.status_code,
+                )
+                continue
+        return summaries
+
+    async def _get_message_summary(self, message_id: str) -> GmailMessageSummary:
+        params = {
+            "format": "metadata",
+            "metadataHeaders": "From,Subject,Date",
+        }
+        data = await self._request("GET", f"/users/me/messages/{message_id}", params=params) or {}
+        headers = _index_headers(data.get("payload", {}).get("headers", []))
+        return GmailMessageSummary(
+            id=data.get("id", ""),
+            thread_id=data.get("threadId", ""),
+            sender=headers.get("from", ""),
+            subject=headers.get("subject", ""),
+            date=headers.get("date", ""),
+            snippet=data.get("snippet", ""),
+        )
+
+    async def get_message(self, message_id: str) -> GmailMessage:
+        """Return the full message including a readable body and link list."""
+        data = (
+            await self._request(
+                "GET", f"/users/me/messages/{message_id}", params={"format": "full"}
+            )
+            or {}
+        )
+        payload = data.get("payload", {})
+        headers = _index_headers(payload.get("headers", []))
+        body = _extract_body(payload)
+        if len(body) > _MAX_BODY_CHARS:
+            body = body[:_MAX_BODY_CHARS] + "\n[...truncated]"
+        links = _extract_links(body)
+        return GmailMessage(
+            id=data.get("id", ""),
+            thread_id=data.get("threadId", ""),
+            sender=headers.get("from", ""),
+            recipients=_split_addresses(headers.get("to", "")),
+            cc=_split_addresses(headers.get("cc", "")),
+            subject=headers.get("subject", ""),
+            date=headers.get("date", ""),
+            body=body,
+            links=links,
+            rfc822_message_id=headers.get("message-id", ""),
+        )
+
+    async def send_message(
+        self,
+        to: list[str],
+        subject: str,
+        body: str,
+        reply_to_message_id: str = "",
+    ) -> GmailSendResult:
+        """Send a new message, optionally threading onto an existing message.
+
+        When *reply_to_message_id* is non-empty we fetch the original message
+        to pull its ``Message-ID`` and ``References`` headers so the reply
+        threads correctly in Gmail (and any other RFC 5322 client). The
+        ``threadId`` field on the send body is what makes Gmail's UI bundle
+        the messages; the headers cover everyone else.
+        """
+        if not self._sender_email:
+            await self.get_profile()
+        if not to:
+            raise ValueError("send_message requires at least one recipient")
+
+        thread_id = ""
+        in_reply_to = ""
+        references = ""
+        if reply_to_message_id:
+            original = await self.get_message(reply_to_message_id)
+            thread_id = original.thread_id
+            in_reply_to = original.rfc822_message_id
+            # Per RFC 5322 section 3.6.4, References is built by appending
+            # the parent's Message-ID to the parent's References (or
+            # In-Reply-To if References is absent). We don't have the
+            # parent's References parsed out, so the simpler chain of
+            # just the parent's ID is acceptable for a one-deep reply.
+            references = in_reply_to
+
+        rfc822 = _build_rfc822(
+            sender=self._sender_email,
+            to=to,
+            subject=subject,
+            body=body,
+            in_reply_to=in_reply_to,
+            references=references,
+        )
+        raw_b64 = base64.urlsafe_b64encode(rfc822).decode("ascii")
+        send_body: dict[str, Any] = {"raw": raw_b64}
+        if thread_id:
+            send_body["threadId"] = thread_id
+
+        data = await self._request("POST", "/users/me/messages/send", json=send_body) or {}
+        return GmailSendResult(
+            id=data.get("id", ""),
+            thread_id=data.get("threadId", ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _index_headers(headers: list[dict[str, Any]]) -> dict[str, str]:
+    """Return a case-insensitive header lookup keyed by lowercase name."""
+    out: dict[str, str] = {}
+    for h in headers:
+        name = (h.get("name") or "").lower()
+        if name and name not in out:
+            out[name] = h.get("value", "")
+    return out
+
+
+def _extract_body(payload: dict[str, Any]) -> str:
+    """Walk a Gmail ``payload`` tree and return the best readable body.
+
+    Preference: ``text/plain`` over ``text/html``. When only ``text/html``
+    is present we strip tags with a tiny regex so the agent gets something
+    legible without dragging in BeautifulSoup. Multipart bodies are walked
+    depth-first.
+    """
+    text_part = _find_part(payload, "text/plain")
+    if text_part is not None:
+        decoded = _decode_part_data(text_part)
+        if decoded:
+            return decoded
+    html_part = _find_part(payload, "text/html")
+    if html_part is not None:
+        decoded = _decode_part_data(html_part)
+        if decoded:
+            return _strip_tags(decoded)
+    # Fall back to the top-level body (common for short single-part messages).
+    decoded = _decode_part_data(payload)
+    return decoded or ""
+
+
+def _find_part(payload: dict[str, Any], mime_type: str) -> dict[str, Any] | None:
+    if payload.get("mimeType") == mime_type and payload.get("body", {}).get("data"):
+        return payload
+    for part in payload.get("parts", []) or []:
+        found = _find_part(part, mime_type)
+        if found is not None:
+            return found
+    return None
+
+
+def _decode_part_data(part: dict[str, Any]) -> str:
+    body = part.get("body", {}) or {}
+    data = body.get("data") or ""
+    if not data:
+        return ""
+    try:
+        # Gmail uses URL-safe base64 with no padding guarantees.
+        padded = data + "=" * (-len(data) % 4)
+        raw = base64.urlsafe_b64decode(padded)
+    except (ValueError, TypeError) as exc:
+        logger.warning("Could not decode Gmail body part: %s", exc)
+        return ""
+    return raw.decode("utf-8", errors="replace")
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"[ \t]+")
+_NL_RE = re.compile(r"\n{3,}")
+
+
+def _strip_tags(html: str) -> str:
+    """Best-effort HTML to text conversion.
+
+    Not a real renderer: this is a regex strip plus whitespace squash, which
+    is good enough for extracting URLs and reading short transactional emails
+    (the only Gmail bodies the agent needs to reason about today). For
+    anything richer we'd swap in BeautifulSoup; not worth the dependency yet.
+    """
+    text = _TAG_RE.sub(" ", html)
+    text = _WS_RE.sub(" ", text)
+    text = _NL_RE.sub("\n\n", text)
+    return text.strip()
+
+
+def _extract_links(body: str) -> list[str]:
+    """Pull URLs out of a body in first-seen order, deduplicated."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for match in _URL_RE.finditer(body):
+        url = match.group(0).rstrip(".,);]>")
+        if url not in seen:
+            seen.add(url)
+            out.append(url)
+    return out
+
+
+def _split_addresses(value: str) -> list[str]:
+    """Split a comma-separated address header into trimmed entries."""
+    if not value:
+        return []
+    return [addr.strip() for addr in value.split(",") if addr.strip()]
+
+
+def _build_rfc822(
+    *,
+    sender: str,
+    to: list[str],
+    subject: str,
+    body: str,
+    in_reply_to: str = "",
+    references: str = "",
+) -> bytes:
+    """Build an RFC 5322 message ready for base64url Gmail send."""
+    msg = EmailMessage()
+    msg["From"] = sender
+    msg["To"] = ", ".join(to)
+    msg["Subject"] = subject
+    msg["Date"] = formatdate(localtime=False)
+    msg["Message-ID"] = make_msgid()
+    if in_reply_to:
+        msg["In-Reply-To"] = in_reply_to
+    if references:
+        msg["References"] = references
+    msg.set_content(body)
+    return bytes(msg)
+
+
+__all__ = [
+    "GmailMessage",
+    "GmailMessageSummary",
+    "GmailSendResult",
+    "GmailService",
+]

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -74,6 +74,11 @@ _FACTORY_META: dict[str, _FactoryMeta] = {
         domain_group="Integrations",
         domain_group_order=2,
     ),
+    "gmail": _FactoryMeta(
+        "Search, read, and send Gmail messages on the user's behalf",
+        domain_group="Integrations",
+        domain_group_order=2,
+    ),
     "companycam": _FactoryMeta(
         "Upload photos, search projects, and manage job documentation with CompanyCam",
         domain_group="Integrations",

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -1169,13 +1169,33 @@ GOOGLE_DRIVE_SCOPES = [
     "https://www.googleapis.com/auth/drive.file",
 ]
 
+# Gmail OAuth 2.0 endpoints. Separate Google OAuth client from Calendar /
+# Drive so the Gmail scope set can be approved independently and so users
+# who only want one of the three never see the others on the consent
+# screen. ``gmail.readonly`` covers search + fetch; ``gmail.send`` covers
+# composing new messages and threaded replies. We deliberately avoid the
+# broader ``gmail.modify`` so the integration cannot delete, archive, or
+# label the user's mail.
+GMAIL_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GMAIL_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GMAIL_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+]
+
 # CompanyCam OAuth 2.0 endpoints
 COMPANYCAM_AUTHORIZE_URL = "https://app.companycam.com/oauth/authorize"
 COMPANYCAM_TOKEN_URL = "https://app.companycam.com/oauth/token"
 COMPANYCAM_SCOPES = ["read", "write", "destroy"]
 
 # Registry of all supported OAuth integrations.
-_OAUTH_INTEGRATIONS = ("quickbooks", "google_calendar", "google_drive", "companycam")
+_OAUTH_INTEGRATIONS = (
+    "quickbooks",
+    "google_calendar",
+    "google_drive",
+    "gmail",
+    "companycam",
+)
 
 
 def get_quickbooks_oauth_config() -> OAuthConfig | None:
@@ -1228,6 +1248,21 @@ def get_google_drive_oauth_config() -> OAuthConfig | None:
     return config if config.is_configured else None
 
 
+def get_gmail_oauth_config() -> OAuthConfig | None:
+    """Build the Gmail OAuth config from settings."""
+    config = OAuthConfig(
+        integration="gmail",
+        client_id=settings.gmail_client_id,
+        client_secret=settings.gmail_client_secret,
+        authorize_url=GMAIL_AUTHORIZE_URL,
+        token_url=GMAIL_TOKEN_URL,
+        scopes=GMAIL_SCOPES,
+        use_pkce=False,
+        extra_auth_params={"access_type": "offline", "prompt": "consent"},
+    )
+    return config if config.is_configured else None
+
+
 def get_companycam_oauth_config() -> OAuthConfig | None:
     """Build the CompanyCam OAuth config from settings."""
     config = OAuthConfig(
@@ -1250,6 +1285,8 @@ def get_oauth_config(integration: str) -> OAuthConfig | None:
         return get_google_calendar_oauth_config()
     if integration == "google_drive":
         return get_google_drive_oauth_config()
+    if integration == "gmail":
+        return get_gmail_oauth_config()
     if integration == "companycam":
         return get_companycam_oauth_config()
     return None

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -183,6 +183,15 @@ When `QUICKBOOKS_CLIENT_ID` and `QUICKBOOKS_CLIENT_SECRET` are set, users can co
 
 When `GOOGLE_CALENDAR_CLIENT_ID` and `GOOGLE_CALENDAR_CLIENT_SECRET` are set, users can connect their Google Calendar via the web dashboard. Once connected, the agent gains specialist calendar tools (`calendar_list_events`, `calendar_create_event`, `calendar_update_event`, `calendar_delete_event`, `calendar_check_availability`).
 
+## Gmail
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GMAIL_CLIENT_ID` | | OAuth client ID from the Google Cloud console |
+| `GMAIL_CLIENT_SECRET` | | OAuth client secret from the Google Cloud console |
+
+Use a separate Google OAuth client from Calendar/Drive so the `gmail.readonly` and `gmail.send` scopes can be approved on their own (Google's verification process treats each OAuth client independently). When both variables are set, users can connect Gmail via `manage_integration(action='connect', target='gmail')` or the Tools page. Once connected, the agent gains four tools: `gmail_search`, `gmail_get_message`, `gmail_list_recent`, and `gmail_send`. All four default to `ask` permission so the user is prompted before any inbox read or outbound send.
+
 ## CompanyCam
 
 | Variable | Default | Description |

--- a/tests/test_gmail_integration.py
+++ b/tests/test_gmail_integration.py
@@ -1,0 +1,680 @@
+"""Tests for the Gmail integration: service, tools, factory, and OAuth wiring."""
+
+from __future__ import annotations
+
+import base64
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from backend.app.agent.approval import PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind
+from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.registry import ToolContext
+from backend.app.config import settings
+from backend.app.integrations.gmail.factory import (
+    _gmail_auth_check,
+    _gmail_factory,
+    create_gmail_tools,
+)
+from backend.app.integrations.gmail.service import (
+    GmailMessage,
+    GmailMessageSummary,
+    GmailSendResult,
+    GmailService,
+    _build_rfc822,
+    _extract_body,
+    _extract_links,
+    _strip_tags,
+)
+from backend.app.models import User
+from backend.app.services.oauth import (
+    GMAIL_SCOPES,
+    get_gmail_oauth_config,
+    get_oauth_config,
+    list_oauth_integrations,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64(data: str) -> str:
+    return base64.urlsafe_b64encode(data.encode("utf-8")).decode("ascii")
+
+
+def _make_service(sender_email: str = "me@example.com") -> GmailService:
+    return GmailService(
+        access_token="test-access",
+        refresh_token="test-refresh",
+        client_id="cid",
+        client_secret="csec",
+        token_expires_at=time.time() + 3600,
+        sender_email=sender_email,
+    )
+
+
+def _get_tool(tools: list[Tool], name: str) -> Tool:
+    for t in tools:
+        if t.name == name:
+            return t
+    msg = f"Tool {name} not found"
+    raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# OAuth config
+# ---------------------------------------------------------------------------
+
+
+def test_gmail_scopes_are_readonly_and_send() -> None:
+    """v1 ships with exactly two Gmail scopes, no broader modify."""
+    assert GMAIL_SCOPES == [
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.send",
+    ]
+
+
+def test_get_gmail_oauth_config_returns_none_when_unconfigured() -> None:
+    with (
+        patch.object(settings, "gmail_client_id", ""),
+        patch.object(settings, "gmail_client_secret", ""),
+    ):
+        assert get_gmail_oauth_config() is None
+
+
+def test_get_gmail_oauth_config_returns_config_when_set() -> None:
+    with (
+        patch.object(settings, "gmail_client_id", "gmail-cid"),
+        patch.object(settings, "gmail_client_secret", "gmail-csec"),
+    ):
+        config = get_gmail_oauth_config()
+    assert config is not None
+    assert config.integration == "gmail"
+    assert config.client_id == "gmail-cid"
+    assert config.scopes == GMAIL_SCOPES
+    assert config.use_pkce is False
+    # access_type=offline is required to receive a refresh_token from Google.
+    assert config.extra_auth_params == {"access_type": "offline", "prompt": "consent"}
+
+
+def test_get_oauth_config_dispatches_gmail() -> None:
+    with (
+        patch.object(settings, "gmail_client_id", "gmail-cid"),
+        patch.object(settings, "gmail_client_secret", "gmail-csec"),
+    ):
+        config = get_oauth_config("gmail")
+    assert config is not None
+    assert config.integration == "gmail"
+
+
+def test_gmail_in_oauth_integrations_registry() -> None:
+    assert "gmail" in list_oauth_integrations()
+
+
+# ---------------------------------------------------------------------------
+# Service: parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def test_extract_body_prefers_text_plain() -> None:
+    payload = {
+        "mimeType": "multipart/alternative",
+        "parts": [
+            {"mimeType": "text/plain", "body": {"data": _b64("plain version")}},
+            {"mimeType": "text/html", "body": {"data": _b64("<b>html version</b>")}},
+        ],
+    }
+    assert _extract_body(payload) == "plain version"
+
+
+def test_extract_body_falls_back_to_html_stripped() -> None:
+    payload = {
+        "mimeType": "text/html",
+        "body": {"data": _b64("<p>Hello <a href='https://x.com'>link</a></p>")},
+    }
+    body = _extract_body(payload)
+    assert "Hello" in body
+    assert "<p>" not in body
+
+
+def test_extract_body_walks_nested_multipart() -> None:
+    payload = {
+        "mimeType": "multipart/mixed",
+        "parts": [
+            {
+                "mimeType": "multipart/alternative",
+                "parts": [
+                    {"mimeType": "text/plain", "body": {"data": _b64("nested plain")}},
+                ],
+            }
+        ],
+    }
+    assert _extract_body(payload) == "nested plain"
+
+
+def test_extract_links_dedupes_in_order() -> None:
+    body = "see https://a.com and https://b.com and https://a.com again"
+    assert _extract_links(body) == ["https://a.com", "https://b.com"]
+
+
+def test_extract_links_strips_trailing_punctuation() -> None:
+    body = "click https://example.com/path."
+    assert _extract_links(body) == ["https://example.com/path"]
+
+
+def test_strip_tags_squashes_whitespace() -> None:
+    out = _strip_tags("<div>  hello   <b>world</b>  </div>")
+    assert "hello" in out
+    assert "world" in out
+    assert "<" not in out
+
+
+def test_build_rfc822_includes_threading_headers_when_set() -> None:
+    raw = _build_rfc822(
+        sender="me@example.com",
+        to=["jane@example.com"],
+        subject="Re: invoice",
+        body="thanks",
+        in_reply_to="<orig@mail.example.com>",
+        references="<orig@mail.example.com>",
+    )
+    text = raw.decode("utf-8", errors="ignore")
+    assert "From: me@example.com" in text
+    assert "To: jane@example.com" in text
+    assert "Subject: Re: invoice" in text
+    assert "In-Reply-To: <orig@mail.example.com>" in text
+    assert "References: <orig@mail.example.com>" in text
+
+
+def test_build_rfc822_omits_threading_headers_for_new_message() -> None:
+    raw = _build_rfc822(
+        sender="me@example.com", to=["jane@example.com"], subject="hi", body="hello"
+    )
+    text = raw.decode("utf-8", errors="ignore")
+    assert "In-Reply-To" not in text
+    assert "References" not in text
+
+
+# ---------------------------------------------------------------------------
+# Service: API methods (mocked _request)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_search_messages_fetches_summaries_per_id() -> None:
+    service = _make_service()
+    list_resp = {"messages": [{"id": "m1"}, {"id": "m2"}]}
+    detail_m1 = {
+        "id": "m1",
+        "threadId": "t1",
+        "snippet": "hello",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "alice@example.com"},
+                {"name": "Subject", "value": "Hi"},
+                {"name": "Date", "value": "Tue, 01 Jan 2026 12:00:00 +0000"},
+            ]
+        },
+    }
+    detail_m2 = {
+        "id": "m2",
+        "threadId": "t2",
+        "snippet": "world",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "bob@example.com"},
+                {"name": "Subject", "value": "Hello"},
+                {"name": "Date", "value": "Tue, 01 Jan 2026 13:00:00 +0000"},
+            ]
+        },
+    }
+
+    responses: list[Any] = [list_resp, detail_m1, detail_m2]
+
+    async def fake_request(_method: str, _path: str, **_kwargs: Any) -> Any:
+        return responses.pop(0)
+
+    with patch.object(service, "_request", side_effect=fake_request):
+        results = await service.search_messages("from:alice", max_results=10)
+
+    assert [r.id for r in results] == ["m1", "m2"]
+    assert results[0].sender == "alice@example.com"
+    assert results[0].subject == "Hi"
+
+
+@pytest.mark.asyncio()
+async def test_search_messages_skips_404_per_id() -> None:
+    service = _make_service()
+    list_resp = {"messages": [{"id": "m1"}, {"id": "m2"}]}
+    detail_m2 = {
+        "id": "m2",
+        "threadId": "t2",
+        "snippet": "ok",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "bob@example.com"},
+                {"name": "Subject", "value": "Hello"},
+                {"name": "Date", "value": ""},
+            ]
+        },
+    }
+    not_found = httpx.HTTPStatusError(
+        "404",
+        request=httpx.Request("GET", "https://example.com"),
+        response=httpx.Response(404),
+    )
+
+    responses: list[Any] = [list_resp, not_found, detail_m2]
+
+    async def fake_request(_method: str, _path: str, **_kwargs: Any) -> Any:
+        nxt = responses.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+    with patch.object(service, "_request", side_effect=fake_request):
+        results = await service.search_messages("anything", max_results=10)
+
+    assert [r.id for r in results] == ["m2"]
+
+
+@pytest.mark.asyncio()
+async def test_search_messages_caps_max_results() -> None:
+    service = _make_service()
+    captured: dict[str, dict[str, str]] = {}
+
+    async def fake_request(
+        _method: str, _path: str, *, params: dict[str, str] | None = None, **_kwargs: Any
+    ) -> Any:
+        captured["params"] = params or {}
+        return {"messages": []}
+
+    with patch.object(service, "_request", side_effect=fake_request):
+        await service.search_messages("q", max_results=10000)
+
+    # Internal ceiling is 500.
+    assert captured["params"]["maxResults"] == "500"
+
+
+@pytest.mark.asyncio()
+async def test_get_message_returns_full_message_with_links() -> None:
+    service = _make_service()
+    body_text = "Hi there\nHere is a link https://magic.example/?token=abc\nThanks"
+    api_resp = {
+        "id": "m1",
+        "threadId": "t1",
+        "payload": {
+            "mimeType": "text/plain",
+            "body": {"data": _b64(body_text)},
+            "headers": [
+                {"name": "From", "value": "alice@example.com"},
+                {"name": "To", "value": "me@example.com, you@example.com"},
+                {"name": "Cc", "value": "cc@example.com"},
+                {"name": "Subject", "value": "Magic link"},
+                {"name": "Date", "value": "Tue, 01 Jan 2026 12:00:00 +0000"},
+                {"name": "Message-ID", "value": "<orig@mail.example.com>"},
+            ],
+        },
+    }
+
+    with patch.object(service, "_request", new_callable=AsyncMock, return_value=api_resp):
+        msg = await service.get_message("m1")
+
+    assert msg.id == "m1"
+    assert msg.sender == "alice@example.com"
+    assert msg.recipients == ["me@example.com", "you@example.com"]
+    assert msg.cc == ["cc@example.com"]
+    assert msg.subject == "Magic link"
+    assert "Hi there" in msg.body
+    assert "https://magic.example/?token=abc" in msg.links
+    assert msg.rfc822_message_id == "<orig@mail.example.com>"
+
+
+@pytest.mark.asyncio()
+async def test_send_message_threads_when_reply_id_given() -> None:
+    service = _make_service()
+    parent = GmailMessage(
+        id="parent",
+        thread_id="thread-1",
+        sender="alice@example.com",
+        recipients=["me@example.com"],
+        cc=[],
+        subject="Original",
+        date="",
+        body="hi",
+        rfc822_message_id="<orig@mail.example.com>",
+    )
+
+    with (
+        patch.object(service, "get_message", new_callable=AsyncMock, return_value=parent),
+        patch.object(service, "_request", new_callable=AsyncMock) as mock_req,
+    ):
+        mock_req.return_value = {"id": "sent-1", "threadId": "thread-1"}
+        result = await service.send_message(
+            to=["alice@example.com"],
+            subject="Re: Original",
+            body="thanks",
+            reply_to_message_id="parent",
+        )
+
+    assert isinstance(result, GmailSendResult)
+    assert result.thread_id == "thread-1"
+    # Inspect the send body
+    args, kwargs = mock_req.call_args
+    assert args[0] == "POST"
+    assert args[1] == "/users/me/messages/send"
+    body = kwargs["json"]
+    assert body["threadId"] == "thread-1"
+    raw_decoded = base64.urlsafe_b64decode(body["raw"]).decode("utf-8", errors="ignore")
+    assert "In-Reply-To: <orig@mail.example.com>" in raw_decoded
+    assert "References: <orig@mail.example.com>" in raw_decoded
+
+
+@pytest.mark.asyncio()
+async def test_send_message_omits_threadid_for_new_message() -> None:
+    service = _make_service()
+    with patch.object(service, "_request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = {"id": "sent-1", "threadId": "thread-x"}
+        await service.send_message(to=["alice@example.com"], subject="hi", body="hello")
+    body = mock_req.call_args.kwargs["json"]
+    assert "threadId" not in body
+
+
+@pytest.mark.asyncio()
+async def test_send_message_requires_recipient() -> None:
+    service = _make_service()
+    with pytest.raises(ValueError, match="recipient"):
+        await service.send_message(to=[], subject="x", body="y")
+
+
+@pytest.mark.asyncio()
+async def test_send_message_resolves_sender_lazily() -> None:
+    service = GmailService(
+        access_token="t",
+        refresh_token="r",
+        client_id="cid",
+        client_secret="csec",
+    )
+    with patch.object(service, "_request", new_callable=AsyncMock) as mock_req:
+        # First call: get_profile resolution. Second call: send.
+        mock_req.side_effect = [
+            {"emailAddress": "me@example.com"},
+            {"id": "sent", "threadId": "t"},
+        ]
+        await service.send_message(to=["a@x.com"], subject="s", body="b")
+    # First request should be /users/me/profile
+    first_args, _ = mock_req.call_args_list[0]
+    assert first_args == ("GET", "/users/me/profile")
+
+
+# ---------------------------------------------------------------------------
+# Tool factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def gmail_tools() -> list[Tool]:
+    service = _make_service()
+    return create_gmail_tools(service)
+
+
+def test_create_gmail_tools_returns_4_tools(gmail_tools: list[Tool]) -> None:
+    assert len(gmail_tools) == 4
+
+
+def test_gmail_tool_names(gmail_tools: list[Tool]) -> None:
+    names = {t.name for t in gmail_tools}
+    assert names == {
+        ToolName.GMAIL_SEARCH,
+        ToolName.GMAIL_GET_MESSAGE,
+        ToolName.GMAIL_LIST_RECENT,
+        ToolName.GMAIL_SEND,
+    }
+
+
+def test_gmail_tools_have_params_model(gmail_tools: list[Tool]) -> None:
+    for tool in gmail_tools:
+        assert tool.params_model is not None, f"Tool {tool.name} missing params_model"
+
+
+def test_all_gmail_tools_default_to_ask(gmail_tools: list[Tool]) -> None:
+    """User asked for ask-before-read AND ask-before-send."""
+    for tool in gmail_tools:
+        assert tool.approval_policy is not None, tool.name
+        assert tool.approval_policy.default_level == PermissionLevel.ASK, tool.name
+
+
+def test_send_description_distinguishes_reply_from_new(gmail_tools: list[Tool]) -> None:
+    tool = _get_tool(gmail_tools, ToolName.GMAIL_SEND)
+    assert tool.approval_policy is not None
+    assert tool.approval_policy.description_builder is not None
+    new_desc = tool.approval_policy.description_builder(
+        {"to": ["alice@example.com"], "subject": "hi"}
+    )
+    assert "alice@example.com" in new_desc
+    reply_desc = tool.approval_policy.description_builder(
+        {"to": ["alice@example.com"], "reply_to_message_id": "m1"}
+    )
+    assert "Reply" in reply_desc
+
+
+# ---------------------------------------------------------------------------
+# Tool behaviour (success and error paths)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_gmail_search_tool_formats_results() -> None:
+    service = _make_service()
+    summaries = [
+        GmailMessageSummary(
+            id="m1",
+            thread_id="t1",
+            sender="alice@example.com",
+            subject="Hi",
+            date="Tue, 01 Jan 2026 12:00:00 +0000",
+            snippet="snippet text",
+        )
+    ]
+    with patch.object(service, "search_messages", new_callable=AsyncMock, return_value=summaries):
+        tools = create_gmail_tools(service)
+        tool = _get_tool(tools, ToolName.GMAIL_SEARCH)
+        result = await tool.function("from:alice", 5)
+
+    assert result.is_error is False
+    assert "Found 1 message(s)" in result.content
+    assert "alice@example.com" in result.content
+    assert "[id: m1]" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_gmail_search_tool_handles_401_as_disconnected() -> None:
+    service = _make_service()
+    err = httpx.HTTPStatusError(
+        "401",
+        request=httpx.Request("GET", "https://example.com"),
+        response=httpx.Response(401),
+    )
+    with patch.object(service, "search_messages", new_callable=AsyncMock, side_effect=err):
+        tools = create_gmail_tools(service)
+        tool = _get_tool(tools, ToolName.GMAIL_SEARCH)
+        result = await tool.function("q", 5)
+
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.SERVICE
+    assert "disconnected" in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_gmail_get_message_tool_renders_full_message() -> None:
+    service = _make_service()
+    msg = GmailMessage(
+        id="m1",
+        thread_id="t1",
+        sender="alice@example.com",
+        recipients=["me@example.com"],
+        cc=[],
+        subject="Magic Link",
+        date="Tue",
+        body="Click https://magic.example/?token=abc",
+        links=["https://magic.example/?token=abc"],
+        rfc822_message_id="<orig@x>",
+    )
+    with patch.object(service, "get_message", new_callable=AsyncMock, return_value=msg):
+        tools = create_gmail_tools(service)
+        tool = _get_tool(tools, ToolName.GMAIL_GET_MESSAGE)
+        result = await tool.function("m1")
+
+    assert result.is_error is False
+    assert "Subject: Magic Link" in result.content
+    assert "https://magic.example/?token=abc" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_gmail_send_tool_emits_receipt() -> None:
+    service = _make_service()
+    sent = GmailSendResult(id="sent-1", thread_id="thread-1")
+    with patch.object(service, "send_message", new_callable=AsyncMock, return_value=sent):
+        tools = create_gmail_tools(service)
+        tool = _get_tool(tools, ToolName.GMAIL_SEND)
+        result = await tool.function(["alice@example.com"], "subj", "body")
+
+    assert result.is_error is False
+    assert result.receipt is not None
+    assert result.receipt.action == "Sent email via Gmail"
+    assert "alice@example.com" in result.receipt.target
+
+
+@pytest.mark.asyncio()
+async def test_gmail_send_tool_rejects_empty_recipients() -> None:
+    service = _make_service()
+    tools = create_gmail_tools(service)
+    tool = _get_tool(tools, ToolName.GMAIL_SEND)
+    result = await tool.function([], "s", "b")
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio()
+async def test_gmail_list_recent_calls_search_with_empty_query() -> None:
+    service = _make_service()
+    with patch.object(service, "search_messages", new_callable=AsyncMock, return_value=[]) as m:
+        tools = create_gmail_tools(service)
+        tool = _get_tool(tools, ToolName.GMAIL_LIST_RECENT)
+        await tool.function(7)
+    m.assert_awaited_once_with("", 7)
+
+
+# ---------------------------------------------------------------------------
+# Factory + auth_check
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx() -> ToolContext:
+    ctx = MagicMock(spec=ToolContext)
+    user = MagicMock(spec=User)
+    user.id = "1"
+    ctx.user = user
+    return ctx
+
+
+@pytest.mark.asyncio()
+async def test_gmail_factory_returns_empty_when_not_configured() -> None:
+    with patch("backend.app.integrations.gmail.factory.settings") as mock_settings:
+        mock_settings.gmail_client_id = ""
+        mock_settings.gmail_client_secret = ""
+        assert await _gmail_factory(_make_ctx()) == []
+
+
+@pytest.mark.asyncio()
+async def test_gmail_factory_returns_empty_when_user_not_connected() -> None:
+    with (
+        patch("backend.app.integrations.gmail.factory.settings") as mock_settings,
+        patch("backend.app.integrations.gmail.factory.oauth_service") as mock_oauth,
+    ):
+        mock_settings.gmail_client_id = "cid"
+        mock_settings.gmail_client_secret = "csec"
+        mock_oauth.get_valid_token = AsyncMock(return_value=None)
+        assert await _gmail_factory(_make_ctx()) == []
+
+
+@pytest.mark.asyncio()
+async def test_gmail_factory_returns_4_tools_when_connected() -> None:
+    token = MagicMock()
+    token.access_token = "ax"
+    token.refresh_token = "rx"
+    token.expires_at = 9999999999.0
+    with (
+        patch("backend.app.integrations.gmail.factory.settings") as mock_settings,
+        patch("backend.app.integrations.gmail.factory.oauth_service") as mock_oauth,
+    ):
+        mock_settings.gmail_client_id = "cid"
+        mock_settings.gmail_client_secret = "csec"
+        mock_oauth.get_valid_token = AsyncMock(return_value=token)
+        tools = await _gmail_factory(_make_ctx())
+    assert len(tools) == 4
+
+
+@pytest.mark.asyncio()
+async def test_gmail_auth_check_returns_none_when_unconfigured() -> None:
+    """When the operator has not configured Gmail, hide the integration entirely."""
+    with patch("backend.app.integrations.gmail.factory.settings") as mock_settings:
+        mock_settings.gmail_client_id = ""
+        mock_settings.gmail_client_secret = ""
+        assert await _gmail_auth_check(_make_ctx()) is None
+
+
+@pytest.mark.asyncio()
+async def test_gmail_auth_check_returns_reason_when_user_not_connected() -> None:
+    """When admin configured Gmail but user hasn't, surface a reason string."""
+    with (
+        patch("backend.app.integrations.gmail.factory.settings") as mock_settings,
+        patch("backend.app.integrations.gmail.factory.oauth_service") as mock_oauth,
+    ):
+        mock_settings.gmail_client_id = "cid"
+        mock_settings.gmail_client_secret = "csec"
+        mock_oauth.load_token = AsyncMock(return_value=None)
+        reason = await _gmail_auth_check(_make_ctx())
+    assert reason is not None
+    assert "Gmail is not connected" in reason
+    assert "manage_integration" in reason
+
+
+@pytest.mark.asyncio()
+async def test_gmail_auth_check_returns_none_when_user_connected() -> None:
+    token = MagicMock()
+    token.access_token = "ax"
+    with (
+        patch("backend.app.integrations.gmail.factory.settings") as mock_settings,
+        patch("backend.app.integrations.gmail.factory.oauth_service") as mock_oauth,
+    ):
+        mock_settings.gmail_client_id = "cid"
+        mock_settings.gmail_client_secret = "csec"
+        mock_oauth.load_token = AsyncMock(return_value=token)
+        assert await _gmail_auth_check(_make_ctx()) is None
+
+
+# ---------------------------------------------------------------------------
+# manage_integration discovery
+# ---------------------------------------------------------------------------
+
+
+def test_manage_integration_includes_gmail_in_display_names() -> None:
+    from backend.app.agent.tools.integration_tools import _DISPLAY_NAMES, _TOOL_OAUTH_MAP
+
+    assert _DISPLAY_NAMES.get("gmail") == "Gmail"
+    assert _TOOL_OAUTH_MAP.get("gmail") == "gmail"
+
+
+def test_manage_integration_hint_mentions_gmail() -> None:
+    """The system-prompt hint built from the integration registries should list Gmail."""
+    from backend.app.agent.tools.integration_tools import _build_available_integrations_hint
+
+    hint = _build_available_integrations_hint()
+    assert "Gmail" in hint
+    assert "'gmail'" in hint

--- a/tests/test_gmail_integration.py
+++ b/tests/test_gmail_integration.py
@@ -174,6 +174,16 @@ def test_strip_tags_squashes_whitespace() -> None:
     assert "<" not in out
 
 
+def test_strip_tags_hoists_anchor_href_urls() -> None:
+    """An HTML-only email with the magic link inside an <a href=...> must
+    still surface the URL so _extract_links can find it."""
+    html = '<p>Click <a href="https://magic.example/?token=abc">here</a> to log in</p>'
+    out = _strip_tags(html)
+    assert "https://magic.example/?token=abc" in out
+    assert "<" not in out
+    assert _extract_links(out) == ["https://magic.example/?token=abc"]
+
+
 def test_build_rfc822_includes_threading_headers_when_set() -> None:
     raw = _build_rfc822(
         sender="me@example.com",
@@ -393,6 +403,43 @@ async def test_send_message_requires_recipient() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_request_refreshes_and_retries_on_401() -> None:
+    """A 401 from Gmail triggers a refresh+retry so a stale access token gets rotated."""
+    service = _make_service()
+
+    response_401 = MagicMock(status_code=401, content=b"")
+    response_401.raise_for_status = MagicMock()
+    response_200 = MagicMock(status_code=200, content=b'{"ok": true}')
+    response_200.json.return_value = {"ok": True}
+    response_200.raise_for_status = MagicMock()
+
+    fake_client = MagicMock()
+    fake_client.request = AsyncMock(side_effect=[response_401, response_200])
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    def rotate_token(_client: httpx.AsyncClient) -> None:
+        service._access_token = "rotated-token"
+
+    with (
+        patch(
+            "backend.app.integrations.gmail.service.httpx.AsyncClient",
+            return_value=fake_client,
+        ),
+        patch.object(
+            service, "_refresh_access_token", new=AsyncMock(side_effect=rotate_token)
+        ) as mock_refresh,
+    ):
+        result = await service._request("GET", "/users/me/profile")
+
+    assert result == {"ok": True}
+    mock_refresh.assert_awaited_once()
+    assert fake_client.request.await_count == 2
+    second_headers = fake_client.request.await_args_list[1].kwargs["headers"]
+    assert second_headers["Authorization"] == "Bearer rotated-token"
+
+
+@pytest.mark.asyncio()
 async def test_send_message_resolves_sender_lazily() -> None:
     service = GmailService(
         access_token="t",
@@ -566,8 +613,10 @@ async def test_gmail_list_recent_calls_search_with_empty_query() -> None:
     with patch.object(service, "search_messages", new_callable=AsyncMock, return_value=[]) as m:
         tools = create_gmail_tools(service)
         tool = _get_tool(tools, ToolName.GMAIL_LIST_RECENT)
-        await tool.function(7)
+        result = await tool.function(7)
     m.assert_awaited_once_with("", 7)
+    # Empty inbox should render a friendly message, not the search-style fallback.
+    assert result.content == "Inbox is empty."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -46,6 +46,7 @@ EXPECTED_INTEGRATION_MODULES: set[str] = {
     "backend.app.integrations.appfolio_vendor.factory",
     "backend.app.integrations.calendar.factory",
     "backend.app.integrations.companycam.factory",
+    "backend.app.integrations.gmail.factory",
     "backend.app.integrations.quickbooks.factory",
     "backend.app.integrations.supplier_pricing.factory",
 }


### PR DESCRIPTION
## Description

Adds a Gmail OAuth integration with four agent tools backed by Gmail's REST API. The integration mirrors the existing Calendar / Drive shape: a dedicated OAuth client, a thin httpx service, a factory that registers tools when both the operator credentials and a per-user token exist, and a hidden state when the operator hasn't configured it.

**Why now:** AppFolio magic links arrive by email and get truncated by iOS / iMessage URL detection when users try to paste them through the chat channel (the URL detector ends the URL at the first dot inside the JWT, so only `.payload.signature` survives). With Gmail tools the agent can fetch the link server-side and feed it straight to `appfolio_connect`, sidestepping the mobile clipboard entirely. The same primitives unlock invoice threads, customer correspondence, and supplier quotes for future work.

**What's in the box:**

- `gmail_search(query, max_results)` — Gmail's native query syntax (`from:`, `subject:`, `newer_than:`, `is:unread`, ...). Returns id+from+subject+date+snippet for each match.
- `gmail_get_message(message_id)` — full message: headers, plain-text body (with HTML fallback), and a deduplicated list of URLs found in the body.
- `gmail_list_recent(max_results)` — convenience wrapper for "what's in my inbox right now."
- `gmail_send(to, subject, body, reply_to_message_id="")` — composes a new message or threads a reply (sets `In-Reply-To` / `References` / `threadId` automatically when `reply_to_message_id` is provided).

All four default to `ask` permission so the user is prompted before any inbox read or outbound send.

**Auth:** new `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` env vars, separate from Calendar / Drive so Google's verification process treats the scope set independently. Scopes: `gmail.readonly` + `gmail.send`. The broader `gmail.modify` is deliberately excluded so the integration cannot delete, archive, or label mail.

**Out of scope (deliberate, follow-up PRs):**
- Dedicated `appfolio_fetch_magic_link` shortcut that chains the new Gmail tools.
- `gmail.modify` / `gmail.compose` operations (drafts, labels, archive, trash).
- Frontend Gmail-specific permissions UI beyond the existing per-tool toggle.

Fixes #1183

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2448 passed, 2 skipped (40 new Gmail tests)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (40 covering OAuth config, parsing helpers, service methods, tool behaviour, factory, auth_check, and `manage_integration` discovery)
- [ ] Bug fixes include regression tests (n/a, this is a feature)

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 drafted the implementation and tests via back-and-forth with @njbrake; the scope and design decisions are mine; the code was reviewed before commit.)
- [ ] No AI used