### PR TITLE
feat(channels): re-add Twilio as SMS/MMS channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,16 @@ TELEGRAM_ALLOWED_CHAT_ID=
 # BLUEBUBBLES_IMESSAGE_ADDRESS=       # iCloud email or phone shown in the UI for users to text
 # BLUEBUBBLES_BACKFILL_LOOKBACK_MINUTES=30 # On startup, replay iMessages from the last N minutes whose webhook never reached us. 0 disables.
 
+# Twilio (SMS/MMS). Twilio does not expose typing indicators over SMS;
+# the channel's send_typing_indicator is a no-op. For iMessage/RCS with
+# typing indicators, use Linq or BlueBubbles instead.
+# TWILIO_ACCOUNT_SID=                 # Twilio account SID, e.g. "AC..."
+# TWILIO_AUTH_TOKEN=                  # Twilio auth token (used for signature validation + media auth)
+# TWILIO_PHONE_NUMBER=                # E.164 outbound sender, e.g. "+15551234567"
+# TWILIO_MESSAGING_SERVICE_SID=       # "MG..." Use a Messaging Service for US A2P 10DLC. Takes precedence over TWILIO_PHONE_NUMBER.
+# TWILIO_ALLOWED_NUMBERS=             # E.164 phone, "*" for all, empty = deny all
+# TWILIO_VALIDATE_SIGNATURES=true     # Set to false only for local dev. Production must keep this on.
+
 # E2E testing
 # TELEGRAM_TEST_CHAT_ID=
 

--- a/backend/app/channels/__init__.py
+++ b/backend/app/channels/__init__.py
@@ -82,6 +82,18 @@ def reset_channel_clients(updates: Mapping[str, object]) -> None:
         except KeyError:
             pass
 
