### PR TITLE
feat(servicetitan): scaffold integration module with client-credentials auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,13 +158,18 @@ LLM_MODEL=
 # APPFOLIO_VENDOR_API_BASE=https://vendor.appf.io
 # APPFOLIO_VENDOR_WEB_BASE=https://vendor.appfolio.com
 
-# ServiceTitan — OAuth 2.0 client-credentials. Each tenant pastes their own
+# ServiceTitan. OAuth 2.0 client-credentials. Each tenant pastes their own
 # tenant ID, client ID, and client secret via the connect_servicetitan tool;
 # the operator wires the app-level App Key here. SERVICETITAN_USE_FAKE=true
 # routes every call to the in-process fake (no real network calls); flip to
-# false once a real sandbox or production tenant is available.
+# false once a real sandbox or production tenant is available. ServiceTitan
+# serves /connect/token on a separate auth host: auth.servicetitan.io for
+# production, auth-integration.servicetitan.io for the integration sandbox.
+# Both API_BASE_URL and AUTH_BASE_URL must be overridden together when
+# pointing at the integration environment.
 # SERVICETITAN_APP_KEY=
 # SERVICETITAN_API_BASE_URL=https://api.servicetitan.io
+# SERVICETITAN_AUTH_BASE_URL=https://auth.servicetitan.io
 # SERVICETITAN_USE_FAKE=true
 
 # Supplier Pricing (SerpApi Home Depot engine)

--- a/.env.example
+++ b/.env.example
@@ -158,6 +158,15 @@ LLM_MODEL=
 # APPFOLIO_VENDOR_API_BASE=https://vendor.appf.io
 # APPFOLIO_VENDOR_WEB_BASE=https://vendor.appfolio.com
 
+# ServiceTitan — OAuth 2.0 client-credentials. Each tenant pastes their own
+# tenant ID, client ID, and client secret via the connect_servicetitan tool;
+# the operator wires the app-level App Key here. SERVICETITAN_USE_FAKE=true
+# routes every call to the in-process fake (no real network calls); flip to
+# false once a real sandbox or production tenant is available.
+# SERVICETITAN_APP_KEY=
+# SERVICETITAN_API_BASE_URL=https://api.servicetitan.io
+# SERVICETITAN_USE_FAKE=true
+
 # Supplier Pricing (SerpApi Home Depot engine)
 # Set SERPAPI_API_KEY to enable product price lookups at Home Depot.
 # Sign up at https://serpapi.com (free tier: 250 searches/month, no credit card).

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -34,10 +34,12 @@ _MAGIC_LINK_INTEGRATIONS: set[str] = {"appfolio_vendor"}
 # These are visibility-paired with another factory: when the user-facing
 # integration is disabled, the backing factory follows. ``appfolio_auth``
 # holds the magic-link connect tools that must stay on the schema even when
-# ``appfolio_vendor`` reports "not connected"; from the user's perspective
-# both are one integration.
+# ``appfolio_vendor`` reports "not connected"; ``servicetitan_auth`` plays
+# the same role for the paste-credentials ``connect_servicetitan`` tool.
+# From the user's perspective each pair is one integration.
 _HIDDEN_CORE_FACTORIES: dict[str, str] = {
     "appfolio_auth": "appfolio_vendor",
+    "servicetitan_auth": "servicetitan",
 }
 
 

--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -89,6 +89,9 @@ class ToolName:
     APPFOLIO_GET_ESTIMATE = "appfolio_get_estimate"
     APPFOLIO_UPDATE_ESTIMATE = "appfolio_update_estimate"
 
+    # ServiceTitan
+    SERVICETITAN_CONNECT = "connect_servicetitan"
+
     # Supplier pricing
     SUPPLIER_SEARCH_PRODUCTS = "supplier_search_products"
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -208,6 +208,12 @@ class Settings(BaseSettings):
     # by tests and by the local dev loop until a real sandbox tenant is wired.
     servicetitan_app_key: str = ""
     servicetitan_api_base_url: str = "https://api.servicetitan.io"
+    # ServiceTitan splits auth and resource traffic across two hosts.
+    # Production: auth.servicetitan.io for tokens, api.servicetitan.io for
+    # resources. Integration sandbox: auth-integration.servicetitan.io plus
+    # api-integration.servicetitan.io. Operators flipping to the
+    # integration environment must override both this and api_base_url.
+    servicetitan_auth_base_url: str = "https://auth.servicetitan.io"
     servicetitan_use_fake: bool = True
 
     # Supplier pricing (SerpApi Home Depot engine)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -200,6 +200,16 @@ class Settings(BaseSettings):
     # Web app base for receipt deep links and the URL users paste from.
     appfolio_vendor_web_base: str = "https://vendor.appfolio.com"
 
+    # ServiceTitan (OAuth 2.0 client-credentials per tenant + app-level App Key).
+    # Each tenant pastes their tenant ID, client ID, and client secret via
+    # ``connect_servicetitan``; the operator wires the app-level App Key here.
+    # ``servicetitan_use_fake`` swaps the real API for the in-process fake
+    # backend (see ``backend/app/integrations/servicetitan/_fake.py``); used
+    # by tests and by the local dev loop until a real sandbox tenant is wired.
+    servicetitan_app_key: str = ""
+    servicetitan_api_base_url: str = "https://api.servicetitan.io"
+    servicetitan_use_fake: bool = True
+
     # Supplier pricing (SerpApi Home Depot engine)
     serpapi_api_key: str = ""  # https://serpapi.com — free tier: 250 searches/month
 

--- a/backend/app/integrations/servicetitan/__init__.py
+++ b/backend/app/integrations/servicetitan/__init__.py
@@ -1,0 +1,24 @@
+"""ServiceTitan integration package.
+
+The integration is split across:
+
+* ``_fake.py``: an in-process fake of the ServiceTitan REST API, used until
+  real sandbox credentials are provisioned and as a deterministic backend
+  for tests. Exposed as an ``httpx.MockTransport`` so callers can swap it
+  in for a real network transport without any code changes.
+
+The auth, factory, service, and tool modules are added by the
+follow-on issues in the ServiceTitan mock-backed MVP milestone.
+"""
+
+from backend.app.integrations.servicetitan._fake import (
+    ServiceTitanFakeBackend,
+    build_fake_transport,
+    get_default_fake_backend,
+)
+
+__all__ = [
+    "ServiceTitanFakeBackend",
+    "build_fake_transport",
+    "get_default_fake_backend",
+]

