### PR TITLE
feat(servicetitan): read tools (search_customers, get_customer, list_appointments)

### DIFF
--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -91,6 +91,9 @@ class ToolName:
 
     # ServiceTitan
     SERVICETITAN_CONNECT = "connect_servicetitan"
+    SERVICETITAN_SEARCH_CUSTOMERS = "st_search_customers"
+    SERVICETITAN_GET_CUSTOMER = "st_get_customer"
+    SERVICETITAN_LIST_APPOINTMENTS = "st_list_appointments"
 
     # Supplier pricing
     SUPPLIER_SEARCH_PRODUCTS = "supplier_search_products"

--- a/backend/app/agent/tools/servicetitan_tools.py
+++ b/backend/app/agent/tools/servicetitan_tools.py
@@ -1,0 +1,384 @@
+"""ServiceTitan read tools.
+
+Three read-only tools that surface customers and appointments from a
+user's ServiceTitan tenant:
+
+* ``st_search_customers`` -- substring search by name or phone.
+* ``st_get_customer`` -- full record by numeric id.
+* ``st_list_appointments`` -- date-range filtered appointment list,
+  defaulting to "today" when no range is given.
+
+Tools are constructed by :func:`build_servicetitan_tools`, which the
+``servicetitan`` data factory calls once the user has connected a
+tenant. None of these tools mutate state, so they ship without an
+``ApprovalPolicy`` and without a ``concurrency_group``.
+
+This module also lives in the auto-discovery path:
+``ensure_tool_modules_imported`` imports every ``*_tools`` module in
+``backend.app.agent.tools`` at startup. The import is side-effect-free
+here (no ``_register()`` call); registration of the data factory lives
+in ``backend/app/integrations/servicetitan/factory.py`` where the
+companion ``servicetitan_auth`` factory and ``auth_check`` are wired.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, time, timedelta
+from typing import Any
+
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.servicetitan.params import (
+    StGetCustomerParams,
+    StListAppointmentsParams,
+    StSearchCustomersParams,
+)
+from backend.app.integrations.servicetitan.service import (
+    ServiceTitanError,
+    ServiceTitanNotConnectedError,
+    ServiceTitanService,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# How many records to display in chat output. ServiceTitan paginates
+# at 50 per page by default; the agent's chat window stays usable up
+# to roughly this many lines before the model starts truncating.
+_MAX_RESULTS_DEFAULT = 5
+_MAX_RESULTS_HARD_CAP = 25
+
+# Threshold for "looks like a phone number". Anything with more than
+# this many digit characters in the query string is treated as a phone
+# search instead of a name search.
+_PHONE_DIGITS_THRESHOLD = 4
+
+
+def _is_phone_query(query: str) -> bool:
+    """True when the query is mostly digits and should hit the phone filter."""
+    digits = sum(1 for ch in query if ch.isdigit())
+    return digits >= _PHONE_DIGITS_THRESHOLD
+
+
+def _service_error(label: str, exc: Exception) -> ToolResult:
+    """Convert an exception from the service layer into a ToolResult."""
+    if isinstance(exc, ServiceTitanNotConnectedError):
+        return ToolResult(
+            content=f"ServiceTitan is not connected (while {label}).",
+            is_error=True,
+            error_kind=ToolErrorKind.AUTH,
+            hint=(
+                "Ask the user to run connect_servicetitan with their Tenant"
+                " ID, Client ID, and Client Secret."
+            ),
+        )
+    if isinstance(exc, ServiceTitanError):
+        return ToolResult(
+            content=f"ServiceTitan error while {label}: {exc}",
+            is_error=True,
+            error_kind=ToolErrorKind.SERVICE,
+        )
+    logger.exception("Unexpected ServiceTitan failure %s", label)
+    return ToolResult(
+        content=f"Unexpected error while {label}: {exc}",
+        is_error=True,
+        error_kind=ToolErrorKind.INTERNAL,
+    )
+
+
+def _format_address(addr: dict[str, Any] | None) -> str:
+    """Render an address sub-object into a single line, skipping blanks."""
+    if not isinstance(addr, dict):
+        return ""
+    parts: list[str] = []
+    street = addr.get("street")
+    unit = addr.get("unit")
+    if street:
+        parts.append(f"{street} {unit}" if unit else str(street))
+    city_state_zip: list[str] = []
+    if addr.get("city"):
+        city_state_zip.append(str(addr["city"]))
+    if addr.get("state"):
+        city_state_zip.append(str(addr["state"]))
+    if addr.get("zip"):
+        city_state_zip.append(str(addr["zip"]))
+    if city_state_zip:
+        parts.append(", ".join(city_state_zip))
+    return " | ".join(parts)
+
+
+def _format_contacts(contacts: list[dict[str, Any]] | None) -> str:
+    """Render a customer's contact list as ``Type: value`` pairs."""
+    if not isinstance(contacts, list) or not contacts:
+        return ""
+    rendered: list[str] = []
+    for c in contacts:
+        if not isinstance(c, dict):
+            continue
+        ctype = c.get("type") or "Contact"
+        value = c.get("value")
+        if value:
+            rendered.append(f"{ctype}: {value}")
+    return ", ".join(rendered)
+
+
+def _customer_summary_line(customer: dict[str, Any]) -> str:
+    """One-line summary used in the search results list."""
+    cid = customer.get("id", "?")
+    name = customer.get("name") or "(no name)"
+    ctype = customer.get("type") or ""
+    address = _format_address(customer.get("address"))
+    contacts = _format_contacts(customer.get("contacts"))
+    pieces = [f"#{cid}", str(name)]
+    if ctype:
+        pieces.append(f"[{ctype}]")
+    if address:
+        pieces.append(address)
+    if contacts:
+        pieces.append(contacts)
+    return " | ".join(pieces)
+
+
+def _format_customer_detail(customer: dict[str, Any]) -> str:
+    """Multi-line full record used by ``st_get_customer``."""
+    cid = customer.get("id", "?")
+    name = customer.get("name") or "(no name)"
+    lines = [f"Customer #{cid}: {name}"]
+    ctype = customer.get("type")
+    if ctype:
+        lines.append(f"  Type: {ctype}")
+    address = _format_address(customer.get("address"))
+    if address:
+        lines.append(f"  Address: {address}")
+    contacts = _format_contacts(customer.get("contacts"))
+    if contacts:
+        lines.append(f"  Contacts: {contacts}")
+    if customer.get("balance") is not None:
+        try:
+            balance = float(customer["balance"])
+            lines.append(f"  Balance: ${balance:,.2f}")
+        except (TypeError, ValueError):
+            lines.append(f"  Balance: {customer['balance']}")
+    flags: list[str] = []
+    if customer.get("active") is False:
+        flags.append("inactive")
+    if customer.get("doNotMail"):
+        flags.append("do not mail")
+    if customer.get("doNotService"):
+        flags.append("do not service")
+    if flags:
+        lines.append(f"  Flags: {', '.join(flags)}")
+    return "\n".join(lines)
+
+
+def _format_appointment_line(appt: dict[str, Any]) -> str:
+    """One-line summary used in the appointment list."""
+    aid = appt.get("id", "?")
+    job_id = appt.get("jobId", "?")
+    start = appt.get("start") or "?"
+    end = appt.get("end") or "?"
+    status = appt.get("status") or "?"
+    tech_ids = appt.get("technicianIds") or []
+    pieces = [f"#{aid}", f"job={job_id}", f"start={start}", f"end={end}", f"[{status}]"]
+    if isinstance(tech_ids, list) and tech_ids:
+        pieces.append("techs=" + ",".join(str(t) for t in tech_ids))
+    return " | ".join(pieces)
+
+
+def _data_from_envelope(payload: Any) -> list[dict[str, Any]]:
+    """Pull the ``data`` list out of ServiceTitan's pagination envelope."""
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    return []
+
+
+def _default_appointment_range() -> tuple[str, str]:
+    """Compute the default "today (UTC)" window for st_list_appointments."""
+    today = datetime.now(UTC).date()
+    start = datetime.combine(today, time.min, tzinfo=UTC)
+    end = start + timedelta(days=1)
+    return _iso_z(start), _iso_z(end)
+
+
+def _iso_z(dt: datetime) -> str:
+    """Render a UTC datetime in the ``...Z`` form ServiceTitan expects."""
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def build_servicetitan_tools(service: ServiceTitanService) -> list[Tool]:
+    """Build the ServiceTitan read tools bound to one user's service.
+
+    The service argument carries the tenant id and authenticated HTTP
+    client. Tools are closures so the agent invokes them with just
+    their pydantic params, mirroring the AppFolio builder pattern.
+    """
+
+    async def st_search_customers(
+        query: str,
+        limit: int = _MAX_RESULTS_DEFAULT,
+    ) -> ToolResult:
+        """Search ServiceTitan customers by name or phone substring."""
+        trimmed = query.strip()
+        if not trimmed:
+            return ToolResult(
+                content="Search query is empty.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint="Pass a name fragment or partial phone number.",
+            )
+        # Clamp the limit so a hallucinated value cannot blow up the
+        # chat response. Pydantic already validates the range via
+        # StSearchCustomersParams; this is belt-and-suspenders for any
+        # direct caller that bypasses the params model.
+        capped_limit = max(1, min(int(limit), _MAX_RESULTS_HARD_CAP))
+
+        params: dict[str, Any] = {}
+        if _is_phone_query(trimmed):
+            params["phone"] = trimmed
+        else:
+            params["name"] = trimmed
+
+        path = f"/crm/v2/tenant/{service.tenant_id}/customers"
+        try:
+            payload = await service.get(path, params=params)
+        except Exception as exc:
+            return _service_error("searching customers", exc)
+
+        records = _data_from_envelope(payload)
+        if not records:
+            return ToolResult(content=f"No customers matched {trimmed!r}.")
+
+        truncated = records[:capped_limit]
+        lines = [f"{len(records)} customer(s) matched {trimmed!r}:"]
+        lines.extend(_customer_summary_line(c) for c in truncated)
+        if len(records) > capped_limit:
+            lines.append(
+                f"... and {len(records) - capped_limit} more (raise limit or narrow the query)."
+            )
+        return ToolResult(content="\n".join(lines))
+
+    async def st_get_customer(customer_id: int) -> ToolResult:
+        """Fetch one customer record by its numeric id."""
+        path = f"/crm/v2/tenant/{service.tenant_id}/customers/{customer_id}"
+        try:
+            payload = await service.get(path)
+        except ServiceTitanError as exc:
+            # The service layer raises ServiceTitanError on any 4xx/5xx.
+            # The most common 4xx here is the 404 the fake and real
+            # APIs return for an unknown id. Surface that as NOT_FOUND
+            # so the agent can offer a follow-up search instead of
+            # treating it as a transient SERVICE failure.
+            text = str(exc)
+            if "HTTP 404" in text:
+                return ToolResult(
+                    content=f"No customer with id {customer_id} in ServiceTitan.",
+                    is_error=True,
+                    error_kind=ToolErrorKind.NOT_FOUND,
+                    hint="Run st_search_customers to find the correct id.",
+                )
+            return _service_error("fetching customer", exc)
+        except Exception as exc:
+            return _service_error("fetching customer", exc)
+
+        if not isinstance(payload, dict) or not payload:
+            return ToolResult(
+                content=f"ServiceTitan returned no record for customer {customer_id}.",
+                is_error=True,
+                error_kind=ToolErrorKind.NOT_FOUND,
+            )
+        return ToolResult(content=_format_customer_detail(payload))
+
+    async def st_list_appointments(
+        from_date: str | None = None,
+        to_date: str | None = None,
+        status: str | None = None,
+    ) -> ToolResult:
+        """List ServiceTitan appointments in a date range, optionally by status."""
+        if not from_date and not to_date:
+            from_date, to_date = _default_appointment_range()
+
+        params: dict[str, Any] = {}
+        if from_date:
+            params["startsOnOrAfter"] = from_date
+        if to_date:
+            params["startsBefore"] = to_date
+        if status:
+            params["status"] = status
+
+        # Sorting by start ascending so today's dispatch view reads in
+        # the order a coordinator expects.
+        params.setdefault("sort", "+Start")
+
+        path = f"/jpm/v2/tenant/{service.tenant_id}/appointments"
+        try:
+            payload = await service.get(path, params=params)
+        except Exception as exc:
+            return _service_error("listing appointments", exc)
+
+        records = _data_from_envelope(payload)
+        if not records:
+            window = f"{from_date or 'any'} -> {to_date or 'any'}"
+            status_clause = f" with status {status}" if status else ""
+            return ToolResult(
+                content=f"No ServiceTitan appointments found for {window}{status_clause}."
+            )
+
+        lines = [f"Found {len(records)} appointment(s):"]
+        lines.extend(_format_appointment_line(a) for a in records)
+        return ToolResult(content="\n".join(lines))
+
+    return [
+        Tool(
+            name=ToolName.SERVICETITAN_SEARCH_CUSTOMERS,
+            description=(
+                "Search ServiceTitan customers by name or phone substring."
+                " Returns a compact list of matches with id, name, type,"
+                " address, and contacts. Use this before st_get_customer"
+                " when only a name or phone fragment is known."
+            ),
+            function=st_search_customers,
+            params_model=StSearchCustomersParams,
+            usage_hint=(
+                "Pass a name fragment (e.g. 'Acme', 'Jane Doe') or a"
+                " partial phone number (e.g. '5550101'). Tool detects"
+                " numeric queries and routes them to the phone filter."
+            ),
+        ),
+        Tool(
+            name=ToolName.SERVICETITAN_GET_CUSTOMER,
+            description=(
+                "Fetch the full ServiceTitan customer record by numeric"
+                " id. Returns name, type, address, contacts, balance,"
+                " and flags (inactive, do-not-mail, do-not-service)."
+            ),
+            function=st_get_customer,
+            params_model=StGetCustomerParams,
+            usage_hint=(
+                "Use after st_search_customers has yielded a confirmed"
+                " customer id. Returns NOT_FOUND when the id does not"
+                " exist in the tenant."
+            ),
+        ),
+        Tool(
+            name=ToolName.SERVICETITAN_LIST_APPOINTMENTS,
+            description=(
+                "List ServiceTitan appointments in a date range. Defaults"
+                " to today (UTC) when no dates are given. Optionally"
+                " filter by appointment status. Returns id, jobId,"
+                " start/end, status, and assigned technician ids."
+            ),
+            function=st_list_appointments,
+            params_model=StListAppointmentsParams,
+            usage_hint=(
+                "Call with no arguments for today's dispatch view. Pass"
+                " from_date / to_date (ISO 8601) to widen or narrow the"
+                " window. Pass status to filter (Scheduled, Dispatched,"
+                " Working, Done, Hold)."
+            ),
+        ),
+    ]

