### PR TITLE
feat(servicetitan): write tool st_add_job_note with approval policy

### DIFF
--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -94,6 +94,7 @@ class ToolName:
     SERVICETITAN_SEARCH_CUSTOMERS = "st_search_customers"
     SERVICETITAN_GET_CUSTOMER = "st_get_customer"
     SERVICETITAN_LIST_APPOINTMENTS = "st_list_appointments"
+    SERVICETITAN_ADD_JOB_NOTE = "st_add_job_note"
 
     # Supplier pricing
     SUPPLIER_SEARCH_PRODUCTS = "supplier_search_products"

--- a/backend/app/agent/tools/servicetitan_tools.py
+++ b/backend/app/agent/tools/servicetitan_tools.py
@@ -1,17 +1,20 @@
-"""ServiceTitan read tools.
+"""ServiceTitan read and write tools.
 
-Three read-only tools that surface customers and appointments from a
+Tools that surface and mutate customer, appointment, and job data on a
 user's ServiceTitan tenant:
 
 * ``st_search_customers`` -- substring search by name or phone.
 * ``st_get_customer`` -- full record by numeric id.
 * ``st_list_appointments`` -- date-range filtered appointment list,
   defaulting to "today" when no range is given.
+* ``st_add_job_note`` -- post a note to a job. First mutating tool;
+  ships with an ``ApprovalPolicy`` (default ASK) and a
+  ``concurrency_group`` so concurrent writes within one turn serialize.
 
 Tools are constructed by :func:`build_servicetitan_tools`, which the
 ``servicetitan`` data factory calls once the user has connected a
-tenant. None of these tools mutate state, so they ship without an
-``ApprovalPolicy`` and without a ``concurrency_group``.
+tenant. The read tools do not declare an ``ApprovalPolicy`` or a
+``concurrency_group``; the write tools do.
 
 This module also lives in the auto-discovery path:
 ``ensure_tool_modules_imported`` imports every ``*_tools`` module in
@@ -27,9 +30,11 @@ import logging
 from datetime import UTC, datetime, time, timedelta
 from typing import Any
 