--- a/backend/app/integrations/servicetitan/_fake.py
+++ b/backend/app/integrations/servicetitan/_fake.py
@@ -1,0 +1,1095 @@
+"""In-process fake of the ServiceTitan REST API.
+
+ServiceTitan does not currently provide a sandbox tenant we can call.
+Until that lands, every layer of the integration (auth, read tools,
+write tools, agent flows, CI) needs a deterministic backend that
+behaves like the real API at the wire level. This module provides
+that backend.
+
+The fake is exposed two ways:
+
+* :class:`ServiceTitanFakeBackend` holds the seed dataset and routes
+  raw method/path requests to handler functions. It carries no httpx
+  dependency in its public surface, so tools can call it directly in
+  unit tests when convenient.
+
+* :func:`build_fake_transport` wraps a backend instance in an
+  :class:`httpx.MockTransport` so a real ``httpx.AsyncClient`` can be
+  pointed at it. This is the path production code will use when the
+  ``servicetitan_use_fake`` setting is true (wired in the auth
+  scaffold issue): the service layer constructs an httpx client with
+  the fake transport instead of a real network transport, and every
+  call site stays identical to what it will be against the live API.
+
+The seed dataset is deliberately small (10 customers, 30 jobs, 15
+appointments) but representative: a mix of Residential and Commercial
+customers, HVAC / Plumbing / Electrical work, jobs in every common
+status (Scheduled, Dispatched, InProgress, Completed, Hold, Canceled),
+and appointments scattered around a fixed reference date ("today") so
+date-range filters have something to find. Names and contact details
+are obviously synthetic per the project-wide PII rules: "Acme
+Plumbing", "Jane Doe", phone numbers in the 555 range, "123 Main St".
+
+Endpoint shapes follow the public ServiceTitan OpenAPI spec
+(developer.servicetitan.io) for the endpoints the MVP needs:
+
+* ``POST /connect/token`` (15-minute Bearer)
+* ``GET /crm/v2/tenant/{tenant}/customers`` (list with search filters)
+* ``GET /crm/v2/tenant/{tenant}/customers/{id}`` (single record, 404 on miss)
+* ``GET /crm/v2/tenant/{tenant}/customers/{id}/contacts``
+* ``GET /jpm/v2/tenant/{tenant}/jobs`` (list with filters)
+* ``GET /jpm/v2/tenant/{tenant}/jobs/{id}``
+* ``GET /jpm/v2/tenant/{tenant}/jobs/{id}/notes``
+* ``POST /jpm/v2/tenant/{tenant}/jobs/{id}/notes``
+* ``GET /jpm/v2/tenant/{tenant}/appointments`` (list, date-range filtered)
+* ``GET /jpm/v2/tenant/{tenant}/appointments/{id}``
+
+Auth + error semantics that real ServiceTitan also surfaces:
+
+* The token endpoint expects ``grant_type=client_credentials`` form
+  data and returns ``{access_token, token_type, expires_in}``.
+* Resource endpoints require both an ``Authorization: Bearer <token>``
+  header and an ``ST-App-Key`` header. Missing or invalid token
+  returns 401; missing app key returns 401 with a distinct payload.
+* Expired tokens return 401 so refresh code paths can be exercised.
+* Unknown customer / job / appointment IDs return 404 with the
+  ServiceTitan-shaped error envelope.
+* A rate-limit override (``ServiceTitanFakeBackend.force_rate_limit_for(n)``)
+  makes the next ``n`` resource calls return 429 with a ``Retry-After``
+  header, so retry/backoff code paths can be tested.
+
+The fake is read-mostly: the only mutating endpoint right now is
+``POST /jobs/{id}/notes``, which appends to the in-memory note list
+and bumps the job's ``modifiedOn`` so downstream "show me what changed"
+flows have a real signal to react to.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import parse_qs
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Default tenant ID used by the seed dataset. Callers can route requests
+# to any tenant ID; the backend only inspects the path segment, but
+# tools and tests will most commonly use this value.
+DEFAULT_TENANT_ID = 1234567
+
+# The Bearer token returned by ``POST /connect/token``. Constant so tests
+# can hardcode it; production swaps for a real ServiceTitan token.
+FAKE_ACCESS_TOKEN = "fake-st-access-token-not-a-real-jwt"
+
+# 15-minute lifetime, mirroring the real ServiceTitan token TTL.
+ACCESS_TOKEN_TTL_SECONDS = 15 * 60
+
+# Reference "today" the seed appointments cluster around. Using a fixed
+# date keeps tests deterministic; the helper ``relative_to_today`` lets
+# callers slide the whole calendar if they want to test date-range
+# logic against ``datetime.now()`` semantics.
+SEED_TODAY = datetime(2026, 5, 11, 12, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Seed dataset
+# ---------------------------------------------------------------------------
+
+# Customer types in ServiceTitan are typically "Residential" or
+# "Commercial"; the API exposes the value as a free-form string but
+# the live tenant constrains it via enum. The fake mirrors that shape.
+CUSTOMER_TYPE_RESIDENTIAL = "Residential"
+CUSTOMER_TYPE_COMMERCIAL = "Commercial"
+
+# Contact types the real API returns on customer contact records.
+CONTACT_TYPE_PHONE = "Phone"
+CONTACT_TYPE_MOBILE = "MobilePhone"
+CONTACT_TYPE_EMAIL = "Email"
+
+# Job-status enum values observed on the live API.
+JOB_STATUS_SCHEDULED = "Scheduled"
+JOB_STATUS_DISPATCHED = "Dispatched"
+JOB_STATUS_IN_PROGRESS = "InProgress"
+JOB_STATUS_COMPLETED = "Completed"
+JOB_STATUS_HOLD = "Hold"
+JOB_STATUS_CANCELED = "Canceled"
+
+# Appointment-status enum values.
+APPT_STATUS_SCHEDULED = "Scheduled"
+APPT_STATUS_DISPATCHED = "Dispatched"
+APPT_STATUS_WORKING = "Working"
+APPT_STATUS_DONE = "Done"
+APPT_STATUS_HOLD = "Hold"
+
+
+def _iso(dt: datetime) -> str:
+    """Format a UTC datetime the way the ServiceTitan API serializes them."""
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _seed_customers() -> list[dict[str, Any]]:
+    """Build the seed customer records.
+
+    Ten customers split 7/3 residential/commercial, each with a
+    primary address and one or two contacts (phone + optionally email
+    or mobile). IDs start at 1001 to make the integer "looks like a
+    real ServiceTitan ID" without leaking real customer numbers.
+    """
+    now_iso = _iso(SEED_TODAY - timedelta(days=365))
+    mod_iso = _iso(SEED_TODAY - timedelta(days=7))
+
+    raw: list[dict[str, Any]] = [
+        {
+            "id": 1001,
+            "name": "Jane Doe",
+            "type": CUSTOMER_TYPE_RESIDENTIAL,
+            "address": {
+                "street": "123 Main St",
+                "city": "Anytown",
+                "state": "PA",
+                "zip": "19103",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5001, "type": CONTACT_TYPE_PHONE, "value": "+15555550101"},
+                {"id": 5002, "type": CONTACT_TYPE_EMAIL, "value": "jane.doe@example.com"},
+            ],
+        },
+        {
+            "id": 1002,
+            "name": "John Roe",
+            "type": CUSTOMER_TYPE_RESIDENTIAL,
+            "address": {
+                "street": "456 Oak Ave",
+                "city": "Anytown",
+                "state": "PA",
+                "zip": "19104",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5003, "type": CONTACT_TYPE_MOBILE, "value": "+15555550102"},
+            ],
+        },
+        {
+            "id": 1003,
+            "name": "Acme Plumbing",
+            "type": CUSTOMER_TYPE_COMMERCIAL,
+            "address": {
+                "street": "789 Industry Park",
+                "unit": "Suite 200",
+                "city": "Commerce City",
+                "state": "PA",
+                "zip": "19105",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5004, "type": CONTACT_TYPE_PHONE, "value": "+15555550103"},
+                {"id": 5005, "type": CONTACT_TYPE_EMAIL, "value": "ops@acme-plumbing.example.com"},
+            ],
+        },
+        {
+            "id": 1004,
+            "name": "Alice Smith",
+            "type": CUSTOMER_TYPE_RESIDENTIAL,
+            "address": {
+                "street": "12 Elm St",
+                "city": "Anytown",
+                "state": "PA",
+                "zip": "19106",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5006, "type": CONTACT_TYPE_PHONE, "value": "+15555550104"},
+                {"id": 5007, "type": CONTACT_TYPE_EMAIL, "value": "alice.smith@example.com"},
+            ],
+        },
+        {
+            "id": 1005,
+            "name": "Bob Johnson",
+            "type": CUSTOMER_TYPE_RESIDENTIAL,
+            "address": {
+                "street": "34 Pine St",
+                "city": "Anytown",
+                "state": "PA",
+                "zip": "19107",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5008, "type": CONTACT_TYPE_MOBILE, "value": "+15555550105"},
+            ],
+        },
+        {
+            "id": 1006,
+            "name": "Carol Williams",
+            "type": CUSTOMER_TYPE_RESIDENTIAL,
+            "address": {
+                "street": "56 Cedar Ln",
+                "city": "Other Town",
+                "state": "NJ",
+                "zip": "08001",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5009, "type": CONTACT_TYPE_PHONE, "value": "+15555550106"},
+                {"id": 5010, "type": CONTACT_TYPE_EMAIL, "value": "carol.williams@example.com"},
+            ],
+        },
+        {
+            "id": 1007,
+            "name": "Globex Property Management",
+            "type": CUSTOMER_TYPE_COMMERCIAL,
+            "address": {
+                "street": "100 Corporate Blvd",
+                "unit": "Floor 5",
+                "city": "Big City",
+                "state": "NJ",
+                "zip": "08002",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5011, "type": CONTACT_TYPE_PHONE, "value": "+15555550107"},
+                {
+                    "id": 5012,
+                    "type": CONTACT_TYPE_EMAIL,
+                    "value": "facilities@globex-pm.example.com",
+                },
+            ],
+        },
+        {
+            "id": 1008,
+            "name": "David Brown",
+            "type": CUSTOMER_TYPE_RESIDENTIAL,
+            "address": {
+                "street": "78 Maple Dr",
+                "city": "Anytown",
+                "state": "PA",
+                "zip": "19108",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5013, "type": CONTACT_TYPE_PHONE, "value": "+15555550108"},
+            ],
+        },
+        {
+            "id": 1009,
+            "name": "Eve Davis",
+            "type": CUSTOMER_TYPE_RESIDENTIAL,
+            "address": {
+                "street": "90 Birch Ave",
+                "city": "Anytown",
+                "state": "PA",
+                "zip": "19109",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5014, "type": CONTACT_TYPE_MOBILE, "value": "+15555550109"},
+                {"id": 5015, "type": CONTACT_TYPE_EMAIL, "value": "eve.davis@example.com"},
+            ],
+        },
+        {
+            "id": 1010,
+            "name": "Initech Holdings",
+            "type": CUSTOMER_TYPE_COMMERCIAL,
+            "address": {
+                "street": "200 Tech Center Way",
+                "city": "Big City",
+                "state": "NJ",
+                "zip": "08003",
+                "country": "USA",
+            },
+            "contacts": [
+                {"id": 5016, "type": CONTACT_TYPE_PHONE, "value": "+15555550110"},
+                {"id": 5017, "type": CONTACT_TYPE_EMAIL, "value": "ap@initech.example.com"},
+            ],
+        },
+    ]
+
+    # Each customer record also exposes a location reference (the real
+    # API has separate locations endpoints; the fake collapses each
+    # customer's primary address into one synthetic location whose ID
+    # equals the customer ID for now, since the MVP tools do not
+    # exercise multi-location customers yet).
+    for c in raw:
+        c.setdefault("active", True)
+        c.setdefault("doNotMail", False)
+        c.setdefault("doNotService", False)
+        c.setdefault("balance", 0.0)
+        c.setdefault("createdOn", now_iso)
+        c.setdefault("modifiedOn", mod_iso)
+        c.setdefault("createdById", 1)
+        c.setdefault("customFields", [])
+    return raw
+
+
+def _seed_jobs() -> list[dict[str, Any]]:
+    """Build the seed job records.
+
+    Thirty jobs distributed across the ten customers with a mix of
+    HVAC, plumbing, and electrical work and every common status. The
+    job ``summary`` field carries a short human description that
+    tools can surface verbatim in chat output.
+    """
+    created_iso = _iso(SEED_TODAY - timedelta(days=30))
+    mod_iso = _iso(SEED_TODAY - timedelta(days=1))
+
+    # (customer_id, job_type, status, summary, business_unit_id)
+    plan: list[tuple[int, str, str, str, int]] = [
+        # HVAC mix
+        (1001, "HVAC", JOB_STATUS_COMPLETED, "AC tune-up, replaced capacitor", 10),
+        (1001, "HVAC", JOB_STATUS_SCHEDULED, "Annual furnace maintenance", 10),
+        (1002, "HVAC", JOB_STATUS_DISPATCHED, "No cooling diagnostic", 10),
+        (1002, "HVAC", JOB_STATUS_COMPLETED, "Replaced thermostat", 10),
+        (1004, "HVAC", JOB_STATUS_IN_PROGRESS, "Heat pump installation, day 2 of 3", 10),
+        (1006, "HVAC", JOB_STATUS_HOLD, "Awaiting condenser part backorder", 10),
+        (1008, "HVAC", JOB_STATUS_COMPLETED, "Duct cleaning", 10),
+        (1009, "HVAC", JOB_STATUS_SCHEDULED, "AC seasonal start-up", 10),
+        # Plumbing mix
+        (1001, "Plumbing", JOB_STATUS_COMPLETED, "Replaced kitchen disposal", 20),
+        (1003, "Plumbing", JOB_STATUS_IN_PROGRESS, "Commercial restroom repipe", 20),
+        (1003, "Plumbing", JOB_STATUS_COMPLETED, "Backflow preventer test", 20),
+        (1004, "Plumbing", JOB_STATUS_SCHEDULED, "Water heater replacement quote", 20),
+        (1005, "Plumbing", JOB_STATUS_DISPATCHED, "Leaking shower valve", 20),
+        (1005, "Plumbing", JOB_STATUS_CANCELED, "Customer rescheduled with neighbor", 20),
+        (1007, "Plumbing", JOB_STATUS_SCHEDULED, "Quarterly grease trap service", 20),
+        (1008, "Plumbing", JOB_STATUS_COMPLETED, "Toilet flange repair", 20),
+        (1010, "Plumbing", JOB_STATUS_IN_PROGRESS, "Office building water main shutoff valve", 20),
+        # Electrical mix
+        (1002, "Electrical", JOB_STATUS_COMPLETED, "Replaced GFCI outlets in kitchen", 30),
+        (1004, "Electrical", JOB_STATUS_COMPLETED, "Ceiling fan installation", 30),
+        (1006, "Electrical", JOB_STATUS_SCHEDULED, "Whole-home surge protector add-on", 30),
+        (1006, "Electrical", JOB_STATUS_DISPATCHED, "Breaker tripping intermittently", 30),
+        (1007, "Electrical", JOB_STATUS_IN_PROGRESS, "Parking lot pole-light retrofit", 30),
+        (1009, "Electrical", JOB_STATUS_HOLD, "Permit pending for sub-panel upgrade", 30),
+        (1010, "Electrical", JOB_STATUS_COMPLETED, "EV charger 240V install", 30),
+        # Mixed leftovers to round out edge statuses
+        (1001, "Electrical", JOB_STATUS_CANCELED, "Outlet add-on, customer canceled", 30),
+        (1003, "HVAC", JOB_STATUS_SCHEDULED, "Rooftop unit quarterly PM", 10),
+        (1005, "Electrical", JOB_STATUS_SCHEDULED, "Smoke detector replacements", 30),
+        (1007, "HVAC", JOB_STATUS_COMPLETED, "Walk-in cooler thermostat swap", 10),
+        (1008, "Electrical", JOB_STATUS_SCHEDULED, "Replace porch light fixture", 30),
+        (1010, "HVAC", JOB_STATUS_IN_PROGRESS, "Server room mini-split commissioning", 10),
+    ]
+
+    jobs: list[dict[str, Any]] = []
+    for i, (cust_id, job_type, status, summary, bu_id) in enumerate(plan, start=1):
+        job_id = 2000 + i
+        completed_on = (
+            _iso(SEED_TODAY - timedelta(days=5)) if status == JOB_STATUS_COMPLETED else None
+        )
+        jobs.append(
+            {
+                "id": job_id,
+                "jobNumber": f"J-{job_id}",
+                "customerId": cust_id,
+                "locationId": cust_id,  # single-location-per-customer simplification
+                "jobStatus": status,
+                "completedOn": completed_on,
+                "businessUnitId": bu_id,
+                "jobTypeId": {"HVAC": 1, "Plumbing": 2, "Electrical": 3}[job_type],
+                "priority": "Normal",
+                "campaignId": 100,
+                "summary": summary,
+                "customFields": [],
+                "appointmentCount": 0,  # patched below once appointments are seeded
+                "firstAppointmentId": None,
+                "lastAppointmentId": None,
+                "noCharge": False,
+                "notificationsEnabled": True,
+                "createdOn": created_iso,
+                "createdById": 1,
+                "modifiedOn": mod_iso,
+                "tagTypeIds": [],
+                "externalData": [],
+            }
+        )
+    return jobs
+
+
+def _seed_appointments(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build the seed appointment records.
+
+    Fifteen appointments spread across "today" plus or minus a few
+    days. Each appointment references a real job. The ``status``
+    reflects the job's lifecycle state at the seed point. Appointments
+    are anchored to ``SEED_TODAY`` so date-range filters like "today"
+    and "this week" exercise real filtering logic.
+    """
+    # Pick a stable subset of jobs to schedule appointments against.
+    # Includes a job in every common status so today's dispatch view
+    # has variety.
+    targets = [
+        (jobs[0], -2, 9),  # completed HVAC, two days ago
+        (jobs[2], 0, 8),  # dispatched HVAC, today 8am
+        (jobs[4], 0, 11),  # in-progress HVAC install, midday
+        (jobs[4], 1, 8),  # follow-up day
+        (jobs[5], -5, 14),  # hold, before going on hold
+        (jobs[8], -1, 10),  # completed plumbing, yesterday
+        (jobs[9], 0, 13),  # in-progress plumbing midday
+        (jobs[11], 1, 9),  # scheduled plumbing tomorrow
+        (jobs[12], 0, 7),  # dispatched plumbing early today
+        (jobs[14], 2, 9),  # scheduled plumbing day after tomorrow
+        (jobs[17], -3, 10),  # completed electrical
+        (jobs[20], 0, 15),  # dispatched electrical late today
+        (jobs[21], 0, 9),  # in-progress electrical today
+        (jobs[23], -7, 9),  # completed electrical last week
+        (jobs[26], 3, 10),  # scheduled electrical later this week
+    ]
+
+    appts: list[dict[str, Any]] = []
+    for appt_seq, (job, day_offset, hour) in enumerate(targets, start=1):
+        appt_id = 3000 + appt_seq
+        start = SEED_TODAY.replace(hour=hour, minute=0, second=0, microsecond=0) + timedelta(
+            days=day_offset
+        )
+        end = start + timedelta(hours=2)
+        arr_start = start - timedelta(minutes=30)
+        arr_end = start + timedelta(minutes=30)
+
+        appt_status = {
+            JOB_STATUS_SCHEDULED: APPT_STATUS_SCHEDULED,
+            JOB_STATUS_DISPATCHED: APPT_STATUS_DISPATCHED,
+            JOB_STATUS_IN_PROGRESS: APPT_STATUS_WORKING,
+            JOB_STATUS_COMPLETED: APPT_STATUS_DONE,
+            JOB_STATUS_HOLD: APPT_STATUS_HOLD,
+            JOB_STATUS_CANCELED: APPT_STATUS_HOLD,
+        }[job["jobStatus"]]
+
+        appts.append(
+            {
+                "id": appt_id,
+                "jobId": job["id"],
+                "appointmentNumber": f"A-{appt_id}",
+                "start": _iso(start),
+                "end": _iso(end),
+                "arrivalWindowStart": _iso(arr_start),
+                "arrivalWindowEnd": _iso(arr_end),
+                "status": appt_status,
+                "specialInstructions": None,
+                "createdOn": _iso(start - timedelta(days=7)),
+                "modifiedOn": _iso(start - timedelta(days=1)),
+            }
+        )
+
+        # Patch the job's appointment counters so the job record
+        # advertises the appointments the way the real API does.
+        job["appointmentCount"] = (job.get("appointmentCount") or 0) + 1
+        if job["firstAppointmentId"] is None:
+            job["firstAppointmentId"] = appt_id
+        job["lastAppointmentId"] = appt_id
+
+    return appts
+
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _IssuedToken:
+    """An access token the fake has minted via ``POST /connect/token``."""
+
+    value: str
+    issued_at: datetime
+    expires_at: datetime
+    expired: bool = False
+
+    def is_valid(self, now: datetime) -> bool:
+        if self.expired:
+            return False
+        return now < self.expires_at
+
+
+@dataclass
+class ServiceTitanFakeBackend:
+    """In-memory ServiceTitan API double.
+
+    The dataclass fields constitute the entire state: seed records,
+    issued tokens, and override flags for forced rate-limit / expired
+    token responses. Tests construct one per case and pass it to
+    :func:`build_fake_transport`.
+
+    The state is intentionally not thread-safe. The integration calls
+    the fake serially per request from a single asyncio task, which
+    matches the locality the real API guarantees.
+    """
+
+    # The tenant the seed data lives under. Requests for other tenants
+    # return empty lists / 404s, mirroring real ServiceTitan multi-
+    # tenant isolation.
+    tenant_id: int = DEFAULT_TENANT_ID
+    app_key: str = "fake-st-app-key"
+    customers: list[dict[str, Any]] = field(default_factory=_seed_customers)
+    jobs: list[dict[str, Any]] = field(default_factory=list)
+    appointments: list[dict[str, Any]] = field(default_factory=list)
+    tokens: list[_IssuedToken] = field(default_factory=list)
+    # Number of resource calls to fail with HTTP 429 before resuming
+    # normal behavior. Decremented each time a 429 is served.
+    rate_limit_calls_remaining: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.jobs:
+            self.jobs = _seed_jobs()
+        if not self.appointments:
+            self.appointments = _seed_appointments(self.jobs)
+
+    # -- public helpers used by tests ------------------------------------
+
+    def expire_all_tokens(self) -> None:
+        """Mark every previously-issued token as expired.
+
+        Useful for testing the refresh path: after this call the next
+        resource request with the old Bearer returns 401.
+        """
+        for tok in self.tokens:
+            tok.expired = True
+
+    def force_rate_limit_for(self, n: int) -> None:
+        """Make the next ``n`` resource calls return HTTP 429.
+
+        ``/connect/token`` is never rate-limited; only resource paths
+        are affected, matching the real API.
+        """
+        self.rate_limit_calls_remaining = max(self.rate_limit_calls_remaining, n)
+
+    def issue_token(self, *, now: datetime | None = None) -> _IssuedToken:
+        """Mint a new access token and record it."""
+        moment = now or datetime.now(UTC)
+        tok = _IssuedToken(
+            value=FAKE_ACCESS_TOKEN,
+            issued_at=moment,
+            expires_at=moment + timedelta(seconds=ACCESS_TOKEN_TTL_SECONDS),
+        )
+        self.tokens.append(tok)
+        return tok
+
+    # -- request entry point --------------------------------------------
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        """Dispatch an httpx request to the right handler.
+
+        This is the function passed to :class:`httpx.MockTransport`.
+        It branches first on path prefix (token vs resource), then on
+        method + parameterized path within each namespace.
+        """
+        path = request.url.path
+        method = request.method.upper()
+
+        if path == "/connect/token":
+            return self._handle_token(request)
+
+        # Every resource path requires authentication.
+        auth_err = self._authenticate(request)
+        if auth_err is not None:
+            return auth_err
+
+        if self.rate_limit_calls_remaining > 0:
+            self.rate_limit_calls_remaining -= 1
+            return _json_response(
+                429,
+                {
+                    "type": "https://api.servicetitan.io/errors/rate-limit",
+                    "title": "Rate limit exceeded",
+                    "status": 429,
+                    "detail": "Too many requests; back off and retry.",
+                },
+                headers={"Retry-After": "1"},
+            )
+
+        # CRM customers namespace.
+        crm_prefix = f"/crm/v2/tenant/{self.tenant_id}/customers"
+        if path.startswith(crm_prefix):
+            return self._handle_crm_customers(method, path[len(crm_prefix) :], request)
+
+        # JPM jobs + appointments namespace.
+        jpm_prefix = f"/jpm/v2/tenant/{self.tenant_id}"
+        if path.startswith(jpm_prefix):
+            return self._handle_jpm(method, path[len(jpm_prefix) :], request)
+
+        # Any tenant that is not the seeded one: return empty list
+        # for collection GETs, 404 for everything else. This mirrors
+        # ServiceTitan's per-tenant scoping where the wrong tenant
+        # simply has no data.
+        if (
+            ("/customers" in path or "/jobs" in path or "/appointments" in path)
+            and method == "GET"
+            and not path.rstrip("/").rsplit("/", 1)[-1].isdigit()
+        ):
+            return _json_response(200, _paginated([]))
+        return _not_found(path)
+
+    # -- token endpoint --------------------------------------------------
+
+    def _handle_token(self, request: httpx.Request) -> httpx.Response:
+        if request.method.upper() != "POST":
+            return _json_response(405, {"error": "method_not_allowed"})
+        body = request.content.decode("utf-8") if request.content else ""
+        form = {k: v[0] for k, v in parse_qs(body).items()}
+        if form.get("grant_type") != "client_credentials":
+            return _json_response(
+                400,
+                {"error": "unsupported_grant_type", "error_description": "Use client_credentials."},
+            )
+        if not form.get("client_id") or not form.get("client_secret"):
+            return _json_response(
+                400,
+                {
+                    "error": "invalid_client",
+                    "error_description": "client_id and client_secret are required.",
+                },
+            )
+        tok = self.issue_token()
+        return _json_response(
+            200,
+            {
+                "access_token": tok.value,
+                "token_type": "Bearer",
+                "expires_in": ACCESS_TOKEN_TTL_SECONDS,
+                "scope": "",
+            },
+        )
+
+    # -- auth check on resource requests --------------------------------
+
+    def _authenticate(self, request: httpx.Request) -> httpx.Response | None:
+        """Return None when the request is authenticated, else a 401 response."""
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.lower().startswith("bearer "):
+            return _json_response(
+                401,
+                {
+                    "type": "https://api.servicetitan.io/errors/unauthenticated",
+                    "title": "Unauthenticated",
+                    "status": 401,
+                    "detail": "Missing or malformed Authorization header.",
+                },
+            )
+        bearer = auth_header.split(" ", 1)[1].strip()
+        now = datetime.now(UTC)
+        valid = any(t.value == bearer and t.is_valid(now) for t in self.tokens)
+        # If no token has been issued yet but the caller is presenting
+        # the well-known constant, accept it. This lets quick tests
+        # skip the token-handshake call when they only care about
+        # resource shapes.
+        if not valid and bearer == FAKE_ACCESS_TOKEN and not self.tokens:
+            self.issue_token()
+            valid = True
+        if not valid:
+            return _json_response(
+                401,
+                {
+                    "type": "https://api.servicetitan.io/errors/unauthenticated",
+                    "title": "Unauthenticated",
+                    "status": 401,
+                    "detail": "Access token is invalid or expired.",
+                },
+            )
+        if not request.headers.get("st-app-key"):
+            return _json_response(
+                401,
+                {
+                    "type": "https://api.servicetitan.io/errors/missing-app-key",
+                    "title": "Missing app key",
+                    "status": 401,
+                    "detail": "Requests must include the ST-App-Key header.",
+                },
+            )
+        return None
+
+    # -- CRM customers ---------------------------------------------------
+
+    def _handle_crm_customers(
+        self, method: str, suffix: str, request: httpx.Request
+    ) -> httpx.Response:
+        """Dispatch ``/crm/v2/tenant/{tenant}/customers...`` requests.
+
+        ``suffix`` is the portion of the path after the prefix, e.g.
+        empty string for the collection root, ``/1001`` for a single
+        customer, ``/1001/contacts`` for the contacts subresource.
+        """
+        if suffix in ("", "/"):
+            if method == "GET":
+                return self._list_customers(request)
+            return _json_response(405, {"error": "method_not_allowed"})
+
+        parts = suffix.lstrip("/").split("/")
+        if not parts[0].isdigit():
+            return _not_found(request.url.path)
+        cust_id = int(parts[0])
+        customer = next((c for c in self.customers if c["id"] == cust_id), None)
+
+        if len(parts) == 1:
+            if method != "GET":
+                return _json_response(405, {"error": "method_not_allowed"})
+            if customer is None:
+                return _not_found(request.url.path)
+            return _json_response(200, deepcopy(customer))
+
+        if len(parts) == 2 and parts[1] == "contacts":
+            if method != "GET":
+                return _json_response(405, {"error": "method_not_allowed"})
+            if customer is None:
+                return _not_found(request.url.path)
+            return _json_response(200, _paginated(deepcopy(customer.get("contacts", []))))
+
+        return _not_found(request.url.path)
+
+    def _list_customers(self, request: httpx.Request) -> httpx.Response:
+        params = request.url.params
+        results = [deepcopy(c) for c in self.customers]
+
+        name_q = params.get("name")
+        if name_q:
+            needle = name_q.lower()
+            results = [c for c in results if needle in c["name"].lower()]
+
+        phone_q = params.get("phone")
+        if phone_q:
+            normalized = _digits_only(phone_q)
+            results = [c for c in results if _customer_matches_phone(c, normalized)]
+
+        zip_q = params.get("zip")
+        if zip_q:
+            results = [c for c in results if c["address"]["zip"] == zip_q]
+
+        active_q = params.get("active")
+        if active_q and active_q.lower() != "any":
+            want_active = active_q.lower() == "true"
+            results = [c for c in results if c["active"] == want_active]
+
+        ids_q = params.get("ids")
+        if ids_q:
+            wanted = {int(x) for x in ids_q.split(",") if x.strip().isdigit()}
+            results = [c for c in results if c["id"] in wanted]
+
+        return _json_response(200, _paginated(results, request))
+
+    # -- JPM jobs + appointments ----------------------------------------
+
+    def _handle_jpm(self, method: str, suffix: str, request: httpx.Request) -> httpx.Response:
+        if suffix.startswith("/jobs"):
+            return self._handle_jobs(method, suffix[len("/jobs") :], request)
+        if suffix.startswith("/appointments"):
+            return self._handle_appointments(method, suffix[len("/appointments") :], request)
+        return _not_found(request.url.path)
+
+    def _handle_jobs(self, method: str, suffix: str, request: httpx.Request) -> httpx.Response:
+        if suffix in ("", "/"):
+            if method == "GET":
+                return self._list_jobs(request)
+            return _json_response(405, {"error": "method_not_allowed"})
+
+        parts = suffix.lstrip("/").split("/")
+        if not parts[0].isdigit():
+            return _not_found(request.url.path)
+        job_id = int(parts[0])
+        job = next((j for j in self.jobs if j["id"] == job_id), None)
+
+        if len(parts) == 1:
+            if method != "GET":
+                return _json_response(405, {"error": "method_not_allowed"})
+            if job is None:
+                return _not_found(request.url.path)
+            return _json_response(200, deepcopy(job))
+
+        if len(parts) == 2 and parts[1] == "notes":
+            if job is None:
+                return _not_found(request.url.path)
+            if method == "GET":
+                return _json_response(200, _paginated(deepcopy(_job_notes(job))))
+            if method == "POST":
+                return self._add_job_note(job, request)
+            return _json_response(405, {"error": "method_not_allowed"})
+
+        return _not_found(request.url.path)
+
+    def _list_jobs(self, request: httpx.Request) -> httpx.Response:
+        params = request.url.params
+        results = [deepcopy(j) for j in self.jobs]
+
+        cust_q = params.get("customerId")
+        if cust_q and cust_q.isdigit():
+            cust_id = int(cust_q)
+            results = [j for j in results if j["customerId"] == cust_id]
+
+        status_q = params.get("jobStatus")
+        if status_q:
+            wanted = {s.strip() for s in status_q.split(",") if s.strip()}
+            results = [j for j in results if j["jobStatus"] in wanted]
+
+        bu_q = params.get("businessUnitIds")
+        if bu_q:
+            wanted_ids = {int(x) for x in bu_q.split(",") if x.strip().isdigit()}
+            results = [j for j in results if j["businessUnitId"] in wanted_ids]
+
+        ids_q = params.get("ids")
+        if ids_q:
+            wanted_job_ids = {int(x) for x in ids_q.split(",") if x.strip().isdigit()}
+            results = [j for j in results if j["id"] in wanted_job_ids]
+
+        return _json_response(200, _paginated(results, request))
+
+    def _add_job_note(self, job: dict[str, Any], request: httpx.Request) -> httpx.Response:
+        try:
+            payload = json.loads(request.content.decode("utf-8")) if request.content else {}
+        except json.JSONDecodeError:
+            return _json_response(
+                400,
+                {
+                    "type": "https://api.servicetitan.io/errors/invalid-body",
+                    "title": "Invalid body",
+                    "status": 400,
+                    "detail": "Request body is not valid JSON.",
+                },
+            )
+        text = (payload.get("text") or "").strip()
+        if not text:
+            return _json_response(
+                400,
+                {
+                    "type": "https://api.servicetitan.io/errors/validation",
+                    "title": "Validation failed",
+                    "status": 400,
+                    "detail": "text is required.",
+                },
+            )
+        now = datetime.now(UTC)
+        note = {
+            "text": text,
+            "isPinned": bool(payload.get("pinToTop", False)),
+            "createdById": 1,
+            "createdOn": _iso(now),
+            "modifiedOn": _iso(now),
+        }
+        notes = job.setdefault("_notes", [])
+        notes.append(note)
+        job["modifiedOn"] = _iso(now)
+        return _json_response(200, deepcopy(note))
+
+    def _handle_appointments(
+        self, method: str, suffix: str, request: httpx.Request
+    ) -> httpx.Response:
+        if suffix in ("", "/"):
+            if method == "GET":
+                return self._list_appointments(request)
+            return _json_response(405, {"error": "method_not_allowed"})
+        parts = suffix.lstrip("/").split("/")
+        if not parts[0].isdigit():
+            return _not_found(request.url.path)
+        appt_id = int(parts[0])
+        appt = next((a for a in self.appointments if a["id"] == appt_id), None)
+        if len(parts) == 1:
+            if method != "GET":
+                return _json_response(405, {"error": "method_not_allowed"})
+            if appt is None:
+                return _not_found(request.url.path)
+            return _json_response(200, deepcopy(appt))
+        return _not_found(request.url.path)
+
+    def _list_appointments(self, request: httpx.Request) -> httpx.Response:
+        params = request.url.params
+        results = [deepcopy(a) for a in self.appointments]
+
+        starts_on_or_after = params.get("startsOnOrAfter")
+        if starts_on_or_after:
+            cutoff = _parse_iso(starts_on_or_after)
+            results = [a for a in results if _parse_iso(a["start"]) >= cutoff]
+        starts_before = params.get("startsBefore")
+        if starts_before:
+            cutoff = _parse_iso(starts_before)
+            results = [a for a in results if _parse_iso(a["start"]) < cutoff]
+
+        job_q = params.get("jobId")
+        if job_q and job_q.isdigit():
+            jid = int(job_q)
+            results = [a for a in results if a["jobId"] == jid]
+
+        status_q = params.get("status")
+        if status_q:
+            wanted = {s.strip() for s in status_q.split(",") if s.strip()}
+            results = [a for a in results if a["status"] in wanted]
+
+        return _json_response(200, _paginated(results, request))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _json_response(
+    status: int, body: dict[str, Any] | list[Any], headers: dict[str, str] | None = None
+) -> httpx.Response:
+    payload = json.dumps(body).encode("utf-8")
+    merged_headers = {"Content-Type": "application/json"}
+    if headers:
+        merged_headers.update(headers)
+    return httpx.Response(status_code=status, content=payload, headers=merged_headers)
+
+
+def _not_found(path: str) -> httpx.Response:
+    return _json_response(
+        404,
+        {
+            "type": "https://api.servicetitan.io/errors/not-found",
+            "title": "Resource not found",
+            "status": 404,
+            "detail": f"No resource at {path}.",
+        },
+    )
+
+
+def _paginated(data: list[dict[str, Any]], request: httpx.Request | None = None) -> dict[str, Any]:
+    """Wrap a list of records in ServiceTitan's pagination envelope.
+
+    The real API honors ``page`` and ``pageSize`` query params; the
+    fake slices accordingly so callers can exercise paging.
+    """
+    page = 1
+    page_size = 50
+    if request is not None:
+        params = request.url.params
+        page_str = params.get("page")
+        if page_str and page_str.isdigit():
+            page = max(int(page_str), 1)
+        ps_str = params.get("pageSize")
+        if ps_str and ps_str.isdigit():
+            page_size = max(int(ps_str), 1)
+    start = (page - 1) * page_size
+    end = start + page_size
+    slice_ = data[start:end]
+    return {
+        "page": page,
+        "pageSize": page_size,
+        "hasMore": end < len(data),
+        "totalCount": len(data),
+        "data": slice_,
+    }
+
+
+def _job_notes(job: dict[str, Any]) -> list[dict[str, Any]]:
+    """Surface a job's notes list.
+
+    Notes are stored on the job under the private ``_notes`` key so
+    the user-facing job payload doesn't expose them; the real API
+    serves them through the dedicated ``/notes`` subresource.
+    """
+    return job.get("_notes", [])
+
+
+def _digits_only(s: str) -> str:
+    return "".join(ch for ch in s if ch.isdigit())
+
+
+def _customer_matches_phone(customer: dict[str, Any], digits: str) -> bool:
+    """True when any of the customer's contacts contain the given digits."""
+    if not digits:
+        return True
+    for contact in customer.get("contacts", []):
+        if contact.get("type") in (CONTACT_TYPE_PHONE, CONTACT_TYPE_MOBILE) and digits in (
+            _digits_only(contact.get("value", ""))
+        ):
+            return True
+    return False
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse a ServiceTitan-formatted ISO timestamp into a UTC datetime."""
+    cleaned = value.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(cleaned)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def build_fake_transport(
+    backend: ServiceTitanFakeBackend | None = None,
+) -> httpx.MockTransport:
+    """Return an httpx transport that serves requests from ``backend``.
+
+    Production code that wants to talk to the fake constructs its
+    ``httpx.AsyncClient`` with ``transport=build_fake_transport()``;
+    the rest of the call site is identical to what it will be against
+    a real ServiceTitan endpoint. When ``backend`` is omitted, a new
+    backend with the default seed dataset is created and routed to.
+    """
+    target = backend or ServiceTitanFakeBackend()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return target.handle(request)
+
+    return httpx.MockTransport(handler)
+
+
+_DEFAULT_BACKEND: ServiceTitanFakeBackend | None = None
+
+
+def get_default_fake_backend() -> ServiceTitanFakeBackend:
+    """Process-wide default backend.
+
+    Useful for the integration's ``service.py`` when ``settings.
+    servicetitan_use_fake`` is true: every async client constructed
+    by the service routes through the same backend instance, so
+    state mutations (a posted job note) are visible across requests
+    within the process.
+    """
+    global _DEFAULT_BACKEND
+    if _DEFAULT_BACKEND is None:
+        _DEFAULT_BACKEND = ServiceTitanFakeBackend()
+    return _DEFAULT_BACKEND
+
+
+def reset_default_fake_backend() -> None:
+    """Drop the cached default backend (used by tests for isolation)."""
+    global _DEFAULT_BACKEND
+    _DEFAULT_BACKEND = None
+
+
+# A side-effect-free way for downstream tools to discover the available
+# seed records without poking at private state: tests in the read-tools
+# issue (#1300) iterate over the result to assert their tools surface a
+# stable subset.
+def iter_seed_customer_ids(backend: ServiceTitanFakeBackend | None = None) -> Iterable[int]:
+    target = backend or get_default_fake_backend()
+    return (c["id"] for c in target.customers)
+
+
+def iter_seed_job_ids(backend: ServiceTitanFakeBackend | None = None) -> Iterable[int]:
+    target = backend or get_default_fake_backend()
+    return (j["id"] for j in target.jobs)
+
+
+# Re-exported so callers can resolve the constant without importing the
+# private name. Useful when read tools build a fixture for the auth
+# scaffold in #1298.
+FAKE_TOKEN_VALUE: str = FAKE_ACCESS_TOKEN
+FAKE_TOKEN_TTL: int = ACCESS_TOKEN_TTL_SECONDS
+
+# Sanity check kept at import time so a regression in the seed builders
+# fails fast in the test session rather than confusing a downstream
+# tool author. Cheap (≤45 dicts) so the cost is irrelevant.
+_sanity_backend = ServiceTitanFakeBackend()
+assert len(_sanity_backend.customers) == 10, "expected 10 seed customers"
+assert len(_sanity_backend.jobs) == 30, "expected 30 seed jobs"
+assert len(_sanity_backend.appointments) == 15, "expected 15 seed appointments"
+del _sanity_backend
+
+
+# Type alias re-exported for the convenience of any downstream consumer
+# that wants to declare a handler that accepts either a request or a
+# raw method/path pair. Defined here so the underscore-prefixed module
+# isn't reached into directly elsewhere.
+RequestHandler = Callable[[httpx.Request], httpx.Response]

--- a/backend/app/integrations/servicetitan/_fake.py
+++ b/backend/app/integrations/servicetitan/_fake.py
@@ -781,9 +781,43 @@ class ServiceTitanFakeBackend:
             normalized = _digits_only(phone_q)
             results = [c for c in results if _customer_matches_phone(c, normalized)]
 
-        zip_q = params.get("zip")
-        if zip_q:
-            results = [c for c in results if c["address"]["zip"] == zip_q]
+        # Address-level filters. ``street``, ``unit``, ``city``, ``state``,
+        # ``zip``, ``country`` all match the address subobject; the real API
+        # does case-insensitive substring on the text fields and exact match
+        # on the structured fields. The fake collapses to case-insensitive
+        # substring for simplicity, which is a strict superset of exact
+        # match for normal callers.
+        for param_name, addr_key in (
+            ("street", "street"),
+            ("unit", "unit"),
+            ("city", "city"),
+            ("state", "state"),
+            ("zip", "zip"),
+            ("country", "country"),
+        ):
+            value = params.get(param_name)
+            if not value:
+                continue
+            needle = value.lower()
+            results = [
+                c for c in results if needle in str(c["address"].get(addr_key) or "").lower()
+            ]
+
+        # ``latitude`` and ``longitude`` are geographic filters in the real
+        # API and are typically paired with a radius. The fake does exact
+        # match against the address coordinates; no seed customer has
+        # coordinates set, so unmodified seed data returns an empty list
+        # for these. Callers that want to exercise geo filtering should
+        # seed their own backend with coordinate-bearing records.
+        for param_name in ("latitude", "longitude"):
+            value = params.get(param_name)
+            if not value:
+                continue
+            try:
+                target = float(value)
+            except ValueError:
+                continue
+            results = [c for c in results if c["address"].get(param_name) == target]
 
         active_q = params.get("active")
         if active_q and active_q.lower() != "any":
@@ -795,6 +829,7 @@ class ServiceTitanFakeBackend:
             wanted = {int(x) for x in ids_q.split(",") if x.strip().isdigit()}
             results = [c for c in results if c["id"] in wanted]
 
+        results = _apply_date_range_filters(results, params)
         return _json_response(200, _paginated(results, request))
 
     # -- JPM jobs + appointments ----------------------------------------
@@ -860,6 +895,25 @@ class ServiceTitanFakeBackend:
             wanted_job_ids = {int(x) for x in ids_q.split(",") if x.strip().isdigit()}
             results = [j for j in results if j["id"] in wanted_job_ids]
 
+        # ``completedOnOrAfter`` / ``completedBefore`` are JPM-specific
+        # date-range filters in addition to the standard created/modified
+        # pair that every list endpoint supports.
+        completed_after = params.get("completedOnOrAfter")
+        if completed_after:
+            cutoff = _parse_iso(completed_after)
+            results = [
+                j
+                for j in results
+                if j.get("completedOn") and _parse_iso(j["completedOn"]) >= cutoff
+            ]
+        completed_before = params.get("completedBefore")
+        if completed_before:
+            cutoff = _parse_iso(completed_before)
+            results = [
+                j for j in results if j.get("completedOn") and _parse_iso(j["completedOn"]) < cutoff
+            ]
+
+        results = _apply_date_range_filters(results, params)
         return _json_response(200, _paginated(results, request))
 
     def _add_job_note(self, job: dict[str, Any], request: httpx.Request) -> httpx.Response:
@@ -942,6 +996,7 @@ class ServiceTitanFakeBackend:
             wanted = {s.strip() for s in status_q.split(",") if s.strip()}
             results = [a for a in results if a["status"] in wanted]
 
+        results = _apply_date_range_filters(results, params)
         return _json_response(200, _paginated(results, request))
 
 
@@ -975,19 +1030,30 @@ def _not_found(path: str) -> httpx.Response:
 def _paginated(data: list[dict[str, Any]], request: httpx.Request | None = None) -> dict[str, Any]:
     """Wrap a list of records in ServiceTitan's pagination envelope.
 
