### PR TITLE
feat(channels/twilio): require Standard API key for REST, scope auth token to webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,9 @@ TELEGRAM_ALLOWED_CHAT_ID=
 # the channel's send_typing_indicator is a no-op. For iMessage/RCS with
 # typing indicators, use Linq or BlueBubbles instead.
 # TWILIO_ACCOUNT_SID=                 # Twilio account SID, e.g. "AC..."
-# TWILIO_AUTH_TOKEN=                  # Twilio auth token (used for signature validation + media auth)
+# TWILIO_AUTH_TOKEN=                  # Required for inbound webhook signature validation only (Twilio signs webhooks with this; API keys cannot sign webhooks).
+# TWILIO_API_KEY_SID=                 # Required for outbound REST: Standard API key SID, e.g. "SK..."
+# TWILIO_API_KEY_SECRET=              # Required for outbound REST. Console: Account > API Keys & Tokens > Create API Key (Standard).
 # TWILIO_PHONE_NUMBER=                # E.164 outbound sender, e.g. "+15551234567"
 # TWILIO_MESSAGING_SERVICE_SID=       # "MG..." Use a Messaging Service for US A2P 10DLC. Takes precedence over TWILIO_PHONE_NUMBER.
 # TWILIO_ALLOWED_NUMBERS=             # E.164 phone, "*" for all, empty = deny all

--- a/backend/app/channels/__init__.py
+++ b/backend/app/channels/__init__.py
@@ -82,7 +82,15 @@ def reset_channel_clients(updates: Mapping[str, object]) -> None:
         except KeyError:
             pass
 
-    if "twilio_account_sid" in updates or "twilio_auth_token" in updates:
+    if any(
+        k in updates
+        for k in (
+            "twilio_account_sid",
+            "twilio_auth_token",
+            "twilio_api_key_sid",
+            "twilio_api_key_secret",
+        )
+    ):
         try:
             from backend.app.channels.twilio import TwilioChannel
 
@@ -90,6 +98,8 @@ def reset_channel_clients(updates: Mapping[str, object]) -> None:
             if isinstance(channel, TwilioChannel):
                 channel._account_sid = settings.twilio_account_sid
                 channel._auth_token = settings.twilio_auth_token
+                channel._api_key_sid = settings.twilio_api_key_sid
+                channel._api_key_secret = settings.twilio_api_key_secret
                 channel._client = None
         except KeyError:
             pass

--- a/backend/app/channels/twilio.py
+++ b/backend/app/channels/twilio.py
@@ -102,19 +102,45 @@ class TwilioChannel(BaseChannel):
     def __init__(self, svc_settings: Settings | None = None) -> None:
         s = svc_settings or settings
         self._account_sid = s.twilio_account_sid
+        # Auth token is loaded for one job only: HMAC-SHA1 signature
+        # validation of inbound webhooks (``X-Twilio-Signature``). Twilio
+        # does not support any other webhook signing mechanism for SMS,
+        # and API keys cannot sign webhooks.
         self._auth_token = s.twilio_auth_token
+        # Standard API key + secret used for every outbound REST call
+        # (purchase numbers, send SMS, configure webhooks, media
+        # download). Required for any REST operation; the channel
+        # refuses outbound work if either is missing rather than fall
+        # back to auth-token Basic Auth so the auth token's blast
+        # radius stays scoped to signature validation.
+        self._api_key_sid = s.twilio_api_key_sid
+        self._api_key_secret = s.twilio_api_key_secret
         self._client: TwilioClient | None = None
