### PR TITLE
fix(appfolio): encrypt refresh token, redact response bodies from errors

### DIFF
--- a/backend/app/integrations/appfolio_vendor/auth.py
+++ b/backend/app/integrations/appfolio_vendor/auth.py
@@ -14,10 +14,10 @@ Three concerns live here:
    life of the credential.
 
 3. **Token persistence.** We piggy-back on the existing ``oauth_tokens``
-   table: ``access_token`` holds the JWT, ``extra_json`` carries the
-   fingerprint and any AppFolio-specific metadata. There is no refresh
-   token. When the JWT expires the integration prompts the user for a
-   new magic link.
+   table: ``access_token`` holds the JWT, ``refresh_token`` holds the
+   OAuth2 refresh token (both envelope-encrypted at rest via
+   ``EncryptedString``), and ``extra_json`` carries the fingerprint plus
+   any AppFolio-specific metadata.
 """
 
 from __future__ import annotations
@@ -126,13 +126,18 @@ async def _load_credential_in_session(
     if not fingerprint:
         # Stale row from a previous failed connect; treat as not connected.
         return None
+    # Prefer the dedicated encrypted column; fall back to the legacy
+    # ``extra_json`` slot so credentials persisted before the column move
+    # keep working until the next refresh rewrites them. The fallback can
+    # be dropped once all live tokens have rotated past it.
+    refresh_token = row.refresh_token or extra.get("refresh_token", "")
     return AppFolioCredential(
         user_id=user_id,
         jwt=row.access_token,
         fingerprint=fingerprint,
         customer_ids=list(extra.get("customer_ids") or []),
         extra=extra,
-        refresh_token=extra.get("refresh_token", ""),
+        refresh_token=refresh_token,
     )
 
 
@@ -144,15 +149,21 @@ async def save_credential(
     extra_metadata: dict[str, Any] | None = None,
     refresh_token: str = "",
 ) -> None:
-    """Persist (or replace) the AppFolio credential for a user."""
+    """Persist (or replace) the AppFolio credential for a user.
+
+    The JWT and refresh token are written to the dedicated encrypted
+    columns on ``oauth_tokens``; only the fingerprint, customer IDs, and
+    free-form metadata land in ``extra_json``.
+    """
     extra: dict[str, Any] = {
         "fingerprint": fingerprint,
         "customer_ids": customer_ids,
     }
-    if refresh_token:
-        extra["refresh_token"] = refresh_token
     if extra_metadata:
         extra.update(extra_metadata)
+    # Strip any legacy ``refresh_token`` left in extra by an older code
+    # path so we never end up with both an encrypted and a plaintext copy.
+    extra.pop("refresh_token", None)
     now = datetime.now(UTC)
     async with db_session_async() as session:
         stmt = sa.select(OAuthToken).where(
@@ -166,6 +177,7 @@ async def save_credential(
                 user_id=user_id,
                 integration=INTEGRATION_NAME,
                 access_token=jwt,
+                refresh_token=refresh_token,
                 token_type="Bearer",
                 extra_json=json.dumps(extra),
                 created_at=now,
@@ -174,6 +186,7 @@ async def save_credential(
             session.add(row)
         else:
             row.access_token = jwt
+            row.refresh_token = refresh_token
             row.token_type = "Bearer"
             row.extra_json = json.dumps(extra)
             row.updated_at = now

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -269,9 +269,10 @@ class AppFolioVendorService:
                 body_for_log,
                 response_text,
             )
-            raise AppFolioError(
-                f"AppFolio {method} {path} failed: {resp.status_code} {response_text}"
-            )
+            # Don't echo response_text into the raised error: AppFolioError
+            # messages flow into ToolResult.content (visible to the LLM and
+            # the end user). The full body stays in the warning log above.
+            raise AppFolioError(f"AppFolio {method} {path} failed: HTTP {resp.status_code}")
         logger.debug(
             "AppFolio %s %s ok (%d, %d bytes)",
             method,
@@ -687,7 +688,9 @@ async def exchange_magic_link(
             resp.status_code,
             response_text,
         )
-        raise AppFolioError(f"AppFolio OAuth exchange failed: {resp.status_code} {response_text}")
+        # Body stays in the log; the raised message is shown to the user
+        # via ToolResult.content, so we keep it status-only.
+        raise AppFolioError(f"AppFolio OAuth exchange failed: HTTP {resp.status_code}")
     payload: dict[str, Any] = resp.json() if resp.content else {}
     jwt = payload.get("access_token") or ""
     if not jwt:

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -144,6 +144,147 @@ async def test_load_credential_without_jwt_returns_none(async_test_user: Any) ->
     assert await is_connected(user_id) is False
 
 
+@pytest.mark.asyncio()
+async def test_save_credential_writes_refresh_token_to_encrypted_column(
+    async_test_user: Any,
+) -> None:
+    """Refresh token must land in the dedicated encrypted column, not extra_json."""
+    import json as _json
+
+    import sqlalchemy as sa
+
+    from backend.app.database import db_session_async
+    from backend.app.integrations.appfolio_vendor.auth import INTEGRATION_NAME
+    from backend.app.models import OAuthToken
+
+    user_id = async_test_user.id
+    await save_credential(
+        user_id=user_id,
+        jwt="jwt-abc",
+        fingerprint="fp-1",
+        customer_ids=["c1"],
+        refresh_token="refresh-secret",
+    )
+
+    async with db_session_async() as session:
+        row = (
+            await session.execute(
+                sa.select(OAuthToken).where(
+                    OAuthToken.user_id == user_id,
+                    OAuthToken.integration == INTEGRATION_NAME,
+                )
+            )
+        ).scalar_one()
+        extra = _json.loads(row.extra_json)
+
+    assert row.refresh_token == "refresh-secret"
+    assert "refresh_token" not in extra, "refresh token must not leak into plaintext extra_json"
+
+    cred = await load_credential(user_id)
+    assert cred is not None
+    assert cred.refresh_token == "refresh-secret"
+
+
+@pytest.mark.asyncio()
+async def test_load_credential_falls_back_to_legacy_extra_refresh_token(
+    async_test_user: Any,
+) -> None:
+    """Pre-fix rows store refresh_token in extra_json; load_credential must still find it."""
+    import json as _json
+    from datetime import UTC, datetime
+
+    from backend.app.database import db_session_async
+    from backend.app.integrations.appfolio_vendor.auth import INTEGRATION_NAME
+    from backend.app.models import OAuthToken
+
+    user_id = async_test_user.id
+    now = datetime.now(UTC)
+    async with db_session_async() as session:
+        session.add(
+            OAuthToken(
+                user_id=user_id,
+                integration=INTEGRATION_NAME,
+                access_token="legacy-jwt",
+                refresh_token="",  # legacy rows left this empty
+                token_type="Bearer",
+                extra_json=_json.dumps(
+                    {
+                        "fingerprint": "fp-legacy",
+                        "customer_ids": ["c1"],
+                        "refresh_token": "legacy-refresh",
+                    }
+                ),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await session.commit()
+
+    cred = await load_credential(user_id)
+    assert cred is not None
+    assert cred.refresh_token == "legacy-refresh"
+
+
+@pytest.mark.asyncio()
+async def test_save_credential_strips_legacy_refresh_token_from_extra(
+    async_test_user: Any,
+) -> None:
+    """A subsequent save must wipe a legacy plaintext refresh_token left in extra_json."""
+    import json as _json
+    from datetime import UTC, datetime
+
+    import sqlalchemy as sa
+
+    from backend.app.database import db_session_async
+    from backend.app.integrations.appfolio_vendor.auth import INTEGRATION_NAME
+    from backend.app.models import OAuthToken
+
+    user_id = async_test_user.id
+    now = datetime.now(UTC)
+    async with db_session_async() as session:
+        session.add(
+            OAuthToken(
+                user_id=user_id,
+                integration=INTEGRATION_NAME,
+                access_token="legacy-jwt",
+                refresh_token="",
+                token_type="Bearer",
+                extra_json=_json.dumps(
+                    {
+                        "fingerprint": "fp-legacy",
+                        "customer_ids": [],
+                        "refresh_token": "old-plaintext",
+                    }
+                ),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await session.commit()
+
+    await save_credential(
+        user_id=user_id,
+        jwt="new-jwt",
+        fingerprint="fp-legacy",
+        customer_ids=[],
+        refresh_token="new-encrypted",
+    )
+
+    async with db_session_async() as session:
+        row = (
+            await session.execute(
+                sa.select(OAuthToken).where(
+                    OAuthToken.user_id == user_id,
+                    OAuthToken.integration == INTEGRATION_NAME,
+                )
+            )
+        ).scalar_one()
+        extra = _json.loads(row.extra_json)
+
+    assert row.refresh_token == "new-encrypted"
+    assert "refresh_token" not in extra
+
+
 # ---------------------------------------------------------------------------
 # Service HTTP layer
 # ---------------------------------------------------------------------------
@@ -240,6 +381,26 @@ async def test_service_5xx_raises_appfolio_error() -> None:
         cls.return_value = _patch_async_client("request", response)
         with pytest.raises(AppFolioError):
             await service.get("/x")
+
+
+@pytest.mark.asyncio()
+async def test_service_error_message_omits_response_body() -> None:
+    """Raised AppFolioError must not echo the response body.
+
+    The error message flows into ToolResult.content (visible to the LLM
+    and the user). The body could include AppFolio-side context we don't
+    want to surface; logs are the right place for it.
+    """
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    secret = "INTERNAL_AF_TRACE_or_pii_we_dont_want_in_chat"
+    response = _mock_response(status_code=500, text=secret)
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        cls.return_value = _patch_async_client("request", response)
+        with pytest.raises(AppFolioError) as exc_info:
+            await service.get("/x")
+    msg = str(exc_info.value)
+    assert "HTTP 500" in msg
+    assert secret not in msg
 
 
 @pytest.mark.asyncio()
@@ -341,6 +502,24 @@ async def test_exchange_magic_link_propagates_4xx() -> None:
         cls.return_value = _patch_async_client("post", response)
         with pytest.raises(AppFolioError, match="OAuth exchange failed"):
             await exchange_magic_link(magic_link_token="t")
+
+
+@pytest.mark.asyncio()
+async def test_exchange_magic_link_error_message_omits_response_body() -> None:
+    """The OAuth exchange's raised error must not include the response body.
+
+    Same reasoning as ``test_service_error_message_omits_response_body``:
+    the message reaches the user via ToolResult.content.
+    """
+    secret = "appfolio_internal_trace_id=abc123"
+    response = _mock_response(json_data={}, status_code=400, text=secret)
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        cls.return_value = _patch_async_client("post", response)
+        with pytest.raises(AppFolioError) as exc_info:
+            await exchange_magic_link(magic_link_token="t")
+    msg = str(exc_info.value)
+    assert "HTTP 400" in msg
+    assert secret not in msg
 
 
 @pytest.mark.asyncio()
@@ -891,9 +1070,10 @@ async def test_4xx_failure_logs_request_body_and_response(caplog: Any) -> None:
         with pytest.raises(AppFolioError) as exc_info:
             await service.schedule_work_order("42", scheduled_at="2024-01-01T00:00:00")
 
-    # ToolResult-side message includes status + response body.
+    # ToolResult-side message carries the status only; the response body
+    # is intentionally redacted so it cannot leak into user-visible chat.
     assert "422" in str(exc_info.value)
-    assert "scheduledAt" in str(exc_info.value)
+    assert "scheduledAt" not in str(exc_info.value)
 
     # Log line includes everything a dev needs to diagnose.
     record_text = "\n".join(r.message for r in caplog.records)


### PR DESCRIPTION
## Description

Two security follow-ups to the OAuth2 migration in #1269:

### 1. Encrypt the AppFolio refresh token at rest

`oauth_tokens` already has a dedicated `refresh_token` column wrapped in `EncryptedString` (envelope encryption with a per-row DEK). The AppFolio code path was bypassing it and stuffing the refresh token into `extra_json` (plain TEXT). The access JWT was encrypted, the refresh token wasn't. With a refresh token an attacker can mint unlimited new JWTs, so the practical exposure was worse than the access token itself.

Changes:
- `save_credential` now writes `refresh_token` to the encrypted column.
- `_load_credential_in_session` reads from the encrypted column with a fallback to the legacy `extra_json` slot so credentials persisted before this PR keep working until the next refresh rewrites them. The fallback can be dropped a release or two from now.
- Every `save_credential` strips any leftover plaintext `refresh_token` out of `extra_json` so we never end up with both copies.

### 2. Redact AppFolio response bodies from raised errors

`exchange_magic_link` and `service._request` were including the raw HTTP response body in the raised `AppFolioError` message. `AppFolioError` flows into `ToolResult.content` via `service_error_to_tool_result`, which is visible to the LLM and the end user. AppFolio's normal `{error, error_description}` shape is unlikely to echo credentials, but a 5xx with HTML or an unexpected error envelope could include trace IDs or other server-side context that has no business surfacing in chat.

Changes:
- Raised `AppFolioError` messages now carry only the HTTP status (`HTTP 422` etc.).
- The full body stays in the existing `logger.warning` lines for ops debugging.
- Updated the existing 4xx-logging test that asserted body-in-error and added explicit redaction tests for both `_request` and `exchange_magic_link`.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (uv run pytest -v)
- [x] Lint passes (ruff check backend/ && ruff format --check backend/)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 implemented the fix and tests; reasoning and approval by @njbrake during pair debugging of #1269)