--- a/backend/app/integrations/servicetitan/factory.py
+++ b/backend/app/integrations/servicetitan/factory.py
@@ -8,10 +8,9 @@ time, mirroring the AppFolio Vendor split:
   ``connect_servicetitan`` tool. Must stay reachable before any credential
   exists since pasting credentials *is* the connect path.
 * ``servicetitan`` (specialist, gated on connection state): the data
-  tools, populated in the read-tools issue (#1300). For now the factory
-  returns an empty tool list; the ``auth_check`` keeps it surfaced
-  under "Not connected" in ``list_capabilities`` until the user runs
-  the connect tool.
+  tools. The read tools landed in #1300; write tools land in #1301. The
+  ``auth_check`` keeps the factory surfaced under "Not connected" in
+  ``list_capabilities`` until the user runs the connect tool.
 
 The split mirrors AppFolio's prod-bug fix: a single combined factory
 would have to keep ``auth_check`` returning ``None`` unconditionally to
@@ -26,8 +25,10 @@ from typing import TYPE_CHECKING
 
 from backend.app.agent.tools.base import Tool
 from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.servicetitan_tools import build_servicetitan_tools
 from backend.app.integrations.servicetitan.auth import is_connected
 from backend.app.integrations.servicetitan.auth_tools import build_auth_tools
+from backend.app.integrations.servicetitan.service import build_service_for_user
 
 if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
@@ -55,17 +56,17 @@ async def _servicetitan_auth_factory(ctx: ToolContext) -> list[Tool]:
 async def _servicetitan_factory(ctx: ToolContext) -> list[Tool]:
     """Assemble the ServiceTitan data tools for an authenticated user.
 
-    Empty for now: the read tools land in #1300 and the write tools in
-    #1301. The factory still exists so ``list_capabilities`` and the
-    Settings page know the integration is real; ``auth_check`` keeps
-    it surfaced as "not connected" until the user pastes credentials.
+    Returns the read tools (#1300) when the user has a usable credential
+    on file. The defensive ``return []`` after ``build_service_for_user``
+    covers the rare race where the credential disappears between the
+    auth check and tool creation (user disconnected mid-turn).
     """
     if not await is_connected(ctx.user.id):
         return []
-    # Resource-tool builders land in subsequent issues and will be wired
-    # in here once they exist. Keep the factory body shaped like
-    # AppFolio's so adding builders later is a one-line edit.
-    return []
+    service = await build_service_for_user(ctx.user.id)
+    if service is None:
+        return []
+    return list(build_servicetitan_tools(service))
 
 
 async def _servicetitan_auth_check(ctx: ToolContext) -> str | None:
@@ -118,7 +119,23 @@ def _register() -> None:
         dashboard_description=("View ServiceTitan customers, jobs, and appointments"),
         dashboard_group="Integrations",
         dashboard_group_order=3,
-        sub_tools=[],
+        sub_tools=[
+            SubToolInfo(
+                ToolName.SERVICETITAN_SEARCH_CUSTOMERS,
+                "Search ServiceTitan customers by name or phone",
+                default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.SERVICETITAN_GET_CUSTOMER,
+                "Fetch a ServiceTitan customer record by id",
+                default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.SERVICETITAN_LIST_APPOINTMENTS,
+                "List ServiceTitan appointments in a date range",
+                default_permission="always",
+            ),
+        ],
         auth_check=_servicetitan_auth_check,
     )
 

