### PR TITLE
chore: ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ENV/
 # IDE
 .idea/
 .vscode/
+.claude/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Description
Add `.claude/` to `.gitignore` under the IDE section so Claude Code's per-project state (settings, history, etc.) is not accidentally committed.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation
- [x] Chore

## Checklist
- [x] Tests pass (no code change)
- [x] Lint passes (no code change)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude drafted the edit and PR text)
- [ ] No AI used