### PR TITLE
fix(sessions): reset last_trim_seq when clearing conversation history

### DIFF
--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -654,6 +654,15 @@ class SessionStore:
 
         Returns the number of messages deleted. The session row itself is
         preserved so the conversation can continue with an empty history.
+
+        Also resets ``last_trim_seq`` to ``None``. After the delete, the
+        next message inserted gets ``seq = max(seq)+1 = 1`` (because
+        ``_select_max_seq`` returns 0 on an empty table), so any stale
+        watermark left over from a prior trim would silently filter out
+        every new message in ``load_conversation_history`` (which keeps
+        only ``seq > last_trim_seq``). Symptom: the agent receives only
+        the live inbound on every turn and behaves as if the conversation
+        has just started, forever.
         """
         async with db_session_async() as db:
             cs = (
@@ -664,6 +673,7 @@ class SessionStore:
             result = await db.execute(_delete_all_messages_for_session(cs.id))
             count: int = cast("CursorResult[object]", result).rowcount
             cs.initial_system_prompt = ""
+            cs.last_trim_seq = None
             await db.commit()
             return count
 

--- a/tests/test_session_db_async.py
+++ b/tests/test_session_db_async.py
@@ -339,6 +339,39 @@ async def test_delete_messages_async_clears_history_and_prompt(
     assert reloaded.initial_system_prompt == ""
 
 
+async def test_delete_messages_async_resets_trim_watermark(
+    async_db: async_sessionmaker,
+) -> None:
+    """Clearing the conversation must reset ``last_trim_seq`` to None.
+
+    Regression for the dev-environment "agent loses all context on every
+    turn" report: after a clear, the next inserted message gets ``seq=1``
+    (because ``_select_max_seq`` returns 0 on an empty table). If
+    ``last_trim_seq`` is left at its pre-clear value (say 199),
+    ``load_conversation_history`` filters every new message out with
+    ``seq > last_trim_seq`` and the LLM only ever sees the live inbound.
+    """
+    user_id = await _create_user(async_db)
+    store = SessionStore(user_id)
+    session, _ = await store.get_or_create_session_async()
+    await store.add_message_async(session, direction="inbound", body="a")
+
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).where(ChatSession.user_id == user_id))
+        ).scalar_one()
+        cs.last_trim_seq = 199
+        await db.commit()
+
+    await store.delete_messages_async(session.session_id)
+
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).where(ChatSession.user_id == user_id))
+        ).scalar_one()
+        assert cs.last_trim_seq is None
+
+
 # ---------------------------------------------------------------------------
 # last-timestamp helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

When a user hits "Clear conversation" (`DELETE /api/user/conversation/messages`), `SessionStore.delete_messages_async` wipes all `messages` rows but leaves `chat_sessions.last_trim_seq` at its pre-clear value.

After the delete, the next inserted message gets `seq = max(seq)+1 = 1` (because `_select_max_seq` returns 0 on an empty table), and `load_conversation_history` filters every new message out with `seq > last_trim_seq` (`backend/app/agent/context.py:384`).

Symptom: for any user whose conversation had previously crossed the trim threshold, clearing the chat puts the session into a stuck state where the agent receives only the live inbound on every turn and replies as if the conversation just started, forever. Caught on dev: user reported "all the sudden it's real dumb"; admin payload export showed `previous_era.min_message_seq_in_prompt=200`, `current_era.min_message_seq_in_prompt=null`, conversation has 18 fresh messages but `last_trim_seq=199`, so all 18 are filtered out.

Fix: clear `last_trim_seq` alongside `initial_system_prompt` in `delete_messages_async`. Regression test seeds a stale watermark, calls `delete_messages_async`, and asserts the watermark is reset to NULL.

Stuck sessions already in the wild need a one-off `UPDATE chat_sessions SET last_trim_seq = NULL WHERE user_id = ?;` to recover; this PR just prevents new ones from getting into the same state.

The watermark mechanism shipped in #1193; `delete_messages_async` is older (#852) and was never updated to know about it.

### Selective deletes

`delete_messages_by_seqs_async` / `delete_message_async` can in theory hit the same trap if they remove every message above the watermark (e.g. multiselect-delete of just the recent turns). That requires a less obvious user action and the right fix is "clamp watermark to max(seq), or null if empty" rather than "reset on every selective delete". Leaving for a follow-up so this PR stays scoped to the actual reported regression.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (\`uv run pytest -v\`) - 2694 passed, 2 skipped
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 4.7 diagnosed the bug from admin LLM payload captures on dev, drafted the fix and regression test, and wrote this PR description in collaboration with @njbrake)
- [ ] No AI used