### PR TITLE
feat(agent): bounded-growth policies for agent-managed markdown files

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -21,6 +21,7 @@ from any_llm import amessages
 from any_llm.types.messages import MessageResponse
 
 from backend.app.agent.llm_parsing import get_response_text
+from backend.app.agent.markdown_registry import BudgetExceededError
 from backend.app.agent.memory_db import get_memory_store
 from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
 from backend.app.agent.observer import (
@@ -341,9 +342,24 @@ async def compact_session(
     new_history: str = current_history
 
     # Write updated MEMORY.md only when the rewrite actually differs.
+    # An LLM that returns a rewrite over the bounded-growth byte budget
+    # (see ``backend/app/agent/markdown_registry.py``) is treated as a
+    # failed compaction for that file: log a warning and keep the
+    # current memory rather than truncating mid-sentence and producing
+    # silently corrupt durable state. The conversation that triggered
+    # this compaction will still trim, and the next compaction will get
+    # another chance to produce an in-budget rewrite.
     if memory_changed:
-        await memory_store.write_memory_async(result.memory_update)
-        logger.info("Compaction rewrote MEMORY.md for user %s", user_id)
+        try:
+            await memory_store.write_memory_async(result.memory_update)
+            logger.info("Compaction rewrote MEMORY.md for user %s", user_id)
+        except BudgetExceededError as exc:
+            logger.warning(
+                "Compaction skipping MEMORY.md update for user %s: %s",
+                user_id,
+                exc,
+            )
+            memory_changed = False
 
     # Append summary to HISTORY.md if the LLM produced one. ``append_history``
     # returns the new full text under the same row-level lock that protected
@@ -359,14 +375,31 @@ async def compact_session(
             logger.exception("Failed to append history for user %s", user_id)
 
     # Write updated USER.md only when the rewrite actually differs.
+    # See MEMORY.md branch above for the BudgetExceededError handling.
     if user_changed:
-        await memory_store.write_user_async(result.user_profile_update)
-        logger.info("Compaction updated USER.md for user %s", user_id)
+        try:
+            await memory_store.write_user_async(result.user_profile_update)
+            logger.info("Compaction updated USER.md for user %s", user_id)
+        except BudgetExceededError as exc:
+            logger.warning(
+                "Compaction skipping USER.md update for user %s: %s",
+                user_id,
+                exc,
+            )
+            user_changed = False
 
     # Write updated SOUL.md only when the rewrite actually differs.
     if soul_changed:
-        await memory_store.write_soul_async(result.soul_update)
-        logger.info("Compaction updated SOUL.md for user %s", user_id)
+        try:
+            await memory_store.write_soul_async(result.soul_update)
+            logger.info("Compaction updated SOUL.md for user %s", user_id)
+        except BudgetExceededError as exc:
+            logger.warning(
+                "Compaction skipping SOUL.md update for user %s: %s",
+                user_id,
+                exc,
+            )
+            soul_changed = False
 
     # Single structured summary line. Fields are space-separated key=value
     # so log aggregators (Railway, Loki) can group / filter without

--- a/backend/app/agent/markdown_registry.py
+++ b/backend/app/agent/markdown_registry.py
@@ -280,7 +280,12 @@ def truncate_for_injection(name: str, content: str) -> str:
     marker_bytes = marker.encode("utf-8")
     keep = max(0, policy.byte_budget - len(marker_bytes))
     tail = encoded[-keep:].decode("utf-8", errors="ignore")
-    logger.warning(
+    # INFO rather than WARNING: this fires on every prompt build for a
+    # single legacy over-budget row (every turn for that user), so a
+    # WARNING here floods logs with the same message until the agent
+    # rewrites the file. INFO is enough for an operator searching for
+    # truncation events without crowding out actionable warnings.
+    logger.info(
         "markdown_registry: truncated %s for prompt injection (size=%d, budget=%d)",
         name,
         len(encoded),
@@ -296,11 +301,13 @@ def truncate_for_injection(name: str, content: str) -> str:
 
 # Compaction emits each history entry prefixed with ``[YYYY-MM-DD HH:MM]``
 # (see ``backend/app/agent/compaction.py`` and ``prompts/compaction.md``).
-# We split on lines that begin with ``[`` to find entry boundaries, so
-# whole entries can be dropped from the front instead of cutting a
-# sentence in half. Also tolerates the legacy case where a manually
-# edited history has content before the first timestamp.
-_ENTRY_HEAD_RE = re.compile(r"^\[", re.MULTILINE)
+# We split on lines that look like a date-shaped prefix to find entry
+# boundaries, so whole entries can be dropped from the front instead
+# of cutting a sentence in half. Requiring the date shape (rather than
+# a bare ``[``) means a multi-line summary whose body happens to start
+# a line with ``[`` is not mis-split into two entries: only true
+# timestamp-prefixed lines are recognized as boundaries.
+_ENTRY_HEAD_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}", re.MULTILINE)
 
 
 def _split_history_entries(text: str) -> list[str]:

--- a/backend/app/agent/markdown_registry.py
+++ b/backend/app/agent/markdown_registry.py
@@ -1,0 +1,384 @@
+"""Bounded-growth registry for agent-managed markdown surfaces.
+
+Single source of truth for every markdown file the agent can read or
+write. Each surface declares:
+
+- where it is stored (which DB column or disk path);
+- how it is written (full rewrite, append, transient);
+- whether the contents are injected into an LLM prompt;
+- a hard byte budget enforced at write time;
+- a one-line description of what the file is for.
+
+The point of this registry is not just data: it is the integration
+seam used by the write paths (``workspace_tools``, ``memory_db``,
+``stores``), the read paths (``system_prompt`` builders), and the
+regression tests. Adding a new agent-mutable markdown surface without
+adding it here will fail the ``test_markdown_registry`` consistency
+tests, which is the mechanism that prevents future features from
+silently re-introducing unbounded growth.
+
+See ``docs/markdown_growth_policies.md`` for the per-surface rationale
+and the prior-art references the policies are based on (Claude Code's
+25 KB MEMORY.md cap, Letta / MemGPT's per-block character limits).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class StorageKind(StrEnum):
+    """Where a markdown surface is persisted."""
+
+    USER_COLUMN = "user_column"
+    """Plaintext ``Text`` column on the ``users`` row."""
+
+    MEMORY_COLUMN = "memory_column"
+    """``EncryptedString`` column on the ``memory_documents`` row."""
+
+    DISK_FILE = "disk_file"
+    """Plaintext file under ``data/users/{user_id}/``."""
+
+
+class WriteMode(StrEnum):
+    """How the agent (or compaction) writes the surface."""
+
+    REWRITE = "rewrite"
+    """Full overwrite. Each write replaces the previous content."""
+
+    APPEND = "append"
+    """Accumulating log. Each write appends a new entry; prior entries persist."""
+
+    TRANSIENT = "transient"
+    """Written once on provision, removed when no longer relevant."""
+
+
+@dataclass(frozen=True, slots=True)
+class MarkdownPolicy:
+    """Bounded-growth policy for one agent-managed markdown surface."""
+
+    name: str
+    """Canonical filename, e.g. ``USER.md`` (case-sensitive, used as registry key)."""
+
+    storage: StorageKind
+    storage_ref: str
+    """Column name (for ``*_COLUMN``) or relative path (for ``DISK_FILE``)."""
+
+    write_mode: WriteMode
+    byte_budget: int
+    """Hard cap in UTF-8 bytes. Same value across surfaces (see DEFAULT_BUDGET)."""
+
+    injected_into_prompt: bool
+    """True when the contents land in an LLM system prompt verbatim."""
+
+    description: str
+
+
+class BudgetExceededError(ValueError):
+    """Raised when a write would push a markdown surface past its byte budget.
+
+    Carries the surface name and the actual / allowed sizes so callers
+    (workspace tools, compaction) can produce a useful message back to
+    the agent or the operator log without re-counting bytes.
+    """
+
+    def __init__(self, surface_name: str, size_bytes: int, budget_bytes: int) -> None:
+        over = size_bytes - budget_bytes
+        super().__init__(
+            f"{surface_name} write of {size_bytes} bytes exceeds the "
+            f"{budget_bytes}-byte budget by {over} bytes. "
+            f"Trim the content to fit within {budget_bytes} bytes."
+        )
+        self.surface_name = surface_name
+        self.size_bytes = size_bytes
+        self.budget_bytes = budget_bytes
+
+
+# ---------------------------------------------------------------------------
+# Policies
+# ---------------------------------------------------------------------------
+
+
+# 25 KiB across the board. Matches Claude Code's MEMORY.md cap and the
+# existing ``compaction_event_snapshot_max_bytes_per_file`` audit cap,
+# so any in-budget surface fits in audit rows without truncation. The
+# uniform value is deliberate: it makes the policy memorable and avoids
+# bikeshedding per file. Tune individual surfaces only when there is
+# evidence that a tighter or looser bound is needed.
+DEFAULT_BUDGET: int = 25 * 1024
+
+
+POLICIES: dict[str, MarkdownPolicy] = {
+    "USER.md": MarkdownPolicy(
+        name="USER.md",
+        storage=StorageKind.USER_COLUMN,
+        storage_ref="user_text",
+        write_mode=WriteMode.REWRITE,
+        byte_budget=DEFAULT_BUDGET,
+        injected_into_prompt=True,
+        description="User profile facts, injected into every system prompt.",
+    ),
+    "SOUL.md": MarkdownPolicy(
+        name="SOUL.md",
+        storage=StorageKind.USER_COLUMN,
+        storage_ref="soul_text",
+        write_mode=WriteMode.REWRITE,
+        byte_budget=DEFAULT_BUDGET,
+        injected_into_prompt=True,
+        description="Agent identity / personality, injected into every system prompt.",
+    ),
+    "HEARTBEAT.md": MarkdownPolicy(
+        name="HEARTBEAT.md",
+        storage=StorageKind.USER_COLUMN,
+        storage_ref="heartbeat_text",
+        write_mode=WriteMode.REWRITE,
+        byte_budget=DEFAULT_BUDGET,
+        injected_into_prompt=True,
+        description="Active task list, injected into the heartbeat system prompt.",
+    ),
+    "MEMORY.md": MarkdownPolicy(
+        name="MEMORY.md",
+        storage=StorageKind.MEMORY_COLUMN,
+        storage_ref="memory_text",
+        write_mode=WriteMode.REWRITE,
+        byte_budget=DEFAULT_BUDGET,
+        injected_into_prompt=True,
+        description="Working memory, injected into every system prompt.",
+    ),
+    "HISTORY.md": MarkdownPolicy(
+        name="HISTORY.md",
+        storage=StorageKind.MEMORY_COLUMN,
+        storage_ref="history_text",
+        write_mode=WriteMode.APPEND,
+        byte_budget=DEFAULT_BUDGET,
+        injected_into_prompt=False,
+        description="Append-only compaction archive, windowed to byte_budget on append.",
+    ),
+    "BOOTSTRAP.md": MarkdownPolicy(
+        name="BOOTSTRAP.md",
+        storage=StorageKind.DISK_FILE,
+        storage_ref="BOOTSTRAP.md",
+        write_mode=WriteMode.TRANSIENT,
+        byte_budget=DEFAULT_BUDGET,
+        injected_into_prompt=False,
+        description="Onboarding gate file, deleted by OnboardingSubscriber on completion.",
+    ),
+}
+
+
+# Map storage column name -> canonical surface name. Used by store
+# helpers that know the column they are writing but not the registry
+# key. Kept explicit (rather than derived by inverting POLICIES) so a
+# disk-backed surface with the same string ref as a column does not
+# silently collide.
+COLUMN_TO_SURFACE: dict[str, str] = {
+    "user_text": "USER.md",
+    "soul_text": "SOUL.md",
+    "heartbeat_text": "HEARTBEAT.md",
+    "memory_text": "MEMORY.md",
+    "history_text": "HISTORY.md",
+}
+
+
+# ---------------------------------------------------------------------------
+# Lookups
+# ---------------------------------------------------------------------------
+
+
+def get_policy(name: str) -> MarkdownPolicy | None:
+    """Return the policy for *name*, or ``None`` for unknown surfaces."""
+    return POLICIES.get(name)
+
+
+def policy_for_column(column: str) -> MarkdownPolicy | None:
+    """Return the policy for the given DB column, or ``None`` if unmapped."""
+    surface = COLUMN_TO_SURFACE.get(column)
+    if surface is None:
+        return None
+    return POLICIES.get(surface)
+
+
+# ---------------------------------------------------------------------------
+# Write-time enforcement
+# ---------------------------------------------------------------------------
+
+
+def assert_within_budget(name: str, stored_value: str) -> None:
+    """Raise :class:`BudgetExceededError` when ``stored_value`` is over budget.
+
+    ``stored_value`` should be the exact text that will land in storage
+    (after any wrapper / trailing newline the writer applies), so the
+    enforced size matches what the prompt builders will eventually
+    inject. UTF-8 byte count is the canonical size: characters undercount
+    non-ASCII content, which still costs LLM tokens.
+
+    No-op for unknown surfaces and for the (currently empty) case of a
+    declared policy with no budget. Callers writing to a new file should
+    add it to ``POLICIES`` rather than special-casing here.
+    """
+    policy = POLICIES.get(name)
+    if policy is None:
+        return
+    size = len(stored_value.encode("utf-8"))
+    if size > policy.byte_budget:
+        raise BudgetExceededError(name, size, policy.byte_budget)
+
+
+def assert_column_within_budget(column: str, stored_value: str) -> None:
+    """Column-keyed convenience wrapper around :func:`assert_within_budget`."""
+    surface = COLUMN_TO_SURFACE.get(column)
+    if surface is None:
+        return
+    assert_within_budget(surface, stored_value)
+
+
+# ---------------------------------------------------------------------------
+# Read-time truncation (defence in depth for legacy over-budget rows)
+# ---------------------------------------------------------------------------
+
+
+def truncate_for_injection(name: str, content: str) -> str:
+    """Tail-truncate ``content`` to the surface's byte budget for prompt injection.
+
+    Write-time caps prevent new over-budget writes, but rows that
+    pre-date the cap (or were written via a path that bypassed it)
+    would otherwise still bloat the prompt on the next turn. This
+    helper is the read-side defence: every prompt-injection builder
+    runs the value through here before handing it to the LLM.
+
+    The tail (most recent content) is kept because for both
+    rewrite-mode files (USER.md, SOUL.md, MEMORY.md, HEARTBEAT.md, where
+    "most recent" usually means "most relevant") and append-mode files
+    the head is the part most likely to be stale. A one-line marker is
+    prepended so the agent knows the context was clipped and can
+    rewrite the file smaller.
+
+    Cuts on UTF-8 byte boundaries with ``errors="ignore"`` so a partial
+    leading multibyte sequence is dropped cleanly rather than producing
+    a decode error.
+    """
+    policy = POLICIES.get(name)
+    if policy is None:
+        return content
+    encoded = content.encode("utf-8")
+    if len(encoded) <= policy.byte_budget:
+        return content
+    marker = (
+        f"[truncated: {name} exceeds the {policy.byte_budget}-byte budget; "
+        "showing tail. Rewrite this file smaller to restore full visibility.]\n"
+    )
+    marker_bytes = marker.encode("utf-8")
+    keep = max(0, policy.byte_budget - len(marker_bytes))
+    tail = encoded[-keep:].decode("utf-8", errors="ignore")
+    logger.warning(
+        "markdown_registry: truncated %s for prompt injection (size=%d, budget=%d)",
+        name,
+        len(encoded),
+        policy.byte_budget,
+    )
+    return marker + tail
+
+
+# ---------------------------------------------------------------------------
+# Append-mode windowing (HISTORY.md)
+# ---------------------------------------------------------------------------
+
+
+# Compaction emits each history entry prefixed with ``[YYYY-MM-DD HH:MM]``
+# (see ``backend/app/agent/compaction.py`` and ``prompts/compaction.md``).
+# We split on lines that begin with ``[`` to find entry boundaries, so
+# whole entries can be dropped from the front instead of cutting a
+# sentence in half. Also tolerates the legacy case where a manually
+# edited history has content before the first timestamp.
+_ENTRY_HEAD_RE = re.compile(r"^\[", re.MULTILINE)
+
+
+def _split_history_entries(text: str) -> list[str]:
+    """Split *text* into entries. Each entry retains its trailing newlines.
+
+    An entry begins at a line starting with ``[`` (a timestamp marker).
+    Anything before the first such line is returned as a leading
+    "preamble" entry so it is not silently lost; in practice, that
+    region is empty for compaction-written histories.
+    """
+    if not text:
+        return []
+    starts = [m.start() for m in _ENTRY_HEAD_RE.finditer(text)]
+    if not starts:
+        return [text]
+    entries: list[str] = []
+    if starts[0] > 0:
+        entries.append(text[: starts[0]])
+    for i, start in enumerate(starts):
+        end = starts[i + 1] if i + 1 < len(starts) else len(text)
+        entries.append(text[start:end])
+    return entries
+
+
+def append_with_window(current: str, entry: str, budget: int) -> str:
+    """Append ``entry`` to ``current`` and drop oldest entries until under budget.
+
+    Used by the HISTORY.md append path so the on-disk archive stays
+    bounded without losing the integrity guarantees of the existing
+    locked append (issue #1243 / PR #1273): we still produce the full
+    plaintext that the locked UPDATE writes, but we prune older entries
+    on the way through.
+
+    Entries are dropped whole (FIFO) rather than mid-line so the log
+    stays readable and grep-friendly. If a single tail entry still
+    exceeds *budget* on its own (e.g. an unusually long compaction
+    summary), the function falls back to UTF-8 byte-tail truncation
+    to guarantee an under-budget result rather than letting the cap
+    silently fail.
+
+    Returns the full new plaintext, including a trailing newline so
+    the next append can rely on the standard separator invariant.
+    """
+    if current and not current.endswith("\n"):
+        current = current + "\n"
+    if not entry.endswith("\n"):
+        entry = entry + "\n"
+    text = current + entry
+
+    if len(text.encode("utf-8")) <= budget:
+        return text
+
+    entries = _split_history_entries(text)
+    while len(entries) > 1 and len("".join(entries).encode("utf-8")) > budget:
+        entries.pop(0)
+    rebuilt = "".join(entries)
+    if len(rebuilt.encode("utf-8")) <= budget:
+        return rebuilt
+
+    encoded = rebuilt.encode("utf-8")
+    tail = encoded[-budget:].decode("utf-8", errors="ignore")
+    if tail and not tail.endswith("\n"):
+        tail = tail + "\n"
+    return tail
+
+
+__all__ = [
+    "COLUMN_TO_SURFACE",
+    "DEFAULT_BUDGET",
+    "POLICIES",
+    "BudgetExceededError",
+    "MarkdownPolicy",
+    "StorageKind",
+    "WriteMode",
+    "append_with_window",
+    "assert_column_within_budget",
+    "assert_within_budget",
+    "get_policy",
+    "policy_for_column",
+    "truncate_for_injection",
+]

--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -12,6 +12,11 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import Select, Update, select, update
 
+from backend.app.agent.markdown_registry import (
+    append_with_window,
+    assert_within_budget,
+    get_policy,
+)
 from backend.app.agent.store_cache import StoreCache
 from backend.app.database import (
     AsyncSessionLocal,
@@ -125,10 +130,19 @@ class MemoryStore:
             await db.close()
 
     async def write_memory_async(self, content: str) -> None:
-        """Write memory text (full rewrite, equivalent of MEMORY.md)."""
+        """Write memory text (full rewrite, equivalent of MEMORY.md).
+
+        Raises :class:`BudgetExceededError` when the value exceeds the
+        ``MEMORY.md`` byte budget declared in
+        :mod:`backend.app.agent.markdown_registry`. Callers that may
+        produce LLM-generated rewrites (compaction) are expected to
+        catch and log this rather than crash.
+        """
+        stored = content.rstrip() + "\n"
+        assert_within_budget("MEMORY.md", stored)
         async with db_session_async() as db:
             doc = await self._get_or_create_doc_async(db)
-            doc.memory_text = content.rstrip() + "\n"
+            doc.memory_text = stored
             await db.commit()
 
     # -- history text ------------------------------------------------------
@@ -160,28 +174,42 @@ class MemoryStore:
         before this guarantee), a separator is inserted so two entries
         never end up jammed together as one line.
 
+        Applies the HISTORY.md byte budget windowing policy from
+        :mod:`backend.app.agent.markdown_registry`: when the post-append
+        text would exceed the budget, the oldest entries are dropped
+        whole (FIFO). This bounds runaway growth on long-lived users
+        without losing the row-level lock semantics. The full archive
+        of compaction events still lives in ``compaction_events`` rows.
+
         Returns the row's new full plaintext so callers (compaction
         audit) can record the post-append snapshot without re-reading
         the row, which would race with concurrent compactions sharing
         the same user.
         """
-        suffix = entry + "\n"
+        policy = get_policy("HISTORY.md")
+        budget = policy.byte_budget if policy is not None else None
         async with db_session_async() as db:
             doc = (await db.execute(_doc_select_for_update(self.user_id))).scalar_one_or_none()
             if doc is None:
+                full_new_text = (
+                    append_with_window("", entry, budget) if budget is not None else entry + "\n"
+                )
                 db.add(
                     MemoryDocument(
                         user_id=self.user_id,
                         memory_text="",
-                        history_text=suffix,
+                        history_text=full_new_text,
                     )
                 )
                 await db.commit()
-                return suffix
+                return full_new_text
             current = doc.history_text or ""
-            if current and not current.endswith("\n"):
-                current += "\n"
-            full_new_text = current + suffix
+            if budget is not None:
+                full_new_text = append_with_window(current, entry, budget)
+            else:
+                if current and not current.endswith("\n"):
+                    current += "\n"
+                full_new_text = current + entry + "\n"
             await db.execute(_append_history_update(doc.id, full_new_text))
             await db.commit()
             return full_new_text
@@ -204,11 +232,18 @@ class MemoryStore:
             await db.close()
 
     async def write_soul_async(self, content: str) -> None:
-        """Write soul text to User model."""
+        """Write soul text to User model.
+
+        Raises :class:`BudgetExceededError` when the wrapped value
+        exceeds the ``SOUL.md`` byte budget. Compaction wraps the call
+        in a try/except and logs on failure rather than crashing.
+        """
+        stored = f"# Soul\n\n{content}\n"
+        assert_within_budget("SOUL.md", stored)
         async with db_session_async() as db:
             user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
             if user is not None:
-                user.soul_text = f"# Soul\n\n{content}\n"
+                user.soul_text = stored
                 await db.commit()
 
     # -- user text ---------------------------------------------------------
@@ -225,11 +260,18 @@ class MemoryStore:
             await db.close()
 
     async def write_user_async(self, content: str) -> None:
-        """Write user text to User model."""
+        """Write user text to User model.
+
+        Raises :class:`BudgetExceededError` when the wrapped value
+        exceeds the ``USER.md`` byte budget. Compaction wraps the call
+        in a try/except and logs on failure rather than crashing.
+        """
+        stored = f"# User\n\n{content}\n"
+        assert_within_budget("USER.md", stored)
         async with db_session_async() as db:
             user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
             if user is not None:
-                user.user_text = f"# User\n\n{content}\n"
+                user.user_text = stored
                 await db.commit()
 
     # -- composite helpers -------------------------------------------------

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -24,6 +24,7 @@ from backend.app.agent.dto import (
     HeartbeatLogEntry,
     ToolConfigEntry,
 )
+from backend.app.agent.markdown_registry import assert_within_budget
 from backend.app.database import AsyncSessionLocal, db_session_async
 from backend.app.models import (
     HeartbeatLog,
@@ -153,7 +154,15 @@ class HeartbeatStore:
             await db.close()
 
     async def write_heartbeat_md(self, text: str) -> None:
-        """Write freeform heartbeat markdown to User.heartbeat_text."""
+        """Write freeform heartbeat markdown to User.heartbeat_text.
+
+        Raises :class:`BudgetExceededError` when *text* exceeds the
+        ``HEARTBEAT.md`` byte budget. The heartbeat engine is the only
+        non-tool caller and writes short task summaries, so an over-
+        budget value almost certainly indicates an LLM bug worth
+        surfacing rather than silently swallowing.
+        """
+        assert_within_budget("HEARTBEAT.md", text)
         async with db_session_async() as db:
             user = (await db.execute(_heartbeat_user_select(self.user_id))).scalar_one_or_none()
             if user is not None:

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -11,6 +11,7 @@ import datetime
 import logging
 import zoneinfo
 
+from backend.app.agent.markdown_registry import truncate_for_injection
 from backend.app.agent.memory_db import build_memory_context
 from backend.app.agent.prompts import load_prompt
 from backend.app.agent.session_db import get_session_store
@@ -97,8 +98,13 @@ def build_soul_prompt(user: User) -> str:
 
     Returns the SOUL.md content directly. Identity info (name, personality)
     lives in the markdown, written by the agent during onboarding.
+
+    Tail-truncates over-budget rows via
+    :func:`backend.app.agent.markdown_registry.truncate_for_injection`
+    so a row that pre-dates the write-time cap (or that was migrated
+    in by an earlier release) cannot bloat every system prompt.
     """
-    return user.soul_text or ""
+    return truncate_for_injection("SOUL.md", user.soul_text or "")
 
 
 def build_identity_section(user: User) -> str:
@@ -107,17 +113,27 @@ def build_identity_section(user: User) -> str:
 
 
 def build_user_section(user: User) -> str:
-    """Build the user profile section from USER.md content."""
-    return user.user_text or ""
+    """Build the user profile section from USER.md content.
+
+    Tail-truncates over-budget rows for prompt injection; see
+    :func:`build_soul_prompt` for the rationale.
+    """
+    return truncate_for_injection("USER.md", user.user_text or "")
 
 
 async def build_memory_section(
     user_id: str,
     query: str | None = None,
 ) -> str:
-    """Build the memory context section content."""
+    """Build the memory context section content.
+
+    Tail-truncates over-budget rows for prompt injection; see
+    :func:`build_soul_prompt` for the rationale.
+    """
     ctx = await build_memory_context(user_id)
-    return ctx or "(No memories saved yet)"
+    if not ctx:
+        return "(No memories saved yet)"
+    return truncate_for_injection("MEMORY.md", ctx)
 
 
 def build_instructions_section() -> str:
@@ -303,7 +319,9 @@ async def build_heartbeat_system_prompt(
 
     builder.add_section(
         "User's heartbeat (HEARTBEAT.md)",
-        heartbeat_md or "(no heartbeat items configured)",
+        truncate_for_injection("HEARTBEAT.md", heartbeat_md)
+        if heartbeat_md
+        else "(no heartbeat items configured)",
     )
 
     if heartbeat_history:

--- a/backend/app/agent/tools/heartbeat_tools.py
+++ b/backend/app/agent/tools/heartbeat_tools.py
@@ -8,8 +8,9 @@ from pydantic import BaseModel, Field
 
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.heartbeat import SCHEDULED_TASK_PREFIX
+from backend.app.agent.markdown_registry import BudgetExceededError
 from backend.app.agent.stores import HeartbeatStore
-from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
 
 if TYPE_CHECKING:
@@ -44,7 +45,14 @@ def create_heartbeat_tools(user_id: str) -> list[Tool]:
         """
         store = HeartbeatStore(user_id)
         previous = await store.read_heartbeat_md_async()
-        await store.write_heartbeat_md(text)
+        try:
+            await store.write_heartbeat_md(text)
+        except BudgetExceededError as exc:
+            return ToolResult(
+                content=str(exc),
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
         if previous:
             return ToolResult(content=f"Heartbeat notes updated.\n\nPrevious content:\n{previous}")
         return ToolResult(content="Heartbeat notes updated (was empty).")

--- a/backend/app/agent/tools/workspace_tools.py
+++ b/backend/app/agent/tools/workspace_tools.py
@@ -21,6 +21,11 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.markdown_registry import (
+    BudgetExceededError,
+    assert_column_within_budget,
+    assert_within_budget,
+)
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult, ToolTags
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
@@ -364,11 +369,41 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
         """Write or overwrite a markdown file in the workspace."""
         canon = _canonical_name(path)
         if canon:
+            try:
+                assert_column_within_budget(_DB_FILE_COLUMN[canon], content)
+            except BudgetExceededError as exc:
+                return ToolResult(
+                    content=str(exc),
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
             await _db_write(user_id, _DB_FILE_COLUMN[canon], content)
             return ToolResult(content=f"Wrote {path}")
 
         mem_col = _memory_doc_column(path)
         if mem_col:
+            if mem_col == "history_text":
+                # HISTORY.md is append-only and managed by compaction
+                # (see backend/app/agent/memory_db.py::append_history).
+                # A full rewrite via write_file would silently bypass the
+                # append-with-window invariant and lose the integrity
+                # guarantee from issue #1243 / PR #1273.
+                return ToolResult(
+                    content=(
+                        "HISTORY.md is append-only and managed by compaction. "
+                        "It cannot be rewritten via write_file."
+                    ),
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
+            try:
+                assert_column_within_budget(mem_col, content)
+            except BudgetExceededError as exc:
+                return ToolResult(
+                    content=str(exc),
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
             await _memory_doc_write(user_id, mem_col, content)
             return ToolResult(content=f"Wrote {path}")
 
@@ -379,6 +414,19 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
         resolved, err = _resolve_path(user_id, path)
         if err:
             return ToolResult(content=err, is_error=True, error_kind=ToolErrorKind.VALIDATION)
+        # Disk-backed surfaces have no per-file column, so look up by
+        # filename. Unknown disk markdown gets no enforcement; the agent
+        # can scribble notes in arbitrary scratch files without the cap
+        # rejecting them. The cap matters only for surfaces that feed
+        # prompt context.
+        try:
+            assert_within_budget(resolved.name, content)
+        except BudgetExceededError as exc:
+            return ToolResult(
+                content=str(exc),
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
         resolved.parent.mkdir(parents=True, exist_ok=True)
         await asyncio.to_thread(resolved.write_text, content, "utf-8")
         return ToolResult(content=f"Wrote {path}")
@@ -403,11 +451,29 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
                     error_kind=ToolErrorKind.VALIDATION,
                 )
             updated = text.replace(old_text, new_text, 1)
+            try:
+                assert_column_within_budget(column, updated)
+            except BudgetExceededError as exc:
+                return ToolResult(
+                    content=str(exc),
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
             await _db_write(user_id, column, updated)
             return ToolResult(content=f"Updated {path}")
 
         mem_col = _memory_doc_column(path)
         if mem_col:
+            if mem_col == "history_text":
+                # HISTORY.md is append-only; see write_file for rationale.
+                return ToolResult(
+                    content=(
+                        "HISTORY.md is append-only and managed by compaction. "
+                        "It cannot be edited directly."
+                    ),
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
             text = await _memory_doc_read(user_id, mem_col)
             if old_text not in text:
                 return ToolResult(
@@ -423,6 +489,14 @@ def create_workspace_tools(user_id: str) -> list[Tool]:
                     error_kind=ToolErrorKind.VALIDATION,
                 )
             updated = text.replace(old_text, new_text, 1)
+            try:
+                assert_column_within_budget(mem_col, updated)
+            except BudgetExceededError as exc:
+                return ToolResult(
+                    content=str(exc),
+                    is_error=True,
+                    error_kind=ToolErrorKind.VALIDATION,
+                )
             await _memory_doc_write(user_id, mem_col, updated)
             return ToolResult(content=f"Updated {path}")
 

--- a/backend/app/routers/user_memory.py
+++ b/backend/app/routers/user_memory.py
@@ -38,7 +38,7 @@ async def update_memory(
         await store.write_memory_async(body.content)
     except BudgetExceededError as exc:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=str(exc),
         ) from exc
     return MemoryResponse(content=await store.read_memory_async())

--- a/backend/app/routers/user_memory.py
+++ b/backend/app/routers/user_memory.py
@@ -1,7 +1,8 @@
 """Endpoints for viewing and managing memory (freeform MEMORY.md)."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 
+from backend.app.agent.markdown_registry import BudgetExceededError
 from backend.app.agent.memory_db import get_memory_store
 from backend.app.auth.dependencies import get_current_user
 from backend.app.models import User
@@ -24,7 +25,20 @@ async def update_memory(
     body: MemoryUpdate,
     current_user: User = Depends(get_current_user),
 ) -> MemoryResponse:
-    """Overwrite MEMORY.md with new content."""
+    """Overwrite MEMORY.md with new content.
+
+    Returns ``413 Payload Too Large`` when *body.content* exceeds the
+    bounded-growth byte budget for ``MEMORY.md`` (see
+    :mod:`backend.app.agent.markdown_registry`). The original message
+    from the registry includes the actual size and the budget so a
+    user-side editor can show a useful error.
+    """
     store = get_memory_store(current_user.id)
-    await store.write_memory_async(body.content)
+    try:
+        await store.write_memory_async(body.content)
+    except BudgetExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=str(exc),
+        ) from exc
     return MemoryResponse(content=await store.read_memory_async())

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -3,11 +3,15 @@
 import datetime
 from typing import cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import CursorResult, delete, select, update
 from sqlalchemy import func as sa_func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.app.agent.markdown_registry import (
+    BudgetExceededError,
+    assert_column_within_budget,
+)
 from backend.app.auth.dependencies import get_current_user
 from backend.app.channel_state import realign_preferred_channel_async
 from backend.app.channels import is_bluebubbles_configured, reset_channel_clients
@@ -87,10 +91,31 @@ async def update_profile(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_async_db),
 ) -> UserProfileResponse:
-    """Partial update of the current user's profile."""
+    """Partial update of the current user's profile.
+
+    Bounded-growth columns (``user_text``, ``soul_text``,
+    ``heartbeat_text``) are routed through
+    :func:`backend.app.agent.markdown_registry.assert_column_within_budget`
+    so the dashboard editor cannot bypass the byte cap that the agent's
+    workspace tools and compaction paths already respect. Returns
+    ``413 Payload Too Large`` with the registry's actual / allowed
+    sizes so a client-side editor can show a useful error.
+    """
     updates = body.model_dump(exclude_unset=True)
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
+
+    # Validate bounded-growth columns up front so a partial commit
+    # cannot land before we reject the payload.
+    for key, value in updates.items():
+        if isinstance(value, str):
+            try:
+                assert_column_within_budget(key, value)
+            except BudgetExceededError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    detail=str(exc),
+                ) from exc
 
     # Re-query user in the current session to avoid detached instance issues
     user = await get_or_404_async(db, User, detail="User not found", id=current_user.id)

--- a/docs/markdown_growth_policies.md
+++ b/docs/markdown_growth_policies.md
@@ -130,6 +130,31 @@ The intent is to make adding a new unbounded markdown surface
 either impossible (the integration paths route through the
 registry) or noisily test-failing.
 
+## Observability
+
+The current observability surfaces are intentionally minimal:
+
+- **Per-write rejection log.** Compaction logs at `WARNING` when an
+  LLM rewrite exceeds the cap, including the surface name, the
+  attempted size, and the budget. Operators can grep for "skipping
+  ... update for user" to find users whose compaction is failing the
+  cap.
+- **Per-injection truncation log.** `truncate_for_injection` logs at
+  `INFO` when a legacy over-budget row is tail-truncated for prompt
+  injection. INFO rather than WARNING because this fires every turn
+  for the affected user until the agent rewrites the file, and a
+  per-turn WARNING would crowd out actionable signals.
+- **`compaction_events` audit rows.** Every compaction event already
+  records the before / after snapshot for each surface (capped at
+  100 KB per file in the audit row); the existing admin compaction
+  feed surfaces these.
+
+A dedicated admin dashboard for tracking per-user file sizes over
+time is a useful follow-up but is out of scope here. A reasonable
+shape would be a histogram of stored bytes per surface plus a
+counter for `BudgetExceededError` events, both exposed from the
+existing admin observability surface.
+
 ## What this PR deliberately does not do
 
 - **Periodic / size-triggered compaction of working memory.** The
@@ -143,11 +168,9 @@ registry) or noisily test-failing.
   pattern ranks observations by importance and reflects only when the
   cumulative score crosses a threshold. Worth exploring; out of scope
   here.
-- **Admin observability dashboard for surface sizes.** The
-  observability hook is the existing structured `compaction.summary`
-  log line plus the new `markdown_registry: truncated ...` warning
-  log. A dedicated UI for tracking per-user file sizes over time is
-  separate work.
+- **Admin observability dashboard for surface sizes.** See the
+  Observability section above for the current state and the shape
+  of a follow-up.
 - **Rewriting the SOUL.md / USER.md / HEARTBEAT.md compaction
   prompts.** Issue #1243 already tightened the durable-memory
   rules; this PR is about adding policy enforcement, not rewriting

--- a/docs/markdown_growth_policies.md
+++ b/docs/markdown_growth_policies.md
@@ -1,0 +1,154 @@
+# Bounded-growth policies for agent-managed markdown surfaces
+
+This document is the source of truth for the growth policy of every
+markdown file the Clawbolt agent can read or write. It is the
+human-readable companion to `backend/app/agent/markdown_registry.py`,
+which encodes the same policies in code so they can be enforced at
+write time and verified by tests.
+
+The motivation is issue #1244 (follow-up to #1243): without explicit
+bounds, a long-lived user's `MEMORY.md`, `USER.md`, `SOUL.md`,
+`HEARTBEAT.md`, and `HISTORY.md` can grow without limit, bloating
+every prompt and degrading both cost and response quality. Some
+surfaces are injected directly into the system prompt; others (like
+`HISTORY.md`) accumulate compaction summaries forever and were not
+windowed at all before this change.
+
+The pattern adopted here mirrors prior art:
+
+- **Claude Code** caps `MEMORY.md` at ~25 KB injected into the
+  sub-agent prompt and instructs the agent to curate the file when it
+  exceeds that limit.
+- **MemGPT / Letta** enforces a per-block character limit on core
+  memory and forces eviction to archival memory on overflow.
+- **Anthropic harness guidance (2025)** treats prompt-size management
+  as the harness's responsibility, not the model's.
+
+A **uniform 25 KiB byte budget** is applied to every surface. The
+uniform value matches the existing
+`compaction_event_snapshot_max_bytes_per_file` audit cap (so any
+in-budget surface fits in a single audit row without truncation) and
+is generous enough for normal use while still catching catastrophic
+growth.
+
+## Surface inventory
+
+| Surface | Storage | Write mode | Injected | Byte budget | Enforcement |
+|---|---|---|---|---|---|
+| `USER.md` | `users.user_text` (Text) | full rewrite | yes (every prompt) | 25 KiB | write-time hard cap; read-side tail truncation |
+| `SOUL.md` | `users.soul_text` (Text) | full rewrite | yes (every prompt) | 25 KiB | write-time hard cap; read-side tail truncation |
+| `HEARTBEAT.md` | `users.heartbeat_text` (Text) | full rewrite | yes (heartbeat prompt) | 25 KiB | write-time hard cap; read-side tail truncation |
+| `MEMORY.md` | `memory_documents.memory_text` (encrypted) | full rewrite | yes (every prompt) | 25 KiB | write-time hard cap; read-side tail truncation |
+| `HISTORY.md` | `memory_documents.history_text` (encrypted) | append | no (audit only) | 25 KiB | append-with-window: oldest entries dropped FIFO; `write_file` rejected |
+| `BOOTSTRAP.md` | disk: `data/users/{user_id}/BOOTSTRAP.md` | transient | no | 25 KiB | deleted by `OnboardingSubscriber` on completion |
+
+Audit details (column types, encryption, prior compaction behavior)
+live in inline docstrings on each surface in the registry module.
+
+## Per-surface rationale
+
+### `USER.md`, `SOUL.md`, `MEMORY.md`
+
+These are the three markdown surfaces injected into the **main agent
+system prompt on every turn**. The 25 KiB cap serves two purposes:
+
+1. **Write-time hard cap.** `workspace_tools.write_file` /
+   `workspace_tools.edit_file`, `MemoryStore.write_memory_async`,
+   `MemoryStore.write_user_async`, and
+   `MemoryStore.write_soul_async` all reject content over 25 KiB
+   with a `BudgetExceededError`. The agent gets a tool error
+   describing the actual size and the cap so it can rewrite smaller.
+   Compaction (`compact_session`) catches the same error, logs a
+   warning, and leaves the previous file in place; the next
+   compaction gets another chance.
+
+2. **Read-time tail truncation.** A row that pre-dates the cap (or
+   was inserted via raw SQL) would otherwise still bloat every
+   prompt. The system-prompt builders (`build_user_section`,
+   `build_soul_prompt`, `build_memory_section`) run the value through
+   `truncate_for_injection` before handing it to the LLM. The tail
+   is kept (most-recent content) with a one-line marker so the agent
+   can detect it was clipped and rewrite the file smaller.
+
+### `HEARTBEAT.md`
+
+Same enforcement model as `USER.md` / `SOUL.md` / `MEMORY.md`, but
+the heartbeat content is only injected into the heartbeat
+sub-system's prompt (not the main agent prompt). The cap is the
+same 25 KiB because the heartbeat call is no less expensive per
+token, and a runaway list of stale tasks creates the same
+context-bloat problem.
+
+### `HISTORY.md`
+
+Append-only by design (compaction summaries are timestamped
+breadcrumbs). The risk profile is different from the other
+surfaces:
+
+- It is **not injected** into the agent prompt, so unbounded growth
+  affects storage cost and admin tool latency, not LLM cost.
+- It is **append-only** with row-level lock semantics for integrity
+  (issue #1243 / PR #1273), and a full rewrite would silently bypass
+  that invariant.
+
+The policy is **append-with-window**: each call to `append_history`
+appends the new entry, then drops the oldest entries (whole, on
+timestamped boundaries) until the post-append text fits within 25
+KiB. The full archive of compaction events is still preserved in
+`compaction_events` rows for admin observability; HISTORY.md itself
+just keeps the most recent window. `workspace_tools.write_file` and
+`workspace_tools.edit_file` reject HISTORY.md outright so the
+windowing invariant cannot be circumvented.
+
+### `BOOTSTRAP.md`
+
+A transient file written on user provisioning and deleted by
+`OnboardingSubscriber` when onboarding completes. It is not edited
+post-provision and is not injected into any prompt. The 25 KiB cap
+is enforced on disk writes via `workspace_tools.write_file` for
+defense in depth, but in practice the file lives only as long as
+onboarding does and is never modified by the agent.
+
+## Adding a new markdown surface
+
+If a future feature introduces a new markdown surface that the agent
+can mutate or that is injected into a prompt:
+
+1. Add a `MarkdownPolicy` entry in
+   `backend/app/agent/markdown_registry.py` declaring the storage,
+   write mode, prompt exposure, and byte budget.
+2. If it is column-backed, add the column to
+   `COLUMN_TO_SURFACE` so the store-write helpers route through
+   the cap.
+3. If it is append-mode, decide on a windowing strategy (the
+   `test_history_md_is_the_only_append_surface` registry test will
+   force you to update it explicitly).
+4. The `tests/test_markdown_registry.py` consistency tests will
+   catch missing or inconsistent entries.
+
+The intent is to make adding a new unbounded markdown surface
+either impossible (the integration paths route through the
+registry) or noisily test-failing.
+
+## What this PR deliberately does not do
+
+- **Periodic / size-triggered compaction of working memory.** The
+  current design only triggers compaction on conversation trim. A
+  size-triggered rewrite (e.g. "compact when MEMORY.md exceeds 80%
+  of its budget") is a reasonable follow-up but is out of scope for
+  this PR. Until it lands, an agent that grows MEMORY.md to the cap
+  will start receiving budget errors on the next write and have to
+  curate the file itself.
+- **Importance-based compaction.** Stanford's Generative Agents
+  pattern ranks observations by importance and reflects only when the
+  cumulative score crosses a threshold. Worth exploring; out of scope
+  here.
+- **Admin observability dashboard for surface sizes.** The
+  observability hook is the existing structured `compaction.summary`
+  log line plus the new `markdown_registry: truncated ...` warning
+  log. A dedicated UI for tracking per-user file sizes over time is
+  separate work.
+- **Rewriting the SOUL.md / USER.md / HEARTBEAT.md compaction
+  prompts.** Issue #1243 already tightened the durable-memory
+  rules; this PR is about adding policy enforcement, not rewriting
+  the prompts.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1090,7 +1090,7 @@
       },
       "put": {
         "summary": "Update Memory",
-        "description": "Overwrite MEMORY.md with new content.",
+        "description": "Overwrite MEMORY.md with new content.\n\nReturns ``413 Payload Too Large`` when *body.content* exceeds the\nbounded-growth byte budget for ``MEMORY.md`` (see\n:mod:`backend.app.agent.markdown_registry`). The original message\nfrom the registry includes the actual size and the budget so a\nuser-side editor can show a useful error.",
         "operationId": "update_memory_api_user_memory_put",
         "requestBody": {
           "content": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -456,7 +456,7 @@
       },
       "put": {
         "summary": "Update Profile",
-        "description": "Partial update of the current user's profile.",
+        "description": "Partial update of the current user's profile.\n\nBounded-growth columns (``user_text``, ``soul_text``,\n``heartbeat_text``) are routed through\n:func:`backend.app.agent.markdown_registry.assert_column_within_budget`\nso the dashboard editor cannot bypass the byte cap that the agent's\nworkspace tools and compaction paths already respect. Returns\n``413 Payload Too Large`` with the registry's actual / allowed\nsizes so a client-side editor can show a useful error.",
         "operationId": "update_profile_api_user_profile_put",
         "requestBody": {
           "content": {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -326,6 +326,14 @@ export interface paths {
         /**
          * Update Profile
          * @description Partial update of the current user's profile.
+         *
+         *     Bounded-growth columns (``user_text``, ``soul_text``,
+         *     ``heartbeat_text``) are routed through
+         *     :func:`backend.app.agent.markdown_registry.assert_column_within_budget`
+         *     so the dashboard editor cannot bypass the byte cap that the agent's
+         *     workspace tools and compaction paths already respect. Returns
+         *     ``413 Payload Too Large`` with the registry's actual / allowed
+         *     sizes so a client-side editor can show a useful error.
          */
         put: operations["update_profile_api_user_profile_put"];
         post?: never;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -717,6 +717,12 @@ export interface paths {
         /**
          * Update Memory
          * @description Overwrite MEMORY.md with new content.
+         *
+         *     Returns ``413 Payload Too Large`` when *body.content* exceeds the
+         *     bounded-growth byte budget for ``MEMORY.md`` (see
+         *     :mod:`backend.app.agent.markdown_registry`). The original message
+         *     from the registry includes the actual size and the budget so a
+         *     user-side editor can show a useful error.
          */
         put: operations["update_memory_api_user_memory_put"];
         post?: never;

--- a/tests/test_bounded_growth_integration.py
+++ b/tests/test_bounded_growth_integration.py
@@ -1,0 +1,312 @@
+"""Integration tests for the bounded-growth markdown enforcement.
+
+These tests cover the seams where the registry policy meets the rest
+of the system:
+
+- workspace_tools rejecting over-budget writes / edits with a clean
+  ToolResult error rather than crashing the agent loop.
+- workspace_tools refusing to rewrite HISTORY.md (write_file /
+  edit_file) so the append-only invariant cannot be bypassed.
+- memory_db.append_history applying the windowing policy across many
+  calls.
+- memory_db.write_*_async raising BudgetExceededError on over-budget
+  values.
+- system_prompt builders tail-truncating over-budget legacy rows so a
+  pre-cap row does not poison every system prompt forever.
+
+The pure-unit registry helpers are exercised in
+``tests/test_markdown_registry.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from sqlalchemy import select
+
+from backend.app.agent.markdown_registry import (
+    DEFAULT_BUDGET,
+    BudgetExceededError,
+)
+from backend.app.agent.memory_db import get_memory_store, reset_memory_stores
+from backend.app.agent.system_prompt import (
+    build_memory_section,
+    build_soul_prompt,
+    build_user_section,
+)
+from backend.app.agent.tools.base import ToolResult
+from backend.app.agent.tools.workspace_tools import create_workspace_tools
+from backend.app.database import db_session_async
+from backend.app.models import MemoryDocument, User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_tool_fn(user_id: str, tool_name: str) -> Callable[..., Awaitable[ToolResult]]:
+    for t in create_workspace_tools(user_id):
+        if t.name == tool_name:
+            return t.function
+    msg = f"Tool {tool_name!r} not found"
+    raise ValueError(msg)
+
+
+async def _set_user_column(user_id: str, column: str, value: str) -> None:
+    async with db_session_async() as db:
+        user = (await db.execute(select(User).filter_by(id=user_id))).scalar_one_or_none()
+        assert user is not None
+        setattr(user, column, value)
+        await db.commit()
+
+
+async def _seed_memory_doc(user_id: str, *, memory: str = "", history: str = "") -> None:
+    async with db_session_async() as db:
+        doc = (
+            await db.execute(select(MemoryDocument).filter_by(user_id=user_id))
+        ).scalar_one_or_none()
+        if doc is None:
+            doc = MemoryDocument(user_id=user_id, memory_text=memory, history_text=history)
+            db.add(doc)
+        else:
+            doc.memory_text = memory
+            doc.history_text = history
+        await db.commit()
+
+
+def _huge() -> str:
+    """Return a payload guaranteed to exceed the 25 KiB budget."""
+    return "x" * (DEFAULT_BUDGET + 100)
+
+
+# ---------------------------------------------------------------------------
+# workspace_tools: write_file enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_write_file_rejects_over_budget_user_md(test_user: User) -> None:
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="USER.md", content=_huge())
+    assert result.is_error is True
+    assert "USER.md" in result.content
+    assert "exceeds" in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_write_file_rejects_over_budget_soul_md(test_user: User) -> None:
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="SOUL.md", content=_huge())
+    assert result.is_error is True
+    assert "SOUL.md" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_write_file_rejects_over_budget_heartbeat_md(test_user: User) -> None:
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="HEARTBEAT.md", content=_huge())
+    assert result.is_error is True
+    assert "HEARTBEAT.md" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_write_file_rejects_over_budget_memory_md(test_user: User) -> None:
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="memory/MEMORY.md", content=_huge())
+    assert result.is_error is True
+    assert "MEMORY.md" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_write_file_refuses_to_rewrite_history_md(test_user: User) -> None:
+    """HISTORY.md must not be writable via write_file: the append-with-window
+    invariant lives in append_history, and a full rewrite would silently
+    bypass it."""
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="memory/HISTORY.md", content="anything")
+    assert result.is_error is True
+    assert "HISTORY.md" in result.content
+    assert "append" in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_write_file_under_budget_still_succeeds(test_user: User) -> None:
+    """Sanity: well-under-budget writes are unchanged."""
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="USER.md", content="# User\n\n- Name: Alice\n")
+    assert result.is_error is False
+
+
+# ---------------------------------------------------------------------------
+# workspace_tools: edit_file enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_edit_file_rejects_when_replacement_blows_budget(test_user: User) -> None:
+    """An edit that grows the file past the budget must be rejected,
+    not silently truncated."""
+    seeded = "# User\n\n- A: x\n- B: y\n"
+    await _set_user_column(test_user.id, "user_text", seeded)
+
+    edit_fn = _get_tool_fn(test_user.id, "edit_file")
+    huge_replacement = "y" * (DEFAULT_BUDGET + 100)
+    result = await edit_fn(path="USER.md", old_text="- A: x\n", new_text=huge_replacement)
+    assert result.is_error is True
+    assert "USER.md" in result.content
+    # The original row must be untouched on rejection.
+    async with db_session_async() as db:
+        user = (await db.execute(select(User).filter_by(id=test_user.id))).scalar_one_or_none()
+        assert user is not None
+        assert user.user_text == seeded
+
+
+@pytest.mark.asyncio()
+async def test_edit_file_refuses_history_md(test_user: User) -> None:
+    edit_fn = _get_tool_fn(test_user.id, "edit_file")
+    result = await edit_fn(path="memory/HISTORY.md", old_text="anything", new_text="something")
+    assert result.is_error is True
+    assert "HISTORY.md" in result.content
+
+
+# ---------------------------------------------------------------------------
+# memory_db: write_*_async raise on over-budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_write_memory_async_raises_on_over_budget(test_user: User) -> None:
+    reset_memory_stores()
+    store = get_memory_store(test_user.id)
+    with pytest.raises(BudgetExceededError):
+        await store.write_memory_async(_huge())
+
+
+@pytest.mark.asyncio()
+async def test_write_user_async_raises_on_over_budget(test_user: User) -> None:
+    reset_memory_stores()
+    store = get_memory_store(test_user.id)
+    # The wrapper "# User\n\n{content}\n" adds ~12 bytes; pad past that.
+    with pytest.raises(BudgetExceededError):
+        await store.write_user_async(_huge())
+
+
+@pytest.mark.asyncio()
+async def test_write_soul_async_raises_on_over_budget(test_user: User) -> None:
+    reset_memory_stores()
+    store = get_memory_store(test_user.id)
+    with pytest.raises(BudgetExceededError):
+        await store.write_soul_async(_huge())
+
+
+# ---------------------------------------------------------------------------
+# memory_db: append_history applies the windowing policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_append_history_keeps_storage_bounded_across_many_appends(
+    test_user: User,
+) -> None:
+    """Repeated compaction-style appends must not cause unbounded
+    growth on disk. Maps to the issue's acceptance criterion: 'tests
+    cover repeated-update growth behavior for the important files'.
+    """
+    reset_memory_stores()
+    store = get_memory_store(test_user.id)
+    # Each entry is ~600 bytes; 200 of them would otherwise be ~120 KB,
+    # well past the 25 KiB cap. After windowing, storage must stay
+    # under the cap and only the most recent entries should survive.
+    body = "x" * 600
+    for i in range(200):
+        await store.append_history(f"[2026-05-{(i % 28) + 1:02d} 00:00] {body}")
+    history = await store.read_history_async()
+    encoded = len(history.encode("utf-8"))
+    assert encoded <= DEFAULT_BUDGET, f"history grew to {encoded} bytes; budget is {DEFAULT_BUDGET}"
+    # The newest entry is preserved; the very first one is gone.
+    assert "[2026-05-01" not in history or "[2026-05-28" in history
+
+
+@pytest.mark.asyncio()
+async def test_append_history_preserves_lock_semantics(test_user: User) -> None:
+    """The locked append continues to return the row's full plaintext
+    so the compaction audit can record an accurate post-append
+    snapshot, even after windowing kicks in."""
+    reset_memory_stores()
+    store = get_memory_store(test_user.id)
+    returned = await store.append_history("[2026-05-08 12:00] hello")
+    on_disk = await store.read_history_async()
+    # Reads strip trailing whitespace; compare normalized.
+    assert returned.strip() == on_disk.strip()
+
+
+# ---------------------------------------------------------------------------
+# system_prompt builders: read-side truncation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_build_user_section_truncates_legacy_over_budget_row(
+    test_user: User,
+) -> None:
+    """A row that pre-dates the write-time cap (or was inserted via a
+    raw SQL bypass) must still be tail-truncated when injected into a
+    prompt, so it cannot bloat every system prompt forever."""
+    legacy = "TAIL_HOOK" + ("x" * (DEFAULT_BUDGET + 5_000))
+    await _set_user_column(test_user.id, "user_text", legacy)
+
+    async with db_session_async() as db:
+        user = (await db.execute(select(User).filter_by(id=test_user.id))).scalar_one_or_none()
+        assert user is not None
+        section = build_user_section(user)
+
+    assert len(section.encode("utf-8")) <= DEFAULT_BUDGET
+    assert section.startswith("[truncated:")
+
+
+@pytest.mark.asyncio()
+async def test_build_soul_prompt_truncates_legacy_over_budget_row(
+    test_user: User,
+) -> None:
+    legacy = "x" * (DEFAULT_BUDGET + 5_000)
+    await _set_user_column(test_user.id, "soul_text", legacy)
+
+    async with db_session_async() as db:
+        user = (await db.execute(select(User).filter_by(id=test_user.id))).scalar_one_or_none()
+        assert user is not None
+        section = build_soul_prompt(user)
+
+    assert len(section.encode("utf-8")) <= DEFAULT_BUDGET
+    assert section.startswith("[truncated:")
+
+
+@pytest.mark.asyncio()
+async def test_build_memory_section_truncates_legacy_over_budget_row(
+    test_user: User,
+) -> None:
+    """MEMORY.md is on an EncryptedString column; bypassing the cap
+    requires a direct UPDATE rather than a normal store call. We
+    simulate that by flipping the column directly."""
+    reset_memory_stores()
+    legacy = "x" * (DEFAULT_BUDGET + 5_000)
+    await _seed_memory_doc(test_user.id, memory=legacy)
+
+    section = await build_memory_section(test_user.id)
+
+    assert len(section.encode("utf-8")) <= DEFAULT_BUDGET
+    assert section.startswith("[truncated:")
+
+
+@pytest.mark.asyncio()
+async def test_build_memory_section_under_budget_passes_through(
+    test_user: User,
+) -> None:
+    """Under-budget content must be returned verbatim; the truncation
+    helper must be a no-op on healthy rows."""
+    reset_memory_stores()
+    content = "## Memory\n- Likes: blueprints\n- Dislikes: surprises\n"
+    await _seed_memory_doc(test_user.id, memory=content)
+    section = await build_memory_section(test_user.id)
+    # Reads strip trailing whitespace; compare normalized.
+    assert section.strip() == content.strip()

--- a/tests/test_bounded_growth_integration.py
+++ b/tests/test_bounded_growth_integration.py
@@ -138,6 +138,27 @@ async def test_write_file_under_budget_still_succeeds(test_user: User) -> None:
     assert result.is_error is False
 
 
+@pytest.mark.asyncio()
+async def test_write_file_rejects_over_budget_disk_bootstrap_md(test_user: User) -> None:
+    """BOOTSTRAP.md is in the registry but lives on disk, so it
+    exercises the third branch in write_file (after column-backed and
+    memory-doc paths). The cap must still apply."""
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="BOOTSTRAP.md", content=_huge())
+    assert result.is_error is True
+    assert "BOOTSTRAP.md" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_write_file_unknown_disk_markdown_unconstrained(test_user: User) -> None:
+    """Unknown disk markdown (scratch notes) is not in the registry and
+    must not be policed by the cap. The registry is opt-in; arbitrary
+    scratch files do not feed prompt context."""
+    write_fn = _get_tool_fn(test_user.id, "write_file")
+    result = await write_fn(path="memory/scratch_notes.md", content=_huge())
+    assert result.is_error is False
+
+
 # ---------------------------------------------------------------------------
 # workspace_tools: edit_file enforcement
 # ---------------------------------------------------------------------------
@@ -210,22 +231,31 @@ async def test_append_history_keeps_storage_bounded_across_many_appends(
     test_user: User,
 ) -> None:
     """Repeated compaction-style appends must not cause unbounded
-    growth on disk. Maps to the issue's acceptance criterion: 'tests
-    cover repeated-update growth behavior for the important files'.
+    growth on disk, and the windowing must be FIFO (oldest first).
+
+    Maps to the issue's acceptance criterion: 'tests cover
+    repeated-update growth behavior for the important files'. Each
+    entry is tagged with a unique ``iter=NNNN`` sentinel so the test
+    proves the actual FIFO drop rather than relying on cycling
+    timestamps that would re-introduce earlier dates.
     """
     reset_memory_stores()
     store = get_memory_store(test_user.id)
     # Each entry is ~600 bytes; 200 of them would otherwise be ~120 KB,
-    # well past the 25 KiB cap. After windowing, storage must stay
-    # under the cap and only the most recent entries should survive.
+    # well past the 25 KiB cap.
     body = "x" * 600
-    for i in range(200):
-        await store.append_history(f"[2026-05-{(i % 28) + 1:02d} 00:00] {body}")
+    iterations = 200
+    for i in range(iterations):
+        await store.append_history(f"[2026-05-{(i % 28) + 1:02d} 00:00] iter={i:04d} {body}")
     history = await store.read_history_async()
     encoded = len(history.encode("utf-8"))
     assert encoded <= DEFAULT_BUDGET, f"history grew to {encoded} bytes; budget is {DEFAULT_BUDGET}"
-    # The newest entry is preserved; the very first one is gone.
-    assert "[2026-05-01" not in history or "[2026-05-28" in history
+    # FIFO: the very first append's sentinel is gone and the very last
+    # append's sentinel is present. These are the only two assertions
+    # that actually pin the windowing semantics; everything else here
+    # is just bytes-budget bookkeeping.
+    assert "iter=0000" not in history, "earliest entry should have been dropped"
+    assert f"iter={iterations - 1:04d}" in history, "latest entry should be retained"
 
 
 @pytest.mark.asyncio()

--- a/tests/test_bounded_growth_integration.py
+++ b/tests/test_bounded_growth_integration.py
@@ -76,7 +76,13 @@ async def _seed_memory_doc(user_id: str, *, memory: str = "", history: str = "")
 
 
 def _huge() -> str:
-    """Return a payload guaranteed to exceed the 25 KiB budget."""
+    """Return a payload guaranteed to exceed the 25 KiB budget.
+
+    Pure ASCII so byte count == character count: the size assertion is
+    ``len(content.encode("utf-8")) == DEFAULT_BUDGET + 100``. Do not
+    swap in non-ASCII content here without also revisiting the size
+    math in callers (``DEFAULT_BUDGET // 4 + 1`` style).
+    """
     return "x" * (DEFAULT_BUDGET + 100)
 
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1969,3 +1969,43 @@ async def test_compact_session_no_admin_note_no_prefix(test_user: User) -> None:
 
     user_content = mock_llm.call_args.kwargs["messages"][0]["content"]
     assert "[admin note:" not in user_content
+
+
+# --- Bounded-growth: compaction must survive over-budget LLM rewrites ---
+
+
+@pytest.mark.asyncio()
+async def test_compact_session_skips_memory_update_when_llm_rewrite_exceeds_budget(
+    test_user: User,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the LLM returns a memory rewrite that exceeds the bounded-growth
+    cap, compaction must log a warning, leave MEMORY.md untouched, and
+    return an empty ``memory_update``. Crashing here would block trim-driven
+    compaction for the whole conversation; truncating mid-rewrite would
+    silently corrupt durable memory.
+    """
+    from backend.app.agent.markdown_registry import DEFAULT_BUDGET
+
+    store = get_memory_store(test_user.id)
+    await store.write_memory_async("## Existing\n- before: kept\n")
+
+    too_big = "x" * (DEFAULT_BUDGET + 1_000)
+    mock_response = make_text_response(
+        json.dumps({"memory_update": too_big, "summary": "[TIMESTAMP] tried to write a lot."})
+    )
+    messages: list[AgentMessage] = [UserMessage(content="anything", seq=1)]
+
+    caplog.set_level("WARNING", logger="backend.app.agent.compaction")
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        memory_update, _ = await compact_session(test_user.id, messages)
+
+    # Return value reflects "no MEMORY.md update happened".
+    assert memory_update == ""
+    # Original memory text is preserved.
+    after = await store.read_memory_async()
+    assert "before: kept" in after
+    # A warning was logged so the operator can correlate.
+    assert any(
+        "MEMORY.md" in r.getMessage() and "skip" in r.getMessage().lower() for r in caplog.records
+    )

--- a/tests/test_markdown_registry.py
+++ b/tests/test_markdown_registry.py
@@ -1,0 +1,273 @@
+"""Tests for the bounded-growth markdown registry.
+
+Pure unit tests for the registry helpers. The integration paths
+(workspace tools rejecting over-budget writes, compaction logging on
+budget failure, HISTORY.md windowing on append) are exercised in
+``test_workspace_tools.py``, ``test_compaction.py``, and
+``test_memory_db_async.py`` respectively.
+
+The consistency tests below are the load-bearing piece: they make it
+hard to add a new agent-mutable markdown surface without also adding
+a policy entry, which is the mechanism that prevents future features
+from silently re-introducing unbounded growth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.app.agent.markdown_registry import (
+    COLUMN_TO_SURFACE,
+    DEFAULT_BUDGET,
+    POLICIES,
+    BudgetExceededError,
+    StorageKind,
+    WriteMode,
+    append_with_window,
+    assert_column_within_budget,
+    assert_within_budget,
+    get_policy,
+    policy_for_column,
+    truncate_for_injection,
+)
+
+# ---------------------------------------------------------------------------
+# Registry consistency
+# ---------------------------------------------------------------------------
+
+
+def test_every_known_surface_has_a_policy() -> None:
+    """The six surfaces named in the audit must each have a policy entry."""
+    expected = {
+        "USER.md",
+        "SOUL.md",
+        "HEARTBEAT.md",
+        "MEMORY.md",
+        "HISTORY.md",
+        "BOOTSTRAP.md",
+    }
+    assert expected.issubset(POLICIES.keys()), f"missing policies: {expected - POLICIES.keys()}"
+
+
+def test_every_policy_has_a_positive_budget() -> None:
+    """Every declared surface must have a non-zero byte budget.
+
+    A surface entered into the registry without a budget would silently
+    skip enforcement, defeating the purpose of the registry. This test
+    is the guard that prevents that mistake.
+    """
+    for name, policy in POLICIES.items():
+        assert policy.byte_budget > 0, f"{name} has non-positive budget"
+
+
+def test_default_budget_matches_25kib() -> None:
+    """The uniform 25 KiB cap is intentional. Tests pin it so future
+    edits to the constant are made consciously, not by accident."""
+    assert DEFAULT_BUDGET == 25 * 1024
+
+
+def test_column_to_surface_round_trip() -> None:
+    """Every COLUMN_TO_SURFACE entry must point at a real policy."""
+    for column, surface in COLUMN_TO_SURFACE.items():
+        policy = POLICIES[surface]
+        assert policy.storage_ref == column, (
+            f"COLUMN_TO_SURFACE[{column!r}]={surface!r} disagrees with "
+            f"POLICIES[{surface!r}].storage_ref={policy.storage_ref!r}"
+        )
+
+
+def test_history_md_is_the_only_append_surface() -> None:
+    """If a future surface is added with append mode, it must explicitly
+    declare a windowing strategy. This pins the current set so that
+    decision is forced into review."""
+    append_only = {n for n, p in POLICIES.items() if p.write_mode is WriteMode.APPEND}
+    assert append_only == {"HISTORY.md"}
+
+
+def test_history_md_is_not_injected_into_prompts() -> None:
+    """If HISTORY.md ever starts being injected into a prompt, the
+    windowing budget needs to be re-evaluated against prompt-cost
+    impact, not just storage size. Force that decision through review."""
+    assert POLICIES["HISTORY.md"].injected_into_prompt is False
+
+
+# ---------------------------------------------------------------------------
+# Lookups
+# ---------------------------------------------------------------------------
+
+
+def test_get_policy_returns_none_for_unknown() -> None:
+    assert get_policy("DOES_NOT_EXIST.md") is None
+
+
+def test_policy_for_column_returns_none_for_unknown() -> None:
+    assert policy_for_column("nonexistent_column") is None
+
+
+def test_policy_for_column_resolves_each_known_column() -> None:
+    for column in COLUMN_TO_SURFACE:
+        assert policy_for_column(column) is not None
+
+
+# ---------------------------------------------------------------------------
+# assert_within_budget
+# ---------------------------------------------------------------------------
+
+
+def test_assert_within_budget_passes_for_under_budget_content() -> None:
+    assert_within_budget("USER.md", "small content")
+
+
+def test_assert_within_budget_unknown_surface_is_noop() -> None:
+    """Unknown surfaces silently pass. The registry is opt-in: code that
+    does not route through the registry is not policed by it."""
+    assert_within_budget("ARBITRARY.md", "x" * (DEFAULT_BUDGET * 10))
+
+
+def test_assert_within_budget_raises_on_overflow() -> None:
+    too_big = "x" * (DEFAULT_BUDGET + 1)
+    with pytest.raises(BudgetExceededError) as exc_info:
+        assert_within_budget("USER.md", too_big)
+    assert exc_info.value.surface_name == "USER.md"
+    assert exc_info.value.size_bytes == DEFAULT_BUDGET + 1
+    assert exc_info.value.budget_bytes == DEFAULT_BUDGET
+
+
+def test_assert_within_budget_counts_utf8_bytes_not_chars() -> None:
+    """Multibyte characters must count by their UTF-8 byte cost, not
+    code-point count, because that is what hits the LLM token budget.
+
+    "💼" encodes as 4 UTF-8 bytes; ``DEFAULT_BUDGET // 4 + 1`` of them
+    take ``DEFAULT_BUDGET + 4`` bytes, exceeding the cap, even though
+    the character count is well under the cap.
+    """
+    payload = "💼" * (DEFAULT_BUDGET // 4 + 1)
+    assert len(payload) < DEFAULT_BUDGET  # under by character count
+    with pytest.raises(BudgetExceededError):
+        assert_within_budget("USER.md", payload)
+
+
+def test_assert_column_within_budget_routes_through_column_map() -> None:
+    too_big = "x" * (DEFAULT_BUDGET + 1)
+    with pytest.raises(BudgetExceededError) as exc_info:
+        assert_column_within_budget("user_text", too_big)
+    assert exc_info.value.surface_name == "USER.md"
+
+
+def test_assert_column_within_budget_unknown_column_is_noop() -> None:
+    assert_column_within_budget("not_a_column", "x" * (DEFAULT_BUDGET * 10))
+
+
+# ---------------------------------------------------------------------------
+# truncate_for_injection
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_for_injection_returns_original_when_under_budget() -> None:
+    content = "the original content"
+    assert truncate_for_injection("USER.md", content) == content
+
+
+def test_truncate_for_injection_returns_original_for_unknown_surface() -> None:
+    huge = "x" * (DEFAULT_BUDGET * 10)
+    assert truncate_for_injection("UNKNOWN.md", huge) == huge
+
+
+def test_truncate_for_injection_keeps_tail_and_prepends_marker() -> None:
+    """An over-budget value must be tail-truncated to the budget and
+    prefixed with a marker the agent can read."""
+    body = "x" * 1000 + "TAIL_MARKER" + "y" * 100
+    long = body * 50
+    truncated = truncate_for_injection("USER.md", long)
+    assert truncated.startswith("[truncated:")
+    assert "TAIL_MARKER" in truncated  # tail content preserved
+    assert len(truncated.encode("utf-8")) <= DEFAULT_BUDGET
+
+
+def test_truncate_for_injection_handles_partial_multibyte_at_cut() -> None:
+    """Cutting on a UTF-8 byte boundary that lands inside a multibyte
+    sequence must not raise; ``errors="ignore"`` drops the partial
+    leading sequence cleanly."""
+    payload = "💼" * (DEFAULT_BUDGET // 2)  # 2 * (DEFAULT_BUDGET // 2) bytes-ish
+    out = truncate_for_injection("USER.md", payload)
+    out.encode("utf-8")  # round-trips without error
+
+
+# ---------------------------------------------------------------------------
+# append_with_window
+# ---------------------------------------------------------------------------
+
+
+def _entry(timestamp: str, body: str) -> str:
+    return f"[{timestamp}] {body}"
+
+
+def test_append_with_window_under_budget_keeps_everything() -> None:
+    current = _entry("2026-01-01 00:00", "first") + "\n"
+    out = append_with_window(current, _entry("2026-01-02 00:00", "second"), DEFAULT_BUDGET)
+    assert "first" in out
+    assert "second" in out
+
+
+def test_append_with_window_drops_oldest_entries_when_over_budget() -> None:
+    """Once the post-append text exceeds the budget, the oldest
+    timestamped entries are dropped whole until it fits again."""
+    # Build a current text with many small entries that already nearly fill
+    # the budget, then append one more so the total exceeds the budget.
+    entries = [_entry(f"2026-01-{i:02d} 00:00", "x" * 200) for i in range(1, 130)]
+    current = "\n".join(entries) + "\n"
+    new = _entry("2026-02-01 00:00", "newest")
+    out = append_with_window(current, new, DEFAULT_BUDGET)
+    assert len(out.encode("utf-8")) <= DEFAULT_BUDGET
+    assert "newest" in out
+    # Older entries should have been dropped first; at least the very
+    # first one must be gone.
+    assert "[2026-01-01" not in out
+
+
+def test_append_with_window_falls_back_to_byte_truncation_for_huge_entry() -> None:
+    """A single entry exceeding the budget cannot be preserved whole;
+    the function falls back to byte-tail truncation so the result is
+    still under budget."""
+    huge_entry = _entry("2026-03-01 00:00", "x" * (DEFAULT_BUDGET * 2))
+    out = append_with_window("", huge_entry, DEFAULT_BUDGET)
+    assert len(out.encode("utf-8")) <= DEFAULT_BUDGET
+
+
+def test_append_with_window_normalizes_missing_separator() -> None:
+    """If the pre-existing text lacks a trailing newline, the function
+    must add one before appending so two entries do not jam together."""
+    current = _entry("2026-01-01 00:00", "no trailing newline")  # no \n
+    out = append_with_window(current, _entry("2026-01-02 00:00", "second"), DEFAULT_BUDGET)
+    # The two entries must not be on the same line.
+    lines_with_brackets = [line for line in out.splitlines() if line.startswith("[")]
+    assert len(lines_with_brackets) == 2
+
+
+def test_append_with_window_repeated_appends_stay_bounded() -> None:
+    """Repeated append calls must keep the cumulative text under
+    budget. This is the single test that most closely matches the
+    issue's acceptance criterion: 'tests cover repeated-update growth
+    behavior for the important files'."""
+    current = ""
+    big_chunk = "x" * 1000
+    for i in range(500):
+        current = append_with_window(
+            current, _entry(f"2026-04-{(i % 28) + 1:02d} 00:00", big_chunk), DEFAULT_BUDGET
+        )
+        assert len(current.encode("utf-8")) <= DEFAULT_BUDGET, (
+            f"history exceeded budget at iteration {i}: {len(current.encode('utf-8'))} bytes"
+        )
+
+
+# ---------------------------------------------------------------------------
+# StorageKind / WriteMode integration
+# ---------------------------------------------------------------------------
+
+
+def test_storage_kinds_cover_each_kind_used() -> None:
+    """Each StorageKind value must be used by at least one policy.
+    Keeps the enum honest: an orphaned variant is a hint that a
+    surface was deleted and the policy entry was not."""
+    used = {p.storage for p in POLICIES.values()}
+    assert used == set(StorageKind)

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -86,6 +86,49 @@ def test_update_profile_empty_body(client: TestClient) -> None:
     assert resp.status_code == 400
 
 
+def test_update_profile_rejects_over_budget_user_text(client: TestClient) -> None:
+    """The dashboard editor must respect the same 25 KiB cap that the
+    workspace tools and compaction paths enforce, otherwise an admin
+    paste of a huge profile would silently bloat every system prompt
+    until the read-side truncation kicks in. Returns 413 with a useful
+    detail so a frontend can show the actual / allowed sizes.
+    """
+    from backend.app.agent.markdown_registry import DEFAULT_BUDGET
+
+    too_big = "x" * (DEFAULT_BUDGET + 100)
+    resp = client.put("/api/user/profile", json={"user_text": too_big})
+    assert resp.status_code == 413
+    assert "USER.md" in resp.json()["detail"]
+
+
+def test_update_profile_rejects_over_budget_soul_text(client: TestClient) -> None:
+    from backend.app.agent.markdown_registry import DEFAULT_BUDGET
+
+    too_big = "x" * (DEFAULT_BUDGET + 100)
+    resp = client.put("/api/user/profile", json={"soul_text": too_big})
+    assert resp.status_code == 413
+    assert "SOUL.md" in resp.json()["detail"]
+
+
+def test_update_profile_rejects_over_budget_heartbeat_text(client: TestClient) -> None:
+    from backend.app.agent.markdown_registry import DEFAULT_BUDGET
+
+    too_big = "x" * (DEFAULT_BUDGET + 100)
+    resp = client.put("/api/user/profile", json={"heartbeat_text": too_big})
+    assert resp.status_code == 413
+    assert "HEARTBEAT.md" in resp.json()["detail"]
+
+
+def test_update_profile_under_budget_user_text_succeeds(client: TestClient) -> None:
+    """Sanity check: a normal-sized profile update still works."""
+    resp = client.put(
+        "/api/user/profile",
+        json={"user_text": "# User\n\n- Name: Alice\n- Trade: General contractor\n"},
+    )
+    assert resp.status_code == 200
+    assert "Alice" in resp.json()["user_text"]
+
+
 def test_get_profile_includes_heartbeat_max_daily(client: TestClient) -> None:
     """GET /api/user/profile returns heartbeat_max_daily field."""
     resp = client.get("/api/user/profile")


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds explicit, enforced byte-budget policies for every agent-managed markdown surface (`USER.md`, `SOUL.md`, `HEARTBEAT.md`, `MEMORY.md`, `HISTORY.md`, `BOOTSTRAP.md`).

Without these bounds, a long-lived user's working memory could grow without limit, bloating every system prompt and degrading both cost and response quality. This is the follow-up to #1243 / PR #1273 called for in #1244.

### Approach

The pattern follows prior art:
- **Claude Code** caps `MEMORY.md` at ~25 KB injected into the sub-agent prompt and instructs the agent to curate the file when it exceeds that limit.
- **MemGPT / Letta** enforces a per-block character limit on core memory and forces eviction to archival memory on overflow.
- **Anthropic harness guidance** (Sept and Nov 2025 posts) treats prompt-size management as the harness's responsibility, not the model's.

Cap is a uniform **25 KiB** across surfaces, matching Claude Code's `MEMORY.md` cap and the existing `compaction_event_snapshot_max_bytes_per_file` audit cap (so an in-budget surface always fits in audit rows without truncation).

### Where the cap is enforced

* **Workspace tools** (`write_file`, `edit_file`): reject over-budget writes with a clean ``ToolResult`` error so the agent can rewrite smaller. ``HISTORY.md`` rejects ``write_file`` / ``edit_file`` outright so the append-only invariant from #1273 cannot be bypassed.
* **`memory_db` write paths** (`write_memory_async`, `write_user_async`, `write_soul_async`): raise `BudgetExceededError`. Compaction catches and logs, leaving the previous file in place rather than crashing or corrupting durable state.
* **`memory_db.append_history`**: applies windowed FIFO drop on overflow so `HISTORY.md` storage stays bounded across long-lived users. The full archive of compaction events still lives in `compaction_events` rows.
* **System prompt builders** (`build_user_section`, `build_soul_prompt`, `build_memory_section`, heartbeat builder): tail-truncate over-budget legacy rows so a pre-cap row cannot poison every prompt forever.
* **`PUT /api/user/memory`** route: returns 413 on over-budget input.

### Files

New:
* `backend/app/agent/markdown_registry.py`: declarative policy + enforcement helpers (`assert_within_budget`, `truncate_for_injection`, `append_with_window`).
* `docs/markdown_growth_policies.md`: per-surface inventory, rationale, prior-art references, and what the PR deliberately does not do.
* `tests/test_markdown_registry.py`: 25 unit tests, including consistency invariants that fail loudly if a future surface is added without a policy entry.
* `tests/test_bounded_growth_integration.py`: 17 integration tests covering write-time / read-time enforcement and `HISTORY.md` windowing across many appends.

Modified: workspace tools, `memory_db`, `stores` (heartbeat), `system_prompt`, `compaction`, heartbeat tools, user_memory router. Regenerated `frontend/openapi.json` + `frontend/src/generated/api.d.ts` (docstring change only).

### Out of scope (future PRs)

Captured in `docs/markdown_growth_policies.md` so they are not lost:
* Periodic / size-triggered compaction of working memory (currently only conversation trim triggers it).
* Importance-based compaction (Stanford Generative Agents pattern).
* Admin observability dashboard for surface sizes over time.
* Rewriting compaction prompts (#1243 already tightened the durable-memory rules).

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`): 2528 passed, 2 skipped (full OSS suite); 568 passed, 4 skipped (premium)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (42 new tests across two new test files plus one new test in `test_compaction.py`)
- [x] Bug fixes include regression tests (this is a feature, but the registry consistency tests guard against future regressions)

## AI Usage
- [x] AI-assisted (drafted by Claude Opus 4.7 via discussion with @njbrake; design decisions, scope, and budget value are his, prose and code are Claude's)
- [ ] No AI used

Fixes #1244