### PR TITLE
fix(companycam): idempotent retry on evicted handle; require explicit original_url

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import random
 import re
@@ -122,6 +123,21 @@ def _scrub_secrets(text: str) -> str:
 _ToolEntry = tuple[int, Tool, dict[str, Any]]
 """(parsed_calls index, Tool, validated args). Threaded through the per-turn
 execution pipeline by validation, approval, and the parallel scheduler."""
+
+
+def _normalize_tool_args(args: dict[str, Any]) -> str:
+    """Canonical string form of validated tool args for duplicate detection.
+
+    Stable across dict iteration order so the same logical call always
+    hashes to the same key, regardless of how the LLM emitted the keys.
+    ``default=str`` so an unexpected non-JSON value cannot crash the
+    telemetry path; the goal here is a diagnostic signal, not a perfect
+    encoder.
+    """
+    try:
+        return json.dumps(args, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return repr(sorted(args.items()))
 
 
 def _resolve_concurrency_group(tool: Tool, validated_args: dict[str, Any]) -> str | None:
@@ -668,6 +684,16 @@ class ClawboltAgent:
         pre_validated: list[tuple[int, Tool, dict[str, Any]]] = []
         tool_results: list[ToolResultMessage] = []
 
+        # Snapshot every (tool_name, normalized_args) pair the model has
+        # already invoked in this turn (across prior rounds). Used to emit
+        # a telemetry warning when the model fires the same call again,
+        # which is how the CompanyCam upload-storm shows up in transcripts.
+        # ``seen_in_round`` catches duplicates within this round's batch.
+        seen_in_prior_rounds: set[tuple[str, str]] = {
+            (rec.name, _normalize_tool_args(rec.args)) for rec in tool_call_records
+        }
+        seen_in_round: set[tuple[str, str]] = set()
+
         for i, tc_req in enumerate(parsed_calls):
             tool_name = tc_req.name
             tool_args = tc_req.arguments
@@ -739,6 +765,20 @@ class ClawboltAgent:
                     )
                 )
                 continue
+
+            dup_key = (tool_name, _normalize_tool_args(validated_args))
+            if dup_key in seen_in_prior_rounds or dup_key in seen_in_round:
+                # Diagnostic only: do not block. The model legitimately
+                # retries on transient errors, so an aggressive short-
+                # circuit would mask real workflows. The structured
+                # warning lets us measure the pattern across users.
+                logger.warning(
+                    "duplicate_tool_call_within_turn user=%s tool=%s args=%s",
+                    self.user.id,
+                    tool_name,
+                    dup_key[1],
+                )
+            seen_in_round.add(dup_key)
 
             pre_validated.append((i, tool_obj, validated_args))
 

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -9,6 +9,13 @@ Each staged entry gets a short handle token (``media_XXXXXX``) so tools
 can reference the bytes without passing raw channel URLs through the
 prompt. Both lookup styles work; the handle-based API is what the agent
 sees.
