### PR TITLE
fix(agent): keep media tools always-on, remove dead specialist activation path

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -71,7 +71,6 @@ from backend.app.agent.tools.base import (
     ToolTags,
     tool_to_function_schema,
 )
-from backend.app.agent.tools.names import ToolName
 from backend.app.agent.tools.registry import ToolContext, ToolRegistry
 from backend.app.agent.trimming import trim_messages
 from backend.app.config import settings
@@ -209,7 +208,6 @@ class ClawboltAgent:
         session_id: str = "",
         excluded_tool_names: set[str] | None = None,
         request_id: str = "",
-        activated_specialists: set[str] | None = None,
         llm_provider_override: str = "",
         llm_model_override: str = "",
     ) -> None:
@@ -222,9 +220,6 @@ class ClawboltAgent:
         self._subscribers: list[Callable[[AgentEvent], Awaitable[None]]] = []
         self._tool_context = tool_context
         self._registry = registry
-        self._activated_specialists: set[str] = (
-            activated_specialists if activated_specialists is not None else set()
-        )
         self._last_input_tokens: int = 0
         self._session_id = session_id
         self._excluded_tool_names = excluded_tool_names
@@ -237,9 +232,8 @@ class ClawboltAgent:
         # a non-monotonic change is logged as a warning.
         self._prev_tool_names: list[str] = []
         # Cached Anthropic tool schemas keyed by the tool-name sequence that
-        # produced them. Rebuilt only when the tool list grows (specialist
-        # activation); otherwise the same list instance is reused across
-        # rounds to avoid recomputing identical JSON schemas every turn.
+        # produced them. Reused across rounds to avoid recomputing identical
+        # JSON schemas every turn.
         self._cached_tool_schemas: list[dict[str, Any]] | None = None
         self._reactive_trim_dropped: list[AgentMessage] = []
         # Remembers ASK decisions within a single agent run so the user is not
@@ -383,65 +377,6 @@ class ClawboltAgent:
                 len(current),
             )
         self._prev_tool_names = current
-
-    async def _activate_specialist(self, factory_name: str) -> None:
-        """Activate a specialist tool factory, injecting its tools for the next round.
-
-        Only marks the factory as activated if at least one tool was
-        actually created (dependencies like storage may prevent creation).
-        """
-        if factory_name in self._activated_specialists:
-            return
-        if self._registry is None or self._tool_context is None:
-            return
-        new_tools = await self._registry.create_tools(
-            self._tool_context,
-            selected_factories={factory_name},
-            excluded_tool_names=self._excluded_tool_names,
-        )
-        if not new_tools:
-            logger.debug(
-                "Specialist factory %r produced no tools (dependencies unmet?)", factory_name
-            )
-            return
-        self._activated_specialists.add(factory_name)
-        new_names: list[str] = []
-        for tool in new_tools:
-            if tool.name not in self._tools_by_name:
-                self.tools.append(tool)
-                self._tools_by_name[tool.name] = tool
-                new_names.append(tool.name)
-        logger.debug(
-            "Activated specialist %r, added tools: %s",
-            factory_name,
-            ", ".join(new_names) or "(none new)",
-        )
-
-    async def _check_specialist_activations(
-        self,
-        parsed_calls: list[ToolCallRequest],
-    ) -> bool:
-        """Check for list_capabilities calls and activate requested specialists.
-
-        Returns True if any new specialist factories were activated (meaning
-        tool schemas need to be rebuilt for the next round).
-        """
-        if self._registry is None:
-            return False
-        activated_any = False
-        specialist_names = self._registry.specialist_factory_names
-        for tc_req in parsed_calls:
-            if tc_req.name != ToolName.LIST_CAPABILITIES:
-                continue
-            category = tc_req.arguments.get("category")
-            if (
-                category
-                and category in specialist_names
-                and category not in self._activated_specialists
-            ):
-                await self._activate_specialist(category)
-                activated_any = True
-        return activated_any
 
     async def _build_system_prompt(self, message_context: str) -> str:
         """Build the full system prompt via the composable builder."""
@@ -1220,20 +1155,6 @@ class ClawboltAgent:
             # generating a tool call, the JSON payload may be incomplete.
             response_truncated = response.stop_reason == "max_tokens"
 
-            # Activate any specialist factories requested via list_capabilities
-            # BEFORE executing tools so specialist tools called in the same
-            # round (e.g. qb_query alongside list_capabilities) are available
-            # immediately rather than failing as "unknown tool".
-            #
-            # We temporarily hide newly activated factories from the shared
-            # _activated_specialists set so that the list_capabilities closure
-            # still returns the full SKILL.md instructions during execution
-            # (it skips instructions for categories already in the set).
-            pre_activated = set(self._activated_specialists)
-            await self._check_specialist_activations(parsed_calls)
-            newly_activated = self._activated_specialists - pre_activated
-            self._activated_specialists -= newly_activated
-
             # Execute the tool round (validate, approve, run)
             tool_results = await self._execute_tool_round(
                 parsed_calls,
@@ -1243,9 +1164,6 @@ class ClawboltAgent:
                 tool_call_records,
                 response_truncated=response_truncated,
             )
-
-            # Mark the specialists as fully activated for future rounds.
-            self._activated_specialists |= newly_activated
 
             # If the response was truncated and produced validation errors,
             # auto-increase max_tokens for the next round so the LLM has

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -324,10 +324,10 @@ class ClawboltAgent:
     def _get_or_build_tool_schemas(self) -> list[dict[str, Any]] | None:
         """Return Anthropic tool schemas, rebuilding only when tools changed.
 
-        The cached list is invalidated whenever ``self.tools`` grows or the
-        name sequence diverges from the cached prefix. Since specialist
-        activation only appends, in the common case this cache hits for
-        every round after the first.
+        The tool list is fixed at agent boot, so in the steady state this
+        cache hits for every round after the first. The invalidation
+        check (rebuild when the name sequence diverges from the cached
+        prefix) stays as defense-in-depth against future regressions.
 
         Callers (``_call_llm_with_retry`` via ``apply_tool_caching``)
         may mutate the last entry to stamp a ``cache_control`` marker.
@@ -352,9 +352,10 @@ class ClawboltAgent:
         """Warn if the current tool-name sequence fails to preserve the prior
         prefix, which would bust the Anthropic tools prompt cache.
 
