### PR TITLE
fix(appfolio): tell users to paste the token, not the full magic-link URL

### DIFF
--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -482,9 +482,12 @@ async def _handle_magic_link_connect(
                 "Walk the user through these steps: "
                 "(1) open vendor.appfolio.com on their phone or laptop, "
                 "(2) enter their email and request a sign-in link, "
-                "(3) when the email arrives, copy the full link and paste "
-                "it back to you. Then call appfolio_connect with the "
-                "pasted text."
+                "(3) when the email arrives, copy only the token from "
+                "the link's URL (everything after 'magic_link_token='), "
+                "not the full URL. iMessage and other SMS clients strip "
+                "query params from pasted links, so the full URL would "
+                "arrive without the token. Then call appfolio_connect "
+                "with the pasted token."
             ),
         )
     return ToolResult(

--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -485,9 +485,8 @@ async def _handle_magic_link_connect(
                 "(3) when the email arrives, copy only the token from "
                 "the link's URL (everything after 'magic_link_token='), "
                 "not the full URL. iMessage and other SMS clients strip "
-                "query params from pasted links, so the full URL would "
-                "arrive without the token. Then call appfolio_connect "
-                "with the pasted token."
+                "query params from pasted links. Then call "
+                "appfolio_connect with the pasted token."
             ),
         )
     return ToolResult(

--- a/backend/app/integrations/appfolio_vendor/SKILL.md
+++ b/backend/app/integrations/appfolio_vendor/SKILL.md
@@ -43,8 +43,7 @@ minutes):
 1. User opens vendor.appfolio.com and requests a magic link.
 2. From the email, they copy only the token from the magic-link URL
    (everything after `magic_link_token=`), not the full URL. iMessage
-   and other SMS clients strip query params from pasted links, so the
-   full URL would arrive without the token.
+   and other SMS clients strip query params from pasted links.
 3. Call `appfolio_connect(magic_link=...)` with the pasted token.
 
 The OAuth2 exchange returns a refresh token alongside the bearer JWT,

--- a/backend/app/integrations/appfolio_vendor/SKILL.md
+++ b/backend/app/integrations/appfolio_vendor/SKILL.md
@@ -41,8 +41,11 @@ AppFolio uses passwordless magic-link login (single-use, expires in
 minutes):
 
 1. User opens vendor.appfolio.com and requests a magic link.
-2. They paste the full URL from the email back to you.
-3. Call `appfolio_connect(magic_link=...)`.
+2. From the email, they copy only the token from the magic-link URL
+   (everything after `magic_link_token=`), not the full URL. iMessage
+   and other SMS clients strip query params from pasted links, so the
+   full URL would arrive without the token.
+3. Call `appfolio_connect(magic_link=...)` with the pasted token.
 
 The OAuth2 exchange returns a refresh token alongside the bearer JWT,
 so live sessions extend automatically on 401. On `auth` errors with no