-from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.integrations.servicetitan.params import (
+    StAddJobNoteParams,
     StGetCustomerParams,
     StListAppointmentsParams,
     StSearchCustomersParams,
@@ -332,6 +337,59 @@ def build_servicetitan_tools(service: ServiceTitanService) -> list[Tool]:
         lines.extend(_format_appointment_line(a) for a in records)
         return ToolResult(content="\n".join(lines))
 
+    async def st_add_job_note(
+        job_id: int,
+        text: str,
+        pin_to_top: bool = False,
+    ) -> ToolResult:
+        """Post a note to a ServiceTitan job."""
+        trimmed = text.strip()
+        if not trimmed:
+            # Belt-and-suspenders: the params model already rejects blank
+            # text, but direct callers that bypass validation should also
+            # see a clear validation error rather than a 400 from the API.
+            return ToolResult(
+                content="Note text is empty.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+                hint="Pass non-whitespace text for the note body.",
+            )
+
+        path = f"/jpm/v2/tenant/{service.tenant_id}/jobs/{job_id}/notes"
+        body = {"text": trimmed, "pinToTop": bool(pin_to_top)}
+        try:
+            payload = await service.post(path, json_body=body)
+        except ServiceTitanError as exc:
+            # Surface a 404 on the job path as NOT_FOUND so the agent can
+            # offer a follow-up lookup rather than treating it as a
+            # transient service failure. Mirrors the st_get_customer
+            # pattern; ServiceTitanService raises ServiceTitanError with
+            # the literal "HTTP 404" substring on any 4xx response.
+            text_repr = str(exc)
+            if "HTTP 404" in text_repr:
+                return ToolResult(
+                    content=f"No ServiceTitan job with id {job_id}.",
+                    is_error=True,
+                    error_kind=ToolErrorKind.NOT_FOUND,
+                    hint="Confirm the job id via st_list_appointments or st_get_customer.",
+                )
+            return _service_error("adding job note", exc)
+        except Exception as exc:
+            return _service_error("adding job note", exc)
+
+        pinned_phrase = " (pinned)" if pin_to_top else ""
+        # The fake and real APIs return the persisted note as a flat
+        # dict; the createdOn timestamp confirms the write landed.
+        created_on = payload.get("createdOn") if isinstance(payload, dict) else None
+        timestamp_phrase = f" at {created_on}" if created_on else ""
+        return ToolResult(
+            content=f"Added note to ServiceTitan job {job_id}{pinned_phrase}{timestamp_phrase}.",
+            receipt=ToolReceipt(
+                action="Added ServiceTitan job note",
+                target=f"job #{job_id}{pinned_phrase}",
+            ),
+        )
+
     return [
         Tool(
             name=ToolName.SERVICETITAN_SEARCH_CUSTOMERS,
@@ -380,5 +438,36 @@ def build_servicetitan_tools(service: ServiceTitanService) -> list[Tool]:
                 " window. Pass status to filter (Scheduled, Dispatched,"
                 " Working, Done, Hold)."
             ),
+        ),
+        Tool(
+            name=ToolName.SERVICETITAN_ADD_JOB_NOTE,
+            description=(
+                "Add a plain-text note to a ServiceTitan job. Optionally"
+                " pin the note above other notes in the job's feed."
+                " Visible to anyone in the tenant with job access."
+            ),
+            function=st_add_job_note,
+            params_model=StAddJobNoteParams,
+            usage_hint=(
+                "Confirm the job id with the user before calling. Use"
+                " pin_to_top=True only when the user explicitly asks for"
+                " a pinned note. The tool requests user approval at"
+                " runtime via its ApprovalPolicy."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                resource_extractor=lambda args: (
+                    f"job:{args.get('job_id')}" if args.get("job_id") is not None else None
+                ),
+                description_builder=lambda args: (
+                    f"Add note to ServiceTitan job {args.get('job_id', '?')}"
+                    + (" (pinned)" if args.get("pin_to_top") else "")
+                ),
+            ),
+            # Serialize ServiceTitan writes within a single agent turn so
+            # two concurrent note posts (or a note racing a future status
+            # update) cannot interleave against the same tenant. Matches
+            # the ``user_outbound`` / ``user_integrations`` naming.
+            concurrency_group="user_st_writes",
         ),
     ]

--- a/backend/app/integrations/servicetitan/factory.py
+++ b/backend/app/integrations/servicetitan/factory.py
@@ -8,9 +8,10 @@ time, mirroring the AppFolio Vendor split:
   ``connect_servicetitan`` tool. Must stay reachable before any credential
   exists since pasting credentials *is* the connect path.
 * ``servicetitan`` (specialist, gated on connection state): the data
-  tools. The read tools landed in #1300; write tools land in #1301. The
-  ``auth_check`` keeps the factory surfaced under "Not connected" in
-  ``list_capabilities`` until the user runs the connect tool.
+  tools. The read tools landed in #1306; the first write tool
+  (``st_add_job_note``) landed in #1302. The ``auth_check`` keeps the
+  factory surfaced under "Not connected" in ``list_capabilities`` until
+  the user runs the connect tool.
 
 The split mirrors AppFolio's prod-bug fix: a single combined factory
 would have to keep ``auth_check`` returning ``None`` unconditionally to
@@ -56,10 +57,11 @@ async def _servicetitan_auth_factory(ctx: ToolContext) -> list[Tool]:
 async def _servicetitan_factory(ctx: ToolContext) -> list[Tool]:
     """Assemble the ServiceTitan data tools for an authenticated user.
 
-    Returns the read tools (#1300) when the user has a usable credential
-    on file. The defensive ``return []`` after ``build_service_for_user``
-    covers the rare race where the credential disappears between the
-    auth check and tool creation (user disconnected mid-turn).
+    Returns the read and write tools when the user has a usable
+    credential on file. The defensive ``return []`` after
+    ``build_service_for_user`` covers the rare race where the credential
+    disappears between the auth check and tool creation (user
+    disconnected mid-turn).
     """
     if not await is_connected(ctx.user.id):
         return []
