### PR TITLE
fix(file-tools): note drive.file scope in find_saved_files description

### DIFF
--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -484,7 +484,9 @@ def create_file_tools(
             description=(
                 "Find files that were already saved to durable storage. Use this "
                 "to pull up older receipts, photos, or documents by client name, "
-                "address, filename, or saved description."
+                "address, filename, or saved description. Only returns files "
+                "Clawbolt uploaded itself; files the user added to the Clawbolt "
+                "folder directly in Drive are not visible to this tool."
             ),
             function=find_saved_files,
             params_model=FindSavedFilesParams,


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

`find_saved_files` only sees files Clawbolt uploaded itself. Files the user added to the Clawbolt folder directly via the Drive web UI are filtered out by Google's `drive.file` OAuth scope before our code ever sees them. That behavior is intentional, but it wasn't surfaced in the tool description, so the agent has been giving confused explanations and re-running the tool in a loop when users push back.

Example exchange that motivated this:

> user: tell me what files are in there
> agent: One file in there: photo_001.png ...
> user: look again
> agent: Same result, just the one file ...
> user: I manually put a file into google drive
> agent: Got it, but I can only see files that were uploaded through me. Manually added files don't show up in my search. You'd need to share the file link with me directly ...
> user: use the tool and look
> agent: Already ran it twice, the tool only surfaces files I've uploaded ...

The agent eventually arrived at the correct explanation but framed it as a tool limitation rather than a Google scope decision, and burned three tool calls getting there.

This PR adds two sentences to the `find_saved_files` tool description so the LLM sees the constraint at call time and can give a correct, calm explanation on the first try.

No code logic changes. No scope changes. No new tests needed: behavior is governed by the LLM prompt, and existing `test_file_cataloging.py` + `test_tool_registry.py` tests still pass (41/41).

Considered also adding a paragraph to `instructions.md` but skipped it: the system prompt loads every turn for every user, and a tool description only loads when Drive is connected and file tools are active. The tool description is the cheaper, more targeted location.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v tests/test_file_cataloging.py tests/test_tool_registry.py`)
- [x] Lint passes (`ruff check backend/app/agent/tools/file_tools.py && ruff format --check backend/app/agent/tools/file_tools.py`)
- [x] Type check passes (`ty check --python .venv backend/app/agent/tools/file_tools.py`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

Skipped regression test: the change is a prompt-string adjustment, not a code path. The existing test suite already covers the tool's behavior.

## AI Usage
- [x] AI-assisted: Claude Opus 4.7 investigated the root cause (drive.file scope constraint in `backend/app/services/storage_service.py:14, 118-121` and `backend/app/services/oauth.py:1216`), proposed four fix options (broaden scope and pay for CASA, add metadata.readonly, add Picker flow, or fix the agent's response), and applied the minimal prompt-string fix after njbrake selected option 4.