### PR TITLE
fix(appfolio): send work-order address with invoice POSTs

### DIFF
--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -50,6 +50,67 @@ def _line_items_to_payload(items: list[AppFolioInvoiceLineItem]) -> list[dict[st
     ]
 
 
+# Canonical SPA address keys (in print order) mapped to the field names we
+# look for on a work-order response. AppFolio's read endpoints have shipped
+# both snake_case and camelCase variants over time; we accept any of them.
+_WO_ADDRESS_FIELD_ALIASES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("property_or_unit_name", ("property_or_unit_name", "unit_name", "property_name")),
+    ("address_1", ("address_1", "address1", "street_address", "street")),
+    ("address_2", ("address_2", "address2", "street_2")),
+    ("city", ("city",)),
+    ("state", ("state", "region")),
+    ("zip_code", ("zip_code", "zip", "postal_code", "postalCode")),
+)
+
+
+def _address_from_work_order(wo: dict[str, Any]) -> dict[str, Any]:
+    """Build the SPA-shaped invoice address block from a work-order dict.
+
+    AppFolio's ``POST /maintenance/api/invoices`` returns HTTP 500 with an
+    empty body when ``address`` is missing, even though the SPA payload
+    documents it as optional. We sidestep that by fetching the work order
+    and mapping its location fields into the SPA's expected shape.
+
+    Falls back to populating ``address_1`` with the formatted
+    ``property_address`` string if no structured fields are present, so a
+    minimally-shaped read response still produces a non-empty block.
+    """
+    address: dict[str, Any] = {}
+    for canonical, candidates in _WO_ADDRESS_FIELD_ALIASES:
+        for name in candidates:
+            value = wo.get(name)
+            if value:
+                address[canonical] = str(value)
+                break
+    if not address:
+        formatted = wo.get("property_address") or wo.get("address") or wo.get("propertyAddress")
+        if formatted:
+            address["address_1"] = str(formatted)
+    return address
+
+
+async def _fetch_invoice_address(
+    service: AppFolioVendorService, customer_id: str, work_order_id: str
+) -> dict[str, Any] | ToolResult:
+    """Fetch the work-order address block, or return a ToolResult on failure.
+
+    Errors here are surfaced to the agent rather than swallowed; the prior
+    behaviour was to POST without ``address`` and let AppFolio respond 500
+    with no body, which is impossible to act on from the chat surface.
+    """
+    try:
+        wo = await service.get_work_order(customer_id, work_order_id)
+    except Exception as exc:
+        return service_error_to_tool_result("fetching work order address for invoice", exc)
+    if not isinstance(wo, dict) or not wo:
+        return ToolResult(
+            content=f"Work order {work_order_id} not found.",
+            is_error=True,
+            error_kind=ToolErrorKind.NOT_FOUND,
+        )
+    return _address_from_work_order(wo)
+
+
 def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[Tool]:
     """Return the AppFolio invoice tools."""
 
@@ -83,11 +144,16 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
         if isinstance(files_or_err, ToolResult):
             return files_or_err
         files = files_or_err
+        address_or_err = await _fetch_invoice_address(service, customer_id, work_order_id)
+        if isinstance(address_or_err, ToolResult):
+            return address_or_err
+        address = address_or_err
         try:
             result = await service.create_invoice(
                 customer_id=customer_id,
                 work_order_id=work_order_id,
                 line_items=_line_items_to_payload(typed_items),
+                address=address or None,
                 reference_number=reference_number,
                 files=files or None,
             )
@@ -133,11 +199,16 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
                 is_error=True,
                 error_kind=ToolErrorKind.NOT_FOUND,
             )