--- a/backend/app/integrations/servicetitan/params.py
+++ b/backend/app/integrations/servicetitan/params.py
@@ -36,3 +36,72 @@ class ServiceTitanConnectParams(BaseModel):
             " password; only shown once at creation time in ServiceTitan."
         ),
     )
+
+
+class StSearchCustomersParams(BaseModel):
+    """Inputs for ``st_search_customers``.
+
+    The agent passes a single free-form query string. The tool
+    decides whether to filter ServiceTitan by name or phone based on
+    whether the query looks numeric. The optional ``limit`` caps the
+    response so chat output stays compact; ServiceTitan's own page
+    size is independent and may return more.
+    """
+
+    query: str = Field(
+        description=(
+            "Free-form lookup string. Treated as a name substring;"
+            " if the input is mostly digits, treated as a phone-number"
+            " substring instead."
+        ),
+    )
+    limit: int = Field(
+        default=5,
+        ge=1,
+        le=25,
+        description="Maximum number of matches to return. Defaults to 5.",
+    )
+
+
+class StGetCustomerParams(BaseModel):
+    """Inputs for ``st_get_customer``."""
+
+    customer_id: int = Field(
+        description=(
+            "The numeric ServiceTitan customer ID to look up. Usually"
+            " obtained from a prior st_search_customers call."
+        ),
+    )
+
+
+class StListAppointmentsParams(BaseModel):
+    """Inputs for ``st_list_appointments``.
+
+    All fields are optional. When ``from_date`` and ``to_date`` are
+    both omitted the tool defaults to today's appointments in UTC,
+    which matches the "today's dispatch view" use case in the issue.
+    """
+
+    from_date: str | None = Field(
+        default=None,
+        description=(
+            "Inclusive lower bound on appointment start time. ISO 8601"
+            " string (e.g. 2026-05-11 or 2026-05-11T08:00:00Z). Omit"
+            " to default to the start of today (UTC)."
+        ),
+    )
+    to_date: str | None = Field(
+        default=None,
+        description=(
+            "Exclusive upper bound on appointment start time. ISO 8601"
+            " string. Omit to default to the start of tomorrow (UTC)."
+        ),
+    )
+    status: str | None = Field(
+        default=None,
+        description=(
+            "Filter to appointments with this status. ServiceTitan"
+            " values: Scheduled, Dispatched, Working, Done, Hold. Omit"
+            " to return all statuses."
+        ),
+    )

