### PR TITLE
refactor(twilio): switch to single-sender RCS via Messaging Service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,13 +48,17 @@ TELEGRAM_ALLOWED_CHAT_ID=
 # BLUEBUBBLES_IMESSAGE_ADDRESS=       # iCloud email or phone shown in the UI for users to text
 # BLUEBUBBLES_BACKFILL_LOOKBACK_MINUTES=30 # On startup, replay iMessages from the last N minutes whose webhook never reached us. 0 disables.
 
-# Twilio (SMS/MMS). Twilio does not expose typing indicators over SMS;
-# the channel's send_typing_indicator is a no-op. For iMessage/RCS with
-# typing indicators, use Linq or BlueBubbles instead.
+# Twilio (RCS via Messaging Service, with SMS/MMS fallback). Register an
+# RCS Agent in the Twilio console (4-6 week onboarding), attach it to a
+# Messaging Service, and point TWILIO_MESSAGING_SERVICE_SID at the
+# service. Twilio routes capable recipients over RCS and falls back to
+# SMS automatically for everyone else.
 # TWILIO_ACCOUNT_SID=                 # Twilio account SID, e.g. "AC..."
-# TWILIO_AUTH_TOKEN=                  # Twilio auth token (used for signature validation + media auth)
-# TWILIO_PHONE_NUMBER=                # E.164 outbound sender, e.g. "+15551234567"
-# TWILIO_MESSAGING_SERVICE_SID=       # "MG..." Use a Messaging Service for US A2P 10DLC. Takes precedence over TWILIO_PHONE_NUMBER.
+# TWILIO_AUTH_TOKEN=                  # Required for inbound webhook signature validation only (Twilio signs webhooks with this; API keys cannot sign webhooks).
+# TWILIO_API_KEY_SID=                 # Required for outbound REST: Standard API key SID, e.g. "SK..."
+# TWILIO_API_KEY_SECRET=              # Required for outbound REST. Console: Account > API Keys & Tokens > Create API Key (Standard).
+# TWILIO_PHONE_NUMBER=                # E.164 fallback sender for SMS-only deployments, e.g. "+15551234567". Ignored when TWILIO_MESSAGING_SERVICE_SID is set.
+# TWILIO_MESSAGING_SERVICE_SID=       # "MG..." Required for RCS. Attach an RCS Agent and any sender numbers to this service in the Twilio console.
 # TWILIO_ALLOWED_NUMBERS=             # E.164 phone, "*" for all, empty = deny all
 # TWILIO_VALIDATE_SIGNATURES=true     # Set to false only for local dev. Production must keep this on.
 

--- a/backend/app/channels/__init__.py
+++ b/backend/app/channels/__init__.py
@@ -82,7 +82,15 @@ def reset_channel_clients(updates: Mapping[str, object]) -> None:
         except KeyError:
             pass
 
-    if "twilio_account_sid" in updates or "twilio_auth_token" in updates:
+    if any(
+        k in updates
+        for k in (
+            "twilio_account_sid",
+            "twilio_auth_token",
+            "twilio_api_key_sid",
+            "twilio_api_key_secret",
+        )
+    ):
         try:
             from backend.app.channels.twilio import TwilioChannel
 
@@ -90,6 +98,8 @@ def reset_channel_clients(updates: Mapping[str, object]) -> None:
             if isinstance(channel, TwilioChannel):
                 channel._account_sid = settings.twilio_account_sid
                 channel._auth_token = settings.twilio_auth_token
+                channel._api_key_sid = settings.twilio_api_key_sid
+                channel._api_key_secret = settings.twilio_api_key_secret
                 channel._client = None
         except KeyError:
             pass

