### PR TITLE
feat(quickbooks): show line-item breakdown in qb_create/qb_update approval prompt

### DIFF
--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -321,6 +321,101 @@ def _extract_entity_type(args: dict[str, Any]) -> str | None:
     return str(args["entity_type"]) if args.get("entity_type") else None
 
 
+# Entity types whose payload carries a ``Line`` array we render in the
+# approval prompt. Customer payloads do not have line items, so they
+# stay on the short legacy form.
+_LINE_ITEMIZED_ENTITIES: frozenset[str] = frozenset({"Invoice", "Estimate"})
+
+
+def _format_qb_write_approval_description(verb: str, args: dict[str, Any]) -> str:
+    """Render a multi-line approval prompt that names every line item.
+
+    The default builder used to print only ``"Create Invoice in
+    QuickBooks"``, which let a billing action slip through with the
+    wrong per-line math because the user could not see quantity, unit
+    price, or total before approving. Surfacing each line as
+    ``qty x $unit = $line_total`` (and the grand total) makes the
+    approval prompt the last place a mistake can be caught before
+    QuickBooks stores it. Mirrors the AppFolio fix in #1292.
+
+    Falls back to the short form (``"<verb> <entity_type> in
+    QuickBooks"``) for entity types without line items (Customer) and
+    on any malformed payload, so the prompt never crashes; the agent's
+    own typed validation will reject a bad call after approval anyway.
+
+    ``verb`` is "Create" or "Update". For Update the header includes
+    the entity Id so an admin reviewing audit logs can trace which row
+    was edited.
+    """
+    entity_type = str(args.get("entity_type") or "entity")
+    data = args.get("data") or {}
+    if not isinstance(data, dict):
+        return f"{verb} {entity_type} in QuickBooks"
+
+    short_form = f"{verb} {entity_type} in QuickBooks"
+    if verb == "Update":
+        entity_id = data.get("Id")
+        if entity_id:
+            short_form = f"{verb} {entity_type} #{entity_id} in QuickBooks"
+
+    if entity_type not in _LINE_ITEMIZED_ENTITIES:
+        return short_form
+
+    lines_raw = data.get("Line")
+    if not isinstance(lines_raw, list) or not lines_raw:
+        return short_form
+
+    parsed: list[tuple[str, float | None, float | None, float]] = []
+    grand_total = 0.0
+    for line in lines_raw:
+        if not isinstance(line, dict):
+            return short_form
+        try:
+            amount = float(line.get("Amount", 0) or 0)
+        except (TypeError, ValueError):
+            return short_form
+        description = str(line.get("Description") or "(no description)")
+        detail = line.get("SalesItemLineDetail")
+        qty: float | None = None
+        unit_price: float | None = None
+        if isinstance(detail, dict):
+            try:
+                if detail.get("Qty") is not None:
+                    qty = float(detail["Qty"])
+                if detail.get("UnitPrice") is not None:
+                    unit_price = float(detail["UnitPrice"])
+            except (TypeError, ValueError):
+                qty = None
+                unit_price = None
+        grand_total += amount
+        parsed.append((description, qty, unit_price, amount))
+
+    if not parsed:
+        return short_form
+
+    if verb == "Update":
+        entity_id = data.get("Id")
+        if entity_id:
+            header = f"{verb} {entity_type} #{entity_id} in QuickBooks for ${grand_total:.2f}"
+        else:
+            header = f"{verb} {entity_type} in QuickBooks for ${grand_total:.2f}"
+    else:
+        header = f"{verb} {entity_type} in QuickBooks for ${grand_total:.2f}"
+
+    rendered = [header]
+    for idx, (description, qty, unit_price, amount) in enumerate(parsed, start=1):
+        short_desc = description if len(description) <= 80 else description[:77] + "..."
+        if qty is not None and unit_price is not None:
+            # ``:g`` drops trailing ``.0`` so ``5.0`` reads as ``5`` while
+            # leaving genuine fractional quantities (e.g. ``1.5``) intact.
+            rendered.append(
+                f"  {idx}. {short_desc} | qty {qty:g} x ${unit_price:.2f} = ${amount:.2f}"
+            )
+        else:
+            rendered.append(f"  {idx}. {short_desc} | ${amount:.2f}")
+    return "\n".join(rendered)
+
+
 # Entity types that have a public QBO web UI page we can deep-link to.
 _WEB_LINKABLE_ENTITIES: dict[str, str] = {
     "Invoice": "invoice",
@@ -593,8 +688,8 @@ def create_quickbooks_tools(
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
                 resource_extractor=_extract_entity_type,
-                description_builder=lambda args: (
-                    f"Create {args.get('entity_type', 'entity')} in QuickBooks"
+                description_builder=lambda args: _format_qb_write_approval_description(
+                    "Create", args
                 ),
             ),
         ),
@@ -615,8 +710,8 @@ def create_quickbooks_tools(
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
                 resource_extractor=_extract_entity_type,
-                description_builder=lambda args: (
-                    f"Update {args.get('entity_type', 'entity')} in QuickBooks"
+                description_builder=lambda args: _format_qb_write_approval_description(
+                    "Update", args
                 ),
             ),
         ),

--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -333,14 +333,18 @@ def _qb_approval_header(verb: str, entity_type: str, entity_id: Any, total: floa
     Update headers include ``#{Id}`` (when available) so audit-log review
     can trace which row was edited; Create headers do not because the
     id only exists after QBO assigns one on the POST response. When
-    ``total`` is set, the header appends ``for ${total:.2f}``.
+    ``total`` is set, the header appends ``for ${total:,.2f}``.
+
+    Thousands separator matches ``_receipt_target`` so the same invoice
+    formats consistently across the approval prompt and the post-write
+    ToolReceipt.
     """
     pieces = [f"{verb} {entity_type}"]
     if verb == "Update" and entity_id:
         pieces[0] = f"{pieces[0]} #{entity_id}"
     pieces.append("in QuickBooks")
     if total is not None:
-        pieces.append(f"for ${total:.2f}")
+        pieces.append(f"for ${total:,.2f}")
     return " ".join(pieces)
 
 
@@ -417,10 +421,10 @@ def _format_qb_write_approval_description(verb: str, args: dict[str, Any]) -> st
             # ``:g`` drops trailing ``.0`` so ``5.0`` reads as ``5`` while
             # leaving genuine fractional quantities (e.g. ``1.5``) intact.
             rendered.append(
-                f"  {idx}. {short_desc} | qty {qty:g} x ${unit_price:.2f} = ${amount:.2f}"
+                f"  {idx}. {short_desc} | qty {qty:g} x ${unit_price:,.2f} = ${amount:,.2f}"
             )
         else:
-            rendered.append(f"  {idx}. {short_desc} | ${amount:.2f}")
+            rendered.append(f"  {idx}. {short_desc} | ${amount:,.2f}")
     return "\n".join(rendered)
 
 

--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -327,6 +327,23 @@ def _extract_entity_type(args: dict[str, Any]) -> str | None:
 _LINE_ITEMIZED_ENTITIES: frozenset[str] = frozenset({"Invoice", "Estimate"})
 
 
+def _qb_approval_header(verb: str, entity_type: str, entity_id: Any, total: float | None) -> str:
+    """Build the first line of a qb_create / qb_update approval prompt.
+
+    Update headers include ``#{Id}`` (when available) so audit-log review
+    can trace which row was edited; Create headers do not because the
+    id only exists after QBO assigns one on the POST response. When
+    ``total`` is set, the header appends ``for ${total:.2f}``.
+    """
+    pieces = [f"{verb} {entity_type}"]
+    if verb == "Update" and entity_id:
+        pieces[0] = f"{pieces[0]} #{entity_id}"
+    pieces.append("in QuickBooks")
+    if total is not None:
+        pieces.append(f"for ${total:.2f}")
+    return " ".join(pieces)
+
+
 def _format_qb_write_approval_description(verb: str, args: dict[str, Any]) -> str:
     """Render a multi-line approval prompt that names every line item.
 
@@ -346,34 +363,34 @@ def _format_qb_write_approval_description(verb: str, args: dict[str, Any]) -> st
     ``verb`` is "Create" or "Update". For Update the header includes
     the entity Id so an admin reviewing audit logs can trace which row
     was edited.
+
+    Trusts that ``args`` came from ``QBCreateParams`` / ``QBUpdateParams``
+    (Pydantic-validated upstream), so ``args["data"]`` is a dict;
+    line-shape tolerance below is for the LLM's freeform payload
+    *inside* ``data``, not for the param envelope itself.
     """
     entity_type = str(args.get("entity_type") or "entity")
-    data = args.get("data") or {}
-    if not isinstance(data, dict):
-        return f"{verb} {entity_type} in QuickBooks"
+    data: dict[str, Any] = args.get("data") or {}
+    entity_id = data.get("Id")
 
-    short_form = f"{verb} {entity_type} in QuickBooks"
-    if verb == "Update":
-        entity_id = data.get("Id")
-        if entity_id:
-            short_form = f"{verb} {entity_type} #{entity_id} in QuickBooks"
+    short_header = _qb_approval_header(verb, entity_type, entity_id, total=None)
 
     if entity_type not in _LINE_ITEMIZED_ENTITIES:
-        return short_form
+        return short_header
 
     lines_raw = data.get("Line")
     if not isinstance(lines_raw, list) or not lines_raw:
-        return short_form
+        return short_header
 
     parsed: list[tuple[str, float | None, float | None, float]] = []
     grand_total = 0.0
     for line in lines_raw:
         if not isinstance(line, dict):
-            return short_form
+            return short_header
         try:
             amount = float(line.get("Amount", 0) or 0)
         except (TypeError, ValueError):
-            return short_form
+            return short_header
         description = str(line.get("Description") or "(no description)")
         detail = line.get("SalesItemLineDetail")
         qty: float | None = None
@@ -391,18 +408,9 @@ def _format_qb_write_approval_description(verb: str, args: dict[str, Any]) -> st
         parsed.append((description, qty, unit_price, amount))
 
     if not parsed:
-        return short_form
+        return short_header
 
-    if verb == "Update":
-        entity_id = data.get("Id")
-        if entity_id:
-            header = f"{verb} {entity_type} #{entity_id} in QuickBooks for ${grand_total:.2f}"
-        else:
-            header = f"{verb} {entity_type} in QuickBooks for ${grand_total:.2f}"
-    else:
-        header = f"{verb} {entity_type} in QuickBooks for ${grand_total:.2f}"
-
-    rendered = [header]
+    rendered = [_qb_approval_header(verb, entity_type, entity_id, total=grand_total)]
     for idx, (description, qty, unit_price, amount) in enumerate(parsed, start=1):
         short_desc = description if len(description) <= 80 else description[:77] + "..."
         if qty is not None and unit_price is not None:

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -884,6 +884,41 @@ def test_qb_update_approval_description_customer_short_form_includes_id() -> Non
     assert description == "Update Customer #100 in QuickBooks"
 
 
+def test_qb_create_approval_description_uses_thousands_separator() -> None:
+    """Currency formatting matches ``_receipt_target``: thousands
+    separator on every dollar amount so the same invoice reads the
+    same in the approval prompt and the post-write ToolReceipt.
+    """
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    description = builder(
+        {
+            "entity_type": "Invoice",
+            "data": {
+                "Line": [
+                    {
+                        "Amount": 12345.67,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": "Kitchen remodel",
+                        "SalesItemLineDetail": {"Qty": 1, "UnitPrice": 12345.67},
+                    },
+                    {
+                        "Amount": 2500.00,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": "Materials",
+                        "SalesItemLineDetail": {"Qty": 1, "UnitPrice": 2500.00},
+                    },
+                ],
+            },
+        }
+    )
+    assert "Create Invoice in QuickBooks for $14,845.67" in description
+    assert "qty 1 x $12,345.67 = $12,345.67" in description
+    assert "qty 1 x $2,500.00 = $2,500.00" in description
+
+
 def test_qb_create_approval_description_survives_format_approval_message() -> None:
     """The multi-line breakdown must pass through ``format_approval_message``
     intact (line items still visible, header still in place) so the

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -882,3 +882,49 @@ def test_qb_update_approval_description_customer_short_form_includes_id() -> Non
         }
     )
     assert description == "Update Customer #100 in QuickBooks"
