### PR TITLE
chore: ignore .playwright-mcp/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ frontend/dist/
 node_modules/
 playwright-report/
 test-results/
+.playwright-mcp/
 
 # Docs site
 docs/node_modules/


### PR DESCRIPTION
## Description

Adds `.playwright-mcp/` to `.gitignore` so the Playwright MCP runtime directory does not get committed.

## Type
- [x] CI/CD

## Checklist
- [x] Tests pass (n/a, gitignore-only)
- [x] Lint passes (n/a)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude drafted the change and PR per user instruction)