+
+This module also tracks a short-lived ``recently_uploaded`` record for each
+``(user_id, original_url)``. After a tool successfully ships the bytes to
+an external service (CompanyCam, etc.) it both ``evict``s the bytes and
+``mark_uploaded``s an ``UploadRecord`` so a same-turn retry on the same
+handle can return an idempotent "already uploaded" result instead of the
+generic "No photo available" error.
 """
 
 from __future__ import annotations
@@ -16,16 +23,44 @@ from __future__ import annotations
 import logging
 import secrets
 import time
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
 STAGING_TTL_SECONDS = 86400  # 24h: long agent sessions can span multiple hours
 STAGING_MAX_PER_USER = 50  # Cap memory growth: oldest-expiring entry is evicted on overflow
 
+# Recently-uploaded receipt cache. Shorter TTL than staging because its job
+# is only to absorb same-turn / same-day retries on a handle the model
+# already shipped. Anything older than this should not look like a fresh
+# success on retry; the tool can return its normal NOT_FOUND.
+UPLOAD_RECORD_TTL_SECONDS = 3600  # 1h
+UPLOAD_RECORD_MAX_PER_USER = 200
+
+
+@dataclass(frozen=True)
+class UploadRecord:
+    """A receipt of a successful external upload, scoped to a (user, handle).
+
+    Returned by :func:`get_uploaded` so a tool that finds its staged bytes
+    already evicted can re-emit the same external receipt instead of an
+    error. Tools should populate ``service`` with a short identifier
+    (e.g. ``"companycam"``) so a future cross-service handle reuse cannot
+    surface the wrong receipt.
+    """
+
+    service: str
+    external_id: str
+    url: str
+    target: str
+    status: str  # "uploaded", "duplicate", "pending", "processing_error"
+
 
 _cache: dict[str, dict[str, tuple[bytes, str, float, str]]] = {}
 # handle token -> (user_id, original_url) reverse index
 _handles: dict[str, tuple[str, str]] = {}
+# user_id -> {original_url: (UploadRecord, expires_at)} recently-uploaded receipts
+_uploaded: dict[str, dict[str, tuple[UploadRecord, float]]] = {}
 
 
 def _mint_handle() -> str:
@@ -204,7 +239,12 @@ def resolve_media_ref(user_id: str, ref: str) -> tuple[str, bytes, str] | None:
 
 
 def evict(user_id: str, original_url: str) -> None:
-    """Remove a staged entry (call after successful upload or explicit deny)."""
+    """Remove a staged entry (call after successful upload or explicit deny).
+
+    The upload-record cache is intentionally NOT cleared here; a same-turn
+    retry on the same handle still needs to find the receipt. Records age
+    out via their own TTL.
+    """
     user_items = _cache.get(user_id)
     if not user_items:
         return
@@ -213,6 +253,86 @@ def evict(user_id: str, original_url: str) -> None:
         _handles.pop(entry[3], None)
     if not user_items:
         _cache.pop(user_id, None)
+
+
+def mark_uploaded(
+    user_id: str,
+    original_url: str,
+    *,
+    service: str,
+    external_id: str,
+    url: str,
+    target: str,
+    status: str,
+) -> None:
+    """Record that ``original_url`` was successfully shipped to *service*.
+
+    Call right before :func:`evict` on the success path of an external
+    upload tool. A later tool call referencing the same handle (within
+    :data:`UPLOAD_RECORD_TTL_SECONDS`) can then look up the record via
+    :func:`get_uploaded` and return an idempotent receipt instead of
+    failing with "No photo available."
+    """
+    if not original_url:
+        return
+    _purge_expired_uploads()
+    expires_at = time.monotonic() + UPLOAD_RECORD_TTL_SECONDS
+    record = UploadRecord(
+        service=service,
+        external_id=external_id,
+        url=url,
+        target=target,
+        status=status,
+    )
+    user_records = _uploaded.setdefault(user_id, {})
+    user_records[original_url] = (record, expires_at)
+    _enforce_upload_record_cap(user_id)
+
+
+def get_uploaded(user_id: str, original_url: str) -> UploadRecord | None:
+    """Return the recently-uploaded receipt for ``(user_id, original_url)``.
+
+    Returns ``None`` if no upload was recorded or the record has expired.
+    The returned record is unscoped by service, so callers must check
+    ``record.service`` matches the tool's own service before re-emitting
+    the receipt.
+    """
+    if not original_url:
+        return None
+    user_records = _uploaded.get(user_id)
+    if not user_records:
+        return None
+    entry = user_records.get(original_url)
+    if entry is None:
+        return None
+    record, expires_at = entry
+    if expires_at <= time.monotonic():
+        # Don't bother purging here; _purge_expired_uploads runs on writes.
+        return None
+    return record
+
+
+def _enforce_upload_record_cap(user_id: str) -> None:
+    """Cap the per-user upload-record count by evicting the soonest-expiring."""
+    user_records = _uploaded.get(user_id)
+    if not user_records or len(user_records) <= UPLOAD_RECORD_MAX_PER_USER:
+        return
+    while len(user_records) > UPLOAD_RECORD_MAX_PER_USER:
+        oldest_url = min(user_records, key=lambda url: user_records[url][1])
+        user_records.pop(oldest_url, None)
+
+
+def _purge_expired_uploads() -> None:
+    now = time.monotonic()
+    empty_users: list[str] = []
+    for user_id, records in _uploaded.items():
+        expired = [url for url, (_rec, exp) in records.items() if exp <= now]
+        for url in expired:
+            del records[url]
+        if not records:
+            empty_users.append(user_id)
+    for user_id in empty_users:
+        del _uploaded[user_id]
 
 
 def evict_by_handle(handle: str) -> bool:
@@ -230,11 +350,12 @@ def evict_by_handle(handle: str) -> bool:
 
 
 def clear_user(user_id: str) -> None:
-    """Drop all staged media for a user (primarily for tests)."""
+    """Drop all staged media and upload records for a user (primarily for tests)."""
     user_items = _cache.pop(user_id, None)
     if user_items:
         for _content, _mime, _exp, handle in user_items.values():
             _handles.pop(handle, None)
+    _uploaded.pop(user_id, None)
 
 
 def _purge_expired() -> None:

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -262,6 +262,26 @@ def create_file_tools(
                 mime_type = staged_mime
 
         if not file_bytes:
+            # A prior tool call in this turn already shipped this handle to
+            # storage and ``evict``ed the bytes. Surface the prior receipt
+            # so the model doesn't read this as a failure and retry. Mirrors
+            # the CompanyCam idempotency in ``companycam_upload_photo``.
+            if original_url:
+                prior = media_staging.get_uploaded(user.id, original_url)
+                if prior is not None and prior.service == "storage":
+                    logger.warning(
+                        "media_handle_referenced_after_eviction service=storage "
+                        "user=%s handle=%s prior_path=%s",
+                        user.id,
+                        original_url,
+                        prior.external_id,
+                    )
+                    return ToolResult(
+                        content=(
+                            f"File {original_url} was already uploaded earlier in "
+                            f"this turn to {prior.external_id}. Not re-uploading."
+                        ),
+                    )
             logger.warning("upload_to_storage called but no file content available")
             return ToolResult(
                 content=(
@@ -299,6 +319,17 @@ def create_file_tools(
         )
 
         if original_url:
+            # Record the receipt before evicting so a same-turn retry on the
+            # same handle hits an idempotent result instead of NOT_FOUND.
+            media_staging.mark_uploaded(
+                user.id,
+                original_url,
+                service="storage",
+                external_id=saved.path,
+                url=saved.web_view_link or "",
+                target=filename,
+                status="uploaded",
+            )
             media_staging.evict(user.id, original_url)
 
         logger.info("File cataloged: %s", saved.path)

--- a/backend/app/integrations/companycam/SKILL.md
+++ b/backend/app/integrations/companycam/SKILL.md
@@ -17,8 +17,10 @@ When the user sends a photo with job context (client name, address, work type):
 
 1. Search for the CompanyCam project: `companycam_search_projects(query="123 Main St")`
 2. If no project found, create one: `companycam_create_project(name="Smith - 123 Main St", address="123 Main St")`
-3. Upload the photo with tags: `companycam_upload_photo(project_id="...", tags=["kitchen", "demo"], description="Kitchen demolition progress")`
+3. Upload the photo, passing the handle shown in the conversation context: `companycam_upload_photo(project_id="...", original_url="media_XXXXXX", tags=["kitchen", "demo"], description="Kitchen demolition progress")`. One call per photo, one handle per call.
 4. Summarize what you assumed (project, tags) in one short line so the user can amend.
+
+`original_url` is required: pass the handle exactly as it appears in `[Photo N, handle=media_XXXXXX]`. Do not retry an upload whose receipt is already in the conversation; a retry on the same handle returns the prior receipt, not a fresh upload.
 
 ## Tags
 

--- a/backend/app/integrations/companycam/params.py
+++ b/backend/app/integrations/companycam/params.py
@@ -55,10 +55,9 @@ class CompanyCamUpdateProjectParams(BaseModel):
 class CompanyCamUploadPhotoParams(BaseModel):
     project_id: str = Field(description="CompanyCam project ID to upload to")
     original_url: str = Field(
-        default="",
         description=(
-            "The original_url of a photo from the current conversation. "
-            "If empty, uploads the most recent photo."
+            "The handle of the photo to upload (e.g. ``media_XXXXXX`` as shown "
+            "in the conversation context). Required; do not leave blank."
         ),
     )
     description: str = Field(default="", description="Photo description")

--- a/backend/app/integrations/companycam/photos.py
+++ b/backend/app/integrations/companycam/photos.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.saved_media import (
     find_saved_file,
-    latest_saved_file,
     read_saved_file_bytes,
 )
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
@@ -90,6 +89,23 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             if description.startswith(("{", "[")):
                 description = ""
 
+        # Require an explicit handle. Previous behavior was to grab
+        # "whatever's first" in staging when original_url was empty, which
+        # silently mis-routed photos when the user sent two media-attached
+        # messages back-to-back. The handle is shown in the prompt as
+        # ``handle=media_XXXXXX``; the model must echo it back.
+        if not original_url:
+            return ToolResult(
+                content=(
+                    "original_url is required. Pass the handle shown in the "
+                    "conversation context (e.g. ``handle=media_XXXXXX``) so the "
+                    "right photo is uploaded; do not call this tool with a blank "
+                    "handle."
+                ),
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+
         file_bytes: bytes = b""
         mime_type = "image/jpeg"
         photo_uri = ""
@@ -98,44 +114,30 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         #    (e.g. "media_abZtYWFs") from analyze_photo instead of the
         #    actual URL. Normalize to original_url + bytes before the
         #    three-tier lookup below.
-        if original_url:
-            resolved = media_staging.resolve_media_ref(ctx.user.id, original_url)
-            if resolved is not None:
-                original_url, file_bytes, mime_type = resolved
+        resolved = media_staging.resolve_media_ref(ctx.user.id, original_url)
+        if resolved is not None:
+            original_url, file_bytes, mime_type = resolved
 
         # 1. Try downloaded_media (current message, not yet evicted)
-        for media in ctx.downloaded_media:
-            if original_url and media.original_url != original_url:
-                continue
-            file_bytes = media.content
-            mime_type = media.mime_type or "image/jpeg"
-            original_url = original_url or media.original_url
-            break
+        if not file_bytes:
+            for media in ctx.downloaded_media:
+                if media.original_url != original_url:
+                    continue
+                file_bytes = media.content
+                mime_type = media.mime_type or "image/jpeg"
+                break
 
         # 2. Try media staging (cached bytes, may have been evicted)
         if not file_bytes:
             all_staged = media_staging.get_all_for_user(ctx.user.id)
-            if original_url and original_url in all_staged:
+            if original_url in all_staged:
                 file_bytes = all_staged[original_url]
-            elif not original_url and all_staged:
-                # Only grab an arbitrary photo when the LLM did not
-                # specify which one. When original_url is set but not
-                # found, we must NOT silently substitute another photo.
-                first_url = next(iter(all_staged))
-                file_bytes = all_staged[first_url]
-                original_url = first_url
 
         # 3. Fall back to a saved file in Drive. The agent quotes a storage
         #    path (e.g. /Astro Home/photos/foo.jpg) when it wants to push a
         #    previously saved file into CompanyCam.
         if not file_bytes and ctx.storage is not None:
-            if original_url:
-                saved = await find_saved_file(ctx.storage, original_url)
-            else:
-                # Same guard as step 2: only grab the most recent media
-                # when the LLM did not specify a particular path.
-                saved = await latest_saved_file(ctx.storage)
-
+            saved = await find_saved_file(ctx.storage, original_url)
             if saved is not None:
                 mime_type = saved.mime_type or "image/jpeg"
                 # Cloud storage: prefer the shareable URL; CompanyCam can
@@ -149,6 +151,33 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                         logger.warning("Saved media missing from storage: %s", saved.path)
 
         if not file_bytes and not photo_uri:
+            # Option A: a prior tool call in this turn already shipped
+            # this handle to CompanyCam, then evict() dropped the bytes.
+            # Surface the prior receipt instead of an error so the model
+            # doesn't read this as "the upload failed" and retry again.
+            prior = media_staging.get_uploaded(ctx.user.id, original_url)
+            if prior is not None and prior.service == "companycam":
+                logger.warning(
+                    "media_handle_referenced_after_eviction service=companycam "
+                    "user=%s handle=%s project=%s prior_status=%s",
+                    ctx.user.id,
+                    original_url,
+                    project_id,
+                    prior.status,
+                )
+                content = (
+                    f"Photo {original_url} was already uploaded to CompanyCam "
+                    f"earlier in this turn (status={prior.status}, ID {prior.external_id}). "
+                    f"Not re-uploading."
+                )
+                return ToolResult(
+                    content=content,
+                    receipt=ToolReceipt(
+                        action="Photo already in CompanyCam",
+                        target=prior.target,
+                        url=prior.url,
+                    ),
+                )
             return ToolResult(
                 content=(
                     "No photo available to upload. Send a photo in the "
@@ -211,7 +240,19 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         # the post-upload eviction in ``file_tools.upload_to_storage``. Skip
         # on ``processing_error``: that status means CompanyCam could not
         # fetch our temp URL, so a retry can still source bytes from staging.
+        # Before evicting, leave a recently-uploaded record so a same-turn
+        # retry on the same handle hits an idempotent receipt instead of
+        # NOT_FOUND.
         if original_url and status != "processing_error":
+            media_staging.mark_uploaded(
+                ctx.user.id,
+                original_url,
+                service="companycam",
+                external_id=str(photo.id),
+                url=app_url or "",
+                target=photo_target(photo),
+                status=status,
+            )
             media_staging.evict(ctx.user.id, original_url)
 
         if status == "processing_error":

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2708,3 +2708,111 @@ async def test_agent_override_falls_back_to_settings_when_field_empty(
     finally:
         settings.llm_provider = original_provider
         settings.llm_model = original_model
+
+
+@pytest.mark.asyncio()
+async def test_duplicate_tool_call_within_turn_emits_telemetry(
+    test_user: User, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The model occasionally re-fires the same (tool, args) twice within
+    one turn (the CompanyCam upload-storm in issue analysis). We surface
+    a structured warning so the pattern is measurable across users; the
+    call is not blocked because legitimate transient retries also happen.
+    """
+    from backend.app.agent.context import StoredToolInteraction
+    from backend.app.agent.llm_parsing import ParsedToolCall
+
+    async def _noop(query: str = "") -> ToolResult:
+        return ToolResult(content="ok")
+
+    tool = Tool(
+        name="search_thing",
+        description="search",
+        function=_noop,
+        params_model=_QueryParams,
+    )
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+
+    # Record an earlier-round call with the same args so the new call
+    # registers as a duplicate. ``_execute_tool_round`` reads from this
+    # list directly.
+    prior_records = [
+        StoredToolInteraction(
+            tool_call_id="prior",
+            name="search_thing",
+            args={"query": "acme"},
+            result="ok",
+            is_error=False,
+        )
+    ]
+
+    args = {"query": "acme"}
+    parsed_calls = [ToolCallRequest(id="call_dup", name="search_thing", arguments=args)]
+    parsed_raw = [ParsedToolCall(id="call_dup", name="search_thing", arguments=args)]
+
+    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
+        await agent._execute_tool_round(
+            parsed_calls=parsed_calls,
+            parsed_raw=parsed_raw,
+            actions_taken=[],
+            memories_saved=[],
+            tool_call_records=prior_records,
+        )
+
+    duplicate_logs = [
+        rec for rec in caplog.records if "duplicate_tool_call_within_turn" in rec.getMessage()
+    ]
+    assert duplicate_logs, "expected a duplicate_tool_call_within_turn warning"
+    assert any("search_thing" in rec.getMessage() for rec in duplicate_logs)
+
+
+@pytest.mark.asyncio()
+async def test_duplicate_tool_call_within_round_emits_telemetry(
+    test_user: User, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Same telemetry fires for a duplicate inside one round, not just across
+    rounds (matches the CompanyCam pattern where the model batches the same
+    upload twice in a single parallel fan-out).
+    """
+    from backend.app.agent.llm_parsing import ParsedToolCall
+
+    async def _noop(query: str = "") -> ToolResult:
+        return ToolResult(content="ok")
+
+    tool = Tool(
+        name="search_thing",
+        description="search",
+        function=_noop,
+        params_model=_QueryParams,
+    )
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+
+    args = {"query": "acme"}
+    # Two identical calls in one round.
+    parsed_calls = [
+        ToolCallRequest(id="call_a", name="search_thing", arguments=args),
+        ToolCallRequest(id="call_b", name="search_thing", arguments=args),
+    ]
+    parsed_raw = [
+        ParsedToolCall(id="call_a", name="search_thing", arguments=args),
+        ParsedToolCall(id="call_b", name="search_thing", arguments=args),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="backend.app.agent.core"):
+        await agent._execute_tool_round(
+            parsed_calls=parsed_calls,
+            parsed_raw=parsed_raw,
+            actions_taken=[],
+            memories_saved=[],
+            tool_call_records=[],
+        )
+
+    duplicate_logs = [
+        rec for rec in caplog.records if "duplicate_tool_call_within_turn" in rec.getMessage()
+    ]
+    assert duplicate_logs, "expected a duplicate_tool_call_within_turn warning"
+    assert any("search_thing" in rec.getMessage() for rec in duplicate_logs)

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -233,12 +233,15 @@ class TestTagsJsonStringCoercion:
     """
 
     def test_upload_photo_accepts_real_list(self) -> None:
-        p = CompanyCamUploadPhotoParams(project_id="p1", tags=["kitchen", "demo"])
+        p = CompanyCamUploadPhotoParams(
+            project_id="p1", original_url="media_abc", tags=["kitchen", "demo"]
+        )
         assert p.tags == ["kitchen", "demo"]
 
     def test_upload_photo_accepts_json_string_array(self) -> None:
         p = CompanyCamUploadPhotoParams(
             project_id="p1",
+            original_url="media_abc",
             tags='["kitchen", "demo"]',  # type: ignore[arg-type]
         )
         assert p.tags == ["kitchen", "demo"]
@@ -246,6 +249,7 @@ class TestTagsJsonStringCoercion:
     def test_upload_photo_accepts_empty_json_string_array(self) -> None:
         p = CompanyCamUploadPhotoParams(
             project_id="p1",
+            original_url="media_abc",
             tags="[]",  # type: ignore[arg-type]
         )
         assert p.tags == []
@@ -254,6 +258,7 @@ class TestTagsJsonStringCoercion:
         with pytest.raises(ValidationError, match="could not parse string as JSON"):
             CompanyCamUploadPhotoParams(
                 project_id="p1",
+                original_url="media_abc",
                 tags="not-json",  # type: ignore[arg-type]
             )
 
@@ -261,6 +266,7 @@ class TestTagsJsonStringCoercion:
         with pytest.raises(ValidationError, match="must be a JSON array"):
             CompanyCamUploadPhotoParams(
                 project_id="p1",
+                original_url="media_abc",
                 tags='{"a": 1}',  # type: ignore[arg-type]
             )
 
@@ -1256,7 +1262,9 @@ async def test_receipt_upload_photo_uses_app_url() -> None:
         ),
     ):
         tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