-        The tool list is meant to grow append-only as specialists activate.
-        Any reorder, removal, or mid-list insert would reset the cache for
-        the tools block. Emits a DEBUG line on normal growth and a WARNING
+        The tool list is fixed at agent boot, so in the steady state the
+        sequence is identical every round. Any reorder, removal, or
+        mid-list insert would reset the cache for the tools block. Kept
+        as defense-in-depth: emits a DEBUG line on growth and a WARNING
         when the prefix diverges.
         """
         current = [t.name for t in self.tools]
@@ -1018,10 +1019,10 @@ class ClawboltAgent:
                 MAX_TOOL_ROUNDS,
                 len(messages),
             )
-            # Rebuild tool schemas only when the tool list changed
-            # (specialist activation appends new tools). Otherwise reuse the
-            # cached list so identical rounds don't re-serialize every
-            # Pydantic params model.
+            # Reuse cached tool schemas across rounds so identical rounds
+            # don't re-serialize every Pydantic params model. The tool
+            # list is fixed at agent boot, so this cache hits every round
+            # after the first.
             tool_schemas = self._get_or_build_tool_schemas()
             self._log_tool_prefix_stability(_round)
             await self._emit(TurnStartEvent(round_number=_round, message_count=len(messages)))

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -582,8 +582,6 @@ async def execute_heartbeat_tasks(
 
     excluded = disabled_groups or set()
 
-    activated_specialists: set[str] = set()
-
     agent = ClawboltAgent(
         user=user,
         channel=channel,
@@ -592,29 +590,23 @@ async def execute_heartbeat_tasks(
         tool_context=tool_context,
         registry=default_registry,
         excluded_tool_names=disabled_sub_tools or None,
-        activated_specialists=activated_specialists,
     )
 
     # Follow the same pattern as run_agent() in router.py:
     # 1. Core tools (always available, respects disabled groups/sub-tools)
-    # 2. Specialist tools the user is already authenticated for, pre-activated
-    #    so the heartbeat agent does not waste a turn calling list_capabilities
+    # 2. Specialist tools the user is already authenticated for
     # 3. list_capabilities meta-tool for discovering unconnected integrations
     tools = await default_registry.create_core_tools(
         tool_context,
         excluded_factories=excluded,
         excluded_tool_names=disabled_sub_tools or None,
     )
-    (
-        ready_specialist_tools,
-        ready_specialist_names,
-    ) = await default_registry.create_ready_specialist_tools(
+    ready_specialist_tools = await default_registry.create_ready_specialist_tools(
         tool_context,
         excluded_factories=excluded,
         excluded_tool_names=disabled_sub_tools or None,
     )
     tools.extend(ready_specialist_tools)
-    activated_specialists |= ready_specialist_names
 
     # Auto-approve the media-delivery tool in heartbeat context (#932).
     # Phase 1 already decided to send this message; asking the user for
@@ -641,7 +633,6 @@ async def execute_heartbeat_tasks(
                 specialist_summaries,
                 unauthenticated=unauthenticated,
                 disabled_sub_tools=disabled_specialist_subs or None,
-                activated_specialists=activated_specialists,
             )
         )
     agent.register_tools(tools)

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -287,13 +287,6 @@ async def run_agent(
 
     await get_approval_store().ensure_complete(user.id)
 
-    # Shared mutable set so the list_capabilities tool closure and the
-    # agent loop both see the same activation state.  This prevents the
-    # tool from returning the full SKILL.md instructions a second time
-    # when the LLM redundantly calls list_capabilities for a category
-    # that was already activated in a prior round.
-    activated_specialists: set[str] = set()
-
     agent = ClawboltAgent(
         user=user,
         channel=channel,
@@ -304,7 +297,6 @@ async def run_agent(
         session_id=session_id,
         excluded_tool_names=disabled_sub_tools or None,
         request_id=request_id,
-        activated_specialists=activated_specialists,
         llm_provider_override=llm_provider_override,
         llm_model_override=llm_model_override,
     )
@@ -315,22 +307,16 @@ async def run_agent(
         excluded_factories=disabled_groups or None,
         excluded_tool_names=disabled_sub_tools or None,
     )
-    # Pre-activate specialists the user is already authenticated for. Without
-    # this, the LLM had to call list_capabilities('calendar') / ('quickbooks')
-    # / ('companycam') on every inbound, which adds a round trip per turn for
-    # users who text about their calendar daily. Now those tools are on the
-    # schema from turn 1; list_capabilities still surfaces unconnected
+    # Specialist tools for integrations the user is authenticated for are
+    # loaded from turn 1 so the LLM can call them without a discovery
+    # round trip; list_capabilities still surfaces unconnected
     # integrations for discovery.
-    (
-        ready_specialist_tools,
-        ready_specialist_names,
-    ) = await default_registry.create_ready_specialist_tools(
+    ready_specialist_tools = await default_registry.create_ready_specialist_tools(
         tool_context,
         excluded_factories=disabled_groups or None,
         excluded_tool_names=disabled_sub_tools or None,
     )
     tools.extend(ready_specialist_tools)
-    activated_specialists |= ready_specialist_names
     specialist_summaries = await default_registry.get_available_specialist_summaries(
         tool_context, excluded_factories=disabled_groups or None
     )
@@ -346,7 +332,6 @@ async def run_agent(
                 specialist_summaries,
                 unauthenticated=unauthenticated,
                 disabled_sub_tools=disabled_specialist_subs or None,
-                activated_specialists=activated_specialists,
             )
         )
     agent.register_tools(tools)

--- a/backend/app/agent/tool_assembly.py
+++ b/backend/app/agent/tool_assembly.py
@@ -2,20 +2,13 @@
 
 The agent's runtime path in :mod:`backend.app.agent.router` builds its
 tool list inline because it needs a fully-populated :class:`ToolContext`
-(storage backend, outbound-publish hook, downloaded media) and a shared
-mutable ``activated_specialists`` set that the ``list_capabilities``
-closure and the agent loop can both observe. This module mirrors only
-the *start-of-turn* shape of that list with stubbed context fields, so
-preview consumers (the system-prompt endpoint, debugging surfaces) can
-render the same tool guidelines the LLM sees on a fresh turn without
-the runtime plumbing.
+(storage backend, outbound-publish hook, downloaded media). This module
+mirrors that shape with stubbed context fields so preview consumers (the
+system-prompt endpoint, debugging surfaces) can render the same tool
+guidelines the LLM sees on a fresh turn without the runtime plumbing.
 
-Keeping it intentionally separate avoids two coupling pitfalls:
-
-* the runtime's shared mutable activation set leaking into preview code
-  paths where it would be confusing or unsafe;
-* preview callers being forced to construct fake storage/publish hooks
-  just to read tool schemas.
+Kept separate so preview callers do not have to construct fake
+storage/publish hooks just to read tool schemas.
 """
 
 from __future__ import annotations