--- a/backend/app/channels/twilio.py
+++ b/backend/app/channels/twilio.py
@@ -1,10 +1,17 @@
-"""Twilio channel: inbound webhook + outbound messaging (SMS/MMS)."""
+"""Twilio channel: inbound webhook + outbound messaging via Messaging Service.
+
+A single Twilio Messaging Service is the canonical sender. The service
+can include an RCS Agent (Twilio routes capable recipients over RCS
+with automatic SMS/MMS fallback), an SMS-only sender pool, or both.
+The channel itself doesn't know or care which: every outbound call
+goes through ``messages.create`` with the Messaging Service SID and
+Twilio decides the wire protocol per recipient.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -30,91 +37,56 @@ TWIML_EMPTY = '<?xml version="1.0" encoding="UTF-8"?><Response/>'
 
 # Hostnames we will issue authenticated media downloads against. Twilio's
 # media URLs all live on these two subdomains; anything else is a
-# misconfiguration or an attacker trying to exfiltrate the account-SID
-# Basic Auth header via SSRF. The check defends the off-prod path where
+# misconfiguration or an attacker trying to exfiltrate the API key Basic
+# Auth header via SSRF. The check defends the off-prod path where
 # ``twilio_validate_signatures`` is disabled (otherwise signature
 # validation already ensures we only fetch what Twilio actually sent).
 _TWILIO_MEDIA_HOST_SUFFIXES = (".twilio.com", ".twiliocdn.com")
 
 
-# ---------------------------------------------------------------------------
-# Premium hooks
-# ---------------------------------------------------------------------------
-
-# Premium deployments provision one Twilio number per user. Two hooks plug
-# into per-user behavior:
-#
-#   FromResolver:  maps an outbound recipient phone back to that user's
-#                  own Twilio number so ``send_text``/``send_media`` can
-#                  pin ``from_`` correctly.
-#   ToVerifier:    on inbound, confirms that the webhook's ``(From, To)``
-#                  pair corresponds to a user's own provisioned Twilio
-#                  number. Without this, a user texting the wrong Twilio
-#                  number (e.g. typo, stale contact) would still route to
-#                  their own bot via the ``From``-based allowlist, but the
-#                  reply would come from a different number than the one
-#                  they texted — confusing UX. OSS leaves both unset and
-#                  the channel behaves as one global bot.
-FromResolver = Callable[[str], Awaitable[str | None]]
-ToVerifier = Callable[[str, str], Awaitable[bool]]
-
-_from_resolver: FromResolver | None = None
-_to_verifier: ToVerifier | None = None
-
-
-def set_twilio_from_resolver(fn: FromResolver) -> None:
-    """Register a callable that returns the per-user ``from_`` for an outbound recipient.
-
-    Called by the premium plugin during startup. ``fn`` receives the
-    recipient phone and returns the user's provisioned Twilio number, or
-    ``None`` to fall back to the global settings.
-    """
-    global _from_resolver
-    _from_resolver = fn
-
-
-def get_twilio_from_resolver() -> FromResolver | None:
-    """Return the current per-user resolver, or ``None`` when unset."""
-    return _from_resolver
-
-
-def set_twilio_to_verifier(fn: ToVerifier) -> None:
-    """Register a callable that confirms an inbound ``(From, To)`` pair is valid.
-
-    Called by the premium plugin during startup. ``fn`` receives
-    ``(from_phone, to_phone)`` and returns ``True`` if those identify a
-    consistent user / provisioned-number pairing. When the verifier
-    returns ``False`` or raises, the inbound webhook is dropped with a
-    200 + empty TwiML (so probing senders can't infer state).
-    """
-    global _to_verifier
-    _to_verifier = fn
-
-
-def get_twilio_to_verifier() -> ToVerifier | None:
-    """Return the current inbound ``(From, To)`` verifier, or ``None`` when unset."""
-    return _to_verifier
-
-
 class TwilioChannel(BaseChannel):
-    """Twilio implementation combining inbound webhooks and outbound SMS/MMS sending."""
+    """Twilio implementation combining inbound webhooks and outbound RCS/SMS/MMS sending."""
 
     def __init__(self, svc_settings: Settings | None = None) -> None:
         s = svc_settings or settings
         self._account_sid = s.twilio_account_sid
+        # Auth token is loaded for one job only: HMAC-SHA1 signature
+        # validation of inbound webhooks (``X-Twilio-Signature``). Twilio
+        # does not support any other webhook signing mechanism for SMS,
+        # and API keys cannot sign webhooks.
         self._auth_token = s.twilio_auth_token
+        # Standard API key + secret used for every outbound REST call
+        # (send messages, media download). Required for any REST
+        # operation; the channel refuses outbound work if either is
+        # missing rather than fall back to auth-token Basic Auth so the
+        # auth token's blast radius stays scoped to signature validation.
+        self._api_key_sid = s.twilio_api_key_sid
+        self._api_key_secret = s.twilio_api_key_secret
         self._client: TwilioClient | None = None
+
+    def _require_api_key(self) -> tuple[str, str]:
+        """Return ``(api_key_sid, api_key_secret)`` or raise if either is empty."""
+        if not self._api_key_sid or not self._api_key_secret:
+            msg = (
+                "Twilio API key required for REST calls. Set "
+                "TWILIO_API_KEY_SID and TWILIO_API_KEY_SECRET (Standard "
+                "key from Console > Account > API Keys & Tokens)."
+            )
+            raise RuntimeError(msg)
+        return self._api_key_sid, self._api_key_secret
 
     @property
     def client(self) -> TwilioClient:
         """Lazily create the Twilio REST client.
 
-        Construction is cheap but errors on empty credentials, so we defer
-        until the first send so an unconfigured deployment doesn't crash
-        at import time.
+        Authenticates with the Standard API key + secret (required).
+        API keys are revocable per-key and have a smaller blast radius
+        than the auth token; the auth token is loaded only for inbound
+        webhook signature validation.
         """
         if self._client is None:
-            self._client = TwilioClient(self._account_sid, self._auth_token)
+            api_key_sid, api_key_secret = self._require_api_key()
+            self._client = TwilioClient(api_key_sid, api_key_secret, self._account_sid)
         return self._client
 
     # -- BaseChannel identity --------------------------------------------------
@@ -169,10 +141,11 @@ class TwilioChannel(BaseChannel):
     async def is_allowed(self, sender_id: str, username: str) -> bool:
         """Return ``True`` if the sender passes the Twilio allowlist gate.
 
-        In premium mode the ``ChannelRoute`` override resolves this. In
-        OSS mode the static ``twilio_allowed_numbers`` setting applies:
-        empty denies all, ``"*"`` allows all, otherwise the sender must
-        match the configured E.164 number exactly.
+        In premium mode the ``ChannelRoute`` override resolves this
+        (one ``ChannelRoute`` row per user routes inbound by sender
+        phone). In OSS mode the static ``twilio_allowed_numbers`` setting
+        applies: empty denies all, ``"*"`` allows all, otherwise the
+        sender must match the configured E.164 number exactly.
         """
         return await self._check_static_allowlist(settings.twilio_allowed_numbers, sender_id)
 
@@ -238,28 +211,6 @@ class TwilioChannel(BaseChannel):
                 return Response(content=TWIML_EMPTY, media_type="application/xml")
 
             inbound = TwilioChannel.parse_form(form_data)
-
-            # Per-user deployments register a verifier that confirms the
-            # webhook's ``(From, To)`` pair corresponds to one user's own
-            # provisioned Twilio number. Dropping mismatches here keeps a
-            # user from accidentally receiving a reply from a different
-            # bot number than the one they texted. OSS leaves the
-            # verifier unset and this check is a no-op.
-            if inbound is not None and _to_verifier is not None:
-                to_phone = form_data.get("To", "")
-                try:
-                    ok = await _to_verifier(inbound.sender_id, to_phone)
-                except Exception:
-                    logger.exception(
-                        "Twilio to_verifier raised; dropping inbound to avoid misrouting",
-                    )
-                    return Response(content=TWIML_EMPTY, media_type="application/xml")
-                if not ok:
-                    logger.warning(
-                        "Twilio inbound: (From, To) pair does not match a known user; dropping"
-                    )
-                    return Response(content=TWIML_EMPTY, media_type="application/xml")
-
             await handle_webhook_inbound(channel, inbound)
             return Response(content=TWIML_EMPTY, media_type="application/xml")
 
@@ -267,79 +218,62 @@ class TwilioChannel(BaseChannel):
 
     # -- Outbound --------------------------------------------------------------
 
-    @staticmethod
-    async def _resolve_per_user_from(to: str) -> str | None:
-        """Ask the premium resolver for the user's own Twilio number, if any."""
-        resolver = _from_resolver
-        if resolver is None:
-            return None
-        try:
-            return await resolver(to)
-        except Exception:
-            # A resolver failure shouldn't block outbound delivery; fall
-            # back to the global sender. The resolver itself is expected
-            # to log its own failures.
-            logger.exception("Twilio from_resolver raised; falling back to global sender")
-            return None
-
-    def _send_kwargs(self, to: str, body: str, from_override: str | None = None) -> dict[str, Any]:
+    def _send_kwargs(self, to: str, body: str) -> dict[str, Any]:
         """Build kwargs for ``messages.create``.
 
-        Precedence: ``from_override`` (per-user, premium) > Messaging
-        Service SID (A2P 10DLC pool) > global ``twilio_phone_number``.
-        Raises ``RuntimeError`` when none is available.
+        Precedence: Messaging Service SID > ``twilio_phone_number``. The
+        Messaging Service is the right choice for RCS-capable deployments
+        because it handles SMS fallback automatically; a bare phone
+        number is the SMS-only fallback. Raises ``RuntimeError`` when
+        neither is set.
         """
         kwargs: dict[str, Any] = {"to": to, "body": body}
-        if from_override:
-            kwargs["from_"] = from_override
-        elif settings.twilio_messaging_service_sid:
+        if settings.twilio_messaging_service_sid:
             kwargs["messaging_service_sid"] = settings.twilio_messaging_service_sid
         elif settings.twilio_phone_number:
             kwargs["from_"] = settings.twilio_phone_number
         else:
             msg = (
                 "Twilio outbound requires either TWILIO_MESSAGING_SERVICE_SID "
-                "or TWILIO_PHONE_NUMBER to be set (or a registered per-user resolver)"
+                "or TWILIO_PHONE_NUMBER to be set"
             )
             raise RuntimeError(msg)
         return kwargs
 
     async def send_text(self, to: str, body: str) -> str:
-        """Send an SMS. *to* is an E.164 phone number. Returns the Twilio Message SID."""
-        from_override = await self._resolve_per_user_from(to)
-        kwargs = self._send_kwargs(to, body, from_override)
+        """Send a text message. *to* is an E.164 phone number. Returns the Twilio Message SID."""
+        kwargs = self._send_kwargs(to, body)
         message = await asyncio.to_thread(self.client.messages.create, **kwargs)
         return str(message.sid)
 
     async def send_media(self, to: str, body: str, media_url: str) -> str:
-        """Send an MMS with one media attachment. Returns the Twilio Message SID."""
-        from_override = await self._resolve_per_user_from(to)
-        kwargs = self._send_kwargs(to, body, from_override)
+        """Send a message with one media attachment. Returns the Twilio Message SID."""
+        kwargs = self._send_kwargs(to, body)
         kwargs["media_url"] = [media_url]
         message = await asyncio.to_thread(self.client.messages.create, **kwargs)
         return str(message.sid)
 
     async def send_message(self, to: str, body: str, media_urls: list[str] | None = None) -> str:
-        """Send SMS or MMS in a single API call.
+        """Send text or media in a single API call.
 
         Required override: Twilio accepts a list of media URLs on one
         ``messages.create`` call, so the multi-URL path should be one
-        MMS (up to 10 media items) instead of N separate sends.
+        message (up to 10 media items) instead of N separate sends.
         """
         if not media_urls:
             return await self.send_text(to, body)
-        from_override = await self._resolve_per_user_from(to)
-        kwargs = self._send_kwargs(to, body, from_override)
+        kwargs = self._send_kwargs(to, body)
         kwargs["media_url"] = list(media_urls)
         message = await asyncio.to_thread(self.client.messages.create, **kwargs)
         return str(message.sid)
 
     async def send_typing_indicator(self, to: str) -> None:
-        """Twilio SMS has no typing-indicator concept. No-op.
+        """No-op.
 
-        Implemented to satisfy ``BaseChannel`` without sending the user
-        misleading UX. Operators who need typing indicators should pick
-        Linq (iMessage/RCS) or BlueBubbles instead.
+        Twilio RCS shows typing indicators in the recipient's messaging
+        app automatically while a reply is being composed and delivered;
+        there is no separate API to trigger them. SMS recipients see
+        nothing either way. The override exists to satisfy ``BaseChannel``.
         """
         return None
 
@@ -347,20 +281,21 @@ class TwilioChannel(BaseChannel):
         """Download media from a Twilio MediaUrl.
 
         For Twilio, ``file_id`` is the full ``MediaUrl{N}`` from the
-        webhook form payload. The URL requires HTTP Basic Auth with the
-        account SID + auth token. Streams with the standard hard size
-        cap and wall-time deadline.
+        webhook form payload. The URL requires HTTP Basic Auth with
+        the Standard API key + secret. Streams with the standard hard
+        size cap and wall-time deadline.
 
         Refuses any URL that doesn't live on a Twilio-owned host. This
         is defense in depth against an attacker who slipped a webhook
         past signature validation (only possible when validation is off
         for dev): without this guard, ``MediaUrl0=http://internal/...``
-        would exfiltrate the account-SID Basic Auth header.
+        would exfiltrate the Basic Auth header.
         """
         if not _is_twilio_host(file_id):
             msg = f"Refusing to download media from non-Twilio host: {file_id}"
             raise ValueError(msg)
-        auth = httpx.BasicAuth(self._account_sid, self._auth_token)
+        api_key_sid, api_key_secret = self._require_api_key()
+        auth = httpx.BasicAuth(api_key_sid, api_key_secret)
         async with httpx.AsyncClient(auth=auth, timeout=settings.http_timeout_seconds) as client:
             content, headers = await download_bounded(client, file_id)
         content_type = headers.get("content-type", "application/octet-stream").split(";")[0]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -173,16 +173,26 @@ class Settings(BaseSettings):
     # outages, down for stricter "no replies to stale messages" behavior.
     bluebubbles_backfill_lookback_minutes: int = Field(default=30, ge=0)
 
-    # Twilio (SMS/MMS). Twilio does not expose typing indicators over SMS;
-    # the channel implements ``send_typing_indicator`` as a no-op. For
-    # iMessage/RCS with typing indicators see Linq or BlueBubbles.
+    # Twilio (RCS via Messaging Service, with SMS/MMS fallback). Register
+    # an RCS Agent in the Twilio console and attach it to a Messaging
+    # Service; Twilio routes RCS-capable recipients over RCS and falls
+    # back to SMS/MMS automatically for everyone else.
     twilio_account_sid: str = ""
+    # Auth token: required for inbound webhook signature validation.
+    # Twilio signs ``X-Twilio-Signature`` with HMAC-SHA1 keyed on this
+    # token and offers no alternative signing mechanism. The codebase
+    # loads it for nothing else; outbound REST uses the API key pair
+    # below.
     twilio_auth_token: str = ""
+    # Standard API key + secret. Required for every outbound REST call
+    # (send messages, media downloads). Create via Twilio Console >
+    # Account > API Keys & Tokens (Standard key).
+    twilio_api_key_sid: str = ""  # "SKxxxxxxxx..."
+    twilio_api_key_secret: str = ""
     # Outbound sender. Pin a specific phone number (E.164) OR a Messaging
-    # Service SID. Messaging Service is recommended for US A2P 10DLC
-    # deployments: numbers join the service's pool and the registered
-    # campaign covers all of them. When both are set, the Messaging Service
-    # SID wins.
+    # Service SID. Messaging Service is the right choice for RCS (the
+    # agent attaches to the service) and for US A2P 10DLC pools. When
+    # both are set, the Messaging Service SID wins.
     twilio_phone_number: str = ""  # E.164 format, e.g. "+15551234567"
     twilio_messaging_service_sid: str = ""  # "MGxxxxxxxx..."
     twilio_allowed_numbers: str = ""  # E.164 phone, "*", or empty (deny all)
@@ -313,6 +323,8 @@ PERSISTABLE_SETTINGS: frozenset[str] = frozenset(
         "bluebubbles_imessage_address",
         "twilio_account_sid",
         "twilio_auth_token",
+        "twilio_api_key_sid",
+        "twilio_api_key_secret",
         "twilio_phone_number",
         "twilio_messaging_service_sid",
         "twilio_allowed_numbers",

--- a/backend/app/config_store.py
+++ b/backend/app/config_store.py
@@ -61,6 +61,7 @@ _SECRET_SETTINGS: frozenset[str] = frozenset(
         "linq_webhook_signing_secret",
         "bluebubbles_password",
         "twilio_auth_token",
+        "twilio_api_key_secret",
     }
 )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -279,6 +279,15 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             else f"phone {mask_pii(settings.twilio_phone_number) or '<unset>'}"
         )
         logger.info("Twilio channel enabled (sender: %s)", sender)
