### PR TITLE
fix(appfolio): collapse line totals before invoice POST + show breakdown in approval prompt

### DIFF
--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -42,15 +42,75 @@ def _line_items_total(items: list[AppFolioInvoiceLineItem]) -> float:
 
 
 def _line_items_to_payload(items: list[AppFolioInvoiceLineItem]) -> list[dict[str, Any]]:
-    """Match the SPA's invoice line-item shape exactly.
+    """Match the SPA's invoice line-item shape.
 
-    SPA sends ``{amount, description, quantity}`` with ``quantity`` as a
-    string. AppFolio's API rejects payloads with the older ``rate`` key.
+    AppFolio's API treats the wire ``amount`` as the **line total**, not
+    the unit price; ``quantity`` is informational on their side. A real
+    submission with ``{quantity: 5, amount: 55}`` posted a line total of
+    ``$55``, not the ``$275`` the user intended, while our tool happily
+    reported ``$275`` to the agent because ``_line_items_total`` did the
+    multiplication locally. To match the user's mental model (and the
+    SPA, which multiplies client-side before sending) we expose
+    ``amount`` as the per-unit price and multiply by quantity here so
+    the wire payload carries the line total AppFolio actually stores.
+
+    ``quantity`` stays on the wire as a string because the SPA capture
+    showed it that way, but it does not affect the stored amount.
     """
     return [
-        {"amount": i.amount, "description": i.description, "quantity": str(i.quantity)}
+        {
+            "amount": i.amount * i.quantity,
+            "description": i.description,
+            "quantity": str(i.quantity),
+        }
         for i in items
     ]
+
+
+def _format_invoice_approval_description(args: dict[str, Any]) -> str:
+    """Render a multi-line approval prompt that names every line item.
+
+    The default builder used to print only ``"Create invoice on AppFolio
+    work order #X (N line item(s))"``, which let an invoice slip
+    through with the wrong per-line math because the user could not see
+    quantity, unit price, or total before approving. Surfacing each
+    line as ``qty x $unit = $line_total`` (and the grand total) makes
+    the approval prompt the last place a billing mistake can be caught
+    before it hits AppFolio.
+
+    Falls back to the original short form if any line item is malformed
+    so the prompt never crashes; the agent's own typed validation will
+    reject the bad call after approval anyway.
+    """
+    wo_id = args.get("work_order_id", "?")
+    items = args.get("line_items") or []
+
+    parsed: list[tuple[str, float, float, float]] = []
+    grand_total = 0.0
+    for item in items:
+        if not isinstance(item, dict):
+            return f"Create invoice on AppFolio work order #{wo_id} ({len(items)} line item(s))"
+        try:
+            description = str(item.get("description") or "(no description)")
+            quantity = float(item.get("quantity", 1) or 1)
+            amount = float(item.get("amount", 0) or 0)
+        except (TypeError, ValueError):
+            return f"Create invoice on AppFolio work order #{wo_id} ({len(items)} line item(s))"
+        line_total = quantity * amount
+        grand_total += line_total
+        parsed.append((description, quantity, amount, line_total))
+
+    if not parsed:
+        return f"Create invoice on AppFolio work order #{wo_id} (no line items)"
+
+    header = f"Create invoice on AppFolio work order #{wo_id} for ${grand_total:.2f}"
+    lines = [header]
+    for idx, (description, quantity, amount, line_total) in enumerate(parsed, start=1):
+        short = description if len(description) <= 80 else description[:77] + "..."
+        # ``:g`` drops trailing ``.0`` so ``5.0`` reads as ``5`` while
+        # leaving genuine fractional quantities (e.g. ``1.5``) intact.
+        lines.append(f"  {idx}. {short} | qty {quantity:g} x ${amount:.2f} = ${line_total:.2f}")
+    return "\n".join(lines)
 
 
 # Canonical SPA address keys (in print order) mapped to the field names
@@ -347,11 +407,7 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
-                description_builder=lambda args: (
-                    f"Create invoice on AppFolio work order"
-                    f" #{args.get('work_order_id', '?')}"
-                    f" ({len(args.get('line_items') or [])} line item(s))"
-                ),
+                description_builder=_format_invoice_approval_description,
             ),
         ),
         Tool(

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -163,7 +163,12 @@ class AppFolioInvoiceLineItem(BaseModel):
     description: str = Field(description="Line-item description (e.g. 'Labor: 4hr').")
     quantity: float = Field(default=1.0, description="Quantity (decimal supported).")
     amount: float = Field(
-        description="Per-unit amount in dollars (the SPA calls this 'amount', not 'rate').",
+        description=(
+            "Per-unit price in dollars. The line total (quantity x amount)"
+            " is what AppFolio actually stores, so a labor line of 5 hours"
+            " at $55/hr should be sent as quantity=5, amount=55, not"
+            " quantity=1, amount=275."
+        ),
     )
 
 

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -708,11 +708,15 @@ class AppFolioVendorService:
         city, state, zip_code}, reference_number}``
 
         ``line_items`` entries use ``amount`` (not ``rate``) and the SPA sends
-        ``quantity`` as a string. ``address`` is sourced from the work-order
-        location and is part of the SPA's payload; we pass it through so the
-        invoice prints the correct property block. ``reference_number`` is
-        the vendor-side invoice number (the SPA auto-suggests one based on
-        the WO).
+        ``quantity`` as a string. The wire ``amount`` is the **line total**
+        (unit price * quantity); AppFolio stores it as-is and does not
+        re-multiply by ``quantity``. The line-itemized tool wrapper does
+        the multiplication before calling this method, so callers passing
+        their own ``line_items`` dicts must do the same. ``address`` is
+        sourced from the work-order location and is part of the SPA's
+        payload; we pass it through so the invoice prints the correct
+        property block. ``reference_number`` is the vendor-side invoice
+        number (the SPA auto-suggests one based on the WO).
 
         ``customer_id`` is optional. Pass ``None`` to resolve the canonical
         property-manager ID from ``/profiles/me``; this is the safe default

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1679,6 +1679,169 @@ async def test_create_invoice_tool_falls_back_when_customer_id_scope_rejected() 
 
 
 # ---------------------------------------------------------------------------
+# Wire-shape: amount * quantity collapsed before POST
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_tool_sends_line_total_not_unit_price() -> None:
+    """The tool wrapper multiplies quantity by amount before POST.
+
+    Regression for a real billing miscount: a user submitted an invoice
+    with ``{quantity: 5, amount: 55}`` expecting a $275 line total. Our
+    tool reported $275 to the user but sent ``amount=55`` on the wire,
+    and AppFolio stored that as the line total ($55). The tool now
+    pre-multiplies on our side so AppFolio's stored line total matches
+    what the user (and the tool's own success message) believes.
+    """
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    service.get_work_order = AsyncMock(  # type: ignore[method-assign]
+        return_value={"id": 42, "address_1": "123 Example Street"}
+    )
+    create_invoice = AsyncMock(return_value={"id": "inv-1"})
+    service.create_invoice = create_invoice  # type: ignore[method-assign]
+
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    tools = build_invoice_tools(service, ctx)
+    create = next(t for t in tools if t.name == "appfolio_create_invoice")
+    result = await create.function(
+        customer_id="cust-1",
+        work_order_id="42",
+        line_items=[
+            {"description": "Materials reimbursement", "quantity": 1.0, "amount": 39.07},
+            {"description": "Labor", "quantity": 5.0, "amount": 55.0},
+        ],
+    )
+    assert result.is_error is False
+    create_invoice.assert_awaited_once()
+    assert create_invoice.call_args is not None
+    wire_items = create_invoice.call_args.kwargs["line_items"]
+    assert wire_items[0]["amount"] == pytest.approx(39.07)
+    assert wire_items[0]["quantity"] == "1.0"
+    # The fix: line 2 wire amount is qty * unit_price, not just unit_price.
+    assert wire_items[1]["amount"] == pytest.approx(275.0)
+    assert wire_items[1]["quantity"] == "5.0"
+    # User-facing total still matches what AppFolio will store.
+    assert "$314.07" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_tool_fractional_quantity_collapses_correctly() -> None:
+    """Decimal quantities multiply too (e.g. 1.5 hours at $80/hr = $120)."""
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    service.get_work_order = AsyncMock(  # type: ignore[method-assign]
+        return_value={"id": 42, "address_1": "123 Example Street"}
+    )
+    create_invoice = AsyncMock(return_value={"id": "inv-1"})
+    service.create_invoice = create_invoice  # type: ignore[method-assign]
+
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+
+    tools = build_invoice_tools(service, ctx)
+    create = next(t for t in tools if t.name == "appfolio_create_invoice")
+    await create.function(
+        customer_id="cust-1",
+        work_order_id="42",
+        line_items=[{"description": "Labor", "quantity": 1.5, "amount": 80.0}],
+    )
+    create_invoice.assert_awaited_once()
+    assert create_invoice.call_args is not None
+    wire_items = create_invoice.call_args.kwargs["line_items"]
+    assert wire_items[0]["amount"] == pytest.approx(120.0)
+    assert wire_items[0]["quantity"] == "1.5"
+
+
+# ---------------------------------------------------------------------------
+# Approval prompt: line-item breakdown so users catch billing mistakes
+# ---------------------------------------------------------------------------
+
+
+def test_create_invoice_approval_description_lists_each_line_with_total() -> None:
+    """The approval prompt must show qty x unit = line total per item.
+
+    Before this change the prompt read "Create invoice on AppFolio work
+    order #X (N line item(s))", which let an invoice with the wrong
+    per-line math slip through unchallenged. The new prompt names every
+    line and prints the grand total so users can sanity-check before
+    typing yes.
+    """
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _format_invoice_approval_description,
+    )
+
+    description = _format_invoice_approval_description(
+        {
+            "work_order_id": "114433",
+            "line_items": [
+                {"description": "Materials reimbursement", "quantity": 1, "amount": 39.07},
+                {
+                    "description": "Adjusted door for tighter closing",
+                    "quantity": 5,
+                    "amount": 55.0,
+                },
+            ],
+        }
+    )
+    # Header carries WO and grand total.
+    assert "#114433" in description
+    assert "$314.07" in description
+    # Each line is enumerated with qty / unit / line total.
+    assert "Materials reimbursement" in description
+    assert "qty 1 x $39.07 = $39.07" in description
+    assert "Adjusted door for tighter closing" in description
+    assert "qty 5 x $55.00 = $275.00" in description
+
+
+def test_create_invoice_approval_description_truncates_long_descriptions() -> None:
+    """Very long line descriptions are truncated so the prompt stays scannable."""
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _format_invoice_approval_description,
+    )
+
+    long = "Adjusted door, weather stripping, new lock, transition strip, " * 5
+    description = _format_invoice_approval_description(
+        {
+            "work_order_id": "1",
+            "line_items": [{"description": long, "quantity": 1, "amount": 100.0}],
+        }
+    )
+    # Truncated form ends with an ellipsis and is shorter than the input.
+    assert "..." in description
+    assert long not in description
+
+
+def test_create_invoice_approval_description_falls_back_on_malformed_items() -> None:
+    """A malformed line item must not raise from the description builder.
+
+    The agent's typed validation will reject the call after approval; the
+    prompt just needs to render *something* readable so the approval flow
+    does not crash.
+    """
+    from backend.app.integrations.appfolio_vendor.invoices import (
+        _format_invoice_approval_description,
+    )
+
+    description = _format_invoice_approval_description(
+        {
+            "work_order_id": "1",
+            "line_items": [{"description": "ok", "quantity": "not-a-number", "amount": 1}],
+        }
+    )
+    # Falls back to the short legacy form rather than raising.
+    assert "#1" in description
+    assert "1 line item" in description
+
+
+# ---------------------------------------------------------------------------
 # Logging diagnostics — failure paths surface enough info to debug
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Two related billing-accuracy bugs in the AppFolio Vendor Portal invoice flow, surfaced from a real submission where the agent told the user it had posted a `$314.07` invoice but AppFolio actually stored `$94.07`.

**1. Wire-shape mismatch.** AppFolio's `amount` field on a line item is the **line total**, not the unit price; `quantity` is informational on their side and does not re-multiply. A submission with `{quantity: 5, amount: 55}` posted a line total of `$55` (not `$275`), while our `_line_items_total` happily reported `$275` to the user because it did the multiplication locally. Fix: pre-multiply on our side in `_line_items_to_payload` so the wire `amount` carries the line total AppFolio actually stores. The tool's `amount` param keeps meaning "per-unit price" so the LLM and user can keep thinking in `qty x unit`; the transformation is contained.

**2. Approval prompt was opaque.** The default approval description read `Create invoice on AppFolio work order #X (N line item(s))` with no quantities, amounts, or total, so an invoice with the wrong per-line math could be approved blind. Replace with a multi-line builder that names every line as `qty x $unit = $line_total` and surfaces the grand total. Falls back to the legacy short form on malformed line items so the prompt never crashes.

Also updates the LLM-facing `AppFolioInvoiceLineItem.amount` docstring and `service.create_invoice` docstring to call out the wire semantics directly so future readers do not re-derive the same bug.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2554 passed, 2 skipped
- [x] Lint passes
- [x] New tests added (5 new: line-total wire shape, fractional quantity, approval breakdown, long-description truncation, malformed-input fallback)
- [x] Bug fixes include regression tests (pinned to the exact `(qty=5, amount=55)` shape that surfaced this)

## AI Usage
- [x] AI-assisted: drafted by Claude through back-and-forth with @njbrake debugging the live failure (admin log inspection, conversation-turn diffing, and root-cause walkthrough). Reasoning and approval are mine; prose is Claude's.