@@ -112,11 +114,13 @@ def _register() -> None:
         _servicetitan_factory,
         core=False,
         summary=(
-            "ServiceTitan: view and act on customers, jobs, and appointments"
-            " (read-only for now; write tools land in a subsequent issue)."
+            "ServiceTitan: view customers, jobs, and appointments; add"
+            " notes to jobs. Note writes require user approval."
         ),
         display_name="ServiceTitan",
-        dashboard_description=("View ServiceTitan customers, jobs, and appointments"),
+        dashboard_description=(
+            "View ServiceTitan customers, jobs, and appointments; add notes to jobs"
+        ),
         dashboard_group="Integrations",
         dashboard_group_order=3,
         sub_tools=[
@@ -134,6 +138,11 @@ def _register() -> None:
                 ToolName.SERVICETITAN_LIST_APPOINTMENTS,
                 "List ServiceTitan appointments in a date range",
                 default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.SERVICETITAN_ADD_JOB_NOTE,
+                "Add a note to a ServiceTitan job",
+                default_permission="ask",
             ),
         ],
         auth_check=_servicetitan_auth_check,

--- a/backend/app/integrations/servicetitan/params.py
+++ b/backend/app/integrations/servicetitan/params.py
@@ -6,7 +6,7 @@ agent's schema stays consistent across the integration.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ServiceTitanConnectParams(BaseModel):
@@ -105,3 +105,42 @@ class StListAppointmentsParams(BaseModel):
             " to return all statuses."
         ),
     )
+
+
+class StAddJobNoteParams(BaseModel):
+    """Inputs for ``st_add_job_note``.
+
+    Posts a free-form note to a ServiceTitan job. The note is visible
+    to anyone in the tenant with access to the job, so the tool gates
+    on approval before sending. ``pin_to_top`` mirrors the API's
+    ``pinToTop`` flag and surfaces the note above other notes in the
+    job's note feed.
+    """
+
+    job_id: int = Field(
+        description=(
+            "The numeric ServiceTitan job ID to attach the note to."
+            " Obtain from a prior appointment lookup or list call."
+        ),
+    )
+    text: str = Field(
+        min_length=1,
+        description=(
+            "The note body to post on the job. Plain text. Empty or"
+            " whitespace-only values are rejected."
+        ),
+    )
+    pin_to_top: bool = Field(
+        default=False,
+        description=(
+            "When true, ServiceTitan pins the note above other notes"
+            " in the job's note feed. Defaults to false."
+        ),
+    )
+
+    @field_validator("text")
+    @classmethod
+    def _text_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("text must contain non-whitespace characters")
+        return value

--- a/tests/test_servicetitan_factory.py
+++ b/tests/test_servicetitan_factory.py
@@ -84,10 +84,11 @@ def test_auth_factory_lists_connect_subtool() -> None:
     assert ToolName.SERVICETITAN_CONNECT in names
 
 