--- a/tests/test_servicetitan_factory.py
+++ b/tests/test_servicetitan_factory.py
@@ -84,6 +84,23 @@ def test_auth_factory_lists_connect_subtool() -> None:
     assert ToolName.SERVICETITAN_CONNECT in names
 
 
+def test_data_factory_lists_read_subtools() -> None:
+    """The data factory must advertise the three read tools so the
+    Settings UI and ``manage_integration`` can render their permission
+    rows even before the user connects.
+    """
+    data = default_registry.get_factory("servicetitan")
+    assert data is not None
+    names = {s.name for s in data.sub_tools}
+    assert ToolName.SERVICETITAN_SEARCH_CUSTOMERS in names
+    assert ToolName.SERVICETITAN_GET_CUSTOMER in names
+    assert ToolName.SERVICETITAN_LIST_APPOINTMENTS in names
+    for sub in data.sub_tools:
+        assert sub.default_permission == "always", (
+            f"{sub.name} should default to ALWAYS (read-only)"
+        )
+
+
 # ---------------------------------------------------------------------------
 # auth_check
 # ---------------------------------------------------------------------------
@@ -130,8 +147,8 @@ async def test_data_factory_returns_empty_when_not_connected(
 
 
 @pytest.mark.asyncio()
-async def test_data_factory_returns_empty_when_connected(async_test_user: Any) -> None:
-    """No data tools wired yet; the scaffold's contract is an empty list."""
+async def test_data_factory_returns_read_tools_when_connected(async_test_user: Any) -> None:
+    """Once #1300 landed, a connected user gets the three read tools."""
     user_id = async_test_user.id
     await save_credentials(
         user_id,
@@ -144,7 +161,12 @@ async def test_data_factory_returns_empty_when_connected(async_test_user: Any) -
     )
     ctx = _make_context(user_id)
     tools = await factory_module._servicetitan_factory(ctx)
-    assert tools == []
+    names = {t.name for t in tools}
+    assert names == {
+        ToolName.SERVICETITAN_SEARCH_CUSTOMERS,
+        ToolName.SERVICETITAN_GET_CUSTOMER,
+        ToolName.SERVICETITAN_LIST_APPOINTMENTS,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_servicetitan_read_tools.py
+++ b/tests/test_servicetitan_read_tools.py
@@ -1,0 +1,315 @@
+"""Tests for the ServiceTitan read tools.
+
+Each tool is exercised end-to-end against a real ``ServiceTitanService``
+instance backed by the in-process fake. No live network is touched.
+Seed customers and appointments live in
+``backend/app/integrations/servicetitan/_fake.py``; the fake mirrors
+real-API wire shapes (pagination envelope, ISO date filters, sort
+ordering) so the tools' behavior under the fake transfers to live.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.servicetitan_tools import (
+    build_servicetitan_tools,
+)
+from backend.app.integrations.servicetitan import _fake as fake_module
+from backend.app.integrations.servicetitan.auth import save_credentials
+from backend.app.integrations.servicetitan.service import (
+    ServiceTitanService,
+    build_service_for_user,
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_fake_backend() -> Any:
+    """Route every test in this module through the in-process fake backend.
+
+    Resets the process-wide fake between tests so a previous note POST
+    or rate-limit override cannot leak. The credential row itself is
+    cleaned by the standard async test isolation fixture.
+    """
+    from backend.app.config import settings as _settings
+
+    with patch.object(_settings, "servicetitan_use_fake", True):
+        fake_module.reset_default_fake_backend()
+        try:
+            yield
+        finally:
+            fake_module.reset_default_fake_backend()
+
+
+def _connected_credential_kwargs() -> dict[str, Any]:
+    """Credential row matching what a fully connected user holds."""
+    return {
+        "tenant_id": str(fake_module.DEFAULT_TENANT_ID),
+        "client_id": "cid",
+        "client_secret": "csec",
+        "app_key": "fake-st-app-key",
+        "access_token": fake_module.FAKE_TOKEN_VALUE,
+        "expires_at": time.time() + 600,
+    }
+
+
+async def _build_connected_service(user_id: str) -> ServiceTitanService:
+    """Persist a credential and return a service bound to it."""
+    await save_credentials(user_id, **_connected_credential_kwargs())
+    service = await build_service_for_user(user_id)
+    assert service is not None
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Tool wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_build_servicetitan_tools_returns_three_tools(async_test_user: Any) -> None:
+    """build_servicetitan_tools must expose exactly the three read tools."""
+    service = await _build_connected_service(async_test_user.id)
+    tools = build_servicetitan_tools(service)
+    names = {t.name for t in tools}
+    assert names == {
+        ToolName.SERVICETITAN_SEARCH_CUSTOMERS,
+        ToolName.SERVICETITAN_GET_CUSTOMER,
+        ToolName.SERVICETITAN_LIST_APPOINTMENTS,
+    }
+
+
+@pytest.mark.asyncio()
+async def test_read_tools_have_no_approval_policy_or_concurrency_group(
+    async_test_user: Any,
+) -> None:
+    """Read-only tools must not declare approval policies or concurrency groups."""
+    service = await _build_connected_service(async_test_user.id)
+    for tool in build_servicetitan_tools(service):
+        assert tool.approval_policy is None, f"{tool.name} should be unrestricted"
+        assert tool.concurrency_group is None, f"{tool.name} should not serialize"
+
+
+def _tool_by_name(tools: list[Any], name: str) -> Any:
+    for t in tools:
+        if t.name == name:
+            return t
+    raise AssertionError(f"tool {name} not found")
+
+
+# ---------------------------------------------------------------------------
+# st_search_customers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_search_customers_by_name_returns_match(async_test_user: Any) -> None:
+    service = await _build_connected_service(async_test_user.id)
+    search = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_SEARCH_CUSTOMERS
+    )
+
+    result = await search.function(query="Acme")
+    assert result.is_error is False
+    # Seed "Acme Plumbing" has id 1003 and a phone in the 555 range.
+    assert "Acme Plumbing" in result.content
+    assert "#1003" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_search_customers_numeric_query_routes_to_phone(
+    async_test_user: Any,
+) -> None:
+    """A digit-heavy query should match against the phone filter."""
+    service = await _build_connected_service(async_test_user.id)
+    search = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_SEARCH_CUSTOMERS
+    )
+
+    # Jane Doe (id 1001) has phone +15555550101; "5550101" is enough
+    # digits to trip the phone heuristic and uniquely match her record.
+    result = await search.function(query="5550101")
+    assert result.is_error is False
+    assert "Jane Doe" in result.content
+    assert "#1001" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_search_customers_empty_query_validation_error(
+    async_test_user: Any,
+) -> None:
+    service = await _build_connected_service(async_test_user.id)
+    search = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_SEARCH_CUSTOMERS
+    )
+
+    result = await search.function(query="   ")
+    assert result.is_error is True
+    assert "empty" in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_search_customers_no_match_returns_friendly_message(
+    async_test_user: Any,
+) -> None:
+    service = await _build_connected_service(async_test_user.id)
+    search = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_SEARCH_CUSTOMERS
+    )
+
+    result = await search.function(query="ZZZZ-no-such-customer-ZZZZ")
+    assert result.is_error is False
+    assert "No customers matched" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_search_customers_truncates_to_limit(async_test_user: Any) -> None:
+    """A broad name query should respect the requested limit and surface a hint."""
+    service = await _build_connected_service(async_test_user.id)
+    search = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_SEARCH_CUSTOMERS
+    )
+
+    # Several seed customers (Jane Doe, John Roe, David Brown, Eve Davis,
+    # Bob Johnson, Alice Smith, Carol Williams) include lower-case "e"
+    # somewhere in their names. The fake matches case-insensitive
+    # substring on the ``name`` filter.
+    result = await search.function(query="e", limit=2)
+    assert result.is_error is False
+    # Header line + truncation note + 2 records.
+    lines = result.content.splitlines()
+    assert any("matched" in ln for ln in lines)
+    record_lines = [ln for ln in lines if ln.startswith("#")]
+    assert len(record_lines) == 2
+    assert any("more" in ln for ln in lines)
+
+
+# ---------------------------------------------------------------------------
+# st_get_customer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_get_customer_returns_full_record(async_test_user: Any) -> None:
+    service = await _build_connected_service(async_test_user.id)
+    get_customer = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_GET_CUSTOMER
+    )
+
+    result = await get_customer.function(customer_id=1003)
+    assert result.is_error is False
+    assert "Acme Plumbing" in result.content
+    assert "Commercial" in result.content
+    assert "789 Industry Park" in result.content
+    assert "+15555550103" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_get_customer_unknown_id_returns_not_found(async_test_user: Any) -> None:
+    service = await _build_connected_service(async_test_user.id)
+    get_customer = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_GET_CUSTOMER
+    )
+
+    result = await get_customer.function(customer_id=999999)
+    assert result.is_error is True
+    assert result.error_kind is not None
+    assert result.error_kind.value == "not_found"
+    assert "999999" in result.content
+
+
+# ---------------------------------------------------------------------------
+# st_list_appointments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_list_appointments_with_wide_range_returns_all(
+    async_test_user: Any,
+) -> None:
+    """A range that covers every seed appointment should return all 15."""
+    service = await _build_connected_service(async_test_user.id)
+    list_appts = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_LIST_APPOINTMENTS
+    )
+
+    # Seed appointments cluster around 2026-05-11. Use a wide window.
+    result = await list_appts.function(
+        from_date="2026-01-01T00:00:00Z",
+        to_date="2027-01-01T00:00:00Z",
+    )
+    assert result.is_error is False
+    assert "Found 15 appointment(s)" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_list_appointments_status_filter_narrows(async_test_user: Any) -> None:
+    """The status filter should narrow the result set by exact status."""
+    service = await _build_connected_service(async_test_user.id)
+    list_appts = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_LIST_APPOINTMENTS
+    )
+
+    wide_window = {
+        "from_date": "2026-01-01T00:00:00Z",
+        "to_date": "2027-01-01T00:00:00Z",
+    }
+    full = await list_appts.function(**wide_window)
+    scheduled = await list_appts.function(status="Scheduled", **wide_window)
+    assert full.is_error is False
+    assert scheduled.is_error is False
+    # The seed mixes statuses across the 15 appointments; the scheduled
+    # subset must be strictly smaller than the full set.
+    full_lines = [ln for ln in full.content.splitlines() if ln.startswith("#")]
+    scheduled_lines = [ln for ln in scheduled.content.splitlines() if ln.startswith("#")]
+    assert 0 < len(scheduled_lines) < len(full_lines)
+    for ln in scheduled_lines:
+        assert "[Scheduled]" in ln
+
+
+@pytest.mark.asyncio()
+async def test_list_appointments_empty_window_reports_no_match(
+    async_test_user: Any,
+) -> None:
+    service = await _build_connected_service(async_test_user.id)
+    list_appts = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_LIST_APPOINTMENTS
+    )
+
+    result = await list_appts.function(
+        from_date="2099-01-01T00:00:00Z",
+        to_date="2099-01-02T00:00:00Z",
+    )
+    assert result.is_error is False
+    assert "No ServiceTitan appointments found" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_list_appointments_defaults_to_today_when_no_dates(
+    async_test_user: Any,
+) -> None:
+    """No-argument call should request the day's window from the API.
+
+    The seed today is 2026-05-11; the test today (per
+    ``datetime.now(UTC)`` at run time) may differ, so we cannot assert
+    on a specific record count. Instead, we assert the tool does not
+    error and that the message is the expected "Found ..." or "No ...
+    appointments found" form, which proves the default window was
+    computed and the request issued.
+    """
+    service = await _build_connected_service(async_test_user.id)
+    list_appts = _tool_by_name(
+        build_servicetitan_tools(service), ToolName.SERVICETITAN_LIST_APPOINTMENTS
+    )
+
+    result = await list_appts.function()
+    assert result.is_error is False
+    first_line = result.content.splitlines()[0]
+    assert first_line.startswith("Found ") or first_line.startswith(
+        "No ServiceTitan appointments found"
+    )

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -40,6 +40,10 @@ EXPECTED_CORE_TOOL_MODULES: set[str] = {
     "backend.app.agent.tools.integration_tools",
     "backend.app.agent.tools.media_tools",
     "backend.app.agent.tools.workspace_tools",
+    # Read-tools helper for the ServiceTitan integration. Importing this
+    # module is side-effect-free (no _register call); registration lives
+    # in backend/app/integrations/servicetitan/factory.py.
+    "backend.app.agent.tools.servicetitan_tools",
 }
 
 EXPECTED_INTEGRATION_MODULES: set[str] = {


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Wires up the ServiceTitan read-only surface. Three tools now land on the data factory once a user has connected a tenant:

- `st_search_customers(query, limit=5)`: substring search by name (default) or phone (when the query is mostly digits). Renders one summary line per match: id, name, type, address, contacts. Caps display at the requested limit and reports the remainder count so the agent can suggest a narrower query.
- `st_get_customer(customer_id)`: full record by numeric id. Surfaces name, type, address, contacts, balance, and the do-not-mail / do-not-service / inactive flags. Returns NOT_FOUND (rather than SERVICE) on a 404 so the agent offers a follow-up search instead of a transient-error retry.
- `st_list_appointments(from_date=None, to_date=None, status=None)`: defaults to today (UTC) when no range is given, sorted by start ascending so it reads in dispatch order. Optional status filter matches ServiceTitan's Scheduled / Dispatched / Working / Done / Hold values.

All three ship without an ApprovalPolicy and without a `concurrency_group` since they are read-only. The data factory now builds them when `build_service_for_user` returns a usable service; the `auth_check` still gates the factory on credential state so the LLM never claims ServiceTitan is connected before the user has run `connect_servicetitan`.

`SubToolInfo` entries land on the data factory with `default_permission="always"` so the Settings page renders the rows correctly. Dashboard registration polish and SKILL.md content are deferred to #1301.

Tests exercise each tool end-to-end against the in-process fake (no real network), covering happy path, empty results, validation errors, not-found, limit truncation, and date-range filtering.

Fixes #1300

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude implemented the change end-to-end under direction from @njbrake; reviewed and committed by @njbrake)
- [ ] No AI used