### PR TITLE
fix(file_tools): Drive read tools default to 'ask' permission

### DIFF
--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -520,6 +520,12 @@ def create_file_tools(
             function=find_saved_files,
             params_model=FindSavedFilesParams,
             usage_hint="Search durable saved files before asking the user to resend one.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Search saved files for {args.get('query') or 'recent files'}"
+                ),
+            ),
         ),
         Tool(
             name=ToolName.ANALYZE_SAVED_FILE,
@@ -530,6 +536,12 @@ def create_file_tools(
             function=analyze_saved_file,
             params_model=AnalyzeSavedFileParams,
             usage_hint="Inspect a saved receipt or photo again without asking for a resend.",
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Analyze saved file {args.get('file_ref') or ''}".rstrip()
+                ),
+            ),
         ),
     ]
 
@@ -599,12 +611,12 @@ def _register() -> None:
             SubToolInfo(
                 ToolName.FIND_SAVED_FILES,
                 "Find previously saved files in Drive",
-                default_permission="always",
+                default_permission="ask",
             ),
             SubToolInfo(
                 ToolName.ANALYZE_SAVED_FILE,
                 "Analyze a previously saved image",
-                default_permission="always",
+                default_permission="ask",
             ),
         ],
         auth_check=_file_auth_check,

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -523,7 +523,9 @@ def create_file_tools(
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
                 description_builder=lambda args: (
-                    f"Search saved files for {args.get('query') or 'recent files'}"
+                    f"Search saved files for '{args['query']}'"
+                    if args.get("query")
+                    else "List recent saved files"
                 ),
             ),
         ),
@@ -538,9 +540,7 @@ def create_file_tools(
             usage_hint="Inspect a saved receipt or photo again without asking for a resend.",
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
-                description_builder=lambda args: (
-                    f"Analyze saved file {args.get('file_ref') or ''}".rstrip()
-                ),
+                description_builder=lambda args: f"Analyze saved file {args['file_ref']}",
             ),
         ),
     ]


### PR DESCRIPTION
## Description
`find_saved_files` and `analyze_saved_file` were registered in `_register()` with `default_permission="always"`, so the agent could enumerate or run vision over anything in a user's Drive without prompting. This PR flips both to `"ask"` and attaches matching `ApprovalPolicy(default_level=PermissionLevel.ASK)` objects on the `Tool` definitions so the runtime gate in `core.py` actually prompts (per the `test_ask_sub_tools_have_approval_policy` contract).

The two write-side tools (`upload_to_storage`, `organize_file`) were already `"ask"`. This brings the read side in line so every Drive sub-tool gates on user confirmation by default. Users can still escalate to `"always"` from the dashboard if they want auto-execute.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) - full suite 2693 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality - existing `test_ask_sub_tools_have_approval_policy` already enforces the invariant; no new test needed
- [x] Bug fixes include regression tests - covered by the existing registry contract test

## AI Usage
- [x] AI-assisted (Claude Code drafted the diff and PR text via discussion with @njbrake; reasoning and decision are his)