+        address_or_err = await _fetch_invoice_address(service, customer_id, work_order_id)
+        if isinstance(address_or_err, ToolResult):
+            return address_or_err
+        address = address_or_err
         try:
             result = await service.upload_invoice_pdf(
                 customer_id=customer_id,
                 work_order_id=work_order_id,
                 files=files,
+                address=address or None,
                 reference_number=reference_number,
             )
         except Exception as exc:

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1270,6 +1270,197 @@ async def test_create_invoice_tool_rejects_malformed_line_item() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Address auto-fetch — invoice POSTs include the SPA-shaped address block
+# ---------------------------------------------------------------------------
+
+
+def test_address_from_work_order_prefers_structured_fields() -> None:
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _address_from_work_order,
+    )
+
+    wo = {
+        "id": 1,
+        "property_or_unit_name": "Test Building Unit 1",
+        "address_1": "123 Example Street",
+        "address_2": "Suite 200",
+        "city": "Anytown",
+        "state": "CA",
+        "zip_code": "99999",
+        # Should be ignored when structured fields are present.
+        "property_address": "ignored formatted string",
+    }
+    assert _address_from_work_order(wo) == {
+        "property_or_unit_name": "Test Building Unit 1",
+        "address_1": "123 Example Street",
+        "address_2": "Suite 200",
+        "city": "Anytown",
+        "state": "CA",
+        "zip_code": "99999",
+    }
+
+
+def test_address_from_work_order_accepts_camelcase_aliases() -> None:
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _address_from_work_order,
+    )
+
+    wo = {"address1": "123 Example Street", "postalCode": "99999"}
+    assert _address_from_work_order(wo) == {
+        "address_1": "123 Example Street",
+        "zip_code": "99999",
+    }
+
+
+def test_address_from_work_order_falls_back_to_formatted_string() -> None:
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _address_from_work_order,
+    )
+
+    wo = {"property_address": "123 Example Street, Anytown, CA 99999"}
+    assert _address_from_work_order(wo) == {
+        "address_1": "123 Example Street, Anytown, CA 99999",
+    }
+
+
+def test_address_from_work_order_returns_empty_when_no_address() -> None:
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _address_from_work_order,
+    )
+
+    assert _address_from_work_order({"id": 1, "status": "open"}) == {}
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_tool_includes_address_from_work_order() -> None:
+    """The tool fetches the WO and ships the SPA-shaped address block."""
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    get_wo = AsyncMock(
+        return_value={
+            "id": 42,
+            "address_1": "123 Example Street",
+            "city": "Anytown",
+            "state": "CA",
+            "zip_code": "99999",
+        }
+    )
+    create_invoice = AsyncMock(return_value={"id": "inv-1"})
+    service.get_work_order = get_wo  # type: ignore[method-assign]
+    service.create_invoice = create_invoice  # type: ignore[method-assign]
+
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    tools = build_invoice_tools(service, ctx)
+    create = next(t for t in tools if t.name == "appfolio_create_invoice")
+    result = await create.function(
+        customer_id="cust-1",
+        work_order_id="42",
+        line_items=[{"description": "Labor 4hr", "quantity": 4.0, "amount": 75.0}],
+    )
+    assert result.is_error is False
+    get_wo.assert_awaited_once_with("cust-1", "42")
+    create_invoice.assert_awaited_once()
+    assert create_invoice.call_args is not None
+    assert create_invoice.call_args.kwargs["address"] == {
+        "address_1": "123 Example Street",
+        "city": "Anytown",
+        "state": "CA",
+        "zip_code": "99999",
+    }
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_tool_skips_address_when_work_order_has_none() -> None:
+    """An empty address dict drops to ``None`` so the body omits the key."""
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    create_invoice = AsyncMock(return_value={"id": "inv-1"})
+    service.get_work_order = AsyncMock(return_value={"id": 42})  # type: ignore[method-assign]
+    service.create_invoice = create_invoice  # type: ignore[method-assign]
+
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    tools = build_invoice_tools(service, ctx)
+    create = next(t for t in tools if t.name == "appfolio_create_invoice")
+    await create.function(
+        customer_id="cust-1",
+        work_order_id="42",
+        line_items=[{"description": "Labor", "quantity": 1.0, "amount": 100.0}],
+    )
+    create_invoice.assert_awaited_once()
+    assert create_invoice.call_args is not None
+    assert create_invoice.call_args.kwargs["address"] is None
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_tool_surfaces_work_order_lookup_failure() -> None:
+    """A failed WO lookup short-circuits before the invoice POST."""
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    create_invoice = AsyncMock()
+    service.get_work_order = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AppFolioError("not found")
+    )
+    service.create_invoice = create_invoice  # type: ignore[method-assign]
+
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    tools = build_invoice_tools(service, ctx)
+    create = next(t for t in tools if t.name == "appfolio_create_invoice")
+    result = await create.function(
+        customer_id="cust-1",
+        work_order_id="42",
+        line_items=[{"description": "Labor", "quantity": 1.0, "amount": 100.0}],
+    )
+    assert result.is_error is True
+    create_invoice.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_upload_invoice_pdf_tool_includes_address_from_work_order() -> None:
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+    from backend.app.integrations.appfolio_vendor.service import FileUpload
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    upload_pdf = AsyncMock(return_value={"id": "inv-2"})
+    service.get_work_order = AsyncMock(  # type: ignore[method-assign]
+        return_value={"address_1": "123 Example Street"}
+    )
+    service.upload_invoice_pdf = upload_pdf  # type: ignore[method-assign]
+
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    staged = FileUpload(name="invoice.pdf", data=b"%PDF-fake")
+    with patch(
+        "backend.app.integrations.appfolio_vendor.invoices.resolve_staged_files",
+        new=AsyncMock(return_value=[staged]),
+    ):
+        tools = build_invoice_tools(service, ctx)
+        upload = next(t for t in tools if t.name == "appfolio_upload_invoice_pdf")
+        result = await upload.function(
+            customer_id="cust-1",
+            work_order_id="42",
+            media_refs=["media_abc"],
+        )
+    assert result.is_error is False
+    upload_pdf.assert_awaited_once()
+    assert upload_pdf.call_args is not None
+    assert upload_pdf.call_args.kwargs["address"] == {"address_1": "123 Example Street"}
+
+
+# ---------------------------------------------------------------------------
 # Logging diagnostics — failure paths surface enough info to debug
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Both AppFolio invoice write paths (`appfolio_create_invoice` and
`appfolio_upload_invoice_pdf`) were building bodies for
`POST /maintenance/api/invoices` without the `address` block that
#1277 documented as part of the SPA-verified shape. AppFolio responds
HTTP 500 with an empty body when `address` is omitted, so every
invoice attempt failed opaquely. Production logs from a user-reported
incident confirm the failure mode: snake_case body sent, no `address`
key, 500 from upstream.