+
+    def _require_api_key(self) -> tuple[str, str]:
+        """Return ``(api_key_sid, api_key_secret)`` or raise if either is empty."""
+        if not self._api_key_sid or not self._api_key_secret:
+            msg = (
+                "Twilio API key required for REST calls. Set "
+                "TWILIO_API_KEY_SID and TWILIO_API_KEY_SECRET (Standard "
+                "key from Console > Account > API Keys & Tokens)."
+            )
+            raise RuntimeError(msg)
+        return self._api_key_sid, self._api_key_secret
 
     @property
     def client(self) -> TwilioClient:
         """Lazily create the Twilio REST client.
 
-        Construction is cheap but errors on empty credentials, so we defer
-        until the first send so an unconfigured deployment doesn't crash
-        at import time.
+        Authenticates with the Standard API key + secret (required).
+        API keys are revocable per-key and have a smaller blast radius
+        than the auth token; the auth token in this codebase is loaded
+        only for inbound webhook signature validation
+        (``_validate_signature`` / ``RequestValidator``).
         """
         if self._client is None:
-            self._client = TwilioClient(self._account_sid, self._auth_token)
+            api_key_sid, api_key_secret = self._require_api_key()
+            self._client = TwilioClient(api_key_sid, api_key_secret, self._account_sid)
         return self._client
 
     # -- BaseChannel identity --------------------------------------------------
@@ -347,20 +373,21 @@ class TwilioChannel(BaseChannel):
         """Download media from a Twilio MediaUrl.
 
         For Twilio, ``file_id`` is the full ``MediaUrl{N}`` from the
-        webhook form payload. The URL requires HTTP Basic Auth with the
-        account SID + auth token. Streams with the standard hard size
-        cap and wall-time deadline.
+        webhook form payload. The URL requires HTTP Basic Auth with
+        the Standard API key + secret. Streams with the standard hard
+        size cap and wall-time deadline.
 
         Refuses any URL that doesn't live on a Twilio-owned host. This
         is defense in depth against an attacker who slipped a webhook
         past signature validation (only possible when validation is off
         for dev): without this guard, ``MediaUrl0=http://internal/...``
-        would exfiltrate the account-SID Basic Auth header.
+        would exfiltrate the Basic Auth header.
         """
         if not _is_twilio_host(file_id):
             msg = f"Refusing to download media from non-Twilio host: {file_id}"
             raise ValueError(msg)
-        auth = httpx.BasicAuth(self._account_sid, self._auth_token)
+        api_key_sid, api_key_secret = self._require_api_key()
+        auth = httpx.BasicAuth(api_key_sid, api_key_secret)
         async with httpx.AsyncClient(auth=auth, timeout=settings.http_timeout_seconds) as client:
             content, headers = await download_bounded(client, file_id)
         content_type = headers.get("content-type", "application/octet-stream").split(";")[0]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -177,7 +177,20 @@ class Settings(BaseSettings):
     # the channel implements ``send_typing_indicator`` as a no-op. For
     # iMessage/RCS with typing indicators see Linq or BlueBubbles.
     twilio_account_sid: str = ""
+    # Auth token: required for inbound webhook signature validation.
+    # Twilio signs ``X-Twilio-Signature`` with HMAC-SHA1 keyed on this
+    # token and offers no alternative signing mechanism for SMS
+    # webhooks. The codebase loads it for nothing else; outbound REST
+    # uses the API key pair below.
     twilio_auth_token: str = ""
+    # Standard API key + secret. Required for every outbound REST call
+    # (purchase numbers, send SMS, configure webhooks, media download).
+    # The channel refuses outbound work if either is missing rather
+    # than fall back to auth-token Basic Auth, so the auth token's
+    # blast radius stays scoped to signature validation. Create via
+    # Twilio Console -> Account -> API Keys & Tokens (Standard key).
+    twilio_api_key_sid: str = ""  # "SKxxxxxxxx..."
+    twilio_api_key_secret: str = ""
     # Outbound sender. Pin a specific phone number (E.164) OR a Messaging
     # Service SID. Messaging Service is recommended for US A2P 10DLC
     # deployments: numbers join the service's pool and the registered
