### PR TITLE
fix(stores): lock ToolConfig row with SELECT FOR UPDATE in set_enabled

### DIFF
--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -531,8 +531,16 @@ def _tool_config_disabled_names_select(user_id: str) -> Select[tuple[str]]:
 
 
 def _tool_config_by_name_select(user_id: str, name: str) -> Select[tuple[ToolConfig]]:
-    """Builder shared by the ``set_enabled`` / ``set_enabled_async`` paths."""
-    return select(ToolConfig).filter_by(user_id=user_id, name=name)
+    """Builder shared by the ``set_enabled`` / ``set_enabled_async`` paths.
+
+    Locks the ``(user_id, name)`` row with ``FOR UPDATE`` so two concurrent
+    toggles serialize through the row lock instead of racing a stale
+    read-modify-write (issue #1222). When no row exists yet, the lock is
+    a no-op and the unique constraint on ``(user_id, name)`` arbitrates
+    the insert race: the loser catches ``IntegrityError``, rolls back,
+    and re-runs this same locked read which now finds the winner's row.
+    """
+    return select(ToolConfig).filter_by(user_id=user_id, name=name).with_for_update()
 
 
 def _tool_config_disabled_sub_tools_select(user_id: str) -> Select[tuple[str]]:
@@ -633,15 +641,36 @@ class ToolConfigStore:
         Creates or updates a ToolConfig row for the given factory name.
         Only stores the name and enabled flag; the router fills in display
         metadata from the registry when building the full tool list.
