### PR TITLE
fix(appfolio): handle nested camelCase address shape on work-order GET

### DIFF
--- a/backend/app/integrations/appfolio_vendor/conversations.py
+++ b/backend/app/integrations/appfolio_vendor/conversations.py
@@ -15,7 +15,10 @@ from typing import Any
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
-from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.errors import (
+    log_unexpected_response_shape,
+    service_error_to_tool_result,
+)
 from backend.app.integrations.appfolio_vendor.params import AppFolioMessageTenantParams
 from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
 
@@ -52,14 +55,17 @@ def build_conversation_tools(service: AppFolioVendorService) -> list[Tool]:
 
         phone_number = _extract_proxy_number(proxy)
         if not phone_number:
-            # Surface the actual response shape so we can adjust
-            # ``_extract_proxy_number`` if AppFolio ever returns a key
-            # we don't currently recognize.
-            logger.warning(
-                "AppFolio proxy_number response had no usable phone field"
-                " | work_order_id=%s response=%r",
-                work_order_id,
+            # The "tenant opted out" path is a legitimate empty
+            # response, but it shares its shape with "AppFolio renamed
+            # the field again." Surface the actual response so we can
+            # adjust ``_extract_proxy_number`` if a new key shows up.
+            log_unexpected_response_shape(
+                f"appfolio_message_tenant proxy lookup (work_order_id={work_order_id})",
                 proxy,
+                expected=(
+                    "dict with one of phone_number / proxy_number / "
+                    "phoneNumber / proxyNumber set to a non-empty string"
+                ),
             )
             return ToolResult(
                 content=(

--- a/backend/app/integrations/appfolio_vendor/errors.py
+++ b/backend/app/integrations/appfolio_vendor/errors.py
@@ -1,14 +1,24 @@
-"""Shared error-to-ToolResult translation for AppFolio tools.
+"""Shared error-to-ToolResult translation and diagnostic logging.
 
 Every tool that calls into :class:`AppFolioVendorService` ends up
 funnelling the same exception types into ToolResult shapes. Centralize
 that mapping here so the auth-expired hint, the service-error wrapping,
 and the unexpected-error logging stay identical across tool modules.
+
+This module also exposes :func:`log_unexpected_response_shape`, used
+by the read-side parsers. AppFolio's API has a long history of small
+shape surprises (camelCase vs snake_case, nested vs flat, optional
+envelope wrappers); when our parser walks a 200-OK response and finds
+nothing usable, the user-facing path returns a generic "no results"
+message and we have nothing to debug from after the fact. The helper
+makes that case loud in the production logs so the *first* report of
+a new shape is enough to understand and fix it.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from backend.app.agent.tools.base import ToolErrorKind, ToolResult
 from backend.app.integrations.appfolio_vendor.service import (
@@ -18,6 +28,61 @@ from backend.app.integrations.appfolio_vendor.service import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Cap on how much of the actual response we paste into the log line.
+# Wide enough to capture the structure (a few keys plus their values)
+# without burying it in base64-encoded photo payloads or massive lists.
+_DIAG_REPR_LIMIT = 1500
+
+
+def log_unexpected_response_shape(
+    tool_label: str,
+    payload: Any,
+    *,
+    expected: str,
+) -> None:
+    """Emit a structured WARNING describing a successful response we couldn't parse.
+
+    Call this from any read-side AppFolio parser when AppFolio answered
+    HTTP 200 (so the request itself is fine) but we couldn't find the
+    fields we expected in the body. The log line names the parser, what
+    it was looking for, and what the response actually looks like:
+
+    * For dicts, the top-level keys (sorted, so diffs across runs are
+      stable).
+    * For lists, length and the first item's keys when it is a dict.
+    * For anything else, just the type name.
+    * Plus a truncated ``repr()`` of the payload itself so the structure
+      is visible without re-running the request.
+
+    Use ``tool_label`` to name the parser ("appfolio_get_work_order
+    address extraction"), and ``expected`` to describe what the parser
+    was looking for ("address fields at top level or nested under
+    `address`/`location`").
+    """
+    if isinstance(payload, dict):
+        shape = f"dict keys={sorted(payload.keys())!r}"
+    elif isinstance(payload, list):
+        if payload and isinstance(payload[0], dict):
+            sample = sorted(payload[0].keys())
+            shape = f"list len={len(payload)} sample_keys={sample!r}"
+        else:
+            shape = f"list len={len(payload)}"
+    else:
+        shape = f"type={type(payload).__name__}"
+
+    body_preview = repr(payload)
+    if len(body_preview) > _DIAG_REPR_LIMIT:
+        body_preview = body_preview[:_DIAG_REPR_LIMIT] + f"...<{len(body_preview)} chars>"
+
+    logger.warning(
+        "AppFolio %s: response did not match expected shape (%s) | actual=%s | body=%s",
+        tool_label,
+        expected,
+        shape,
+        body_preview,
+    )
 
 
 _AUTH_EXPIRED_HINT = "Have the user request a fresh magic link and re-run appfolio_connect."

--- a/backend/app/integrations/appfolio_vendor/estimates.py
+++ b/backend/app/integrations/appfolio_vendor/estimates.py
@@ -8,7 +8,10 @@ from typing import Any
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
-from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.errors import (
+    log_unexpected_response_shape,
+    service_error_to_tool_result,
+)
 from backend.app.integrations.appfolio_vendor.params import (
     AppFolioGetEstimateParams,
     AppFolioUpdateEstimateParams,
@@ -59,6 +62,25 @@ def build_estimate_tools(service: AppFolioVendorService) -> list[Tool]:
                 is_error=True,
                 error_kind=ToolErrorKind.NOT_FOUND,
             )
+        # If the JSON:API envelope is missing both ``data`` and the
+        # core attributes (amount/description/status), log so we can
+        # see the actual shape rather than rendering an empty card.
+        if isinstance(payload, dict):
+            data = payload.get("data") if "data" in payload else payload
+            attrs: dict[str, Any] = (
+                data.get("attributes")
+                if isinstance(data, dict) and isinstance(data.get("attributes"), dict)
+                else (data if isinstance(data, dict) else {})
+            )
+            if not any(attrs.get(k) for k in ("amount", "total", "description", "status")):
+                log_unexpected_response_shape(
+                    f"appfolio_get_estimate(estimate_id={estimate_id})",
+                    payload,
+                    expected=(
+                        "JSON:API envelope with `data.attributes` containing "
+                        "at least one of amount/total/description/status"
+                    ),
+                )
         return ToolResult(content=_fmt_estimate(payload))
 
     async def appfolio_update_estimate(

--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -53,42 +53,86 @@ def _line_items_to_payload(items: list[AppFolioInvoiceLineItem]) -> list[dict[st
     ]
 
 
-# Canonical SPA address keys (in print order) mapped to the field names we
-# look for on a work-order response. AppFolio's read endpoints have shipped
-# both snake_case and camelCase variants over time; we accept any of them.
+# Canonical SPA address keys (in print order) mapped to the field names
+# we look for on a work-order response. AppFolio's read endpoints ship
+# both snake_case and camelCase variants and the production
+# ``list_work_orders`` response nests the location under
+# ``address: {propertyOrUnitName, address1, address2, city, state,
+# zipCode}``, so we accept all of those forms.
 _WO_ADDRESS_FIELD_ALIASES: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("property_or_unit_name", ("property_or_unit_name", "unit_name", "property_name")),
+    (
+        "property_or_unit_name",
+        ("property_or_unit_name", "propertyOrUnitName", "unit_name", "property_name"),
+    ),
     ("address_1", ("address_1", "address1", "street_address", "street")),
     ("address_2", ("address_2", "address2", "street_2")),
     ("city", ("city",)),
     ("state", ("state", "region")),
-    ("zip_code", ("zip_code", "zip", "postal_code", "postalCode")),
+    ("zip_code", ("zip_code", "zipCode", "zip", "postal_code", "postalCode")),
 )
+
+# Container fields that may hold a nested address dict instead of the
+# flat top-level fields. ``list_work_orders`` puts the address inside
+# ``wo["address"]`` (a dict). Some envelope shapes might also wrap the
+# whole work order at ``wo["work_order"]`` or ``wo["data"]``.
+_WO_ADDRESS_CONTAINERS: tuple[str, ...] = ("address", "location", "propertyAddress")
+_WO_TOP_CONTAINERS: tuple[str, ...] = ("work_order", "data")
 
 
 def _address_from_work_order(wo: dict[str, Any]) -> dict[str, Any]:
     """Build the SPA-shaped invoice address block from a work-order dict.
 
-    AppFolio's ``POST /maintenance/api/invoices`` returns HTTP 500 with an
-    empty body when ``address`` is missing, even though the SPA payload
-    documents it as optional. We sidestep that by fetching the work order
-    and mapping its location fields into the SPA's expected shape.
+    AppFolio's ``POST /maintenance/api/invoices`` returns HTTP 500 with
+    an empty body when ``address`` is missing, even though the SPA
+    payload documents it as optional. We sidestep that by fetching the
+    work order and mapping its location fields into the SPA's expected
+    shape.
 
-    Falls back to populating ``address_1`` with the formatted
-    ``property_address`` string if no structured fields are present, so a
-    minimally-shaped read response still produces a non-empty block.
+    Resilient to three observed response shapes:
+
+    * Address fields at the top level: ``wo.get("address_1")`` etc.
+    * Nested under an ``address`` (or ``location`` / ``propertyAddress``)
+      dict, the shape ``list_work_orders`` returns in production.
+    * The whole work order wrapped in a ``work_order`` / ``data`` envelope.
+
+    Returns an empty dict when nothing matches; the caller logs a
+    diagnostic in that case (see :func:`_fetch_invoice_address`).
     """
+    # If the WO is wrapped in a single-key envelope, unwrap it.
+    for envelope_key in _WO_TOP_CONTAINERS:
+        inner = wo.get(envelope_key)
+        if isinstance(inner, dict) and inner:
+            wo = inner
+            break
+
+    # Search both the top-level dict and any nested address container.
+    sources: list[dict[str, Any]] = [wo]
+    for container_key in _WO_ADDRESS_CONTAINERS:
+        nested = wo.get(container_key)
+        if isinstance(nested, dict) and nested:
+            sources.append(nested)
+
     address: dict[str, Any] = {}
     for canonical, candidates in _WO_ADDRESS_FIELD_ALIASES:
-        for name in candidates:
-            value = wo.get(name)
-            if value:
-                address[canonical] = str(value)
+        for source in sources:
+            for name in candidates:
+                value = source.get(name)
+                if value:
+                    address[canonical] = str(value)
+                    break
+            if canonical in address:
                 break
+
     if not address:
-        formatted = wo.get("property_address") or wo.get("address") or wo.get("propertyAddress")
-        if formatted:
-            address["address_1"] = str(formatted)
+        # Last-ditch: a flat string in one of the address container keys
+        # (some endpoints return the formatted address as a single
+        # string, not a dict). Send it as ``address_1`` so AppFolio at
+        # least has something to print on the invoice.
+        for container_key in (*_WO_ADDRESS_CONTAINERS, "property_address"):
+            formatted = wo.get(container_key)
+            if isinstance(formatted, str) and formatted:
+                address["address_1"] = formatted
+                break
     return address
 
 
@@ -136,7 +180,36 @@ async def _fetch_invoice_address(
             is_error=True,
             error_kind=ToolErrorKind.NOT_FOUND,
         )
-    return canonical_customer_id, _address_from_work_order(wo)
+    address = _address_from_work_order(wo)
+    if not address:
+        # AppFolio rejects invoice POSTs without an address block (HTTP
+        # 500 with an empty body), so an empty extraction here is going
+        # to fail the invoice anyway. Log the WO key shape so the next
+        # response variant we hit is debuggable, and surface a clear
+        # error to the agent instead of letting the POST go out
+        # half-formed.
+        logger.warning(
+            "AppFolio _address_from_work_order returned empty"
+            " | work_order_id=%s top_keys=%r address_field_type=%s",
+            work_order_id,
+            sorted(wo.keys()),
+            type(wo.get("address")).__name__,
+        )
+        return ToolResult(
+            content=(
+                f"AppFolio returned work order {work_order_id} but no"
+                " address fields could be extracted; cannot build the"
+                " invoice payload."
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.SERVICE,
+            hint=(
+                "The work-order response shape may have changed. Check"
+                " the warning log entry from the appfolio_vendor.invoices"
+                " module for the field names AppFolio returned."
+            ),
+        )
+    return canonical_customer_id, address
 
 
 def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[Tool]:

--- a/backend/app/integrations/appfolio_vendor/notes.py
+++ b/backend/app/integrations/appfolio_vendor/notes.py
@@ -15,7 +15,10 @@ from typing import TYPE_CHECKING, Any
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
-from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.errors import (
+    log_unexpected_response_shape,
+    service_error_to_tool_result,
+)
 from backend.app.integrations.appfolio_vendor.media_resolver import resolve_staged_files
 from backend.app.integrations.appfolio_vendor.params import (
     AppFolioAddNoteParams,
@@ -30,11 +33,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_KNOWN_NOTE_LIST_ENVELOPES = ("notes", "data", "results")
+
+
 def _normalize_notes(payload: Any) -> list[dict[str, Any]]:
     if isinstance(payload, list):
         return [n for n in payload if isinstance(n, dict)]
     if isinstance(payload, dict):
-        for key in ("notes", "data", "results"):
+        for key in _KNOWN_NOTE_LIST_ENVELOPES:
             value = payload.get(key)
             if isinstance(value, list):
                 return [n for n in value if isinstance(n, dict)]
@@ -51,6 +57,15 @@ def build_note_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[T
             return service_error_to_tool_result("listing notes", exc)
         notes = _normalize_notes(payload)
         if not notes:
+            if isinstance(payload, dict) and payload:
+                log_unexpected_response_shape(
+                    f"appfolio_list_notes(work_order_id={work_order_id})",
+                    payload,
+                    expected=(
+                        "list of note dicts, or a dict with one of "
+                        f"{list(_KNOWN_NOTE_LIST_ENVELOPES)} containing the list"
+                    ),
+                )
             return ToolResult(content=f"No notes on work order {work_order_id}.")
         lines = [f"{len(notes)} note(s) on work order {work_order_id}:"]
         for n in notes[:30]:

--- a/backend/app/integrations/appfolio_vendor/payments.py
+++ b/backend/app/integrations/appfolio_vendor/payments.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import log_unexpected_response_shape
 from backend.app.integrations.appfolio_vendor.params import AppFolioListPaymentsParams
 from backend.app.integrations.appfolio_vendor.service import (
     AppFolioError,
@@ -17,11 +18,14 @@ from backend.app.integrations.appfolio_vendor.service import (
 logger = logging.getLogger(__name__)
 
 
+_KNOWN_PAYMENT_LIST_ENVELOPES = ("payments", "data", "results", "vendor_portal_payable_payments")
+
+
 def _normalize_list(payload: Any) -> list[dict[str, Any]]:
     if isinstance(payload, list):
         return [p for p in payload if isinstance(p, dict)]
     if isinstance(payload, dict):
-        for key in ("payments", "data", "results", "vendor_portal_payable_payments"):
+        for key in _KNOWN_PAYMENT_LIST_ENVELOPES:
             value = payload.get(key)
             if isinstance(value, list):
                 return [p for p in value if isinstance(p, dict)]
@@ -81,6 +85,15 @@ def build_payment_tools(service: AppFolioVendorService) -> list[Tool]:
 
         items = _normalize_list(payload)
         if not items:
+            if isinstance(payload, dict) and payload:
+                log_unexpected_response_shape(
+                    "appfolio_list_payments",
+                    payload,
+                    expected=(
+                        "list of payment dicts, or a dict with one of "
+                        f"{list(_KNOWN_PAYMENT_LIST_ENVELOPES)} containing the list"
+                    ),
+                )
             return ToolResult(content="No payments found for those filters.")
         lines = [f"Found {len(items)} payment(s):"]
         lines.extend(_fmt_payment_line(p) for p in items[:30])

--- a/backend/app/integrations/appfolio_vendor/profile.py
+++ b/backend/app/integrations/appfolio_vendor/profile.py
@@ -13,7 +13,10 @@ from typing import Any
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
-from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.errors import (
+    log_unexpected_response_shape,
+    service_error_to_tool_result,
+)
 from backend.app.integrations.appfolio_vendor.params import AppFolioGetProfileParams
 from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
 
@@ -70,6 +73,34 @@ def build_profile_tools(service: AppFolioVendorService) -> list[Tool]:
                 content="AppFolio returned no profile.",
                 is_error=True,
                 error_kind=ToolErrorKind.NOT_FOUND,
+            )
+        # If none of the recognized fields are populated (either at the
+        # top level or under a ``user``/``company`` block), the response
+        # shape has likely drifted; log so the next mismatch is
+        # debuggable rather than just rendering an empty profile card.
+        recognized_present = any(
+            (payload.get(k) or (isinstance(payload.get("user"), dict) and payload["user"].get(k)))
+            for k in (
+                "firstName",
+                "first_name",
+                "lastName",
+                "last_name",
+                "companyName",
+                "company_name",
+                "email",
+                "phoneNumber",
+                "phone_number",
+            )
+        ) or isinstance(payload.get("company"), dict)
+        if not recognized_present:
+            log_unexpected_response_shape(
+                "appfolio_get_profile",
+                payload,
+                expected=(
+                    "dict with at least one of firstName/lastName/email/"
+                    "phoneNumber/companyName at the top level or under a "
+                    "'user' / 'company' sub-object"
+                ),
             )
         return ToolResult(content=_fmt_profile(payload))
 

--- a/backend/app/integrations/appfolio_vendor/work_orders.py
+++ b/backend/app/integrations/appfolio_vendor/work_orders.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import log_unexpected_response_shape
 from backend.app.integrations.appfolio_vendor.params import (
     AppFolioGetWorkOrderParams,
     AppFolioListWorkOrdersParams,
@@ -85,12 +86,21 @@ def _fmt_work_order_line(wo: dict[str, Any]) -> str:
     return f"- ID: {wo_id} | " + " | ".join(pieces)
 
 
+_KNOWN_WO_LIST_ENVELOPES = ("work_orders", "workOrders", "results", "data")
+
+
 def _normalize_list(payload: Any) -> list[dict[str, Any]]:
-    """Return a list of work-order dicts from whichever envelope AppFolio used."""
+    """Return a list of work-order dicts from whichever envelope AppFolio used.
+
+    Returns ``[]`` when the response shape is not one we recognize; the
+    *caller* is responsible for logging that case via
+    :func:`log_unexpected_response_shape` so the empty-list semantics
+    stay simple and the diagnostic carries the calling tool's label.
+    """
     if isinstance(payload, list):
         return [w for w in payload if isinstance(w, dict)]
     if isinstance(payload, dict):
-        for key in ("work_orders", "workOrders", "results", "data"):
+        for key in _KNOWN_WO_LIST_ENVELOPES:
             value = payload.get(key)
             if isinstance(value, list):
                 return [w for w in value if isinstance(w, dict)]
@@ -118,6 +128,19 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
 
         items = _normalize_list(payload)
         if not items:
+            # An empty list is a legitimate result, but if the response
+            # was a non-empty dict the shape is probably the issue (we
+            # didn't recognize the envelope). Log so the next mismatch
+            # is debuggable rather than just looking like "no results".
+            if isinstance(payload, dict) and payload:
+                log_unexpected_response_shape(
+                    "appfolio_list_work_orders",
+                    payload,
+                    expected=(
+                        "list of work-order dicts, or a dict with one of "
+                        f"{list(_KNOWN_WO_LIST_ENVELOPES)} containing the list"
+                    ),
+                )
             return ToolResult(content="No matching work orders.")
         lines = [f"Found {len(items)} work order(s):"]
         lines.extend(_fmt_work_order_line(w) for w in items[:30])
@@ -133,6 +156,15 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
 
         items = _normalize_list(payload)
         if not items:
+            if isinstance(payload, dict) and payload:
+                log_unexpected_response_shape(
+                    f"appfolio_search_work_orders(search_term={search_term!r})",
+                    payload,
+                    expected=(
+                        "list of work-order dicts, or a dict with one of "
+                        f"{list(_KNOWN_WO_LIST_ENVELOPES)} containing the list"
+                    ),
+                )
             return ToolResult(content=f"No work orders matched '{search_term}'.")
         lines = [f"{len(items)} match(es) for '{search_term}':"]
         lines.extend(_fmt_work_order_line(w) for w in items[:20])
@@ -162,6 +194,27 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
         except AppFolioError as exc:
             logger.info("work_order_details unavailable for %s: %s", work_order_id, exc)
 
+        # If none of the expected fields are present, the response shape
+        # has likely drifted; surface a diagnostic so we don't silently
+        # render a "Work order #X | Status: ? | Address: ?" stub.
+        recognised_fields = (
+            "work_order_number",
+            "status",
+            "status_label",
+            "property_address",
+            "address",
+            "description",
+            "summary",
+        )
+        if not any(wo.get(k) for k in recognised_fields):
+            log_unexpected_response_shape(
+                f"appfolio_get_work_order(customer_id={customer_id}, "
+                f"work_order_id={work_order_id})",
+                wo,
+                expected=(
+                    f"work-order dict with at least one of {list(recognised_fields)} populated"
+                ),
+            )
         lines = [
             f"Work order #{wo.get('work_order_number') or work_order_id}",
             f"  Status: {wo.get('status') or wo.get('status_label') or '?'}",

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1351,6 +1351,70 @@ def test_address_from_work_order_returns_empty_when_no_address() -> None:
     assert _address_from_work_order({"id": 1, "status": "open"}) == {}
 
 
+def test_address_from_work_order_handles_nested_camelcase_dict() -> None:
+    """Production WO responses nest the address as a camelCase dict.
+
+    Reproduces the shape observed in ``list_work_orders`` output:
+    ``wo["address"]`` is a dict with ``propertyOrUnitName``,
+    ``address1``, ``address2``, ``city``, ``state``, ``zipCode``.
+    The parser must descend into that container and translate the
+    camelCase keys to the SPA's snake_case shape.
+    """
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _address_from_work_order,
+    )
+
+    wo = {
+        "id": 113468,
+        "address": {
+            "propertyOrUnitName": "Test Building Unit 2L",
+            "address1": "123 Example Street - 2L",
+            "address2": "",
+            "city": "Anytown",
+            "state": "CA",
+            "zipCode": "99999",
+        },
+    }
+    assert _address_from_work_order(wo) == {
+        "property_or_unit_name": "Test Building Unit 2L",
+        "address_1": "123 Example Street - 2L",
+        "city": "Anytown",
+        "state": "CA",
+        "zip_code": "99999",
+    }
+
+
+def test_address_from_work_order_unwraps_envelope() -> None:
+    """A WO wrapped in ``{"work_order": {...}}`` still extracts cleanly."""
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _address_from_work_order,
+    )
+
+    wo = {
+        "work_order": {
+            "id": 1,
+            "address": {"address1": "123 Example Street", "city": "Anytown"},
+        }
+    }
+    assert _address_from_work_order(wo) == {
+        "address_1": "123 Example Street",
+        "city": "Anytown",
+    }
+
+
+def test_address_from_work_order_top_level_overrides_nested() -> None:
+    """Top-level structured fields win over nested ones when both present."""
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _address_from_work_order,
+    )
+
+    wo = {
+        "address_1": "Top Level Street",
+        "address": {"address1": "Nested Street"},
+    }
+    assert _address_from_work_order(wo)["address_1"] == "Top Level Street"
+
+
 @pytest.mark.asyncio()
 async def test_create_invoice_tool_includes_address_from_work_order() -> None:
     """The tool fetches the WO and ships the SPA-shaped address block."""
@@ -1394,8 +1458,14 @@ async def test_create_invoice_tool_includes_address_from_work_order() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_create_invoice_tool_skips_address_when_work_order_has_none() -> None:
-    """An empty address dict drops to ``None`` so the body omits the key."""
+async def test_create_invoice_tool_short_circuits_when_address_extraction_empty() -> None:
+    """Empty address extraction surfaces a clear error and skips the POST.
+
+    AppFolio rejects invoice POSTs without an ``address`` block (HTTP
+    500 with empty body), so shipping a no-address payload would just
+    fail noisily anyway. Surface a clear ToolResult instead and emit a
+    warning log so we can debug the response-shape mismatch.
+    """
     from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
 
     service = AppFolioVendorService(_credential(), api_base="https://api.test")
@@ -1409,14 +1479,13 @@ async def test_create_invoice_tool_skips_address_when_work_order_has_none() -> N
 
     tools = build_invoice_tools(service, ctx)
     create = next(t for t in tools if t.name == "appfolio_create_invoice")
-    await create.function(
+    result = await create.function(
         customer_id="cust-1",
         work_order_id="42",
         line_items=[{"description": "Labor", "quantity": 1.0, "amount": 100.0}],
     )
-    create_invoice.assert_awaited_once()
-    assert create_invoice.call_args is not None
-    assert create_invoice.call_args.kwargs["address"] is None
+    assert result.is_error is True
+    create_invoice.assert_not_awaited()
 
 
 @pytest.mark.asyncio()

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -425,6 +425,40 @@ async def test_service_error_to_tool_result_distinguishes_scope_from_expired() -
     assert "reconnect" not in (scope.content or "").lower()
 
 
+def test_log_unexpected_response_shape_dict(caplog: Any) -> None:
+    """The helper logs a structured WARNING with sorted keys and a body preview."""
+    import logging
+
+    from backend.app.integrations.appfolio_vendor.errors import (
+        log_unexpected_response_shape,
+    )
+
+    payload = {"unexpected_field": "value", "other": [1, 2]}
+    with caplog.at_level(logging.WARNING, logger="backend.app.integrations.appfolio_vendor.errors"):
+        log_unexpected_response_shape("test_tool", payload, expected="dict with `data` key")
+    assert any(
+        "test_tool" in r.message
+        and "dict with `data` key" in r.message
+        and "['other', 'unexpected_field']" in r.message
+        and "unexpected_field" in r.message
+        for r in caplog.records
+    )
+
+
+def test_log_unexpected_response_shape_list(caplog: Any) -> None:
+    """List payloads log length plus the first item's keys when that item is a dict."""
+    import logging
+
+    from backend.app.integrations.appfolio_vendor.errors import (
+        log_unexpected_response_shape,
+    )
+
+    payload = [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+    with caplog.at_level(logging.WARNING, logger="backend.app.integrations.appfolio_vendor.errors"):
+        log_unexpected_response_shape("test_tool", payload, expected="dict envelope")
+    assert any("list len=2" in r.message and "['id', 'name']" in r.message for r in caplog.records)
+
+
 @pytest.mark.asyncio()
 async def test_service_5xx_raises_appfolio_error() -> None:
     service = AppFolioVendorService(_credential(), api_base="https://api.test")


### PR DESCRIPTION
## Description

Continuation of #1286 / #1288. Production saw jesse's invoice retry
go through the customer_id resolution path correctly (canonical id
resolved via ``/profiles/me``, work-order GET returned 200 with 3207
bytes), but the invoice POST still 500'd because the body went out
without an ``address`` block.

Cause: ``_address_from_work_order`` only checked for top-level flat
fields, but the actual response embeds the location as a nested
camelCase dict at ``wo["address"]`` (same shape ``list_work_orders``
returns: ``{propertyOrUnitName, address1, address2, city, state,
zipCode}``).

### Fix

- Descend into nested ``address`` / ``location`` / ``propertyAddress``
  containers when top-level extraction yields nothing.
- Unwrap a single-key envelope (``work_order`` / ``data``) before
  extraction, in case the GET endpoint wraps the WO.
- Extend the alias map to include ``propertyOrUnitName`` and
  ``zipCode`` (camelCase variants the production list response uses).
- Top-level fields still win when both top-level and nested are
  present, preserving back-compat with the existing flat shapes.

### Diagnostic + short-circuit on empty extraction

When extraction returns empty, log a WARNING with the WO's top-level
keys and the type of its ``address`` field, then surface a clear
``ToolResult`` instead of letting the invoice POST go out
half-formed. AppFolio answers 500 with empty body in that case, which
is opaque from the chat surface and was exactly the trust-eroding
pattern we just shipped a fix for. Now if the response shape changes
again, the next caller has a clear log line to read.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2546 passed, 2 skipped
- [x] Lint passes
- [x] Type checking passes
- [x] New tests added: nested camelCase dict, envelope-unwrapping,
  top-level-overrides-nested, and the empty-extraction short-circuit.
- [x] Updated the prior ``test_create_invoice_tool_skips_address...``
  test (was asserting the wrong behaviour given AppFolio's 500-on-empty
  contract).

## AI Usage
- [x] AI-assisted: drafted by Claude (Opus 4.7) after the previous
  fix's deploy showed the customer_id retry working but the body still
  shipping without an address block.