### PR TITLE
feat(servicetitan): add SKILL.md for the integration

### DIFF
--- a/backend/app/integrations/servicetitan/SKILL.md
+++ b/backend/app/integrations/servicetitan/SKILL.md
@@ -1,0 +1,57 @@
+# ServiceTitan
+
+ServiceTitan is a field-service management platform for HVAC, plumbing, and electrical trades. Customers, jobs, appointments, estimates, and invoices live in the tenant; this integration currently surfaces customers and appointments as read-only.
+
+## Available Tools
+
+| Tool | Purpose | Approval |
+|------|---------|----------|
+| `st_search_customers` | Find customers by name or phone substring | Auto |
+| `st_get_customer` | Fetch one customer record by numeric id | Auto |
+| `st_list_appointments` | List appointments in a date window, optionally by status | Auto |
+
+## Entity vocabulary
+
+- **Customer**: the billable party. Has `id`, `name`, `type`, `address`, `contacts`, `balance`, and flags (`active`, `doNotMail`, `doNotService`).
+- **Job**: a unit of work for a customer. Returned indirectly via `appointment.jobId`. Not directly queryable through these tools.
+- **Appointment**: a scheduled visit on a job. Has `id`, `jobId`, `start`, `end`, `status`, `technicianIds`. One job typically has one appointment; recalls and multi-visit work generate additional appointments tied to the same `jobId`.
+
+Appointment status values: `Scheduled`, `Dispatched`, `Working`, `Done`, `Hold`.
+
+## Dates
+
+All date inputs to `st_list_appointments` are ISO 8601. Append `Z` for UTC (`2026-05-11T00:00:00Z`) or use a local-offset suffix (`2026-05-11T08:00:00-04:00`). Omitting both `from_date` and `to_date` defaults to today (UTC, midnight to midnight); pass an explicit window for any other range.
+
+## Connecting
+
+ServiceTitan auth is OAuth2 client credentials, not a browser flow. The user pastes three values from ServiceTitan Settings, Integrations, API Application Access:
+
+1. Tenant ID
+2. Client ID
+3. Client Secret
+
+Then call `connect_servicetitan(tenant_id=..., client_id=..., client_secret=...)`. Until that runs, the data tools stay surfaced under "Not connected" in `list_capabilities` and refuse to execute.
+
+## Common Workflows
+
+### Customer just called
+
+1. `st_search_customers(query="<name or phone fragment>")`. The tool routes numeric queries to ServiceTitan's phone filter automatically; alphabetic queries go to the name filter.
+2. If multiple matches, narrow the query or ask the user. If none, confirm spelling before reporting "no customer found"; the tenant may use a business name instead of a personal one.
+3. `st_get_customer(customer_id=<id>)` for the full record (address, contacts, balance, flags). Check `doNotService` before promising work.
+
+### What's my day
+
+1. `st_list_appointments()` with no arguments. Returns today's appointments sorted by start time.
+2. Group the output by status (`Scheduled` / `Dispatched` first, then `Working`, then `Done` / `Hold`) when summarizing for a coordinator.
+3. For a specific window (this week, tomorrow), pass `from_date` and `to_date` explicitly.
+
+### Status-filtered dispatch view
+
+`st_list_appointments(status="Scheduled")` for today's unstarted work, or pair with `from_date` and `to_date` to audit a past day for missed `Hold` entries.
+
+## Companion integrations
+
+- **QuickBooks**: use for invoice and estimate workflows. ServiceTitan customer ids are not QuickBooks customer ids; match on name or phone when crossing layers.
+- **Google Calendar**: ServiceTitan appointments are the source of truth for scheduled work. If the user wants a calendar event mirroring an appointment, build it from the appointment fields rather than treating Calendar as the schedule.
+- **CompanyCam**: photo evidence for a ServiceTitan job lives in a CompanyCam project keyed by the customer's address; resolve the address via `st_get_customer` before searching CompanyCam.

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -66,6 +66,19 @@ def test_get_skill_instructions_returns_none_for_unknown() -> None:
     assert get_skill_instructions("nonexistent_skill") is None
 
 
+def test_load_all_skills_discovers_servicetitan() -> None:
+    """load_all_skills should find the servicetitan integration SKILL.md."""
+    load_all_skills()
+    content = get_skill_instructions("servicetitan")
+    assert content is not None
+    assert content.strip() != ""
+    # Pin a few load-bearing references so accidental deletes surface in CI.
+    assert "ServiceTitan" in content
+    assert "st_search_customers" in content
+    assert "st_list_appointments" in content
+    assert "connect_servicetitan" in content
+
+
 # ---------------------------------------------------------------------------
 # list_capabilities integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds `backend/app/integrations/servicetitan/SKILL.md` so the agent has a map of the integration when it activates the `servicetitan` specialist category via `list_capabilities`. Around 60 lines, terse, modeled on the CompanyCam and AppFolio Vendor SKILL.md files rather than the much larger QuickBooks one, since ServiceTitan currently exposes only three read tools.

What the file covers:

- One-line framing for ServiceTitan and the entity vocabulary (customer, job, appointment) including the appointment-vs-job distinction
- Appointment status enum values (Scheduled, Dispatched, Working, Done, Hold)
- ISO 8601 date handling and the default-today (UTC) window behavior for `st_list_appointments`
- The paste-credentials connect flow pointing at `connect_servicetitan`
- Two workflow recipes ("Customer just called", "What's my day") that match the agent's most common entry points
- Companion-integration cross-references for QuickBooks, Google Calendar, and CompanyCam

Dashboard registration (`display_name`, `dashboard_description="View ServiceTitan customers, jobs, and appointments"`, `dashboard_group="Integrations"`, sub-tool entries for all three read tools) is already complete in `backend/app/integrations/servicetitan/factory.py` from PR #1306 and is not modified here.

The skill loader (`backend/app/agent/skills/loader.py`) already auto-discovers any `backend/app/integrations/<name>/SKILL.md`, so no wiring changes are needed; dropping the file in is sufficient.

A smoke test in `tests/test_skill_loader.py` pins discovery of the new skill plus a few load-bearing references (`st_search_customers`, `st_list_appointments`, `connect_servicetitan`) so accidental deletions surface in CI.

The companion write tool from #1302 (`st_add_job_note`) is intentionally not mentioned here; the write-tool PR will append its own section.

Fixes #1301

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude drafted the SKILL.md content and the smoke test in back-and-forth with @njbrake)
- [ ] No AI used