### PR TITLE
chore: harden npm supply chain security

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,22 @@
+# Delay installation of newly published packages by 7 days.
+# Malware is typically detected and removed within hours; this window prevents most attacks.
+# Requires npm >= 11.10.0
 min-release-age=7
+
+# Block all lifecycle scripts (preinstall, install, postinstall) during npm install.
+# This is the #1 mitigation against supply chain attacks — all recent major npm attacks
+# (Shai-Hulud, Axios RAT, event-stream) relied on postinstall hooks to execute payloads.
+# Packages that genuinely need native compilation (e.g. esbuild, vite-plugin-pwa workbox)
+# must be rebuilt explicitly after install: npm rebuild <package> --ignore-scripts=false
+ignore-scripts=true
+
+# Run npm audit automatically on every install and fail on moderate+ vulnerabilities.
+audit=true
+audit-level=moderate
+
+# Pin exact versions when adding new packages (no ^ or ~ ranges).
+# Prevents range-based attacks where a malicious patch/minor version satisfies a loose range.
+save-exact=true
+
+# Suppress funding messages so security warnings aren't buried in noise.
+fund=false


### PR DESCRIPTION
## Summary

Hardens `frontend/.npmrc` against supply chain attacks. Clawbolt uses npm rather than pnpm, so the equivalent npm-native protections are applied here, mirroring the approach taken in the pnpm repos ([octonous #3541](https://github.com/mozilla-ai/octonous/pull/3541), [cq-exchange #160](https://github.com/mozilla-ai/cq-exchange/pull/160), [any-llm-platform #868](https://github.com/mozilla-ai/any-llm-platform/pull/868)).

> _This PR was created automatically by [octonous.com](https://octonous.com)._

## Changes

### `ignore-scripts=true` — new

<cite index="1-10,1-11">The dominant payload pattern in npm attacks is a lifecycle script that runs during install — disabling those scripts breaks the default delivery vehicle.</cite> <cite index="3-4,3-5">The September 2025 Shai-Hulud worm and the March 2026 Axios compromise both followed this exact pattern, using postinstall hooks to execute a remote access payload.</cite>

> ⚠️ Some packages in the dependency tree require native compilation or binary downloads (e.g. `esbuild` via Vite, `workbox-precaching`). After running `npm install`, those packages may need a targeted rebuild:
> ```sh
> npm rebuild esbuild --ignore-scripts=false
> ```
> Verify the build still works in CI after this change and add explicit `npm rebuild` steps as needed.

### `min-release-age=7` — already set, kept

<cite index="3-1">Pairing `ignore-scripts=true` with `min-release-age=7` avoids installing packages published in the last week — the window when most attacks are active and undetected.</cite> No change needed here.

### `audit=true` + `audit-level=moderate` — new

Runs `npm audit` automatically on every install and fails on moderate or higher severity findings. <cite index="2-37,2-38">npm's built-in `npm audit` can detect known malicious packages — integrating SCA scanning into the CI/CD pipeline ensures compromised dependencies are caught before they reach production.</cite>

### `save-exact=true` — new

<cite index="1-25,1-26">Pins exact versions in `package.json` whenever a package is added. Without it, `npm install axios` writes `"axios": "^1.14.0"` — a caret range that silently resolves to a newer (potentially malicious) version on the next clean install.</cite>

### `fund=false` — new

Suppresses funding messages so that security warnings (audit findings, deprecations, peer conflicts) aren't buried in install output noise.