+        if not settings.twilio_api_key_sid or not settings.twilio_api_key_secret:
+            logger.warning(
+                "Twilio account SID and auth token are set, but "
+                "TWILIO_API_KEY_SID and TWILIO_API_KEY_SECRET are not. "
+                "Inbound webhook signature validation will work, but every "
+                "outbound send will fail at runtime. Create a Standard API "
+                "key in the Twilio console (Account, API Keys & Tokens) and "
+                "set both env vars."
+            )
         if not settings.twilio_phone_number and not settings.twilio_messaging_service_sid:
             logger.warning(
                 "Twilio credentials are set but neither TWILIO_PHONE_NUMBER "

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -209,7 +209,11 @@ def _build_channel_config_response() -> ChannelConfigResponse:
         bluebubbles_configured=is_bluebubbles_configured(),
         bluebubbles_allowed_numbers=settings.bluebubbles_allowed_numbers,
         bluebubbles_imessage_address=settings.bluebubbles_imessage_address,
-        twilio_configured=bool(settings.twilio_account_sid and settings.twilio_auth_token),
+        twilio_configured=bool(
+            settings.twilio_account_sid
+            and settings.twilio_api_key_sid
+            and settings.twilio_api_key_secret
+        ),
         twilio_phone_number=settings.twilio_phone_number,
         twilio_messaging_service_sid=settings.twilio_messaging_service_sid,
         twilio_allowed_numbers=settings.twilio_allowed_numbers,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -166,9 +166,13 @@ class ChannelConfigResponse(BaseModel):
     # The UI uses this to render a single iMessage card without exposing which
     # backend powers it; None means iMessage is not configured on this server.
     imessage_backend: str | None = None
-    # Twilio (SMS/MMS). ``twilio_configured`` is true when both account SID
-    # and auth token are set (the minimum to talk to Twilio's API);
-    # outbound also needs either a phone number or a Messaging Service.
+    # Twilio (RCS via Messaging Service, with SMS/MMS fallback).
+    # ``twilio_configured`` requires the account SID plus the Standard API
+    # key pair used for REST calls; the auth token alone is not enough
+    # because outbound message creation now runs through API-key Basic
+    # auth. The auth token is still required separately for inbound
+    # webhook signature validation, but it is not part of the
+    # "ready to send" check.
     twilio_configured: bool = False
     twilio_phone_number: str = ""
     twilio_messaging_service_sid: str = ""
@@ -189,6 +193,8 @@ class ChannelConfigUpdate(BaseModel):
     bluebubbles_imessage_address: str | None = None
     twilio_account_sid: str | None = None
     twilio_auth_token: str | None = None
+    twilio_api_key_sid: str | None = None
+    twilio_api_key_secret: str | None = None
     twilio_phone_number: str | None = None
     twilio_messaging_service_sid: str | None = None
     twilio_allowed_numbers: str | None = None

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -79,20 +79,33 @@ When `LINQ_API_TOKEN` is set, the iMessage channel is powered by Linq and users 
 
 When `BLUEBUBBLES_SERVER_URL` and `BLUEBUBBLES_PASSWORD` are set, the iMessage channel is powered by BlueBubbles. [BlueBubbles](https://github.com/BlueBubblesApp/bluebubbles-server) is a free, open-source iMessage bridge that runs on any Mac with iMessage signed in.
 
-## Twilio (SMS/MMS)
+## Twilio (RCS with SMS/MMS fallback)
+
+The Twilio channel sends through a Messaging Service which can carry an RCS Agent for capable recipients and a phone-number pool for SMS fallback. RCS-capable recipients get rich messaging (branded sender, no character limits, optional read receipts and suggested-reply chips); everyone else receives SMS or MMS, decided by Twilio per recipient.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TWILIO_ACCOUNT_SID` | | Twilio account SID (`AC...`) |
-| `TWILIO_AUTH_TOKEN` | | Twilio auth token. Used for webhook signature validation and authenticating media URL downloads. |
-| `TWILIO_PHONE_NUMBER` | | E.164 outbound sender, e.g. `+15551234567`. Pinned as `from_` on every send. |
-| `TWILIO_MESSAGING_SERVICE_SID` | | Messaging Service SID (`MG...`). Use for US A2P 10DLC: the service holds a pool of campaign-registered numbers. When set, takes precedence over `TWILIO_PHONE_NUMBER`. |
+| `TWILIO_AUTH_TOKEN` | | Twilio account auth token. Loaded for one purpose only: validating `X-Twilio-Signature` on inbound webhooks. Twilio signs webhooks with HMAC-SHA1 keyed on this token and offers no alternative signing mechanism, so API keys cannot replace it for inbound. |
+| `TWILIO_API_KEY_SID` | | Standard API key SID (`SK...`). **Required** for every outbound REST call (send messages, media downloads). The channel refuses outbound work if missing rather than falling back to auth-token Basic Auth, so a leaked auth token cannot be replayed against the REST API. Create via Twilio Console > Account > API Keys & Tokens (Standard key). |
+| `TWILIO_API_KEY_SECRET` | | The API key's secret value. Shown once at key creation; record it then. |
+| `TWILIO_PHONE_NUMBER` | | E.164 fallback sender for SMS-only deployments, e.g. `+15551234567`. Ignored when `TWILIO_MESSAGING_SERVICE_SID` is set. |
+| `TWILIO_MESSAGING_SERVICE_SID` | | Messaging Service SID (`MG...`). Required for RCS; the RCS Agent attaches to the service. When set, takes precedence over `TWILIO_PHONE_NUMBER`. |
 | `TWILIO_ALLOWED_NUMBERS` | (empty) | E.164 phone number, `*` for all, or empty to deny all. |
 | `TWILIO_VALIDATE_SIGNATURES` | `true` | Validate `X-Twilio-Signature` on inbound webhooks. Leave on in production; turning off is only safe behind a private tunnel during local dev. |
 
-Twilio SMS has no typing-indicator concept, so the channel's `send_typing_indicator` is a no-op. If typing indicators on iMessage / RCS are required, use Linq or BlueBubbles instead.
+### RCS setup
 
-For US deployments, configure a Twilio Messaging Service with A2P 10DLC registration and set `TWILIO_MESSAGING_SERVICE_SID`. Toll-free numbers can skip 10DLC entirely; pin one via `TWILIO_PHONE_NUMBER` and complete Twilio's toll-free verification flow.
+1. Register your brand and an RCS Agent in the Twilio console. See [Twilio's RCS onboarding guide](https://www.twilio.com/docs/rcs/onboarding) for the brand/agent/carrier-approval workflow (allow 4-6 weeks for the first agent on an account; subsequent agents on an approved brand are faster).
+2. Create a Messaging Service and attach the RCS Agent to it. Add any backup SMS sender numbers (toll-free, long-code, or short-code) to the same service so RCS-incapable recipients get SMS without operator intervention.
+3. Configure the Messaging Service's inbound webhook (`A MESSAGE COMES IN`) to `https://<your host>/api/webhooks/twilio`, HTTP POST.
+4. Set `TWILIO_MESSAGING_SERVICE_SID` to the service SID. Do not set `TWILIO_PHONE_NUMBER`; the service decides the sender per recipient.
+
+Typing indicators are handled by the recipient's messaging app while a reply is in flight; there is no separate API to trigger them, and the channel's `send_typing_indicator` is a no-op.
+
+### SMS-only setup (no RCS)
+
+Skip the agent and Messaging Service. Set `TWILIO_PHONE_NUMBER` to a single E.164 sender and complete the relevant US verification flow (toll-free verification for `+18xx`, A2P 10DLC registration for long-code).
 
 ## Google Drive integration
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1706,6 +1706,28 @@
             ],
             "title": "Twilio Auth Token"
           },