-    The real API honors ``page`` and ``pageSize`` query params; the
-    fake slices accordingly so callers can exercise paging.
+    Honors ``page`` and ``pageSize`` for slicing, ``sort=+/-Field`` for
+    ordering (recognized fields: ``Id``, ``ModifiedOn``, ``CreatedOn``,
+    ``Start`` for appointments), and ``includeTotal=false`` to suppress
+    the total count (signaled by ``totalCount: -1``, which is the
+    sentinel commonly used by .NET-paginated APIs when the count is
+    intentionally not computed).
     """
     page = 1
     page_size = 50
+    include_total = True
     if request is not None:
         params = request.url.params
+        sort_q = params.get("sort")
+        if sort_q:
+            data = _apply_sort(data, sort_q)
         page_str = params.get("page")
         if page_str and page_str.isdigit():
             page = max(int(page_str), 1)
         ps_str = params.get("pageSize")
         if ps_str and ps_str.isdigit():
             page_size = max(int(ps_str), 1)
+        include_total_q = params.get("includeTotal")
+        if include_total_q is not None and include_total_q.lower() == "false":
+            include_total = False
     start = (page - 1) * page_size
     end = start + page_size
     slice_ = data[start:end]
@@ -995,9 +1061,60 @@ def _paginated(data: list[dict[str, Any]], request: httpx.Request | None = None)
         "page": page,
         "pageSize": page_size,
         "hasMore": end < len(data),
-        "totalCount": len(data),
+        "totalCount": len(data) if include_total else -1,
         "data": slice_,
     }
+
+
+# Map sort field names (PascalCase per ServiceTitan docs) to the
+# camelCase record keys in the fake. Anything else is ignored.
+_SORT_FIELD_KEYS: dict[str, str] = {
+    "Id": "id",
+    "ModifiedOn": "modifiedOn",
+    "CreatedOn": "createdOn",
+    "Start": "start",
+}
+
+
+def _apply_sort(data: list[dict[str, Any]], sort_q: str) -> list[dict[str, Any]]:
+    """Apply a ``sort=+/-Field`` query parameter to a record list."""
+    descending = sort_q.startswith("-")
+    field_name = sort_q.lstrip("+-")
+    key = _SORT_FIELD_KEYS.get(field_name)
+    if key is None:
+        return data
+    return sorted(data, key=lambda r: r.get(key) or "", reverse=descending)
+
+
+def _apply_date_range_filters(
+    data: list[dict[str, Any]],
+    params: httpx.QueryParams,
+    *,
+    created_field: str = "createdOn",
+    modified_field: str = "modifiedOn",
+) -> list[dict[str, Any]]:
+    """Apply the standard ``createdBefore`` / ``createdOnOrAfter`` /
+    ``modifiedBefore`` / ``modifiedOnOrAfter`` filters every list endpoint
+    in the real API supports.
+    """
+    spec = (
+        ("createdBefore", "<", created_field),
+        ("createdOnOrAfter", ">=", created_field),
+        ("modifiedBefore", "<", modified_field),
+        ("modifiedOnOrAfter", ">=", modified_field),
+    )
+    for param_name, comparator, record_field in spec:
+        value = params.get(param_name)
+        if not value:
+            continue
+        cutoff = _parse_iso(value)
+        if comparator == "<":
+            data = [r for r in data if r.get(record_field) and _parse_iso(r[record_field]) < cutoff]
+        else:
+            data = [
+                r for r in data if r.get(record_field) and _parse_iso(r[record_field]) >= cutoff
+            ]
+    return data
 
 
 def _job_notes(job: dict[str, Any]) -> list[dict[str, Any]]:

--- a/backend/app/integrations/servicetitan/_fake.py
+++ b/backend/app/integrations/servicetitan/_fake.py
@@ -401,6 +401,16 @@ def _seed_jobs() -> list[dict[str, Any]]:
                 "appointmentCount": 0,  # patched below once appointments are seeded
                 "firstAppointmentId": None,
                 "lastAppointmentId": None,
+                # These six fields are nullable in the live ``CrmV2JobResponse``
+                # but are always serialized. Surfacing them as ``None`` keeps
+                # the wire shape complete so tools that probe for their presence
+                # behave the same against the fake and the real API.
+                "recallForId": None,
+                "warrantyId": None,
+                "jobGeneratedLeadSource": None,
+                "leadCallId": None,
+                "bookingId": None,
+                "soldById": None,
                 "noCharge": False,
                 "notificationsEnabled": True,
                 "createdOn": created_iso,
@@ -443,6 +453,12 @@ def _seed_appointments(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
         (jobs[26], 3, 10),  # scheduled electrical later this week
     ]
 
+    # Synthetic technician IDs assigned in round-robin so dispatch-style
+    # tools can group appointments by tech. Three techs are enough to
+    # exercise the "who's on this job" surface area without bloating the
+    # seed.
+    tech_pool = [101, 102, 103]
+
     appts: list[dict[str, Any]] = []
     for appt_seq, (job, day_offset, hour) in enumerate(targets, start=1):
         appt_id = 3000 + appt_seq
@@ -462,6 +478,14 @@ def _seed_appointments(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
             JOB_STATUS_CANCELED: APPT_STATUS_HOLD,
         }[job["jobStatus"]]
 
+        # Real ``JpmV2AppointmentResponse`` ships ``technicianIds`` as a
+        # plural list because one appointment can be co-dispatched. Most
+        # appointments here get one tech; appointments on in-progress
+        # multi-day work get two so the second-tech case is exercised.
+        assigned: list[int] = [tech_pool[appt_seq % len(tech_pool)]]
+        if job["jobStatus"] == JOB_STATUS_IN_PROGRESS and appt_seq % 2 == 0:
+            assigned.append(tech_pool[(appt_seq + 1) % len(tech_pool)])
+
         appts.append(
             {
                 "id": appt_id,
@@ -473,6 +497,7 @@ def _seed_appointments(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "arrivalWindowEnd": _iso(arr_end),
                 "status": appt_status,
                 "specialInstructions": None,
+                "technicianIds": assigned,
                 "createdOn": _iso(start - timedelta(days=7)),
                 "modifiedOn": _iso(start - timedelta(days=1)),
             }

--- a/backend/app/integrations/servicetitan/auth.py
+++ b/backend/app/integrations/servicetitan/auth.py
@@ -1,0 +1,317 @@
+"""ServiceTitan credential storage and client-credentials token minting.
+
+ServiceTitan exposes an OAuth 2.0 ``client_credentials`` grant rather than
+a user-consent flow: each tenant gives the integrator a Client ID, a
+Client Secret, and a Tenant ID, and the integrator separately holds an
+app-level App Key that goes in the ``ST-App-Key`` header on every call.
+
+This module persists those four values in the ``oauth_tokens`` row for
+``integration='servicetitan'``:
+
+* ``access_token`` (encrypted) carries the current bearer token. Empty
+  before the first mint, repopulated on every refresh.
+* ``expires_at`` carries the absolute Unix timestamp at which the bearer
+  expires. The real ServiceTitan token lives 15 minutes; we honor the
+  ``expires_in`` returned by the token endpoint.
+* ``extra_json`` carries the tenant-specific metadata:
+  ``{tenant_id, client_id, client_secret, app_key}``. ``client_secret``
+  is kept here rather than in a dedicated encrypted column because
+  ``oauth_tokens.refresh_token`` is reserved for OAuth refresh tokens
+  and the surrounding code paths (e.g. ``oauth_service.refresh_token``)
+  assume the standard ``grant_type=refresh_token`` shape. Storing the
+  secret in ``extra_json`` keeps the row shape compatible with the
+  existing OAuth machinery without overloading semantics. The
+  ``extra_json`` column is plaintext on the wire to the DB, but the
+  row-level access patterns (``oauth_service.load_token`` only) keep
+  the value inside the same trust boundary as the encrypted columns;
+  if that ever changes, switching to ``refresh_token`` is a one-line
+  edit.
+
+The connect tool calls :func:`save_credentials` with the user's pasted
+values plus the freshly minted access token; downstream tools call
+:func:`get_valid_token` to lazily refresh the bearer on each call.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from backend.app.config import settings
+from backend.app.integrations.servicetitan._fake import build_fake_transport
+from backend.app.services.oauth import OAuthTokenData, oauth_service
+
+logger = logging.getLogger(__name__)
+
+INTEGRATION_NAME = "servicetitan"
+"""Value stored in ``oauth_tokens.integration`` for this integration."""
+
+
+# Path on ``settings.servicetitan_api_base_url`` that mints client-credentials
+# bearer tokens. The real ServiceTitan endpoint and the in-process fake both
+# expose ``POST /connect/token``.
+TOKEN_PATH = "/connect/token"
+
+# Treat a token as expired this many seconds before its declared expiry so
+# the bearer never lapses mid-call. The real bearer lives 15 minutes; a
+# 30-second buffer is short enough to keep token mints rare and long enough
+# to absorb clock skew plus any in-flight request.
+_TOKEN_EXPIRY_BUFFER_SECONDS = 30
+
+# Per-request timeout for the token endpoint. The mint itself is fast; the
+# generous ceiling absorbs cold-path TLS handshakes against real ServiceTitan.
+_TOKEN_REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+class ServiceTitanAuthError(RuntimeError):
+    """Raised when token minting against ServiceTitan fails.
+
+    Surfaces to the user via the connect tool when the pasted credentials
+    are wrong, and via the refresh path when an existing credential stops
+    working (e.g. the tenant rotated the secret).
+    """
+
+
+@dataclass
+class ServiceTitanCredential:
+    """Loaded ServiceTitan credential for a single tenant.
+
+    The fields mirror what gets persisted: the four user-supplied values
+    plus the integrator's app-level App Key (snapshotted at connect time
+    so a later operator-level App Key rotation does not silently break
+    existing tenants until they reconnect).
+    """
+
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    app_key: str
+    access_token: str = ""
+    expires_at: float = 0.0
+
+    def is_token_expired(self, *, now: float | None = None) -> bool:
+        """Return True when the stored bearer is empty or about to expire."""
+        if not self.access_token:
+            return True
+        if self.expires_at <= 0:
+            # No expiry recorded yet. Treat as expired so the first call
+            # mints a fresh token rather than presenting an unknown one.
+            return True
+        current = now if now is not None else time.time()
+        return current >= (self.expires_at - _TOKEN_EXPIRY_BUFFER_SECONDS)
+
+
+def _build_token_client() -> httpx.AsyncClient:
+    """Return an httpx client wired to the configured ServiceTitan host.
+
+    When ``settings.servicetitan_use_fake`` is true the client routes
+    through the in-process fake (no real network). Otherwise it points
+    at ``settings.servicetitan_api_base_url`` directly. Same code path
+    in both modes; the only difference is the transport.
+    """
+    timeout = httpx.Timeout(_TOKEN_REQUEST_TIMEOUT_SECONDS)
+    if settings.servicetitan_use_fake:
+        return httpx.AsyncClient(
+            transport=build_fake_transport(),
+            base_url=settings.servicetitan_api_base_url,
+            timeout=timeout,
+        )
+    return httpx.AsyncClient(
+        base_url=settings.servicetitan_api_base_url,
+        timeout=timeout,
+    )
+
+
+async def mint_access_token(
+    *,
+    client_id: str,
+    client_secret: str,
+) -> tuple[str, float]:
+    """Exchange a tenant's client credentials for a Bearer access token.
+
+    Returns ``(access_token, expires_at)`` where ``expires_at`` is an
+    absolute Unix timestamp. Raises :class:`ServiceTitanAuthError` for
+    any non-2xx response or transport failure.
+
+    The credentials are scoped to one tenant; the App Key header is not
+    required for ``/connect/token`` (only resource endpoints check it).
+    """
+    body = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    try:
+        async with _build_token_client() as client:
+            resp = await client.post(TOKEN_PATH, data=body)
+    except httpx.HTTPError as exc:
+        logger.warning("ServiceTitan token mint network failure: %s", exc)
+        raise ServiceTitanAuthError(f"ServiceTitan token endpoint unreachable: {exc!r}") from exc
+
+    if resp.status_code >= 400:
+        logger.warning(
+            "ServiceTitan token mint failed: status=%d body=%s",
+            resp.status_code,
+            resp.text[:500],
+        )
+        raise ServiceTitanAuthError(
+            f"ServiceTitan rejected the client credentials (HTTP {resp.status_code})"
+        )
+
+    try:
+        payload: dict[str, Any] = resp.json()
+    except ValueError as exc:
+        raise ServiceTitanAuthError("ServiceTitan token endpoint returned non-JSON body") from exc
+
+    access_token = payload.get("access_token") or ""
+    if not access_token:
+        raise ServiceTitanAuthError("ServiceTitan token endpoint returned no access_token")
+
+    expires_in = payload.get("expires_in")
+    if isinstance(expires_in, int | float) and expires_in > 0:
+        expires_at = time.time() + float(expires_in)
+    else:
+        # The fake always populates ``expires_in``; the real API is
+        # documented to as well. Fall back to a short ceiling rather
+        # than 0 so a missing field does not produce a token that the
+        # cache treats as immortal.
+        expires_at = time.time() + 60.0
+    return access_token, expires_at
+
+
+def _serialize_extra(cred: ServiceTitanCredential) -> dict[str, Any]:
+    """Build the ``extra_json`` payload from a credential."""
+    return {
+        "tenant_id": cred.tenant_id,
+        "client_id": cred.client_id,
+        "client_secret": cred.client_secret,
+        "app_key": cred.app_key,
+    }
+
+
+def _credential_from_extra(extra: dict[str, Any], token: OAuthTokenData) -> ServiceTitanCredential:
+    """Reconstruct a credential from a loaded token row's extra_json."""
+    return ServiceTitanCredential(
+        tenant_id=str(extra.get("tenant_id") or ""),
+        client_id=str(extra.get("client_id") or ""),
+        client_secret=str(extra.get("client_secret") or ""),
+        app_key=str(extra.get("app_key") or ""),
+        access_token=token.access_token,
+        expires_at=token.expires_at,
+    )
+
+
+async def save_credentials(
+    user_id: str,
+    *,
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    app_key: str,
+    access_token: str = "",
+    expires_at: float = 0.0,
+) -> ServiceTitanCredential:
+    """Persist (or replace) the ServiceTitan credential for a user.
+
+    Returns the credential object that was written so callers can pass it
+    straight to a service constructor without re-reading.
+    """
+    cred = ServiceTitanCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+        app_key=app_key,
+        access_token=access_token,
+        expires_at=expires_at,
+    )
+    token = OAuthTokenData(
+        access_token=access_token,
+        refresh_token="",
+        token_type="Bearer",
+        expires_at=expires_at,
+        scopes=[],
+        realm_id=tenant_id,
+        extra=_serialize_extra(cred),
+    )
+    await oauth_service.save_token(user_id, INTEGRATION_NAME, token)
+    logger.info(
+        "ServiceTitan credentials saved: user=%s tenant=%s",
+        user_id,
+        tenant_id,
+    )
+    return cred
+
+
+async def load_credentials(user_id: str) -> ServiceTitanCredential | None:
+    """Load the user's persisted ServiceTitan credential, if any."""
+    token = await oauth_service.load_token(user_id, INTEGRATION_NAME)
+    if token is None:
+        return None
+    extra = token.extra or {}
+    cred = _credential_from_extra(extra, token)
+    if not cred.tenant_id or not cred.client_id or not cred.client_secret:
+        # Partial row (e.g. a failed connect that wrote nothing useful).
+        # Surface as "not connected" rather than handing the caller a
+        # half-built credential.
+        return None
+    return cred
+
+
+async def clear_credentials(user_id: str) -> None:
+    """Delete the stored ServiceTitan credential. Used on disconnect."""
+    await oauth_service.delete_token(user_id, INTEGRATION_NAME)
+
+
+async def is_connected(user_id: str) -> bool:
+    """Return True when a usable ServiceTitan credential is on file.
+
+    Cheap auth-check used by ``auth_check`` callbacks: confirms the row
+    has tenant + client credentials but does not exercise the token
+    endpoint. The first real tool call refreshes the bearer if needed.
+    """
+    cred = await load_credentials(user_id)
+    return cred is not None
+
+
+async def get_valid_token(
+    user_id: str, *, force_refresh: bool = False
+) -> ServiceTitanCredential | None:
+    """Return a credential with a current bearer, minting one if needed.
+
+    The wrapper around :func:`load_credentials` plus :func:`mint_access_token`
+    that the service layer calls per request. Persists the freshly minted
+    bearer back to ``oauth_tokens`` so peer workers and subsequent calls
+    in this process see it via the OAuth service cache.
+
+    Set ``force_refresh=True`` to mint a new bearer even when the stored
+    expiry is in the future. Used by the service's 401 retry path: the
+    real ServiceTitan API can revoke a bearer before its declared
+    ``expires_in`` (e.g. on a secret rotation), and the recorded
+    expires_at would otherwise mask the revocation.
+
+    Returns ``None`` when no credential exists; raises
+    :class:`ServiceTitanAuthError` when minting against the token endpoint
+    fails (caller decides whether to clear the row).
+    """
+    cred = await load_credentials(user_id)
+    if cred is None:
+        return None
+    if not force_refresh and not cred.is_token_expired():
+        return cred
+    access_token, expires_at = await mint_access_token(
+        client_id=cred.client_id,
+        client_secret=cred.client_secret,
+    )
+    return await save_credentials(
+        user_id,
+        tenant_id=cred.tenant_id,
+        client_id=cred.client_id,
+        client_secret=cred.client_secret,
+        app_key=cred.app_key,
+        access_token=access_token,
+        expires_at=expires_at,
+    )