+    if "twilio_account_sid" in updates or "twilio_auth_token" in updates:
+        try:
+            from backend.app.channels.twilio import TwilioChannel
+
+            channel = _manager.get("twilio")
+            if isinstance(channel, TwilioChannel):
+                channel._account_sid = settings.twilio_account_sid
+                channel._auth_token = settings.twilio_auth_token
+                channel._client = None
+        except KeyError:
+            pass
+
 
 __all__ = [
     "BaseChannel",

--- a/backend/app/channels/twilio.py
+++ b/backend/app/channels/twilio.py
@@ -1,0 +1,241 @@
+"""Twilio channel: inbound webhook + outbound messaging (SMS/MMS)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import Response
+from twilio.request_validator import RequestValidator
+from twilio.rest import Client as TwilioClient
+
+from backend.app.agent.ingestion import InboundMessage
+from backend.app.channels.base import BaseChannel, handle_webhook_inbound
+from backend.app.config import Settings, settings
+from backend.app.media.download import DownloadedMedia, download_bounded, generate_filename
+from backend.app.services.rate_limiter import check_webhook_rate_limit
+
+logger = logging.getLogger(__name__)
+
+TWILIO_SIGNATURE_HEADER = "X-Twilio-Signature"
+# TwiML empty response. Twilio expects a 200 with valid TwiML; an empty
+# <Response/> tells it "do nothing" so the agent loop, which delivers
+# replies via the outbound dispatcher, isn't double-sending.
+TWIML_EMPTY = '<?xml version="1.0" encoding="UTF-8"?><Response/>'
+
+
+class TwilioChannel(BaseChannel):
+    """Twilio implementation combining inbound webhooks and outbound SMS/MMS sending."""
+
+    def __init__(self, svc_settings: Settings | None = None) -> None:
+        s = svc_settings or settings
+        self._account_sid = s.twilio_account_sid
+        self._auth_token = s.twilio_auth_token
+        self._client: TwilioClient | None = None
+
+    @property
+    def client(self) -> TwilioClient:
+        """Lazily create the Twilio REST client.
+
+        Construction is cheap but errors on empty credentials, so we defer
+        until the first send so an unconfigured deployment doesn't crash
+        at import time.
+        """
+        if self._client is None:
+            self._client = TwilioClient(self._account_sid, self._auth_token)
+        return self._client
+
+    # -- BaseChannel identity --------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "twilio"
+
+    # -- Inbound ---------------------------------------------------------------
+
+    @staticmethod
+    def _validate_signature(request: Request, form_data: dict[str, str]) -> bool:
+        """Validate Twilio's ``X-Twilio-Signature`` header.
+
+        Returns ``False`` if validation is enabled and the signature does
+        not match; callers should drop the request silently (200 + empty
+        TwiML) so a probing attacker can't tell whether validation is on.
+        """
+        if not settings.twilio_validate_signatures:
+            return True
+        signature = request.headers.get(TWILIO_SIGNATURE_HEADER, "")
+        validator = RequestValidator(settings.twilio_auth_token)
+        # Twilio signs the exact URL the request arrived at, so reverse
+        # proxies that rewrite the host or scheme will break validation
+        # unless the public URL is reconstructed. ``request.url`` reflects
+        # ASGI's view, which for our PaaS deployments matches the URL
+        # Twilio saw because the proxy sets X-Forwarded-* headers and
+        # Starlette honors them when ``proxy_headers=True`` (the uvicorn
+        # default in our deployment).
+        url = str(request.url)
+        return validator.validate(url, form_data, signature)
+
+    @staticmethod
+    def _extract_media(form_data: dict[str, str]) -> list[tuple[str, str]]:
+        """Pull media URLs + MIME types from Twilio's flat form payload."""
+        try:
+            num_media = int(form_data.get("NumMedia", "0"))
+        except ValueError:
+            return []
+        media: list[tuple[str, str]] = []
+        for i in range(num_media):
+            url = form_data.get(f"MediaUrl{i}", "")
+            content_type = form_data.get(f"MediaContentType{i}", "")
+            if url:
+                media.append((url, content_type or "application/octet-stream"))
+        return media
+
+    async def is_allowed(self, sender_id: str, username: str) -> bool:
+        """Return ``True`` if the sender passes the Twilio allowlist gate.
+
+        In premium mode the ``ChannelRoute`` override resolves this. In
+        OSS mode the static ``twilio_allowed_numbers`` setting applies:
+        empty denies all, ``"*"`` allows all, otherwise the sender must
+        match the configured E.164 number exactly.
+        """
+        return await self._check_static_allowlist(settings.twilio_allowed_numbers, sender_id)
+
+    @staticmethod
+    def parse_form(form_data: dict[str, str]) -> InboundMessage | None:
+        """Parse a Twilio webhook form payload into an ``InboundMessage``.
+
+        Returns ``None`` if the payload is missing the fields we need.
+        """
+        sender = form_data.get("From", "").strip()
+        if not sender:
+            logger.warning("Twilio webhook missing From, ignoring")
+            return None
+
+        body = form_data.get("Body", "")
+        message_sid = form_data.get("MessageSid", "") or form_data.get("SmsMessageSid", "")
+        external_id = f"twilio_{message_sid}" if message_sid else ""
+        media = TwilioChannel._extract_media(form_data)
+
+        return InboundMessage(
+            channel="twilio",
+            sender_id=sender,
+            text=body,
+            media_refs=media,
+            external_message_id=external_id,
+            sender_username=None,
+        )
+
+    def get_router(self) -> APIRouter:
+        """Build a router with the Twilio webhook endpoint."""
+        router = APIRouter()
+        channel = self
+
+        @router.post("/webhooks/twilio")
+        async def twilio_inbound(
+            request: Request,
+            _rate_limit: None = Depends(check_webhook_rate_limit),
+        ) -> Response:
+            """Receive inbound SMS/MMS from Twilio.
+
+            Returns an empty TwiML response immediately; the agent loop
+            replies through the outbound dispatcher via the REST API so
+            this endpoint stays under Twilio's 15s ack window even when
+            the LLM call takes longer.
+            """
+            try:
+                raw_form = await request.form()
+            except Exception:
+                logger.warning("Twilio webhook received unparseable form body")
+                return Response(content=TWIML_EMPTY, media_type="application/xml")
+            form_data = {k: str(v) for k, v in raw_form.items()}
+
+            if not TwilioChannel._validate_signature(request, form_data):
+                logger.warning("Invalid Twilio webhook signature")
+                return Response(content=TWIML_EMPTY, media_type="application/xml")
+
+            inbound = TwilioChannel.parse_form(form_data)
+            await handle_webhook_inbound(channel, inbound)
+            return Response(content=TWIML_EMPTY, media_type="application/xml")
+
+        return router
+
+    # -- Outbound --------------------------------------------------------------
+
+    def _send_kwargs(self, to: str, body: str) -> dict[str, Any]:
+        """Build kwargs for ``messages.create``.
+
+        Pins ``messaging_service_sid`` when configured (the A2P 10DLC
+        path) so Twilio picks an appropriate sender from the campaign
+        pool; otherwise pins ``from_`` to the single configured number.
+        """
+        kwargs: dict[str, Any] = {"to": to, "body": body}
+        if settings.twilio_messaging_service_sid:
+            kwargs["messaging_service_sid"] = settings.twilio_messaging_service_sid
+        elif settings.twilio_phone_number:
+            kwargs["from_"] = settings.twilio_phone_number
+        else:
+            msg = (
+                "Twilio outbound requires either TWILIO_MESSAGING_SERVICE_SID "
+                "or TWILIO_PHONE_NUMBER to be set"
+            )
+            raise RuntimeError(msg)
+        return kwargs
+
+    async def send_text(self, to: str, body: str) -> str:
+        """Send an SMS. *to* is an E.164 phone number. Returns the Twilio Message SID."""
+        kwargs = self._send_kwargs(to, body)
+        message = await asyncio.to_thread(self.client.messages.create, **kwargs)
+        return str(message.sid)
+
+    async def send_media(self, to: str, body: str, media_url: str) -> str:
+        """Send an MMS with one media attachment. Returns the Twilio Message SID."""
+        kwargs = self._send_kwargs(to, body)
+        kwargs["media_url"] = [media_url]
+        message = await asyncio.to_thread(self.client.messages.create, **kwargs)
+        return str(message.sid)
+
+    async def send_message(self, to: str, body: str, media_urls: list[str] | None = None) -> str:
+        """Send SMS or MMS in a single API call.
+
+        Required override: Twilio accepts a list of media URLs on one
+        ``messages.create`` call, so the multi-URL path should be one
+        MMS (up to 10 media items) instead of N separate sends.
+        """
+        if not media_urls:
+            return await self.send_text(to, body)
+        kwargs = self._send_kwargs(to, body)
+        kwargs["media_url"] = list(media_urls)
+        message = await asyncio.to_thread(self.client.messages.create, **kwargs)
+        return str(message.sid)
+
+    async def send_typing_indicator(self, to: str) -> None:
+        """Twilio SMS has no typing-indicator concept. No-op.
+
+        Implemented to satisfy ``BaseChannel`` without sending the user
+        misleading UX. Operators who need typing indicators should pick
+        Linq (iMessage/RCS) or BlueBubbles instead.
+        """
+        return None
+
+    async def download_media(self, file_id: str) -> DownloadedMedia:
+        """Download media from a Twilio MediaUrl.
+
+        For Twilio, ``file_id`` is the full ``MediaUrl{N}`` from the
+        webhook form payload. The URL requires HTTP Basic Auth with the
+        account SID + auth token. Streams with the standard hard size
+        cap and wall-time deadline.
+        """
+        auth = httpx.BasicAuth(self._account_sid, self._auth_token)
+        async with httpx.AsyncClient(auth=auth, timeout=settings.http_timeout_seconds) as client:
+            content, headers = await download_bounded(client, file_id)
+        content_type = headers.get("content-type", "application/octet-stream").split(";")[0]
+        filename = generate_filename(content_type)
+        return DownloadedMedia(
+            content=content,
+            mime_type=content_type,
+            original_url=file_id,
+            filename=filename,
+        )

--- a/backend/app/channels/twilio.py
+++ b/backend/app/channels/twilio.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -25,6 +26,36 @@ TWILIO_SIGNATURE_HEADER = "X-Twilio-Signature"
 # <Response/> tells it "do nothing" so the agent loop, which delivers
 # replies via the outbound dispatcher, isn't double-sending.
 TWIML_EMPTY = '<?xml version="1.0" encoding="UTF-8"?><Response/>'
+
+
+# ---------------------------------------------------------------------------
+# Per-user outbound sender resolver (premium hook)
+# ---------------------------------------------------------------------------
+
+# Premium deployments provision one Twilio number per user; the resolver
+# maps an outbound recipient phone back to that user's own Twilio number
+# so ``send_text``/``send_media`` can pin ``from_`` correctly. OSS leaves
+# the resolver unset and falls back to the single global TWILIO_PHONE_NUMBER
+# / TWILIO_MESSAGING_SERVICE_SID.
+FromResolver = Callable[[str], Awaitable[str | None]]
+
+_from_resolver: FromResolver | None = None
+
+
+def set_twilio_from_resolver(fn: FromResolver) -> None:
+    """Register a callable that returns the per-user ``from_`` for an outbound recipient.
+
+    Called by the premium plugin during startup. ``fn`` receives the
+    recipient phone and returns the user's provisioned Twilio number, or
+    ``None`` to fall back to the global settings.
+    """
+    global _from_resolver
+    _from_resolver = fn
+
+
+def get_twilio_from_resolver() -> FromResolver | None:
+    """Return the current per-user resolver, or ``None`` when unset."""
+    return _from_resolver
 
 
 class TwilioChannel(BaseChannel):
@@ -164,35 +195,54 @@ class TwilioChannel(BaseChannel):
 
     # -- Outbound --------------------------------------------------------------
 
-    def _send_kwargs(self, to: str, body: str) -> dict[str, Any]:
+    @staticmethod
+    async def _resolve_per_user_from(to: str) -> str | None:
+        """Ask the premium resolver for the user's own Twilio number, if any."""
+        resolver = _from_resolver
+        if resolver is None:
+            return None
+        try:
+            return await resolver(to)
+        except Exception:
+            # A resolver failure shouldn't block outbound delivery; fall
+            # back to the global sender. The resolver itself is expected
+            # to log its own failures.
+            logger.exception("Twilio from_resolver raised; falling back to global sender")
+            return None
+
+    def _send_kwargs(self, to: str, body: str, from_override: str | None = None) -> dict[str, Any]:
         """Build kwargs for ``messages.create``.
 
-        Pins ``messaging_service_sid`` when configured (the A2P 10DLC
-        path) so Twilio picks an appropriate sender from the campaign
-        pool; otherwise pins ``from_`` to the single configured number.
+        Precedence: ``from_override`` (per-user, premium) > Messaging
+        Service SID (A2P 10DLC pool) > global ``twilio_phone_number``.
+        Raises ``RuntimeError`` when none is available.
         """
         kwargs: dict[str, Any] = {"to": to, "body": body}
-        if settings.twilio_messaging_service_sid:
+        if from_override:
+            kwargs["from_"] = from_override
+        elif settings.twilio_messaging_service_sid:
             kwargs["messaging_service_sid"] = settings.twilio_messaging_service_sid
         elif settings.twilio_phone_number:
             kwargs["from_"] = settings.twilio_phone_number
         else:
             msg = (
                 "Twilio outbound requires either TWILIO_MESSAGING_SERVICE_SID "
-                "or TWILIO_PHONE_NUMBER to be set"
+                "or TWILIO_PHONE_NUMBER to be set (or a registered per-user resolver)"
             )
             raise RuntimeError(msg)
         return kwargs
 
     async def send_text(self, to: str, body: str) -> str:
         """Send an SMS. *to* is an E.164 phone number. Returns the Twilio Message SID."""
-        kwargs = self._send_kwargs(to, body)
+        from_override = await self._resolve_per_user_from(to)
+        kwargs = self._send_kwargs(to, body, from_override)
         message = await asyncio.to_thread(self.client.messages.create, **kwargs)
         return str(message.sid)
 
     async def send_media(self, to: str, body: str, media_url: str) -> str:
         """Send an MMS with one media attachment. Returns the Twilio Message SID."""
-        kwargs = self._send_kwargs(to, body)
+        from_override = await self._resolve_per_user_from(to)
+        kwargs = self._send_kwargs(to, body, from_override)
         kwargs["media_url"] = [media_url]
         message = await asyncio.to_thread(self.client.messages.create, **kwargs)
         return str(message.sid)
@@ -206,7 +256,8 @@ class TwilioChannel(BaseChannel):
         """
         if not media_urls:
             return await self.send_text(to, body)
-        kwargs = self._send_kwargs(to, body)
+        from_override = await self._resolve_per_user_from(to)
+        kwargs = self._send_kwargs(to, body, from_override)
         kwargs["media_url"] = list(media_urls)
         message = await asyncio.to_thread(self.client.messages.create, **kwargs)
         return str(message.sid)

--- a/backend/app/channels/twilio.py
+++ b/backend/app/channels/twilio.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, Request
@@ -27,19 +28,38 @@ TWILIO_SIGNATURE_HEADER = "X-Twilio-Signature"
 # replies via the outbound dispatcher, isn't double-sending.
 TWIML_EMPTY = '<?xml version="1.0" encoding="UTF-8"?><Response/>'
 
+# Hostnames we will issue authenticated media downloads against. Twilio's
+# media URLs all live on these two subdomains; anything else is a
+# misconfiguration or an attacker trying to exfiltrate the account-SID
+# Basic Auth header via SSRF. The check defends the off-prod path where
+# ``twilio_validate_signatures`` is disabled (otherwise signature
+# validation already ensures we only fetch what Twilio actually sent).
+_TWILIO_MEDIA_HOST_SUFFIXES = (".twilio.com", ".twiliocdn.com")
+
 
 # ---------------------------------------------------------------------------
-# Per-user outbound sender resolver (premium hook)
+# Premium hooks
 # ---------------------------------------------------------------------------
 
-# Premium deployments provision one Twilio number per user; the resolver
-# maps an outbound recipient phone back to that user's own Twilio number
-# so ``send_text``/``send_media`` can pin ``from_`` correctly. OSS leaves
-# the resolver unset and falls back to the single global TWILIO_PHONE_NUMBER
-# / TWILIO_MESSAGING_SERVICE_SID.
+# Premium deployments provision one Twilio number per user. Two hooks plug
+# into per-user behavior:
+#
+#   FromResolver:  maps an outbound recipient phone back to that user's
+#                  own Twilio number so ``send_text``/``send_media`` can
+#                  pin ``from_`` correctly.
+#   ToVerifier:    on inbound, confirms that the webhook's ``(From, To)``
+#                  pair corresponds to a user's own provisioned Twilio
+#                  number. Without this, a user texting the wrong Twilio
+#                  number (e.g. typo, stale contact) would still route to
+#                  their own bot via the ``From``-based allowlist, but the
+#                  reply would come from a different number than the one
+#                  they texted — confusing UX. OSS leaves both unset and
+#                  the channel behaves as one global bot.
 FromResolver = Callable[[str], Awaitable[str | None]]
+ToVerifier = Callable[[str, str], Awaitable[bool]]
 
 _from_resolver: FromResolver | None = None
+_to_verifier: ToVerifier | None = None
 
 
 def set_twilio_from_resolver(fn: FromResolver) -> None:
@@ -56,6 +76,24 @@ def set_twilio_from_resolver(fn: FromResolver) -> None:
 def get_twilio_from_resolver() -> FromResolver | None:
     """Return the current per-user resolver, or ``None`` when unset."""
     return _from_resolver
+
+
+def set_twilio_to_verifier(fn: ToVerifier) -> None:
+    """Register a callable that confirms an inbound ``(From, To)`` pair is valid.
+
+    Called by the premium plugin during startup. ``fn`` receives
+    ``(from_phone, to_phone)`` and returns ``True`` if those identify a
+    consistent user / provisioned-number pairing. When the verifier
+    returns ``False`` or raises, the inbound webhook is dropped with a
+    200 + empty TwiML (so probing senders can't infer state).
+    """
+    global _to_verifier
+    _to_verifier = fn
+
+
+def get_twilio_to_verifier() -> ToVerifier | None:
+    """Return the current inbound ``(From, To)`` verifier, or ``None`` when unset."""
+    return _to_verifier
 
 
 class TwilioChannel(BaseChannel):
@@ -105,8 +143,12 @@ class TwilioChannel(BaseChannel):
         # ASGI's view, which for our PaaS deployments matches the URL
         # Twilio saw because the proxy sets X-Forwarded-* headers and
         # Starlette honors them when ``proxy_headers=True`` (the uvicorn
-        # default in our deployment).
+        # default in our deployment). The debug log surfaces the exact
+        # URL we're validating against so a deployment behind a proxy
+        # that strips https can diagnose signature failures without
+        # tcpdump.
         url = str(request.url)
+        logger.debug("Twilio signature validation: url=%s", url)
         return validator.validate(url, form_data, signature)
 
     @staticmethod
@@ -147,6 +189,14 @@ class TwilioChannel(BaseChannel):
 
         body = form_data.get("Body", "")
         message_sid = form_data.get("MessageSid", "") or form_data.get("SmsMessageSid", "")
+        if not message_sid:
+            # Real Twilio always sends MessageSid; an empty value here
+            # means the payload came from a misconfigured proxy or a
+            # spoofed request that slipped past signature validation
+            # (only possible when validation is off). Without an SID we
+            # can't dedupe Twilio's 24h retry loop, so log loud enough
+            # for operators to notice and fix the upstream.
+            logger.warning("Twilio webhook missing MessageSid; idempotency skipped")
         external_id = f"twilio_{message_sid}" if message_sid else ""
         media = TwilioChannel._extract_media(form_data)
 
@@ -188,6 +238,28 @@ class TwilioChannel(BaseChannel):
                 return Response(content=TWIML_EMPTY, media_type="application/xml")
 
             inbound = TwilioChannel.parse_form(form_data)
+
+            # Per-user deployments register a verifier that confirms the
+            # webhook's ``(From, To)`` pair corresponds to one user's own
+            # provisioned Twilio number. Dropping mismatches here keeps a
+            # user from accidentally receiving a reply from a different
+            # bot number than the one they texted. OSS leaves the
+            # verifier unset and this check is a no-op.
+            if inbound is not None and _to_verifier is not None:
+                to_phone = form_data.get("To", "")
+                try:
+                    ok = await _to_verifier(inbound.sender_id, to_phone)
+                except Exception:
+                    logger.exception(
+                        "Twilio to_verifier raised; dropping inbound to avoid misrouting",
+                    )
+                    return Response(content=TWIML_EMPTY, media_type="application/xml")
+                if not ok:
+                    logger.warning(
+                        "Twilio inbound: (From, To) pair does not match a known user; dropping"
+                    )
+                    return Response(content=TWIML_EMPTY, media_type="application/xml")
+
             await handle_webhook_inbound(channel, inbound)
             return Response(content=TWIML_EMPTY, media_type="application/xml")
 
@@ -278,7 +350,16 @@ class TwilioChannel(BaseChannel):
         webhook form payload. The URL requires HTTP Basic Auth with the
         account SID + auth token. Streams with the standard hard size
         cap and wall-time deadline.
+
+        Refuses any URL that doesn't live on a Twilio-owned host. This
+        is defense in depth against an attacker who slipped a webhook
+        past signature validation (only possible when validation is off
+        for dev): without this guard, ``MediaUrl0=http://internal/...``
+        would exfiltrate the account-SID Basic Auth header.
         """
+        if not _is_twilio_host(file_id):
+            msg = f"Refusing to download media from non-Twilio host: {file_id}"
+            raise ValueError(msg)
         auth = httpx.BasicAuth(self._account_sid, self._auth_token)
         async with httpx.AsyncClient(auth=auth, timeout=settings.http_timeout_seconds) as client:
             content, headers = await download_bounded(client, file_id)
@@ -290,3 +371,21 @@ class TwilioChannel(BaseChannel):
             original_url=file_id,
             filename=filename,
         )
+
+
+def _is_twilio_host(url: str) -> bool:
+    """Return True if *url*'s host is on the Twilio media domain.
+
+    Returns False on malformed URLs and URLs with no host part (e.g. a
+    bare path); callers should treat both as "not Twilio" and refuse.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme not in ("http", "https"):
+        return False
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return False
+    return any(host == s.lstrip(".") or host.endswith(s) for s in _TWILIO_MEDIA_HOST_SUFFIXES)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -173,6 +173,25 @@ class Settings(BaseSettings):
     # outages, down for stricter "no replies to stale messages" behavior.
     bluebubbles_backfill_lookback_minutes: int = Field(default=30, ge=0)
 
+    # Twilio (SMS/MMS). Twilio does not expose typing indicators over SMS;
+    # the channel implements ``send_typing_indicator`` as a no-op. For
+    # iMessage/RCS with typing indicators see Linq or BlueBubbles.
+    twilio_account_sid: str = ""
+    twilio_auth_token: str = ""
+    # Outbound sender. Pin a specific phone number (E.164) OR a Messaging
+    # Service SID. Messaging Service is recommended for US A2P 10DLC
+    # deployments: numbers join the service's pool and the registered
+    # campaign covers all of them. When both are set, the Messaging Service
+    # SID wins.
+    twilio_phone_number: str = ""  # E.164 format, e.g. "+15551234567"
+    twilio_messaging_service_sid: str = ""  # "MGxxxxxxxx..."
+    twilio_allowed_numbers: str = ""  # E.164 phone, "*", or empty (deny all)
+    # Validate inbound webhook signatures via ``X-Twilio-Signature``. Off
+    # in development is fine; ON in production. The validator needs the
+    # exact public URL of the webhook, so behind a proxy / tunnel the
+    # ``app_base_url`` setting must reflect what Twilio actually sees.
+    twilio_validate_signatures: bool = True
+
     # Google Calendar
     google_calendar_client_id: str = ""
     google_calendar_client_secret: str = ""
@@ -276,6 +295,12 @@ PERSISTABLE_SETTINGS: frozenset[str] = frozenset(
         "bluebubbles_allowed_numbers",
         "bluebubbles_send_method",
         "bluebubbles_imessage_address",
+        "twilio_account_sid",
+        "twilio_auth_token",
+        "twilio_phone_number",
+        "twilio_messaging_service_sid",
+        "twilio_allowed_numbers",
+        "twilio_validate_signatures",
         "llm_provider",
         "llm_model",
         "llm_api_base",

--- a/backend/app/config_store.py
+++ b/backend/app/config_store.py
@@ -60,6 +60,7 @@ _SECRET_SETTINGS: frozenset[str] = frozenset(
         "linq_api_token",
         "linq_webhook_signing_secret",
         "bluebubbles_password",
+        "twilio_auth_token",
     }
 )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from backend.app.channels import get_manager, register_channel
 from backend.app.channels.bluebubbles import BlueBubblesChannel
 from backend.app.channels.linq import LinqChannel
 from backend.app.channels.telegram import TelegramChannel
+from backend.app.channels.twilio import TwilioChannel
 from backend.app.channels.webchat import WebChatChannel
 from backend.app.config import (
     log_config_warnings,
@@ -62,6 +63,7 @@ register_channel(TelegramChannel(bot_token=settings.telegram_bot_token))
 register_channel(WebChatChannel())
 register_channel(LinqChannel())
 register_channel(BlueBubblesChannel())
+register_channel(TwilioChannel())
 
 
 async def _enforce_single_channel() -> None:
@@ -266,6 +268,26 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         if not settings.bluebubbles_allowed_numbers:
             logger.warning(
                 "No BlueBubbles allowed numbers configured (BLUEBUBBLES_ALLOWED_NUMBERS). "
+                "All messages will be rejected. "
+                'Set to "*" to allow all, or provide an E.164 phone number.'
+            )
+
+    if settings.twilio_account_sid and settings.twilio_auth_token:
+        sender = (
+            f"Messaging Service {settings.twilio_messaging_service_sid}"
+            if settings.twilio_messaging_service_sid
+            else f"phone {mask_pii(settings.twilio_phone_number) or '<unset>'}"
+        )
+        logger.info("Twilio channel enabled (sender: %s)", sender)
+        if not settings.twilio_phone_number and not settings.twilio_messaging_service_sid:
+            logger.warning(
+                "Twilio credentials are set but neither TWILIO_PHONE_NUMBER "
+                "nor TWILIO_MESSAGING_SERVICE_SID is configured. Outbound sends "
+                "will fail until one is set."
+            )
+        if not settings.twilio_allowed_numbers:
+            logger.warning(
+                "No Twilio allowed numbers configured (TWILIO_ALLOWED_NUMBERS). "
                 "All messages will be rejected. "
                 'Set to "*" to allow all, or provide an E.164 phone number.'
             )

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -209,6 +209,10 @@ def _build_channel_config_response() -> ChannelConfigResponse:
         bluebubbles_configured=is_bluebubbles_configured(),
         bluebubbles_allowed_numbers=settings.bluebubbles_allowed_numbers,
         bluebubbles_imessage_address=settings.bluebubbles_imessage_address,
+        twilio_configured=bool(settings.twilio_account_sid and settings.twilio_auth_token),
+        twilio_phone_number=settings.twilio_phone_number,
+        twilio_messaging_service_sid=settings.twilio_messaging_service_sid,
+        twilio_allowed_numbers=settings.twilio_allowed_numbers,
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -166,6 +166,13 @@ class ChannelConfigResponse(BaseModel):
     # The UI uses this to render a single iMessage card without exposing which
     # backend powers it; None means iMessage is not configured on this server.
     imessage_backend: str | None = None
+    # Twilio (SMS/MMS). ``twilio_configured`` is true when both account SID
+    # and auth token are set (the minimum to talk to Twilio's API);
+    # outbound also needs either a phone number or a Messaging Service.
+    twilio_configured: bool = False
+    twilio_phone_number: str = ""
+    twilio_messaging_service_sid: str = ""
+    twilio_allowed_numbers: str = ""
 
 
 class ChannelConfigUpdate(BaseModel):
@@ -180,6 +187,11 @@ class ChannelConfigUpdate(BaseModel):
     bluebubbles_password: str | None = None
     bluebubbles_allowed_numbers: str | None = None
     bluebubbles_imessage_address: str | None = None
+    twilio_account_sid: str | None = None
+    twilio_auth_token: str | None = None
+    twilio_phone_number: str | None = None
+    twilio_messaging_service_sid: str | None = None
+    twilio_allowed_numbers: str | None = None
 
 
 class ChannelRouteResponse(BaseModel):

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -79,6 +79,21 @@ When `LINQ_API_TOKEN` is set, the iMessage channel is powered by Linq and users 
 
 When `BLUEBUBBLES_SERVER_URL` and `BLUEBUBBLES_PASSWORD` are set, the iMessage channel is powered by BlueBubbles. [BlueBubbles](https://github.com/BlueBubblesApp/bluebubbles-server) is a free, open-source iMessage bridge that runs on any Mac with iMessage signed in.
 
+## Twilio (SMS/MMS)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TWILIO_ACCOUNT_SID` | | Twilio account SID (`AC...`) |
+| `TWILIO_AUTH_TOKEN` | | Twilio auth token. Used for webhook signature validation and authenticating media URL downloads. |
+| `TWILIO_PHONE_NUMBER` | | E.164 outbound sender, e.g. `+15551234567`. Pinned as `from_` on every send. |
+| `TWILIO_MESSAGING_SERVICE_SID` | | Messaging Service SID (`MG...`). Use for US A2P 10DLC: the service holds a pool of campaign-registered numbers. When set, takes precedence over `TWILIO_PHONE_NUMBER`. |
+| `TWILIO_ALLOWED_NUMBERS` | (empty) | E.164 phone number, `*` for all, or empty to deny all. |
+| `TWILIO_VALIDATE_SIGNATURES` | `true` | Validate `X-Twilio-Signature` on inbound webhooks. Leave on in production; turning off is only safe behind a private tunnel during local dev. |
+
+Twilio SMS has no typing-indicator concept, so the channel's `send_typing_indicator` is a no-op. If typing indicators on iMessage / RCS are required, use Linq or BlueBubbles instead.
+
+For US deployments, configure a Twilio Messaging Service with A2P 10DLC registration and set `TWILIO_MESSAGING_SERVICE_SID`. Toll-free numbers can skip 10DLC entirely; pin one via `TWILIO_PHONE_NUMBER` and complete Twilio's toll-free verification flow.
+
 ## Google Drive integration
 
 Google Drive is the integration Clawbolt uses for file storage. Each user grants `drive.file` scope through `manage_integration` in chat; files land in the user's own Drive under a top-level "Clawbolt" folder. Without these credentials set, the integration stays unavailable and the file tools (upload, retrieve, analyze) never load for any user.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -436,6 +436,23 @@
         }
       }
     },
+    "/api/webhooks/twilio": {
+      "post": {
+        "summary": "Twilio Inbound",
+        "description": "Receive inbound SMS/MMS from Twilio.\n\nReturns an empty TwiML response immediately; the agent loop\nreplies through the outbound dispatcher via the REST API so\nthis endpoint stays under Twilio's 15s ack window even when\nthe LLM call takes longer.",
+        "operationId": "twilio_inbound_api_webhooks_twilio_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/user/profile": {
       "get": {
         "summary": "Get Profile",

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1532,6 +1532,26 @@
               }
             ],
             "title": "Imessage Backend"
+          },
+          "twilio_configured": {
+            "type": "boolean",
+            "title": "Twilio Configured",
+            "default": false
+          },
+          "twilio_phone_number": {
+            "type": "string",
+            "title": "Twilio Phone Number",
+            "default": ""
+          },
+          "twilio_messaging_service_sid": {
+            "type": "string",
+            "title": "Twilio Messaging Service Sid",
+            "default": ""
+          },
+          "twilio_allowed_numbers": {
+            "type": "string",
+            "title": "Twilio Allowed Numbers",
+            "default": ""
           }
         },
         "type": "object",
@@ -1663,6 +1683,61 @@
               }
             ],
             "title": "Bluebubbles Imessage Address"
+          },
+          "twilio_account_sid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twilio Account Sid"
+          },
+          "twilio_auth_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twilio Auth Token"
+          },
+          "twilio_phone_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twilio Phone Number"
+          },
+          "twilio_messaging_service_sid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twilio Messaging Service Sid"
+          },
+          "twilio_allowed_numbers": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twilio Allowed Numbers"
           }
         },
         "type": "object",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -330,6 +330,60 @@ const api = {
     return res.json() as Promise<{ phone_number: string | null; connected: boolean }>;
   },
 
+  getTwilioLink: async () => {
+    const res = await fetch('/api/channels/twilio', { headers: _getAuthHeaders() });
+    if (!res.ok) throw new Error('Failed to fetch Twilio link');
+    return res.json() as Promise<{
+      personal_phone: string | null;
+      twilio_phone_number: string | null;
+      status: string;
+      error_message: string;
+      connected: boolean;
+    }>;
+  },
+  // Provision a Twilio number for the current user. The server runs
+  // search + purchase synchronously, so this resolves with the final
+  // status ("active" on success, "failed" on inventory / Twilio errors).
+  connectTwilio: async (body: {
+    personal_phone: string;
+    number_type?: string;
+    area_code?: string;
+  }) => {
+    const res = await fetch('/api/channels/twilio/connect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ..._getAuthHeaders() },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const detail = await res.json().catch(() => ({})) as { detail?: string };
+      throw new Error(detail.detail || `Failed to connect: ${res.status}`);
+    }
+    return res.json() as Promise<{
+      personal_phone: string | null;
+      twilio_phone_number: string | null;
+      status: string;
+      error_message: string;
+      connected: boolean;
+    }>;
+  },
+  disconnectTwilio: async () => {
+    const res = await fetch('/api/channels/twilio', {
+      method: 'DELETE',
+      headers: _getAuthHeaders(),
+    });
+    if (!res.ok) {
+      const detail = await res.json().catch(() => ({})) as { detail?: string };
+      throw new Error(detail.detail || `Failed to disconnect: ${res.status}`);
+    }
+    return res.json() as Promise<{
+      personal_phone: string | null;
+      twilio_phone_number: string | null;
+      status: string;
+      error_message: string;
+      connected: boolean;
+    }>;
+  },
+
   // Activity stream: real-time agent status from any channel.
   // Auto-reconnects on disconnect so transient drops (proxy timeout,
   // network glitch) don't permanently kill the spinner updates.

--- a/frontend/src/components/ChannelConfigForm.tsx
+++ b/frontend/src/components/ChannelConfigForm.tsx
@@ -465,14 +465,22 @@ function PremiumTwilioForm({ twilioLinkData, onSaved }: SubFormProps) {
   const status = twilioLinkData?.status ?? 'not_provisioned';
   const isActive = status === 'active' && twilioLinkData?.twilio_phone_number;
 
-  // ``provisioning`` is a transient state. If we ever land here in the UI
-  // (e.g. the user refreshed mid-connect) we just show a spinner; the
-  // request that started it owns the resolution.
+  // ``provisioning`` is a transient state, normally only seen for a few
+  // seconds during connect. If we land here on page load it usually
+  // means the previous connect request crashed mid-flow; the server
+  // recovers stale rows after a timeout but the user needs an escape
+  // hatch in the meantime. The Refresh button re-fetches the link
+  // state so the user can poll for resolution without a full reload.
   if (status === 'provisioning') {
     return (
       <div className="grid gap-2">
         <p className="text-sm">Provisioning your number...</p>
         <p className="text-xs text-muted-foreground">This usually takes a few seconds.</p>
+        <div className="flex justify-end">
+          <Button onClick={onSaved} variant="secondary">
+            Refresh
+          </Button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/components/ChannelConfigForm.tsx
+++ b/frontend/src/components/ChannelConfigForm.tsx
@@ -13,6 +13,7 @@ import api from '@/api';
 
 // Types derived from API return types, exported for consumers
 export type TelegramLinkData = Awaited<ReturnType<typeof api.getTelegramLink>>;
+export type TwilioLinkData = Awaited<ReturnType<typeof api.getTwilioLink>>;
 
 // Generic premium link data shape (all premium link endpoints share this structure)
 export type PremiumLinkData = { identifier: string | null; connected: boolean };
@@ -22,6 +23,7 @@ interface ChannelConfigFormProps {
   isPremium: boolean;
   channelConfig: ChannelConfigResponse | undefined;
   telegramLinkData: TelegramLinkData | null;
+  twilioLinkData: TwilioLinkData | null;
   premiumLinkData: PremiumLinkData | null;
   onSaved: () => void;
 }
@@ -29,6 +31,9 @@ interface ChannelConfigFormProps {
 export function ChannelConfigForm({ channelKey, isPremium, ...rest }: ChannelConfigFormProps) {
   if (channelKey === 'telegram') {
     return isPremium ? <PremiumTelegramForm {...rest} /> : <OssTelegramForm {...rest} />;
+  }
+  if (channelKey === 'twilio') {
+    return isPremium ? <PremiumTwilioForm {...rest} /> : <OssTwilioForm {...rest} />;
   }
   if (isPremium) {
     const config = PREMIUM_LINK_CONFIGS[channelKey];
@@ -371,6 +376,240 @@ function BlueBubblesForm({ channelConfig, onSaved }: SubFormProps) {
       <div className="flex justify-end">
         <Button onClick={handleSave} disabled={updateMutation.isPending || channelConfig === undefined} isLoading={updateMutation.isPending}>
           Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// --- OSS Twilio form (operator allowlist config) ---
+
+function OssTwilioForm({ channelConfig, onSaved }: SubFormProps) {
+  const updateMutation = useUpdateChannelConfig();
+  const [allowedNumbers, setAllowedNumbers] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const displayedNumbers = allowedNumbers ?? channelConfig?.twilio_allowed_numbers ?? '';
+
+  const handleSave = () => {
+    setError(null);
+    const trimmed = (allowedNumbers ?? '').trim();
+    const normalized = trimmed && trimmed !== '*' ? normalizeUsPhone(trimmed) : trimmed;
+    if (normalized && normalized !== '*' && !isValidE164(normalized)) {
+      setError(PHONE_FORMAT_ERROR);
+      return;
+    }
+    if (allowedNumbers === null || normalized === (channelConfig?.twilio_allowed_numbers ?? '')) {
+      toast.error('No changes to save');
+      return;
+    }
+    updateMutation.mutate({ twilio_allowed_numbers: normalized }, {
+      onSuccess: () => {
+        setAllowedNumbers(null);
+        toast.success('Twilio settings updated');
+        onSaved();
+      },
+      onError: (e) => toast.error(e.message),
+    });
+  };
+
+  return (
+    <div className="grid gap-4">
+      <Field label="Allowed Phone Number">
+        <Input
+          value={displayedNumbers}
+          onChange={(e) => {
+            setAllowedNumbers(e.target.value);
+            if (error) setError(null);
+          }}
+          placeholder="e.g. +15551234567"
+          inputMode="tel"
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? 'oss-twilio-error' : undefined}
+        />
+        {error ? (
+          <p id="oss-twilio-error" className="text-xs text-danger mt-1">{error}</p>
+        ) : (
+          <p className="text-xs text-muted-foreground mt-1">
+            E.164 phone number, or * to allow all. Empty = deny all.
+            Twilio account credentials are managed in server settings.
+          </p>
+        )}
+      </Field>
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={updateMutation.isPending || channelConfig === undefined} isLoading={updateMutation.isPending}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// --- Premium Twilio form (per-user number provisioning) ---
+
+const TWILIO_NUMBER_TYPES = [
+  { value: 'toll-free', label: 'Toll-free (+1 8xx)' },
+  { value: 'local', label: 'Local (US area code)' },
+] as const;
+
+function PremiumTwilioForm({ twilioLinkData, onSaved }: SubFormProps) {
+  // The connect form is shown when the user hasn't provisioned a number
+  // yet (status: not_provisioned / released / failed). Once active, we
+  // show the connected number plus a disconnect button.
+  const [personalPhone, setPersonalPhone] = useState('');
+  const [numberType, setNumberType] = useState<string>('toll-free');
+  const [areaCode, setAreaCode] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const status = twilioLinkData?.status ?? 'not_provisioned';
+  const isActive = status === 'active' && twilioLinkData?.twilio_phone_number;
+
+  // ``provisioning`` is a transient state. If we ever land here in the UI
+  // (e.g. the user refreshed mid-connect) we just show a spinner; the
+  // request that started it owns the resolution.
+  if (status === 'provisioning') {
+    return (
+      <div className="grid gap-2">
+        <p className="text-sm">Provisioning your number...</p>
+        <p className="text-xs text-muted-foreground">This usually takes a few seconds.</p>
+      </div>
+    );
+  }
+
+  if (isActive) {
+    return <PremiumTwilioConnected twilioLinkData={twilioLinkData!} onSaved={onSaved} />;
+  }
+
+  const handleConnect = async () => {
+    setError(null);
+    const normalized = normalizeUsPhone(personalPhone);
+    if (!isValidE164(normalized)) {
+      setError(PHONE_FORMAT_ERROR);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await api.connectTwilio({
+        personal_phone: normalized,
+        number_type: numberType,
+        area_code: areaCode.trim(),
+      });
+      toast.success('Twilio number provisioned');
+      onSaved();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to connect Twilio';
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Previously-failed attempts surface the reason inline so the user
+  // can adjust (e.g. different area code) before retrying.
+  const previousError = status === 'failed' ? twilioLinkData?.error_message : '';
+
+  return (
+    <div className="grid gap-4">
+      {previousError && (
+        <p className="text-xs text-danger" role="alert">
+          Last attempt failed: {previousError}
+        </p>
+      )}
+      <Field label="Your Phone Number">
+        <Input
+          value={personalPhone}
+          onChange={(e) => {
+            setPersonalPhone(e.target.value);
+            if (error) setError(null);
+          }}
+          placeholder="e.g. +15551234567"
+          inputMode="tel"
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? 'twilio-personal-error' : undefined}
+        />
+        {error ? (
+          <p id="twilio-personal-error" className="text-xs text-danger mt-1">{error}</p>
+        ) : (
+          <p className="text-xs text-muted-foreground mt-1">
+            E.164 format. Only this number will be able to message your assistant via SMS.
+          </p>
+        )}
+      </Field>
+      <Field label="Number Type">
+        <Select
+          value={numberType}
+          onChange={(e) => setNumberType(e.target.value)}
+          aria-label="Twilio number type"
+        >
+          {TWILIO_NUMBER_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>{t.label}</option>
+          ))}
+        </Select>
+        <p className="text-xs text-muted-foreground mt-1">
+          Toll-free skips US A2P 10DLC registration. Local is cheaper per message but the operator
+          must have a registered messaging service.
+        </p>
+      </Field>
+      <Field label="Area Code (optional)">
+        <Input
+          value={areaCode}
+          onChange={(e) => setAreaCode(e.target.value)}
+          placeholder={numberType === 'toll-free' ? 'e.g. 800' : 'e.g. 415'}
+          inputMode="numeric"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Leave blank to let Twilio pick from available inventory.
+        </p>
+      </Field>
+      <div className="flex justify-end">
+        <Button onClick={handleConnect} disabled={submitting || !personalPhone} isLoading={submitting}>
+          Connect Twilio
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function PremiumTwilioConnected({
+  twilioLinkData,
+  onSaved,
+}: { twilioLinkData: TwilioLinkData; onSaved: () => void }) {
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await api.disconnectTwilio();
+      toast.success('Twilio disconnected');
+      onSaved();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to disconnect');
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-3">
+      <div className="text-sm">
+        Text{' '}
+        <span className="font-mono font-medium text-primary">
+          {twilioLinkData.twilio_phone_number}
+        </span>{' '}
+        from{' '}
+        <span className="font-mono font-medium">{twilioLinkData.personal_phone}</span>{' '}
+        to chat with your assistant.
+      </div>
+      <div className="flex justify-end">
+        <Button
+          onClick={handleDisconnect}
+          isLoading={disconnecting}
+          disabled={disconnecting}
+          variant="secondary"
+        >
+          Disconnect
         </Button>
       </div>
     </div>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -980,6 +980,26 @@ export interface components {
             bluebubbles_imessage_address: string;
             /** Imessage Backend */
             imessage_backend?: string | null;
+            /**
+             * Twilio Configured
+             * @default false
+             */
+            twilio_configured: boolean;
+            /**
+             * Twilio Phone Number
+             * @default
+             */
+            twilio_phone_number: string;
+            /**
+             * Twilio Messaging Service Sid
+             * @default
+             */
+            twilio_messaging_service_sid: string;
+            /**
+             * Twilio Allowed Numbers
+             * @default
+             */
+            twilio_allowed_numbers: string;
         };
         /** ChannelConfigUpdate */
         ChannelConfigUpdate: {
@@ -1005,6 +1025,16 @@ export interface components {
             bluebubbles_allowed_numbers?: string | null;
             /** Bluebubbles Imessage Address */
             bluebubbles_imessage_address?: string | null;
+            /** Twilio Account Sid */
+            twilio_account_sid?: string | null;
+            /** Twilio Auth Token */
+            twilio_auth_token?: string | null;
+            /** Twilio Phone Number */
+            twilio_phone_number?: string | null;
+            /** Twilio Messaging Service Sid */
+            twilio_messaging_service_sid?: string | null;
+            /** Twilio Allowed Numbers */
+            twilio_allowed_numbers?: string | null;
         };
         /** ChannelRouteListResponse */
         ChannelRouteListResponse: {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -311,6 +311,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/webhooks/twilio": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Twilio Inbound
+         * @description Receive inbound SMS/MMS from Twilio.
+         *
+         *     Returns an empty TwiML response immediately; the agent loop
+         *     replies through the outbound dispatcher via the REST API so
+         *     this endpoint stays under Twilio's 15s ack window even when
+         *     the LLM call takes longer.
+         */
+        post: operations["twilio_inbound_api_webhooks_twilio_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/user/profile": {
         parameters: {
             query?: never;
@@ -1813,6 +1838,26 @@ export interface operations {
         };
     };
     bluebubbles_inbound_api_webhooks_bluebubbles_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    twilio_inbound_api_webhooks_twilio_post: {
         parameters: {
             query?: never;
             header?: never;

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -253,6 +253,14 @@ export function useBlueBubblesLink(enabled: boolean) {
   });
 }
 
+export function useTwilioLink(enabled: boolean) {
+  return useQuery({
+    queryKey: queryKeys.twilioLink,
+    queryFn: () => api.getTwilioLink(),
+    enabled,
+  });
+}
+
 // --- Channel routes ---
 
 export function useChannelRoutes() {

--- a/frontend/src/hooks/useChannelStates.ts
+++ b/frontend/src/hooks/useChannelStates.ts
@@ -6,6 +6,7 @@ import {
   useTelegramBotInfo,
   useLinqLink,
   useBlueBubblesLink,
+  useTwilioLink,
 } from '@/hooks/queries';
 import { useAuth } from '@/contexts/AuthContext';
 import {
@@ -16,7 +17,11 @@ import {
   type PremiumChannelData,
 } from '@/lib/channel-utils';
 import type { ChannelConfigResponse } from '@/types';
-import type { PremiumLinkData, TelegramLinkData } from '@/components/ChannelConfigForm';
+import type {
+  PremiumLinkData,
+  TelegramLinkData,
+  TwilioLinkData,
+} from '@/components/ChannelConfigForm';
 
 type TelegramBotInfo = NonNullable<Awaited<ReturnType<typeof useTelegramBotInfo>>['data']>;
 
@@ -33,6 +38,8 @@ export interface ChannelStatesResult {
   linkDataMap: Partial<Record<ChannelKey, PremiumLinkData | null>>;
   /** Telegram-specific premium link data (for ChannelConfigForm). */
   telegramLinkData: TelegramLinkData | null;
+  /** Twilio-specific premium link data (for ChannelConfigForm). */
+  twilioLinkData: TwilioLinkData | null;
   /** Telegram bot info (premium only). */
   botInfo: TelegramBotInfo | null;
   /** Refresh premium link data for a specific channel after config save. */
@@ -68,17 +75,29 @@ export function useChannelStates(): ChannelStatesResult {
   const telegramBotInfoQuery = useTelegramBotInfo(isPremium && telegramBotTokenSet);
   const linqLinkQuery = useLinqLink(isPremium);
   const blueBubblesLinkQuery = useBlueBubblesLink(isPremium);
+  const twilioLinkQuery = useTwilioLink(isPremium);
 
   // Build premium data from React Query results
   const linkDataMap = useMemo<Partial<Record<ChannelKey, PremiumLinkData | null>>>(() => {
     const map: Partial<Record<ChannelKey, PremiumLinkData | null>> = {};
     if (linqLinkQuery.data) map.linq = normalizeLinkData(linqLinkQuery.data);
     if (blueBubblesLinkQuery.data) map.bluebubbles = normalizeLinkData(blueBubblesLinkQuery.data);
+    if (twilioLinkQuery.data) {
+      // Twilio's premium-link contract is "personal phone is linked + an
+      // active Twilio number is provisioned"; collapse to the generic
+      // PremiumLinkData shape so getChannelState's existing derivation
+      // works without a twilio-specific branch.
+      map.twilio = {
+        identifier: twilioLinkQuery.data.personal_phone,
+        connected: twilioLinkQuery.data.connected,
+      };
+    }
     return map;
-  }, [linqLinkQuery.data, blueBubblesLinkQuery.data]);
+  }, [linqLinkQuery.data, blueBubblesLinkQuery.data, twilioLinkQuery.data]);
 
   const telegramLinkData = telegramLinkQuery.data ?? null;
   const telegramUserId = telegramLinkData?.telegram_user_id;
+  const twilioLinkData = twilioLinkQuery.data ?? null;
   const botInfo = telegramBotInfoQuery.data ?? null;
 
   // Derive states (deps are all primitives or memoized objects for stable identity)
@@ -100,6 +119,7 @@ export function useChannelStates(): ChannelStatesResult {
     if (key === 'telegram') void telegramLinkQuery.refetch();
     if (key === 'linq') void linqLinkQuery.refetch();
     if (key === 'bluebubbles') void blueBubblesLinkQuery.refetch();
+    if (key === 'twilio') void twilioLinkQuery.refetch();
   };
 
   return {
@@ -113,6 +133,7 @@ export function useChannelStates(): ChannelStatesResult {
     channelConfig,
     linkDataMap,
     telegramLinkData,
+    twilioLinkData,
     botInfo,
     invalidateLink,
   };

--- a/frontend/src/lib/__tests__/channel-utils.test.ts
+++ b/frontend/src/lib/__tests__/channel-utils.test.ts
@@ -13,6 +13,10 @@ const baseConfig: ChannelConfigResponse = {
   bluebubbles_allowed_numbers: '',
   bluebubbles_imessage_address: '',
   imessage_backend: null,
+  twilio_configured: false,
+  twilio_phone_number: '',
+  twilio_messaging_service_sid: '',
+  twilio_allowed_numbers: '',
 };
 
 describe('getVisibleChannels', () => {

--- a/frontend/src/lib/channel-utils.ts
+++ b/frontend/src/lib/channel-utils.ts
@@ -8,10 +8,14 @@ export type ChannelKey = (typeof MESSAGING_CHANNELS)[number]['key'];
 // Real backend channel keys. `linq` and `bluebubbles` are both rendered to the
 // user as "iMessage"; which one shows up at runtime is determined by which
 // backend the admin has configured. Users never see the backend name.
+// `twilio` is plain SMS/MMS; it does not collapse into iMessage because
+// the deliverability and feature set are different (no typing indicators,
+// no rich attachments past MMS).
 export const MESSAGING_CHANNELS = [
   { key: 'telegram', label: 'Telegram' },
   { key: 'linq', label: 'iMessage' },
   { key: 'bluebubbles', label: 'iMessage' },
+  { key: 'twilio', label: 'SMS' },
 ] as const;
 
 /** Return the subset of MESSAGING_CHANNELS the user should see, filtered by
@@ -28,6 +32,7 @@ export function getVisibleChannels(
   if (!config) return [];
   return MESSAGING_CHANNELS.filter((ch) => {
     if (ch.key === 'telegram') return config.telegram_bot_token_set;
+    if (ch.key === 'twilio') return config.twilio_configured;
     return ch.key === config.imessage_backend;
   });
 }
@@ -56,6 +61,7 @@ export function isServerAvailable(key: ChannelKey, config: ChannelConfigResponse
   if (key === 'telegram') return config.telegram_bot_token_set;
   if (key === 'linq') return config.imessage_backend === 'linq';
   if (key === 'bluebubbles') return config.imessage_backend === 'bluebubbles';
+  if (key === 'twilio') return config.twilio_configured;
   return false;
 }
 
@@ -80,6 +86,9 @@ function isUserConfigured(
   }
   if (key === 'bluebubbles') {
     return config.bluebubbles_allowed_numbers !== '';
+  }
+  if (key === 'twilio') {
+    return config.twilio_allowed_numbers !== '';
   }
   return false;
 }

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -23,4 +23,5 @@ export const queryKeys = {
   telegramBotInfo: ['telegramBotInfo'] as const,
   linqLink: ['linqLink'] as const,
   blueBubblesLink: ['blueBubblesLink'] as const,
+  twilioLink: ['twilioLink'] as const,
 };

--- a/frontend/src/pages/ChannelsPage.tsx
+++ b/frontend/src/pages/ChannelsPage.tsx
@@ -12,7 +12,12 @@ import {
   type ChannelKey,
   type ChannelState,
 } from '@/lib/channel-utils';
-import { ChannelConfigForm, type TelegramLinkData, type PremiumLinkData } from '@/components/ChannelConfigForm';
+import {
+  ChannelConfigForm,
+  type TelegramLinkData,
+  type TwilioLinkData,
+  type PremiumLinkData,
+} from '@/components/ChannelConfigForm';
 import type { ChannelStatesResult } from '@/hooks/useChannelStates';
 
 type TelegramBotInfo = ChannelStatesResult['botInfo'];
@@ -20,7 +25,7 @@ type TelegramBotInfo = ChannelStatesResult['botInfo'];
 export default function ChannelsPage() {
   const { isPremium } = useAuth();
   const toggleMutation = useToggleChannelRoute();
-  const { states: channelStates, channelConfig, telegramLinkData, botInfo, linkDataMap, invalidateLink } = useChannelStates();
+  const { states: channelStates, channelConfig, telegramLinkData, twilioLinkData, botInfo, linkDataMap, invalidateLink } = useChannelStates();
   const visibleChannels = getVisibleChannels(channelConfig);
   const routesQuery = useChannelRoutes();
   const imessageAddress = getImessageAddress(channelConfig);
@@ -160,6 +165,7 @@ export default function ChannelsPage() {
                     channelConfig={channelConfig}
                     botInfo={key === 'telegram' ? botInfo : null}
                     telegramLinkData={key === 'telegram' ? telegramLinkData : null}
+                    twilioLinkData={key === 'twilio' ? twilioLinkData : null}
                     premiumLinkData={linkDataMap[key] ?? null}
                     imessageAddress={imessageAddress}
                     verified={verifiedByChannel[key] ?? false}
@@ -187,6 +193,7 @@ export default function ChannelsPage() {
               channelConfig={channelConfig}
               botInfo={key === 'telegram' ? botInfo : null}
               telegramLinkData={key === 'telegram' ? telegramLinkData : null}
+              twilioLinkData={key === 'twilio' ? twilioLinkData : null}
               premiumLinkData={linkDataMap[key] ?? null}
               imessageAddress={imessageAddress}
               verified={verifiedByChannel[key] ?? false}
@@ -219,6 +226,7 @@ interface ChannelCardProps {
   channelConfig: ChannelStatesResult['channelConfig'];
   botInfo: TelegramBotInfo | null;
   telegramLinkData: TelegramLinkData | null;
+  twilioLinkData: TwilioLinkData | null;
   premiumLinkData: PremiumLinkData | null;
   imessageAddress: string | null;
   verified: boolean;
@@ -239,6 +247,7 @@ function ChannelCard({
   channelConfig,
   botInfo,
   telegramLinkData,
+  twilioLinkData,
   premiumLinkData,
   imessageAddress,
   verified,
@@ -330,6 +339,44 @@ function ChannelCard({
         </div>
       )}
 
+      {/* Twilio address banner. OSS uses the global twilio_phone_number;
+          premium uses the per-user provisioned number from the link. */}
+      {channelKey === 'twilio'
+        && (state === 'configured' || state === 'active') && (
+        (() => {
+          const address = isPremium
+            ? twilioLinkData?.twilio_phone_number
+            : channelConfig?.twilio_phone_number;
+          if (!address) return null;
+          return (
+            <div className="mt-3 ml-7 text-sm">
+              Text{' '}
+              <span className="font-mono font-medium text-primary">{address}</span>
+              {' '}from your phone to chat with your assistant.
+              <div className="mt-1.5">
+                {verified ? (
+                  <span
+                    className="inline-flex items-center gap-1 text-xs text-success bg-success-bg px-2 py-0.5 rounded-full font-medium"
+                    aria-label="Connection verified"
+                  >
+                    <CheckIcon />
+                    Verified
+                  </span>
+                ) : (
+                  <span
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full font-medium"
+                    aria-label="Waiting for first message to verify connection"
+                  >
+                    <span className="w-2 h-2 rounded-full bg-muted-foreground/50 animate-pulse" />
+                    Waiting for your first message
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })()
+      )}
+
       {/* iMessage address banner + verification status */}
       {(channelKey === 'linq' || channelKey === 'bluebubbles')
         && imessageAddress
@@ -368,6 +415,7 @@ function ChannelCard({
             isPremium={isPremium}
             channelConfig={channelConfig}
             telegramLinkData={telegramLinkData}
+            twilioLinkData={twilioLinkData}
             premiumLinkData={premiumLinkData}
             onSaved={onConfigSaved}
           />
@@ -393,6 +441,7 @@ function ChannelCard({
                 isPremium={isPremium}
                 channelConfig={channelConfig}
                 telegramLinkData={telegramLinkData}
+                twilioLinkData={twilioLinkData}
                 premiumLinkData={premiumLinkData}
                 onSaved={onConfigSaved}
               />
@@ -461,6 +510,7 @@ function getUnavailableHint(key: ChannelKey): string {
   if (key === 'linq' || key === 'bluebubbles') {
     return 'Contact your administrator to enable iMessage.';
   }
+  if (key === 'twilio') return 'Contact your administrator to enable SMS.';
   return '';
 }
 
@@ -492,6 +542,14 @@ function ChannelIcon({ channelKey }: { channelKey: ChannelKey }) {
     return (
       <svg className="w-5 h-5 text-muted-foreground shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" />
+      </svg>
+    );
+  }
+  if (channelKey === 'twilio') {
+    // Phone handset icon for SMS.
+    return (
+      <svg className="w-5 h-5 text-muted-foreground shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 5a2 2 0 012-2h2.879a1 1 0 01.948.684l1.06 3.18a1 1 0 01-.502 1.21l-2.1 1.05a11.042 11.042 0 005.591 5.59l1.05-2.1a1 1 0 011.21-.501l3.18 1.06a1 1 0 01.684.948V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
       </svg>
     );
   }

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -16,7 +16,7 @@ import {
 import { useAuth } from '@/contexts/AuthContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { getVisibleChannels, isServerAvailable, type ChannelKey } from '@/lib/channel-utils';
-import { ChannelConfigForm, type TelegramLinkData, type PremiumLinkData } from '@/components/ChannelConfigForm';
+import { ChannelConfigForm, type TelegramLinkData, type TwilioLinkData, type PremiumLinkData } from '@/components/ChannelConfigForm';
 import { normalizeUsPhone, isValidE164, PHONE_FORMAT_ERROR } from '@/lib/phone';
 import api from '@/api';
 
@@ -35,6 +35,7 @@ export default function GetStartedPage() {
 
   // Premium link data (fetched once, same pattern as ChannelsPage)
   const [telegramLinkData, setTelegramLinkData] = useState<TelegramLinkData | null>(null);
+  const [twilioLinkData, setTwilioLinkData] = useState<TwilioLinkData | null>(null);
   const [linkDataMap, setLinkDataMap] = useState<Partial<Record<ChannelKey, PremiumLinkData | null>>>({});
 
   useEffect(() => {
@@ -49,6 +50,15 @@ export default function GetStartedPage() {
           setLinkDataMap((prev) => ({ ...prev, [key]: { identifier: data.phone_number, connected: data.connected } }));
         }).catch(() => {});
       }
+      // Twilio uses a separate shape (personal_phone + twilio_phone_number);
+      // store the raw response and project into linkDataMap for state derivation.
+      api.getTwilioLink().then((data) => {
+        setTwilioLinkData(data);
+        setLinkDataMap((prev) => ({
+          ...prev,
+          twilio: { identifier: data.personal_phone, connected: data.connected },
+        }));
+      }).catch(() => {});
     }
   }, [isPremium]);
 
@@ -59,6 +69,10 @@ export default function GetStartedPage() {
   const bbAddress = channelConfig?.bluebubbles_imessage_address ?? '';
   const bbConfigured = channelConfig ? isServerAvailable('bluebubbles', channelConfig) : false;
   const telegramConfigured = channelConfig ? isServerAvailable('telegram', channelConfig) : false;
+  // For OSS Twilio the bot's number is operator-configured; for premium it
+  // comes from the per-user provisioned number on the link.
+  const twilioAddress =
+    twilioLinkData?.twilio_phone_number || channelConfig?.twilio_phone_number || '';
   const [telegramBotInfo, setTelegramBotInfo] = useState<{ bot_username: string; bot_link: string } | null>(null);
   useEffect(() => {
     if (telegramConfigured) {
@@ -125,6 +139,15 @@ export default function GetStartedPage() {
   const handleConfigSaved = (key: ChannelKey) => {
     if (isPremium) {
       if (key === 'telegram') api.getTelegramLink().then(setTelegramLinkData).catch(() => {});
+      if (key === 'twilio') {
+        api.getTwilioLink().then((data) => {
+          setTwilioLinkData(data);
+          setLinkDataMap((prev) => ({
+            ...prev,
+            twilio: { identifier: data.personal_phone, connected: data.connected },
+          }));
+        }).catch(() => {});
+      }
       const fetchers: Partial<Record<ChannelKey, () => Promise<{ phone_number: string | null; connected: boolean }>>> = {
         linq: () => api.getLinqLink(),
         bluebubbles: () => api.getBlueBubblesLink(),
@@ -254,6 +277,7 @@ export default function GetStartedPage() {
                     isPremium={isPremium}
                     channelConfig={channelConfig}
                     telegramLinkData={telegramLinkData}
+                    twilioLinkData={twilioLinkData}
                     premiumLinkData={linkDataMap[selectedChannel] ?? null}
                     onSaved={() => handleConfigSaved(selectedChannel)}
                   />
@@ -294,6 +318,14 @@ export default function GetStartedPage() {
                     qrSize={120}
                   />
                 </div>
+              ) : selectedChannel === 'twilio' && twilioAddress ? (
+                <div className="mt-2 grid gap-2">
+                  <TextAssistantCard
+                    fromNumber={twilioAddress}
+                    subtitle="Text this number to chat with your assistant."
+                    qrSize={120}
+                  />
+                </div>
               ) : (
                 <p className="text-sm text-muted-foreground mt-1">
                   {selectedChannel === 'none'
@@ -302,7 +334,9 @@ export default function GetStartedPage() {
                       ? 'Open Telegram and send a message to your bot to get started.'
                       : selectedChannel === 'linq' || selectedChannel === 'bluebubbles'
                         ? 'Send an iMessage to your assistant to get started.'
-                        : (
+                        : selectedChannel === 'twilio'
+                          ? 'Text your Twilio number from your personal phone to get started.'
+                          : (
                             <>
                               No messaging channel is configured yet. You can also{' '}
                               <button

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "httpx>=0.27",
     "any-llm-sdk[all]>=1.13",
     "python-telegram-bot>=22.0",
+    "twilio>=9.0",
     "google-api-python-client>=2.0",
     "google-auth-oauthlib>=1.0",
     "sqlalchemy>=2.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -531,6 +531,39 @@ async def linq_client(test_user: User) -> AsyncGenerator[httpx.AsyncClient]:
 
 
 @pytest_asyncio.fixture()
+async def twilio_client(test_user: User) -> AsyncGenerator[httpx.AsyncClient]:
+    """FastAPI test client with the Twilio channel ready for webhook tests.
+
+    The Twilio channel is always registered at module level in main.py.
+    This fixture patches settings to allow all numbers and disable signature
+    validation; tests that exercise signature validation patch it back on
+    locally.
+    """
+
+    def _override_get_current_user() -> User:
+        return test_user
+
+    webhook_rate_limiter.reset()
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+
+    with (
+        patch("backend.app.main._verify_llm_settings", new_callable=AsyncMock),
+        patch("backend.app.main._enforce_single_channel", new_callable=AsyncMock),
+        patch("backend.app.agent.heartbeat.heartbeat_scheduler.start"),
+        patch("backend.app.channels.twilio.settings.twilio_allowed_numbers", "*"),
+        patch("backend.app.channels.twilio.settings.twilio_validate_signatures", False),
+        patch("backend.app.channels.telegram.settings.telegram_allowed_chat_id", "*"),
+        patch("backend.app.channels.telegram.settings.telegram_bot_token", ""),
+        patch("backend.app.agent.ingestion.settings.message_batch_window_ms", 0),
+    ):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as c:
+            yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture()
 async def bluebubbles_client(test_user: User) -> AsyncGenerator[httpx.AsyncClient]:
     """FastAPI test client with BlueBubbles channel available.
 

--- a/tests/mocks/twilio.py
+++ b/tests/mocks/twilio.py
@@ -1,0 +1,47 @@
+"""Helpers for crafting Twilio webhook fixtures in tests."""
+
+from twilio.request_validator import RequestValidator
+
+TWILIO_TEST_AUTH_TOKEN = "test-twilio-auth-token-12345"
+
+
+def make_twilio_form(
+    sender: str = "+15551234567",
+    to: str = "+15559876543",
+    text: str = "Hello Clawbolt",
+    message_sid: str = "SM" + "0" * 30 + "01",
+    media: list[tuple[str, str]] | None = None,
+) -> dict[str, str]:
+    """Build a Twilio inbound webhook form payload matching the real shape.
+
+    ``media`` is a list of ``(url, content_type)`` tuples that becomes
+    ``NumMedia`` + ``MediaUrl{N}`` + ``MediaContentType{N}`` fields.
+    """
+    form: dict[str, str] = {
+        "From": sender,
+        "To": to,
+        "Body": text,
+        "MessageSid": message_sid,
+        "SmsMessageSid": message_sid,
+        "AccountSid": "AC" + "0" * 32,
+        "NumMedia": str(len(media) if media else 0),
+    }
+    if media:
+        for i, (url, content_type) in enumerate(media):
+            form[f"MediaUrl{i}"] = url
+            form[f"MediaContentType{i}"] = content_type
+    return form
+
+
+def sign_twilio_form(
+    url: str,
+    form: dict[str, str],
+    auth_token: str = TWILIO_TEST_AUTH_TOKEN,
+) -> str:
+    """Compute the ``X-Twilio-Signature`` for *form* at *url*.
+
+    Mirrors what Twilio's edge does so test webhook POSTs can pass the
+    signature validation gate when it's enabled.
+    """
+    validator = RequestValidator(auth_token)
+    return validator.compute_signature(url, form)

--- a/tests/test_twilio_channel.py
+++ b/tests/test_twilio_channel.py
@@ -7,6 +7,7 @@ at its REST entry point so no live Twilio account is required.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -379,3 +380,118 @@ async def test_download_media_uses_basic_auth(monkeypatch: pytest.MonkeyPatch) -
     assert media.mime_type == "image/jpeg"
     assert media.filename.endswith(".jpg")
     assert isinstance(captured_auth[0], httpx.BasicAuth)
+
+
+async def test_download_media_rejects_non_twilio_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """download_media refuses URLs that aren't on a Twilio-owned host.
+
+    Defense in depth: even if signature validation is off and a malicious
+    webhook injects ``MediaUrl0=http://internal/...``, we must not send
+    the account-SID Basic Auth header to that host.
+    """
+    called = False
+
+    async def fake_download_bounded(*_args: object, **_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        return b"", httpx.Headers()
+
+    monkeypatch.setattr("backend.app.channels.twilio.download_bounded", fake_download_bounded)
+
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+
+    with pytest.raises(ValueError, match="non-Twilio host"):
+        await channel.download_media("http://attacker.example.com/leak")
+    assert called is False
+
+
+async def test_to_verifier_drops_inbound_when_pair_unknown(
+    twilio_client: httpx.AsyncClient,
+) -> None:
+    """A registered To-verifier returning False causes the webhook to drop the message."""
+    from backend.app.channels.twilio import set_twilio_to_verifier
+
+    seen: list[tuple[str, str]] = []
+
+    async def verifier(from_phone: str, to_phone: str) -> bool:
+        seen.append((from_phone, to_phone))
+        return False
+
+    set_twilio_to_verifier(verifier)
+    try:
+        with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+            form = make_twilio_form(sender="+15555555555", to="+18001111111", text="hi")
+            resp = await _post_form(twilio_client, form)
+    finally:
+        import backend.app.channels.twilio as twilio_mod
+
+        twilio_mod._to_verifier = None
+
+    assert resp.status_code == 200
+    assert resp.text == TWIML_EMPTY
+    mock_pub.assert_not_called()
+    assert seen == [("+15555555555", "+18001111111")]
+
+
+async def test_to_verifier_accepts_inbound_when_pair_matches(
+    twilio_client: httpx.AsyncClient,
+) -> None:
+    """A verifier returning True lets the message through to the bus."""
+    from backend.app.channels.twilio import set_twilio_to_verifier
+
+    async def verifier(from_phone: str, to_phone: str) -> bool:
+        return True
+
+    set_twilio_to_verifier(verifier)
+    try:
+        with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+            form = make_twilio_form(text="ok")
+            await _post_form(twilio_client, form)
+    finally:
+        import backend.app.channels.twilio as twilio_mod
+
+        twilio_mod._to_verifier = None
+
+    mock_pub.assert_called_once()
+
+
+async def test_to_verifier_exception_drops_inbound(
+    twilio_client: httpx.AsyncClient,
+) -> None:
+    """A verifier that raises should drop the message, not 500.
+
+    Choosing drop-on-error rather than fall-back-to-allow because the
+    verifier is the *security* hook for premium; the from-resolver is
+    the *outbound* hook where failure can safely degrade.
+    """
+    from backend.app.channels.twilio import set_twilio_to_verifier
+
+    async def verifier(from_phone: str, to_phone: str) -> bool:
+        raise RuntimeError("db unreachable")
+
+    set_twilio_to_verifier(verifier)
+    try:
+        with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+            form = make_twilio_form()
+            resp = await _post_form(twilio_client, form)
+    finally:
+        import backend.app.channels.twilio as twilio_mod
+
+        twilio_mod._to_verifier = None
+
+    assert resp.status_code == 200
+    mock_pub.assert_not_called()
+
+
+async def test_parse_form_warns_on_missing_message_sid(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Missing MessageSid is real-world impossible from Twilio; log loud to surface upstream issues."""
+    form = {"From": "+15551234567", "Body": "test", "NumMedia": "0"}
+    caplog.set_level(logging.WARNING, logger="backend.app.channels.twilio")
+    inbound = TwilioChannel.parse_form(form)
+    assert inbound is not None
+    assert inbound.external_message_id == ""
+    assert any("missing MessageSid" in rec.message for rec in caplog.records)

--- a/tests/test_twilio_channel.py
+++ b/tests/test_twilio_channel.py
@@ -1,0 +1,312 @@
+"""Tests for the Twilio channel: webhook handling, signature validation,
+parsing, allowlist gating, idempotency, and outbound SMS/MMS sending.
+
+Mirrors the structure of ``test_linq_channel.py``. The Twilio SDK is mocked
+at its REST entry point so no live Twilio account is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from backend.app.channels.twilio import TWIML_EMPTY, TwilioChannel
+from tests.mocks.twilio import TWILIO_TEST_AUTH_TOKEN, make_twilio_form, sign_twilio_form
+
+_PATCH_BUS_PUBLISH = "backend.app.bus.message_bus.publish_inbound"
+_WEBHOOK_URL = "http://testserver/api/webhooks/twilio"
+
+
+async def _post_form(
+    client: httpx.AsyncClient,
+    form: dict[str, str],
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """POST a Twilio-style form payload to the webhook endpoint."""
+    return await client.post(
+        "/api/webhooks/twilio",
+        data=form,
+        headers=headers or {"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Webhook endpoint tests
+# ---------------------------------------------------------------------------
+
+
+async def test_inbound_webhook_returns_empty_twiml(twilio_client: httpx.AsyncClient) -> None:
+    """Valid webhook payload returns 200 with empty TwiML."""
+    with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock):
+        resp = await _post_form(twilio_client, make_twilio_form(text="Hello"))
+    assert resp.status_code == 200
+    assert resp.text == TWIML_EMPTY
+    assert resp.headers["content-type"].startswith("application/xml")
+
+
+async def test_inbound_webhook_publishes_text(twilio_client: httpx.AsyncClient) -> None:
+    """Inbound text message is published to the bus."""
+    with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+        form = make_twilio_form(sender="+15559876543", text="Need a quote")
+        await _post_form(twilio_client, form)
+
+    mock_pub.assert_called_once()
+    inbound = mock_pub.call_args[0][0]
+    assert inbound.channel == "twilio"
+    assert inbound.sender_id == "+15559876543"
+    assert inbound.text == "Need a quote"
+
+
+async def test_inbound_webhook_publishes_media(twilio_client: httpx.AsyncClient) -> None:
+    """MediaUrl/MediaContentType fields are surfaced in the published InboundMessage."""
+    media = [
+        ("https://api.twilio.com/Accounts/AC0/Messages/MM0/Media/ME0", "image/jpeg"),
+        ("https://api.twilio.com/Accounts/AC0/Messages/MM0/Media/ME1", "image/png"),
+    ]
+    with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+        form = make_twilio_form(text="Pics", media=media)
+        await _post_form(twilio_client, form)
+
+    mock_pub.assert_called_once()
+    inbound = mock_pub.call_args[0][0]
+    assert inbound.text == "Pics"
+    assert inbound.media_refs == media
+
+
+async def test_inbound_webhook_uses_message_sid_for_idempotency(
+    twilio_client: httpx.AsyncClient,
+) -> None:
+    """external_message_id is keyed off MessageSid so duplicates are dropped."""
+    with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+        form = make_twilio_form(message_sid="SM1234567890")
+        await _post_form(twilio_client, form)
+        # Send the same MessageSid again to trigger dedup
+        await _post_form(twilio_client, form)
+
+    # Only the first delivery should publish; the duplicate is blocked at
+    # the idempotency store inside handle_webhook_inbound.
+    assert mock_pub.call_count == 1
+    inbound = mock_pub.call_args[0][0]
+    assert inbound.external_message_id == "twilio_SM1234567890"
+
+
+async def test_inbound_webhook_blocked_by_allowlist(twilio_client: httpx.AsyncClient) -> None:
+    """A sender not on the allowlist is rejected before bus publish."""
+    with (
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+        patch(
+            "backend.app.channels.twilio.settings.twilio_allowed_numbers",
+            "+15550000000",
+        ),
+    ):
+        form = make_twilio_form(sender="+15551111111")
+        resp = await _post_form(twilio_client, form)
+
+    assert resp.status_code == 200
+    mock_pub.assert_not_called()
+
+
+async def test_inbound_webhook_missing_from_returns_empty(
+    twilio_client: httpx.AsyncClient,
+) -> None:
+    """A payload without From is ignored gracefully (no crash, no publish)."""
+    with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+        form = make_twilio_form()
+        del form["From"]
+        resp = await _post_form(twilio_client, form)
+
+    assert resp.status_code == 200
+    assert resp.text == TWIML_EMPTY
+    mock_pub.assert_not_called()
+
+
+async def test_inbound_webhook_invalid_signature_dropped(
+    twilio_client: httpx.AsyncClient,
+) -> None:
+    """When signature validation is on and the header is wrong, the bus is not called."""
+    with (
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+        patch("backend.app.channels.twilio.settings.twilio_validate_signatures", True),
+        patch(
+            "backend.app.channels.twilio.settings.twilio_auth_token",
+            TWILIO_TEST_AUTH_TOKEN,
+        ),
+    ):
+        form = make_twilio_form()
+        resp = await _post_form(
+            twilio_client,
+            form,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-Twilio-Signature": "obviously-wrong-signature",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.text == TWIML_EMPTY
+    mock_pub.assert_not_called()
+
+
+async def test_inbound_webhook_valid_signature_accepted(
+    twilio_client: httpx.AsyncClient,
+) -> None:
+    """A correctly signed request passes the signature gate and reaches the bus."""
+    form = make_twilio_form(text="signed")
+    signature = sign_twilio_form(_WEBHOOK_URL, form)
+
+    with (
+        patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub,
+        patch("backend.app.channels.twilio.settings.twilio_validate_signatures", True),
+        patch(
+            "backend.app.channels.twilio.settings.twilio_auth_token",
+            TWILIO_TEST_AUTH_TOKEN,
+        ),
+    ):
+        resp = await _post_form(
+            twilio_client,
+            form,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-Twilio-Signature": signature,
+            },
+        )
+
+    assert resp.status_code == 200
+    mock_pub.assert_called_once()
+    inbound = mock_pub.call_args[0][0]
+    assert inbound.text == "signed"
+
+
+# ---------------------------------------------------------------------------
+# Outbound tests (mock the Twilio REST SDK at the boundary)
+# ---------------------------------------------------------------------------
+
+
+def _make_channel_with_mocked_client() -> tuple[TwilioChannel, MagicMock]:
+    """Build a channel whose ``client.messages.create`` returns a stub message."""
+    channel = TwilioChannel()
+    mock_message = MagicMock()
+    mock_message.sid = "SMabcdef"
+    mock_client = MagicMock()
+    mock_client.messages.create = MagicMock(return_value=mock_message)
+    channel._client = mock_client
+    return channel, mock_client
+
+
+async def test_send_text_uses_phone_number_when_no_messaging_service() -> None:
+    """With only ``twilio_phone_number`` set, ``from_`` is pinned."""
+    channel, mock_client = _make_channel_with_mocked_client()
+
+    with (
+        patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"),
+        patch("backend.app.channels.twilio.settings.twilio_messaging_service_sid", ""),
+    ):
+        sid = await channel.send_text("+15551234567", "hi")
+
+    assert sid == "SMabcdef"
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs == {
+        "to": "+15551234567",
+        "body": "hi",
+        "from_": "+15550000001",
+    }
+
+
+async def test_send_text_prefers_messaging_service_sid() -> None:
+    """When both are set, the Messaging Service SID wins (A2P 10DLC path)."""
+    channel, mock_client = _make_channel_with_mocked_client()
+
+    with (
+        patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"),
+        patch(
+            "backend.app.channels.twilio.settings.twilio_messaging_service_sid",
+            "MG" + "0" * 32,
+        ),
+    ):
+        await channel.send_text("+15551234567", "hi")
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert "from_" not in kwargs
+    assert kwargs["messaging_service_sid"] == "MG" + "0" * 32
+
+
+async def test_send_text_raises_when_no_sender_configured() -> None:
+    """Refuse to send when neither sender is configured: silent drops would hide misconfig."""
+    channel, _ = _make_channel_with_mocked_client()
+    with (
+        patch("backend.app.channels.twilio.settings.twilio_phone_number", ""),
+        patch("backend.app.channels.twilio.settings.twilio_messaging_service_sid", ""),
+        pytest.raises(RuntimeError, match="TWILIO_PHONE_NUMBER"),
+    ):
+        await channel.send_text("+15551234567", "hi")
+
+
+async def test_send_media_attaches_single_media_url() -> None:
+    """send_media wraps the URL in a one-element list for the SDK."""
+    channel, mock_client = _make_channel_with_mocked_client()
+    with patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"):
+        await channel.send_media("+15551234567", "see attached", "https://example.com/img.jpg")
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs["media_url"] == ["https://example.com/img.jpg"]
+    assert kwargs["body"] == "see attached"
+
+
+async def test_send_message_sends_one_mms_for_multiple_media() -> None:
+    """Multi-URL outbound is one MMS, not N sends (overrides BaseChannel default)."""
+    channel, mock_client = _make_channel_with_mocked_client()
+    urls = ["https://example.com/a.jpg", "https://example.com/b.jpg"]
+    with patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"):
+        await channel.send_message("+15551234567", "two pics", media_urls=urls)
+
+    # Exactly one create() call, not two.
+    assert mock_client.messages.create.call_count == 1
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs["media_url"] == urls
+    assert kwargs["body"] == "two pics"
+
+
+async def test_send_typing_indicator_is_noop() -> None:
+    """send_typing_indicator must not raise and must not touch the SDK.
+
+    SMS has no typing-indicator concept; the override exists only to
+    satisfy BaseChannel.
+    """
+    channel, mock_client = _make_channel_with_mocked_client()
+    await channel.send_typing_indicator("+15551234567")
+    mock_client.messages.create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Media download tests
+# ---------------------------------------------------------------------------
+
+
+async def test_download_media_uses_basic_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """download_media authenticates with the account SID + auth token."""
+    captured_auth: list[httpx.BasicAuth] = []
+
+    async def fake_download_bounded(
+        client: httpx.AsyncClient, url: str
+    ) -> tuple[bytes, httpx.Headers]:
+        # Capture the auth attached to the client so the test can verify
+        # we passed Basic Auth instead of a raw Bearer.
+        captured_auth.append(client.auth)  # type: ignore[arg-type]
+        return b"image-bytes", httpx.Headers({"content-type": "image/jpeg"})
+
+    monkeypatch.setattr("backend.app.channels.twilio.download_bounded", fake_download_bounded)
+
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+
+    media = await channel.download_media(
+        "https://api.twilio.com/Accounts/AC0/Messages/MM0/Media/ME0"
+    )
+
+    assert media.content == b"image-bytes"
+    assert media.mime_type == "image/jpeg"
+    assert media.filename.endswith(".jpg")
+    assert isinstance(captured_auth[0], httpx.BasicAuth)

--- a/tests/test_twilio_channel.py
+++ b/tests/test_twilio_channel.py
@@ -268,6 +268,75 @@ async def test_send_message_sends_one_mms_for_multiple_media() -> None:
     assert kwargs["body"] == "two pics"
 
 
+async def test_per_user_from_resolver_overrides_global_sender() -> None:
+    """When a from_resolver is registered, its return value pins from_ per recipient."""
+    from backend.app.channels.twilio import set_twilio_from_resolver
+
+    channel, mock_client = _make_channel_with_mocked_client()
+
+    async def resolver(to: str) -> str | None:
+        return "+18001111111" if to == "+15551234567" else None
+
+    set_twilio_from_resolver(resolver)
+    try:
+        with patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"):
+            await channel.send_text("+15551234567", "hi")
+    finally:
+        # Reset so other tests aren't poisoned by this one's resolver.
+        import backend.app.channels.twilio as twilio_mod
+
+        twilio_mod._from_resolver = None
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    # The per-user resolver should win over the global TWILIO_PHONE_NUMBER.
+    assert kwargs["from_"] == "+18001111111"
+
+
+async def test_per_user_from_resolver_falls_back_when_none() -> None:
+    """A resolver that returns None falls back to the global Twilio sender."""
+    from backend.app.channels.twilio import set_twilio_from_resolver
+
+    channel, mock_client = _make_channel_with_mocked_client()
+
+    async def resolver(to: str) -> str | None:
+        return None
+
+    set_twilio_from_resolver(resolver)
+    try:
+        with patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"):
+            await channel.send_text("+15551234567", "hi")
+    finally:
+        import backend.app.channels.twilio as twilio_mod
+
+        twilio_mod._from_resolver = None
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs["from_"] == "+15550000001"
+
+
+async def test_per_user_resolver_failure_falls_back_to_global() -> None:
+    """A resolver that raises should not block the send; we fall back to global."""
+    from backend.app.channels.twilio import set_twilio_from_resolver
+
+    channel, mock_client = _make_channel_with_mocked_client()
+
+    async def resolver(to: str) -> str | None:
+        raise RuntimeError("db unreachable")
+
+    set_twilio_from_resolver(resolver)
+    try:
+        with patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"):
+            sid = await channel.send_text("+15551234567", "hi")
+    finally:
+        import backend.app.channels.twilio as twilio_mod
+
+        twilio_mod._from_resolver = None
+
+    assert sid == "SMabcdef"
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs["from_"] == "+15550000001"
+
+
 async def test_send_typing_indicator_is_noop() -> None:
     """send_typing_indicator must not raise and must not touch the SDK.
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-04T13:13:44.80209309Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -121,6 +121,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/e6/1b3566e103eca6da5be4ae6713e112a053725c584e96574caf117568ffef/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cb19177205d93b881f3f89e6081593676043a6828f59c78c17a0fd6c1fbed2ba", size = 1782635, upload-time = "2026-03-28T17:18:43.073Z" },
     { url = "https://files.pythonhosted.org/packages/37/58/1b11c71904b8d079eb0c39fe664180dd1e14bebe5608e235d8bfbadc8929/aiohttp-3.13.4-cp314-cp314t-win32.whl", hash = "sha256:c606aa5656dab6552e52ca368e43869c916338346bfaf6304e15c58fb113ea30", size = 472537, upload-time = "2026-03-28T17:18:46.286Z" },
     { url = "https://files.pythonhosted.org/packages/bc/8f/87c56a1a1977d7dddea5b31e12189665a140fdb48a71e9038ff90bb564ec/aiohttp-3.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:014dcc10ec8ab8db681f0d68e939d1e9286a5aa2b993cbbdb0db130853e02144", size = 506381, upload-time = "2026-03-28T17:18:48.74Z" },
+]
+
+[[package]]
+name = "aiohttp-retry"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981, upload-time = "2024-11-06T10:44:52.917Z" },
 ]
 
 [[package]]
@@ -648,6 +660,7 @@ dependencies = [
     { name = "python-telegram-bot" },
     { name = "simpleeval" },
     { name = "sqlalchemy" },
+    { name = "twilio" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -700,6 +713,7 @@ requires-dist = [
     { name = "simpleeval", specifier = ">=1.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "twilio", specifier = ">=9.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
@@ -2854,6 +2868,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3466,6 +3489,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "twilio"
+version = "9.10.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pyjwt" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/97/c439bc2c058f8a24edd732f5cc82adedd8794bcc2da0836c2eff1e2dbe91/twilio-9.10.5.tar.gz", hash = "sha256:d9f93b9280349ee7b52e7f17a0600fd7bfd0f7ff88eb00c40270164bc058743f", size = 1641690, upload-time = "2026-04-14T09:52:09.392Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/97/4fdde5e54fcbb789aa1a70c371f2f33d7eb1e58e8a6131fdbd8a98490976/twilio-9.10.5-py2.py3-none-any.whl", hash = "sha256:7972db54496fbf501b238f34d1f717f80ff22720313dc706632787aad5934997", size = 2284944, upload-time = "2026-04-14T09:52:07.333Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Restores Twilio as an integration option after it was removed in #92. The OSS implementation matches the existing Telegram/Linq/BlueBubbles channels: one `BaseChannel` subclass handling inbound webhook + outbound SMS/MMS, with the standard idempotency and allowlist plumbing.

Key shape:

- `TwilioChannel(BaseChannel)` in `backend/app/channels/twilio.py`.
- Inbound webhook at `POST /api/webhooks/twilio` (form-encoded). Signature validation via `twilio.request_validator.RequestValidator`, defaulting on. `TWILIO_VALIDATE_SIGNATURES=false` only for local dev.
- Idempotency keyed off `MessageSid` (`external_message_id = "twilio_<sid>"`), so Twilio's 24h retry loop is deduped against the existing `IdempotencyStore`.
- Outbound supports both single-number (`TWILIO_PHONE_NUMBER`) and Messaging Service (`TWILIO_MESSAGING_SERVICE_SID`) senders. Messaging Service wins when both are set, which is the right default for US A2P 10DLC deployments; toll-free or international deployments use the single-number path.
- `send_typing_indicator` is intentionally a no-op. SMS has no typing-indicator concept, so silently doing nothing keeps the rest of the channel functional while operators who need typing indicators stick with Linq or BlueBubbles. Documented in `.env.example` and `docs/self-host/configuration.md`.
- `download_media` authenticates via HTTP Basic Auth with the account SID + auth token and runs through `download_bounded` so the standard size + wall-time caps apply.
- Allowlist follows the same `_check_static_allowlist` pattern as Linq, so premium's `ChannelRoute` override resolves per-user routing for free (per-user number provisioning lands in a follow-up premium PR).
- Adds `twilio>=9.0` to `pyproject.toml` / `uv.lock`.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2570 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (15 tests in `tests/test_twilio_channel.py`)
- [x] Bug fixes include regression tests — N/A (feature)

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 paired interactively: market research on Twilio capabilities re: typing indicators, design discussion, code, tests, docs)
- [ ] No AI used

Fixes #1057