### PR TITLE
fix(appfolio): align write paths with SPA-verified body shapes

### DIFF
--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -35,11 +35,19 @@ logger = logging.getLogger(__name__)
 
 
 def _line_items_total(items: list[AppFolioInvoiceLineItem]) -> float:
-    return sum(item.quantity * item.rate for item in items)
+    return sum(item.quantity * item.amount for item in items)
 
 
 def _line_items_to_payload(items: list[AppFolioInvoiceLineItem]) -> list[dict[str, Any]]:
-    return [{"description": i.description, "quantity": i.quantity, "rate": i.rate} for i in items]
+    """Match the SPA's invoice line-item shape exactly.
+
+    SPA sends ``{amount, description, quantity}`` with ``quantity`` as a
+    string. AppFolio's API rejects payloads with the older ``rate`` key.
+    """
+    return [
+        {"amount": i.amount, "description": i.description, "quantity": str(i.quantity)}
+        for i in items
+    ]
 
 
 def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[Tool]:
@@ -49,8 +57,7 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
         customer_id: str,
         work_order_id: str,
         line_items: list[dict[str, Any]],
-        invoice_number: str = "",
-        due_date: str = "",
+        reference_number: str = "",
         media_refs: list[str] | None = None,
     ) -> ToolResult:
         # Pydantic-coerce raw dicts the LLM emits into the typed shape.
@@ -62,7 +69,8 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
                 is_error=True,
                 error_kind=ToolErrorKind.VALIDATION,
                 hint=(
-                    "Each line item needs description (str), quantity (number), and rate (number)."
+                    "Each line item needs description (str), quantity (number),"
+                    " and amount (number)."
                 ),
             )
         if not typed_items:
@@ -80,8 +88,7 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
                 customer_id=customer_id,
                 work_order_id=work_order_id,
                 line_items=_line_items_to_payload(typed_items),
-                invoice_number=invoice_number,
-                due_date=due_date,
+                reference_number=reference_number,
                 files=files or None,
             )
         except Exception as exc:
@@ -108,6 +115,7 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
         customer_id: str,
         work_order_id: str,
         media_refs: list[str],
+        reference_number: str = "",
     ) -> ToolResult:
         if not media_refs:
             return ToolResult(
@@ -130,6 +138,7 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
                 customer_id=customer_id,
                 work_order_id=work_order_id,
                 files=files,
+                reference_number=reference_number,
             )
         except Exception as exc:
             return service_error_to_tool_result("uploading invoice", exc)

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -88,19 +88,13 @@ class AppFolioAcceptWorkOrderParams(BaseModel):
 
 class AppFolioScheduleWorkOrderParams(BaseModel):
     work_order_id: str = Field(description="AppFolio work order ID to schedule.")