+
+
+def test_qb_create_approval_description_survives_format_approval_message() -> None:
+    """The multi-line breakdown must pass through ``format_approval_message``
+    intact (line items still visible, header still in place) so the
+    user sees the breakdown in their actual channel, not just in a
+    unit-test assertion. Belt-and-suspenders for the approval pipeline.
+    """
+    from backend.app.agent.approval import format_approval_message
+
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    description = builder(
+        {
+            "entity_type": "Invoice",
+            "data": {
+                "CustomerRef": {"value": "16", "name": "Acme Plumbing"},
+                "Line": [
+                    {
+                        "Amount": 39.07,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": "Materials reimbursement",
+                        "SalesItemLineDetail": {"Qty": 1, "UnitPrice": 39.07},
+                    },
+                    {
+                        "Amount": 275.00,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": "Labor",
+                        "SalesItemLineDetail": {"Qty": 5, "UnitPrice": 55.00},
+                    },
+                ],
+            },
+        }
+    )
+    prompt = format_approval_message("qb_create", description)
+
+    # The header and every line item must survive the wrapping.
+    assert "Create Invoice in QuickBooks for $314.07" in prompt
+    assert "qty 1 x $39.07 = $39.07" in prompt
+    assert "qty 5 x $55.00 = $275.00" in prompt
+    # And the prompt still ends with the four-option menu so the
+    # multi-line description has not stomped the reply instructions.
+    assert "yes: allow this once" in prompt
+    assert "never: deny and remember" in prompt

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -657,3 +657,228 @@ async def test_invariant_no_url_duplication_across_qb_tools() -> None:
                 "tool result inlined receipt URL into content "
                 f"(content={result.content!r}, url={result.receipt.url!r})"
             )
