### PR TITLE
docs(appfolio): refresh stale comments and usage hints after #1277

### DIFF
--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -167,8 +167,8 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
             function=appfolio_create_invoice,
             params_model=AppFolioCreateInvoiceParams,
             usage_hint=(
-                "Confirm each line item's description, quantity, and rate with"
-                " the user before submitting; this is a billing action."
+                "Confirm each line item's description, quantity, and amount"
+                " with the user before submitting; this is a billing action."
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,

--- a/backend/app/integrations/appfolio_vendor/media_resolver.py
+++ b/backend/app/integrations/appfolio_vendor/media_resolver.py
@@ -1,7 +1,7 @@
 """Resolve staged photos into AppFolio's base64 file payload shape.
 
 AppFolio's notes and invoice endpoints accept JSON-inlined files via
-``files: [{file_base64, name}]`` rather than multipart upload. The
+``files: [{file_in_base64, name}]`` rather than multipart upload. The
 agent receives photos through the OSS staging pipeline (current
 message ``downloaded_media`` then the in-memory media staging cache),
 and may also reference a previously saved file by its storage path.

--- a/backend/app/integrations/appfolio_vendor/work_order_writes.py
+++ b/backend/app/integrations/appfolio_vendor/work_order_writes.py
@@ -113,8 +113,11 @@ def build_work_order_write_tools(service: AppFolioVendorService) -> list[Tool]:
             function=appfolio_schedule_work_order,
             params_model=AppFolioScheduleWorkOrderParams,
             usage_hint=(
-                "Confirm the date, time, and timezone with the user before"
-                " calling. AppFolio sends the tenant a 24-hour reminder."
+                "Pick a time_slot_id from the slots the property manager"
+                " published on the work order; AppFolio does not accept"
+                " arbitrary timestamps. Confirm the chosen slot with the"
+                " user before calling. AppFolio sends the tenant a 24-hour"
+                " reminder."
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,


### PR DESCRIPTION
## Description

Three small follow-ups to the SPA-shape alignment in #1277. Comments and
usage hints that drifted out of sync with the corrected body shapes:

- `media_resolver` module docstring still referenced `file_base64`, the
  very field name #1277 corrected to `file_in_base64`.
- `appfolio_schedule_work_order` `usage_hint` told the agent to
  "Confirm the date, time, and timezone." Under the new `time_slot_id`
  model the agent picks from PM-published slots, not free-form
  timestamps. Hint now says so.
- `appfolio_create_invoice` `usage_hint` said "description, quantity,
  and rate." The SPA field is `amount`; renamed to match so the hint,
  the params model, and the API are consistent.

No behavior change. Comment and string-literal updates only.

## Type
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: spotted by Claude during a dead-code/stale-comment sweep after #1277. Reasoning and decisions reviewed by @njbrake.