### PR TITLE
fix(appfolio): unwrap camelCase `workOrder` envelope on work-order GET

### DIFF
--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -73,10 +73,13 @@ _WO_ADDRESS_FIELD_ALIASES: tuple[tuple[str, tuple[str, ...]], ...] = (
 
 # Container fields that may hold a nested address dict instead of the
 # flat top-level fields. ``list_work_orders`` puts the address inside
-# ``wo["address"]`` (a dict). Some envelope shapes might also wrap the
-# whole work order at ``wo["work_order"]`` or ``wo["data"]``.
+# ``wo["address"]`` (a dict). Some envelope shapes also wrap the whole
+# work order; production traffic confirmed ``GET /work_order/{cust}/{id}.json``
+# returns ``{"workOrder": {...}}`` (camelCase singular), and the JSON:API
+# convention is ``{"data": {...}}``. The snake_case ``work_order`` form
+# is kept defensively in case AppFolio changes its mind again.
 _WO_ADDRESS_CONTAINERS: tuple[str, ...] = ("address", "location", "propertyAddress")
-_WO_TOP_CONTAINERS: tuple[str, ...] = ("work_order", "data")
+_WO_TOP_CONTAINERS: tuple[str, ...] = ("workOrder", "work_order", "data")
 
 
 def _address_from_work_order(wo: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1418,8 +1418,8 @@ def test_address_from_work_order_handles_nested_camelcase_dict() -> None:
     }
 
 
-def test_address_from_work_order_unwraps_envelope() -> None:
-    """A WO wrapped in ``{"work_order": {...}}`` still extracts cleanly."""
+def test_address_from_work_order_unwraps_snake_case_envelope() -> None:
+    """A WO wrapped in ``{"work_order": {...}}`` (snake_case) extracts cleanly."""
     from backend.app.integrations.appfolio_vendor.invoices import (
         _address_from_work_order,
     )
@@ -1433,6 +1433,38 @@ def test_address_from_work_order_unwraps_envelope() -> None:
     assert _address_from_work_order(wo) == {
         "address_1": "123 Example Street",
         "city": "Anytown",
+    }
+
+
+def test_address_from_work_order_unwraps_camelcase_envelope() -> None:
+    """Regression: production WO GET returns ``{"workOrder": {...}}``.
+
+    The diagnostic warning from the previous deploy logged
+    ``top_keys=['workOrder']`` for jesse's failing invoice. Pin a
+    regression test to that exact envelope key so we don't lose it.
+    """
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _address_from_work_order,
+    )
+
+    wo = {
+        "workOrder": {
+            "id": 1,
+            "address": {
+                "propertyOrUnitName": "Test Building Unit 2L",
+                "address1": "123 Example Street",
+                "city": "Anytown",
+                "state": "CA",
+                "zipCode": "99999",
+            },
+        }
+    }
+    assert _address_from_work_order(wo) == {
+        "property_or_unit_name": "Test Building Unit 2L",
+        "address_1": "123 Example Street",
+        "city": "Anytown",
+        "state": "CA",
+        "zip_code": "99999",
     }
 
 


### PR DESCRIPTION
## Description

Continuation of #1289. The diagnostic warning we added there did its
job on the first new production failure: jesse's invoice retry
surfaced

```
WARNING [appfolio_vendor.invoices] AppFolio _address_from_work_order returned empty
| work_order_id=113468 top_keys=['workOrder'] address_field_type=NoneType
```

So ``GET /work_order/{customer_id}/{work_order_id}.json`` actually
returns ``{"workOrder": {...}}`` (camelCase singular envelope). My
previous fix added ``("work_order", "data")`` to the unwrap list but
missed the camelCase variant; the unwrap was a no-op for this shape
and address extraction returned empty.

### Fix

Add ``"workOrder"`` to ``_WO_TOP_CONTAINERS`` in ``invoices.py``.
That's the literal one-line fix the diagnostic pointed at. Keep the
snake_case ``"work_order"`` and JSON:API ``"data"`` entries as
defensive aliases so a future shape change between any of those
shapes still extracts cleanly.

### Test

Pin a regression test
(``test_address_from_work_order_unwraps_camelcase_envelope``) to the
exact envelope key the diagnostic surfaced, with the full nested
camelCase address shape we observed in production. The previous
``unwraps_envelope`` test (snake_case only) was renamed to
``unwraps_snake_case_envelope`` for symmetry.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass
- [x] Lint passes
- [x] Type checking passes
- [x] Bug fix includes regression test pinned to the exact production envelope key

## AI Usage
- [x] AI-assisted: drafted by Claude (Opus 4.7) after the v0.4.8 diagnostic warning surfaced the actual response shape on jesse's third invoice retry.