-        result = await tool.function(project_id="94772883")
+        result = await tool.function(
+            project_id="94772883", original_url="https://example.com/photo.jpg"
+        )
 
     _assert_receipt_clean(result.receipt, expect_url=True)
     assert "photos/39951388" in result.receipt.url
@@ -1307,7 +1315,9 @@ async def test_receipt_upload_duplicate_photo_uses_app_url() -> None:
         ),
     ):
         tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
-        result = await tool.function(project_id="94772883")
+        result = await tool.function(
+            project_id="94772883", original_url="https://example.com/photo.jpg"
+        )
 
     _assert_receipt_clean(result.receipt, expect_url=True)
     assert "photos/39951388" in result.receipt.url
@@ -1612,7 +1622,11 @@ async def test_upload_photo_strips_dict_description() -> None:
         ),
     ):
         tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
-        await tool.function(project_id="94772883", description=dict_description)
+        await tool.function(
+            project_id="94772883",
+            original_url="https://example.com/photo.jpg",
+            description=dict_description,
+        )
 
     # The description sent to CompanyCam must be empty, not the dict repr
     call_kwargs = service.upload_photo.call_args
@@ -1734,6 +1748,188 @@ async def test_receipt_rendered_output_has_no_raw_ids() -> None:
 
     # Block stays compact (grouping saves lines).
     assert len(block) < 500