+
+
+# ---------------------------------------------------------------------------
+# Approval prompt: line-item breakdown so users catch billing mistakes
+# ---------------------------------------------------------------------------
+
+
+def _get_description_builder(tools: list, name: str) -> Any:
+    for t in tools:
+        if t.name == name:
+            assert t.approval_policy is not None
+            assert t.approval_policy.description_builder is not None
+            return t.approval_policy.description_builder
+    raise KeyError(f"Tool {name} not found")
+
+
+def test_qb_create_approval_description_renders_invoice_line_items() -> None:
+    """The qb_create approval prompt for an Invoice must show qty x unit
+    = line total per item plus a grand total, mirroring the AppFolio fix
+    in #1292.
+    """
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    description = builder(
+        {
+            "entity_type": "Invoice",
+            "data": {
+                "CustomerRef": {"value": "16", "name": "Acme Plumbing"},
+                "Line": [
+                    {
+                        "Amount": 39.07,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": "Materials reimbursement",
+                        "SalesItemLineDetail": {"Qty": 1, "UnitPrice": 39.07},
+                    },
+                    {
+                        "Amount": 275.00,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": "Labor",
+                        "SalesItemLineDetail": {"Qty": 5, "UnitPrice": 55.00},
+                    },
+                ],
+            },
+        }
+    )
+    assert "Create Invoice in QuickBooks" in description
+    assert "$314.07" in description
+    assert "Materials reimbursement" in description
+    assert "qty 1 x $39.07 = $39.07" in description
+    assert "Labor" in description
+    assert "qty 5 x $55.00 = $275.00" in description
+
+
+def test_qb_create_approval_description_estimate_uses_same_breakdown() -> None:
+    """Estimate payloads share Invoice's line shape and must render
+    the same breakdown."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    description = builder(
+        {
+            "entity_type": "Estimate",
+            "data": {
+                "Line": [
+                    {
+                        "Amount": 600.00,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": "Labor",
+                        "SalesItemLineDetail": {"Qty": 12, "UnitPrice": 50.00},
+                    },
+                ],
+            },
+        }
+    )
+    assert "Create Estimate in QuickBooks for $600.00" in description
+    assert "qty 12 x $50.00 = $600.00" in description
+
+
+def test_qb_create_approval_description_customer_keeps_short_form() -> None:
+    """Customer payloads have no Line array; the prompt must stay the
+    legacy short form rather than render an empty breakdown."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    description = builder(
+        {
+            "entity_type": "Customer",
+            "data": {"DisplayName": "Acme Plumbing", "PrimaryEmailAddr": {"Address": "x@y.z"}},
+        }
+    )
+    assert description == "Create Customer in QuickBooks"
+
+
+def test_qb_create_approval_description_falls_back_without_sales_item_detail() -> None:
+    """A line missing SalesItemLineDetail still renders, using Amount alone."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    description = builder(
+        {
+            "entity_type": "Invoice",
+            "data": {
+                "Line": [
+                    {
+                        "Amount": 100.00,
+                        "DetailType": "DescriptionOnly",
+                        "Description": "Free-form note",
+                    },
+                ],
+            },
+        }
+    )
+    assert "Create Invoice in QuickBooks for $100.00" in description
+    assert "$100.00" in description
+    # No qty/unit breakdown when the detail block is absent.
+    assert "qty" not in description.lower()
+
+
+def test_qb_create_approval_description_truncates_long_descriptions() -> None:
+    """Very long line descriptions are truncated so the prompt stays
+    scannable in a chat channel."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    long = "Lorem ipsum dolor sit amet consectetur adipiscing elit, " * 5
+    description = builder(
+        {
+            "entity_type": "Invoice",
+            "data": {
+                "Line": [
+                    {
+                        "Amount": 100.0,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": long,
+                        "SalesItemLineDetail": {"Qty": 1, "UnitPrice": 100.0},
+                    },
+                ],
+            },
+        }
+    )
+    assert "..." in description
+    assert long not in description
+
+
+def test_qb_create_approval_description_falls_back_on_malformed_payload() -> None:
+    """A malformed payload must not raise from the description builder.
+
+    QBCreateParams validation runs after the approval prompt is rendered,
+    so the prompt has to tolerate bad input rather than crash the
+    approval flow.
+    """
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    # Non-dict line entry should fall back to the short form rather than
+    # raise an AttributeError.
+    description = builder(
+        {
+            "entity_type": "Invoice",
+            "data": {"Line": ["not-a-dict"]},
+        }
+    )
+    assert description == "Create Invoice in QuickBooks"
+
+    # Non-numeric Amount should also fall back rather than blow up
+    # ``float()`` and crash the approval prompt.
+    description = builder(
+        {
+            "entity_type": "Invoice",
+            "data": {"Line": [{"Amount": "not-a-number", "Description": "ok"}]},
+        }
+    )
+    assert description == "Create Invoice in QuickBooks"
+
+
+def test_qb_update_approval_description_includes_entity_id() -> None:
+    """The qb_update prompt must call out which Id is being changed so
+    an admin reviewing audit logs can trace it. Line item breakdown
+    follows the same rules as qb_create."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_update")
+
+    description = builder(
+        {
+            "entity_type": "Estimate",
+            "data": {
+                "Id": "2001",
+                "SyncToken": "0",
+                "Line": [
+                    {
+                        "Amount": 600.00,
+                        "DetailType": "SalesItemLineDetail",
+                        "Description": "Labor (revised)",
+                        "SalesItemLineDetail": {"Qty": 12, "UnitPrice": 50.00},
+                    },
+                ],
+            },
+        }
+    )
+    assert "Update Estimate #2001 in QuickBooks for $600.00" in description
+    assert "qty 12 x $50.00 = $600.00" in description
+
+
+def test_qb_update_approval_description_customer_short_form_includes_id() -> None:
+    """For non-itemized entity types (Customer), the qb_update short
+    form should still reference the Id being updated."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_update")
+
+    description = builder(
+        {
+            "entity_type": "Customer",
+            "data": {"Id": "100", "SyncToken": "1", "DisplayName": "Acme"},
+        }
+    )
+    assert description == "Update Customer #100 in QuickBooks"