+
+        The ``(user_id, name)`` row is read under ``SELECT ... FOR UPDATE``
+        so two concurrent toggles serialize on the row lock and the last
+        writer wins (issue #1222). When no row exists yet, the loser of
+        the insert race catches the unique-constraint ``IntegrityError``,
+        rolls back, and re-runs the locked read against the winner's row.
         """
         async with db_session_async() as db:
             existing = (
                 await db.execute(_tool_config_by_name_select(self.user_id, name))
             ).scalar_one_or_none()
-            if existing:
+            if existing is not None:
                 existing.enabled = enabled
-            else:
-                db.add(_new_disabled_tool_config(self.user_id, name, enabled))
+                await db.commit()
+                return
+            db.add(_new_disabled_tool_config(self.user_id, name, enabled))
+            try:
+                await db.commit()
+                return
+            except IntegrityError:
+                await db.rollback()
+            existing = (
+                await db.execute(_tool_config_by_name_select(self.user_id, name))
+            ).scalar_one_or_none()
+            if existing is None:
+                raise RuntimeError(
+                    f"set_enabled: ToolConfig row for user_id={self.user_id} "
+                    f"name={name!r} vanished after IntegrityError on insert"
+                )
+            existing.enabled = enabled
             await db.commit()
 
     async def set_enabled_async(self, name: str, enabled: bool) -> None:

--- a/tests/test_tool_config_store_async.py
+++ b/tests/test_tool_config_store_async.py
@@ -9,13 +9,16 @@ PR #1199.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import uuid
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from backend.app.agent.dto import ToolConfigEntry
 from backend.app.agent.stores import ToolConfigStore
+from backend.app.database import db_session_async
 from backend.app.models import ToolConfig, User
 
 # ---------------------------------------------------------------------------
@@ -245,6 +248,116 @@ async def test_async_get_disabled_sub_tool_names_empty(
     store = ToolConfigStore(async_test_user.id)
     await store.save_async([_entry("workspace")])
     assert await store.get_disabled_sub_tool_names_async() == set()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: SELECT FOR UPDATE on set_enabled (issue #1222)
+# ---------------------------------------------------------------------------
+#
+# These tests deliberately do NOT use the ``async_db`` fixture. ``async_db``
+# rebinds the session factory to a single shared connection so writes can
+# be rolled back, which would serialize concurrent ``set_enabled`` calls
+# at the connection level and hide the production race. The session-scoped
+# NullPool engine instead gives each ``AsyncSessionLocal()`` its own
+# asyncpg connection, so concurrent tasks contend on the real Postgres
+# row lock (and the real unique constraint). Cleanup is handled by the
+# autouse ``_isolate_stores`` fixture, which TRUNCATEs every table after
+# each test.
+
+
+async def _insert_concurrency_user() -> str:
+    """Insert a fresh User row through the session-scoped factory and
+    return its id. Bypasses ``async_test_user`` so the row is committed
+    on a normal connection (visible to concurrent tasks) rather than
+    living inside the ``async_db`` SAVEPOINT."""
+    user_id = str(uuid.uuid4())
+    async with db_session_async() as db:
+        db.add(
+            User(
+                id=user_id,
+                user_id=f"concurrency-{user_id[:8]}",
+                phone="+15555550123",
+                channel_identifier=f"concurrency-channel-{user_id[:8]}",
+                preferred_channel="telegram",
+                onboarding_complete=True,
+            )
+        )
+        await db.commit()
+    return user_id
+
+
+async def test_set_enabled_insert_race_does_not_raise() -> None:
+    """Two concurrent ``set_enabled`` calls on the same ``(user_id, name)``
+    when no row exists yet. The unique constraint on ``(user_id, name)``
+    lets only one INSERT win; the loser catches ``IntegrityError``,
+    rolls back, re-runs the locked read, and updates the winner's row.
+
+    Without the ``IntegrityError`` retry, the loser would surface the
+    exception to the caller. Without the ``with_for_update()`` on the
+    re-read, the loser could read a stale snapshot and miss the
+    winning row.
+    """
+    user_id = await _insert_concurrency_user()
+    store = ToolConfigStore(user_id)
+    name = "concurrent-insert-tool"
+    start = asyncio.Event()
+
+    async def toggle(value: bool) -> None:
+        await start.wait()
+        await store.set_enabled(name, value)
+
+    task_a = asyncio.create_task(toggle(True))
+    task_b = asyncio.create_task(toggle(False))
+    start.set()
+    await asyncio.gather(task_a, task_b)
+
+    async with db_session_async() as db:
+        rows = (
+            (await db.execute(select(ToolConfig).filter_by(user_id=user_id, name=name)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1, (
+        f"expected exactly one row after concurrent inserts, got {len(rows)}: "
+        f"the unique constraint should have collapsed the race"
+    )
+    # Final state matches one of the two writers. The exact value is
+    # non-deterministic (depends on scheduling), but it must be a clean
+    # boolean from one of the two callers, not a corrupted state.
+    assert rows[0].enabled in (True, False)
+
+
+async def test_set_enabled_update_race_serializes_via_row_lock() -> None:
+    """Two concurrent ``set_enabled`` calls on a pre-existing row
+    serialize on the ``SELECT ... FOR UPDATE`` row lock. Exactly one
+    row remains (no duplicate insert) and the final state matches
+    whichever transaction committed last."""
+    user_id = await _insert_concurrency_user()
+    store = ToolConfigStore(user_id)
+    name = "concurrent-update-tool"
+    # Seed the row so both contenders take the update path.
+    await store.set_enabled(name, True)
+
+    start = asyncio.Event()
+
+    async def toggle(value: bool) -> None:
+        await start.wait()
+        await store.set_enabled(name, value)
+
+    task_a = asyncio.create_task(toggle(True))
+    task_b = asyncio.create_task(toggle(False))
+    start.set()
+    await asyncio.gather(task_a, task_b)
+
+    async with db_session_async() as db:
+        count = (
+            await db.scalar(select(func.count(ToolConfig.id)).where(ToolConfig.user_id == user_id))
+        ) or 0
+        row = (
+            await db.execute(select(ToolConfig).filter_by(user_id=user_id, name=name))
+        ).scalar_one()
+    assert count == 1
+    assert row.enabled in (True, False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Adds a row-level lock to `ToolConfigStore.set_enabled` so two concurrent toggles on the same `(user_id, name)` row cannot race a stale read-modify-write or hit the unique constraint on a duplicate INSERT.

- `_tool_config_by_name_select` now ends in `.with_for_update()`. Concurrent toggles on an existing row serialize on the Postgres row lock and last-writer-wins.
- `set_enabled` catches `IntegrityError` on the INSERT path. FOR UPDATE alone cannot lock an absent row, so the unique constraint on `(user_id, name)` arbitrates the insert race instead. The loser rolls back, re-runs the now-locked read, and updates the winner's row. Mirrors the established pattern in `backend/app/agent/ingestion.py::_get_or_create_user`.
- Note on AC wording: the dual sync+async surface was already collapsed by #1160. `set_enabled_async` is a thin alias delegating to `set_enabled`, so the lock applies to both names automatically.

Fixes #1222

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Two regression tests added in `tests/test_tool_config_store_async.py`:

- `test_set_enabled_insert_race_does_not_raise` exercises the absent-row case: two concurrent tasks racing to INSERT the same `(user_id, name)`. Without the production fix, one task surfaces `UniqueViolationError`; I verified the test fails on the pre-fix tree and passes on the post-fix tree.
- `test_set_enabled_update_race_serializes_via_row_lock` exercises the existing-row case: two concurrent tasks toggling a pre-seeded row. Exactly one row remains and the value is a clean boolean from one of the two callers.

Both tests deliberately skip the `async_db` fixture (which serializes through a single shared connection and hides the production race) and rely on the session-scoped NullPool engine so each task gets its own asyncpg connection through `db_session_async()`.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Drafted by Claude Code via back-and-forth with @njbrake. The reasoning and decisions are his; the prose and code edits are Claude's.