-    scheduled_at: str = Field(
+    time_slot_id: str = Field(
         description=(
-            "When the visit will start, as an ISO 8601 timestamp (e.g."
-            " '2026-05-08T14:00:00-04:00'). Use the user's timezone."
+            "Pre-defined time-slot ID published by the property manager."
+            " AppFolio's vendor portal does not accept arbitrary timestamps;"
+            " vendors pick from offered slots. Slot IDs come from the work"
+            " order's ``time_slots`` (or from ``appfolio_get_work_order``)."
         ),
-    )
-    duration_minutes: int = Field(
-        default=0,
-        description="Estimated visit duration in minutes (0 to omit).",
-    )
-    notes: str = Field(
-        default="",
-        description="Optional scheduling notes for the tenant or PM.",
     )
 
 
@@ -172,7 +166,9 @@ class AppFolioMessageTenantParams(BaseModel):
 class AppFolioInvoiceLineItem(BaseModel):
     description: str = Field(description="Line-item description (e.g. 'Labor: 4hr').")
     quantity: float = Field(default=1.0, description="Quantity (decimal supported).")
-    rate: float = Field(description="Per-unit rate in dollars.")
+    amount: float = Field(
+        description="Per-unit amount in dollars (the SPA calls this 'amount', not 'rate').",
+    )
 
 
 class AppFolioCreateInvoiceParams(BaseModel):
@@ -182,16 +178,16 @@ class AppFolioCreateInvoiceParams(BaseModel):
     work_order_id: str = Field(description="Work order ID this invoice bills against.")
     line_items: list[AppFolioInvoiceLineItem] = Field(
         description=(
-            "List of line items for the invoice. Each entry has description, quantity, and rate."
+            "List of line items for the invoice. Each entry has description, quantity, and amount."
         ),
     )
-    invoice_number: str = Field(
+    reference_number: str = Field(
         default="",
-        description="Optional vendor-side invoice number to print on the document.",
-    )
-    due_date: str = Field(
-        default="",
-        description="Optional due date in ISO YYYY-MM-DD format.",
+        description=(
+            "Optional vendor-side reference number to print on the invoice."
+            " The SPA defaults this to '<workOrderNumber>-<sequence>'; leave"
+            " empty to let AppFolio generate one."
+        ),
     )
     media_refs: list[str] = Field(
         default_factory=list,
@@ -213,6 +209,10 @@ class AppFolioUploadInvoicePdfParams(BaseModel):
             " an original_url or a media handle. AppFolio uploads them as"
             " a single invoice document."
         ),
+    )
+    reference_number: str = Field(
+        default="",
+        description="Optional vendor-side reference number printed on the invoice.",
     )
 
 

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -88,7 +88,7 @@ class AuthExpiredError(AppFolioError):
 class FileUpload:
     """Binary file to attach to a note or invoice request body.
 
-    AppFolio expects ``{file_base64, name}`` JSON entries rather than
+    AppFolio expects ``{file_in_base64, name}`` JSON entries rather than
     multipart form-data. ``data`` is the raw bytes; the caller does not
     need to base64-encode them.
     """
@@ -147,7 +147,7 @@ def _encode_files(files: list[FileUpload]) -> list[dict[str, str]]:
     out: list[dict[str, str]] = []
     for f in files:
         data = _maybe_compress_photo(f.name, f.data)
-        out.append({"name": f.name, "file_base64": base64.b64encode(data).decode("ascii")})
+        out.append({"name": f.name, "file_in_base64": base64.b64encode(data).decode("ascii")})
     return out
 
 
@@ -162,7 +162,7 @@ def _summarize_body_for_log(body: Any) -> Any:
 
     AppFolio note/invoice bodies inline photo bytes as base64 strings,
     which dwarf the rest of the JSON and bury the actual API contract
-    we're trying to debug. Replace each ``file_base64`` string with a
+    we're trying to debug. Replace each ``file_in_base64`` string with a
     ``<base64 N bytes>`` marker; leave everything else intact.
     """
     if isinstance(body, dict):
@@ -175,12 +175,12 @@ def _summarize_body_for_log(body: Any) -> Any:
 
 
 def _summarize_file_entry(entry: Any) -> Any:
-    """Replace a ``{file_base64, name}`` dict's payload with a size marker."""
+    """Replace a ``{file_in_base64, name}`` dict's payload with a size marker."""
     if not isinstance(entry, dict):
         return entry
     summarized: dict[str, Any] = {}
     for k, v in entry.items():
-        if k == "file_base64" and isinstance(v, str):
+        if k == "file_in_base64" and isinstance(v, str):
             summarized[k] = f"<{len(v)} chars base64>"
         else:
             summarized[k] = v
@@ -190,8 +190,8 @@ def _summarize_file_entry(entry: Any) -> Any:
 def _summarize_files_field(body: Any) -> Any:
     """Specialize the generic summarizer for AppFolio's file payload shapes.
 
-    Handles both the plural form (``files: [{file_base64, name}, ...]``,
-    used by notes and invoices) and the singular form (``file: {file_base64,
+    Handles both the plural form (``files: [{file_in_base64, name}, ...]``,
+    used by notes and invoices) and the singular form (``file: {file_in_base64,
     name}``, used by compliance uploads).
     """
     if not isinstance(body, dict):
@@ -405,7 +405,7 @@ class AppFolioVendorService:
     async def search_work_orders(self, search_term: str) -> Any:
         return await self.get(
             "/api/v1/search/work_order_search",
-            params={"searchTerm": search_term},
+            params={"search_term": search_term},
         )
 
     async def get_work_order(self, customer_id: str, work_order_id: str) -> Any:
@@ -491,39 +491,52 @@ class AppFolioVendorService:
         self,
         work_order_id: str,
         *,
-        scheduled_at: str,
-        duration_minutes: int | None = None,
-        notes: str = "",
+        time_slot_id: str,
+        customer_id: str | None = None,
     ) -> Any:
         """POST a schedule onto a work order.
 
-        Body shape mirrors the SPA: a flat dict whose keys are camelCase.
-        ``scheduled_at`` should be an ISO 8601 string with timezone (or
-        local with offset) so AppFolio can render it correctly back to
-        the property manager.
+        SPA-verified shape: ``{"time_slot_id": "<id>", "customer_id": "..."}``.
+        AppFolio's vendor portal does not accept arbitrary timestamps; the
+        property manager publishes available time slots and the vendor
+        picks one. Use :meth:`list_schedule_time_slots` to fetch the
+        available slots for a work order before calling this.
         """