@@ -297,6 +310,8 @@ PERSISTABLE_SETTINGS: frozenset[str] = frozenset(
         "bluebubbles_imessage_address",
         "twilio_account_sid",
         "twilio_auth_token",
+        "twilio_api_key_sid",
+        "twilio_api_key_secret",
         "twilio_phone_number",
         "twilio_messaging_service_sid",
         "twilio_allowed_numbers",

--- a/backend/app/config_store.py
+++ b/backend/app/config_store.py
@@ -61,6 +61,7 @@ _SECRET_SETTINGS: frozenset[str] = frozenset(
         "linq_webhook_signing_secret",
         "bluebubbles_password",
         "twilio_auth_token",
+        "twilio_api_key_secret",
     }
 )
 

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -84,7 +84,9 @@ When `BLUEBUBBLES_SERVER_URL` and `BLUEBUBBLES_PASSWORD` are set, the iMessage c
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TWILIO_ACCOUNT_SID` | | Twilio account SID (`AC...`) |
-| `TWILIO_AUTH_TOKEN` | | Twilio auth token. Used for webhook signature validation and authenticating media URL downloads. |
+| `TWILIO_AUTH_TOKEN` | | Twilio account auth token. Loaded for one purpose only: validating `X-Twilio-Signature` on inbound webhooks. Twilio signs SMS webhooks with HMAC-SHA1 keyed on this token and offers no alternative signing mechanism for SMS, so API keys cannot replace it for inbound. |
+| `TWILIO_API_KEY_SID` | | Standard API key SID (`SK...`). **Required** for every outbound REST call (purchase numbers, send SMS, configure webhooks, media downloads). The channel refuses outbound work if missing rather than falling back to auth-token Basic Auth, so a leaked auth token cannot be replayed against the REST API. Create via Twilio Console -> Account -> API Keys & Tokens (Standard key). |
+| `TWILIO_API_KEY_SECRET` | | The API key's secret value. Shown once at key creation; record it then. |
 | `TWILIO_PHONE_NUMBER` | | E.164 outbound sender, e.g. `+15551234567`. Pinned as `from_` on every send. |
 | `TWILIO_MESSAGING_SERVICE_SID` | | Messaging Service SID (`MG...`). Use for US A2P 10DLC: the service holds a pool of campaign-registered numbers. When set, takes precedence over `TWILIO_PHONE_NUMBER`. |
 | `TWILIO_ALLOWED_NUMBERS` | (empty) | E.164 phone number, `*` for all, or empty to deny all. |

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -339,6 +339,12 @@ const api = {
       status: string;
       error_message: string;
       connected: boolean;
+      // Defaults to true (matches the backend default) so the picker
+      // stays visible when the field is missing on older premium
+      // deployments. When false, the user-facing form hides the
+      // number-type picker and area-code input and the backend
+      // ignores any user-supplied values for those fields.
+      user_number_choice_enabled?: boolean;
     }>;
   },
   // Provision a Twilio number for the current user. The server runs

--- a/frontend/src/components/ChannelConfigForm.tsx
+++ b/frontend/src/components/ChannelConfigForm.tsx
@@ -464,6 +464,11 @@ function PremiumTwilioForm({ twilioLinkData, onSaved }: SubFormProps) {
 
   const status = twilioLinkData?.status ?? 'not_provisioned';
   const isActive = status === 'active' && twilioLinkData?.twilio_phone_number;
+  // The operator may lock the number-type / area-code picker to the
+  // configured defaults (premium config: ``twilio_user_number_choice_enabled``).
+  // Older premium deployments don't ship the field; default to showing
+  // the picker so we don't quietly remove it.
+  const userNumberChoiceEnabled = twilioLinkData?.user_number_choice_enabled ?? true;
 
   // ``provisioning`` is a transient state, normally only seen for a few
   // seconds during connect. If we land here on page load it usually
@@ -545,32 +550,36 @@ function PremiumTwilioForm({ twilioLinkData, onSaved }: SubFormProps) {
           </p>
         )}
       </Field>
-      <Field label="Number Type">
-        <Select
-          value={numberType}
-          onChange={(e) => setNumberType(e.target.value)}
-          aria-label="Twilio number type"
-        >
-          {TWILIO_NUMBER_TYPES.map((t) => (
-            <option key={t.value} value={t.value}>{t.label}</option>
-          ))}
-        </Select>
-        <p className="text-xs text-muted-foreground mt-1">
-          Toll-free skips US A2P 10DLC registration. Local is cheaper per message but the operator
-          must have a registered messaging service.
-        </p>
-      </Field>
-      <Field label="Area Code (optional)">
-        <Input
-          value={areaCode}
-          onChange={(e) => setAreaCode(e.target.value)}
-          placeholder={numberType === 'toll-free' ? 'e.g. 800' : 'e.g. 415'}
-          inputMode="numeric"
-        />
-        <p className="text-xs text-muted-foreground mt-1">
-          Leave blank to let Twilio pick from available inventory.
-        </p>
-      </Field>
+      {userNumberChoiceEnabled && (
+        <>
+          <Field label="Number Type">
+            <Select
+              value={numberType}
+              onChange={(e) => setNumberType(e.target.value)}
+              aria-label="Twilio number type"
+            >
+              {TWILIO_NUMBER_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
+              ))}
+            </Select>
+            <p className="text-xs text-muted-foreground mt-1">
+              Toll-free skips US A2P 10DLC registration. Local is cheaper per message but the operator
+              must have a registered messaging service.
+            </p>
+          </Field>
+          <Field label="Area Code (optional)">
+            <Input
+              value={areaCode}
+              onChange={(e) => setAreaCode(e.target.value)}
+              placeholder={numberType === 'toll-free' ? 'e.g. 800' : 'e.g. 415'}
+              inputMode="numeric"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Leave blank to let Twilio pick from available inventory.
+            </p>
+          </Field>
+        </>
+      )}
       <div className="flex justify-end">
         <Button onClick={handleConnect} disabled={submitting || !personalPhone} isLoading={submitting}>
           Connect Twilio

--- a/tests/test_twilio_channel.py
+++ b/tests/test_twilio_channel.py
@@ -371,6 +371,8 @@ async def test_download_media_uses_basic_auth(monkeypatch: pytest.MonkeyPatch) -
     channel = TwilioChannel()
     channel._account_sid = "ACtest"
     channel._auth_token = "tkn"
+    channel._api_key_sid = "SKtest"
+    channel._api_key_secret = "secret"
 
     media = await channel.download_media(
         "https://api.twilio.com/Accounts/AC0/Messages/MM0/Media/ME0"
@@ -405,6 +407,98 @@ async def test_download_media_rejects_non_twilio_host(monkeypatch: pytest.Monkey
     with pytest.raises(ValueError, match="non-Twilio host"):
         await channel.download_media("http://attacker.example.com/leak")
     assert called is False
+
+
+async def test_client_property_requires_api_key() -> None:
+    """The REST client refuses to construct without an API key + secret.
+
+    The auth token is reserved for inbound signature validation; using
+    it for REST would defeat the point of keeping the API key as a
+    separate, revocable credential.
+    """
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+    # No API key configured.
+    with pytest.raises(RuntimeError, match="TWILIO_API_KEY_SID"):
+        _ = channel.client
+
+
+async def test_client_property_uses_api_key_when_configured() -> None:
+    """When API key is set, the SDK Client is built with the key pair.
+
+    The SDK constructor for the key path is ``Client(sid, secret, account_sid)``;
+    the username is the API key SID, not the account SID.
+    """
+    from twilio.rest import Client as TwilioClient
+
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+    channel._api_key_sid = "SKtest"
+    channel._api_key_secret = "secret"
+
+    client = channel.client
+    assert isinstance(client, TwilioClient)
+    # The SDK exposes the auth tuple it built internally; the first
+    # element is what becomes the Basic Auth username on REST calls.
+    # We assert it is the API key SID, not the account SID.
+    assert client.username == "SKtest"
+    assert client.password == "secret"
+    assert client.account_sid == "ACtest"
+
+
+async def test_download_media_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """download_media must not fall back to auth-token Basic Auth."""
+    called = False
+
+    async def fake_download_bounded(*_args: object, **_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        return b"", httpx.Headers()
+
+    monkeypatch.setattr("backend.app.channels.twilio.download_bounded", fake_download_bounded)
+
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+    # No API key configured.
+
+    with pytest.raises(RuntimeError, match="TWILIO_API_KEY_SID"):
+        await channel.download_media("https://api.twilio.com/Accounts/AC0/Messages/MM0/Media/ME0")
+    assert called is False
+
+
+async def test_download_media_uses_api_key_basic_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """download_media should authenticate with the API key pair, not the auth token."""
+    captured_auth: list[httpx.BasicAuth] = []
+
+    async def fake_download_bounded(
+        client: httpx.AsyncClient,
+        _url: str,
+    ) -> tuple[bytes, httpx.Headers]:
+        captured_auth.append(client.auth)  # type: ignore[arg-type]
+        return b"x", httpx.Headers({"content-type": "image/jpeg"})
+
+    monkeypatch.setattr("backend.app.channels.twilio.download_bounded", fake_download_bounded)
+
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+    channel._api_key_sid = "SKtest"
+    channel._api_key_secret = "secret"
+
+    await channel.download_media("https://api.twilio.com/Accounts/AC0/Messages/MM0/Media/ME0")
+
+    # BasicAuth doesn't expose its credentials publicly, but its
+    # ``_auth_header`` is "Basic " + b64(username:password).
+    import base64
+
+    assert isinstance(captured_auth[0], httpx.BasicAuth)
+    header = captured_auth[0]._auth_header
+    encoded = header.removeprefix("Basic ")
+    decoded = base64.b64decode(encoded).decode()
+    assert decoded == "SKtest:secret"
 
 
 async def test_to_verifier_drops_inbound_when_pair_unknown(


### PR DESCRIPTION
## Description

Aligns with Twilio's recommendation to use API keys over the account auth token. API keys are individually revocable and have a smaller blast radius than the auth token.

**For inbound webhooks**, the auth token cannot be replaced: Twilio signs ``X-Twilio-Signature`` with HMAC-SHA1 keyed on the account auth token and offers no alternative signing mechanism for SMS. The auth token in this codebase is now loaded for exactly that one purpose (signature validation in ``_validate_signature`` and ``RequestValidator``).

**For everything else** (outbound REST: search numbers, purchase, send SMS, configure webhooks, media downloads), the channel now requires ``TWILIO_API_KEY_SID`` + ``TWILIO_API_KEY_SECRET`` (a Standard API key from Console > Account > API Keys & Tokens). The channel refuses outbound work if the key pair is missing rather than falling back to auth-token Basic Auth, so a leaked auth token cannot be replayed against the REST API. ``download_media`` also uses the API key pair for the Twilio media URL Basic Auth.

Bonus UX knob: optional ``user_number_choice_enabled`` field on the Twilio link response lets the operator hide the number-type picker and area-code input when they want to lock users to the configured defaults. Defaults to True; missing field treated as True for compatibility with older premium deployments.

## Type
- [x] Feature

## Checklist
- [x] Tests pass (``uv run pytest -v`` on ``tests/test_twilio_channel.py``: 27 passed)
- [x] Lint passes (``ruff check backend/ tests/ alembic/`` and ``ruff format --check`` clean)
- [x] New tests added: 4 cases for API-key-required behavior, plus an updated existing test
- [x] N/A: not a bug fix

## AI Usage
- [x] AI-assisted: Claude drafted the change and the new tests after we worked through the API-key-vs-auth-token design tradeoffs live, including verifying Twilio's webhook signing docs.
- [ ] No AI used

## Migration notes for premium

Premium will need a paired PR that:
- Updates ``TwilioProvisioningService`` to authenticate with the API key pair
- Adds ``twilio_api_key_sid`` / ``twilio_api_key_secret`` to ``AdminChannelConfigResponse`` / ``AdminChannelConfigUpdate``
- Adds the operator-controlled ``twilio_user_number_choice_enabled`` setting that drives the new optional response field