### PR TITLE
fix(companycam): route search_photos through project-scoped endpoint

### DIFF
--- a/backend/app/integrations/companycam/service.py
+++ b/backend/app/integrations/companycam/service.py
@@ -341,17 +341,26 @@ class CompanyCamService:
         page: int = 1,
         per_page: int = 50,
     ) -> list[Photo]:
-        """Search photos across all projects with optional filters."""
+        """Search photos with optional filters.
+
+        When ``project_id`` is set, requests the project-scoped
+        ``/projects/{project_id}/photos`` endpoint. The global
+        ``/photos`` endpoint silently ignores a singular ``project_id``
+        query param (its filter is ``project_ids[]``, an array), so
+        passing one through there returned the most-recent photos
+        across every project regardless of which project was requested.
+        Routing through the project-scoped endpoint is unambiguous and
+        accepts the same date / pagination filters.
+        """
         params: dict[str, str | int] = {"page": page, "per_page": per_page}
-        if project_id:
-            params["project_id"] = project_id
         if start_date is not None:
             params["start_date"] = start_date
         if end_date is not None:
             params["end_date"] = end_date
+        url = f"{_API_BASE}/projects/{project_id}/photos" if project_id else f"{_API_BASE}/photos"
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(
-                f"{_API_BASE}/photos",
+                url,
                 params=params,
                 headers=self._headers(),
             )

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -573,6 +573,75 @@ async def test_search_photos_normalize() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_search_photos_with_project_id_uses_project_scoped_endpoint() -> None:
+    """Regression: a singular project_id query param on /v2/photos is silently
+    ignored by CompanyCam (its filter is project_ids[], an array), so the
+    service routes through /projects/{id}/photos when a project is named.
+    Without this, two different project_ids returned the same recent-photos
+    list and the agent reported "the search isn't filtering by project."
+    """
+    service = CompanyCamService(access_token="test-token")
+
+    with patch("backend.app.integrations.companycam.service.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=_mock_response([]))
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await service.search_photos(project_id="98845509")
+
+    url = client.get.call_args.args[0]
+    params = client.get.call_args.kwargs.get("params", {})
+    assert url.endswith("/projects/98845509/photos")
+    assert "project_id" not in params
+    assert "project_ids" not in params
+
+
+@pytest.mark.asyncio()
+async def test_search_photos_without_project_id_uses_global_endpoint() -> None:
+    """When no project_id is given, hit the global /photos endpoint."""
+    service = CompanyCamService(access_token="test-token")
+
+    with patch("backend.app.integrations.companycam.service.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=_mock_response([]))
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await service.search_photos()
+
+    url = client.get.call_args.args[0]
+    assert url.endswith("/v2/photos")
+
+
+@pytest.mark.asyncio()
+async def test_search_photos_passes_dates_and_pagination_on_project_route() -> None:
+    """Date and pagination filters must travel through the project-scoped path,
+    not get dropped when project_id is supplied."""
+    service = CompanyCamService(access_token="test-token")
+
+    with patch("backend.app.integrations.companycam.service.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=_mock_response([]))
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await service.search_photos(
+            project_id="42",
+            start_date=1700000000,
+            end_date=1700086399,
+            page=2,
+            per_page=25,
+        )
+
+    params = client.get.call_args.kwargs.get("params", {})
+    assert params["start_date"] == 1700000000
+    assert params["end_date"] == 1700086399
+    assert params["page"] == 2
+    assert params["per_page"] == 25
+
+
+@pytest.mark.asyncio()
 async def test_delete_photo() -> None:
     service = CompanyCamService(access_token="test-token")
 


### PR DESCRIPTION
## Description

`companycam_search_photos` was returning the same recent-photos list regardless of which `project_id` the agent passed. Surfaced when a Clawbolt user asked the agent to pull photos from two different jobs back to back; the agent itself caught the duplicate output and reported "the search isn't filtering by project."

Root cause: `search_photos` in `service.py` calls the global `/v2/photos` endpoint with `project_id=<id>` as a query param. CompanyCam's filter on that endpoint is `project_ids[]` (array, plural); a singular `project_id` is silently ignored, so the request degraded to "list all photos newest first."

Fix: when `project_id` is supplied, route to the project-scoped `/projects/{id}/photos` endpoint instead. Both endpoints accept the same `start_date` / `end_date` / pagination filters, so the no-project-id branch still hits `/photos` for global searches.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Three new regressions in `tests/test_companycam_tools.py`:
- `test_search_photos_with_project_id_uses_project_scoped_endpoint` — asserts URL is `/projects/{id}/photos`, no `project_id` / `project_ids` in query params.
- `test_search_photos_without_project_id_uses_global_endpoint` — no-project-id calls still hit `/v2/photos`.
- `test_search_photos_passes_dates_and_pagination_on_project_route` — date / page / per_page flow through the project-scoped path.

## AI Usage
- [x] AI-assisted (drafted by Claude via discussion with @njbrake; bug surfaced in a real user conversation, root cause and fix verified against CompanyCam API docs.)
- [ ] No AI used