-def test_data_factory_lists_read_subtools() -> None:
-    """The data factory must advertise the three read tools so the
-    Settings UI and ``manage_integration`` can render their permission
-    rows even before the user connects.
+def test_data_factory_lists_subtools_with_expected_defaults() -> None:
+    """The data factory must advertise the read tools (default ALWAYS) and
+    the write tool ``st_add_job_note`` (default ASK), so the Settings UI
+    and ``manage_integration`` render the right permission rows even
+    before the user connects.
     """
     data = default_registry.get_factory("servicetitan")
     assert data is not None
@@ -95,9 +96,17 @@ def test_data_factory_lists_read_subtools() -> None:
     assert ToolName.SERVICETITAN_SEARCH_CUSTOMERS in names
     assert ToolName.SERVICETITAN_GET_CUSTOMER in names
     assert ToolName.SERVICETITAN_LIST_APPOINTMENTS in names
+    assert ToolName.SERVICETITAN_ADD_JOB_NOTE in names
+
+    expected_defaults = {
+        ToolName.SERVICETITAN_SEARCH_CUSTOMERS: "always",
+        ToolName.SERVICETITAN_GET_CUSTOMER: "always",
+        ToolName.SERVICETITAN_LIST_APPOINTMENTS: "always",
+        ToolName.SERVICETITAN_ADD_JOB_NOTE: "ask",
+    }
     for sub in data.sub_tools:
-        assert sub.default_permission == "always", (
-            f"{sub.name} should default to ALWAYS (read-only)"
+        assert sub.default_permission == expected_defaults[sub.name], (
+            f"{sub.name} default_permission should be {expected_defaults[sub.name]}"
         )
 
 
@@ -147,8 +156,8 @@ async def test_data_factory_returns_empty_when_not_connected(
 
 
 @pytest.mark.asyncio()
-async def test_data_factory_returns_read_tools_when_connected(async_test_user: Any) -> None:
-    """Once #1300 landed, a connected user gets the three read tools."""
+async def test_data_factory_returns_all_tools_when_connected(async_test_user: Any) -> None:
+    """A connected user gets the read tools plus the write tool."""
     user_id = async_test_user.id
     await save_credentials(
         user_id,
@@ -166,6 +175,7 @@ async def test_data_factory_returns_read_tools_when_connected(async_test_user: A
         ToolName.SERVICETITAN_SEARCH_CUSTOMERS,
         ToolName.SERVICETITAN_GET_CUSTOMER,
         ToolName.SERVICETITAN_LIST_APPOINTMENTS,
+        ToolName.SERVICETITAN_ADD_JOB_NOTE,
     }
 
 

--- a/tests/test_servicetitan_read_tools.py
+++ b/tests/test_servicetitan_read_tools.py
@@ -72,8 +72,8 @@ async def _build_connected_service(user_id: str) -> ServiceTitanService:
 
 
 @pytest.mark.asyncio()
-async def test_build_servicetitan_tools_returns_three_tools(async_test_user: Any) -> None:
-    """build_servicetitan_tools must expose exactly the three read tools."""
+async def test_build_servicetitan_tools_returns_all_tools(async_test_user: Any) -> None:
+    """build_servicetitan_tools must expose the read tools plus st_add_job_note."""
     service = await _build_connected_service(async_test_user.id)
     tools = build_servicetitan_tools(service)
     names = {t.name for t in tools}
@@ -81,6 +81,7 @@ async def test_build_servicetitan_tools_returns_three_tools(async_test_user: Any
         ToolName.SERVICETITAN_SEARCH_CUSTOMERS,
         ToolName.SERVICETITAN_GET_CUSTOMER,
         ToolName.SERVICETITAN_LIST_APPOINTMENTS,
+        ToolName.SERVICETITAN_ADD_JOB_NOTE,
     }
 
 
@@ -89,8 +90,15 @@ async def test_read_tools_have_no_approval_policy_or_concurrency_group(
     async_test_user: Any,
 ) -> None:
     """Read-only tools must not declare approval policies or concurrency groups."""
+    read_only = {
+        ToolName.SERVICETITAN_SEARCH_CUSTOMERS,
+        ToolName.SERVICETITAN_GET_CUSTOMER,
+        ToolName.SERVICETITAN_LIST_APPOINTMENTS,
+    }
     service = await _build_connected_service(async_test_user.id)
     for tool in build_servicetitan_tools(service):
+        if tool.name not in read_only:
+            continue
         assert tool.approval_policy is None, f"{tool.name} should be unrestricted"
         assert tool.concurrency_group is None, f"{tool.name} should not serialize"
 

--- a/tests/test_servicetitan_write_tools.py
+++ b/tests/test_servicetitan_write_tools.py
@@ -1,0 +1,270 @@
+"""Tests for the ServiceTitan write tools.
+
+The first write tool is ``st_add_job_note``. It is exercised end-to-end
+against the in-process fake backend, plus a few static checks on the
+``Tool`` definition (approval policy, concurrency group) to lock in the
+runtime contract the agent depends on for permission gating and
+parallel-tool serialization.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from backend.app.agent.approval import PermissionLevel
+from backend.app.agent.tools.names import ToolName
+from backend.app.agent.tools.servicetitan_tools import build_servicetitan_tools
+from backend.app.config import settings as _settings
+from backend.app.integrations.servicetitan import _fake as fake_module
+from backend.app.integrations.servicetitan._fake import (
+    ServiceTitanFakeBackend,
+)
+from backend.app.integrations.servicetitan._fake import (
+    build_fake_transport as real_build_fake_transport,
+)
+from backend.app.integrations.servicetitan.auth import save_credentials
+from backend.app.integrations.servicetitan.params import StAddJobNoteParams
+from backend.app.integrations.servicetitan.service import (
+    ServiceTitanService,
+    build_service_for_user,
+)
+
+
+@pytest.fixture()
+def shared_backend() -> Any:
+    """A fresh fake backend bound across every service request in the test.
+
+    ``service.py``'s ``_build_http_client`` calls ``build_fake_transport()``
+    with no argument, which constructs a new backend per request, so a
+    POST and a follow-up inspection cannot see each other's state. The
+    write-tool tests need cross-request state to confirm the note
+    persisted, so we patch the transport factory to bind every request
+    to the same backend instance for the duration of the test.
+    """
+    backend = ServiceTitanFakeBackend()
+
+    def _build(_backend: Any = None) -> Any:
+        return real_build_fake_transport(backend)
+
+    with patch(
+        "backend.app.integrations.servicetitan.service.build_fake_transport",
+        side_effect=_build,
+    ):
+        yield backend
+
+
+@pytest.fixture(autouse=True)
+def _force_fake_backend(shared_backend: Any) -> Any:
+    """Route every test in this module through the in-process fake backend.
+
+    Resets the process-wide default fake between tests so a previous
+    note POST cannot leak via any other code path that uses
+    ``get_default_fake_backend`` directly. The credential row is cleaned
+    by the standard async test isolation fixture.
+    """
+    with patch.object(_settings, "servicetitan_use_fake", True):
+        fake_module.reset_default_fake_backend()
+        try:
+            yield
+        finally:
+            fake_module.reset_default_fake_backend()
+
+
+def _connected_credential_kwargs() -> dict[str, Any]:
+    return {
+        "tenant_id": str(fake_module.DEFAULT_TENANT_ID),
+        "client_id": "cid",
+        "client_secret": "csec",
+        "app_key": "fake-st-app-key",
+        "access_token": fake_module.FAKE_TOKEN_VALUE,
+        "expires_at": time.time() + 600,
+    }
+
+
+async def _build_connected_service(user_id: str) -> ServiceTitanService:
+    await save_credentials(user_id, **_connected_credential_kwargs())
+    service = await build_service_for_user(user_id)
+    assert service is not None
+    return service
+
+
+def _tool_by_name(tools: list[Any], name: str) -> Any:
+    for t in tools:
+        if t.name == name:
+            return t
+    raise AssertionError(f"tool {name} not found")
+
+
+# ---------------------------------------------------------------------------
+# Tool definition: approval policy + concurrency group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_add_job_note_has_ask_approval_policy(async_test_user: Any) -> None:
+    """The write tool must declare an ApprovalPolicy with default ASK.
+
+    Without this, the dashboard would surface the SubToolInfo's
+    ``default_permission='ask'`` but core.py would short-circuit to
+    ALWAYS at runtime, auto-executing the write without user consent.
+    """
+    service = await _build_connected_service(async_test_user.id)
+    tool = _tool_by_name(build_servicetitan_tools(service), ToolName.SERVICETITAN_ADD_JOB_NOTE)
+    assert tool.approval_policy is not None
+    assert tool.approval_policy.default_level == PermissionLevel.ASK
+
+
+@pytest.mark.asyncio()
+async def test_add_job_note_description_builder_quotes_job_id(
+    async_test_user: Any,
+) -> None:
+    """The approval prompt must reference the job id so the user has context."""
+    service = await _build_connected_service(async_test_user.id)
+    tool = _tool_by_name(build_servicetitan_tools(service), ToolName.SERVICETITAN_ADD_JOB_NOTE)
+    policy = tool.approval_policy
+    assert policy is not None and policy.description_builder is not None
+    prompt = policy.description_builder({"job_id": 2001, "text": "foo"})
+    assert "2001" in prompt
+    pinned_prompt = policy.description_builder({"job_id": 2001, "text": "foo", "pin_to_top": True})
+    assert "pinned" in pinned_prompt.lower()
+
+
+@pytest.mark.asyncio()
+async def test_add_job_note_resource_extractor_returns_per_job_key(
+    async_test_user: Any,
+) -> None:
+    """resource_extractor lets stored approvals be scoped to a single job."""
+    service = await _build_connected_service(async_test_user.id)
+    tool = _tool_by_name(build_servicetitan_tools(service), ToolName.SERVICETITAN_ADD_JOB_NOTE)
+    policy = tool.approval_policy
+    assert policy is not None and policy.resource_extractor is not None
+    assert policy.resource_extractor({"job_id": 2001}) == "job:2001"
+    assert policy.resource_extractor({}) is None
+
+
+@pytest.mark.asyncio()
+async def test_add_job_note_has_concurrency_group(async_test_user: Any) -> None:
+    """The write tool must declare a concurrency group.
+
+    The agent runs approved tool calls from a single LLM turn in
+    parallel by default. A note write must serialize with any other
+    ServiceTitan write so two concurrent posts cannot race on the
+    same tenant.
+    """
+    service = await _build_connected_service(async_test_user.id)
+    tool = _tool_by_name(build_servicetitan_tools(service), ToolName.SERVICETITAN_ADD_JOB_NOTE)
+    assert tool.concurrency_group == "user_st_writes"
+
+
+# ---------------------------------------------------------------------------
+# Params validation
+# ---------------------------------------------------------------------------
+
+
+def test_params_reject_blank_text() -> None:
+    """Whitespace-only text is rejected before the request is issued."""
+    with pytest.raises(ValidationError):
+        StAddJobNoteParams(job_id=2001, text="   ")
+
+
+def test_params_reject_empty_text() -> None:
+    """Pydantic's ``min_length=1`` rejects an empty string."""
+    with pytest.raises(ValidationError):
+        StAddJobNoteParams(job_id=2001, text="")
+
+
+def test_params_accept_minimal_inputs() -> None:
+    """Happy path: job_id + non-blank text is enough; pin_to_top defaults to False."""
+    params = StAddJobNoteParams(job_id=2001, text="Customer confirmed time")
+    assert params.job_id == 2001
+    assert params.text == "Customer confirmed time"
+    assert params.pin_to_top is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end against the fake
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_add_job_note_happy_path_posts_to_fake(
+    async_test_user: Any, shared_backend: Any
+) -> None:
+    """A successful POST persists the note and returns a receipt."""
+    service = await _build_connected_service(async_test_user.id)
+    add_note = _tool_by_name(build_servicetitan_tools(service), ToolName.SERVICETITAN_ADD_JOB_NOTE)
+
+    note_text = "Customer confirmed 9am Tuesday."
+    result = await add_note.function(job_id=2001, text=note_text)
+    assert result.is_error is False
+    assert "2001" in result.content
+    assert result.receipt is not None
+    assert "ServiceTitan" in result.receipt.action
+    assert "2001" in result.receipt.target
+
+    # The fake persists notes on the job's ``_notes`` list. Read it back
+    # off the shared backend so we do not depend on a separate read
+    # endpoint that the agent has not exposed yet.
+    job = next(j for j in shared_backend.jobs if j["id"] == 2001)
+    assert job.get("_notes"), "fake did not persist the posted note"
+    persisted = job["_notes"][-1]
+    assert persisted["text"] == note_text
+    assert persisted["isPinned"] is False
+
+
+@pytest.mark.asyncio()
+async def test_add_job_note_pin_to_top_propagates(
+    async_test_user: Any, shared_backend: Any
+) -> None:
+    """The pin_to_top flag flows through to the API body and persists."""
+    service = await _build_connected_service(async_test_user.id)
+    add_note = _tool_by_name(build_servicetitan_tools(service), ToolName.SERVICETITAN_ADD_JOB_NOTE)
+
+    result = await add_note.function(
+        job_id=2001,
+        text="Read before next visit",
+        pin_to_top=True,
+    )
+    assert result.is_error is False
+    assert "pinned" in result.content.lower()
+
+    job = next(j for j in shared_backend.jobs if j["id"] == 2001)
+    persisted = job["_notes"][-1]
+    assert persisted["isPinned"] is True
+
+
+@pytest.mark.asyncio()
+async def test_add_job_note_unknown_job_returns_not_found(
+    async_test_user: Any,
+) -> None:
+    """A 404 from the fake surfaces as a NOT_FOUND ToolResult, not SERVICE."""
+    service = await _build_connected_service(async_test_user.id)
+    add_note = _tool_by_name(build_servicetitan_tools(service), ToolName.SERVICETITAN_ADD_JOB_NOTE)
+
+    result = await add_note.function(job_id=999999, text="anything")
+    assert result.is_error is True
+    assert result.error_kind is not None
+    assert result.error_kind.value == "not_found"
+    assert "999999" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_add_job_note_blank_text_validation_error(async_test_user: Any) -> None:
+    """The tool function rejects whitespace-only text up front.
+
+    Direct callers that bypass the params model (e.g. test code, future
+    pipeline wiring) still get a clear VALIDATION error rather than a
+    400 surfaced as a generic SERVICE failure.
+    """
+    service = await _build_connected_service(async_test_user.id)
+    add_note = _tool_by_name(build_servicetitan_tools(service), ToolName.SERVICETITAN_ADD_JOB_NOTE)
+
+    result = await add_note.function(job_id=2001, text="   ")
+    assert result.is_error is True
+    assert result.error_kind is not None
+    assert result.error_kind.value == "validation"


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds the first mutating ServiceTitan tool, `st_add_job_note`, which posts a plain-text note to a job via `POST /jpm/v2/tenant/{tenant}/jobs/{job_id}/notes`, with optional `pinToTop`. The tool ships with the safety wiring write tools require:

- `ApprovalPolicy(default_level=PermissionLevel.ASK)` so the runtime asks the user before each post. The policy carries:
  - `resource_extractor` returning `job:<id>` so stored approvals can scope to a single job.
  - `description_builder` that quotes the job id (and notes when the user requested a pinned note) in the approval prompt.
- `concurrency_group="user_st_writes"` so concurrent ServiceTitan writes within one agent turn serialize against a shared tenant, matching the `user_outbound` / `user_integrations` naming pattern.
- Matching `SubToolInfo(default_permission="ask")` so the dashboard's permission row and the runtime gate agree, preventing the "WebUI says ask, runtime says always" silent skip.

Surfaces `HTTP 404` from the service as a `NOT_FOUND` ToolResult, mirroring the `st_get_customer` pattern; surfaces blank text up front as a `VALIDATION` error so a direct caller that bypasses the params model still gets a clear failure rather than a relayed 400. Returns a `ToolReceipt` so plain-text channels can confirm the write.

The fake's `POST /jobs/{id}/notes` (from #1303) already validates and persists the note; the read tools (from #1306) build under the same factory, so this PR only adds the write tool entry alongside them.

Fixes #1302

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

New tests in `tests/test_servicetitan_write_tools.py` cover:

- Happy-path POST against the in-process fake, including persistence verification via a shared backend fixture (the production `_build_http_client` constructs a fresh fake per request, so the fixture patches `build_fake_transport` to bind one backend across the test).
- `pin_to_top` propagation.
- `NOT_FOUND` on an unknown job id.
- Blank-text VALIDATION rejection at the tool boundary.
- `StAddJobNoteParams` validator rejecting empty and whitespace-only text.
- `ApprovalPolicy` presence, default level, description builder output, and per-job resource extractor.
- `concurrency_group == "user_st_writes"`.

Existing tests updated:

- `tests/test_servicetitan_read_tools.py`: the "exactly N tools" assertion now expects four tools; the no-approval-policy assertion is scoped to the read tools.
- `tests/test_servicetitan_factory.py`: the data factory subtool list and connected-tools assertion now include `st_add_job_note` with `default_permission="ask"`.

The global registry guards `test_ask_sub_tools_have_approval_policy` and `test_state_mutating_tools_have_concurrency_group` both stay green with the new tool.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude (Opus 4.7) drafted the patch and tests under @njbrake's direction.