### PR TITLE
fix(stores): serialize MemoryStore first-append with advisory lock

### DIFF
--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Select, Update, select, update
+from sqlalchemy import Select, TextClause, Update, select, text, update
 
 from backend.app.agent.markdown_registry import (
     append_with_window,
@@ -60,9 +60,27 @@ def _doc_select_for_update(user_id: str) -> Select[tuple[MemoryDocument]]:
     Instead, the append path SELECTs the row under ``FOR UPDATE``,
     decrypts automatically on read, concatenates in Python, and writes
     the full new plaintext back. The row-level lock serializes
-    concurrent appenders so neither side loses its update.
+    concurrent appenders against an existing row; first-append
+    callers (no row yet) are serialized by the per-user advisory
+    lock in ``append_history`` because ``FOR UPDATE`` on a missing
+    row acquires no predicate lock.
     """
     return select(MemoryDocument).filter_by(user_id=user_id).with_for_update()
+
+
+def _advisory_lock_key(user_id: str) -> str:
+    """Stable string key for the per-user MemoryDocument advisory lock."""
+    return f"memory_doc:{user_id}"
+
+
+def _advisory_lock_sql() -> TextClause:
+    """``pg_advisory_xact_lock`` SQL bound to a ``:k`` parameter.
+
+    The lock is transaction-scoped and released only on COMMIT / ROLLBACK,
+    not when the Python execute() returns. Caller binds ``{"k": <key>}``.
+    Mirrors the pattern in ``backend/app/agent/session_db.py``.
+    """
+    return text("SELECT pg_advisory_xact_lock(hashtext(:k))")
 
 
 def _append_history_update(doc_id: int, full_new_text: str) -> Update:
@@ -169,6 +187,14 @@ class MemoryStore:
         is an ``EncryptedString`` column whose envelope format is not
         concat-safe.
 
+        Takes a per-user ``pg_advisory_xact_lock`` at the top so the
+        first-append branch (no row yet) cannot race: ``FOR UPDATE``
+        on a missing row acquires no predicate lock, so two concurrent
+        first-appends would otherwise both see ``None``, both INSERT,
+        and one would lose to ``uq_memory_documents_user_id``
+        (issue #1224). The lock is released automatically on COMMIT
+        or ROLLBACK of the surrounding transaction.
+
         Guarantees a newline between the existing text and the new
         entry: if the stored text is non-empty and does not already
         end with a newline (e.g. a manual edit, or older text written
@@ -190,6 +216,10 @@ class MemoryStore:
         policy = get_policy("HISTORY.md")
         budget = policy.byte_budget if policy is not None else None
         async with db_session_async() as db:
+            await db.execute(
+                _advisory_lock_sql(),
+                {"k": _advisory_lock_key(self.user_id)},
+            )
             doc = (await db.execute(_doc_select_for_update(self.user_id))).scalar_one_or_none()
             if doc is None:
                 full_new_text = (

--- a/tests/test_memory_db_async.py
+++ b/tests/test_memory_db_async.py
@@ -16,9 +16,11 @@ in ``tests/conftest.py``.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from backend.app.agent.memory_db import MemoryStore, get_memory_store
 from backend.app.models import MemoryDocument, User
@@ -318,3 +320,98 @@ async def test_async_writer_reads_back_through_async_session(
     reader = getattr(store, attr_reader)
     await writer("smoke value")
     assert await reader() == "smoke value"
+
+
+# ---------------------------------------------------------------------------
+# First-append concurrency: regression for issue #1224.
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryStoreFirstAppendConcurrency:
+    """Regression for issue #1224: ``MemoryStore.append_history`` first-append race.
+
+    Before the fix, the create-on-first-append branch ran an
+    unsynchronized SELECT then INSERT: ``SELECT ... FOR UPDATE`` on a
+    missing row acquires no predicate lock, so two concurrent
+    first-appends could both see ``None``, both INSERT, and the loser
+    would hit ``IntegrityError`` on ``uq_memory_documents_user_id``.
+
+    The fix takes a per-user ``pg_advisory_xact_lock`` at the top of
+    ``append_history`` so the create branch is serialized. This test
+    exercises the race directly: two tasks call ``append_history``
+    against the same user with no row yet, gated through an
+    ``asyncio.Barrier`` so both enter the critical section together.
+    Both must succeed and the final history must contain both entries.
+
+    These tests do NOT use the ``async_db`` fixture: ``async_db``
+    rebinds the session factory to a single shared connection, which
+    would serialize the two append calls inside Python and defeat the
+    race. The session-scoped ``_isolate_async_engine`` autouse fixture
+    already binds ``_async_session_factory`` to a ``NullPool`` async
+    engine, so each ``db_session_async()`` opens its own asyncpg
+    connection from the engine. The ``_isolate_stores`` autouse
+    teardown TRUNCATEs every table after the test.
+    """
+
+    _ACQUIRE_TIMEOUT_S = 10.0
+
+    async def _seed_user(self, engine: AsyncEngine, user_pk: str, phone: str) -> None:
+        """Insert the User row through a dedicated connection.
+
+        Commits immediately so concurrent tasks below can see the row
+        through their own connections under READ COMMITTED.
+        """
+        async with AsyncSession(engine, expire_on_commit=False) as db:
+            db.add(
+                User(
+                    id=user_pk,
+                    user_id=f"async-mem-{user_pk[:8]}",
+                    phone=phone,
+                    channel_identifier=f"mem-race-{user_pk[:8]}",
+                    preferred_channel="telegram",
+                    onboarding_complete=True,
+                )
+            )
+            await db.commit()
+
+    async def _append_in_task(
+        self,
+        user_pk: str,
+        entry: str,
+        barrier: asyncio.Barrier,
+    ) -> str:
+        """Wait at the barrier, then call ``append_history`` once.
+
+        Both tasks release together so they hit the critical section
+        in ``append_history`` concurrently. Each call goes through
+        ``db_session_async()``, which under the session-scoped
+        ``NullPool`` engine opens its own asyncpg connection.
+        """
+        await barrier.wait()
+        store = MemoryStore(user_pk)
+        return await store.append_history(entry)
+
+    async def test_two_concurrent_first_appends_both_succeed(
+        self,
+        _pg_async_engine: AsyncEngine,
+    ) -> None:
+        """Two concurrent first-appends for the same user both land."""
+        user_pk = "memstore-first-append-race-user"
+        await self._seed_user(_pg_async_engine, user_pk, "+15555550144")
+
+        barrier = asyncio.Barrier(2)
+        task_a = asyncio.create_task(self._append_in_task(user_pk, "entry-A", barrier))
+        task_b = asyncio.create_task(self._append_in_task(user_pk, "entry-B", barrier))
+
+        # Both must complete without IntegrityError. ``asyncio.gather``
+        # raises the first exception it sees, so a pre-fix run would
+        # surface the race here.
+        await asyncio.wait_for(
+            asyncio.gather(task_a, task_b),
+            timeout=self._ACQUIRE_TIMEOUT_S,
+        )
+
+        store = MemoryStore(user_pk)
+        history = await store.read_history_async()
+        assert "entry-A" in history, f"missing entry-A; history={history!r}"
+        assert "entry-B" in history, f"missing entry-B; history={history!r}"


### PR DESCRIPTION
## Description

Fixes #1224.

`MemoryStore.append_history`'s create-on-first-append branch did `SELECT ... FOR UPDATE` then `INSERT`, but `FOR UPDATE` on a missing row acquires no predicate lock. Two concurrent first-appends for the same user both saw the row as absent, both `INSERT`ed, and the loser hit `IntegrityError` on `uq_memory_documents_user_id`.

This PR takes a per-user `pg_advisory_xact_lock` at the top of `append_history`, mirroring the pattern in `backend/app/agent/session_db.py` (`_advisory_lock_key` / `_advisory_lock_sql`). The lock is transaction-scoped and released automatically on `COMMIT` or `ROLLBACK`, so no explicit unlock is needed. `FOR UPDATE` is kept to continue serializing the update branch against an existing row.

Adds `TestMemoryStoreFirstAppendConcurrency::test_two_concurrent_first_appends_both_succeed`: gates two `append_history` tasks through an `asyncio.Barrier(2)` so they enter the critical section together, with each task on its own asyncpg connection from the session-scoped `NullPool` engine. Verified the test fails on the pre-fix code with the exact `UniqueViolationError` and passes after the fix.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude Code drafted the patch and the regression test via back-and-forth with @njbrake; the reasoning and decisions are his.