+          "twilio_api_key_sid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twilio Api Key Sid"
+          },
+          "twilio_api_key_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twilio Api Key Secret"
+          },
           "twilio_phone_number": {
             "anyOf": [
               {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -333,55 +333,19 @@ const api = {
   getTwilioLink: async () => {
     const res = await fetch('/api/channels/twilio', { headers: _getAuthHeaders() });
     if (!res.ok) throw new Error('Failed to fetch Twilio link');
-    return res.json() as Promise<{
-      personal_phone: string | null;
-      twilio_phone_number: string | null;
-      status: string;
-      error_message: string;
-      connected: boolean;
-    }>;
+    return res.json() as Promise<{ phone_number: string | null; connected: boolean }>;
   },
-  // Provision a Twilio number for the current user. The server runs
-  // search + purchase synchronously, so this resolves with the final
-  // status ("active" on success, "failed" on inventory / Twilio errors).
-  connectTwilio: async (body: {
-    personal_phone: string;
-    number_type?: string;
-    area_code?: string;
-  }) => {
-    const res = await fetch('/api/channels/twilio/connect', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ..._getAuthHeaders() },
-      body: JSON.stringify(body),
-    });
-    if (!res.ok) {
-      const detail = await res.json().catch(() => ({})) as { detail?: string };
-      throw new Error(detail.detail || `Failed to connect: ${res.status}`);
-    }
-    return res.json() as Promise<{
-      personal_phone: string | null;
-      twilio_phone_number: string | null;
-      status: string;
-      error_message: string;
-      connected: boolean;
-    }>;
-  },
-  disconnectTwilio: async () => {
+  setTwilioLink: async (phoneNumber: string) => {
     const res = await fetch('/api/channels/twilio', {
-      method: 'DELETE',
-      headers: _getAuthHeaders(),
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ..._getAuthHeaders() },
+      body: JSON.stringify({ phone_number: phoneNumber }),
     });
     if (!res.ok) {
-      const detail = await res.json().catch(() => ({})) as { detail?: string };
-      throw new Error(detail.detail || `Failed to disconnect: ${res.status}`);
+      const body = await res.json().catch(() => ({})) as { detail?: string };
+      throw new Error(body.detail || `Failed to save: ${res.status}`);
     }
-    return res.json() as Promise<{
-      personal_phone: string | null;
-      twilio_phone_number: string | null;
-      status: string;
-      error_message: string;
-      connected: boolean;
-    }>;
+    return res.json() as Promise<{ phone_number: string | null; connected: boolean }>;
   },
 
   // Activity stream: real-time agent status from any channel.

--- a/frontend/src/components/ChannelConfigForm.tsx
+++ b/frontend/src/components/ChannelConfigForm.tsx
@@ -13,7 +13,6 @@ import api from '@/api';
 
 // Types derived from API return types, exported for consumers
 export type TelegramLinkData = Awaited<ReturnType<typeof api.getTelegramLink>>;
-export type TwilioLinkData = Awaited<ReturnType<typeof api.getTwilioLink>>;
 
 // Generic premium link data shape (all premium link endpoints share this structure)
 export type PremiumLinkData = { identifier: string | null; connected: boolean };
@@ -23,7 +22,6 @@ interface ChannelConfigFormProps {
   isPremium: boolean;
   channelConfig: ChannelConfigResponse | undefined;
   telegramLinkData: TelegramLinkData | null;
-  twilioLinkData: TwilioLinkData | null;
   premiumLinkData: PremiumLinkData | null;
   onSaved: () => void;
 }
@@ -32,14 +30,14 @@ export function ChannelConfigForm({ channelKey, isPremium, ...rest }: ChannelCon
   if (channelKey === 'telegram') {
     return isPremium ? <PremiumTelegramForm {...rest} /> : <OssTelegramForm {...rest} />;
   }
-  if (channelKey === 'twilio') {
-    return isPremium ? <PremiumTwilioForm {...rest} /> : <OssTwilioForm {...rest} />;
-  }
   if (isPremium) {
     const config = PREMIUM_LINK_CONFIGS[channelKey];
     if (config) {
       return <PremiumChannelLinkForm config={config} {...rest} />;
     }
+  }
+  if (channelKey === 'twilio') {
+    return <OssTwilioForm {...rest} />;
   }
   if (channelKey === 'linq') {
     return <OssLinqForm {...rest} />;
@@ -81,6 +79,15 @@ const PREMIUM_LINK_CONFIGS: Partial<Record<ChannelKey, PremiumLinkConfig>> = {
     placeholder: 'e.g. +15551234567 or user@icloud.com',
     helpText: 'The phone number or iCloud email you send iMessages from.',
     setLink: (id) => api.setBlueBubblesLink(id),
+  },
+  twilio: {
+    channelKey: 'twilio',
+    displayName: 'Twilio',
+    label: 'Your Phone Number',
+    placeholder: 'e.g. +15551234567',
+    helpText: "E.164 format phone number. This is the number you'll send messages from.",
+    inputMode: 'tel',
+    setLink: (id) => api.setTwilioLink(id),
   },
 };
 
@@ -439,185 +446,6 @@ function OssTwilioForm({ channelConfig, onSaved }: SubFormProps) {
       <div className="flex justify-end">
         <Button onClick={handleSave} disabled={updateMutation.isPending || channelConfig === undefined} isLoading={updateMutation.isPending}>
           Save
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-// --- Premium Twilio form (per-user number provisioning) ---
-
-const TWILIO_NUMBER_TYPES = [
-  { value: 'toll-free', label: 'Toll-free (+1 8xx)' },
-  { value: 'local', label: 'Local (US area code)' },
-] as const;
-
-function PremiumTwilioForm({ twilioLinkData, onSaved }: SubFormProps) {
-  // The connect form is shown when the user hasn't provisioned a number
-  // yet (status: not_provisioned / released / failed). Once active, we
-  // show the connected number plus a disconnect button.
-  const [personalPhone, setPersonalPhone] = useState('');
-  const [numberType, setNumberType] = useState<string>('toll-free');
-  const [areaCode, setAreaCode] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const status = twilioLinkData?.status ?? 'not_provisioned';
-  const isActive = status === 'active' && twilioLinkData?.twilio_phone_number;
-
-  // ``provisioning`` is a transient state, normally only seen for a few
-  // seconds during connect. If we land here on page load it usually
-  // means the previous connect request crashed mid-flow; the server
-  // recovers stale rows after a timeout but the user needs an escape
-  // hatch in the meantime. The Refresh button re-fetches the link
-  // state so the user can poll for resolution without a full reload.
-  if (status === 'provisioning') {
-    return (
-      <div className="grid gap-2">
-        <p className="text-sm">Provisioning your number...</p>
-        <p className="text-xs text-muted-foreground">This usually takes a few seconds.</p>
-        <div className="flex justify-end">
-          <Button onClick={onSaved} variant="secondary">
-            Refresh
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  if (isActive) {
-    return <PremiumTwilioConnected twilioLinkData={twilioLinkData!} onSaved={onSaved} />;
-  }
-
-  const handleConnect = async () => {
-    setError(null);
-    const normalized = normalizeUsPhone(personalPhone);
-    if (!isValidE164(normalized)) {
-      setError(PHONE_FORMAT_ERROR);
-      return;
-    }
-    setSubmitting(true);
-    try {
-      await api.connectTwilio({
-        personal_phone: normalized,
-        number_type: numberType,
-        area_code: areaCode.trim(),
-      });
-      toast.success('Twilio number provisioned');
-      onSaved();
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : 'Failed to connect Twilio';
-      setError(msg);
-      toast.error(msg);
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  // Previously-failed attempts surface the reason inline so the user
-  // can adjust (e.g. different area code) before retrying.
-  const previousError = status === 'failed' ? twilioLinkData?.error_message : '';
-
-  return (
-    <div className="grid gap-4">
-      {previousError && (
-        <p className="text-xs text-danger" role="alert">
-          Last attempt failed: {previousError}
-        </p>
-      )}
-      <Field label="Your Phone Number">
-        <Input
-          value={personalPhone}
-          onChange={(e) => {
-            setPersonalPhone(e.target.value);
-            if (error) setError(null);
-          }}
-          placeholder="e.g. +15551234567"
-          inputMode="tel"
-          aria-invalid={error ? true : undefined}
-          aria-describedby={error ? 'twilio-personal-error' : undefined}
-        />
-        {error ? (
-          <p id="twilio-personal-error" className="text-xs text-danger mt-1">{error}</p>
-        ) : (
-          <p className="text-xs text-muted-foreground mt-1">
-            E.164 format. Only this number will be able to message your assistant via SMS.
-          </p>
-        )}
-      </Field>
-      <Field label="Number Type">
-        <Select
-          value={numberType}
-          onChange={(e) => setNumberType(e.target.value)}
-          aria-label="Twilio number type"
-        >
-          {TWILIO_NUMBER_TYPES.map((t) => (
-            <option key={t.value} value={t.value}>{t.label}</option>
-          ))}
-        </Select>
-        <p className="text-xs text-muted-foreground mt-1">
-          Toll-free skips US A2P 10DLC registration. Local is cheaper per message but the operator
-          must have a registered messaging service.
-        </p>
-      </Field>
-      <Field label="Area Code (optional)">
-        <Input
-          value={areaCode}
-          onChange={(e) => setAreaCode(e.target.value)}
-          placeholder={numberType === 'toll-free' ? 'e.g. 800' : 'e.g. 415'}
-          inputMode="numeric"
-        />
-        <p className="text-xs text-muted-foreground mt-1">
-          Leave blank to let Twilio pick from available inventory.
-        </p>
-      </Field>
-      <div className="flex justify-end">
-        <Button onClick={handleConnect} disabled={submitting || !personalPhone} isLoading={submitting}>
-          Connect Twilio
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function PremiumTwilioConnected({
-  twilioLinkData,
-  onSaved,
-}: { twilioLinkData: TwilioLinkData; onSaved: () => void }) {
-  const [disconnecting, setDisconnecting] = useState(false);
-
-  const handleDisconnect = async () => {
-    setDisconnecting(true);
-    try {
-      await api.disconnectTwilio();
-      toast.success('Twilio disconnected');
-      onSaved();
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to disconnect');
-    } finally {
-      setDisconnecting(false);
-    }
-  };
-
-  return (
-    <div className="grid gap-3">
-      <div className="text-sm">
-        Text{' '}
-        <span className="font-mono font-medium text-primary">
-          {twilioLinkData.twilio_phone_number}
-        </span>{' '}
-        from{' '}
-        <span className="font-mono font-medium">{twilioLinkData.personal_phone}</span>{' '}
-        to chat with your assistant.
-      </div>
-      <div className="flex justify-end">
-        <Button
-          onClick={handleDisconnect}
-          isLoading={disconnecting}
-          disabled={disconnecting}
-          variant="secondary"
-        >
-          Disconnect
         </Button>
       </div>
     </div>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1029,6 +1029,10 @@ export interface components {
             twilio_account_sid?: string | null;
             /** Twilio Auth Token */
             twilio_auth_token?: string | null;
+            /** Twilio Api Key Sid */
+            twilio_api_key_sid?: string | null;
+            /** Twilio Api Key Secret */
+            twilio_api_key_secret?: string | null;
             /** Twilio Phone Number */
             twilio_phone_number?: string | null;
             /** Twilio Messaging Service Sid */

--- a/frontend/src/hooks/useChannelStates.ts
+++ b/frontend/src/hooks/useChannelStates.ts
@@ -20,7 +20,6 @@ import type { ChannelConfigResponse } from '@/types';
 import type {
   PremiumLinkData,
   TelegramLinkData,
-  TwilioLinkData,
 } from '@/components/ChannelConfigForm';
 
 type TelegramBotInfo = NonNullable<Awaited<ReturnType<typeof useTelegramBotInfo>>['data']>;
@@ -38,8 +37,6 @@ export interface ChannelStatesResult {
   linkDataMap: Partial<Record<ChannelKey, PremiumLinkData | null>>;
   /** Telegram-specific premium link data (for ChannelConfigForm). */
   telegramLinkData: TelegramLinkData | null;
-  /** Twilio-specific premium link data (for ChannelConfigForm). */
-  twilioLinkData: TwilioLinkData | null;
   /** Telegram bot info (premium only). */
   botInfo: TelegramBotInfo | null;
   /** Refresh premium link data for a specific channel after config save. */
@@ -82,22 +79,12 @@ export function useChannelStates(): ChannelStatesResult {
     const map: Partial<Record<ChannelKey, PremiumLinkData | null>> = {};
     if (linqLinkQuery.data) map.linq = normalizeLinkData(linqLinkQuery.data);
     if (blueBubblesLinkQuery.data) map.bluebubbles = normalizeLinkData(blueBubblesLinkQuery.data);
-    if (twilioLinkQuery.data) {
-      // Twilio's premium-link contract is "personal phone is linked + an
-      // active Twilio number is provisioned"; collapse to the generic
-      // PremiumLinkData shape so getChannelState's existing derivation
-      // works without a twilio-specific branch.
-      map.twilio = {
-        identifier: twilioLinkQuery.data.personal_phone,
-        connected: twilioLinkQuery.data.connected,
-      };
-    }
+    if (twilioLinkQuery.data) map.twilio = normalizeLinkData(twilioLinkQuery.data);
     return map;
   }, [linqLinkQuery.data, blueBubblesLinkQuery.data, twilioLinkQuery.data]);
 
   const telegramLinkData = telegramLinkQuery.data ?? null;
   const telegramUserId = telegramLinkData?.telegram_user_id;
-  const twilioLinkData = twilioLinkQuery.data ?? null;
   const botInfo = telegramBotInfoQuery.data ?? null;
 
   // Derive states (deps are all primitives or memoized objects for stable identity)
@@ -133,7 +120,6 @@ export function useChannelStates(): ChannelStatesResult {
     channelConfig,
     linkDataMap,
     telegramLinkData,
-    twilioLinkData,
     botInfo,
     invalidateLink,
   };

--- a/frontend/src/pages/ChannelsPage.tsx
+++ b/frontend/src/pages/ChannelsPage.tsx
@@ -15,7 +15,6 @@ import {
 import {
   ChannelConfigForm,
   type TelegramLinkData,
-  type TwilioLinkData,
   type PremiumLinkData,
 } from '@/components/ChannelConfigForm';
 import type { ChannelStatesResult } from '@/hooks/useChannelStates';
@@ -25,7 +24,7 @@ type TelegramBotInfo = ChannelStatesResult['botInfo'];
 export default function ChannelsPage() {
   const { isPremium } = useAuth();
   const toggleMutation = useToggleChannelRoute();
-  const { states: channelStates, channelConfig, telegramLinkData, twilioLinkData, botInfo, linkDataMap, invalidateLink } = useChannelStates();
+  const { states: channelStates, channelConfig, telegramLinkData, botInfo, linkDataMap, invalidateLink } = useChannelStates();
   const visibleChannels = getVisibleChannels(channelConfig);
   const routesQuery = useChannelRoutes();
   const imessageAddress = getImessageAddress(channelConfig);
@@ -165,7 +164,6 @@ export default function ChannelsPage() {
                     channelConfig={channelConfig}
                     botInfo={key === 'telegram' ? botInfo : null}
                     telegramLinkData={key === 'telegram' ? telegramLinkData : null}
-                    twilioLinkData={key === 'twilio' ? twilioLinkData : null}
                     premiumLinkData={linkDataMap[key] ?? null}
                     imessageAddress={imessageAddress}
                     verified={verifiedByChannel[key] ?? false}
@@ -193,7 +191,6 @@ export default function ChannelsPage() {
               channelConfig={channelConfig}
               botInfo={key === 'telegram' ? botInfo : null}
               telegramLinkData={key === 'telegram' ? telegramLinkData : null}
-              twilioLinkData={key === 'twilio' ? twilioLinkData : null}
               premiumLinkData={linkDataMap[key] ?? null}
               imessageAddress={imessageAddress}
               verified={verifiedByChannel[key] ?? false}
@@ -226,7 +223,6 @@ interface ChannelCardProps {
   channelConfig: ChannelStatesResult['channelConfig'];
   botInfo: TelegramBotInfo | null;
   telegramLinkData: TelegramLinkData | null;
-  twilioLinkData: TwilioLinkData | null;
   premiumLinkData: PremiumLinkData | null;
   imessageAddress: string | null;
   verified: boolean;
@@ -247,7 +243,6 @@ function ChannelCard({
   channelConfig,
   botInfo,
   telegramLinkData,
-  twilioLinkData,
   premiumLinkData,
   imessageAddress,
   verified,
@@ -339,14 +334,13 @@ function ChannelCard({
         </div>
       )}
 
-      {/* Twilio address banner. OSS uses the global twilio_phone_number;
-          premium uses the per-user provisioned number from the link. */}
+      {/* Twilio address banner. The operator-configured outbound sender
+          is the bot's address in both OSS and premium modes (premium
+          shares one Messaging Service across all users). */}
       {channelKey === 'twilio'
         && (state === 'configured' || state === 'active') && (
         (() => {
-          const address = isPremium
-            ? twilioLinkData?.twilio_phone_number
-            : channelConfig?.twilio_phone_number;
+          const address = channelConfig?.twilio_phone_number;
           if (!address) return null;
           return (
             <div className="mt-3 ml-7 text-sm">
@@ -415,7 +409,6 @@ function ChannelCard({
             isPremium={isPremium}
             channelConfig={channelConfig}
             telegramLinkData={telegramLinkData}
-            twilioLinkData={twilioLinkData}
             premiumLinkData={premiumLinkData}
             onSaved={onConfigSaved}
           />
@@ -441,7 +434,6 @@ function ChannelCard({
                 isPremium={isPremium}
                 channelConfig={channelConfig}
                 telegramLinkData={telegramLinkData}
-                twilioLinkData={twilioLinkData}
                 premiumLinkData={premiumLinkData}
                 onSaved={onConfigSaved}
               />

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -16,7 +16,7 @@ import {
 import { useAuth } from '@/contexts/AuthContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { getVisibleChannels, isServerAvailable, type ChannelKey } from '@/lib/channel-utils';
-import { ChannelConfigForm, type TelegramLinkData, type TwilioLinkData, type PremiumLinkData } from '@/components/ChannelConfigForm';
+import { ChannelConfigForm, type TelegramLinkData, type PremiumLinkData } from '@/components/ChannelConfigForm';
 import { normalizeUsPhone, isValidE164, PHONE_FORMAT_ERROR } from '@/lib/phone';
 import api from '@/api';
 
@@ -35,7 +35,6 @@ export default function GetStartedPage() {
 
   // Premium link data (fetched once, same pattern as ChannelsPage)
   const [telegramLinkData, setTelegramLinkData] = useState<TelegramLinkData | null>(null);
-  const [twilioLinkData, setTwilioLinkData] = useState<TwilioLinkData | null>(null);
   const [linkDataMap, setLinkDataMap] = useState<Partial<Record<ChannelKey, PremiumLinkData | null>>>({});
 
   useEffect(() => {
@@ -44,21 +43,13 @@ export default function GetStartedPage() {
       const fetchers: Partial<Record<ChannelKey, () => Promise<{ phone_number: string | null; connected: boolean }>>> = {
         linq: () => api.getLinqLink(),
         bluebubbles: () => api.getBlueBubblesLink(),
+        twilio: () => api.getTwilioLink(),
       };
       for (const [key, fetcher] of Object.entries(fetchers)) {
         fetcher().then((data) => {
           setLinkDataMap((prev) => ({ ...prev, [key]: { identifier: data.phone_number, connected: data.connected } }));
         }).catch(() => {});
       }
-      // Twilio uses a separate shape (personal_phone + twilio_phone_number);
-      // store the raw response and project into linkDataMap for state derivation.
-      api.getTwilioLink().then((data) => {
-        setTwilioLinkData(data);
-        setLinkDataMap((prev) => ({
-          ...prev,
-          twilio: { identifier: data.personal_phone, connected: data.connected },
-        }));
-      }).catch(() => {});
     }
   }, [isPremium]);
 
@@ -69,10 +60,10 @@ export default function GetStartedPage() {
   const bbAddress = channelConfig?.bluebubbles_imessage_address ?? '';
   const bbConfigured = channelConfig ? isServerAvailable('bluebubbles', channelConfig) : false;
   const telegramConfigured = channelConfig ? isServerAvailable('telegram', channelConfig) : false;
-  // For OSS Twilio the bot's number is operator-configured; for premium it
-  // comes from the per-user provisioned number on the link.
-  const twilioAddress =
-    twilioLinkData?.twilio_phone_number || channelConfig?.twilio_phone_number || '';
+  // Bot's outbound sender for display. Operator-configured in both OSS
+  // and premium modes (premium uses a single shared RCS/SMS sender via
+  // Messaging Service).
+  const twilioAddress = channelConfig?.twilio_phone_number || '';
   const [telegramBotInfo, setTelegramBotInfo] = useState<{ bot_username: string; bot_link: string } | null>(null);
   useEffect(() => {
     if (telegramConfigured) {
@@ -139,18 +130,10 @@ export default function GetStartedPage() {
   const handleConfigSaved = (key: ChannelKey) => {
     if (isPremium) {
       if (key === 'telegram') api.getTelegramLink().then(setTelegramLinkData).catch(() => {});
-      if (key === 'twilio') {
-        api.getTwilioLink().then((data) => {
-          setTwilioLinkData(data);
-          setLinkDataMap((prev) => ({
-            ...prev,
-            twilio: { identifier: data.personal_phone, connected: data.connected },
-          }));
-        }).catch(() => {});
-      }
       const fetchers: Partial<Record<ChannelKey, () => Promise<{ phone_number: string | null; connected: boolean }>>> = {
         linq: () => api.getLinqLink(),
         bluebubbles: () => api.getBlueBubblesLink(),
+        twilio: () => api.getTwilioLink(),
       };
       const fetcher = fetchers[key];
       if (fetcher) {
@@ -277,7 +260,6 @@ export default function GetStartedPage() {
                     isPremium={isPremium}
                     channelConfig={channelConfig}
                     telegramLinkData={telegramLinkData}
-                    twilioLinkData={twilioLinkData}
                     premiumLinkData={linkDataMap[selectedChannel] ?? null}
                     onSaved={() => handleConfigSaved(selectedChannel)}
                   />

--- a/tests/test_twilio_channel.py
+++ b/tests/test_twilio_channel.py
@@ -269,80 +269,12 @@ async def test_send_message_sends_one_mms_for_multiple_media() -> None:
     assert kwargs["body"] == "two pics"
 
 
-async def test_per_user_from_resolver_overrides_global_sender() -> None:
-    """When a from_resolver is registered, its return value pins from_ per recipient."""
-    from backend.app.channels.twilio import set_twilio_from_resolver
-
-    channel, mock_client = _make_channel_with_mocked_client()
-
-    async def resolver(to: str) -> str | None:
-        return "+18001111111" if to == "+15551234567" else None
-
-    set_twilio_from_resolver(resolver)
-    try:
-        with patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"):
-            await channel.send_text("+15551234567", "hi")
-    finally:
-        # Reset so other tests aren't poisoned by this one's resolver.
-        import backend.app.channels.twilio as twilio_mod
-
-        twilio_mod._from_resolver = None
-
-    kwargs = mock_client.messages.create.call_args.kwargs
-    # The per-user resolver should win over the global TWILIO_PHONE_NUMBER.
-    assert kwargs["from_"] == "+18001111111"
-
-
-async def test_per_user_from_resolver_falls_back_when_none() -> None:
-    """A resolver that returns None falls back to the global Twilio sender."""
-    from backend.app.channels.twilio import set_twilio_from_resolver
-
-    channel, mock_client = _make_channel_with_mocked_client()
-
-    async def resolver(to: str) -> str | None:
-        return None
-
-    set_twilio_from_resolver(resolver)
-    try:
-        with patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"):
-            await channel.send_text("+15551234567", "hi")
-    finally:
-        import backend.app.channels.twilio as twilio_mod
-
-        twilio_mod._from_resolver = None
-
-    kwargs = mock_client.messages.create.call_args.kwargs
-    assert kwargs["from_"] == "+15550000001"
-
-
-async def test_per_user_resolver_failure_falls_back_to_global() -> None:
-    """A resolver that raises should not block the send; we fall back to global."""
-    from backend.app.channels.twilio import set_twilio_from_resolver
-
-    channel, mock_client = _make_channel_with_mocked_client()
-
-    async def resolver(to: str) -> str | None:
-        raise RuntimeError("db unreachable")
-
-    set_twilio_from_resolver(resolver)
-    try:
-        with patch("backend.app.channels.twilio.settings.twilio_phone_number", "+15550000001"):
-            sid = await channel.send_text("+15551234567", "hi")
-    finally:
-        import backend.app.channels.twilio as twilio_mod
-
-        twilio_mod._from_resolver = None
-
-    assert sid == "SMabcdef"
-    kwargs = mock_client.messages.create.call_args.kwargs
-    assert kwargs["from_"] == "+15550000001"
-
-
 async def test_send_typing_indicator_is_noop() -> None:
     """send_typing_indicator must not raise and must not touch the SDK.
 
-    SMS has no typing-indicator concept; the override exists only to
-    satisfy BaseChannel.
+    Twilio RCS typing indicators are managed by the recipient's
+    messaging app; there is no separate API to trigger them. The
+    override exists only to satisfy BaseChannel.
     """
     channel, mock_client = _make_channel_with_mocked_client()
     await channel.send_typing_indicator("+15551234567")
@@ -354,15 +286,15 @@ async def test_send_typing_indicator_is_noop() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_download_media_uses_basic_auth(monkeypatch: pytest.MonkeyPatch) -> None:
-    """download_media authenticates with the account SID + auth token."""
+async def test_download_media_uses_api_key_basic_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """download_media authenticates with the Standard API key + secret."""
+    import base64
+
     captured_auth: list[httpx.BasicAuth] = []
 
     async def fake_download_bounded(
         client: httpx.AsyncClient, url: str
     ) -> tuple[bytes, httpx.Headers]:
-        # Capture the auth attached to the client so the test can verify
-        # we passed Basic Auth instead of a raw Bearer.
         captured_auth.append(client.auth)  # type: ignore[arg-type]
         return b"image-bytes", httpx.Headers({"content-type": "image/jpeg"})
 
@@ -371,6 +303,8 @@ async def test_download_media_uses_basic_auth(monkeypatch: pytest.MonkeyPatch) -
     channel = TwilioChannel()
     channel._account_sid = "ACtest"
     channel._auth_token = "tkn"
+    channel._api_key_sid = "SKtest"
+    channel._api_key_secret = "secret"
 
     media = await channel.download_media(
         "https://api.twilio.com/Accounts/AC0/Messages/MM0/Media/ME0"
@@ -380,6 +314,30 @@ async def test_download_media_uses_basic_auth(monkeypatch: pytest.MonkeyPatch) -
     assert media.mime_type == "image/jpeg"
     assert media.filename.endswith(".jpg")
     assert isinstance(captured_auth[0], httpx.BasicAuth)
+    header = captured_auth[0]._auth_header
+    encoded = header.removeprefix("Basic ")
+    assert base64.b64decode(encoded).decode() == "SKtest:secret"
+
+
+async def test_download_media_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """download_media must not fall back to auth-token Basic Auth."""
+    called = False
+
+    async def fake_download_bounded(*_args: object, **_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        return b"", httpx.Headers()
+
+    monkeypatch.setattr("backend.app.channels.twilio.download_bounded", fake_download_bounded)
+
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+    # No API key configured.
+
+    with pytest.raises(RuntimeError, match="TWILIO_API_KEY_SID"):
+        await channel.download_media("https://api.twilio.com/Accounts/AC0/Messages/MM0/Media/ME0")
+    assert called is False
 
 
 async def test_download_media_rejects_non_twilio_host(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -387,7 +345,7 @@ async def test_download_media_rejects_non_twilio_host(monkeypatch: pytest.Monkey
 
     Defense in depth: even if signature validation is off and a malicious
     webhook injects ``MediaUrl0=http://internal/...``, we must not send
-    the account-SID Basic Auth header to that host.
+    the API key Basic Auth header to that host.
     """
     called = False
 
@@ -401,88 +359,38 @@ async def test_download_media_rejects_non_twilio_host(monkeypatch: pytest.Monkey
     channel = TwilioChannel()
     channel._account_sid = "ACtest"
     channel._auth_token = "tkn"
+    channel._api_key_sid = "SKtest"
+    channel._api_key_secret = "secret"
 
     with pytest.raises(ValueError, match="non-Twilio host"):
         await channel.download_media("http://attacker.example.com/leak")
     assert called is False
 
 
-async def test_to_verifier_drops_inbound_when_pair_unknown(
-    twilio_client: httpx.AsyncClient,
-) -> None:
-    """A registered To-verifier returning False causes the webhook to drop the message."""
-    from backend.app.channels.twilio import set_twilio_to_verifier
-
-    seen: list[tuple[str, str]] = []
-
-    async def verifier(from_phone: str, to_phone: str) -> bool:
-        seen.append((from_phone, to_phone))
-        return False
-
-    set_twilio_to_verifier(verifier)
-    try:
-        with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
-            form = make_twilio_form(sender="+15555555555", to="+18001111111", text="hi")
-            resp = await _post_form(twilio_client, form)
-    finally:
-        import backend.app.channels.twilio as twilio_mod
-
-        twilio_mod._to_verifier = None
-
-    assert resp.status_code == 200
-    assert resp.text == TWIML_EMPTY
-    mock_pub.assert_not_called()
-    assert seen == [("+15555555555", "+18001111111")]
+async def test_client_property_requires_api_key() -> None:
+    """The REST client refuses to construct without an API key + secret."""
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+    with pytest.raises(RuntimeError, match="TWILIO_API_KEY_SID"):
+        _ = channel.client
 
 
-async def test_to_verifier_accepts_inbound_when_pair_matches(
-    twilio_client: httpx.AsyncClient,
-) -> None:
-    """A verifier returning True lets the message through to the bus."""
-    from backend.app.channels.twilio import set_twilio_to_verifier
+async def test_client_property_uses_api_key_when_configured() -> None:
+    """When API key is set, the SDK Client is built with the key pair."""
+    from twilio.rest import Client as TwilioClient
 
-    async def verifier(from_phone: str, to_phone: str) -> bool:
-        return True
+    channel = TwilioChannel()
+    channel._account_sid = "ACtest"
+    channel._auth_token = "tkn"
+    channel._api_key_sid = "SKtest"
+    channel._api_key_secret = "secret"
 
-    set_twilio_to_verifier(verifier)
-    try:
-        with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
-            form = make_twilio_form(text="ok")
-            await _post_form(twilio_client, form)
-    finally:
-        import backend.app.channels.twilio as twilio_mod
-
-        twilio_mod._to_verifier = None
-
-    mock_pub.assert_called_once()
-
-
-async def test_to_verifier_exception_drops_inbound(
-    twilio_client: httpx.AsyncClient,
-) -> None:
-    """A verifier that raises should drop the message, not 500.
-
-    Choosing drop-on-error rather than fall-back-to-allow because the
-    verifier is the *security* hook for premium; the from-resolver is
-    the *outbound* hook where failure can safely degrade.
-    """
-    from backend.app.channels.twilio import set_twilio_to_verifier
-
-    async def verifier(from_phone: str, to_phone: str) -> bool:
-        raise RuntimeError("db unreachable")
-
-    set_twilio_to_verifier(verifier)
-    try:
-        with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
-            form = make_twilio_form()
-            resp = await _post_form(twilio_client, form)
-    finally:
-        import backend.app.channels.twilio as twilio_mod
-
-        twilio_mod._to_verifier = None
-
-    assert resp.status_code == 200
-    mock_pub.assert_not_called()
+    client = channel.client
+    assert isinstance(client, TwilioClient)
+    assert client.username == "SKtest"
+    assert client.password == "secret"
+    assert client.account_sid == "ACtest"
 
 
 async def test_parse_form_warns_on_missing_message_sid(


### PR DESCRIPTION
## Description

Rips out the per-user Twilio extension surface and switches to a single shared sender model (RCS via Messaging Service, with SMS/MMS auto-fallback). The OSS Twilio channel now:

- Routes inbound webhooks by `From` via the existing OSS `ChannelRoute` lookup, the same pattern Telegram and BlueBubbles already use. No more `FromResolver` / `ToVerifier` extension points.
- Requires a Standard Twilio API key (`TWILIO_API_KEY_SID` + `TWILIO_API_KEY_SECRET`) for all REST calls. The account auth token is retained only for inbound webhook `X-Twilio-Signature` validation (Twilio's API keys cannot sign webhooks).
- Drops the per-user-number provisioning hook (`set_twilio_from_resolver` / `_resolve_per_user_from`) and the corresponding `from_override` parameter on `send_text` / `send_media` / `send_message`.

Frontend mirrors the change: the "connect Twilio" flow is now a plain phone-number link (same shape as BlueBubbles/Linq), `TwilioLinkData` is gone, and the channel form has no Twilio-specific branch left.

This is the prerequisite for premium switching to a single-sender RCS architecture (mozilla-ai/clawbolt-premium follow-up PR). Premium previously layered per-user provisioning on top of these hooks; with the hooks gone, premium converges on the same shape it uses for every other channel.

## Type
- [x] Refactor

## Checklist
- [x] Tests pass (`uv run pytest -v` on `tests/test_twilio_channel.py`: 20 passed)
- [x] Lint passes (`ruff check backend/ tests/ alembic/ && ruff format --check`)
- [x] Type checking passes (`uv run ty check --python .venv backend/ tests/ alembic/`)
- [x] Frontend typecheck passes (`cd frontend && npm run typecheck`)
- [x] OpenAPI spec + generated types regenerated (no drift)
- [x] `.env.example` and `docs/self-host/configuration.md` updated for RCS/API-key setup

## AI Usage
- [x] AI-assisted: drafted with Claude Code, reviewed and shaped iteratively by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)