### PR TITLE
refactor(stores): drop append_history_async alias, keep plain name

### DIFF
--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -93,8 +93,9 @@ class MemoryStore:
 
     Async-only API after the issue #1160 final pass. The dual sync/async
     surface from issue #1153 (PR #1199 pilot) has been collapsed: only the
-    ``*_async`` peers remain. Premium and OSS callers all reach for the
-    async API directly.
+    ``*_async`` peers remain, plus ``append_history`` which keeps its
+    historical plain name (issue #1221). Premium and OSS callers all reach
+    for the async API directly.
     """
 
     def __init__(self, user_id: str) -> None:
@@ -185,10 +186,6 @@ class MemoryStore:
             await db.execute(_append_history_update(doc.id, full_new_text))
             await db.commit()
             return full_new_text
-
-    async def append_history_async(self, entry: str) -> str:
-        """Deprecated alias of :meth:`append_history`."""
-        return await self.append_history(entry)
 
     # -- soul text ---------------------------------------------------------
 

--- a/tests/test_memory_db_async.py
+++ b/tests/test_memory_db_async.py
@@ -94,9 +94,9 @@ async def test_async_append_history_creates_row(
     async_db: async_sessionmaker,
     async_test_user: User,
 ) -> None:
-    """``append_history_async`` creates the MemoryDocument row on first call."""
+    """``append_history`` creates the MemoryDocument row on first call."""
     store = MemoryStore(async_test_user.id)
-    await store.append_history_async("first entry")
+    await store.append_history("first entry")
 
     history = await store.read_history_async()
     assert "first entry" in history
@@ -114,13 +114,13 @@ async def test_async_append_history_multi_append_round_trips(
     concatenated ciphertext envelopes and broke decryption on read
     after the second append. The fix reads the row under
     ``SELECT ... FOR UPDATE``, concatenates plaintext in Python, and
-    rewrites the column with a fresh envelope. Both sync and async
-    paths share the rewritten ``_append_history_update`` helper.
+    rewrites the column with a fresh envelope via the
+    ``_append_history_update`` helper.
     """
     store = MemoryStore(async_test_user.id)
-    await store.append_history_async("first entry")
-    await store.append_history_async("second entry")
-    await store.append_history_async("third entry")
+    await store.append_history("first entry")
+    await store.append_history("second entry")
+    await store.append_history("third entry")
 
     history = await store.read_history_async()
     # Each entry was appended with a trailing newline. ``read_history_async``
@@ -142,8 +142,8 @@ async def test_async_append_history_sequential_appends_after_seed(
     concatenation glued two ciphertext envelopes together.
     """
     store = MemoryStore(async_test_user.id)
-    await store.append_history_async("seed")
-    await store.append_history_async("follow-up")
+    await store.append_history("seed")
+    await store.append_history("follow-up")
 
     history = await store.read_history_async()
     assert history == "seed\nfollow-up"
@@ -156,7 +156,7 @@ async def test_async_append_history_does_not_disturb_memory_text(
     """Appending history must not clobber memory_text on the same row."""
     store = MemoryStore(async_test_user.id)
     await store.write_memory_async("memory body")
-    await store.append_history_async("history line")
+    await store.append_history("history line")
 
     assert await store.read_memory_async() == "memory body"
     assert await store.read_history_async() == "history line"


### PR DESCRIPTION
## Description

`MemoryStore` had two names for the same async method: `append_history` (plain, async-since-before the dual-API epic) and `append_history_async` (deprecated alias added by the encrypted-history fix in #1200). The dual-API contract from `AGENTS.md` (sync plain, async `_async`) no longer applies because the sync surface was removed in the issue #1160 final pass. Pick the historical plain name and drop the alias.

Changes:
- `backend/app/agent/memory_db.py`: remove the `append_history_async` deprecated alias; tighten the class docstring to note that `append_history` keeps its plain name.
- `tests/test_memory_db_async.py`: update the seven call sites and two stale docstrings.

No callers in OSS or premium reference `append_history_async` after this change.

Fixes #1221

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code drafted the diff after njbrake described the scope; verified by running the full OSS suite and the premium suite, both green)
- [ ] No AI used