### PR DESCRIPTION
Fixes #1294.

## Description

The `qb_create` approval prompt for Invoice and Estimate used to read `Create Invoice in QuickBooks` with no quantities, amounts, or total, so a user had no way to spot-check whether the agent assembled the right numbers before typing `yes`. Same class of UX gap that bit AppFolio in #1292: the agent talks the user through a multi-line invoice in chat, then the approval prompt collapses it to a two-word description and the user approves blind.

Adds `_format_qb_write_approval_description("Create" | "Update", args)` that renders, for line-itemized entities (Invoice, Estimate), a header plus one bullet per line item, and falls back to the short legacy form for Customer (no line items), malformed payloads, and any line whose `Amount` does not parse. Wired into both `qb_create` and `qb_update` approval policies. The Update variant additionally surfaces the entity `Id` in the header so audit-log review can identify which row was edited.

Sample rendered prompt for an Invoice:

```
Create Invoice in QuickBooks for $314.07
  1. Materials reimbursement | qty 1 x $39.07 = $39.07
  2. Labor | qty 5 x $55.00 = $275.00
```

QBO does not have AppFolio's wire-shape pitfall (`Amount` is the line total there by convention, with `Qty` and `UnitPrice` nested under `SalesItemLineDetail` for display), so no math change is needed; this is purely approval-prompt enrichment.

## Type
- [x] Feature
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2563 passed, 2 skipped
- [x] Lint passes
- [x] New tests added (8 new in `tests/test_quickbooks_write.py`: Invoice breakdown, Estimate parity, Customer short form, missing SalesItemLineDetail, long-description truncation, malformed-payload fallback, qb_update Id header, qb_update Customer short form with Id)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: drafted by Claude as a follow-up to #1292's AppFolio approval-prompt fix. The opacity pattern was identified during the same debugging session, then filed and addressed as a separate concern. Reasoning and approval are mine; prose is Claude's.