--- a/backend/app/integrations/servicetitan/auth.py
+++ b/backend/app/integrations/servicetitan/auth.py
@@ -108,22 +108,26 @@ class ServiceTitanCredential:
 
 
 def _build_token_client() -> httpx.AsyncClient:
-    """Return an httpx client wired to the configured ServiceTitan host.
+    """Return an httpx client wired to the ServiceTitan auth host.
 
-    When ``settings.servicetitan_use_fake`` is true the client routes
-    through the in-process fake (no real network). Otherwise it points
-    at ``settings.servicetitan_api_base_url`` directly. Same code path
-    in both modes; the only difference is the transport.
+    ServiceTitan serves ``/connect/token`` on a dedicated auth host
+    (``auth.servicetitan.io`` in production, ``auth-integration.servicetitan.io``
+    in the integration sandbox) that is distinct from the resource host
+    on ``settings.servicetitan_api_base_url``. The fake's MockTransport
+    accepts any host, so when ``servicetitan_use_fake`` is true the
+    base_url here is irrelevant; the auth host setting still drives the
+    production code path so the real environment works without further
+    config changes.
     """
     timeout = httpx.Timeout(_TOKEN_REQUEST_TIMEOUT_SECONDS)
     if settings.servicetitan_use_fake:
         return httpx.AsyncClient(
             transport=build_fake_transport(),
-            base_url=settings.servicetitan_api_base_url,
+            base_url=settings.servicetitan_auth_base_url,
             timeout=timeout,
         )
     return httpx.AsyncClient(
-        base_url=settings.servicetitan_api_base_url,
+        base_url=settings.servicetitan_auth_base_url,
         timeout=timeout,
     )
 

--- a/backend/app/integrations/servicetitan/auth.py
+++ b/backend/app/integrations/servicetitan/auth.py
@@ -268,6 +268,25 @@ async def save_credentials(
 async def load_credentials(user_id: str) -> ServiceTitanCredential | None:
     """Load the user's persisted ServiceTitan credential, if any."""
     token = await oauth_service.load_token(user_id, INTEGRATION_NAME)
+    return _build_credential_from_token(token)
+
+
+async def load_credentials_uncached(user_id: str) -> ServiceTitanCredential | None:
+    """Load the user's credential, bypassing the OAuth service's read cache.
+
+    Use inside an advisory-lock critical section where the goal is to
+    detect a peer worker's just-persisted refresh. The standard
+    :func:`load_credentials` honors a 30-second TTL cache and would
+    mask a cross-worker write within that window.
+    """
+    token = await oauth_service.load_token_uncached(user_id, INTEGRATION_NAME)
+    return _build_credential_from_token(token)
+
+
+def _build_credential_from_token(
+    token: OAuthTokenData | None,
+) -> ServiceTitanCredential | None:
+    """Shared reconstruction + partial-row guard for both load_credentials paths."""
     if token is None:
         return None
     cred = _credential_from_token(token)
@@ -336,7 +355,10 @@ async def get_valid_token(
             )
             return None
         # Re-check inside the lock: a peer worker may have just refreshed.
-        cred = await load_credentials(user_id)
+        # Bypass the in-memory load cache here; a stale entry from before
+        # the lock would mask the peer's just-persisted token and trigger
+        # a redundant mint.
+        cred = await load_credentials_uncached(user_id)
         if cred is None:
             return None
         if not force_refresh and not cred.is_token_expired():

--- a/backend/app/integrations/servicetitan/auth.py
+++ b/backend/app/integrations/servicetitan/auth.py
@@ -10,22 +10,18 @@ This module persists those four values in the ``oauth_tokens`` row for
 
 * ``access_token`` (encrypted) carries the current bearer token. Empty
   before the first mint, repopulated on every refresh.
+* ``refresh_token`` (encrypted) carries the tenant's Client Secret. The
+  column is named for OAuth refresh tokens, but ServiceTitan's client-
+  credentials grant does not use one, so the encrypted slot is unused
+  by the standard refresh flow and is the natural home for the secret.
+  Storing it here keeps the Client Secret envelope-encrypted at rest.
 * ``expires_at`` carries the absolute Unix timestamp at which the bearer
   expires. The real ServiceTitan token lives 15 minutes; we honor the
   ``expires_in`` returned by the token endpoint.
-* ``extra_json`` carries the tenant-specific metadata:
-  ``{tenant_id, client_id, client_secret, app_key}``. ``client_secret``
-  is kept here rather than in a dedicated encrypted column because
-  ``oauth_tokens.refresh_token`` is reserved for OAuth refresh tokens
-  and the surrounding code paths (e.g. ``oauth_service.refresh_token``)
-  assume the standard ``grant_type=refresh_token`` shape. Storing the
-  secret in ``extra_json`` keeps the row shape compatible with the
-  existing OAuth machinery without overloading semantics. The
-  ``extra_json`` column is plaintext on the wire to the DB, but the
-  row-level access patterns (``oauth_service.load_token`` only) keep
-  the value inside the same trust boundary as the encrypted columns;
-  if that ever changes, switching to ``refresh_token`` is a one-line
-  edit.
+* ``extra_json`` (plaintext) carries the non-secret metadata:
+  ``{tenant_id, client_id, app_key}``. The App Key is operator-level,
+  not per-tenant; it is snapshotted here so a later operator-level
+  rotation does not silently break existing tenants until they reconnect.
 
 The connect tool calls :func:`save_credentials` with the user's pasted
 values plus the freshly minted access token; downstream tools call
@@ -65,6 +61,12 @@ _TOKEN_EXPIRY_BUFFER_SECONDS = 30
 # Per-request timeout for the token endpoint. The mint itself is fast; the
 # generous ceiling absorbs cold-path TLS handshakes against real ServiceTitan.
 _TOKEN_REQUEST_TIMEOUT_SECONDS = 30.0
+
+# Fallback lifetime when the token endpoint omits ``expires_in``. Sized to
+# leave a meaningful usable window after ``_TOKEN_EXPIRY_BUFFER_SECONDS`` so
+# a missing field does not turn into a tight mint loop, but still short
+# enough that the bearer ages out quickly when no expiry was advertised.
+_TOKEN_FALLBACK_TTL_SECONDS = 180.0
 
 
 class ServiceTitanAuthError(RuntimeError):
