### PR TITLE
fix(integrations): carry oauth_name on tool config response so Drive and Gmail render correctly

### DIFF
--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -22,6 +22,7 @@ from backend.app.schemas import (
     ToolConfigResponse,
     ToolConfigUpdate,
 )
+from backend.app.services.oauth import list_oauth_integrations
 
 router = APIRouter()
 
@@ -130,6 +131,22 @@ async def _get_auth_status(user: UserData | None = None) -> dict[str, str]:
     return status
 
 
+def _effective_oauth_name(factory_name: str) -> str:
+    """Return the OAuth integration backing *factory_name*, or empty.
+
+    Resolves the factory's registered ``oauth_name`` when set, falling back
+    to the factory name itself when that name is a registered OAuth
+    integration. Lets the Settings UI render Connect/Disconnect for OAuth-
+    backed tools without hand-maintaining a factory-to-OAuth map per
+    integration in the frontend.
+    """
+    factory = default_registry.get_factory(factory_name)
+    if factory is None:
+        return ""
+    candidate = factory.oauth_name or factory_name
+    return candidate if candidate in list_oauth_integrations() else ""
+
+
 def _entry_to_response(
     e: ToolConfigEntry,
     auth_issues: dict[str, str] | None = None,
@@ -146,6 +163,7 @@ def _entry_to_response(
         enabled=e.enabled,
         configured=not bool(auth_reason),
         auth_message=auth_reason,
+        oauth_name=_effective_oauth_name(e.name),
         sub_tools=[
             SubToolEntryResponse(
                 name=st.name,

--- a/backend/app/routers/user_tools.py
+++ b/backend/app/routers/user_tools.py
@@ -139,6 +139,11 @@ def _effective_oauth_name(factory_name: str) -> str:
     integration. Lets the Settings UI render Connect/Disconnect for OAuth-
     backed tools without hand-maintaining a factory-to-OAuth map per
     integration in the frontend.
+
+    Kept in user_tools.py rather than on ``ToolRegistry`` (the inverse
+    direction, ``find_factory_by_oauth_name``, lives there) so the registry
+    module stays free of an import from ``services/oauth.py``. The router is
+    already the only consumer.
     """
     factory = default_registry.get_factory(factory_name)
     if factory is None:
@@ -154,6 +159,7 @@ def _entry_to_response(
     """Convert a ToolConfigEntry DTO to an API response model."""
     issues = auth_issues or {}
     auth_reason = issues.get(e.name, "")
+    factory = default_registry.get_factory(e.name)
     return ToolConfigEntryResponse(
         name=e.name,
         description=e.description,
@@ -164,6 +170,7 @@ def _entry_to_response(
         configured=not bool(auth_reason),
         auth_message=auth_reason,
         oauth_name=_effective_oauth_name(e.name),
+        always_enabled=factory.dashboard_always_enabled if factory else False,
         sub_tools=[
             SubToolEntryResponse(
                 name=st.name,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -286,6 +286,13 @@ class ToolConfigEntryResponse(BaseModel):
     # OAuth-backed. Lets the Settings UI render Connect/Disconnect buttons
     # without hand-maintaining a factory-to-OAuth map per integration.
     oauth_name: str = ""
+    # When ``True``, the backend refuses to disable this tool (mirrors
+    # ``ToolFactory.dashboard_always_enabled``). The Settings UI uses this
+    # to hide the enable/disable toggle so the user does not see a switch
+    # that silently bounces back. Decoupled from ``category`` so future
+    # purely-internal categories cannot accidentally hide the toggle for
+    # always-on OAuth tools (Google Drive).
+    always_enabled: bool = False
     sub_tools: list[SubToolEntryResponse] = Field(default_factory=list)
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -281,6 +281,11 @@ class ToolConfigEntryResponse(BaseModel):
     enabled: bool
     configured: bool = True
     auth_message: str = ""
+    # Name of the OAuth integration backing this tool (as registered in
+    # ``backend.app.services.oauth``), or empty when the tool is not
+    # OAuth-backed. Lets the Settings UI render Connect/Disconnect buttons
+    # without hand-maintaining a factory-to-OAuth map per integration.
+    oauth_name: str = ""
     sub_tools: list[SubToolEntryResponse] = Field(default_factory=list)
 
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2577,6 +2577,11 @@
             "title": "Auth Message",
             "default": ""
           },
+          "oauth_name": {
+            "type": "string",
+            "title": "Oauth Name",
+            "default": ""
+          },
           "sub_tools": {
             "items": {
               "$ref": "#/components/schemas/SubToolEntryResponse"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2582,6 +2582,11 @@
             "title": "Oauth Name",
             "default": ""
           },
+          "always_enabled": {
+            "type": "boolean",
+            "title": "Always Enabled",
+            "default": false
+          },
           "sub_tools": {
             "items": {
               "$ref": "#/components/schemas/SubToolEntryResponse"

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1399,6 +1399,11 @@ export interface components {
              * @default
              */
             auth_message: string;
+            /**
+             * Oauth Name
+             * @default
+             */
+            oauth_name: string;
             /** Sub Tools */
             sub_tools?: components["schemas"]["SubToolEntryResponse"][];
         };

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1404,6 +1404,11 @@ export interface components {
              * @default
              */
             oauth_name: string;
+            /**
+             * Always Enabled
+             * @default false
+             */
+            always_enabled: boolean;
             /** Sub Tools */
             sub_tools?: components["schemas"]["SubToolEntryResponse"][];
         };

--- a/frontend/src/lib/tool-utils.ts
+++ b/frontend/src/lib/tool-utils.ts
@@ -1,24 +1,16 @@
 /**
- * Shared tool display names and OAuth mappings.
+ * Shared tool display names and OAuth helpers.
  *
  * Centralised here so that DashboardPage, ToolsPage, and any future page
  * that renders tool status stay in sync. When adding a new tool:
  *
  * 1. Add an entry to DISPLAY_NAMES.
  * 2. Add sub-tool entries to SUB_TOOL_NAMES.
- * 3. If the tool requires OAuth, add it to TOOL_OAUTH_MAP.
- *    If it does NOT require auth (like supplier_pricing), leave it out
- *    and it will be treated as "always available."
+ *
+ * The OAuth integration backing each tool is carried on the API response
+ * itself (``ToolConfigEntryResponse.oauth_name``), so new OAuth-backed
+ * integrations do not need to touch this file at all.
  */
-
-/** Map tool factory names to integration identifiers. Tools NOT in this
- *  map are treated as non-connectable (always configured, always connected). */
-export const TOOL_OAUTH_MAP: Record<string, string> = {
-  quickbooks: 'quickbooks',
-  calendar: 'google_calendar',
-  companycam: 'companycam',
-  file: 'google_drive',
-};
 
 /** Human-readable display names for tool factories. */
 const DISPLAY_NAMES: Record<string, string> = {
@@ -76,23 +68,24 @@ export function subToolDisplayName(name: string): string {
 /**
  * Determine whether a tool needs auth and its connection/config status.
  *
- * For connectable tools: checks TOOL_OAUTH_MAP + oauthMap for configured/connected.
- * For non-connectable tools: uses the `configured` field from the backend API response
- * (populated from the tool's auth_check). If the backend says configured=false,
- * the tool shows as "Not configured" (e.g. missing SERPAPI_API_KEY).
+ * For OAuth-backed tools (``oauthName`` non-empty): looks up the connection
+ * state in *oauthMap*, which mirrors the /oauth/status response.
+ * For non-OAuth tools: uses the ``configured`` field from /user/tools
+ * (populated from the tool's ``auth_check``). If the backend says
+ * configured=false, the tool shows as "Not configured" (e.g. missing
+ * SERPAPI_API_KEY for supplier_pricing).
  */
 export function getToolOAuthStatus(
-  toolName: string,
+  oauthName: string,
   oauthMap: Record<string, { configured?: boolean; connected?: boolean }>,
   backendConfigured?: boolean,
 ): { needsOAuth: boolean; isConfigured: boolean; isConnected: boolean } {
-  const oauthIntegration = TOOL_OAUTH_MAP[toolName];
-  const needsOAuth = !!oauthIntegration;
+  const needsOAuth = !!oauthName;
   if (!needsOAuth) {
     const configured = backendConfigured ?? true;
     return { needsOAuth: false, isConfigured: configured, isConnected: configured };
   }
-  const entry = oauthMap[oauthIntegration];
+  const entry = oauthMap[oauthName];
   return {
     needsOAuth: true,
     isConfigured: entry?.configured ?? false,

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -104,9 +104,9 @@ function setupMocks(overrides?: {
   mockGetToolConfig.mockResolvedValue(
     overrides?.tools ?? {
       tools: [
-        { name: 'workspace', description: '', category: 'core', enabled: true, domain_group: '', domain_group_order: 0 },
+        { name: 'workspace', description: '', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '' },
         {
-          name: 'calendar', description: '', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0,
+          name: 'calendar', description: '', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'google_calendar',
           sub_tools: [
             { name: 'calendar_list_events', description: '', enabled: true, permission_level: 'auto' },
             { name: 'calendar_create_event', description: '', enabled: true, permission_level: 'ask' },
@@ -290,9 +290,9 @@ describe('DashboardPage', () => {
     setupMocks({
       tools: {
         tools: [
-          { name: 'workspace', description: '', category: 'core', enabled: true, domain_group: '', domain_group_order: 0 },
-          { name: 'calendar', description: '', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0 },
-          { name: 'quickbooks', description: '', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0 },
+          { name: 'workspace', description: '', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '' },
+          { name: 'calendar', description: '', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'google_calendar' },
+          { name: 'quickbooks', description: '', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'quickbooks' },
         ],
       },
       oauth: {

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -104,9 +104,9 @@ function setupMocks(overrides?: {
   mockGetToolConfig.mockResolvedValue(
     overrides?.tools ?? {
       tools: [
-        { name: 'workspace', description: '', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '' },
+        { name: 'workspace', description: '', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '', always_enabled: true },
         {
-          name: 'calendar', description: '', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'google_calendar',
+          name: 'calendar', description: '', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_calendar', always_enabled: false,
           sub_tools: [
             { name: 'calendar_list_events', description: '', enabled: true, permission_level: 'auto' },
             { name: 'calendar_create_event', description: '', enabled: true, permission_level: 'ask' },
@@ -290,9 +290,9 @@ describe('DashboardPage', () => {
     setupMocks({
       tools: {
         tools: [
-          { name: 'workspace', description: '', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '' },
-          { name: 'calendar', description: '', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'google_calendar' },
-          { name: 'quickbooks', description: '', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'quickbooks' },
+          { name: 'workspace', description: '', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '', always_enabled: true },
+          { name: 'calendar', description: '', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_calendar', always_enabled: false },
+          { name: 'quickbooks', description: '', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'quickbooks', always_enabled: false },
         ],
       },
       oauth: {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -237,7 +237,6 @@ export default function DashboardPage() {
             <div className="space-y-2.5">
               {integrationTools.map((tool) => {
                 const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(tool.oauth_name, oauthMap, tool.configured);
-                const isAlwaysEnabled = tool.category === 'core';
                 const enabledSubTools = (tool.sub_tools ?? []).filter((st) => st.enabled).length;
                 const totalSubTools = (tool.sub_tools ?? []).length;
                 return (
@@ -257,7 +256,7 @@ export default function DashboardPage() {
                           </span>
                         )}
                       </div>
-                      {isConnected && !isAlwaysEnabled && (
+                      {isConnected && !tool.always_enabled && (
                         /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
                         <div onClick={stopCardPress}>
                           <Switch

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -124,11 +124,14 @@ export default function DashboardPage() {
 
   // --- Tools ---
   const allTools = tools.data?.tools ?? [];
-  const domainTools = allTools.filter((t) => t.category === 'domain');
+  // Mirror the ToolsPage filter: integrations group plus OAuth-backed
+  // always-on tools (Google Drive). Keeps the dashboard card in sync with
+  // what the Settings page actually renders.
+  const integrationTools = allTools.filter((t) => t.category === 'domain' || !!t.oauth_name);
   const integrations = oauth.data?.integrations ?? [];
   const oauthMap = Object.fromEntries(integrations.map((i) => [i.integration, i]));
   const enabledCalendars = calendarConfig.data?.calendars ?? [];
-  const toolsConfigured = domainTools.some((t) => t.enabled);
+  const toolsConfigured = integrationTools.some((t) => t.enabled);
 
   // --- Memory ---
   const memoryContent = memory.data?.content ?? '';
@@ -230,10 +233,11 @@ export default function DashboardPage() {
           isLoading={(tools.isPending && !tools.data) || (oauth.isPending && !oauth.data)}
           isError={tools.isError && !tools.data}
         >
-          {domainTools.length > 0 ? (
+          {integrationTools.length > 0 ? (
             <div className="space-y-2.5">
-              {domainTools.map((tool) => {
-                const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(tool.name, oauthMap, tool.configured);
+              {integrationTools.map((tool) => {
+                const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(tool.oauth_name, oauthMap, tool.configured);
+                const isAlwaysEnabled = tool.category === 'core';
                 const enabledSubTools = (tool.sub_tools ?? []).filter((st) => st.enabled).length;
                 const totalSubTools = (tool.sub_tools ?? []).length;
                 return (
@@ -253,7 +257,7 @@ export default function DashboardPage() {
                           </span>
                         )}
                       </div>
-                      {isConnected && (
+                      {isConnected && !isAlwaysEnabled && (
                         /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
                         <div onClick={stopCardPress}>
                           <Switch

--- a/frontend/src/pages/ToolsPage.test.tsx
+++ b/frontend/src/pages/ToolsPage.test.tsx
@@ -49,8 +49,8 @@ function setupMocks(overrides?: {
   mockGetToolConfig.mockResolvedValue(
     overrides?.tools ?? {
       tools: [
-        { name: 'workspace', description: 'Workspace tools', category: 'core', enabled: true, domain_group: '', domain_group_order: 0 },
-        { name: 'calendar', description: 'Google Calendar integration', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0 },
+        { name: 'workspace', description: 'Workspace tools', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '' },
+        { name: 'calendar', description: 'Google Calendar integration', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'google_calendar' },
       ],
     },
   );
@@ -134,5 +134,53 @@ describe('ToolsPage', () => {
     // Card should NOT have opacity-50
     const cardElement = screen.getByText('Google Calendar').closest('.opacity-50');
     expect(cardElement).toBeNull();
+  });
+
+  it('renders OAuth-backed always-on tools (Google Drive) with Connect button and no toggle', async () => {
+    // Regression: Google Drive uses ``dashboard_always_enabled=True`` so
+    // the backend reports ``category="core"``. The Settings UI must still
+    // render it (with Connect / Disconnect) but skip the enable / disable
+    // toggle because the backend silently ignores toggle attempts.
+    setupMocks({
+      tools: {
+        tools: [
+          { name: 'file', description: 'Google Drive storage', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_drive' },
+        ],
+      },
+      oauth: {
+        integrations: [{ integration: 'google_drive', connected: false, configured: true }],
+      },
+    });
+    renderWithRouter(<ToolsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Google Drive')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Connect')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Toggle Google Drive')).not.toBeInTheDocument();
+  });
+
+  it('renders Disconnect button for connected OAuth-backed tools using oauth_name from response', async () => {
+    // Regression: previously the Settings UI looked up OAuth integration
+    // names via a hand-maintained TOOL_OAUTH_MAP in the frontend. New
+    // integrations (e.g. Gmail) that were never added to the map lost
+    // their Connect / Disconnect buttons silently. The fix carries
+    // ``oauth_name`` on the API response so the UI stays in sync.
+    setupMocks({
+      tools: {
+        tools: [
+          { name: 'gmail', description: 'Gmail integration', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'gmail' },
+        ],
+      },
+      oauth: {
+        integrations: [{ integration: 'gmail', connected: true, configured: true }],
+      },
+    });
+    renderWithRouter(<ToolsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Disconnect')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Connected')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ToolsPage.test.tsx
+++ b/frontend/src/pages/ToolsPage.test.tsx
@@ -49,8 +49,8 @@ function setupMocks(overrides?: {
   mockGetToolConfig.mockResolvedValue(
     overrides?.tools ?? {
       tools: [
-        { name: 'workspace', description: 'Workspace tools', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '' },
-        { name: 'calendar', description: 'Google Calendar integration', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'google_calendar' },
+        { name: 'workspace', description: 'Workspace tools', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '', always_enabled: true },
+        { name: 'calendar', description: 'Google Calendar integration', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_calendar', always_enabled: false },
       ],
     },
   );
@@ -144,7 +144,7 @@ describe('ToolsPage', () => {
     setupMocks({
       tools: {
         tools: [
-          { name: 'file', description: 'Google Drive storage', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_drive' },
+          { name: 'file', description: 'Google Drive storage', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_drive', always_enabled: true },
         ],
       },
       oauth: {
@@ -169,7 +169,7 @@ describe('ToolsPage', () => {
     setupMocks({
       tools: {
         tools: [
-          { name: 'gmail', description: 'Gmail integration', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'gmail' },
+          { name: 'gmail', description: 'Gmail integration', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'gmail', always_enabled: false },
         ],
       },
       oauth: {

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -4,7 +4,7 @@ import Button from '@/components/ui/button';
 import { Switch } from '@heroui/switch';
 import { Tooltip } from '@heroui/tooltip';
 import { toast } from '@/lib/toast';
-import { displayName, subToolDisplayName, TOOL_OAUTH_MAP, getToolOAuthStatus } from '@/lib/tool-utils';
+import { displayName, subToolDisplayName, getToolOAuthStatus } from '@/lib/tool-utils';
 import { IntegrationIcon } from '@/components/integration-icons';
 import { useToolConfig, useUpdateToolConfig, useOAuthStatus, useOAuthDisconnect, useCalendarList, useCalendarConfig, useUpdateCalendarConfig } from '@/hooks/queries';
 import api from '@/api';
@@ -125,18 +125,26 @@ export default function ToolsPage() {
     );
   }
 
-  const domainTools = tools.filter((t: ToolConfigEntryResponse) => t.category === 'domain');
+  // Render any tool the backend marks as part of an integrations group
+  // (``category === 'domain'``) plus any OAuth-backed tool that is rendered
+  // as always-on in Settings (``category === 'core'`` with ``oauth_name``,
+  // e.g. Google Drive). The latter has no toggle but still needs Connect /
+  // Disconnect.
+  const integrationTools = tools.filter(
+    (t: ToolConfigEntryResponse) => t.category === 'domain' || !!t.oauth_name,
+  );
 
   return (
     <div>
       <h2 className="text-xl font-semibold font-display mb-6">Tools</h2>
 
-      {domainTools.length > 0 && (
+      {integrationTools.length > 0 && (
         <section>
           <div className="grid gap-3">
-            {domainTools.map((tool) => {
-              const oauthIntegration = TOOL_OAUTH_MAP[tool.name];
-              const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(tool.name, oauthMap, tool.configured);
+            {integrationTools.map((tool) => {
+              const oauthIntegration = tool.oauth_name;
+              const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(oauthIntegration, oauthMap, tool.configured);
+              const isAlwaysEnabled = tool.category === 'core';
 
               return (
                 <Card key={tool.name}>
@@ -170,7 +178,7 @@ export default function ToolsPage() {
                         <Button
                           variant="secondary"
                           size="sm"
-                          onClick={() => handleDisconnect(oauthIntegration!)}
+                          onClick={() => handleDisconnect(oauthIntegration)}
                           disabled={disconnectMutation.isPending}
                         >
                           Disconnect
@@ -179,7 +187,7 @@ export default function ToolsPage() {
                       {needsOAuth && !isConnected && (
                         <Button
                           size="sm"
-                          onClick={() => void handleConnect(oauthIntegration!)}
+                          onClick={() => void handleConnect(oauthIntegration)}
                           disabled={connectingIntegration === oauthIntegration}
                           isLoading={connectingIntegration === oauthIntegration}
                         >
@@ -189,8 +197,10 @@ export default function ToolsPage() {
                     </div>
                   </div>
 
-                  {/* Enable/disable toggle: show when connected (OAuth) or always (non-OAuth) */}
-                  {isConnected && (
+                  {/* Enable/disable toggle. Always-enabled integrations
+                      (e.g. Google Drive) skip the toggle because the backend
+                      silently ignores attempts to disable them. */}
+                  {isConnected && !isAlwaysEnabled && (
                     <div className="flex items-center justify-between mt-3 pt-3 border-t border-border">
                       <span className="text-xs text-muted-foreground">
                         {tool.enabled ? 'Available to assistant' : 'Disabled'}

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -127,9 +127,8 @@ export default function ToolsPage() {
 
   // Render any tool the backend marks as part of an integrations group
   // (``category === 'domain'``) plus any OAuth-backed tool that is rendered
-  // as always-on in Settings (``category === 'core'`` with ``oauth_name``,
-  // e.g. Google Drive). The latter has no toggle but still needs Connect /
-  // Disconnect.
+  // as always-on in Settings (e.g. Google Drive). The latter has no toggle
+  // but still needs Connect / Disconnect.
   const integrationTools = tools.filter(
     (t: ToolConfigEntryResponse) => t.category === 'domain' || !!t.oauth_name,
   );
@@ -144,7 +143,6 @@ export default function ToolsPage() {
             {integrationTools.map((tool) => {
               const oauthIntegration = tool.oauth_name;
               const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(oauthIntegration, oauthMap, tool.configured);
-              const isAlwaysEnabled = tool.category === 'core';
 
               return (
                 <Card key={tool.name}>
@@ -200,7 +198,7 @@ export default function ToolsPage() {
                   {/* Enable/disable toggle. Always-enabled integrations
                       (e.g. Google Drive) skip the toggle because the backend
                       silently ignores attempts to disable them. */}
-                  {isConnected && !isAlwaysEnabled && (
+                  {isConnected && !tool.always_enabled && (
                     <div className="flex items-center justify-between mt-3 pt-3 border-t border-border">
                       <span className="text-xs text-muted-foreground">
                         {tool.enabled ? 'Available to assistant' : 'Disabled'}

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -196,6 +196,33 @@ def test_get_tool_config_includes_oauth_name(client: TestClient) -> None:
     assert tools_by_name["supplier_pricing"]["oauth_name"] == ""
 
 
+def test_get_tool_config_includes_always_enabled(client: TestClient) -> None:
+    """GET /api/user/tools surfaces ``always_enabled`` so the UI can hide the
+    disable toggle for tools the backend refuses to disable.
+
+    Mirrors ``ToolFactory.dashboard_always_enabled``. Decoupled from
+    ``category`` so future internal-only categories cannot accidentally
+    hide the toggle for always-on OAuth tools (Google Drive).
+    """
+    response = client.get("/api/user/tools")
+    assert response.status_code == 200
+    tools_by_name = {t["name"]: t for t in response.json()["tools"]}
+
+    # All response entries declare the field (default False).
+    for tool in tools_by_name.values():
+        assert "always_enabled" in tool, f"{tool['name']} missing always_enabled"
+
+    # Always-on factories report True. ``file`` (Google Drive) is the
+    # canonical always-on OAuth factory; ``workspace`` is the canonical
+    # always-on non-OAuth factory.
+    assert tools_by_name["file"]["always_enabled"] is True
+    assert tools_by_name["workspace"]["always_enabled"] is True
+
+    # Specialist factories with toggles report False.
+    assert tools_by_name["gmail"]["always_enabled"] is False
+    assert tools_by_name["quickbooks"]["always_enabled"] is False
+
+
 def test_put_tool_config_disable_domain_tool(client: TestClient) -> None:
     """PUT /api/user/tools can disable a domain tool."""
     response = client.put(

--- a/tests/test_tool_config.py
+++ b/tests/test_tool_config.py
@@ -161,6 +161,41 @@ def test_get_tool_config_domain_group(client: TestClient) -> None:
         assert t["domain_group_order"] == 0, f"{t['name']} should have zero order"
 
 
+def test_get_tool_config_includes_oauth_name(client: TestClient) -> None:
+    """GET /api/user/tools surfaces the OAuth integration backing each tool.
+
+    The frontend Settings UI uses ``oauth_name`` to render Connect /
+    Disconnect buttons. Without this field, integrations whose factory
+    name differs from the OAuth integration name (``file`` ->
+    ``google_drive``, ``calendar`` -> ``google_calendar``) drop their
+    Connect button silently, and integrations whose factory was never
+    added to the frontend's hand-maintained map (e.g. ``gmail`` after the
+    refactor in #1285) lose theirs too.
+    """
+    response = client.get("/api/user/tools")
+    assert response.status_code == 200
+    tools_by_name = {t["name"]: t for t in response.json()["tools"]}
+
+    # All response entries declare the field (default empty string).
+    for tool in tools_by_name.values():
+        assert "oauth_name" in tool, f"{tool['name']} missing oauth_name field"
+
+    # OAuth-backed factories report the integration name registered in
+    # backend.app.services.oauth, including both the matching-name case
+    # (``gmail``, ``quickbooks``, ``companycam``) and the renamed case
+    # (``file`` -> ``google_drive``, ``calendar`` -> ``google_calendar``).
+    assert tools_by_name["file"]["oauth_name"] == "google_drive"
+    assert tools_by_name["calendar"]["oauth_name"] == "google_calendar"
+    assert tools_by_name["quickbooks"]["oauth_name"] == "quickbooks"
+    assert tools_by_name["companycam"]["oauth_name"] == "companycam"
+    assert tools_by_name["gmail"]["oauth_name"] == "gmail"
+
+    # Non-OAuth factories report empty string so the UI knows there is
+    # nothing to connect.
+    assert tools_by_name["workspace"]["oauth_name"] == ""
+    assert tools_by_name["supplier_pricing"]["oauth_name"] == ""
+
+
 def test_put_tool_config_disable_domain_tool(client: TestClient) -> None:
     """PUT /api/user/tools can disable a domain tool."""
     response = client.put(


### PR DESCRIPTION
## Description

The Settings UI rendered Google Drive and Gmail incorrectly:

* **Google Drive disappeared from the Integrations list entirely.** PR #1285 set ``dashboard_always_enabled=True`` on the ``file`` factory, which pushes its API ``category`` to ``\"core\"``. The Settings page filter only renders ``\"domain\"`` tools, so Drive vanished even when configured.
* **Gmail showed in the list but with no Connect or Disconnect button.** The frontend looked up each tool's OAuth integration via a hardcoded ``TOOL_OAUTH_MAP`` in ``frontend/src/lib/tool-utils.ts``. Gmail was never added to that map; the row rendered but both buttons were gated on the map lookup succeeding.

Root cause: PR #1285 moved the factory-to-OAuth mapping onto ``ToolFactory.oauth_name`` on the backend but never wired the frontend through, leaving the hardcoded map as a maintenance landmine.

### Fix

Surface ``oauth_name`` on ``ToolConfigEntryResponse``. The router resolves the effective name from the factory's ``oauth_name`` field, falling back to the factory name when that name is itself a registered OAuth integration (covers the matching-name case for ``gmail`` / ``quickbooks`` / ``companycam``). The Settings and Dashboard pages now:

* Include any tool with a non-empty ``oauth_name`` in the Integrations list, regardless of ``category``.
* Read the integration name from ``tool.oauth_name`` instead of the hardcoded map.
* Skip the disable toggle for always-enabled OAuth tools (Drive), matching the backend's silent-ignore on toggle attempts.

After this change, adding a new OAuth-backed integration touches ``services/oauth.py`` + ``integrations/<name>/factory.py`` only. The frontend stays in sync automatically.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (focused subset of ``pytest -v``; full suite not run in sandbox)
- [x] Lint passes (``ruff check``, ``ruff format --check``, ``ty check``)
- [x] Frontend passes (``npm run typecheck``, ``npm run deadcode``, ``npm run test``)
- [x] New tests added: backend pins both the matching-name and renamed-name oauth_name cases plus the empty-for-non-OAuth case; frontend adds two ToolsPage tests covering Drive-as-always-on-OAuth and Gmail-uses-response-oauth-name.
- [x] Bug fixes include regression tests

### Pre-existing test note

``ToolsPage.test.tsx > shows \"Not configured\" with dimmed card`` was already failing on main before this PR. PR #965 removed the ``opacity-50`` / ``\"Not configured\"`` rendering from ``ToolsPage.tsx`` without updating the test. Not in scope here.

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake; reasoning and decisions are his, prose is Claude's).