--- a/backend/app/integrations/appfolio_vendor/auth.py
+++ b/backend/app/integrations/appfolio_vendor/auth.py
@@ -72,7 +72,7 @@ def extract_magic_link_token(text: str) -> str:
     """
     candidate = text.strip()
     if not candidate:
-        raise MagicLinkError("empty input; paste the full magic-link URL")
+        raise MagicLinkError("empty input")
 
     if "magic_link_token=" in candidate:
         if "://" in candidate:

--- a/backend/app/integrations/appfolio_vendor/auth_tools.py
+++ b/backend/app/integrations/appfolio_vendor/auth_tools.py
@@ -41,8 +41,12 @@ def build_auth_tools(user_id: str) -> list[Tool]:
                 is_error=True,
                 error_kind=ToolErrorKind.VALIDATION,
                 hint=(
-                    "Paste the full URL from the AppFolio email,"
-                    " including everything after '?magic_link_token='."
+                    "Ask the user to paste only the magic-link token"
+                    " (the long string after 'magic_link_token=' in the"
+                    " AppFolio email URL), not the full URL. iMessage"
+                    " and other SMS clients strip query params from"
+                    " pasted links, so the full URL would arrive without"
+                    " the token."
                 ),
             )
 
@@ -81,7 +85,7 @@ def build_auth_tools(user_id: str) -> list[Tool]:
         Tool(
             name=ToolName.APPFOLIO_CONNECT,
             description=(
-                "Connect AppFolio Vendor Portal by pasting the magic-link URL"
+                "Connect AppFolio Vendor Portal with the magic-link token"
                 " from the user's AppFolio email."
             ),
             function=appfolio_connect,
@@ -89,7 +93,10 @@ def build_auth_tools(user_id: str) -> list[Tool]:
             usage_hint=(
                 "Use when the user wants to start using AppFolio tools."
                 " Tell them: open vendor.appfolio.com, request a magic link,"
-                " then paste the full URL from the email."
+                " then paste only the token from the URL (everything after"
+                " 'magic_link_token='), not the full URL. iMessage and"
+                " other SMS clients strip query params from pasted links,"
+                " so the full URL would arrive without the token."
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ALWAYS,

--- a/backend/app/integrations/appfolio_vendor/auth_tools.py
+++ b/backend/app/integrations/appfolio_vendor/auth_tools.py
@@ -45,8 +45,7 @@ def build_auth_tools(user_id: str) -> list[Tool]:
                     " (the long string after 'magic_link_token=' in the"
                     " AppFolio email URL), not the full URL. iMessage"
                     " and other SMS clients strip query params from"
-                    " pasted links, so the full URL would arrive without"
-                    " the token."
+                    " pasted links."
                 ),
             )
 
@@ -95,8 +94,7 @@ def build_auth_tools(user_id: str) -> list[Tool]:
                 " Tell them: open vendor.appfolio.com, request a magic link,"
                 " then paste only the token from the URL (everything after"
                 " 'magic_link_token='), not the full URL. iMessage and"
-                " other SMS clients strip query params from pasted links,"
-                " so the full URL would arrive without the token."
+                " other SMS clients strip query params from pasted links."
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ALWAYS,

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -12,9 +12,11 @@ from pydantic import BaseModel, Field
 class AppFolioConnectParams(BaseModel):
     magic_link: str = Field(
         description=(
-            "The full magic-link URL the user pasted from their AppFolio email,"
-            " e.g. 'https://vendor.appfolio.com/?magic_link_token=eyJ...'."
-            " The bare token is also accepted."
+            "The magic-link token the user pasted from their AppFolio email"
+            " (the value after 'magic_link_token=' in the URL, e.g. 'eyJ...')."
+            " A full URL is also accepted, but ask the user to paste only the"
+            " token: iMessage and other SMS clients strip query params from"
+            " pasted links."
         ),
     )
 

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -12,11 +12,9 @@ from pydantic import BaseModel, Field
 class AppFolioConnectParams(BaseModel):
     magic_link: str = Field(
         description=(
-            "The magic-link token the user pasted from their AppFolio email"
-            " (the value after 'magic_link_token=' in the URL, e.g. 'eyJ...')."
-            " A full URL is also accepted, but ask the user to paste only the"
-            " token: iMessage and other SMS clients strip query params from"
-            " pasted links."
+            "The magic-link token from the user's AppFolio email (the value"
+            " after 'magic_link_token=' in the URL, e.g. 'eyJ...')."
+            " A full URL is also accepted as a fallback."
         ),
     )
 

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1949,6 +1949,32 @@ async def test_appfolio_connect_message_omits_customer_count(async_test_user: An
 
 
 @pytest.mark.asyncio()
+async def test_appfolio_connect_parse_failure_hint_steers_to_token_paste(
+    async_test_user: Any,
+) -> None:
+    """Regression for #1297: parse-failure hint must mention the iMessage gotcha.
+
+    When the user pastes a full magic-link URL over iMessage, the SMS
+    client strips the query params and the token never reaches us. The
+    validation hint has to tell the agent to ask for the token alone, not
+    the full URL, so the next attempt actually succeeds.
+    """
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.integrations.appfolio_vendor.auth_tools import build_auth_tools
+
+    tools = build_auth_tools(async_test_user.id)
+    connect = next(t for t in tools if t.name == ToolName.APPFOLIO_CONNECT)
+
+    # Empty input triggers MagicLinkError -> the validation hint we care about.
+    result = await connect.function(magic_link="")
+
+    assert result.is_error is True
+    assert result.hint is not None
+    assert "magic_link_token=" in result.hint
+    assert "iMessage" in result.hint
+
+
+@pytest.mark.asyncio()
 async def test_access_failure_does_not_log_magic_link(caplog: Any) -> None:
     import logging
 

--- a/tests/test_integration_tools.py
+++ b/tests/test_integration_tools.py
@@ -505,7 +505,10 @@ async def test_connect_appfolio_returns_magic_link_instructions(test_user: User)
 
     The agent-facing message must mention vendor.appfolio.com (so the
     agent can guide the user to the right site) and appfolio_connect (so
-    the agent knows which tool finishes the flow).
+    the agent knows which tool finishes the flow). It must also tell the
+    agent to ask the user for the token only (not the full URL), because
+    iMessage strips query params from pasted links and the token gets
+    lost. Regression for issue #1297.
     """
     with patch(
         "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
@@ -517,6 +520,9 @@ async def test_connect_appfolio_returns_magic_link_instructions(test_user: User)
     assert "appfolio_connect" in result.content
     # Should NOT claim AppFolio "does not use OAuth" or look like a rejection.
     assert "does not use OAuth" not in result.content
+    # Must steer the agent toward the token-only paste flow.
+    assert "magic_link_token=" in result.content
+    assert "iMessage" in result.content
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description

The user pastes the magic-link URL from their AppFolio email into the chat. Over iMessage (and other SMS clients), the message app treats the URL as a regular hyperlink and strips the query string before delivery, so `magic_link_token=...` never reaches us and `appfolio_connect` rejects every attempt.

`extract_magic_link_token` already accepts a bare token, so this is purely a copy fix. The four user-facing strings the agent reads when guiding the user through the connect flow now ask for the token alone (the value after `magic_link_token=`) and explain why pasting the full URL fails:

- `backend/app/integrations/appfolio_vendor/SKILL.md`, step 2 of the Connecting workflow
- `backend/app/integrations/appfolio_vendor/auth_tools.py`: `appfolio_connect` tool `description`, `usage_hint`, and the `MagicLinkError` validation hint
- `backend/app/integrations/appfolio_vendor/params.py`: `AppFolioConnectParams.magic_link` Field description
- `backend/app/agent/tools/integration_tools.py`: `_handle_magic_link_connect` step (3)

Regression tests cover both the integration meta-tool instructions and the `appfolio_connect` validation hint.

Fixes #1297

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`)
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code drafted the copy and regression tests; reasoning and decisions are mine)
- [ ] No AI used