### PR TITLE
fix(admin-compact): surface previous_event_id on no-op so retries are unambiguous

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -411,12 +411,45 @@ async def get_or_create_conversation(user_id: str) -> tuple[SessionState, bool]:
 
 
 class AdminCompactionResult(BaseModel):
-    """Outcome of an admin-triggered context compaction."""
+    """Outcome of an admin-triggered context compaction.
+
+    ``event_id`` is the row this call wrote and is non-null only when this
+    call did real work. ``previous_event_id`` is populated only on no-op
+    returns and points at the most recent prior ``CompactionEvent`` for
+    the user (if any). The two together let an admin tell apart three
+    states that previously all rendered as the same all-null no-op:
+
+    * ``event_id != None``: this call did the work; ignore previous_event_id.
+    * ``event_id is None`` and ``previous_event_id != None``: this call
+      was a no-op because that prior event already advanced the
+      watermark. Common when the admin retries within seconds of a
+      successful first call.
+    * Both ``None``: the user has never been compacted; nothing to do.
+    """
 
     compacted_message_count: int
     new_watermark: int | None
     memory_updated: bool
     event_id: int | None
+    previous_event_id: int | None = None
+
+
+async def _most_recent_compaction_event_id(user_id: str) -> int | None:
+    """Return the most recent ``CompactionEvent.id`` for ``user_id``, or None.
+
+    Used by :func:`admin_compact_visible_messages` to disambiguate no-op
+    returns; see ``AdminCompactionResult`` for the call-site rationale.
+    Read-only, no side effects.
+    """
+    async with db_session_async() as db:
+        return (
+            await db.execute(
+                select(CompactionEvent.id)
+                .filter_by(user_id=user_id)
+                .order_by(CompactionEvent.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
 
 
 async def admin_compact_visible_messages(
@@ -475,6 +508,7 @@ async def admin_compact_visible_messages(
             new_watermark=state.last_trim_seq,
             memory_updated=False,
             event_id=None,
+            previous_event_id=await _most_recent_compaction_event_id(user_id),
         )
 
     agent_messages = _stored_messages_to_agent_messages(to_compact_stored)
@@ -489,6 +523,7 @@ async def admin_compact_visible_messages(
             new_watermark=max_seq,
             memory_updated=False,
             event_id=None,
+            previous_event_id=await _most_recent_compaction_event_id(user_id),
         )
 
     # Mirror ``_seqs_from_dropped``: only ``UserMessage`` /
@@ -502,6 +537,7 @@ async def admin_compact_visible_messages(
             new_watermark=state.last_trim_seq,
             memory_updated=False,
             event_id=None,
+            previous_event_id=await _most_recent_compaction_event_id(user_id),
         )
     min_seq = min(seqs)
     max_seq = max(seqs)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1868,6 +1868,8 @@ async def test_admin_compact_visible_messages_no_visible_returns_zero(
     assert result.new_watermark == 5
     assert result.memory_updated is False
     assert result.event_id is None
+    # User has never been compacted, so the no-op carries no previous_event_id.
+    assert result.previous_event_id is None
 
     async with db_session_async() as db:
         events = (
@@ -1876,6 +1878,43 @@ async def test_admin_compact_visible_messages_no_visible_returns_zero(
             .all()
         )
         assert events == []
+
+
+@pytest.mark.asyncio()
+async def test_admin_compact_visible_messages_no_op_surfaces_previous_event_id(
+    test_user: User,
+) -> None:
+    """A no-op retry must surface the most recent prior CompactionEvent.id.
+
+    Regression for issue #1291: an admin firing compact-now twice in
+    quick succession used to see the second call return all-null fields,
+    which was indistinguishable from a fresh "nothing to do" call. The
+    second call now sets ``previous_event_id`` to the prior event's id
+    so admin tooling can tell apart "you already did this" from
+    "there was never anything to do".
+    """
+    await _seed_session_with_messages(test_user, message_count=5)
+
+    # First call: real work; produces a CompactionEvent row.
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("## Notes\n- compacted", 5)),
+    ):
+        first = await admin_compact_visible_messages(test_user.id)
+    assert first.event_id is not None
+    assert first.previous_event_id is None
+
+    # Second call: same conversation, watermark already advanced — no-op.
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("", None)),
+    ) as mock_compact:
+        second = await admin_compact_visible_messages(test_user.id)
+
+    mock_compact.assert_not_awaited()
+    assert second.compacted_message_count == 0
+    assert second.event_id is None
+    assert second.previous_event_id == first.event_id
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
Closes #1291.

## Description

When `admin_compact_visible_messages` returned the all-null no-op shape (`compacted_message_count: 0, event_id: null, memory_updated: false`), the caller could not tell apart two states:

1. There genuinely was nothing to compact (no messages above the trim watermark, user has never been compacted).
2. A prior compaction had just advanced the watermark, so this call correctly returned a no-op because the work was already done.

Hit this in practice when a CLI client ate stdout on the first POST, the admin retried thinking the first call had failed, and the second response carried zero signal that the first had actually done the work.

## Fix

Adds `AdminCompactionResult.previous_event_id`, populated only on no-op returns from a small read-only helper that fetches the most recent `CompactionEvent.id` for the user. The success path leaves it `None` (`event_id` is the only signal callers need there). All three no-op early returns surface it: watermark-already-covers, filtered-only-rows, and seq-less message set.

The shape now disambiguates three states cleanly:

| event_id | previous_event_id | Meaning |
|---|---|---|
| not None | None | This call did the work |
| None | not None | No-op; the prior event already advanced the watermark |
| None | None | User has never been compacted |

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (75 in `tests/test_compaction.py`, including 1 new + 1 extended)
- [x] Lint, format, type-check pass
- [x] Bug fixes include regression tests (the new test pins both call sequences end-to-end)

## AI Usage
- [x] AI-assisted: drafted by Claude as a follow-up to issue #1291 which I (njbrake) filed earlier today after observing the ambiguity in production. Reasoning and approval are mine; prose is Claude's.