The service-layer methods on `AppFolioVendorService` already accept
an `address: dict | None` parameter, but the tool wrappers in
`invoices.py` never passed one and the Pydantic params models did not
expose a way to provide it. Reaching the bug just required a user to
actually run `appfolio_create_invoice` post-#1277.

### Fix

Each invoice tool now fetches the work order via `get_work_order`
before posting, maps the location fields into the SPA-shaped block
(`property_or_unit_name`, `address_1`, `address_2`, `city`, `state`,
`zip_code`), and ships it. Field-name mapping accepts the snake_case
and camelCase variants AppFolio's read endpoints have shipped over
time, and falls back to populating `address_1` with the formatted
`property_address` string when no structured fields are present.

A failed work-order lookup is surfaced to the agent rather than
letting the invoice POST go out half-formed.

### Audit of other write paths

I audited every write method on `AppFolioVendorService` against its
tool wrapper and Pydantic params model to find any other endpoints
with the same shape. `create_invoice` and `upload_invoice_pdf` are
the only ones where a service-method parameter is unreachable from
the tool surface. The rest are fine:

| Service method | Tool wrapper | Status |
|---|---|---|
| `accept_work_order` | `work_order_writes.py` | OK — `customer_id` resolves inside the service |
| `schedule_work_order` | `work_order_writes.py` | OK — same fallback |
| `update_work_order_status` | `work_order_writes.py` | OK — same |
| `undo_work_order_status` | `work_order_writes.py` | OK — same |
| `add_work_order_note` | `notes.py` | OK — fixed in #1277, plumbing complete |
| `update_work_order_note` | `notes.py` | OK |
| `message_tenant` | `conversations.py` | OK — `phone_number` fetched via `get_proxy_number` inside the tool |
| `create_invoice` | `invoices.py` | **fixed in this PR** |
| `upload_invoice_pdf` | `invoices.py` | **fixed in this PR** |
| `upload_compliance_document` | `compliance.py` | OK |
| `update_estimate` | `estimates.py` | OK — params model intentionally constrains the attribute surface |

`update_profile` has a service method and a Pydantic params model but
no tool wrapper at all, by design (read-only profile surface today).

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

### Test coverage added

- `_address_from_work_order` helper: structured fields, camelCase
  aliases, formatted-string fallback, empty input.
- `appfolio_create_invoice` tool: address block makes it into the
  kwargs handed to the service; empty address downgrades to `None`;
  work-order lookup failure short-circuits before the POST.
- `appfolio_upload_invoice_pdf` tool: address is plumbed through the
  PDF upload path too.

## AI Usage
- [x] AI-assisted: drafted by Claude (Opus 4.7) after diagnosing the
  failure from production logs and the service-layer docstring.