### PR TITLE
fix(sessions): stop re-appending receipt block on webchat history loads

### DIFF
--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -14,12 +14,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 
 from backend.app.agent.concurrency import user_locks
-from backend.app.agent.context import StoredToolInteraction
 from backend.app.agent.onboarding import build_onboarding_system_prompt, is_in_onboarding_flow
 from backend.app.agent.session_db import get_session_store
 from backend.app.agent.system_prompt import build_agent_system_prompt
 from backend.app.agent.tool_assembly import build_initial_turn_tools
-from backend.app.agent.tool_summary import append_receipts
 from backend.app.auth.dependencies import get_current_user
 from backend.app.database import AsyncSessionLocal
 from backend.app.models import ChatSession, User
@@ -85,25 +83,15 @@ async def get_conversation(
             with contextlib.suppress(json.JSONDecodeError, TypeError):
                 tool_interactions = json.loads(msg.tool_interactions_json)
 
-        # Mirror the channel-side transform: outbound replies render with the
-        # deterministic receipt block appended, matching what iMessage/Telegram
-        # users receive. Messages in the DB store the raw LLM reply so the
-        # agent's own history stays clean; the receipt block is recomputed
-        # here for the display surface.
-        body = msg.body
-        if msg.direction == "outbound" and tool_interactions:
-            stored: list[StoredToolInteraction] = []
-            for entry in tool_interactions:
-                with contextlib.suppress(Exception):
-                    stored.append(StoredToolInteraction.model_validate(entry))
-            if stored:
-                body = append_receipts(body, stored)
-
+        # ``msg.body`` already contains the receipt block when applicable:
+        # ``dispatch_reply_step`` appends receipts before publishing, and
+        # ``persist_outbound`` stores that dispatched body. Re-appending here
+        # would duplicate every receipt line on webchat history loads.
         messages.append(
             SessionMessage(
                 seq=msg.seq,
                 direction=msg.direction,
-                body=body,
+                body=msg.body,
                 timestamp=msg.timestamp,
                 tool_interactions=tool_interactions,
             )

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -99,10 +99,20 @@ async def test_get_conversation_full_detail(client: TestClient, test_user: User)
     assert data["messages"][1]["tool_interactions"][0]["tool"] == "save_fact"
 
 
-async def test_get_conversation_appends_receipts_to_outbound(
+async def test_get_conversation_serves_outbound_body_verbatim(
     client: TestClient, test_user: User
 ) -> None:
-    """Outbound messages with tool receipts include the rendered receipt block."""
+    """Outbound bodies are returned exactly as stored.
+
+    ``persist_outbound`` stores ``AgentResponse.dispatched_body``, which is
+    the LLM prose with any receipt block already appended by
+    ``dispatch_reply_step``. The session-history endpoint must not re-append:
+    doing so duplicates every receipt line on webchat history loads
+    (regression from PR #1055 surfaced by #1328).
+    """
+    dispatched_body = (
+        "Done!\n\n- Created CompanyCam project Smith Residence\n  app.companycam.com/projects/12345"
+    )
     tool_json = json.dumps(
         [
             {
@@ -130,7 +140,7 @@ async def test_get_conversation_appends_receipts_to_outbound(
             },
             {
                 "direction": "outbound",
-                "body": "Done!",
+                "body": dispatched_body,
                 "timestamp": "2025-01-15T10:02:00",
                 "seq": 2,
                 "tool_interactions_json": tool_json,
@@ -140,15 +150,14 @@ async def test_get_conversation_appends_receipts_to_outbound(
     resp = client.get("/api/user/conversation")
     assert resp.status_code == 200
     body = resp.json()["messages"][1]["body"]
-    assert body.startswith("Done!")
-    assert "Created CompanyCam project Smith Residence" in body
-    # Compact URL rendering (issue #976) strips the https:// prefix.
-    assert "app.companycam.com/projects/12345" in body
-    assert "https://" not in body
+    assert body == dispatched_body
+    # The receipt line must appear exactly once; the bug was that the
+    # endpoint re-appended a second copy from ``tool_interactions``.
+    assert body.count("Created CompanyCam project Smith Residence") == 1
 
 
 async def test_get_conversation_inbound_body_unchanged(client: TestClient, test_user: User) -> None:
-    """Receipt append must only apply to outbound messages, never inbound."""
+    """Inbound bodies pass through unchanged regardless of tool_interactions."""
     tool_json = json.dumps(
         [
             {


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Fixes #1328.

## Description

`GET /api/user/conversation` was duplicating the receipt block on outbound messages every time webchat reloaded session history. The fix is one call site removal.

### Root cause

Two PRs combined to create the regression:

- #988 (Apr 21) added `append_receipts(body, stored)` to `user_sessions.py` to give webchat the same receipt-augmented rendering iMessage and Telegram get. At that point, `persist_outbound` stored `response.reply_text` (raw LLM prose), so re-appending on display was the correct way to reach parity.
- #1055 (Apr 28) fixed a different duplicate-receipt bug (the LLM-echo-into-tool-result path) and, as part of that fix, changed `persist_outbound` to store `response.dispatched_body or response.reply_text` so the DB matched what the user actually saw. `dispatched_body` already contains the receipt block.

The display-side append in `user_sessions.py` kept running against the new contract, producing one duplicate receipt line per write-side tool result on every webchat history load. iMessage and Telegram never reload session history, so they were not affected.

### Change

`backend/app/routers/user_sessions.py` now serves `msg.body` verbatim. The stale comment block describing the pre-#1055 transform is removed, along with two now-unused imports (`StoredToolInteraction`, `append_receipts`) and the `model_validate` loop that fed the append call. `tool_interactions` is still parsed and returned in the response unchanged, so the frontend's per-tool affordances continue to work.

### Test

`tests/test_session_endpoints.py::test_get_conversation_appends_receipts_to_outbound` encoded the old contract (stored body raw, endpoint appends) and was failing this fix. Rewritten as `test_get_conversation_serves_outbound_body_verbatim`: stores a body that already contains a receipt line, asserts the endpoint returns it unchanged with the receipt line appearing exactly once. `test_get_conversation_inbound_body_unchanged` is kept as-is (inbound bodies must still pass through).

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -q`: 2693 passed, 2 skipped)
- [x] Lint passes (`ruff check backend/ tests/ alembic/`, `ruff format --check`)
- [x] Type check passes (`ty check --python .venv backend/ tests/ alembic/`)
- [x] New tests added for new functionality (n/a, this is a bug fix)
- [x] Bug fixes include regression tests (`test_get_conversation_serves_outbound_body_verbatim` locks in the no-duplicate-receipt invariant)

## AI Usage
- [x] AI-assisted: Claude diagnosed the regression chain (#988 + #1055 interaction) and drafted the fix end to end via back-and-forth with @njbrake. Reasoning and decisions are his; the prose and code shape are Claude's.