@@ -39,11 +32,10 @@ async def build_initial_turn_tools(
 ) -> list[Tool]:
     """Return the tools the agent would have at the start of a turn.
 
-    This is core tools (always-on) plus the ``list_capabilities``
-    meta-tool when there are specialist categories or unauthenticated
-    services to surface. Specialist tools that get activated mid-turn
-    via ``list_capabilities`` are NOT included here, matching how the
-    agent itself starts each turn fresh.
+    This is core tools (always-on), specialist tools for integrations
+    the user has authenticated for, plus the ``list_capabilities``
+    meta-tool when there are unconnected integrations to surface for
+    discovery.
 
     Storage, downloaded media, and outbound-publish hooks are left as
     stubs because callers of this helper only need the tools' schemas
@@ -75,12 +67,9 @@ async def build_initial_turn_tools(
         excluded_tool_names=disabled_sub_tools or None,
     )
     # Mirror router.py: specialist tools for connected integrations are
-    # pre-activated at agent boot, so the preview's tool list reflects what
-    # the LLM actually sees on a fresh turn.
-    (
-        ready_specialist_tools,
-        ready_specialist_names,
-    ) = await default_registry.create_ready_specialist_tools(
+    # loaded at agent boot, so the preview's tool list reflects what the
+    # LLM actually sees on a fresh turn.
+    ready_specialist_tools = await default_registry.create_ready_specialist_tools(
         tool_context,
         excluded_factories=disabled_groups or None,
         excluded_tool_names=disabled_sub_tools or None,
@@ -101,7 +90,6 @@ async def build_initial_turn_tools(
                 specialist_summaries,
                 unauthenticated=unauthenticated,
                 disabled_sub_tools=disabled_specialist_subs or None,
-                activated_specialists=ready_specialist_names,
             )
         )
     return tools

--- a/backend/app/agent/tools/media_tools.py
+++ b/backend/app/agent/tools/media_tools.py
@@ -178,11 +178,16 @@ def create_media_tools(
 
 
 def _media_factory(ctx: ToolContext) -> list[Tool]:
-    """Factory for agent-native media tools. Gated on presence of staged media."""
-    has_downloaded = bool(ctx.downloaded_media)
-    has_staged = bool(media_staging.get_all_for_user(ctx.user.id))
-    if not has_downloaded and not has_staged:
-        return []
+    """Factory for agent-native media tools.
+
+    Always returns the two tools so the Anthropic prompt-cache key (which
+    includes the tools block) stays stable across text-only and media
+    turns. Gating on per-message media presence flipped the tool count
+    between turns, busting the cache prefix and rewriting the ~135k-token
+    system prompt at ~$0.65 per miss (issue #1170). The runtime tools
+    handle missing handles gracefully (analyze_photo returns NOT_FOUND,
+    discard_media is idempotent), so always-on is safe.
+    """
     # Per-turn analysis cache. Scoped to the factory call so it lives for the
     # duration of the agent loop for this message.
     analyze_cache: dict[str, str] = {}

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -173,7 +173,9 @@ def create_list_capabilities_tool(
 
         guidance_msg = (
             f'Tools for "{category}" are already loaded and callable. '
-            "Call the specific tool to perform the user's request."
+            "Call the specific tool to perform the user's request. Do not "
+            "tell the user the action is complete until the corresponding "
+            "tool has run and returned a successful result."
         )
         disabled_for_cat = _disabled_subs.get(category, [])
         if disabled_for_cat:

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -5,10 +5,20 @@ The router calls ``create_tools(context)`` instead of manually importing
 and assembling tools from every module.
 
 Factories are classified as **core** (always-available) or **specialist**
-(discovered on demand via the ``list_capabilities`` meta-tool).  Core tools
-are registered to the LLM on every message; specialist tools require the
-agent to explicitly activate them, keeping the initial schema payload small
-and enabling progressive disclosure as tool count grows.
+(per-integration, listed via the ``list_capabilities`` meta-tool). Both
+tiers are loaded on every message for a given user when their
+dependencies are met: core unconditionally, specialists when the user is
+authenticated for the underlying integration (see
+``create_ready_specialist_tools``). The Anthropic prompt-cache key
+includes the tools block, so the per-message tool list is held stable as
+a function of the user's auth state and dashboard config; varying it per
+message busts the cached system prompt prefix (issue #1170).
+
+The ``list_capabilities`` meta-tool is a discovery hint, not an
+activation mechanism: it tells the LLM which integrations the user could
+connect, so the agent can prompt the user to authenticate. Tools for
+authenticated integrations are already on the schema from turn 1 and do
+not need a runtime activation round trip.
 """
 
 from __future__ import annotations
@@ -88,7 +98,10 @@ class ListCapabilitiesParams(BaseModel):
 
     category: str | None = Field(
         default=None,
-        description="Category name to activate. Omit to see all available categories.",
+        description=(
+            "Category name to look up usage guidance for. Omit to see all "
+            "available categories and connection status."
+        ),
     )
 
 
@@ -96,32 +109,27 @@ def create_list_capabilities_tool(
     specialist_summaries: dict[str, str],
     unauthenticated: dict[str, str] | None = None,
     disabled_sub_tools: dict[str, list[SubToolInfo]] | None = None,
-    activated_specialists: set[str] | None = None,
 ) -> Tool:
     """Create the ``list_capabilities`` meta-tool.
 
-    The tool itself only returns text describing available specialist
-    categories.  Actual tool schema injection is handled by the agent
-    loop in ``core.py`` after detecting a ``list_capabilities`` call.
-
-    When a category is activated that has an associated SKILL.md, the
-    skill instructions are included in the response so the LLM has
-    usage guidance alongside the new tool schemas.
+    Discovery and documentation lookup for specialist tool categories.
+    Tools for authenticated integrations are already loaded on the
+    schema; this tool exists to surface unconnected integrations and
+    deliver SKILL.md usage guidance on demand.
 
     *unauthenticated* maps category names to human-readable reasons why
-    the integration is not yet connected (e.g. missing OAuth).  These
-    categories are listed but cannot be activated.
+    the integration is not yet connected (e.g. missing OAuth). These
+    categories are listed but their tools are not loaded.
 
     *disabled_sub_tools* maps specialist factory names to lists of
-    ``SubToolInfo`` for individual tools the user has disabled.  This
-    information is surfaced in listings and activation messages so the
-    LLM can tell users about disabled capabilities.
+    ``SubToolInfo`` for individual tools the user has disabled. This
+    information is surfaced so the LLM can tell users about disabled
+    capabilities.
     """
     from backend.app.agent.skills.loader import get_skill_instructions
 
     _unauthenticated = unauthenticated or {}
     _disabled_subs = disabled_sub_tools or {}
-    _activated = activated_specialists
 
     async def list_capabilities(category: str | None = None) -> ToolResult:
         if category is None:
@@ -130,8 +138,9 @@ def create_list_capabilities_tool(
             lines: list[str] = []
             if specialist_summaries:
                 lines.append(
-                    "Available specialist capabilities "
-                    "(call list_capabilities with a category name to activate):"
+                    "Connected specialist capabilities "
+                    "(tools are already loaded; call list_capabilities with a "
+                    "category name for usage guidance):"
                 )
                 for name, summary in sorted(specialist_summaries.items()):
                     disabled_for_cat = _disabled_subs.get(name, [])
@@ -162,34 +171,22 @@ def create_list_capabilities_tool(
                 error_kind=ToolErrorKind.NOT_FOUND,
             )
 
-        if _activated is not None and category in _activated:
-            return ToolResult(
-                content=(
-                    f'Category "{category}" is already active. No action has been performed. '
-                    "Call the specific tool now to actually do the work the user asked for."
-                ),
-            )
-
-        activation_msg = (
-            f'Category "{category}" activated: the tools are now callable, '
-            "but no work has been done yet. To actually perform the user's "
-            "request, call the specific tool (for example upload_photo, "
-            "qb_create_invoice) in your next response. Do not tell the user "
-            "an action is complete until the corresponding tool has run and "
-            "returned a successful result."
+        guidance_msg = (
+            f'Tools for "{category}" are already loaded and callable. '
+            "Call the specific tool to perform the user's request."
         )
         disabled_for_cat = _disabled_subs.get(category, [])
         if disabled_for_cat:
             disabled_names = ", ".join(st.name for st in disabled_for_cat)
-            activation_msg += (
+            guidance_msg += (
                 f"\nNote: the following tools in this category are disabled by the user "
                 f"and will not be available: {disabled_names}. "
                 "The user can re-enable them in Settings."
             )
         skill_instructions = get_skill_instructions(category)
         if skill_instructions:
-            activation_msg += f"\n\n{skill_instructions}"
-        return ToolResult(content=activation_msg)
+            guidance_msg += f"\n\n{skill_instructions}"
+        return ToolResult(content=guidance_msg)
 
     summary_lines = [
         f"  - {name}: {summary}" for name, summary in sorted(specialist_summaries.items())
@@ -201,8 +198,8 @@ def create_list_capabilities_tool(
         unauth_hint = (
             "\nThe following integrations are configured but not yet connected:\n"
             + "\n".join(unauth_lines)
-            + "\nDo NOT attempt to activate these. If the user asks about them, "
-            "let them know they need to connect the integration first."
+            + "\nIf the user asks about them, let them know they need to "
+            "connect the integration first."
         )
     disabled_hint = ""
     if _disabled_subs:
@@ -214,18 +211,18 @@ def create_list_capabilities_tool(
     return Tool(
         name=ToolName.LIST_CAPABILITIES,
         description=(
-            "Discover and activate specialist tool capabilities. "
-            "Call without arguments to see available categories. "
-            "Call with a category name to activate those tools."
+            "Discover specialist capabilities and look up usage guidance. "
+            "Call without arguments to see connected and unconnected categories. "
+            "Call with a category name for detailed usage guidance for that "
+            "category's already-loaded tools."
         ),
         function=list_capabilities,
         params_model=ListCapabilitiesParams,
         usage_hint=(
-            "You have specialist capabilities:\n"
+            "You have specialist capabilities (tools already loaded):\n"
             f"{summary_block}\n"
-            "Call list_capabilities with a category name to activate the tools "
-            "before using them. Activate proactively when the user's message "
-            "relates to a specialist category."
+            "Call list_capabilities with a category name when you need usage "
+            "guidance for that category's tools."
             f"{unauth_hint}"
             f"{disabled_hint}"
         ),
@@ -401,7 +398,7 @@ class ToolRegistry:
         *,
         excluded_factories: set[str] | None = None,
         excluded_tool_names: set[str] | None = None,
-    ) -> tuple[list[Tool], set[str]]:
+    ) -> list[Tool]:
         """Materialize specialist tools for categories the user is ready to use.
 
         A specialist is "ready" when:
@@ -409,11 +406,8 @@ class ToolRegistry:
         - its infrastructure deps (storage, outbound) are met,
         - its ``auth_check`` is None OR returns None (user authenticated).
 
-        Returns ``(tools, factory_names)`` so callers can both register the
-        tools with the agent AND pre-populate the shared
-        ``activated_specialists`` set. Pre-activation skips the otherwise-mandatory
-        round trip through ``list_capabilities`` for users with connected
-        integrations: the calendar tools are simply on the schema from turn 1.
+        Loaded onto the schema from turn 1 so the LLM can call them
+        directly without a discovery round trip.
         """
         ready: set[str] = set()
         for name, factory in self._factories.items():
@@ -429,13 +423,12 @@ class ToolRegistry:
                 continue
             ready.add(name)
         if not ready:
-            return [], set()
-        tools = await self.create_tools(
+            return []
+        return await self.create_tools(
             context,
             selected_factories=ready,
             excluded_tool_names=excluded_tool_names,
         )
-        return tools, ready
 
     async def get_unauthenticated_specialists(
         self,

--- a/tests/test_agent_native_storage.py
+++ b/tests/test_agent_native_storage.py
@@ -1,8 +1,8 @@
 """Tests for the agent-native storage refactor.
 
 Covers: MediaHandle minting + reverse lookup, pipeline gating on
-``agent_native_storage``, analyze_photo / discard_media tools, the registry
-predicate that gates the media factory on staged media, and the startup
+``agent_native_storage``, analyze_photo / discard_media tools, the media
+factory's always-on registration (issue #1170), and the startup
 mutual-exclusion check for personal storage backends.
 """
 
@@ -272,14 +272,20 @@ async def test_discard_media_missing_handle_returns_idempotent_success(
 
 
 # ---------------------------------------------------------------------------
-# Registry gating
+# Registry: always-on media tools (issue #1170)
 # ---------------------------------------------------------------------------
 
 
-def test_media_factory_returns_empty_when_no_media(test_user: User) -> None:
-    """No media attached and none staged = no tool surface (avoid prompt bloat)."""
+def test_media_factory_always_registers_tools(test_user: User) -> None:
+    """Tools are present even with no current or staged media.
+
+    Regression for #1170: gating on per-message media presence flipped the
+    tool count between turns, busting the Anthropic prompt cache.
+    """
     ctx = ToolContext(user=test_user, downloaded_media=[])
-    assert _media_factory(ctx) == []
+    tools = _media_factory(ctx)
+    names = {t.name for t in tools}
+    assert names == {ToolName.ANALYZE_PHOTO, ToolName.DISCARD_MEDIA}
 
 
 def test_media_factory_registers_tools_when_staged(test_user: User) -> None:
@@ -291,12 +297,21 @@ def test_media_factory_registers_tools_when_staged(test_user: User) -> None:
     assert ToolName.DISCARD_MEDIA in names
 
 
-def test_media_factory_registers_when_staged_without_current_downloads(test_user: User) -> None:
-    """Agent may call analyze_photo on a later turn that has no new attachments."""
+def test_media_factory_tool_list_stable_across_media_state(test_user: User) -> None:
+    """The tool name sequence must be identical regardless of media state.
+
+    The Anthropic prompt-cache key includes the tools block, so any
+    per-message variance in the tool list invalidates the cache for the
+    ~135k-token system prompt prefix (issue #1170).
+    """
+    no_media_ctx = ToolContext(user=test_user, downloaded_media=[])
+    no_media_names = [t.name for t in _media_factory(no_media_ctx)]
+
     media_staging.stage(test_user.id, "url-1", b"b", "image/jpeg")
-    ctx = ToolContext(user=test_user, downloaded_media=[])
-    tools = _media_factory(ctx)
-    assert len(tools) == 2
+    with_media_ctx = ToolContext(user=test_user, downloaded_media=[_make_media("url-1")])
+    with_media_names = [t.name for t in _media_factory(with_media_ctx)]
+
+    assert no_media_names == with_media_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1883,7 +1883,7 @@ class TestExecuteHeartbeatTasks:
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
             mock_registry.create_core_tools = AsyncMock(return_value=[])
-            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
+            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=[])
             mock_registry.get_available_specialist_summaries = AsyncMock(return_value={})
             mock_registry.get_unauthenticated_specialists = AsyncMock(return_value={})
             mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -1915,7 +1915,7 @@ class TestExecuteHeartbeatTasks:
             mock_agent_instance.process_message = AsyncMock(side_effect=Exception("LLM down"))
             MockAgent.return_value = mock_agent_instance
             mock_registry.create_core_tools = AsyncMock(return_value=[])
-            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
+            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=[])
             mock_registry.get_available_specialist_summaries = AsyncMock(return_value={})
             mock_registry.get_unauthenticated_specialists = AsyncMock(return_value={})
             mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -1949,7 +1949,7 @@ class TestExecuteHeartbeatTasks:
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
             mock_registry.create_core_tools = AsyncMock(return_value=[])
-            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
+            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=[])
             mock_registry.get_available_specialist_summaries = AsyncMock(return_value={})
             mock_registry.get_unauthenticated_specialists = AsyncMock(return_value={})
             mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -1985,7 +1985,7 @@ class TestExecuteHeartbeatTasks:
             mock_agent_instance.process_message = AsyncMock(return_value=mock_response)
             MockAgent.return_value = mock_agent_instance
             mock_registry.create_core_tools = AsyncMock(return_value=[])
-            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
+            mock_registry.create_ready_specialist_tools = AsyncMock(return_value=[])
             mock_registry.get_available_specialist_summaries = AsyncMock(
                 return_value={"quickbooks": "QB tools"}
             )
@@ -3606,7 +3606,7 @@ async def test_execute_heartbeat_uses_core_tools_and_list_capabilities(user: Use
 
     mock_registry = MagicMock()
     mock_registry.create_core_tools = AsyncMock(return_value=[MagicMock(name="core_tool")])
-    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
+    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=[])
     mock_registry.get_available_specialist_summaries = AsyncMock(
         return_value={"quickbooks": "QB tools"}
     )
@@ -3666,7 +3666,7 @@ async def test_execute_heartbeat_respects_disabled_tools(user: User) -> None:
 
     mock_registry = MagicMock()
     mock_registry.create_core_tools = AsyncMock(return_value=[])
-    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
+    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=[])
     mock_registry.get_available_specialist_summaries = AsyncMock(return_value={})
     mock_registry.get_unauthenticated_specialists = AsyncMock(return_value={})
     mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -3723,7 +3723,7 @@ async def test_execute_heartbeat_task_context_includes_cleanup_instruction(
 
     mock_registry = MagicMock()
     mock_registry.create_core_tools = AsyncMock(return_value=[])
-    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
+    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=[])
     mock_registry.get_available_specialist_summaries = AsyncMock(return_value={})
     mock_registry.get_unauthenticated_specialists = AsyncMock(return_value={})
     mock_registry.get_disabled_specialist_sub_tools.return_value = {}
@@ -3965,7 +3965,7 @@ async def test_heartbeat_auto_approves_send_media_reply(user: User) -> None:
 
     mock_registry = MagicMock()
     mock_registry.create_core_tools = AsyncMock(return_value=core_tools)
-    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=([], set()))
+    mock_registry.create_ready_specialist_tools = AsyncMock(return_value=[])
     mock_registry.get_available_specialist_summaries = AsyncMock(return_value={})
     mock_registry.get_unauthenticated_specialists = AsyncMock(return_value={})
     mock_registry.get_disabled_specialist_sub_tools.return_value = {}

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -1,4 +1,9 @@
-"""Tests for progressive tool disclosure via list_capabilities meta-tool."""
+"""Tests for the list_capabilities meta-tool and core/specialist registry split.
+
+list_capabilities is a discovery + guidance lookup, not an activation
+mechanism: tools for authenticated integrations are loaded on the schema
+from turn 1 (see ``create_ready_specialist_tools``).
+"""
 
 import pytest
 from pydantic import BaseModel
@@ -150,11 +155,11 @@ class TestListCapabilitiesTool:
         assert not result.is_error
 
     @pytest.mark.asyncio
-    async def test_activate_valid_category(self) -> None:
+    async def test_lookup_known_category_returns_guidance(self) -> None:
         summaries = {"estimate": "Generate estimates"}
         tool = create_list_capabilities_tool(summaries)
         result = await tool.function(category="estimate")
-        assert "activated" in result.content.lower()
+        assert "already loaded" in result.content.lower()
         assert not result.is_error
 
     @pytest.mark.asyncio
@@ -187,51 +192,16 @@ class TestListCapabilitiesTool:
         assert "estimate" in tool.usage_hint
 
     @pytest.mark.asyncio
-    async def test_already_activated_category_returns_short_message(self) -> None:
-        """Calling list_capabilities for an already-activated category returns a
-        short 'already active' message instead of the full SKILL.md instructions."""
-        summaries = {"estimate": "Generate estimates"}
-        activated: set[str] = set()
-        tool = create_list_capabilities_tool(summaries, activated_specialists=activated)
-
-        # First call: should return the full activation message
-        result = await tool.function(category="estimate")
-        assert "activated" in result.content.lower()
-        assert "no work has been done yet" in result.content.lower()
-
-        # Mark as activated (normally done by the agent loop)
-        activated.add("estimate")
-
-        # Second call: should return a short message, not the full instructions
-        result2 = await tool.function(category="estimate")
-        assert "already active" in result2.content.lower()
-        assert not result2.is_error
-        # Should NOT contain the full activation message again
-        assert len(result2.content) < len(result.content)
-
-    @pytest.mark.asyncio
-    async def test_activation_warns_against_hallucinating_completion(self) -> None:
-        """The activation message must explicitly say that no work has been
-        done yet. Without this, the LLM occasionally treats specialist
-        activation as completion and replies 'I uploaded the photo' without
-        ever calling the actual upload tool.
+    async def test_lookup_directs_llm_to_call_tool(self) -> None:
+        """Looking up a category must explicitly direct the LLM to call the
+        specific tool. Without this, the LLM occasionally treats the lookup
+        as completion and replies 'I uploaded the photo' without ever
+        calling the actual upload tool.
         """
         tool = create_list_capabilities_tool({"companycam": "Photo uploads"})
         result = await tool.function(category="companycam")
         lower = result.content.lower()
-        assert "no work has been done yet" in lower
-        assert "call the specific tool" in lower
-
-    @pytest.mark.asyncio
-    async def test_already_active_warns_against_hallucinating_completion(self) -> None:
-        """The 'already active' branch also has to discourage hallucinated
-        completion, since the LLM may loop back to it."""
-        summaries = {"companycam": "Photo uploads"}
-        activated: set[str] = {"companycam"}
-        tool = create_list_capabilities_tool(summaries, activated_specialists=activated)
-        result = await tool.function(category="companycam")
-        lower = result.content.lower()
-        assert "no action has been performed" in lower
+        assert "already loaded" in lower
         assert "call the specific tool" in lower
 
 
@@ -261,222 +231,3 @@ class TestDefaultRegistryCoreSpecialistSplit:
         core = default_registry.core_factory_names
         specialist = default_registry.specialist_factory_names
         assert not core & specialist
-
-
-class TestDynamicToolActivation:
-    """The agent activates specialist tools when list_capabilities is called."""
-
-    @pytest.mark.asyncio()
-    async def test_activate_specialist_adds_tools(self) -> None:
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.messages import ToolCallRequest
-
-        registry = _build_test_registry()
-        ctx = ToolContext(user=User(id="1"))
-        agent = ClawboltAgent(
-            user=User(id="1"),
-            tool_context=ctx,
-            registry=registry,
-        )
-        core_tools = await registry.create_core_tools(ctx)
-        agent.register_tools(core_tools)
-
-        # Before activation, no estimate tools
-        assert "generate_estimate" not in agent._tools_by_name
-
-        # Simulate list_capabilities call
-        calls = [
-            ToolCallRequest(
-                id="call_1",
-                name=ToolName.LIST_CAPABILITIES,
-                arguments={"category": "estimate"},
-            )
-        ]
-        activated = await agent._check_specialist_activations(calls)
-        assert activated
-        assert "generate_estimate" in agent._tools_by_name
-
-    @pytest.mark.asyncio()
-    async def test_activation_is_idempotent(self) -> None:
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.messages import ToolCallRequest
-
-        registry = _build_test_registry()
-        ctx = ToolContext(user=User(id="1"))
-        agent = ClawboltAgent(
-            user=User(id="1"),
-            tool_context=ctx,
-            registry=registry,
-        )
-        agent.register_tools(await registry.create_core_tools(ctx))
-
-        calls = [
-            ToolCallRequest(
-                id="call_1",
-                name=ToolName.LIST_CAPABILITIES,
-                arguments={"category": "estimate"},
-            )
-        ]
-        await agent._check_specialist_activations(calls)
-        tool_count_after_first = len(agent.tools)
-
-        # Second activation should not add duplicate tools
-        activated = await agent._check_specialist_activations(calls)
-        assert not activated
-        assert len(agent.tools) == tool_count_after_first
-
-    @pytest.mark.asyncio()
-    async def test_non_list_capabilities_call_ignored(self) -> None:
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.messages import ToolCallRequest
-
-        registry = _build_test_registry()
-        ctx = ToolContext(user=User(id="1"))
-        agent = ClawboltAgent(
-            user=User(id="1"),
-            tool_context=ctx,
-            registry=registry,
-        )
-        agent.register_tools(await registry.create_core_tools(ctx))
-
-        calls = [
-            ToolCallRequest(id="call_1", name="send_media_reply", arguments={"message": "hello"})
-        ]
-        activated = await agent._check_specialist_activations(calls)
-        assert not activated
-
-    @pytest.mark.asyncio()
-    async def test_unknown_category_not_activated(self) -> None:
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.messages import ToolCallRequest
-
-        registry = _build_test_registry()
-        ctx = ToolContext(user=User(id="1"))
-        agent = ClawboltAgent(
-            user=User(id="1"),
-            tool_context=ctx,
-            registry=registry,
-        )
-        agent.register_tools(await registry.create_core_tools(ctx))
-        initial_count = len(agent.tools)
-
-        calls = [
-            ToolCallRequest(
-                id="call_1",
-                name=ToolName.LIST_CAPABILITIES,
-                arguments={"category": "nonexistent"},
-            )
-        ]
-        activated = await agent._check_specialist_activations(calls)
-        assert not activated
-        assert len(agent.tools) == initial_count
-
-    @pytest.mark.asyncio()
-    async def test_no_registry_returns_false(self) -> None:
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.messages import ToolCallRequest
-
-        agent = ClawboltAgent(
-            user=User(id="1"),
-        )
-        calls = [
-            ToolCallRequest(
-                id="call_1",
-                name=ToolName.LIST_CAPABILITIES,
-                arguments={"category": "estimate"},
-            )
-        ]
-        activated = await agent._check_specialist_activations(calls)
-        assert not activated
-
-    @pytest.mark.asyncio
-    async def test_specialist_tool_available_in_same_round_as_activation(self) -> None:
-        """Regression: LLM calls list_capabilities + specialist tool in the same round.
-
-        Previously, _check_specialist_activations ran AFTER _execute_tool_round,
-        so the specialist tool would fail as "unknown tool" even though
-        list_capabilities was called in the same batch. This caused the LLM
-        to conclude the integration was broken (e.g. "QuickBooks connection
-        dropped") when it was actually connected.
-
-        The agent loop now pre-activates specialists before execution, while
-        temporarily hiding them from the shared _activated_specialists set so
-        list_capabilities still returns the full activation message with
-        SKILL.md instructions.
-        """
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.llm_parsing import ParsedToolCall
-        from backend.app.agent.messages import ToolCallRequest
-
-        activated_set: set[str] = set()
-        registry = _build_test_registry()
-        ctx = ToolContext(user=User(id="1"))
-        agent = ClawboltAgent(
-            user=User(id="1"),
-            tool_context=ctx,
-            registry=registry,
-            activated_specialists=activated_set,
-        )
-
-        specialist_summaries = await registry.get_available_specialist_summaries(ctx)
-        list_cap_tool = create_list_capabilities_tool(
-            specialist_summaries,
-            activated_specialists=activated_set,
-        )
-        core_tools = await registry.create_core_tools(ctx)
-        core_tools.append(list_cap_tool)
-        agent.register_tools(core_tools)
-
-        # Simulate LLM calling list_capabilities AND a specialist tool in one round
-        parsed_calls = [
-            ToolCallRequest(
-                id="call_1",
-                name=ToolName.LIST_CAPABILITIES,
-                arguments={"category": "estimate"},
-            ),
-            ToolCallRequest(
-                id="call_2",
-                name="generate_estimate",
-                arguments={},
-            ),
-        ]
-        parsed_raw = [
-            ParsedToolCall(
-                id="call_1",
-                name=ToolName.LIST_CAPABILITIES,
-                arguments={"category": "estimate"},
-            ),
-            ParsedToolCall(
-                id="call_2",
-                name="generate_estimate",
-                arguments={},
-            ),
-        ]
-
-        # Replicate the agent loop's activation pattern: pre-activate, then
-        # temporarily hide from the shared set during execution.
-        pre_activated = set(agent._activated_specialists)
-        await agent._check_specialist_activations(parsed_calls)
-        newly_activated = agent._activated_specialists - pre_activated
-        agent._activated_specialists -= newly_activated
-
-        # Execute the tool round
-        results = await agent._execute_tool_round(parsed_calls, parsed_raw, [], [], [])
-
-        # Restore the activated set (as the agent loop does)
-        agent._activated_specialists |= newly_activated
-
-        # The specialist tool should NOT be an error
-        estimate_result = next(r for r in results if r.tool_call_id == "call_2")
-        assert not estimate_result.is_error, (
-            f"Specialist tool failed despite activation: {estimate_result.content}"
-        )
-
-        # list_capabilities should return the full activation message (not
-        # the "already active" short-circuit) since the set was hidden
-        cap_result = next(r for r in results if r.tool_call_id == "call_1")
-        assert "activated" in cap_result.content.lower()
-        assert "already active" not in cap_result.content.lower()
-
-        # After restoration, the category is in the activated set
-        assert "estimate" in agent._activated_specialists

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -194,15 +194,17 @@ class TestListCapabilitiesTool:
     @pytest.mark.asyncio
     async def test_lookup_directs_llm_to_call_tool(self) -> None:
         """Looking up a category must explicitly direct the LLM to call the
-        specific tool. Without this, the LLM occasionally treats the lookup
-        as completion and replies 'I uploaded the photo' without ever
-        calling the actual upload tool.
+        specific tool, and warn against claiming completion before the
+        tool has run. Without this, the LLM occasionally treats the
+        lookup as completion and replies 'I uploaded the photo' without
+        ever calling the actual upload tool.
         """
         tool = create_list_capabilities_tool({"companycam": "Photo uploads"})
         result = await tool.function(category="companycam")
         lower = result.content.lower()
         assert "already loaded" in lower
         assert "call the specific tool" in lower
+        assert "do not tell the user the action is complete" in lower
 
 
 class TestDefaultRegistryCoreSpecialistSplit:

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -73,12 +73,12 @@ def test_get_skill_instructions_returns_none_for_unknown() -> None:
 
 @pytest.mark.asyncio()
 async def test_list_capabilities_includes_skill_instructions() -> None:
-    """Activating a category with a SKILL.md should include instructions in the response."""
+    """Looking up a category with a SKILL.md should include the SKILL guidance."""
     load_all_skills()
     tool = create_list_capabilities_tool({"quickbooks": "QB tools"})
     result: ToolResult = await tool.function(category="quickbooks")
     assert result.is_error is False
-    assert "activated" in result.content.lower()
+    assert "already loaded" in result.content.lower()
     assert "QuickBooks" in result.content
     assert "qb_query" in result.content
     assert "Common Workflows" in result.content
@@ -86,11 +86,11 @@ async def test_list_capabilities_includes_skill_instructions() -> None:
 
 @pytest.mark.asyncio()
 async def test_list_capabilities_without_skill_instructions() -> None:
-    """Activating a category without a SKILL.md should just show the activation message."""
+    """Looking up a category without a SKILL.md should just show the guidance message."""
     tool = create_list_capabilities_tool({"other_category": "Some tools"})
     result: ToolResult = await tool.function(category="other_category")
     assert result.is_error is False
-    assert "activated" in result.content.lower()
+    assert "already loaded" in result.content.lower()
     # Should not contain skill instructions since "other_category" has no SKILL.md
     assert "SKILL" not in result.content
 

--- a/tests/test_tool_auth_check.py
+++ b/tests/test_tool_auth_check.py
@@ -177,13 +177,13 @@ class TestListCapabilitiesWithUnauthenticated:
         assert "not connected" in result.content.lower()
 
     @pytest.mark.asyncio
-    async def test_activating_authenticated_category_still_works(self) -> None:
+    async def test_lookup_authenticated_category_returns_guidance(self) -> None:
         summaries = {"heartbeat": "Manage heartbeats"}
         unauth = {"quickbooks": "QuickBooks is not connected."}
         tool = create_list_capabilities_tool(summaries, unauthenticated=unauth)
         result = await tool.function(category="heartbeat")
         assert not result.is_error
-        assert "activated" in result.content.lower()
+        assert "already loaded" in result.content.lower()
 
     @pytest.mark.asyncio
     async def test_usage_hint_mentions_unauthenticated(self) -> None:
@@ -409,13 +409,13 @@ class TestListCapabilitiesWithDisabledSubTools:
         assert "disabled" in result.content.lower()
 
     @pytest.mark.asyncio
-    async def test_activation_notes_disabled_tools(self) -> None:
+    async def test_lookup_notes_disabled_tools(self) -> None:
         summaries = {"quickbooks": "QB tools"}
         disabled = {"quickbooks": [SubToolInfo("qb_create", "Create")]}
         tool = create_list_capabilities_tool(summaries, disabled_sub_tools=disabled)
         result = await tool.function(category="quickbooks")
         assert not result.is_error
-        assert "activated" in result.content.lower()
+        assert "already loaded" in result.content.lower()
         assert "qb_create" in result.content
         assert "disabled" in result.content.lower()
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -96,8 +96,8 @@ async def test_create_ready_specialist_tools_skips_unauthenticated() -> None:
 
     Regression for the prod calendar bug observed 2026-04-29: the LLM was
     forced to call ``list_capabilities('calendar')`` on every turn because
-    specialist tools were never pre-activated. Pre-activation now happens
-    at agent boot for ready specialists, but only those passing auth.
+    specialist tools were not loaded at agent boot. Connected specialists
+    now load at boot; unconnected ones stay out of the schema.
     """
     from backend.app.agent.tools.registry import ToolRegistry
 
@@ -129,18 +129,13 @@ async def test_create_ready_specialist_tools_skips_unauthenticated() -> None:
     ctx.storage = MagicMock()
     ctx.publish_outbound = AsyncMock()
 
-    tools, names = await reg.create_ready_specialist_tools(ctx)
-    assert names == {"calendar"}
+    tools = await reg.create_ready_specialist_tools(ctx)
     assert len(tools) == 1
 
 
 @pytest.mark.asyncio()
 async def test_create_ready_specialist_tools_returns_empty_when_none_ready() -> None:
-    """No connected specialists -> empty tool list and empty name set.
-
-    Important: the caller uses the returned name set to seed
-    ``activated_specialists``. An empty set must not pre-activate anything.
-    """
+    """No connected specialists -> empty tool list."""
     from backend.app.agent.tools.registry import ToolRegistry
 
     reg = ToolRegistry()
@@ -161,14 +156,13 @@ async def test_create_ready_specialist_tools_returns_empty_when_none_ready() -> 
     ctx.storage = MagicMock()
     ctx.publish_outbound = AsyncMock()
 
-    tools, names = await reg.create_ready_specialist_tools(ctx)
+    tools = await reg.create_ready_specialist_tools(ctx)
     assert tools == []
-    assert names == set()
 
 
 @pytest.mark.asyncio()
 async def test_create_ready_specialist_tools_respects_excluded_factories() -> None:
-    """User-disabled tool groups must not be pre-activated even when connected."""
+    """User-disabled tool groups must not load even when connected."""
     from backend.app.agent.tools.registry import ToolRegistry
 
     reg = ToolRegistry()
@@ -189,9 +183,8 @@ async def test_create_ready_specialist_tools_respects_excluded_factories() -> No
     ctx.storage = MagicMock()
     ctx.publish_outbound = AsyncMock()
 
-    tools, names = await reg.create_ready_specialist_tools(ctx, excluded_factories={"calendar"})
+    tools = await reg.create_ready_specialist_tools(ctx, excluded_factories={"calendar"})
     assert tools == []
-    assert names == set()
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Production symptom (#1170): the agent's media factory returned an empty tool list when the current message had no attached or staged media. Because the Anthropic prompt-cache key includes the tools block, switching between text-only and media-bearing turns flipped the tool count from 40 to 42 and back, busting the cache prefix on the ~135k-token system prompt. Production data showed about 5 such cache misses in 27 LLM calls over 23 minutes, costing roughly $3.40 of avoidable spend per user burst.

**Fix:** drop the gate in `_media_factory`. The two media tools (`analyze_photo`, `discard_media`) have fully static schemas, and their runtime handlers already handle missing handles gracefully (NOT_FOUND for `analyze_photo`, idempotent return for `discard_media`), so always-on is safe.

**Bundled cleanup:** while verifying the fix, the runtime specialist-activation path turned out to be dead. Every specialist factory has an `auth_check`; ready specialists are loaded by `create_ready_specialist_tools` at agent boot, and unauthenticated ones return AUTH errors before activation can happen. The mid-loop activation plumbing (`_check_specialist_activations`, `_activate_specialist`, the agent loop's pre/post-activation block, the `activated_specialists` set threaded through `router.py`, `heartbeat.py`, `tool_assembly.py`, and `create_list_capabilities_tool`, plus the meta-tool's "already active" branch) never injected new tools in production. `list_capabilities` now serves a single live purpose: discovery and SKILL.md guidance lookup for unconnected integrations. The bundled removal is intentional because the rationale is the same (cache stability via stable tool list) and it lets the meta-tool's docstring be honest about what it actually does.

**Net diff:** +144 / -505 lines across 12 files (6 source, 6 test).

## Type
- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`) — 2477 passed, 2 skipped, 13 deselected
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] New tests added for new functionality — `test_media_factory_tool_list_stable_across_media_state` regression test for #1170
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Investigation, root-cause analysis, dead-code map, and patch authored by Claude (Opus 4.7, 1M context) via interactive discussion with @njbrake. Direction, scope decisions, and approvals are his.

Fixes #1170