+
+
+# ---------------------------------------------------------------------------
+# Option A + C: idempotent retry on a recently-uploaded handle, plus
+# explicit-handle enforcement.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_upload_photo_rejects_empty_original_url() -> None:
+    """Option C: empty ``original_url`` must hit a clear validation error.
+
+    Previously the tool silently grabbed "whatever was first" in staging,
+    which non-deterministically routed photos when the user sent two
+    media-attached messages back-to-back. The model must echo the handle
+    shown in the conversation context.
+    """
+    from backend.app.agent.tools.names import ToolName
+
+    service = MagicMock(spec=CompanyCamService)
+    ctx = MagicMock()
+    ctx.user.id = "test-user-reject-empty"
+    ctx.downloaded_media = []
+
+    tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+    result = await tool.function(project_id="42", original_url="")
+
+    assert result.is_error
+    assert "original_url is required" in result.content
+    service.upload_photo.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_upload_photo_idempotent_retry_after_eviction(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Option A: a same-turn retry on an evicted handle returns the prior receipt.
+
+    Two parallel ``companycam_upload_photo`` calls from one LLM round on
+    the same handle previously raced: the first evicted the staged bytes
+    on success, the second fell through to NOT_FOUND ("No photo available
+    to upload"). The model read the error as a failed upload and retried,
+    causing the upload-storm pattern seen in production. This test pins
+    the new behavior: the second call must surface the prior receipt
+    instead.
+    """
+    import logging
+
+    from backend.app.agent import media_staging
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.integrations.companycam.models import ImageURI, Photo
+    from backend.app.media.download import DownloadedMedia
+
+    user_id = "test-user-idempotent-retry"
+    photo_url = "https://example.com/photo-once.jpg"
+
+    media_staging.clear_user(user_id)
+    media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
+
+    service = MagicMock(spec=CompanyCamService)
+    photo_obj = Photo(
+        id="33333333",
+        processing_status="processed",
+        uris=[ImageURI(type="original", uri="https://img.companycam.com/x.jpg")],
+    )
+    service.upload_photo = AsyncMock(return_value=photo_obj)
+
+    ctx = MagicMock()
+    ctx.user.id = user_id
+    ctx.storage = None
+    ctx.downloaded_media = [
+        DownloadedMedia(
+            content=b"fake-jpg",
+            mime_type="image/jpeg",
+            original_url=photo_url,
+            filename="photo.jpg",
+        )
+    ]
+
+    try:
+        with (
+            patch(
+                "backend.app.services.webhook.discover_tunnel_url",
+                new_callable=AsyncMock,
+                return_value="https://tunnel.example.com",
+            ),
+            patch(
+                "backend.app.routers.media_temp.create_temp_media_url",
+                return_value="https://tunnel.example.com/media/tmp/abc",
+            ),
+        ):
+            tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+            first = await tool.function(project_id="44444444", original_url=photo_url)
+            # Simulate the second-in-turn race: downloaded_media empty
+            # (the prior call consumed and evicted), staging evicted, but
+            # the model retries with the same handle.
+            ctx.downloaded_media = []
+
+            with caplog.at_level(logging.WARNING):
+                second = await tool.function(project_id="44444444", original_url=photo_url)
+
+        assert first.is_error is False
+        # Service was only hit once; the retry did not re-upload.
+        service.upload_photo.assert_called_once()
+
+        assert second.is_error is False, (
+            "retry on an evicted handle must return a soft idempotent receipt, "
+            "not NOT_FOUND -- otherwise the model reads it as a failure and "
+            "retries again"
+        )
+        assert second.receipt is not None
+        assert "photos/33333333" in second.receipt.url
+        assert "already uploaded" in second.content.lower()
+        # Telemetry: the retry-after-eviction signal must be emitted so we
+        # can measure the pattern across users.
+        assert any(
+            "media_handle_referenced_after_eviction" in rec.message for rec in caplog.records
+        )
+    finally:
+        media_staging.clear_user(user_id)
+
+
+@pytest.mark.asyncio()
+async def test_upload_photo_records_duplicate_status_for_retry() -> None:
+    """When CompanyCam dedupes the first upload, a retry on the same handle
+    still surfaces the duplicate receipt (no spurious ``No photo`` error).
+    """
+    from backend.app.agent import media_staging
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.integrations.companycam.models import ImageURI, Photo
+    from backend.app.media.download import DownloadedMedia
+
+    user_id = "test-user-dup-retry"
+    photo_url = "https://example.com/photo-dup.jpg"
+
+    media_staging.clear_user(user_id)
+    media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
+
+    service = MagicMock(spec=CompanyCamService)
+    photo_obj = Photo(
+        id="55555555",
+        processing_status="duplicate",
+        uris=[ImageURI(type="original", uri="https://img.companycam.com/dup.jpg")],
+    )
+    service.upload_photo = AsyncMock(return_value=photo_obj)
+
+    ctx = MagicMock()
+    ctx.user.id = user_id
+    ctx.storage = None
+    ctx.downloaded_media = [
+        DownloadedMedia(
+            content=b"fake-jpg",
+            mime_type="image/jpeg",
+            original_url=photo_url,
+            filename="photo.jpg",
+        )
+    ]
+
+    try:
+        with (
+            patch(
+                "backend.app.services.webhook.discover_tunnel_url",
+                new_callable=AsyncMock,
+                return_value="https://tunnel.example.com",
+            ),
+            patch(
+                "backend.app.routers.media_temp.create_temp_media_url",
+                return_value="https://tunnel.example.com/media/tmp/abc",
+            ),
+        ):
+            tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+            first = await tool.function(project_id="66666666", original_url=photo_url)
+            ctx.downloaded_media = []
+            second = await tool.function(project_id="66666666", original_url=photo_url)
+
+        assert first.is_error is False
+        assert second.is_error is False
+        # The cached receipt must carry the duplicate status so the model
+        # does not think the retry actually shipped a new copy.
+        assert "duplicate" in second.content.lower() or "already" in second.content.lower()
+    finally:
+        media_staging.clear_user(user_id)
 
 
 # ---------------------------------------------------------------------------
@@ -1916,13 +2112,20 @@ async def test_two_photo_upload_renders_each_url_exactly_once() -> None:
 
     ctx = MagicMock()
     ctx.user.id = "test-user"
+    ctx.storage = None
     ctx.downloaded_media = [
         DownloadedMedia(
-            content=b"fake-jpg",
+            content=b"fake-jpg-a",
             mime_type="image/jpeg",
-            original_url="https://example.com/photo.jpg",
-            filename="photo.jpg",
-        )
+            original_url="https://example.com/photo-a.jpg",
+            filename="photo-a.jpg",
+        ),
+        DownloadedMedia(
+            content=b"fake-jpg-b",
+            mime_type="image/jpeg",
+            original_url="https://example.com/photo-b.jpg",
+            filename="photo-b.jpg",
+        ),
     ]
 
     with (
@@ -1937,8 +2140,12 @@ async def test_two_photo_upload_renders_each_url_exactly_once() -> None:
         ),
     ):
         upload = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
-        result_one = await upload.function(project_id="98845509")
-        result_two = await upload.function(project_id="98845509")
+        result_one = await upload.function(
+            project_id="98845509", original_url="https://example.com/photo-a.jpg"
+        )
+        result_two = await upload.function(
+            project_id="98845509", original_url="https://example.com/photo-b.jpg"
+        )
 
     # The tool now keeps URLs out of content — the LLM cannot copy them.
     assert result_one.receipt is not None and result_one.receipt.url

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -71,6 +71,74 @@ def test_isolation_between_users() -> None:
     media_staging.clear_user("user-b")
 
 
+def test_upload_record_round_trip(test_user: User) -> None:
+    media_staging.mark_uploaded(
+        test_user.id,
+        "bb_photo",
+        service="companycam",
+        external_id="cc-123",
+        url="https://app.companycam.com/photos/cc-123",
+        target="123 Main St",
+        status="uploaded",
+    )
+    rec = media_staging.get_uploaded(test_user.id, "bb_photo")
+    assert rec is not None
+    assert rec.service == "companycam"
+    assert rec.external_id == "cc-123"
+    assert rec.status == "uploaded"
+
+
+def test_upload_record_survives_evict(test_user: User) -> None:
+    """A successful upload evicts staged bytes but keeps the receipt so a
+    same-turn retry on the same handle returns an idempotent result.
+    """
+    media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+    media_staging.mark_uploaded(
+        test_user.id,
+        "bb_photo",
+        service="companycam",
+        external_id="cc-999",
+        url="https://app.companycam.com/photos/cc-999",
+        target="Some target",
+        status="uploaded",
+    )
+    media_staging.evict(test_user.id, "bb_photo")
+    assert media_staging.get_all_for_user(test_user.id) == {}
+    rec = media_staging.get_uploaded(test_user.id, "bb_photo")
+    assert rec is not None
+    assert rec.external_id == "cc-999"
+
+
+def test_upload_record_expires(test_user: User, monkeypatch: pytest.MonkeyPatch) -> None:
+    media_staging.mark_uploaded(
+        test_user.id,
+        "bb_photo",
+        service="companycam",
+        external_id="cc-1",
+        url="https://app.companycam.com/photos/cc-1",
+        target="t",
+        status="uploaded",
+    )
+    real_monotonic = time.monotonic
+    future = real_monotonic() + media_staging.UPLOAD_RECORD_TTL_SECONDS + 1
+    monkeypatch.setattr(media_staging.time, "monotonic", lambda: future)
+    assert media_staging.get_uploaded(test_user.id, "bb_photo") is None
+
+
+def test_upload_record_isolated_per_user() -> None:
+    media_staging.mark_uploaded(
+        "user-a",
+        "bb_photo",
+        service="companycam",
+        external_id="cc-a",
+        url="https://app.companycam.com/photos/cc-a",
+        target="t",
+        status="uploaded",
+    )
+    assert media_staging.get_uploaded("user-b", "bb_photo") is None
+    media_staging.clear_user("user-a")
+
+
 @pytest.mark.asyncio()
 async def test_file_factory_merges_staged_bytes_when_current_turn_has_none(
     test_user: User,
@@ -180,6 +248,51 @@ async def test_upload_evicts_staged_entry(test_user: User) -> None:
     )
     assert result.is_error is False
     assert media_staging.get_all_for_user(test_user.id) == {}
+
+
+@pytest.mark.asyncio()
+async def test_upload_to_storage_idempotent_retry_after_eviction(
+    test_user: User, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Regression for the same upload-storm pattern that hit CompanyCam:
+    a same-turn retry on an evicted handle previously returned NOT_FOUND,
+    which the model read as failure and retried. Now the second call
+    surfaces the prior upload's path as an idempotent receipt.
+    """
+    import logging
+
+    media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+    storage = MockStorageBackend()
+    # pending_media is the per-turn snapshot the factory closes over; we
+    # mutate it after the first call to simulate the bytes being consumed.
+    pending = {"bb_photo": b"bytes"}
+    tools = create_file_tools(test_user, storage, pending_media=pending)
+    upload = tools[0].function
+
+    first = await upload(
+        file_category="job_photo",
+        original_url="bb_photo",
+        client_name="Jane",
+    )
+    assert first.is_error is False
+
+    # Simulate the second call in the same turn: bytes are gone from
+    # pending_media (we just popped them, which mirrors what eviction
+    # does to the closure-held map) and from staging.
+    pending.pop("bb_photo", None)
+
+    with caplog.at_level(logging.WARNING, logger="backend.app.agent.tools.file_tools"):
+        second = await upload(
+            file_category="job_photo",
+            original_url="bb_photo",
+            client_name="Jane",
+        )
+
+    assert second.is_error is False, (
+        "second upload on the same handle must return an idempotent receipt, not NOT_FOUND"
+    )
+    assert "already uploaded" in second.content.lower()
+    assert any("media_handle_referenced_after_eviction" in rec.message for rec in caplog.records)
 
 
 class _FakeUploadParams(BaseModel):


### PR DESCRIPTION
## Description

When a user sends two media-attached messages back-to-back (each pointing at a different job), `MessageBatcher` coalesces them so one consolidated agent turn handles both. The CompanyCam upload tool evicted staged bytes immediately on a successful ship, so any second reference to the same handle within the same turn hit a generic "No photo available to upload" error. The model read that as a failed upload and retried, producing a duplicate-call storm in production (one observed case: 43 tool calls in one turn, 13 NOT_FOUND errors, and a confused agent reply that the user had to manually reassure).

Three changes, scoped to the smallest surgical fix:

**A. Idempotent retry on an evicted handle.** `media_staging` now records an `UploadRecord` on every successful CompanyCam / storage ship (1h TTL, per-user cap). The upload tools check this cache before returning `NOT_FOUND` and re-emit the prior receipt instead, with a `media_handle_referenced_after_eviction` structured warning for telemetry. Applied to both `companycam_upload_photo` and `upload_to_storage` so they share the same recovery path.

**C. `original_url` is required on `companycam_upload_photo`.** The old fallback ("grab whatever's first in staging" when the LLM omitted the handle) silently mis-routed photos across rapid-fire messages. The Pydantic param model has no default now; the tool body also returns a clear `VALIDATION` error if empty. `SKILL.md` updated to show the handle being passed.

**G. Duplicate tool-call telemetry.** `_execute_tool_round` snapshots prior `(tool_name, normalized_args)` pairs (across rounds and within the current round) and emits `duplicate_tool_call_within_turn` on a repeat. Diagnostic only; the call is not blocked, because legitimate retries on transient errors also share args.

## Type
- [x] Bug fix
- [x] Documentation (SKILL.md update so the model passes the handle)

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ tests/ alembic/`)
- [x] Format passes (`ruff format --check backend/ tests/ alembic/`)
- [x] Type check passes (`ty check --python .venv backend/ tests/ alembic/`)
- [x] Premium suite still green against this branch
- [x] New tests added: idempotent retry (both tools), duplicate-status retry, empty-handle rejection, upload-record cache lifecycle, duplicate-call telemetry
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: Claude Opus 4.7 (1M ctx) read the admin shared-data conversation transcript that surfaced this pattern, proposed Options A through G, then implemented A + C + G after a human picked which to ship. All diffs reviewed locally before push.