-        body: dict[str, Any] = {"scheduledAt": scheduled_at}
-        if duration_minutes is not None:
-            body["durationMinutes"] = duration_minutes
-        if notes:
-            body["notes"] = notes
+        cid = customer_id or await self._resolve_primary_customer_id()
         return await self.post(
             f"/maintenance/api/work_orders/{work_order_id}/schedule",
-            json_body=body,
+            json_body={"time_slot_id": str(time_slot_id), "customer_id": cid},
         )
 
-    async def update_work_order_status(self, work_order_id: str, *, status_code: int) -> Any:
+    async def update_work_order_status(
+        self,
+        work_order_id: str,
+        *,
+        status_code: int,
+        customer_id: str | None = None,
+    ) -> Any:
+        """PATCH a work order's status code.
+
+        SPA-verified shape: ``{"work_order": {"status_code": N}, "customer_id": "..."}``.
+        snake_case throughout; ``customer_id`` is required.
+        """
+        cid = customer_id or await self._resolve_primary_customer_id()
         return await self.patch(
             f"/maintenance/api/work_orders/{work_order_id}",
-            json_body={"workOrder": {"statusCode": status_code}},
+            json_body={"work_order": {"status_code": status_code}, "customer_id": cid},
         )
 
     async def undo_work_order_status(
-        self, work_order_id: str, *, previous_status: int | str
+        self,
+        work_order_id: str,
+        *,
+        previous_status: int | str,
+        customer_id: str | None = None,
     ) -> Any:
+        cid = customer_id or await self._resolve_primary_customer_id()
         return await self.patch(
             f"/maintenance/api/work_orders/{work_order_id}/undo_status",
-            json_body={"workOrder": {"status": previous_status}},
+            json_body={"work_order": {"status": previous_status}, "customer_id": cid},
         )
 
     async def list_work_order_notes(self, work_order_id: str) -> Any:
@@ -612,27 +625,34 @@ class AppFolioVendorService:
         customer_id: str,
         work_order_id: str,
         line_items: list[dict[str, Any]],
-        invoice_number: str = "",
-        due_date: str = "",
+        address: dict[str, Any] | None = None,
+        reference_number: str = "",
         files: list[FileUpload] | None = None,
     ) -> Any:
         """Create a line-itemized invoice tied to a work order.
 
-        ``line_items`` should be a list of ``{description, quantity, rate}``
-        entries (or whichever shape AppFolio's UI emits — confirmed
-        post-smoke-test). Optional ``files`` attach photos or supporting
-        docs inline as base64. ``invoice_number`` and ``due_date``
-        (ISO YYYY-MM-DD) are passed through when present.
+        SPA-verified body shape (snake_case throughout):
+
+        ``{customer_id, work_order_id (int), line_items: [{amount, description,
+        quantity}], address: {property_or_unit_name, address_1, address_2,
+        city, state, zip_code}, reference_number}``
+
+        ``line_items`` entries use ``amount`` (not ``rate``) and the SPA sends
+        ``quantity`` as a string. ``address`` is sourced from the work-order
+        location and is part of the SPA's payload; we pass it through so the
+        invoice prints the correct property block. ``reference_number`` is
+        the vendor-side invoice number (the SPA auto-suggests one based on
+        the WO).
         """
         body: dict[str, Any] = {
-            "customerId": customer_id,
-            "workOrderId": work_order_id,
-            "lineItems": line_items,
+            "customer_id": str(customer_id),
+            "work_order_id": int(work_order_id) if str(work_order_id).isdigit() else work_order_id,
+            "line_items": line_items,
         }
