### PR TITLE
fix(appfolio): drop customer count from connect success message

### DIFF
--- a/backend/app/integrations/appfolio_vendor/auth_tools.py
+++ b/backend/app/integrations/appfolio_vendor/auth_tools.py
@@ -69,13 +69,11 @@ def build_auth_tools(user_id: str) -> list[Tool]:
             refresh_token=result.refresh_token,
         )
 
-        count = len(result.customer_ids)
-        customers = f" across {count} customer account(s)" if count else ""
         return ToolResult(
-            content=f"AppFolio connected{customers}. Tools are now available.",
+            content="AppFolio connected. Tools are now available.",
             receipt=ToolReceipt(
                 action="Connected AppFolio Vendor Portal",
-                target=f"{len(result.customer_ids)} customer(s)",
+                target="vendor account",
             ),
         )
 

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1151,6 +1151,42 @@ async def test_4xx_log_summarizes_singular_file_compliance_upload(caplog: Any) -
 
 
 @pytest.mark.asyncio()
+async def test_appfolio_connect_message_omits_customer_count(async_test_user: Any) -> None:
+    """Regression for #1275: connect must not surface 'customer' counts.
+
+    The OAuth2 migration in #1269 stopped populating ``customer_ids`` on
+    the exchange result, leaving the receipt forever rendering "0
+    customer(s)". Rather than backfill via /profiles/me just to print a
+    number that vendors don't think in, we drop the framing entirely.
+    """
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.integrations.appfolio_vendor.auth_tools import build_auth_tools
+    from backend.app.integrations.appfolio_vendor.service import AccessExchangeResult
+
+    user_id = async_test_user.id
+    tools = build_auth_tools(user_id)
+    connect = next(t for t in tools if t.name == ToolName.APPFOLIO_CONNECT)
+
+    fake_result = AccessExchangeResult(
+        jwt="jwt-1",
+        customer_ids=[],
+        raw={},
+        refresh_token="rt-1",
+    )
+    with patch(
+        "backend.app.integrations.appfolio_vendor.auth_tools.exchange_magic_link",
+        new=AsyncMock(return_value=fake_result),
+    ):
+        result = await connect.function(magic_link="eyJ.fake.token")
+
+    assert result.is_error is False
+    assert result.content == "AppFolio connected. Tools are now available."
+    assert "customer" not in result.content.lower()
+    assert result.receipt is not None
+    assert "customer" not in (result.receipt.target or "").lower()
+
+
+@pytest.mark.asyncio()
 async def test_access_failure_does_not_log_magic_link(caplog: Any) -> None:
     import logging
 


### PR DESCRIPTION
## Description

The connect tool was rendering ``0 customer(s)`` in the receipt for every successful AppFolio connection, including @njbrake's smoke test today after the prod deploy. That's because the OAuth2 migration in #1269 stopped populating ``result.customer_ids`` (the legacy ``/access`` endpoint included them in the response body; the new ``oauth.appf.io/oauth/token`` does not).

Two ways to fix this:
1. Backfill the customer IDs by calling ``/profiles/me`` after the exchange, so the receipt reads ``"3 customer(s)"`` accurately.
2. Just stop mentioning customers in the success message and receipt.

(2) is the right call. "Customer" is AppFolio's internal term for the property management companies a vendor works under. Vendors don't think in those terms. The success message doesn't need a count, and the receipt should describe what was connected, not enumerate something behind it.

If we ever need to filter by customer (e.g., ``list_work_orders(customer_id=...)``), the agent can fetch the IDs lazily via ``get_profile()`` at call time. Persisting them on connect just to print "1 customer(s)" once isn't worth the round-trip and the failure-mode complexity (what if the profile fetch fails after a successful exchange?).

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (uv run pytest -v)
- [x] Lint passes (ruff check backend/ && ruff format --check backend/)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

(Existing tests already exercise ``appfolio_connect``; no test asserted on the misleading ``"customer(s)"`` rendering, so nothing needed updating.)

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 drafted the fix; @njbrake spotted the misleading "0 customers" text in the prod receipt and decided the right fix was to stop surfacing it.)