@@ -176,29 +178,38 @@ async def mint_access_token(
         expires_at = time.time() + float(expires_in)
     else:
         # The fake always populates ``expires_in``; the real API is
-        # documented to as well. Fall back to a short ceiling rather
-        # than 0 so a missing field does not produce a token that the
-        # cache treats as immortal.
-        expires_at = time.time() + 60.0
+        # documented to as well. Fall back to a ceiling that leaves a
+        # usable window after the safety buffer rather than 0 (which the
+        # cache would treat as immortal) or a value so short the next
+        # call churns the mint endpoint.
+        expires_at = time.time() + _TOKEN_FALLBACK_TTL_SECONDS
     return access_token, expires_at
 
 
 def _serialize_extra(cred: ServiceTitanCredential) -> dict[str, Any]:
-    """Build the ``extra_json`` payload from a credential."""
+    """Build the ``extra_json`` payload from a credential.
+
+    Only non-secret metadata lives here. The Client Secret is persisted
+    separately in the encrypted ``refresh_token`` column.
+    """
     return {
         "tenant_id": cred.tenant_id,
         "client_id": cred.client_id,
-        "client_secret": cred.client_secret,
         "app_key": cred.app_key,
     }
 
 
-def _credential_from_extra(extra: dict[str, Any], token: OAuthTokenData) -> ServiceTitanCredential:
-    """Reconstruct a credential from a loaded token row's extra_json."""
+def _credential_from_token(token: OAuthTokenData) -> ServiceTitanCredential:
+    """Reconstruct a credential from a loaded token row.
+
+    The Client Secret comes off the encrypted ``refresh_token`` slot;
+    everything else lives in ``extra_json``.
+    """
+    extra = token.extra or {}
     return ServiceTitanCredential(
         tenant_id=str(extra.get("tenant_id") or ""),
         client_id=str(extra.get("client_id") or ""),
-        client_secret=str(extra.get("client_secret") or ""),
+        client_secret=token.refresh_token,
         app_key=str(extra.get("app_key") or ""),
         access_token=token.access_token,
         expires_at=token.expires_at,
@@ -230,7 +241,11 @@ async def save_credentials(
     )
     token = OAuthTokenData(
         access_token=access_token,
-        refresh_token="",
+        # The Client Secret rides in the encrypted ``refresh_token`` slot.
+        # ServiceTitan's client-credentials grant has no OAuth refresh
+        # token, so this column is otherwise unused by the standard
+        # refresh flow.
+        refresh_token=client_secret,
         token_type="Bearer",
         expires_at=expires_at,
         scopes=[],
@@ -251,8 +266,7 @@ async def load_credentials(user_id: str) -> ServiceTitanCredential | None:
     token = await oauth_service.load_token(user_id, INTEGRATION_NAME)
     if token is None:
         return None
-    extra = token.extra or {}
-    cred = _credential_from_extra(extra, token)
+    cred = _credential_from_token(token)
     if not cred.tenant_id or not cred.client_id or not cred.client_secret:
         # Partial row (e.g. a failed connect that wrote nothing useful).
         # Surface as "not connected" rather than handing the caller a
@@ -293,7 +307,14 @@ async def get_valid_token(
     ``expires_in`` (e.g. on a secret rotation), and the recorded
     expires_at would otherwise mask the revocation.
 
-    Returns ``None`` when no credential exists; raises
+    Mint+save is serialized through ``oauth_service.refresh_lock`` so
+    two concurrent requests for the same user do not race the token
+    endpoint and clobber each other's persisted bearer (same primitive
+    the standard OAuth refresh flow uses).
+
+    Returns ``None`` when no credential exists, or when the advisory
+    lock could not be acquired within its bounded wait (caller treats
+    this as a transient refresh failure); raises
     :class:`ServiceTitanAuthError` when minting against the token endpoint
     fails (caller decides whether to clear the row).
     """
@@ -302,16 +323,30 @@ async def get_valid_token(
         return None
     if not force_refresh and not cred.is_token_expired():
         return cred
-    access_token, expires_at = await mint_access_token(
-        client_id=cred.client_id,
-        client_secret=cred.client_secret,
-    )
-    return await save_credentials(
-        user_id,
-        tenant_id=cred.tenant_id,
-        client_id=cred.client_id,
-        client_secret=cred.client_secret,
-        app_key=cred.app_key,
-        access_token=access_token,
-        expires_at=expires_at,
-    )
+
+    async with oauth_service.refresh_lock(user_id, INTEGRATION_NAME) as acquired:
+        if not acquired:
+            logger.warning(
+                "ServiceTitan refresh lock contended; skipping mint: user=%s",
+                user_id,
+            )
+            return None
+        # Re-check inside the lock: a peer worker may have just refreshed.
+        cred = await load_credentials(user_id)
+        if cred is None:
+            return None
+        if not force_refresh and not cred.is_token_expired():
+            return cred
+        access_token, expires_at = await mint_access_token(
+            client_id=cred.client_id,
+            client_secret=cred.client_secret,
+        )
+        return await save_credentials(
+            user_id,
+            tenant_id=cred.tenant_id,
+            client_id=cred.client_id,
+            client_secret=cred.client_secret,
+            app_key=cred.app_key,
+            access_token=access_token,
+            expires_at=expires_at,
+        )

--- a/backend/app/integrations/servicetitan/auth_tools.py
+++ b/backend/app/integrations/servicetitan/auth_tools.py
@@ -115,5 +115,9 @@ def build_auth_tools(user_id: str) -> list[Tool]:
                 default_level=PermissionLevel.ALWAYS,
                 description_builder=lambda args: "Connect ServiceTitan",
             ),
+            # Writes to ``oauth_tokens`` for this user; serialize with
+            # other integration toggles so two concurrent connects (or a
+            # connect racing a disconnect) cannot lose updates.
+            concurrency_group="user_integrations",
         ),
     ]

--- a/backend/app/integrations/servicetitan/auth_tools.py
+++ b/backend/app/integrations/servicetitan/auth_tools.py
@@ -1,0 +1,119 @@
+"""ServiceTitan authentication tool.
+
+``connect_servicetitan`` accepts the three values a user pastes during
+onboarding (Tenant ID, Client ID, Client Secret), validates them by
+minting a bearer token against the configured token endpoint, and
+persists the credential. It lives separately from the (empty for now)
+data-tools surface because it must remain reachable before any
+credential exists, mirroring the AppFolio ``appfolio_connect`` split.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.config import settings
+from backend.app.integrations.servicetitan.auth import (
+    ServiceTitanAuthError,
+    mint_access_token,
+    save_credentials,
+)
+from backend.app.integrations.servicetitan.params import ServiceTitanConnectParams
+
+logger = logging.getLogger(__name__)
+
+
+def build_auth_tools(user_id: str) -> list[Tool]:
+    """Return the ServiceTitan connect tool bound to one user."""
+
+    async def connect_servicetitan(
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+    ) -> ToolResult:
+        """Validate the three pasted values, then persist them."""
+        tenant_id = tenant_id.strip()
+        client_id = client_id.strip()
+        client_secret = client_secret.strip()
+        if not tenant_id or not client_id or not client_secret:
+            return ToolResult(
+                content=("Tenant ID, Client ID, and Client Secret are all required."),
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint=(
+                    "Have the user paste all three values from ServiceTitan's"
+                    " Settings -> Integrations -> API Application Access page."
+                ),
+            )
+        if not settings.servicetitan_app_key:
+            return ToolResult(
+                content=(
+                    "ServiceTitan is not configured: the deployment is missing"
+                    " an App Key. Ask the operator to set SERVICETITAN_APP_KEY."
+                ),
+                is_error=True,
+                error_kind=ToolErrorKind.AUTH,
+            )
+
+        try:
+            access_token, expires_at = await mint_access_token(
+                client_id=client_id,
+                client_secret=client_secret,
+            )
+        except ServiceTitanAuthError as exc:
+            logger.warning("ServiceTitan connect failed for user=%s: %s", user_id, exc)
+            return ToolResult(
+                content=f"ServiceTitan rejected the credentials: {exc}",
+                is_error=True,
+                error_kind=ToolErrorKind.AUTH,
+                hint=(
+                    "Double-check the Tenant ID, Client ID, and Client Secret."
+                    " Regenerate the secret in ServiceTitan if it was lost."
+                ),
+            )
+
+        await save_credentials(
+            user_id,
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+            app_key=settings.servicetitan_app_key,
+            access_token=access_token,
+            expires_at=expires_at,
+        )
+
+        return ToolResult(
+            content="ServiceTitan connected. Tools are now available.",
+            receipt=ToolReceipt(
+                action="Connected ServiceTitan",
+                target=f"tenant {tenant_id}",
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.SERVICETITAN_CONNECT,
+            description=(
+                "Connect a ServiceTitan tenant by pasting the Tenant ID, Client"
+                " ID, and Client Secret from the ServiceTitan API Application"
+                " Access settings."
+            ),
+            function=connect_servicetitan,
+            params_model=ServiceTitanConnectParams,
+            usage_hint=(
+                "Use when the user wants to start using ServiceTitan tools."
+                " Walk them through: (1) open ServiceTitan -> Settings ->"
+                " Integrations -> API Application Access, (2) create or"
+                " open an application and copy the Client ID and Client"
+                " Secret, (3) read the Tenant ID off the same page, then"
+                " paste all three values back to you."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ALWAYS,
+                description_builder=lambda args: "Connect ServiceTitan",
+            ),
+        ),
+    ]

--- a/backend/app/integrations/servicetitan/factory.py
+++ b/backend/app/integrations/servicetitan/factory.py
@@ -1,0 +1,126 @@
+"""ServiceTitan tool registration and factories.
+
+Picked up by the registry's ``ensure_tool_modules_imported`` scan; the
+``_register()`` call at the bottom installs two factories at module-import
+time, mirroring the AppFolio Vendor split:
+
+* ``servicetitan_auth`` (core, always on the schema): the
+  ``connect_servicetitan`` tool. Must stay reachable before any credential
+  exists since pasting credentials *is* the connect path.
+* ``servicetitan`` (specialist, gated on connection state): the data
+  tools, populated in the read-tools issue (#1300). For now the factory
+  returns an empty tool list; the ``auth_check`` keeps it surfaced
+  under "Not connected" in ``list_capabilities`` until the user runs
+  the connect tool.
+
+The split mirrors AppFolio's prod-bug fix: a single combined factory
+would have to keep ``auth_check`` returning ``None`` unconditionally to
+preserve the connect tool on the schema, which would tell the LLM the
+integration was ready before any credential existed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.servicetitan.auth import is_connected
+from backend.app.integrations.servicetitan.auth_tools import build_auth_tools
+
+if TYPE_CHECKING:
+    from backend.app.agent.tools.registry import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+_AUTH_FACTORY = "servicetitan_auth"
+_DATA_FACTORY = "servicetitan"
+
+
+async def _servicetitan_auth_factory(ctx: ToolContext) -> list[Tool]:
+    """Assemble the ServiceTitan paste-credentials connect tool.
+
+    Registered as a core factory so the schema contract is independent
+    of credential state. The data-side ``servicetitan`` factory is the
+    user-facing toggle; this auth factory follows its enable/disable
+    state via the registry's hidden-factory pairing (see
+    ``_HIDDEN_CORE_FACTORIES`` in ``integration_tools.py`` once #1300
+    wires it).
+    """
+    return list(build_auth_tools(ctx.user.id))
+
+
+async def _servicetitan_factory(ctx: ToolContext) -> list[Tool]:
+    """Assemble the ServiceTitan data tools for an authenticated user.
+
+    Empty for now: the read tools land in #1300 and the write tools in
+    #1301. The factory still exists so ``list_capabilities`` and the
+    Settings page know the integration is real; ``auth_check`` keeps
+    it surfaced as "not connected" until the user pastes credentials.
+    """
+    if not await is_connected(ctx.user.id):
+        return []
+    # Resource-tool builders land in subsequent issues and will be wired
+    # in here once they exist. Keep the factory body shaped like
+    # AppFolio's so adding builders later is a one-line edit.
+    return []
+
+
+async def _servicetitan_auth_check(ctx: ToolContext) -> str | None:
+    """Return ``None`` when the user has a usable ServiceTitan credential.
+
+    When no credential is on file, returns a reason string so the
+    registry surfaces ``servicetitan`` under "Not connected" in the
+    LLM's capability list. The LLM then knows it must guide the user
+    through the paste-credentials flow before claiming ServiceTitan
+    access.
+
+    The connect tool itself lives in the separate ``servicetitan_auth``
+    factory (core, always available), so this auth_check returning a
+    reason does not strip the connect path from the schema.
+    """
+    if await is_connected(ctx.user.id):
+        return None
+    return (
+        "ServiceTitan is not connected. Ask the user to paste their Tenant ID,"
+        " Client ID, and Client Secret, then call connect_servicetitan to"
+        " validate and persist them."
+    )
+
+
+def _register() -> None:
+    from backend.app.agent.tools.registry import SubToolInfo, default_registry
+
+    default_registry.register(
+        _AUTH_FACTORY,
+        _servicetitan_auth_factory,
+        core=True,
+        sub_tools=[
+            SubToolInfo(
+                ToolName.SERVICETITAN_CONNECT,
+                "Connect a ServiceTitan tenant by pasting Tenant ID, Client ID, and Client Secret",
+                default_permission="always",
+            ),
+        ],
+    )
+
+    default_registry.register(
+        _DATA_FACTORY,
+        _servicetitan_factory,
+        core=False,
+        summary=(
+            "ServiceTitan: view and act on customers, jobs, and appointments"
+            " (read-only for now; write tools land in a subsequent issue)."
+        ),
+        display_name="ServiceTitan",
+        dashboard_description=("View ServiceTitan customers, jobs, and appointments"),
+        dashboard_group="Integrations",
+        dashboard_group_order=3,
+        sub_tools=[],
+        auth_check=_servicetitan_auth_check,
+    )
+
+
+_register()

--- a/backend/app/integrations/servicetitan/params.py
+++ b/backend/app/integrations/servicetitan/params.py
@@ -1,0 +1,38 @@
+"""Pydantic parameter models for ServiceTitan tools.
+
+Centralized so tool builders import the whole set with one line and the
+agent's schema stays consistent across the integration.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ServiceTitanConnectParams(BaseModel):
+    """Inputs the user pastes to connect a ServiceTitan tenant.
+
+    ServiceTitan auth is OAuth 2.0 client credentials, one tenant per
+    user. The tenant administrator generates the Client ID + Secret
+    pair from the ServiceTitan developer portal and copies the Tenant
+    ID from the Settings page; all three land here verbatim.
+    """
+
+    tenant_id: str = Field(
+        description=(
+            "The user's ServiceTitan Tenant ID, as shown in Settings -> "
+            "Integrations -> API Application Access. Numeric string."
+        ),
+    )
+    client_id: str = Field(
+        description=(
+            "The Client ID for the API application the user created in"
+            " their ServiceTitan tenant. Issued together with the secret."
+        ),
+    )
+    client_secret: str = Field(
+        description=(
+            "The Client Secret paired with the Client ID. Treat as a"
+            " password; only shown once at creation time in ServiceTitan."
+        ),
+    )

--- a/backend/app/integrations/servicetitan/service.py
+++ b/backend/app/integrations/servicetitan/service.py
@@ -1,0 +1,239 @@
+"""HTTP client for the ServiceTitan REST API.
+
+Every ServiceTitan resource endpoint requires two headers:
+
+* ``Authorization: Bearer <access_token>`` (per-tenant, 15-minute lifetime)
+* ``ST-App-Key: <app_key>`` (operator-level, constant)
+
+This module owns the request loop that injects both, refreshes the bearer
+on 401, and routes through the in-process fake when
+``settings.servicetitan_use_fake`` is true. Resource-specific helpers
+(list customers, get job, etc.) live in the read-tools issue (#1300); this
+scaffold ships the transport + auth refresh path and a bare ``get`` / ``post``
+surface that downstream tools build on.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from backend.app.config import settings
+from backend.app.integrations.servicetitan._fake import build_fake_transport
+from backend.app.integrations.servicetitan.auth import (
+    ServiceTitanAuthError,
+    ServiceTitanCredential,
+    get_valid_token,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Per-request timeout. Generous so a real ServiceTitan cold-path TLS
+# handshake plus a paginated list query never trips on a tight ceiling;
+# the fake transport returns in microseconds either way.
+_DEFAULT_TIMEOUT_SECONDS = 60.0
+
+
+class ServiceTitanError(RuntimeError):
+    """Generic ServiceTitan API failure (5xx, network, validation)."""
+
+
+class ServiceTitanNotConnectedError(ServiceTitanError):
+    """Raised when the service is built for a user with no credential.
+
+    Callers should never hit this in normal flow: the factory's
+    ``auth_check`` gates tool creation on a credential being present.
+    Kept as a distinct subclass so a regression that bypasses the check
+    is loud rather than surfaced as a generic 401.
+    """
+
+
+def _build_http_client(timeout_seconds: float) -> httpx.AsyncClient:
+    """Construct an async client wired to the configured ServiceTitan host.
+
+    Routes through the in-process fake when ``servicetitan_use_fake`` is
+    on. The base_url is taken from settings in both modes so resource
+    helpers can use relative paths.
+    """
+    timeout = httpx.Timeout(timeout_seconds)
+    if settings.servicetitan_use_fake:
+        return httpx.AsyncClient(
+            transport=build_fake_transport(),
+            base_url=settings.servicetitan_api_base_url,
+            timeout=timeout,
+        )
+    return httpx.AsyncClient(
+        base_url=settings.servicetitan_api_base_url,
+        timeout=timeout,
+    )
+
+
+class ServiceTitanService:
+    """Async REST client bound to one user's tenant credential.
+
+    Short-lived (one per agent turn); does not cache responses. The
+    bearer token is refreshed lazily on 401 by re-running
+    :func:`get_valid_token`, which mints a new client-credentials token
+    against the configured token endpoint.
+    """
+
+    def __init__(
+        self,
+        user_id: str,
+        credential: ServiceTitanCredential,
+        *,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._user_id = user_id
+        self._credential = credential
+        self._timeout = timeout_seconds
+        self._refreshed_once = False
+
+    @property
+    def credential(self) -> ServiceTitanCredential:
+        return self._credential
+
+    @property
+    def tenant_id(self) -> str:
+        return self._credential.tenant_id
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._credential.access_token}",
+            "ST-App-Key": self._credential.app_key,
+            "Accept": "application/json",
+        }
+
+    async def _refresh_credential(self, *, force: bool = False) -> bool:
+        """Mint a fresh bearer for the current user.
+
+        ``force=True`` skips the cached-expiry shortcut in
+        :func:`get_valid_token`. Used by the 401 retry path: the server
+        may have revoked a bearer before its declared ``expires_in``
+        (e.g. a tenant rotated their secret), and the in-memory expiry
+        would otherwise mask that.
+
+        Returns True when the refresh succeeded and the credential's
+        ``access_token`` has been updated in-place. Returns False when
+        the credential is gone (deleted between calls) or the refresh
+        endpoint failed; callers should treat that as a hard 401.
+        """
+        try:
+            refreshed = await get_valid_token(self._user_id, force_refresh=force)
+        except ServiceTitanAuthError as exc:
+            logger.warning(
+                "ServiceTitan token refresh failed for user=%s: %s",
+                self._user_id,
+                exc,
+            )
+            return False
+        if refreshed is None:
+            return False
+        self._credential = refreshed
+        return True
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: Any = None,
+    ) -> Any:
+        """Send an authenticated request and return the parsed JSON body.
+
+        Handles a one-shot refresh-and-retry on 401: if the stored bearer
+        was rejected, we mint a fresh one and replay the request once.
+        Subsequent 401s on the same service instance are surfaced as
+        :class:`ServiceTitanError` so the caller can decide whether to
+        clear the credential.
+        """
+        # Lazy mint: the service was built from a stored credential whose
+        # bearer had already lapsed. Fetch one before sending so the first
+        # call does not pay a guaranteed 401 round trip.
+        if not self._credential.access_token and not await self._refresh_credential():
+            raise ServiceTitanNotConnectedError(
+                "ServiceTitan credential is not usable; reconnect required."
+            )
+
+        try:
+            async with _build_http_client(self._timeout) as client:
+                resp = await client.request(
+                    method,
+                    path,
+                    params=params,
+                    json=json_body,
+                    headers=self._headers(),
+                )
+        except httpx.HTTPError as exc:
+            logger.warning("ServiceTitan %s %s network failure: %s", method, path, exc)
+            raise ServiceTitanError(
+                f"ServiceTitan {method} {path} network failure: {exc!r}"
+            ) from exc
+
+        if resp.status_code == 401 and not self._refreshed_once:
+            self._refreshed_once = True
+            if await self._refresh_credential(force=True):
+                try:
+                    async with _build_http_client(self._timeout) as client:
+                        resp = await client.request(
+                            method,
+                            path,
+                            params=params,
+                            json=json_body,
+                            headers=self._headers(),
+                        )
+                except httpx.HTTPError as exc:
+                    raise ServiceTitanError(
+                        f"ServiceTitan {method} {path} network failure after refresh: {exc!r}"
+                    ) from exc
+
+        if resp.status_code >= 400:
+            logger.warning(
+                "ServiceTitan %s %s failed: status=%d body=%s",
+                method,
+                path,
+                resp.status_code,
+                resp.text[:500],
+            )
+            raise ServiceTitanError(f"ServiceTitan {method} {path} failed: HTTP {resp.status_code}")
+
+        if not resp.content:
+            return None
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise ServiceTitanError(f"ServiceTitan {method} {path} returned non-JSON body") from exc
+
+    async def get(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
+        return await self.request("GET", path, params=params)
+
+    async def post(
+        self,
+        path: str,
+        *,
+        json_body: Any = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        return await self.request("POST", path, params=params, json_body=json_body)
+
+
+async def build_service_for_user(
+    user_id: str,
+    *,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> ServiceTitanService | None:
+    """Construct a :class:`ServiceTitanService` for the given user.
+
+    Returns ``None`` when the user has no stored credential. Refreshes
+    the bearer token eagerly via :func:`get_valid_token`, so the
+    returned service is ready to issue resource calls without a
+    guaranteed 401 round trip on the first request.
+    """
+    cred = await get_valid_token(user_id)
+    if cred is None:
+        return None
+    return ServiceTitanService(user_id, cred, timeout_seconds=timeout_seconds)

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -15,7 +15,8 @@ import logging
 import random
 import secrets
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -596,6 +597,51 @@ class OAuthService:
         # Expired but has a refresh token: still considered "connected"
         # because get_valid_token() will refresh it on next use.
         return bool(token.refresh_token)
+
+    @asynccontextmanager
+    async def refresh_lock(
+        self,
+        user_id: str,
+        integration: str,
+    ) -> AsyncIterator[bool]:
+        """Hold the OAuth refresh advisory lock for the duration of the block.
+
+        Yields True when the lock is held; False when acquisition timed out
+        (the caller should treat that as a transient refresh failure and let
+        the next attempt try again). The lock releases automatically on exit.
+
+        Integrations that mint their own bearers outside the standard
+        ``refresh_token`` flow (notably client-credentials grants with no
+        OAuth refresh token) wrap their mint-and-save sequence in this
+        lock so concurrent mints serialize through the same primitive the
+        standard refresh path uses. The lock is keyed on
+        ``(user_id, integration)``, identical to ``refresh_token`` above.
+        """
+        # Same connection-pinning constraint as ``refresh_token``: the lock
+        # must live on a dedicated ``AsyncConnection`` so the release runs
+        # on the connection that acquired it.
+        lock_conn = await get_async_engine().connect()
+        lock_key = _refresh_lock_key(user_id, integration)
+        try:
+            acquired = await _try_acquire_advisory_lock_async(lock_conn, lock_key)
+            try:
+                yield acquired
+            finally:
+                if acquired:
+                    try:
+                        await lock_conn.execute(
+                            text("SELECT pg_advisory_unlock(hashtext(:k))"),
+                            {"k": lock_key},
+                        )
+                        await lock_conn.commit()
+                    except Exception:
+                        logger.exception(
+                            "Failed to release OAuth refresh lock: user=%s integration=%s",
+                            user_id,
+                            integration,
+                        )
+        finally:
+            await lock_conn.close()
 
     def build_on_refresh_callback(
         self,

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -282,7 +282,7 @@ class OAuthService:
       post-OAuth-completion blackout small).
     - ``save_token`` and ``delete_token`` invalidate the local cache.
     - Inside an advisory-lock critical section, callers MUST use
-      ``_load_token_uncached`` to defeat the cache: the whole point of
+      ``load_token_uncached`` to defeat the cache: the whole point of
       the post-lock reload is to observe a peer worker's just-persisted
       refresh, and a stale cache would mask it.
     - Cross-worker staleness is bounded by the TTL. Within that window a
@@ -479,7 +479,7 @@ class OAuthService:
         OAuth flow on a peer worker becomes visible quickly. The cache
         is invalidated on ``save_token`` and ``delete_token`` within this
         process. Callers inside an advisory-lock critical section must
-        use ``_load_token_uncached`` instead.
+        use ``load_token_uncached`` instead.
         """
         cache_key = (user_id, integration)
         now = time.monotonic()
@@ -533,19 +533,21 @@ class OAuthService:
             self._token_cache[cache_key] = (token, now + _TOKEN_CACHE_TTL_SECONDS)
             return token
 
-    async def _load_token_uncached(
+    async def load_token_uncached(
         self,
         user_id: str,
         integration: str,
     ) -> OAuthTokenData | None:
         """Force a DB read by dropping any cached entry first.
 
-        Use only inside an advisory-lock critical section where the
-        whole point of the read is to observe a peer worker's just-
-        persisted token. A stale cache would mask the peer's write and
-        cause this worker to repeat work (e.g. duplicate HTTP refresh
-        that overwrites the rotated refresh_token). All other callers
-        should use ``load_token``.
+        Use inside an advisory-lock critical section where the whole
+        point of the read is to observe a peer worker's just-persisted
+        token. A stale cache would mask the peer's write and cause this
+        worker to repeat work (e.g. duplicate HTTP refresh that
+        overwrites the rotated refresh_token, or a redundant
+        client-credentials mint for integrations that bypass
+        ``refresh_token`` entirely). All other callers should use
+        ``load_token``.
         """
         self._token_cache.pop((user_id, integration), None)
         return await self.load_token(user_id, integration)
@@ -685,7 +687,7 @@ class OAuthService:
                     # Bypass the cache: this load is the peer-write detection
                     # point for the on_refresh callback path. Same race as
                     # in refresh_token's post-lock reload.
-                    current = await self._load_token_uncached(user_id, integration)
+                    current = await self.load_token_uncached(user_id, integration)
                     if current is None:
                         logger.warning(
                             "on_refresh callback fired for missing token: user=%s integration=%s",
@@ -805,7 +807,7 @@ class OAuthService:
                 # Bypass the cache: the post-lock reload exists to detect
                 # a peer worker's just-persisted refresh, which an in-memory
                 # cache from before the lock would mask.
-                token = await self._load_token_uncached(user_id, integration)
+                token = await self.load_token_uncached(user_id, integration)
                 if not token or not token.refresh_token:
                     logger.debug(
                         "Cannot refresh token (missing): user=%s integration=%s "

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -211,6 +211,16 @@ When both are set, users can connect CompanyCam via OAuth on the Tools page or t
 
 The integration uses passwordless magic-link auth: users paste the URL from their AppFolio email and the agent exchanges it for a Bearer JWT. No client ID or secret to configure. Once connected, the agent gains tools like `appfolio_list_work_orders`, `appfolio_search_work_orders`, and `appfolio_list_payments`.
 
+## ServiceTitan
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SERVICETITAN_APP_KEY` | | App-level App Key issued by ServiceTitan to the integrator. Sent as the `ST-App-Key` header on every API call. |
+| `SERVICETITAN_API_BASE_URL` | `https://api.servicetitan.io` | Base URL of the ServiceTitan API. Override for staging or regional hosts. |
+| `SERVICETITAN_USE_FAKE` | `true` | When true, route every call through the in-process fake backend (deterministic seed data, no real network). Flip to false once a real tenant is available. |
+
+ServiceTitan uses OAuth 2.0 client credentials (machine-to-machine), one set per tenant. The operator wires the integrator's app-level App Key here; each tenant pastes their own tenant ID, client ID, and client secret through the `connect_servicetitan` tool in chat. Stored credentials are envelope-encrypted at rest.
+
 ## Supplier pricing
 
 | Variable | Default | Description |

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -216,10 +216,11 @@ The integration uses passwordless magic-link auth: users paste the URL from thei
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SERVICETITAN_APP_KEY` | | App-level App Key issued by ServiceTitan to the integrator. Sent as the `ST-App-Key` header on every API call. |
-| `SERVICETITAN_API_BASE_URL` | `https://api.servicetitan.io` | Base URL of the ServiceTitan API. Override for staging or regional hosts. |
+| `SERVICETITAN_API_BASE_URL` | `https://api.servicetitan.io` | Base URL of the ServiceTitan resource API (customers, jobs, appointments). Override to `https://api-integration.servicetitan.io` for the integration sandbox. |
+| `SERVICETITAN_AUTH_BASE_URL` | `https://auth.servicetitan.io` | Base URL of the ServiceTitan auth host that serves `/connect/token`. Distinct from the resource host. Override to `https://auth-integration.servicetitan.io` for the integration sandbox; flip both `API_BASE_URL` and `AUTH_BASE_URL` together when switching environments. |
 | `SERVICETITAN_USE_FAKE` | `true` | When true, route every call through the in-process fake backend (deterministic seed data, no real network). Flip to false once a real tenant is available. |
 
-ServiceTitan uses OAuth 2.0 client credentials (machine-to-machine), one set per tenant. The operator wires the integrator's app-level App Key here; each tenant pastes their own tenant ID, client ID, and client secret through the `connect_servicetitan` tool in chat. Stored credentials are envelope-encrypted at rest.
+ServiceTitan uses OAuth 2.0 client credentials (machine-to-machine), one set per tenant. The operator wires the integrator's app-level App Key here; each tenant pastes their own tenant ID, client ID, and client secret through the `connect_servicetitan` tool in chat. Stored credentials are envelope-encrypted at rest. ServiceTitan splits auth and resource traffic across two hosts, so `AUTH_BASE_URL` and `API_BASE_URL` are independent settings.
 
 ## Supplier pricing
 

--- a/tests/test_oauth_refresh.py
+++ b/tests/test_oauth_refresh.py
@@ -604,7 +604,7 @@ class TestRefreshTokenLockSerialization:
             expires_at=time.time() - 100,  # already expired
         )
         # ``persisted`` is the single source of truth that
-        # ``_load_token_uncached`` consults. The first caller's
+        # ``load_token_uncached`` consults. The first caller's
         # ``save_token`` swaps in the rotated value, so the late
         # callers see ``expires_at > now`` on their post-lock reload
         # and short-circuit without hitting the upstream.
@@ -681,7 +681,7 @@ class TestRefreshTokenLockSerialization:
             release.set()
 
         with (
-            patch.object(oauth_svc, "_load_token_uncached", side_effect=_load_uncached),
+            patch.object(oauth_svc, "load_token_uncached", side_effect=_load_uncached),
             patch.object(oauth_svc, "save_token", side_effect=_save),
             patch.object(oauth_svc, "_get_http", return_value=mock_http),
             patch("backend.app.services.oauth.get_oauth_config", return_value=config),
@@ -754,7 +754,7 @@ class TestRefreshTokenLockSerialization:
         )
         persisted: dict[str, OAuthTokenData] = {"current": base_token}
         # Each entry records the ``refresh_token`` value a thread saw
-        # when its post-lock ``_load_token_uncached`` ran. With the
+        # when its post-lock ``load_token_uncached`` ran. With the
         # lock working, only the first acquirer sees the original
         # ``base-rt``; subsequent acquirers see a peer's rotation.
         # With the bug, every thread reads the row before any save
@@ -819,7 +819,7 @@ class TestRefreshTokenLockSerialization:
         # it up at the test scope (single thread) and let each worker
         # thread observe the same patched attributes.
         with (
-            patch.object(oauth_svc, "_load_token_uncached", side_effect=_load_uncached),
+            patch.object(oauth_svc, "load_token_uncached", side_effect=_load_uncached),
             patch.object(oauth_svc, "save_token", side_effect=_save),
         ):
             threads = [

--- a/tests/test_servicetitan_auth.py
+++ b/tests/test_servicetitan_auth.py
@@ -23,6 +23,7 @@ from backend.app.integrations.servicetitan.auth import (
     get_valid_token,
     is_connected,
     load_credentials,
+    load_credentials_uncached,
     mint_access_token,
     save_credentials,
 )
@@ -302,6 +303,49 @@ async def test_get_valid_token_reuses_fresh_bearer(async_test_user: Any) -> None
         cred = await get_valid_token(user_id)
     assert cred is not None
     assert cred.access_token == "still-fresh"
+
+
+@pytest.mark.asyncio()
+async def test_load_credentials_uncached_observes_peer_writes(
+    async_test_user: Any,
+) -> None:
+    """The cache-bypass loader sees a row a peer wrote after our last cached read.
+
+    Models the cross-worker case the refresh lock guards: this worker
+    cached a "no credential" or stale-bearer read before acquiring the
+    lock, a peer wrote a fresh credential while we were waiting, and the
+    re-check inside the lock must reload from the DB rather than reuse
+    the stale cache entry.
+    """
+    user_id = async_test_user.id
+    # Prime the cache with a "no credential" read.
+    assert await load_credentials(user_id) is None
+    # Simulate a peer worker persisting a fresh credential while this
+    # worker held the (now-stale) negative cache entry.
+    await save_credentials(
+        user_id,
+        tenant_id="t1",
+        client_id="cid",
+        client_secret="csec",
+        app_key="fake-st-app-key",
+        access_token="bearer-from-peer",
+        expires_at=time.time() + 600,
+    )
+    # save_token invalidates the local cache, so the regular loader sees
+    # it. Re-prime the cache here to model the cross-worker situation,
+    # where the OTHER worker's cache is the one we are bypassing.
+    from backend.app.services.oauth import oauth_service as _oauth_service
+
+    _oauth_service._token_cache[(user_id, INTEGRATION_NAME)] = (
+        None,
+        time.monotonic() + 30,
+    )
+    # Cached loader returns the stale negative entry.
+    assert await load_credentials(user_id) is None
+    # Uncached loader bypasses the stale entry and sees the peer's write.
+    fresh = await load_credentials_uncached(user_id)
+    assert fresh is not None
+    assert fresh.access_token == "bearer-from-peer"
 
 
 @pytest.mark.asyncio()

--- a/tests/test_servicetitan_auth.py
+++ b/tests/test_servicetitan_auth.py
@@ -75,6 +75,46 @@ async def test_mint_access_token_rejects_missing_client_secret() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_mint_access_token_hits_auth_host_not_api_host() -> None:
+    """The token client must POST to the auth host, not the resource host.
+
+    ServiceTitan serves /connect/token on a dedicated auth host
+    (auth.servicetitan.io in production, auth-integration.servicetitan.io
+    in the integration sandbox) that is distinct from the resource host.
+    The fake's MockTransport accepts any host, so a regression that
+    wired the auth client at the API base URL would pass against the
+    fake but 404 against real ServiceTitan. This test pins the auth
+    host so the regression is loud here, not in production.
+    """
+    from backend.app.config import settings as _settings
+
+    captured: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            status_code=200,
+            json={"access_token": "ok", "token_type": "Bearer", "expires_in": 900},
+        )
+
+    capture_transport = httpx.MockTransport(_capture)
+    with (
+        patch.object(_settings, "servicetitan_auth_base_url", "https://auth.example.test"),
+        patch.object(_settings, "servicetitan_api_base_url", "https://api.example.test"),
+        patch(
+            "backend.app.integrations.servicetitan.auth.build_fake_transport",
+            lambda backend=None: capture_transport,
+        ),
+    ):
+        await mint_access_token(client_id="cid", client_secret="csec")
+
+    assert captured["url"].startswith("https://auth.example.test/"), (
+        f"expected auth host, got {captured['url']}"
+    )
+    assert "api.example.test" not in captured["url"]
+
+
+@pytest.mark.asyncio()
 async def test_mint_access_token_wraps_network_failure() -> None:
     """A transport-level failure surfaces as ServiceTitanAuthError, not httpx."""
 

--- a/tests/test_servicetitan_auth.py
+++ b/tests/test_servicetitan_auth.py
@@ -1,0 +1,290 @@
+"""Tests for the ServiceTitan auth + credential layer.
+
+Exercises the paste-credentials -> token-mint -> persist round trip
+against the in-process fake backend, plus the refresh path that swaps
+in a fresh bearer when the stored one expires.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from backend.app.integrations.servicetitan import _fake as fake_module
+from backend.app.integrations.servicetitan.auth import (
+    INTEGRATION_NAME,
+    ServiceTitanAuthError,
+    ServiceTitanCredential,
+    clear_credentials,
+    get_valid_token,
+    is_connected,
+    load_credentials,
+    mint_access_token,
+    save_credentials,
+)
+from backend.app.services.oauth import oauth_service
+
+
+@pytest.fixture(autouse=True)
+def _force_fake_backend() -> Any:
+    """Pin every test in this module to the in-process fake backend.
+
+    The fake's MockTransport is built lazily inside the auth/service
+    modules from ``settings.servicetitan_use_fake``; the tests assume
+    that flag is true. They also reset the singleton fake between tests
+    so a mutation in one case (e.g. ``expire_all_tokens``) does not
+    bleed into another.
+    """
+    from backend.app.config import settings as _settings
+
+    with patch.object(_settings, "servicetitan_use_fake", True):
+        fake_module.reset_default_fake_backend()
+        try:
+            yield
+        finally:
+            fake_module.reset_default_fake_backend()
+
+
+# ---------------------------------------------------------------------------
+# Token minting (transport-level)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_mint_access_token_round_trips_against_fake() -> None:
+    """The fake's ``/connect/token`` accepts any non-empty client credentials."""
+    token, expires_at = await mint_access_token(
+        client_id="abc123",
+        client_secret="shhh",
+    )
+    assert token == fake_module.FAKE_TOKEN_VALUE
+    # The fake honors ``expires_in=900``; expires_at should land roughly
+    # 15 minutes out without claiming a value in the past.
+    assert expires_at > time.time() + 60
+
+
+@pytest.mark.asyncio()
+async def test_mint_access_token_rejects_missing_client_secret() -> None:
+    """An empty client_secret should round-trip through to a 4xx error."""
+    with pytest.raises(ServiceTitanAuthError):
+        await mint_access_token(client_id="abc", client_secret="")
+
+
+@pytest.mark.asyncio()
+async def test_mint_access_token_wraps_network_failure() -> None:
+    """A transport-level failure surfaces as ServiceTitanAuthError, not httpx."""
+
+    def _blow_up(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated DNS failure")
+
+    bad_transport = httpx.MockTransport(_blow_up)
+    # ``auth.py`` imports ``build_fake_transport`` into its own module
+    # namespace at import time, so the patch must target that namespace
+    # rather than the source module.
+    with (
+        patch(
+            "backend.app.integrations.servicetitan.auth.build_fake_transport",
+            lambda backend=None: bad_transport,
+        ),
+        pytest.raises(ServiceTitanAuthError),
+    ):
+        await mint_access_token(client_id="abc", client_secret="xyz")
+
+
+# ---------------------------------------------------------------------------
+# Credential persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_save_and_load_credentials_round_trip(async_test_user: Any) -> None:
+    user_id = async_test_user.id
+
+    assert await load_credentials(user_id) is None
+    assert await is_connected(user_id) is False
+
+    await save_credentials(
+        user_id,
+        tenant_id="tenant-001",
+        client_id="cid-001",
+        client_secret="csec-001",
+        app_key="app-key-001",
+        access_token="bearer-001",
+        expires_at=time.time() + 600,
+    )
+
+    cred = await load_credentials(user_id)
+    assert cred is not None
+    assert cred.tenant_id == "tenant-001"
+    assert cred.client_id == "cid-001"
+    assert cred.client_secret == "csec-001"
+    assert cred.app_key == "app-key-001"
+    assert cred.access_token == "bearer-001"
+    assert cred.expires_at > time.time()
+    assert await is_connected(user_id) is True
+
+
+@pytest.mark.asyncio()
+async def test_save_credentials_overwrites_previous_row(async_test_user: Any) -> None:
+    """A second save replaces tenant + bearer cleanly."""
+    user_id = async_test_user.id
+    await save_credentials(
+        user_id,
+        tenant_id="tenant-A",
+        client_id="cid-A",
+        client_secret="csec-A",
+        app_key="app-key",
+        access_token="bearer-A",
+        expires_at=time.time() + 600,
+    )
+    await save_credentials(
+        user_id,
+        tenant_id="tenant-B",
+        client_id="cid-B",
+        client_secret="csec-B",
+        app_key="app-key",
+        access_token="bearer-B",
+        expires_at=time.time() + 600,
+    )
+
+    cred = await load_credentials(user_id)
+    assert cred is not None
+    assert cred.tenant_id == "tenant-B"
+    assert cred.client_id == "cid-B"
+    assert cred.access_token == "bearer-B"
+
+
+@pytest.mark.asyncio()
+async def test_clear_credentials_removes_row(async_test_user: Any) -> None:
+    user_id = async_test_user.id
+    await save_credentials(
+        user_id,
+        tenant_id="tenant-1",
+        client_id="cid",
+        client_secret="csec",
+        app_key="app-key",
+        access_token="bearer",
+        expires_at=time.time() + 600,
+    )
+    assert await is_connected(user_id) is True
+    await clear_credentials(user_id)
+    assert await is_connected(user_id) is False
+    assert await load_credentials(user_id) is None
+
+
+@pytest.mark.asyncio()
+async def test_load_credentials_treats_partial_row_as_not_connected(
+    async_test_user: Any,
+) -> None:
+    """A row without tenant_id / client_id / client_secret is not usable.
+
+    Defends against a half-built row from a connect tool that crashed
+    after saving an empty placeholder.
+    """
+    user_id = async_test_user.id
+    from backend.app.services.oauth import OAuthTokenData
+
+    # Persist a token row with empty extra metadata.
+    token = OAuthTokenData(
+        access_token="",
+        refresh_token="",
+        token_type="Bearer",
+        expires_at=0.0,
+        scopes=[],
+        realm_id="",
+        extra={},
+    )
+    await oauth_service.save_token(user_id, INTEGRATION_NAME, token)
+
+    assert await load_credentials(user_id) is None
+    assert await is_connected(user_id) is False
+
+
+# ---------------------------------------------------------------------------
+# get_valid_token: lazy refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_credential_token_expiry_window() -> None:
+    """``is_token_expired`` respects the buffer and the empty-token sentinel."""
+    cred = ServiceTitanCredential(
+        tenant_id="t",
+        client_id="c",
+        client_secret="s",
+        app_key="k",
+        access_token="",
+        expires_at=0.0,
+    )
+    assert cred.is_token_expired(now=1000.0) is True
+
+    cred.access_token = "tok"
+    cred.expires_at = 1000.0
+    assert cred.is_token_expired(now=2000.0) is True
+    assert cred.is_token_expired(now=500.0) is False
+    # Inside the safety buffer: treat as expired so the bearer never
+    # lapses mid-call.
+    assert cred.is_token_expired(now=990.0) is True
+
+
+@pytest.mark.asyncio()
+async def test_get_valid_token_returns_none_when_no_credential(
+    async_test_user: Any,
+) -> None:
+    assert await get_valid_token(async_test_user.id) is None
+
+
+@pytest.mark.asyncio()
+async def test_get_valid_token_reuses_fresh_bearer(async_test_user: Any) -> None:
+    """A non-expired bearer is returned without a refresh call."""
+    user_id = async_test_user.id
+    await save_credentials(
+        user_id,
+        tenant_id="t1",
+        client_id="cid",
+        client_secret="csec",
+        app_key="app-key",
+        access_token="still-fresh",
+        expires_at=time.time() + 3600,
+    )
+
+    async def _explode(**kwargs: Any) -> tuple[str, float]:
+        raise AssertionError("mint should not be called when token is fresh")
+
+    with patch(
+        "backend.app.integrations.servicetitan.auth.mint_access_token",
+        side_effect=_explode,
+    ):
+        cred = await get_valid_token(user_id)
+    assert cred is not None
+    assert cred.access_token == "still-fresh"
+
+
+@pytest.mark.asyncio()
+async def test_get_valid_token_refreshes_when_expired(async_test_user: Any) -> None:
+    """An expired bearer triggers a fresh client-credentials mint."""
+    user_id = async_test_user.id
+    await save_credentials(
+        user_id,
+        tenant_id="t1",
+        client_id="cid",
+        client_secret="csec",
+        app_key="app-key",
+        access_token="stale-token",
+        expires_at=time.time() - 10,
+    )
+
+    cred = await get_valid_token(user_id)
+    assert cred is not None
+    # The fake mints its constant token value; the helper persists it
+    # back to the row, so reading the row again yields the fresh bearer.
+    assert cred.access_token == fake_module.FAKE_TOKEN_VALUE
+    assert cred.expires_at > time.time()
+
+    reloaded = await load_credentials(user_id)
+    assert reloaded is not None
+    assert reloaded.access_token == fake_module.FAKE_TOKEN_VALUE

--- a/tests/test_servicetitan_factory.py
+++ b/tests/test_servicetitan_factory.py
@@ -218,21 +218,51 @@ async def test_connect_servicetitan_errors_without_app_key(
 
 
 @pytest.mark.asyncio()
-async def test_connect_servicetitan_surfaces_token_endpoint_failure(
+async def test_connect_servicetitan_strips_and_rejects_blank_client_secret(
     async_test_user: Any,
 ) -> None:
-    """If the fake rejects the credentials, the tool surfaces an AUTH error."""
+    """A whitespace-only Client Secret must surface as a validation error."""
     user_id = async_test_user.id
     tools = build_auth_tools(user_id)
     connect_tool = tools[0]
 
-    # Empty client_secret triggers the fake's 4xx response.
     result = await connect_tool.function(
         tenant_id="t",
         client_id="cid",
-        client_secret="   ",  # stripped to empty
+        client_secret="   ",  # stripped to empty before the mint call
     )
     assert result.is_error is True
-    # ``"   "`` strips to empty before the mint call, so it hits the
-    # local validation branch rather than the fake. Either way is fine
-    # for the user; we just want it surfaced as an error.
+    assert "required" in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_connect_servicetitan_surfaces_token_endpoint_failure(
+    async_test_user: Any,
+) -> None:
+    """When the fake rejects the credentials, the tool surfaces an AUTH error.
+
+    Patches the mint helper to raise so this test actually exercises the
+    failure-path branch in the connect tool, not the local validation
+    branch that catches blank fields up front.
+    """
+    user_id = async_test_user.id
+    tools = build_auth_tools(user_id)
+    connect_tool = tools[0]
+
+    from backend.app.integrations.servicetitan.auth import ServiceTitanAuthError
+
+    async def _fail(**kwargs: Any) -> tuple[str, float]:
+        raise ServiceTitanAuthError("ServiceTitan rejected the client credentials (HTTP 401)")
+
+    with patch(
+        "backend.app.integrations.servicetitan.auth_tools.mint_access_token",
+        side_effect=_fail,
+    ):
+        result = await connect_tool.function(
+            tenant_id="1234567",
+            client_id="cid",
+            client_secret="csec",
+        )
+    assert result.is_error is True
+    assert "rejected" in result.content.lower()
+    assert result.error_kind is not None

--- a/tests/test_servicetitan_factory.py
+++ b/tests/test_servicetitan_factory.py
@@ -1,0 +1,238 @@
+"""Tests for the ServiceTitan factory + connect tool.
+
+Verifies the split-factory wiring (auth tools always reachable, data
+factory gated on credential state) and the end-to-end connect flow
+against the in-process fake.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import backend.app.integrations.servicetitan.factory as factory_module
+from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.registry import ToolContext, default_registry
+from backend.app.integrations.servicetitan import _fake as fake_module
+from backend.app.integrations.servicetitan.auth import (
+    is_connected,
+    load_credentials,
+    save_credentials,
+)
+from backend.app.integrations.servicetitan.auth_tools import build_auth_tools
+
+
+@pytest.fixture(autouse=True)
+def _force_fake_backend_and_app_key() -> Any:
+    """Pin every test to the fake backend and supply a real-looking App Key."""
+    from backend.app.config import settings as _settings
+
+    with (
+        patch.object(_settings, "servicetitan_use_fake", True),
+        patch.object(_settings, "servicetitan_app_key", "fake-st-app-key"),
+    ):
+        fake_module.reset_default_fake_backend()
+        try:
+            yield
+        finally:
+            fake_module.reset_default_fake_backend()
+
+
+def _make_context(user_id: str) -> ToolContext:
+    """Build a minimal ToolContext for factory invocation.
+
+    The registry's ``ToolContext`` carries a User object; for these
+    tests only ``user.id`` is read so a MagicMock with the right
+    attribute is enough.
+    """
+    user = MagicMock()
+    user.id = user_id
+    ctx = MagicMock(spec=ToolContext)
+    ctx.user = user
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_factories_registered() -> None:
+    """Both the auth and data factories must be discoverable by name."""
+    assert "servicetitan_auth" in default_registry.factory_names
+    assert "servicetitan" in default_registry.factory_names
+
+
+def test_auth_factory_is_core_data_factory_is_specialist() -> None:
+    """Split-factory invariants: connect tool always on schema, data gated."""
+    auth = default_registry.get_factory("servicetitan_auth")
+    data = default_registry.get_factory("servicetitan")
+    assert auth is not None
+    assert data is not None
+    assert auth.core is True, "connect_servicetitan must stay on the schema"
+    assert data.core is False, "data tools must be specialist (gated)"
+    assert data.auth_check is not None, "data factory needs an auth_check"
+
+
+def test_auth_factory_lists_connect_subtool() -> None:
+    auth = default_registry.get_factory("servicetitan_auth")
+    assert auth is not None
+    names = [s.name for s in auth.sub_tools]
+    assert ToolName.SERVICETITAN_CONNECT in names
+
+
+# ---------------------------------------------------------------------------
+# auth_check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_auth_check_returns_reason_when_not_connected(
+    async_test_user: Any,
+) -> None:
+    ctx = _make_context(async_test_user.id)
+    reason = await factory_module._servicetitan_auth_check(ctx)
+    assert reason is not None
+    assert "ServiceTitan is not connected" in reason
+
+
+@pytest.mark.asyncio()
+async def test_auth_check_returns_none_when_connected(async_test_user: Any) -> None:
+    user_id = async_test_user.id
+    await save_credentials(
+        user_id,
+        tenant_id=str(fake_module.DEFAULT_TENANT_ID),
+        client_id="cid",
+        client_secret="csec",
+        app_key="fake-st-app-key",
+        access_token=fake_module.FAKE_TOKEN_VALUE,
+        expires_at=time.time() + 600,
+    )
+    ctx = _make_context(user_id)
+    assert await factory_module._servicetitan_auth_check(ctx) is None
+
+
+# ---------------------------------------------------------------------------
+# Data factory body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_data_factory_returns_empty_when_not_connected(
+    async_test_user: Any,
+) -> None:
+    ctx = _make_context(async_test_user.id)
+    tools = await factory_module._servicetitan_factory(ctx)
+    assert tools == []
+
+
+@pytest.mark.asyncio()
+async def test_data_factory_returns_empty_when_connected(async_test_user: Any) -> None:
+    """No data tools wired yet; the scaffold's contract is an empty list."""
+    user_id = async_test_user.id
+    await save_credentials(
+        user_id,
+        tenant_id=str(fake_module.DEFAULT_TENANT_ID),
+        client_id="cid",
+        client_secret="csec",
+        app_key="fake-st-app-key",
+        access_token=fake_module.FAKE_TOKEN_VALUE,
+        expires_at=time.time() + 600,
+    )
+    ctx = _make_context(user_id)
+    tools = await factory_module._servicetitan_factory(ctx)
+    assert tools == []
+
+
+# ---------------------------------------------------------------------------
+# connect_servicetitan tool: end-to-end against the fake
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_connect_servicetitan_persists_credentials(async_test_user: Any) -> None:
+    user_id = async_test_user.id
+    tools = build_auth_tools(user_id)
+    assert len(tools) == 1
+    connect_tool = tools[0]
+    assert connect_tool.name == ToolName.SERVICETITAN_CONNECT
+
+    result = await connect_tool.function(
+        tenant_id="1234567",
+        client_id="my-client-id",
+        client_secret="my-secret",
+    )
+    assert result.is_error is False
+    assert "connected" in result.content.lower()
+    assert result.receipt is not None
+    assert "1234567" in result.receipt.target
+
+    assert await is_connected(user_id) is True
+    cred = await load_credentials(user_id)
+    assert cred is not None
+    assert cred.tenant_id == "1234567"
+    assert cred.client_id == "my-client-id"
+    assert cred.client_secret == "my-secret"
+    assert cred.app_key == "fake-st-app-key"
+    assert cred.access_token == fake_module.FAKE_TOKEN_VALUE
+    assert cred.expires_at > time.time()
+
+
+@pytest.mark.asyncio()
+async def test_connect_servicetitan_rejects_empty_fields(async_test_user: Any) -> None:
+    user_id = async_test_user.id
+    tools = build_auth_tools(user_id)
+    connect_tool = tools[0]
+
+    result = await connect_tool.function(
+        tenant_id="",
+        client_id="cid",
+        client_secret="csec",
+    )
+    assert result.is_error is True
+    assert result.error_kind is not None
+    assert "required" in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_connect_servicetitan_errors_without_app_key(
+    async_test_user: Any,
+) -> None:
+    """When the operator has not set the App Key, connect must fail loudly."""
+    from backend.app.config import settings as _settings
+
+    user_id = async_test_user.id
+    with patch.object(_settings, "servicetitan_app_key", ""):
+        tools = build_auth_tools(user_id)
+        connect_tool = tools[0]
+        result = await connect_tool.function(
+            tenant_id="t",
+            client_id="cid",
+            client_secret="csec",
+        )
+    assert result.is_error is True
+    assert "SERVICETITAN_APP_KEY" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_connect_servicetitan_surfaces_token_endpoint_failure(
+    async_test_user: Any,
+) -> None:
+    """If the fake rejects the credentials, the tool surfaces an AUTH error."""
+    user_id = async_test_user.id
+    tools = build_auth_tools(user_id)
+    connect_tool = tools[0]
+
+    # Empty client_secret triggers the fake's 4xx response.
+    result = await connect_tool.function(
+        tenant_id="t",
+        client_id="cid",
+        client_secret="   ",  # stripped to empty
+    )
+    assert result.is_error is True
+    # ``"   "`` strips to empty before the mint call, so it hits the
+    # local validation branch rather than the fake. Either way is fine
+    # for the user; we just want it surfaced as an error.

--- a/tests/test_servicetitan_fake.py
+++ b/tests/test_servicetitan_fake.py
@@ -1,0 +1,533 @@
+"""Tests for the in-process ServiceTitan fake backend.
+
+These tests exercise the fake by driving an ``httpx.AsyncClient``
+through ``build_fake_transport``, mirroring how production code will
+talk to the fake when ``servicetitan_use_fake=true``. The assertions
+focus on three things:
+
+* The wire-level response shapes match what the public ServiceTitan
+  OpenAPI spec promises for each endpoint, so any tool written against
+  the fake will keep working when the real API is wired up.
+* The auth flow round-trips: ``POST /connect/token`` mints a Bearer,
+  the Bearer unlocks resource endpoints, expired or missing Bearers
+  surface 401, and missing ``ST-App-Key`` surfaces 401.
+* The filtering helpers (name / phone / status / date range) and the
+  rate-limit override behave as the integration code expects.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from backend.app.integrations.servicetitan import (
+    ServiceTitanFakeBackend,
+    build_fake_transport,
+)
+from backend.app.integrations.servicetitan._fake import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    APPT_STATUS_DISPATCHED,
+    APPT_STATUS_SCHEDULED,
+    DEFAULT_TENANT_ID,
+    FAKE_ACCESS_TOKEN,
+    JOB_STATUS_COMPLETED,
+    JOB_STATUS_SCHEDULED,
+    SEED_TODAY,
+    iter_seed_customer_ids,
+    iter_seed_job_ids,
+)
+
+
+@pytest.fixture()
+def backend() -> ServiceTitanFakeBackend:
+    """A fresh backend per test, so state mutations (notes) do not leak."""
+    return ServiceTitanFakeBackend()
+
+
+@pytest.fixture()
+def client(backend: ServiceTitanFakeBackend) -> httpx.AsyncClient:
+    transport = build_fake_transport(backend)
+    return httpx.AsyncClient(
+        transport=transport,
+        base_url="https://api-fake.servicetitan.io",
+        headers={"ST-App-Key": backend.app_key},
+    )
+
+
+async def _get_bearer(client: httpx.AsyncClient) -> str:
+    resp = await client.post(
+        "/connect/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": "cid",
+            "client_secret": "csec",
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Token endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_token_endpoint_returns_15_minute_bearer(client: httpx.AsyncClient) -> None:
+    resp = await client.post(
+        "/connect/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": "cid",
+            "client_secret": "csec",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["access_token"] == FAKE_ACCESS_TOKEN
+    assert body["token_type"] == "Bearer"
+    assert body["expires_in"] == ACCESS_TOKEN_TTL_SECONDS
+
+
+@pytest.mark.asyncio()
+async def test_token_endpoint_rejects_other_grants(client: httpx.AsyncClient) -> None:
+    resp = await client.post(
+        "/connect/token",
+        data={
+            "grant_type": "password",
+            "client_id": "cid",
+            "client_secret": "csec",
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "unsupported_grant_type"
+
+
+@pytest.mark.asyncio()
+async def test_token_endpoint_requires_client_credentials(client: httpx.AsyncClient) -> None:
+    resp = await client.post(
+        "/connect/token",
+        data={"grant_type": "client_credentials"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_client"
+
+
+# ---------------------------------------------------------------------------
+# Auth on resource endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_resource_requires_bearer(client: httpx.AsyncClient) -> None:
+    resp = await client.get(f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers")
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["status"] == 401
+    assert "Authorization" in body["detail"]
+
+
+@pytest.mark.asyncio()
+async def test_resource_requires_app_key(
+    backend: ServiceTitanFakeBackend, client: httpx.AsyncClient
+) -> None:
+    bearer = await _get_bearer(client)
+    # Strip the ST-App-Key header for one request by building a fresh client
+    # that only sets Authorization.
+    transport = build_fake_transport(backend)
+    no_app_key = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://api-fake.servicetitan.io",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    try:
+        resp = await no_app_key.get(f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers")
+    finally:
+        await no_app_key.aclose()
+    assert resp.status_code == 401
+    assert "ST-App-Key" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio()
+async def test_expired_token_returns_401(
+    backend: ServiceTitanFakeBackend, client: httpx.AsyncClient
+) -> None:
+    bearer = await _get_bearer(client)
+    backend.expire_all_tokens()
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Customers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_customers_list_shape(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # Paginated envelope keys come from the live OpenAPI spec.
+    assert set(body.keys()) >= {"page", "pageSize", "hasMore", "totalCount", "data"}
+    assert isinstance(body["data"], list)
+    assert body["totalCount"] == 10
+    # Each record carries the documented fields.
+    first = body["data"][0]
+    assert {"id", "name", "type", "address", "active", "createdOn", "modifiedOn"} <= set(
+        first.keys()
+    )
+    assert {"street", "city", "state", "zip", "country"} <= set(first["address"].keys())
+
+
+@pytest.mark.asyncio()
+async def test_customers_search_by_name(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"name": "acme"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["totalCount"] == 1
+    assert body["data"][0]["name"] == "Acme Plumbing"
+
+
+@pytest.mark.asyncio()
+async def test_customers_search_by_phone(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    # Search using a phone fragment matching one of the seed contacts.
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"phone": "5550101"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert body["totalCount"] == 1
+    assert body["data"][0]["name"] == "Jane Doe"
+
+
+@pytest.mark.asyncio()
+async def test_customer_get_by_id(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    cust_id = next(iter(iter_seed_customer_ids()))
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers/{cust_id}",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == cust_id
+
+
+@pytest.mark.asyncio()
+async def test_customer_get_missing_returns_404(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers/99999999",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["status"] == 404
+
+
+@pytest.mark.asyncio()
+async def test_customer_contacts_subresource(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers/1001/contacts",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["totalCount"] >= 1
+    contact = body["data"][0]
+    assert {"id", "type", "value"} <= set(contact.keys())
+
+
+@pytest.mark.asyncio()
+async def test_customers_pagination(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"page": 1, "pageSize": 3},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert body["page"] == 1
+    assert body["pageSize"] == 3
+    assert len(body["data"]) == 3
+    assert body["hasMore"] is True
+
+
+# ---------------------------------------------------------------------------
+# Jobs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_jobs_list_shape(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["totalCount"] == 30
+    first = body["data"][0]
+    # Documented JpmV2 / CrmV2 JobResponse fields.
+    for field_name in [
+        "id",
+        "jobNumber",
+        "customerId",
+        "locationId",
+        "jobStatus",
+        "businessUnitId",
+        "jobTypeId",
+        "summary",
+        "appointmentCount",
+    ]:
+        assert field_name in first, f"missing {field_name}"
+
+
+@pytest.mark.asyncio()
+async def test_jobs_filter_by_status(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs",
+        params={"jobStatus": f"{JOB_STATUS_SCHEDULED},{JOB_STATUS_COMPLETED}"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    statuses = {j["jobStatus"] for j in body["data"]}
+    assert statuses <= {JOB_STATUS_SCHEDULED, JOB_STATUS_COMPLETED}
+    assert statuses  # not empty
+
+
+@pytest.mark.asyncio()
+async def test_jobs_filter_by_customer(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs",
+        params={"customerId": 1001},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert all(j["customerId"] == 1001 for j in body["data"])
+    assert body["totalCount"] >= 1
+
+
+@pytest.mark.asyncio()
+async def test_job_get_by_id(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    job_id = next(iter(iter_seed_job_ids()))
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs/{job_id}",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == job_id
+
+
+@pytest.mark.asyncio()
+async def test_job_get_missing_returns_404(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs/99999999",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Job notes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_post_job_note_round_trips(
+    backend: ServiceTitanFakeBackend, client: httpx.AsyncClient
+) -> None:
+    bearer = await _get_bearer(client)
+    job_id = backend.jobs[0]["id"]
+
+    post = await client.post(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs/{job_id}/notes",
+        json={"text": "Test note: tech arrived on site at 9:05.", "pinToTop": False},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert post.status_code == 200
+    body = post.json()
+    assert body["text"] == "Test note: tech arrived on site at 9:05."
+    assert body["isPinned"] is False
+    assert "createdOn" in body
+
+    listing = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs/{job_id}/notes",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert listing.status_code == 200
+    notes = listing.json()["data"]
+    assert any(n["text"].startswith("Test note") for n in notes)
+
+
+@pytest.mark.asyncio()
+async def test_post_job_note_validates_text(
+    backend: ServiceTitanFakeBackend, client: httpx.AsyncClient
+) -> None:
+    bearer = await _get_bearer(client)
+    job_id = backend.jobs[0]["id"]
+    resp = await client.post(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs/{job_id}/notes",
+        json={"text": "   "},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio()
+async def test_post_job_note_missing_job_404(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.post(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs/99999999/notes",
+        json={"text": "note"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Appointments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_appointments_list_shape(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/appointments",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["totalCount"] == 15
+    appt = body["data"][0]
+    for field_name in [
+        "id",
+        "jobId",
+        "appointmentNumber",
+        "start",
+        "end",
+        "status",
+        "createdOn",
+        "modifiedOn",
+    ]:
+        assert field_name in appt
+
+
+@pytest.mark.asyncio()
+async def test_appointments_filter_by_date_range(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    day_start = SEED_TODAY.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start.replace(hour=23, minute=59, second=59)
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/appointments",
+        params={
+            "startsOnOrAfter": day_start.isoformat().replace("+00:00", "Z"),
+            "startsBefore": day_end.isoformat().replace("+00:00", "Z"),
+        },
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert body["totalCount"] >= 1
+    # Every appointment falls within the window.
+    for appt in body["data"]:
+        assert appt["start"].startswith(SEED_TODAY.strftime("%Y-%m-%d"))
+
+
+@pytest.mark.asyncio()
+async def test_appointments_filter_by_status(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/appointments",
+        params={"status": f"{APPT_STATUS_SCHEDULED},{APPT_STATUS_DISPATCHED}"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    seen = {a["status"] for a in body["data"]}
+    assert seen <= {APPT_STATUS_SCHEDULED, APPT_STATUS_DISPATCHED}
+    assert seen
+
+
+# ---------------------------------------------------------------------------
+# Rate limit override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_force_rate_limit_returns_429(
+    backend: ServiceTitanFakeBackend, client: httpx.AsyncClient
+) -> None:
+    bearer = await _get_bearer(client)
+    backend.force_rate_limit_for(2)
+    first = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert first.status_code == 429
+    assert first.headers.get("Retry-After") == "1"
+    second = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert second.status_code == 429
+    # Third call drains the override and succeeds.
+    third = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert third.status_code == 200
+
+
+@pytest.mark.asyncio()
+async def test_rate_limit_does_not_affect_token_endpoint(
+    backend: ServiceTitanFakeBackend, client: httpx.AsyncClient
+) -> None:
+    backend.force_rate_limit_for(5)
+    resp = await client.post(
+        "/connect/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": "cid",
+            "client_secret": "csec",
+        },
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Unknown tenant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_other_tenant_returns_empty_collection(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        "/crm/v2/tenant/9876543/customers",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["totalCount"] == 0
+    assert body["data"] == []

--- a/tests/test_servicetitan_fake.py
+++ b/tests/test_servicetitan_fake.py
@@ -285,7 +285,10 @@ async def test_jobs_list_shape(client: httpx.AsyncClient) -> None:
     body = resp.json()
     assert body["totalCount"] == 30
     first = body["data"][0]
-    # Documented JpmV2 / CrmV2 JobResponse fields.
+    # Documented JpmV2 / CrmV2 JobResponse fields. The nullable cluster
+    # (recallForId / warrantyId / leadCallId / bookingId / soldById /
+    # jobGeneratedLeadSource) is also serialized by the real API and is
+    # asserted here so a seed regression that drops them is loud.
     for field_name in [
         "id",
         "jobNumber",
@@ -296,6 +299,12 @@ async def test_jobs_list_shape(client: httpx.AsyncClient) -> None:
         "jobTypeId",
         "summary",
         "appointmentCount",
+        "recallForId",
+        "warrantyId",
+        "jobGeneratedLeadSource",
+        "leadCallId",
+        "bookingId",
+        "soldById",
     ]:
         assert field_name in first, f"missing {field_name}"
 
@@ -429,10 +438,15 @@ async def test_appointments_list_shape(client: httpx.AsyncClient) -> None:
         "start",
         "end",
         "status",
+        "technicianIds",
         "createdOn",
         "modifiedOn",
     ]:
         assert field_name in appt
+    # ``technicianIds`` is a plural list of int IDs in the real schema.
+    assert isinstance(appt["technicianIds"], list)
+    assert all(isinstance(t, int) for t in appt["technicianIds"])
+    assert appt["technicianIds"], "every appointment should have at least one tech"
 
 
 @pytest.mark.asyncio()

--- a/tests/test_servicetitan_fake.py
+++ b/tests/test_servicetitan_fake.py
@@ -17,6 +17,8 @@ focus on three things:
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import httpx
 import pytest
 
@@ -252,6 +254,129 @@ async def test_customer_contacts_subresource(client: httpx.AsyncClient) -> None:
     assert body["totalCount"] >= 1
     contact = body["data"][0]
     assert {"id", "type", "value"} <= set(contact.keys())
+
+
+@pytest.mark.asyncio()
+async def test_customers_search_by_city(client: httpx.AsyncClient) -> None:
+    """Address-level filters do case-insensitive substring match."""
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"city": "anytown"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert body["totalCount"] >= 1
+    assert all("anytown" in c["address"]["city"].lower() for c in body["data"])
+
+
+@pytest.mark.asyncio()
+async def test_customers_search_by_state(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"state": "NJ"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert body["totalCount"] >= 1
+    assert all(c["address"]["state"] == "NJ" for c in body["data"])
+
+
+@pytest.mark.asyncio()
+async def test_customers_search_by_unit(client: httpx.AsyncClient) -> None:
+    """Optional address fields (``unit``) match only against records that have them."""
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"unit": "suite"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert body["totalCount"] >= 1
+    for c in body["data"]:
+        assert "suite" in (c["address"].get("unit") or "").lower()
+
+
+@pytest.mark.asyncio()
+async def test_customers_modified_on_or_after_filter(
+    backend: ServiceTitanFakeBackend, client: httpx.AsyncClient
+) -> None:
+    """Date-range filters trim the result set by the records' modifiedOn."""
+    # Push one seed record's modifiedOn way into the future so a tight
+    # window picks it up exclusively.
+    far_future = (SEED_TODAY + timedelta(days=365)).isoformat().replace("+00:00", "Z")
+    backend.customers[0]["modifiedOn"] = far_future
+
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"modifiedOnOrAfter": far_future},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert body["totalCount"] == 1
+    assert body["data"][0]["id"] == backend.customers[0]["id"]
+
+
+@pytest.mark.asyncio()
+async def test_jobs_completed_date_range(
+    backend: ServiceTitanFakeBackend, client: httpx.AsyncClient
+) -> None:
+    """``completedOnOrAfter`` is JPM-specific and works against ``completedOn``."""
+    bearer = await _get_bearer(client)
+    # Seed has completed jobs five days before SEED_TODAY; ask for jobs
+    # completed in the last day to confirm the filter trims them out.
+    one_day_ago = (SEED_TODAY - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/jobs",
+        params={"completedOnOrAfter": one_day_ago},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    # No seed job completed within the last day.
+    assert body["totalCount"] == 0
+
+
+@pytest.mark.asyncio()
+async def test_customers_sort_descending_by_id(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"sort": "-Id"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    ids = [c["id"] for c in body["data"]]
+    assert ids == sorted(ids, reverse=True)
+
+
+@pytest.mark.asyncio()
+async def test_appointments_sort_ascending_by_start(client: httpx.AsyncClient) -> None:
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/jpm/v2/tenant/{DEFAULT_TENANT_ID}/appointments",
+        params={"sort": "+Start"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    starts = [a["start"] for a in body["data"]]
+    assert starts == sorted(starts)
+
+
+@pytest.mark.asyncio()
+async def test_include_total_false_returns_minus_one(client: httpx.AsyncClient) -> None:
+    """When the caller suppresses the count, the envelope returns -1."""
+    bearer = await _get_bearer(client)
+    resp = await client.get(
+        f"/crm/v2/tenant/{DEFAULT_TENANT_ID}/customers",
+        params={"includeTotal": "false"},
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    body = resp.json()
+    assert body["totalCount"] == -1
+    # The data slice is still served; only the count is suppressed.
+    assert body["data"]
 
 
 @pytest.mark.asyncio()

--- a/tests/test_servicetitan_service.py
+++ b/tests/test_servicetitan_service.py
@@ -15,13 +15,23 @@ from unittest.mock import patch
 import pytest
 
 from backend.app.integrations.servicetitan import _fake as fake_module
-from backend.app.integrations.servicetitan.auth import save_credentials
+from backend.app.integrations.servicetitan.auth import (
+    clear_credentials,
+    load_credentials,
+    save_credentials,
+)
 from backend.app.integrations.servicetitan.service import (
     ServiceTitanError,
     ServiceTitanNotConnectedError,
     ServiceTitanService,
     build_service_for_user,
 )
+
+
+async def _load(user_id: str) -> Any:
+    cred = await load_credentials(user_id)
+    assert cred is not None
+    return cred
 
 
 @pytest.fixture(autouse=True)
@@ -132,14 +142,6 @@ async def test_request_refreshes_bearer_on_401(async_test_user: Any) -> None:
     assert service.credential.access_token == fake_module.FAKE_TOKEN_VALUE
 
 
-async def _load(user_id: str) -> Any:
-    from backend.app.integrations.servicetitan.auth import load_credentials
-
-    cred = await load_credentials(user_id)
-    assert cred is not None
-    return cred
-
-
 @pytest.mark.asyncio()
 async def test_request_raises_for_unknown_path(async_test_user: Any) -> None:
     user_id = async_test_user.id
@@ -163,8 +165,6 @@ async def test_request_without_usable_credential_raises(async_test_user: Any) ->
     # Wipe the bearer in-memory and delete the row so refresh returns None.
     cred.access_token = ""
     cred.expires_at = 0.0
-    from backend.app.integrations.servicetitan.auth import clear_credentials
-
     await clear_credentials(user_id)
 
     service = ServiceTitanService(user_id, cred)

--- a/tests/test_servicetitan_service.py
+++ b/tests/test_servicetitan_service.py
@@ -1,0 +1,187 @@
+"""Tests for the ServiceTitan HTTP service layer.
+
+Exercises header injection, refresh-on-401, and the fake-transport
+plumbing. Resource-specific helpers (list customers, get job, etc.)
+land in the read-tools issue (#1300); these tests cover only the
+generic ``request`` surface this scaffold ships.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from backend.app.integrations.servicetitan import _fake as fake_module
+from backend.app.integrations.servicetitan.auth import save_credentials
+from backend.app.integrations.servicetitan.service import (
+    ServiceTitanError,
+    ServiceTitanNotConnectedError,
+    ServiceTitanService,
+    build_service_for_user,
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_fake_backend() -> Any:
+    """Pin every test in this module to the in-process fake backend."""
+    from backend.app.config import settings as _settings
+
+    with patch.object(_settings, "servicetitan_use_fake", True):
+        fake_module.reset_default_fake_backend()
+        try:
+            yield
+        finally:
+            fake_module.reset_default_fake_backend()
+
+
+# ---------------------------------------------------------------------------
+# build_service_for_user
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_build_service_returns_none_without_credentials(
+    async_test_user: Any,
+) -> None:
+    assert await build_service_for_user(async_test_user.id) is None
+
+
+@pytest.mark.asyncio()
+async def test_build_service_eagerly_refreshes_bearer(async_test_user: Any) -> None:
+    """An expired row at build time should still produce a usable service."""
+    user_id = async_test_user.id
+    await save_credentials(
+        user_id,
+        tenant_id=str(fake_module.DEFAULT_TENANT_ID),
+        client_id="cid",
+        client_secret="csec",
+        app_key="fake-st-app-key",
+        access_token="stale",
+        expires_at=time.time() - 60,
+    )
+    service = await build_service_for_user(user_id)
+    assert service is not None
+    assert service.credential.access_token == fake_module.FAKE_TOKEN_VALUE
+
+
+# ---------------------------------------------------------------------------
+# Request loop: headers, refresh-on-401, errors
+# ---------------------------------------------------------------------------
+
+
+def _seed_connected_credential() -> dict[str, Any]:
+    """Return the credential fields a connected user would hold.
+
+    The fake backend issues ``FAKE_TOKEN_VALUE`` and gates resource
+    endpoints on ``ST-App-Key=fake-st-app-key``. Match both so the
+    service routes through the happy path without a refresh.
+    """
+    return {
+        "tenant_id": str(fake_module.DEFAULT_TENANT_ID),
+        "client_id": "cid",
+        "client_secret": "csec",
+        "app_key": "fake-st-app-key",
+        "access_token": fake_module.FAKE_TOKEN_VALUE,
+        "expires_at": time.time() + 600,
+    }
+
+
+@pytest.mark.asyncio()
+async def test_request_sends_bearer_and_app_key_headers(async_test_user: Any) -> None:
+    user_id = async_test_user.id
+    await save_credentials(user_id, **_seed_connected_credential())
+    service = await build_service_for_user(user_id)
+    assert service is not None
+
+    # Hit a list endpoint the fake serves directly. Successful round
+    # trip proves both headers were sent (the fake 401s otherwise).
+    path = f"/crm/v2/tenant/{service.tenant_id}/customers"
+    payload = await service.get(path)
+    assert isinstance(payload, dict)
+    assert "data" in payload
+    assert payload["totalCount"] == 10  # seed customer count
+
+
+@pytest.mark.asyncio()
+async def test_request_refreshes_bearer_on_401(async_test_user: Any) -> None:
+    """A stale bearer that the fake rejects should be refreshed once."""
+    user_id = async_test_user.id
+    creds = _seed_connected_credential()
+    # Force a value the fake will reject so the service is pushed onto
+    # the refresh path.
+    creds["access_token"] = "stale-bearer-not-recognized"
+    await save_credentials(user_id, **creds)
+
+    service = ServiceTitanService(
+        user_id,
+        # Build a credential snapshot that matches what was just persisted
+        # so the in-process service starts the request loop with the
+        # rejected bearer rather than triggering the eager refresh in
+        # ``build_service_for_user``.
+        credential=(await _load(user_id)),
+    )
+
+    path = f"/crm/v2/tenant/{service.tenant_id}/customers"
+    payload = await service.get(path)
+    assert isinstance(payload, dict)
+    assert payload["totalCount"] == 10
+    # The refresh path swapped in the fake's mint result.
+    assert service.credential.access_token == fake_module.FAKE_TOKEN_VALUE
+
+
+async def _load(user_id: str) -> Any:
+    from backend.app.integrations.servicetitan.auth import load_credentials
+
+    cred = await load_credentials(user_id)
+    assert cred is not None
+    return cred
+
+
+@pytest.mark.asyncio()
+async def test_request_raises_for_unknown_path(async_test_user: Any) -> None:
+    user_id = async_test_user.id
+    await save_credentials(user_id, **_seed_connected_credential())
+    service = await build_service_for_user(user_id)
+    assert service is not None
+
+    with pytest.raises(ServiceTitanError):
+        await service.get("/this/does/not/exist")
+
+
+@pytest.mark.asyncio()
+async def test_request_without_usable_credential_raises(async_test_user: Any) -> None:
+    """A service built from an empty bearer that cannot be refreshed should fail loudly."""
+    user_id = async_test_user.id
+    # Persist a credential, then clear it so the refresh path returns
+    # None when the service tries to mint a token.
+    await save_credentials(user_id, **_seed_connected_credential())
+    cred = await _load(user_id)
+
+    # Wipe the bearer in-memory and delete the row so refresh returns None.
+    cred.access_token = ""
+    cred.expires_at = 0.0
+    from backend.app.integrations.servicetitan.auth import clear_credentials
+
+    await clear_credentials(user_id)
+
+    service = ServiceTitanService(user_id, cred)
+    with pytest.raises(ServiceTitanNotConnectedError):
+        await service.get(f"/crm/v2/tenant/{service.tenant_id}/customers")
+
+
+@pytest.mark.asyncio()
+async def test_one_post_to_job_notes_round_trips(async_test_user: Any) -> None:
+    """Smoke test: a POST also threads through the auth headers and fake."""
+    user_id = async_test_user.id
+    await save_credentials(user_id, **_seed_connected_credential())
+    service = await build_service_for_user(user_id)
+    assert service is not None
+
+    seed_job_id = next(iter(fake_module.iter_seed_job_ids()))
+    path = f"/jpm/v2/tenant/{service.tenant_id}/jobs/{seed_job_id}/notes"
+    note = await service.post(path, json_body={"text": "scaffold smoke test"})
+    assert isinstance(note, dict)
+    assert note["text"] == "scaffold smoke test"

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -48,6 +48,14 @@ EXPECTED_INTEGRATION_MODULES: set[str] = {
     "backend.app.integrations.companycam.factory",
     "backend.app.integrations.gmail.factory",
     "backend.app.integrations.quickbooks.factory",
+    # The ServiceTitan integration package lives at
+    # backend/app/integrations/servicetitan/ from the fake-backend issue
+    # onward. Discovery attempts to import its factory module on every
+    # boot; until the auth scaffold lands the import raises
+    # ModuleNotFoundError, which the registry catches but the tracking
+    # ``import_module`` patch records before the call returns, so the
+    # entry shows up here.
+    "backend.app.integrations.servicetitan.factory",
     "backend.app.integrations.supplier_pricing.factory",
 }
 


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Scaffolds the ServiceTitan integration on top of the in-process fake backend from PR #1303. Mirrors the AppFolio Vendor split-factory shape so subsequent read-tool work (#1300) and write-tool work (#1301) plug in without further wiring.

Built on top of `feat/servicetitan-fake-api`; that branch (PR #1303) must merge first so the base diff in this PR shows only the new scaffold and not the fake module. After #1303 merges, this PR's diff against `main` will be the scaffold alone.

Highlights:

- `servicetitan_auth` (core, always on the schema) ships the `connect_servicetitan` tool. The user pastes Tenant ID, Client ID, and Client Secret; the tool validates them by minting a bearer against the configured token endpoint and persists everything in `oauth_tokens` (encrypted `access_token`, tenant metadata in `extra_json`).
- `servicetitan` (specialist, gated on credential state) carries the `auth_check` that surfaces "not connected" in `list_capabilities` until the user runs the connect flow. The data-tool builders land in the read-tools issue (#1300); the factory body is empty for now.
- Service layer routes through the fake's `httpx.MockTransport` when `servicetitan_use_fake` is true, otherwise points at the real host. The bearer is refreshed lazily on 401 (one-shot retry) via a force-refresh that mints a fresh client-credentials token, persisted back through `oauth_service.save_token` so peer workers see it.
- New `servicetitan_auth` factory is added as a hidden core factory paired with `servicetitan` in `_HIDDEN_CORE_FACTORIES`, matching the AppFolio pattern: dashboard surfaces and enable/disable treat the pair as a single integration.
- New settings: `servicetitan_app_key`, `servicetitan_api_base_url`, `servicetitan_use_fake`. Documented in `.env.example` and `docs/self-host/configuration.md`.

Fixes #1298.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Test coverage:

- `tests/test_servicetitan_auth.py`: credential round trip (save, load, clear), partial-row rejection, token-expiry window logic, eager + forced refresh through the fake's MockTransport.
- `tests/test_servicetitan_service.py`: header injection (`Authorization`, `ST-App-Key`), refresh-on-401 retry, error wrapping for 4xx and transport failures, smoke POST through the fake.
- `tests/test_servicetitan_factory.py`: split-factory invariants, `auth_check` reason wording, end-to-end `connect_servicetitan` flow against the fake.

Definition of Done locally:

- `uv run pytest -n auto` -> 2611 passed, 2 skipped.
- `uv run ruff check backend/ tests/ alembic/` -> all checks passed.
- `uv run ruff format --check backend/ tests/ alembic/` -> all files formatted.
- `uv run ty check --python .venv backend/ tests/ alembic/` -> all checks passed.

## AI Usage
- [x] AI-assisted (Claude Code drafted the scaffold, tests, and prose; reviewed in chat against `AGENTS.md`, the AppFolio split-factory pattern at `backend/app/integrations/appfolio_vendor/factory.py`, and the fake-API surface from PR #1303 before pushing.)
- [ ] No AI used