-        if invoice_number:
-            body["invoiceNumber"] = invoice_number
-        if due_date:
-            body["dueDate"] = due_date
+        if address:
+            body["address"] = address
+        if reference_number:
+            body["reference_number"] = reference_number
         if files:
             body["files"] = _encode_files(files)
         return await self.post("/maintenance/api/invoices", json_body=body)
@@ -643,23 +663,27 @@ class AppFolioVendorService:
         customer_id: str,
         work_order_id: str,
         files: list[FileUpload],
+        address: dict[str, Any] | None = None,
+        reference_number: str = "",
     ) -> Any:
         """Upload one or more pre-built invoice PDFs as a single AppFolio invoice.
 
-        AppFolio reuses the ``/maintenance/api/invoices`` endpoint for
-        both shapes; the absence of ``lineItems`` plus presence of
-        ``files`` switches it to the "uploaded PDF" mode.
+        Uses the same ``/maintenance/api/invoices`` endpoint as line-itemized
+        invoices; the SPA distinguishes by sending ``files`` without
+        ``line_items``.
         """
         if not files:
             raise ValueError("upload_invoice_pdf requires at least one file")
-        return await self.post(
-            "/maintenance/api/invoices",
-            json_body={
-                "customerId": customer_id,
-                "workOrderId": work_order_id,
-                "files": _encode_files(files),
-            },
-        )
+        body: dict[str, Any] = {
+            "customer_id": str(customer_id),
+            "work_order_id": int(work_order_id) if str(work_order_id).isdigit() else work_order_id,
+            "files": _encode_files(files),
+        }
+        if address:
+            body["address"] = address
+        if reference_number:
+            body["reference_number"] = reference_number
+        return await self.post("/maintenance/api/invoices", json_body=body)
 
     async def upload_compliance_document(
         self,
@@ -673,14 +697,18 @@ class AppFolioVendorService:
         Note the singular ``file`` field; AppFolio's compliance endpoint
         does not take an array.
         """
+        # Body shape extrapolated from the snake_case pattern used by every
+        # other write endpoint we've SPA-verified (notes, status, schedule,
+        # invoice). Not yet directly Playwright-confirmed for compliance
+        # docs; revisit if AppFolio rejects.
         return await self.post(
             "/maintenance/api/compliance_documents",
             json_body={
-                "customerId": customer_id,
-                "complianceType": compliance_type,
+                "customer_id": customer_id,
+                "compliance_type": compliance_type,
                 "file": {
                     "name": file.name,
-                    "file_base64": base64.b64encode(file.data).decode("ascii"),
+                    "file_in_base64": base64.b64encode(file.data).decode("ascii"),
                 },
             },
         )

--- a/backend/app/integrations/appfolio_vendor/work_order_writes.py
+++ b/backend/app/integrations/appfolio_vendor/work_order_writes.py
@@ -45,24 +45,17 @@ def build_work_order_write_tools(service: AppFolioVendorService) -> list[Tool]:
 
     async def appfolio_schedule_work_order(
         work_order_id: str,
-        scheduled_at: str,
-        duration_minutes: int = 0,
-        notes: str = "",
+        time_slot_id: str,
     ) -> ToolResult:
         try:
-            await service.schedule_work_order(
-                work_order_id,
-                scheduled_at=scheduled_at,
-                duration_minutes=duration_minutes or None,
-                notes=notes,
-            )
+            await service.schedule_work_order(work_order_id, time_slot_id=time_slot_id)
         except Exception as exc:
             return service_error_to_tool_result("scheduling work order", exc)
         return ToolResult(
-            content=f"Scheduled work order {work_order_id} for {scheduled_at}.",
+            content=f"Scheduled work order {work_order_id} (slot {time_slot_id}).",
             receipt=ToolReceipt(
                 action="Scheduled AppFolio work order",
-                target=f"#{work_order_id} at {scheduled_at}",
+                target=f"#{work_order_id} slot {time_slot_id}",
             ),
         )
 
@@ -127,7 +120,7 @@ def build_work_order_write_tools(service: AppFolioVendorService) -> list[Tool]:
                 default_level=PermissionLevel.ASK,
                 description_builder=lambda args: (
                     f"Schedule AppFolio work order #{args.get('work_order_id', '?')}"
-                    f" for {args.get('scheduled_at', '?')}"
+                    f" (slot {args.get('time_slot_id', '?')})"
                 ),
             ),
         ),

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -417,7 +417,7 @@ def test_encode_files_compresses_oversized_photos() -> None:
     encoded = _encode_files([FileUpload(name="damage.jpg", data=big)])
     assert len(encoded) == 1
     assert encoded[0]["name"] == "damage.jpg"
-    raw = base64.b64decode(encoded[0]["file_base64"])
+    raw = base64.b64decode(encoded[0]["file_in_base64"])
     assert len(raw) <= _APPFOLIO_PHOTO_TARGET_BYTES
     assert len(raw) < len(big)
 
@@ -428,7 +428,7 @@ def test_encode_files_passes_small_images_through() -> None:
 
     small = _noisy_jpeg(200, 150, quality=85)
     encoded = _encode_files([FileUpload(name="thumb.jpg", data=small)])
-    raw = base64.b64decode(encoded[0]["file_base64"])
+    raw = base64.b64decode(encoded[0]["file_in_base64"])
     assert raw == small  # bytes preserved exactly
 
 
@@ -438,7 +438,7 @@ def test_encode_files_passes_non_image_through() -> None:
 
     pdf_bytes = b"%PDF-1.4\n" + b"\x00" * 4_000_000
     encoded = _encode_files([FileUpload(name="invoice.pdf", data=pdf_bytes)])
-    raw = base64.b64decode(encoded[0]["file_base64"])
+    raw = base64.b64decode(encoded[0]["file_in_base64"])
     assert raw == pdf_bytes
 
 
@@ -449,7 +449,7 @@ def test_encode_files_falls_back_when_compression_fails() -> None:
     # Bytes that won't decode as any image despite the .jpg extension.
     junk = b"not actually a JPEG" + b"\xff" * 2_000_000
     encoded = _encode_files([FileUpload(name="broken.jpg", data=junk)])
-    raw = base64.b64decode(encoded[0]["file_base64"])
+    raw = base64.b64decode(encoded[0]["file_in_base64"])
     assert raw == junk
 
 
@@ -475,18 +475,18 @@ def test_fmt_work_order_line_prefers_number_for_display() -> None:
     """
     from backend.app.integrations.appfolio_vendor.work_orders import _fmt_work_order_line
 
-    line = _fmt_work_order_line({"id": 114433, "numberForDisplay": "WO-2026-0042"})
-    assert "ID: 114433" in line
+    line = _fmt_work_order_line({"id": 999001, "numberForDisplay": "WO-2026-0042"})
+    assert "ID: 999001" in line
     assert "#WO-2026-0042" in line
-    assert "#114433" not in line
+    assert "#999001" not in line
 
 
 def test_fmt_work_order_line_falls_back_to_id_when_no_display_number() -> None:
     from backend.app.integrations.appfolio_vendor.work_orders import _fmt_work_order_line
 
-    line = _fmt_work_order_line({"id": 114433})
-    assert "ID: 114433" in line
-    assert "#114433" in line
+    line = _fmt_work_order_line({"id": 999001})
+    assert "ID: 999001" in line
+    assert "#999001" in line
 
 
 def test_fmt_work_order_line_underscored_alias_also_supported() -> None:
@@ -503,8 +503,8 @@ def test_fmt_work_order_line_surfaces_customer_id() -> None:
     """
     from backend.app.integrations.appfolio_vendor.work_orders import _fmt_work_order_line
 
-    line = _fmt_work_order_line({"id": 114433, "customer_id": "1963538"})
-    assert "customer_id=1963538" in line
+    line = _fmt_work_order_line({"id": 999001, "customer_id": "cust-9001"})
+    assert "customer_id=cust-9001" in line
 
 
 @pytest.mark.asyncio()
@@ -519,7 +519,7 @@ async def test_add_work_order_note_includes_customer_id_in_body() -> None:
         user_id="u1",
         jwt="jwt-1",
         fingerprint="fp-1",
-        customer_ids=["1963538"],
+        customer_ids=["cust-9001"],
         extra={},
     )
     service = AppFolioVendorService(cred, api_base="https://api.test")
@@ -531,10 +531,10 @@ async def test_add_work_order_note_includes_customer_id_in_body() -> None:
         cm.__aenter__ = AsyncMock(return_value=client)
         cm.__aexit__ = AsyncMock(return_value=False)
         cls.return_value = cm
-        await service.add_work_order_note("114433", body_text="status update")
+        await service.add_work_order_note("999001", body_text="status update")
     _, kwargs = client.request.call_args
     sent = kwargs["json"]
-    assert sent["customer_id"] == "1963538"
+    assert sent["customer_id"] == "cust-9001"
     assert sent["note"] == {"body": "status update"}
     assert sent["files"] == []
 
@@ -555,7 +555,7 @@ async def test_add_work_order_note_resolves_customer_id_when_missing() -> None:
     service = AppFolioVendorService(cred, api_base="https://api.test")
 
     profile_response = _mock_response(
-        json_data={"customers": [{"customer_id": 1963538, "customer_name": "Arbors"}]}
+        json_data={"customers": [{"customer_id": "cust-9001", "customer_name": "Acme Properties"}]}
     )
     note_response = _mock_response(json_data={"id": 42})
 
@@ -566,7 +566,7 @@ async def test_add_work_order_note_resolves_customer_id_when_missing() -> None:
         cm.__aenter__ = AsyncMock(return_value=client)
         cm.__aexit__ = AsyncMock(return_value=False)
         cls.return_value = cm
-        await service.add_work_order_note("114433", body_text="status update")
+        await service.add_work_order_note("999001", body_text="status update")
 
     # First call: GET /profiles/me to discover customer_id
     first_args, _ = client.request.call_args_list[0]
@@ -576,10 +576,10 @@ async def test_add_work_order_note_resolves_customer_id_when_missing() -> None:
     second_args, second_kwargs = client.request.call_args_list[1]
     assert second_args[0] == "POST"
     assert "/notes" in second_args[1]
-    assert second_kwargs["json"]["customer_id"] == "1963538"
+    assert second_kwargs["json"]["customer_id"] == "cust-9001"
     # The credential should be backfilled in-memory so subsequent calls
     # don't refetch.
-    assert cred.customer_ids == ["1963538"]
+    assert cred.customer_ids == ["cust-9001"]
 
 
 @pytest.mark.asyncio()
@@ -599,7 +599,7 @@ async def test_resolve_customer_id_raises_when_profile_has_none() -> None:
     with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
         cls.return_value = _patch_async_client("request", response)
         with pytest.raises(AppFolioError, match="no customer IDs"):
-            await service.add_work_order_note("114433", body_text="x")
+            await service.add_work_order_note("999001", body_text="x")
 
 
 def test_client_version_header_is_opaque_hex() -> None:
@@ -887,7 +887,9 @@ async def test_accept_work_order_passes_ref_param() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_schedule_work_order_omits_unset_fields() -> None:
+async def test_schedule_work_order_uses_time_slot_id_shape() -> None:
+    """Verified against SPA capture: AppFolio expects time_slot_id +
+    customer_id, not free-form ISO timestamps."""
     service = AppFolioVendorService(_credential(), api_base="https://api.test")
     response = _mock_response(json_data={})
     with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
@@ -897,38 +899,18 @@ async def test_schedule_work_order_omits_unset_fields() -> None:
         cm.__aenter__ = AsyncMock(return_value=client)
         cm.__aexit__ = AsyncMock(return_value=False)
         cls.return_value = cm
-        await service.schedule_work_order("42", scheduled_at="2026-05-08T14:00:00-04:00")
+        await service.schedule_work_order("42", time_slot_id="slot-99")
     _, kwargs = client.request.call_args
-    assert kwargs["json"] == {"scheduledAt": "2026-05-08T14:00:00-04:00"}
+    sent = kwargs["json"]
+    assert sent["time_slot_id"] == "slot-99"
+    assert sent["customer_id"] == "c1"
 
 
 @pytest.mark.asyncio()
-async def test_schedule_work_order_includes_optional_fields() -> None:
-    service = AppFolioVendorService(_credential(), api_base="https://api.test")
-    response = _mock_response(json_data={})
-    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
-        client = AsyncMock()
-        client.request = AsyncMock(return_value=response)
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(return_value=client)
-        cm.__aexit__ = AsyncMock(return_value=False)
-        cls.return_value = cm
-        await service.schedule_work_order(
-            "42",
-            scheduled_at="2026-05-08T14:00:00",
-            duration_minutes=90,
-            notes="bring ladder",
-        )
-    _, kwargs = client.request.call_args
-    assert kwargs["json"] == {
-        "scheduledAt": "2026-05-08T14:00:00",
-        "durationMinutes": 90,
-        "notes": "bring ladder",
-    }
-
-
-@pytest.mark.asyncio()
-async def test_update_status_uses_camelcase_envelope() -> None:
+async def test_update_status_uses_snake_case_with_customer_id() -> None:
+    """Verified against SPA capture: snake_case body wrapping plus
+    ``customer_id`` at the top level. Previously sent camelCase and no
+    customer_id, which AppFolio rejects with a 422 + empty body."""
     service = AppFolioVendorService(_credential(), api_base="https://api.test")
     response = _mock_response(json_data={})
     with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
@@ -941,7 +923,7 @@ async def test_update_status_uses_camelcase_envelope() -> None:
         await service.update_work_order_status("42", status_code=8)
     args, kwargs = client.request.call_args
     assert args[0] == "PATCH"
-    assert kwargs["json"] == {"workOrder": {"statusCode": 8}}
+    assert kwargs["json"] == {"work_order": {"status_code": 8}, "customer_id": "c1"}
 
 
 @pytest.mark.asyncio()
@@ -968,7 +950,7 @@ async def test_add_note_inlines_base64_files() -> None:
     # base64 of b"\x89PNGfake"
     import base64
 
-    assert entry["file_base64"] == base64.b64encode(b"\x89PNGfake").decode("ascii")
+    assert entry["file_in_base64"] == base64.b64encode(b"\x89PNGfake").decode("ascii")
 
 
 @pytest.mark.asyncio()
@@ -1135,23 +1117,29 @@ async def test_create_invoice_serializes_line_items() -> None:
         cls.return_value = cm
         await service.create_invoice(
             customer_id="cust-1",
-            work_order_id="wo-1",
+            work_order_id="42",
             line_items=[
-                {"description": "Labor 4hr", "quantity": 4.0, "rate": 75.0},
-                {"description": "Materials", "quantity": 1.0, "rate": 120.0},
+                {"description": "Labor 4hr", "quantity": 4.0, "amount": 75.0},
+                {"description": "Materials", "quantity": 1.0, "amount": 120.0},
             ],
-            invoice_number="INV-001",
-            due_date="2026-06-01",
+            address={
+                "property_or_unit_name": "Acme Bldg Unit 1",
+                "address_1": "123 Example Street",
+            },
+            reference_number="REF-001",
             files=[FileUpload(name="receipt.pdf", data=b"%PDF-fake")],
         )
     args, kwargs = client.request.call_args
     assert args[0] == "POST"
     payload = kwargs["json"]
-    assert payload["customerId"] == "cust-1"
-    assert payload["workOrderId"] == "wo-1"
-    assert payload["lineItems"][0]["description"] == "Labor 4hr"
-    assert payload["invoiceNumber"] == "INV-001"
-    assert payload["dueDate"] == "2026-06-01"
+    # SPA-verified shape: snake_case keys, work_order_id as int, line_items
+    # with ``amount``, ``address`` block, ``reference_number``.
+    assert payload["customer_id"] == "cust-1"
+    assert payload["work_order_id"] == 42
+    assert payload["line_items"][0]["description"] == "Labor 4hr"
+    assert payload["line_items"][0]["amount"] == 75.0
+    assert payload["address"]["address_1"] == "123 Example Street"
+    assert payload["reference_number"] == "REF-001"
     assert len(payload["files"]) == 1
 
 
@@ -1166,14 +1154,14 @@ async def test_upload_invoice_pdf_omits_line_items() -> None:
         cls.return_value = cm
         await service.upload_invoice_pdf(
             customer_id="cust-1",
-            work_order_id="wo-1",
+            work_order_id="999001",
             files=[FileUpload(name="invoice.pdf", data=b"%PDF-fake")],
         )
     _, kwargs = client.request.call_args
     payload = kwargs["json"]
-    assert "lineItems" not in payload
-    assert payload["customerId"] == "cust-1"
-    assert payload["workOrderId"] == "wo-1"
+    assert "line_items" not in payload
+    assert payload["customer_id"] == "cust-1"
+    assert payload["work_order_id"] == 999001
     assert len(payload["files"]) == 1
 
 
@@ -1193,8 +1181,8 @@ async def test_upload_compliance_document_uses_singular_file() -> None:
         )
     _, kwargs = client.request.call_args
     payload = kwargs["json"]
-    assert payload["customerId"] == "cust-1"
-    assert payload["complianceType"] == "w9"
+    assert payload["customer_id"] == "cust-1"
+    assert payload["compliance_type"] == "w9"
     assert isinstance(payload["file"], dict)
     assert payload["file"]["name"] == "w9.pdf"
     assert "files" not in payload
@@ -1292,9 +1280,9 @@ async def test_4xx_failure_logs_request_body_and_response(caplog: Any) -> None:
 
     service = AppFolioVendorService(_credential(), api_base="https://api.test")
     response = _mock_response(
-        json_data={"errors": ["scheduledAt: must be in the future"]},
+        json_data={"errors": ["time_slot_id: not available"]},
         status_code=422,
-        text='{"errors":["scheduledAt: must be in the future"]}',
+        text='{"errors":["time_slot_id: not available"]}',
     )
 
     with (
@@ -1304,18 +1292,18 @@ async def test_4xx_failure_logs_request_body_and_response(caplog: Any) -> None:
         cm, _ = _patch_request(response)
         cls.return_value = cm
         with pytest.raises(AppFolioError) as exc_info:
-            await service.schedule_work_order("42", scheduled_at="2024-01-01T00:00:00")
+            await service.schedule_work_order("42", time_slot_id="slot-99")
 
     # ToolResult-side message carries the status only; the response body
     # is intentionally redacted so it cannot leak into user-visible chat.
     assert "422" in str(exc_info.value)
-    assert "scheduledAt" not in str(exc_info.value)
+    assert "time_slot_id: not available" not in str(exc_info.value)
 
     # Log line includes everything a dev needs to diagnose.
     record_text = "\n".join(r.message for r in caplog.records)
     assert "POST" in record_text
     assert "/maintenance/api/work_orders/42/schedule" in record_text
-    assert "scheduledAt" in record_text  # request body logged
+    assert "time_slot_id" in record_text  # request body logged
     assert "422" in record_text
 
 


### PR DESCRIPTION
## Description

Fixes a class of AppFolio Vendor Portal write failures that surfaced
after the OAuth migration in #1269. The legacy `/access` flow masked
several body-shape defaults: the production API expects snake_case keys
plus `customer_id` at the top level on most writes, and the SPA bundle
we originally reverse-engineered used camelCase in some places. Direct
SPA network capture (Playwright with fetch interception, no calls hit
the production account) shows the real shapes:

- `search_work_orders`: `?search_term=` (was `?searchTerm=`, silently
  ignored, returning 0 results)
- `add_work_order_note` files: `file_in_base64` (was `file_base64`),
  caused 500-with-empty-body when photos were attached
- `update_work_order_status`: `{"work_order": {"status_code": N},
  "customer_id": ...}` (was camelCase and missing `customer_id`)
- `undo_work_order_status`: same snake_case + `customer_id` treatment
- `schedule_work_order`: `{"time_slot_id": "<id>", "customer_id": ...}`
  (was free-form `{"scheduledAt": ISO8601, ...}`). The vendor portal
  does not accept arbitrary timestamps; vendors pick from PM-published
  time slots, so the tool surface now takes `time_slot_id`.
- `create_invoice`: `{customer_id, work_order_id (int), line_items:
  [{amount, description, quantity}], address: {...}, reference_number}`.
  Previously camelCase + `rate` + `invoice_number`/`due_date`. Drops
  `due_date` (not in SPA shape), renames `invoice_number` to
  `reference_number`.
- `upload_invoice_pdf`: same snake_case + `reference_number` alignment
- `upload_compliance_document`: snake_case keys (extrapolated, not yet
  Playwright-verified, flagged in code)

Tools that need `customer_id` either resolve it from the cached
credential, lazy-fetch `/profiles/me` on first call, or surface it in
the work-order list so the agent can pass it through.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: SPA capture, shape diffs, test rewrites, and PII scrub done with Claude. Reasoning and decisions reviewed by @njbrake.