### PR TITLE
fix(media): persist inbound staging to disk + DB with 7-day TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,13 @@ LLM_MODEL=
 # GOOGLE_DRIVE_CLIENT_ID=
 # GOOGLE_DRIVE_CLIENT_SECRET=
 
+# Inbound media staging — bytes for photos/files the user sends over the
+# messaging channel land here until the agent uploads them durably (Drive,
+# CompanyCam) or the 7-day TTL expires. Point this at a persistent volume in
+# production so the bytes survive process restarts. Metadata lives in the
+# ``staged_media`` Postgres table.
+# MEDIA_STAGING_BASE_DIR=data/staged_media
+
 # Agent loop
 # APPROVAL_TIMEOUT_SECONDS=120  # Seconds to wait for user approval before denying
 # AGENT_PROCESSING_TIMEOUT_SECONDS=300  # Max seconds for agent processing (includes lock wait)

--- a/alembic/versions/035_create_staged_media.py
+++ b/alembic/versions/035_create_staged_media.py
@@ -1,0 +1,70 @@
+"""Create the ``staged_media`` table.
+
+Persistence layer for inbound media bytes that the user has sent over a
+messaging channel but the agent has not yet uploaded somewhere durable
+(CompanyCam, Drive) or chosen to discard. The bytes themselves live on
+the deployment's persistent volume under
+``settings.media_staging_base_dir``; this table holds the metadata
+(handle, original_url, mime, expiry, disk path) so a process restart
+does not lose the agent's reference to photos a contractor sent earlier
+in the week.
+
+Replaces a prior in-process ``dict`` cache that lost everything on every
+deploy (issue #1333).
+
+Revision ID: 035
+Revises: 034
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "035"
+down_revision: str = "034"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "staged_media",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+        sa.Column("handle", sa.String(), nullable=False),
+        sa.Column("original_url", sa.Text(), nullable=False),
+        sa.Column(
+            "mime_type", sa.String(), nullable=False, server_default="application/octet-stream"
+        ),
+        sa.Column("disk_path", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("handle", name="uq_staged_media_handle"),
+        sa.UniqueConstraint("user_id", "original_url", name="uq_staged_media_user_original_url"),
+    )
+    # Lazy purges run ``DELETE WHERE expires_at < now()``; index keeps that
+    # cheap as the table grows.
+    op.create_index(
+        "ix_staged_media_expires_at",
+        "staged_media",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_staged_media_expires_at", table_name="staged_media")
+    op.drop_table("staged_media")

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -110,9 +110,11 @@ def _disk_path_for(user_id: str, handle: str) -> Path:
 def _mint_handle() -> str:
     """Generate a short opaque handle token for a staged media item.
 
-    Collisions on 48 bits of entropy are astronomically unlikely; the
-    INSERT either takes or hits the ``uq_staged_media_handle``
-    constraint, in which case the caller retries with a fresh handle.
+    48 bits of entropy: collision probability across a 10k-entry table
+    is on the order of 1e-7 over the table's lifetime, so the INSERT
+    either takes or raises ``uq_staged_media_handle`` and the
+    exception propagates. ``stage`` does not catch it; a caller seeing
+    the error should retry, which mints a fresh handle.
     """
     return f"media_{secrets.token_urlsafe(6)}"
 

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -104,7 +104,37 @@ def _user_dir(user_id: str) -> Path:
 
 
 def _disk_path_for(user_id: str, handle: str) -> Path:
+    """Absolute filesystem path for ``(user, handle)``'s bytes.
+
+    Used by callers that need to write or unlink the file. The DB stores
+    the relative suffix (see :func:`_store_disk_path`) so the staging
+    window survives an operator changing ``MEDIA_STAGING_BASE_DIR``.
+    """
     return _user_dir(user_id) / f"{handle}.bin"
+
+
+def _store_disk_path(user_id: str, handle: str) -> str:
+    """Suffix stored in ``staged_media.disk_path``, relative to the staging root.
+
+    Storing the suffix (e.g. ``<user_id>/media_abZtYWFs.bin``) rather than
+    an absolute path means a deployment that re-mounts its volume under a
+    different ``MEDIA_STAGING_BASE_DIR`` can still find its 7-day window of
+    bytes after a restart.
+    """
+    return f"{user_id}/{handle}.bin"
+
+
+def _resolve_disk_path(stored: str) -> Path:
+    """Reconstruct an absolute path from a stored ``disk_path`` suffix.
+
+    Defensively handles a legacy absolute path (e.g. from a pre-PR row
+    or a hand-inserted test fixture): if the stored value is already
+    absolute, return it as-is. New writes always use the relative form.
+    """
+    p = Path(stored)
+    if p.is_absolute():
+        return p
+    return _staging_root() / stored
 
 
 def _mint_handle() -> str:
@@ -140,7 +170,7 @@ async def stage(user_id: str, original_url: str, content: bytes, mime_type: str)
 
     expires_at = datetime.now(UTC) + timedelta(seconds=STAGING_TTL_SECONDS)
     fresh_handle = _mint_handle()
-    fresh_disk_path = _disk_path_for(user_id, fresh_handle)
+    fresh_disk_path = _store_disk_path(user_id, fresh_handle)
 
     async with db_session_async() as db:
         # INSERT ... ON CONFLICT DO UPDATE: an existing row for
@@ -155,7 +185,7 @@ async def stage(user_id: str, original_url: str, content: bytes, mime_type: str)
                 handle=fresh_handle,
                 original_url=original_url,
                 mime_type=mime_type,
-                disk_path=str(fresh_disk_path),
+                disk_path=fresh_disk_path,
                 expires_at=expires_at,
             )
             .on_conflict_do_update(
@@ -170,7 +200,7 @@ async def stage(user_id: str, original_url: str, content: bytes, mime_type: str)
         row = (await db.execute(stmt)).one()
         await db.commit()
         handle = cast("str", row.handle)
-        disk_path = Path(cast("str", row.disk_path))
+        disk_path = _resolve_disk_path(cast("str", row.disk_path))
 
     # Write bytes after commit so a transient DB failure doesn't leave
     # an orphan file behind. A crash between commit and write leaves
@@ -206,7 +236,7 @@ async def _enforce_per_user_cap(user_id: str) -> None:
             return
         overflow = rows[: len(rows) - STAGING_MAX_PER_USER]
         for row in overflow:
-            _unlink_quiet(Path(row.disk_path))
+            _unlink_quiet(_resolve_disk_path(row.disk_path))
             logger.warning(
                 "media_staging cap reached for user %s, evicted %s (handle=%s)",
                 user_id,
@@ -243,7 +273,7 @@ async def get_all_for_user(user_id: str) -> dict[str, bytes]:
             .all()
         )
         for row in rows:
-            content = _read_bytes(Path(row.disk_path))
+            content = _read_bytes(_resolve_disk_path(row.disk_path))
             if content is None:
                 orphan_ids.append(row.id)
                 continue
@@ -273,6 +303,42 @@ async def _delete_rows_by_id(ids: list[str]) -> None:
     async with db_session_async() as db:
         await db.execute(delete(StagedMedia).where(StagedMedia.id.in_(ids)))
         await db.commit()
+
+
+async def list_urls_for_user(user_id: str) -> list[str]:
+    """Return non-expired ``original_url`` values for a user, newest first.
+
+    Cheaper than :func:`get_all_for_user` when the caller only needs to
+    know which URLs are staged (e.g. to pick a fallback target for an
+    arg-less ``upload_to_storage`` call). The caller loads bytes on
+    demand for the chosen URL via :func:`resolve_media_ref`, avoiding
+    the per-turn disk-read storm that would come from eager-loading
+    everything just in case.
+
+    Ordering is ``expires_at desc`` so the most recently staged or
+    touched item lands first, matching "the photo the user probably
+    meant" intuition.
+    """
+    now = datetime.now(UTC)
+    db = AsyncSessionLocal()
+    try:
+        rows = (
+            (
+                await db.execute(
+                    select(StagedMedia.original_url)
+                    .where(
+                        StagedMedia.user_id == user_id,
+                        StagedMedia.expires_at > now,
+                    )
+                    .order_by(StagedMedia.expires_at.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+    finally:
+        await db.close()
+    return list(rows)
 
 
 async def get_mime_type(user_id: str, original_url: str) -> str | None:
@@ -338,7 +404,7 @@ async def get_by_handle(handle: str) -> tuple[str, str, bytes, str] | None:
         ).scalar_one_or_none()
         if row is None:
             return None
-        content = _read_bytes(Path(row.disk_path))
+        content = _read_bytes(_resolve_disk_path(row.disk_path))
         user_id = row.user_id
         original_url = row.original_url
         mime = row.mime_type
@@ -353,12 +419,18 @@ async def get_by_handle(handle: str) -> tuple[str, str, bytes, str] | None:
     return user_id, original_url, content, mime
 
 
-async def touch(handle: str) -> bool:
+async def touch(handle: str, user_id: str) -> bool:
     """Extend the TTL on a staged entry because a tool referenced it.
 
     Long agent sessions span multiple back-and-forth turns; touching on
     every tool reference prevents a stale-TTL eviction mid-conversation.
-    Returns True if the handle was found and its TTL was extended.
+    Returns True if the handle was found, owned by ``user_id``, and its
+    TTL was extended.
+
+    The ``user_id`` scope is defensive: today every caller does an
+    ownership check via :func:`get_by_handle` first, but a future
+    caller that forgets shouldn't be able to extend another user's TTL
+    just by guessing a handle.
     """
     new_expires_at = datetime.now(UTC) + timedelta(seconds=STAGING_TTL_SECONDS)
     async with db_session_async() as db:
@@ -366,7 +438,7 @@ async def touch(handle: str) -> bool:
             "CursorResult[object]",
             await db.execute(
                 update(StagedMedia)
-                .where(StagedMedia.handle == handle)
+                .where(StagedMedia.handle == handle, StagedMedia.user_id == user_id)
                 .values(expires_at=new_expires_at)
             ),
         )
@@ -410,7 +482,7 @@ async def resolve_media_ref(user_id: str, ref: str) -> tuple[str, bytes, str] | 
         ).scalar_one_or_none()
         if row is None:
             return None
-        content = _read_bytes(Path(row.disk_path))
+        content = _read_bytes(_resolve_disk_path(row.disk_path))
         mime = row.mime_type
         orphan_id = row.id if content is None else None
     finally:
@@ -441,7 +513,7 @@ async def evict(user_id: str, original_url: str) -> None:
         ).scalar_one_or_none()
         if row is None:
             return
-        _unlink_quiet(Path(row.disk_path))
+        _unlink_quiet(_resolve_disk_path(row.disk_path))
         await db.delete(row)
         await db.commit()
 
@@ -454,7 +526,7 @@ async def evict_by_handle(handle: str) -> bool:
         ).scalar_one_or_none()
         if row is None:
             return False
-        _unlink_quiet(Path(row.disk_path))
+        _unlink_quiet(_resolve_disk_path(row.disk_path))
         await db.delete(row)
         await db.commit()
         return True
@@ -469,7 +541,7 @@ async def clear_user(user_id: str) -> None:
             .all()
         )
         for row in rows:
-            _unlink_quiet(Path(row.disk_path))
+            _unlink_quiet(_resolve_disk_path(row.disk_path))
         await db.execute(delete(StagedMedia).where(StagedMedia.user_id == user_id))
         await db.commit()
     _uploaded.pop(user_id, None)
@@ -491,7 +563,7 @@ async def purge_expired() -> int:
             .all()
         )
         for row in rows:
-            _unlink_quiet(Path(row.disk_path))
+            _unlink_quiet(_resolve_disk_path(row.disk_path))
         if rows:
             await db.execute(delete(StagedMedia).where(StagedMedia.expires_at <= now))
             await db.commit()

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -1,21 +1,35 @@
-"""In-memory staging cache for inbound media bytes.
+"""DB- and disk-backed staging cache for inbound media bytes.
 
-Holds downloaded media content keyed by ``(user_id, original_url)`` for a
-TTL window so agent tools (``analyze_photo``, ``upload_to_storage``,
-``discard_media``, etc.) can find the bytes across turns. Scoped per-user
-and per-process; not durable.
+Holds downloaded media content keyed by ``(user_id, original_url)`` for
+a 7-day window so agent tools (``analyze_photo``, ``upload_to_storage``,
+``discard_media``, etc.) can find the bytes across turns and across
+process restarts. The bytes themselves live on the deployment's
+persistent volume under ``settings.media_staging_base_dir``; metadata
+(handle, original_url, mime, expiry, disk path) lives in the
+``staged_media`` Postgres table.
 
 Each staged entry gets a short handle token (``media_XXXXXX``) so tools
 can reference the bytes without passing raw channel URLs through the
 prompt. Both lookup styles work; the handle-based API is what the agent
 sees.
 
-This module also tracks a short-lived ``recently_uploaded`` record for each
-``(user_id, original_url)``. After a tool successfully ships the bytes to
-an external service (CompanyCam, etc.) it both ``evict``s the bytes and
-``mark_uploaded``s an ``UploadRecord`` so a same-turn retry on the same
-handle can return an idempotent "already uploaded" result instead of the
-generic "No photo available" error.
+This module also tracks a short-lived ``recently_uploaded`` record for
+each ``(user_id, original_url)``. After a tool successfully ships the
+bytes to an external service (CompanyCam, etc.) it both ``evict``s the
+bytes and ``mark_uploaded``s an ``UploadRecord`` so a same-turn retry
+on the same handle can return an idempotent "already uploaded" result
+instead of the generic "No photo available" error. The receipt cache
+stays in-process and is intentionally short-lived (1 h); its job is
+only to absorb same-turn / same-day retries within one worker.
+
+MULTI-REPLICA WARNING: this module assumes a single application
+instance with exclusive write access to ``media_staging_base_dir``. If
+clawbolt is ever deployed across multiple replicas, the on-disk bytes
+are no longer shared and a replica that did not receive the inbound
+message cannot find the file. Tracked at
+https://github.com/mozilla-ai/clawbolt/issues/1336. When that work
+lands, move ``content`` into Postgres ``BYTEA`` or an object store so
+every replica can read it.
 """
 
 from __future__ import annotations
@@ -24,16 +38,31 @@ import logging
 import secrets
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import cast
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.engine.cursor import CursorResult
+
+from backend.app.config import settings
+from backend.app.database import AsyncSessionLocal, db_session_async
+from backend.app.models import StagedMedia
 
 logger = logging.getLogger(__name__)
 
-STAGING_TTL_SECONDS = 86400  # 24h: long agent sessions can span multiple hours
+# 7 days: long enough that a contractor sending photos earlier in the
+# week can still reference them mid-conversation later. Bytes survive
+# process restarts via the persistent volume, so the cap is real wall
+# clock, not "since the last deploy."
+STAGING_TTL_SECONDS = 604800
 STAGING_MAX_PER_USER = 50  # Cap memory growth: oldest-expiring entry is evicted on overflow
 
-# Recently-uploaded receipt cache. Shorter TTL than staging because its job
-# is only to absorb same-turn / same-day retries on a handle the model
-# already shipped. Anything older than this should not look like a fresh
-# success on retry; the tool can return its normal NOT_FOUND.
+# Recently-uploaded receipt cache. Shorter TTL than staging because its
+# job is only to absorb same-turn / same-day retries on a handle the
+# model already shipped. Anything older than this should not look like
+# a fresh success on retry; the tool can return its normal NOT_FOUND.
 UPLOAD_RECORD_TTL_SECONDS = 3600  # 1h
 UPLOAD_RECORD_MAX_PER_USER = 200
 
@@ -56,156 +85,294 @@ class UploadRecord:
     status: str  # "uploaded", "duplicate", "pending", "processing_error"
 
 
-_cache: dict[str, dict[str, tuple[bytes, str, float, str]]] = {}
-# handle token -> (user_id, original_url) reverse index
-_handles: dict[str, tuple[str, str]] = {}
 # user_id -> {original_url: (UploadRecord, expires_at)} recently-uploaded receipts
 _uploaded: dict[str, dict[str, tuple[UploadRecord, float]]] = {}
+
+
+def _staging_root() -> Path:
+    """Return the configured staging directory, ensuring it exists."""
+    root = Path(settings.media_staging_base_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _user_dir(user_id: str) -> Path:
+    """Return ``<staging_root>/<user_id>``, ensuring it exists."""
+    d = _staging_root() / user_id
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _disk_path_for(user_id: str, handle: str) -> Path:
+    return _user_dir(user_id) / f"{handle}.bin"
 
 
 def _mint_handle() -> str:
     """Generate a short opaque handle token for a staged media item.
 
-    Collisions on 48 bits of entropy are astronomically unlikely, but a
-    retry loop is free insurance against silent cross-user overwrite of
-    the ``_handles`` index.
+    Collisions on 48 bits of entropy are astronomically unlikely; the
+    INSERT either takes or hits the ``uq_staged_media_handle``
+    constraint, in which case the caller retries with a fresh handle.
     """
-    while True:
-        handle = f"media_{secrets.token_urlsafe(6)}"
-        if handle not in _handles:
-            return handle
+    return f"media_{secrets.token_urlsafe(6)}"
 
 
-def stage(user_id: str, original_url: str, content: bytes, mime_type: str) -> str | None:
+def _unlink_quiet(path: Path) -> None:
+    """Best-effort delete: log a warning on unexpected errors."""
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("Failed to unlink staged media file %s: %s", path, exc)
+
+
+async def stage(user_id: str, original_url: str, content: bytes, mime_type: str) -> str | None:
     """Cache media bytes for later retrieval within the TTL window.
 
-    Returns the handle token for the staged entry, or ``None`` when staging
-    was skipped (empty url or empty content). Safe to call repeatedly for
-    the same ``original_url``, the handle is stable across re-stage within
-    the same user's scope.
+    Returns the handle token for the staged entry, or ``None`` when
+    staging was skipped (empty url or empty content). Safe to call
+    repeatedly for the same ``original_url``: the handle is stable
+    across re-stage within the same user's scope.
     """
     if not original_url or not content:
         return None
-    # Purge first so re-stage of an expired URL doesn't resurrect a stale
-    # handle that may no longer be indexed in _handles.
-    _purge_expired()
-    expires_at = time.monotonic() + STAGING_TTL_SECONDS
-    user_items = _cache.setdefault(user_id, {})
-    existing = user_items.get(original_url)
-    if existing is not None:
-        handle = existing[3]
-    else:
-        handle = _mint_handle()
-        _handles[handle] = (user_id, original_url)
-    user_items[original_url] = (content, mime_type, expires_at, handle)
-    _enforce_per_user_cap(user_id)
+
+    expires_at = datetime.now(UTC) + timedelta(seconds=STAGING_TTL_SECONDS)
+    fresh_handle = _mint_handle()
+    fresh_disk_path = _disk_path_for(user_id, fresh_handle)
+
+    async with db_session_async() as db:
+        # INSERT ... ON CONFLICT DO UPDATE: an existing row for
+        # (user_id, original_url) keeps its handle and disk_path (so the
+        # agent's prior reference still resolves) but refreshes mime,
+        # expiry, and the underlying bytes. The RETURNING tells us which
+        # disk path actually won the conflict so we write bytes there.
+        stmt = (
+            pg_insert(StagedMedia)
+            .values(
+                user_id=user_id,
+                handle=fresh_handle,
+                original_url=original_url,
+                mime_type=mime_type,
+                disk_path=str(fresh_disk_path),
+                expires_at=expires_at,
+            )
+            .on_conflict_do_update(
+                index_elements=["user_id", "original_url"],
+                set_={
+                    "mime_type": mime_type,
+                    "expires_at": expires_at,
+                },
+            )
+            .returning(StagedMedia.handle, StagedMedia.disk_path)
+        )
+        row = (await db.execute(stmt)).one()
+        await db.commit()
+        handle = cast("str", row.handle)
+        disk_path = Path(cast("str", row.disk_path))
+
+    # Write bytes after commit so a transient DB failure doesn't leave
+    # an orphan file behind. A crash between commit and write leaves
+    # an orphan row; the next ``get_*`` call detects the missing file
+    # and prunes the row.
+    disk_path.parent.mkdir(parents=True, exist_ok=True)
+    disk_path.write_bytes(content)
+
+    await _enforce_per_user_cap(user_id)
     return handle
 
 
-def _enforce_per_user_cap(user_id: str) -> None:
-    """Evict the soonest-expiring entry when a user exceeds the per-user cap.
+async def _enforce_per_user_cap(user_id: str) -> None:
+    """Evict soonest-expiring rows when a user exceeds the per-user cap.
 
-    Prevents unbounded memory growth when a single contractor sends hundreds
-    of photos within the TTL window. The eviction is silent at the API level
-    but logs a warning.
+    Prevents unbounded growth when a single contractor sends hundreds
+    of photos within the TTL window. Eviction is silent at the API
+    level but logs a warning so we notice if it happens routinely.
     """
-    user_items = _cache.get(user_id)
-    if not user_items or len(user_items) <= STAGING_MAX_PER_USER:
-        return
-    # Drop entries with the smallest expires_at until within cap.
-    while len(user_items) > STAGING_MAX_PER_USER:
-        oldest_url = min(user_items, key=lambda url: user_items[url][2])
-        _content, _mime, _exp, handle = user_items.pop(oldest_url)
-        _handles.pop(handle, None)
-        logger.warning(
-            "media_staging cap reached for user %s, evicted %s (handle=%s)",
-            user_id,
-            oldest_url,
-            handle,
+    async with db_session_async() as db:
+        rows = list(
+            (
+                await db.execute(
+                    select(StagedMedia)
+                    .where(StagedMedia.user_id == user_id)
+                    .order_by(StagedMedia.expires_at.asc())
+                )
+            )
+            .scalars()
+            .all()
         )
+        if len(rows) <= STAGING_MAX_PER_USER:
+            return
+        overflow = rows[: len(rows) - STAGING_MAX_PER_USER]
+        for row in overflow:
+            _unlink_quiet(Path(row.disk_path))
+            logger.warning(
+                "media_staging cap reached for user %s, evicted %s (handle=%s)",
+                user_id,
+                row.original_url,
+                row.handle,
+            )
+            await db.delete(row)
+        await db.commit()
 
 
-def get_all_for_user(user_id: str) -> dict[str, bytes]:
-    """Return non-expired staged bytes for a user as ``{original_url: bytes}``."""
-    _purge_expired()
-    now = time.monotonic()
-    return {
-        url: content
-        for url, (content, _mime, exp, _handle) in _cache.get(user_id, {}).items()
-        if exp > now
-    }
+async def get_all_for_user(user_id: str) -> dict[str, bytes]:
+    """Return non-expired staged bytes for a user as ``{original_url: bytes}``.
 
-
-def get_mime_type(user_id: str, original_url: str) -> str | None:
-    """Return the staged mime type for ``original_url``, or None if not cached.
-
-    The download step knows the authoritative mime type; the LLM is guessing.
-    ``upload_to_storage`` uses this to override its argument when available.
+    Rows whose backing file has gone missing (e.g. a partial write or a
+    manual scrub) are pruned in passing so subsequent calls don't keep
+    walking dead rows.
     """
-    _purge_expired()
-    now = time.monotonic()
-    entry = _cache.get(user_id, {}).get(original_url)
-    if entry is None:
+    now = datetime.now(UTC)
+    result: dict[str, bytes] = {}
+    orphan_ids: list[str] = []
+
+    db = AsyncSessionLocal()
+    try:
+        rows = (
+            (
+                await db.execute(
+                    select(StagedMedia).where(
+                        StagedMedia.user_id == user_id,
+                        StagedMedia.expires_at > now,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            content = _read_bytes(Path(row.disk_path))
+            if content is None:
+                orphan_ids.append(row.id)
+                continue
+            result[row.original_url] = content
+    finally:
+        await db.close()
+
+    if orphan_ids:
+        await _delete_rows_by_id(orphan_ids)
+    return result
+
+
+def _read_bytes(path: Path) -> bytes | None:
+    """Read a staging file. ``None`` signals "treat the row as missing"."""
+    try:
+        return path.read_bytes()
+    except FileNotFoundError:
         return None
-    _content, mime, exp, _handle = entry
-    return mime if exp > now else None
+    except OSError as exc:
+        logger.warning("Failed to read staged media file %s: %s", path, exc)
+        return None
 
 
-def get_handle_for(user_id: str, original_url: str) -> str | None:
+async def _delete_rows_by_id(ids: list[str]) -> None:
+    if not ids:
+        return
+    async with db_session_async() as db:
+        await db.execute(delete(StagedMedia).where(StagedMedia.id.in_(ids)))
+        await db.commit()
+
+
+async def get_mime_type(user_id: str, original_url: str) -> str | None:
+    """Return the staged mime type for ``original_url``, or None.
+
+    The download step knows the authoritative mime type; the LLM is
+    guessing. ``upload_to_storage`` uses this to override its argument
+    when available.
+    """
+    now = datetime.now(UTC)
+    db = AsyncSessionLocal()
+    try:
+        row = (
+            await db.execute(
+                select(StagedMedia).where(
+                    StagedMedia.user_id == user_id,
+                    StagedMedia.original_url == original_url,
+                    StagedMedia.expires_at > now,
+                )
+            )
+        ).scalar_one_or_none()
+    finally:
+        await db.close()
+    return row.mime_type if row is not None else None
+
+
+async def get_handle_for(user_id: str, original_url: str) -> str | None:
     """Return the staged handle for ``(user_id, original_url)`` or ``None``."""
-    _purge_expired()
-    entry = _cache.get(user_id, {}).get(original_url)
-    if entry is None:
-        return None
-    _content, _mime, exp, handle = entry
-    return handle if exp > time.monotonic() else None
+    now = datetime.now(UTC)
+    db = AsyncSessionLocal()
+    try:
+        row = (
+            await db.execute(
+                select(StagedMedia).where(
+                    StagedMedia.user_id == user_id,
+                    StagedMedia.original_url == original_url,
+                    StagedMedia.expires_at > now,
+                )
+            )
+        ).scalar_one_or_none()
+    finally:
+        await db.close()
+    return row.handle if row is not None else None
 
 
-def get_by_handle(handle: str) -> tuple[str, str, bytes, str] | None:
+async def get_by_handle(handle: str) -> tuple[str, str, bytes, str] | None:
     """Look up a staged entry by its handle token.
 
-    Returns ``(user_id, original_url, content, mime_type)`` or ``None`` if
-    the handle is unknown or the entry has expired.
+    Returns ``(user_id, original_url, content, mime_type)`` or ``None``
+    if the handle is unknown, expired, or the backing file has been
+    swept from disk.
     """
-    _purge_expired()
-    ref = _handles.get(handle)
-    if ref is None:
+    now = datetime.now(UTC)
+    db = AsyncSessionLocal()
+    try:
+        row = (
+            await db.execute(
+                select(StagedMedia).where(
+                    StagedMedia.handle == handle,
+                    StagedMedia.expires_at > now,
+                )
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            return None
+        content = _read_bytes(Path(row.disk_path))
+        user_id = row.user_id
+        original_url = row.original_url
+        mime = row.mime_type
+        orphan_id = row.id if content is None else None
+    finally:
+        await db.close()
+
+    if orphan_id is not None:
+        await _delete_rows_by_id([orphan_id])
         return None
-    user_id, original_url = ref
-    entry = _cache.get(user_id, {}).get(original_url)
-    if entry is None:
-        _handles.pop(handle, None)
-        return None
-    content, mime, exp, stored_handle = entry
-    now = time.monotonic()
-    if exp <= now or stored_handle != handle:
-        return None
+    assert content is not None
     return user_id, original_url, content, mime
 
 
-def touch(handle: str) -> bool:
+async def touch(handle: str) -> bool:
     """Extend the TTL on a staged entry because a tool referenced it.
 
     Long agent sessions span multiple back-and-forth turns; touching on
     every tool reference prevents a stale-TTL eviction mid-conversation.
     Returns True if the handle was found and its TTL was extended.
     """
-    ref = _handles.get(handle)
-    if ref is None:
-        return False
-    user_id, original_url = ref
-    entry = _cache.get(user_id, {}).get(original_url)
-    if entry is None:
-        return False
-    content, mime, _old_exp, stored_handle = entry
-    if stored_handle != handle:
-        return False
-    new_exp = time.monotonic() + STAGING_TTL_SECONDS
-    _cache[user_id][original_url] = (content, mime, new_exp, stored_handle)
-    return True
+    new_expires_at = datetime.now(UTC) + timedelta(seconds=STAGING_TTL_SECONDS)
+    async with db_session_async() as db:
+        result = cast(
+            "CursorResult[object]",
+            await db.execute(
+                update(StagedMedia)
+                .where(StagedMedia.handle == handle)
+                .values(expires_at=new_expires_at)
+            ),
+        )
+        await db.commit()
+        return result.rowcount > 0
 
 
-def resolve_media_ref(user_id: str, ref: str) -> tuple[str, bytes, str] | None:
+async def resolve_media_ref(user_id: str, ref: str) -> tuple[str, bytes, str] | None:
     """Resolve a media reference that may be a handle or an original URL.
 
     The LLM sees media handles (``media_XXXXXX``) in the prompt and may
@@ -213,12 +380,13 @@ def resolve_media_ref(user_id: str, ref: str) -> tuple[str, bytes, str] | None:
     either form and returns ``(original_url, content, mime_type)`` when
     the referenced media is still staged for the given user.
 
-    Returns ``None`` when the reference cannot be resolved (unknown handle,
-    wrong user, expired entry, or URL not in staging).
+    Returns ``None`` when the reference cannot be resolved (unknown
+    handle, wrong user, expired entry, or URL not in staging).
     """
-    # Try handle resolution first (handles start with "media_" but so could
-    # a theoretical URL, so always check the handle index regardless).
-    entry = get_by_handle(ref)
+    # Try handle resolution first (handles start with "media_" but so
+    # could a theoretical URL, so always check the handle index
+    # regardless).
+    entry = await get_by_handle(ref)
     if entry is not None:
         stored_uid, original_url, content, mime = entry
         if stored_uid == user_id:
@@ -226,33 +394,118 @@ def resolve_media_ref(user_id: str, ref: str) -> tuple[str, bytes, str] | None:
         return None
 
     # Fall back to URL lookup in the user's staged entries.
-    _purge_expired()
-    now = time.monotonic()
-    user_items = _cache.get(user_id, {})
-    item = user_items.get(ref)
-    if item is not None:
-        content, mime, exp, _handle = item
-        if exp > now:
-            return ref, content, mime
+    now = datetime.now(UTC)
+    db = AsyncSessionLocal()
+    try:
+        row = (
+            await db.execute(
+                select(StagedMedia).where(
+                    StagedMedia.user_id == user_id,
+                    StagedMedia.original_url == ref,
+                    StagedMedia.expires_at > now,
+                )
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            return None
+        content = _read_bytes(Path(row.disk_path))
+        mime = row.mime_type
+        orphan_id = row.id if content is None else None
+    finally:
+        await db.close()
 
-    return None
+    if orphan_id is not None:
+        await _delete_rows_by_id([orphan_id])
+        return None
+    assert content is not None
+    return ref, content, mime
 
 
-def evict(user_id: str, original_url: str) -> None:
+async def evict(user_id: str, original_url: str) -> None:
     """Remove a staged entry (call after successful upload or explicit deny).
 
-    The upload-record cache is intentionally NOT cleared here; a same-turn
-    retry on the same handle still needs to find the receipt. Records age
-    out via their own TTL.
+    The upload-record cache is intentionally NOT cleared here; a
+    same-turn retry on the same handle still needs to find the receipt.
+    Records age out via their own TTL.
     """
-    user_items = _cache.get(user_id)
-    if not user_items:
-        return
-    entry = user_items.pop(original_url, None)
-    if entry is not None:
-        _handles.pop(entry[3], None)
-    if not user_items:
-        _cache.pop(user_id, None)
+    async with db_session_async() as db:
+        row = (
+            await db.execute(
+                select(StagedMedia).where(
+                    StagedMedia.user_id == user_id,
+                    StagedMedia.original_url == original_url,
+                )
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            return
+        _unlink_quiet(Path(row.disk_path))
+        await db.delete(row)
+        await db.commit()
+
+
+async def evict_by_handle(handle: str) -> bool:
+    """Remove a staged entry by its handle. Returns True if something was removed."""
+    async with db_session_async() as db:
+        row = (
+            await db.execute(select(StagedMedia).where(StagedMedia.handle == handle))
+        ).scalar_one_or_none()
+        if row is None:
+            return False
+        _unlink_quiet(Path(row.disk_path))
+        await db.delete(row)
+        await db.commit()
+        return True
+
+
+async def clear_user(user_id: str) -> None:
+    """Drop all staged media and upload records for a user (primarily for tests)."""
+    async with db_session_async() as db:
+        rows = list(
+            (await db.execute(select(StagedMedia).where(StagedMedia.user_id == user_id)))
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            _unlink_quiet(Path(row.disk_path))
+        await db.execute(delete(StagedMedia).where(StagedMedia.user_id == user_id))
+        await db.commit()
+    _uploaded.pop(user_id, None)
+
+
+async def purge_expired() -> int:
+    """Drop every expired row and its on-disk bytes. Returns rows deleted.
+
+    Called from app startup so a fresh process doesn't accumulate dead
+    rows across deploys. Inline ``stage`` cleanup keeps the table tidy
+    during steady-state operation, but a missed-eviction-on-crash row
+    can linger past its TTL until something explicitly sweeps it.
+    """
+    now = datetime.now(UTC)
+    async with db_session_async() as db:
+        rows = list(
+            (await db.execute(select(StagedMedia).where(StagedMedia.expires_at <= now)))
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            _unlink_quiet(Path(row.disk_path))
+        if rows:
+            await db.execute(delete(StagedMedia).where(StagedMedia.expires_at <= now))
+            await db.commit()
+        return len(rows)
+
+
+# ---------------------------------------------------------------------------
+# In-process upload-receipt cache
+# ---------------------------------------------------------------------------
+#
+# Same-turn retries on a handle that already shipped to an external
+# service need a positive idempotent answer instead of "no bytes found".
+# This is short-lived (1h) and intentionally not persisted: by the time
+# a retry happens >1h later, the agent should just succeed via the
+# normal staged-bytes path. Keeping it in-memory avoids extra DB writes
+# on every successful upload.
 
 
 def mark_uploaded(
@@ -265,14 +518,7 @@ def mark_uploaded(
     target: str,
     status: str,
 ) -> None:
-    """Record that ``original_url`` was successfully shipped to *service*.
-
-    Call right before :func:`evict` on the success path of an external
-    upload tool. A later tool call referencing the same handle (within
-    :data:`UPLOAD_RECORD_TTL_SECONDS`) can then look up the record via
-    :func:`get_uploaded` and return an idempotent receipt instead of
-    failing with "No photo available."
-    """
+    """Record that ``original_url`` was successfully shipped to *service*."""
     if not original_url:
         return
     _purge_expired_uploads()
@@ -290,13 +536,7 @@ def mark_uploaded(
 
 
 def get_uploaded(user_id: str, original_url: str) -> UploadRecord | None:
-    """Return the recently-uploaded receipt for ``(user_id, original_url)``.
-
-    Returns ``None`` if no upload was recorded or the record has expired.
-    The returned record is unscoped by service, so callers must check
-    ``record.service`` matches the tool's own service before re-emitting
-    the receipt.
-    """
+    """Return the recently-uploaded receipt for ``(user_id, original_url)``."""
     if not original_url:
         return None
     user_records = _uploaded.get(user_id)
@@ -307,13 +547,11 @@ def get_uploaded(user_id: str, original_url: str) -> UploadRecord | None:
         return None
     record, expires_at = entry
     if expires_at <= time.monotonic():
-        # Don't bother purging here; _purge_expired_uploads runs on writes.
         return None
     return record
 
 
 def _enforce_upload_record_cap(user_id: str) -> None:
-    """Cap the per-user upload-record count by evicting the soonest-expiring."""
     user_records = _uploaded.get(user_id)
     if not user_records or len(user_records) <= UPLOAD_RECORD_MAX_PER_USER:
         return
@@ -333,43 +571,3 @@ def _purge_expired_uploads() -> None:
             empty_users.append(user_id)
     for user_id in empty_users:
         del _uploaded[user_id]
-
-
-def evict_by_handle(handle: str) -> bool:
-    """Remove a staged entry by its handle. Returns True if something was removed."""
-    ref = _handles.pop(handle, None)
-    if ref is None:
-        return False
-    user_id, original_url = ref
-    user_items = _cache.get(user_id)
-    if user_items is not None:
-        user_items.pop(original_url, None)
-        if not user_items:
-            _cache.pop(user_id, None)
-    return True
-
-
-def clear_user(user_id: str) -> None:
-    """Drop all staged media and upload records for a user (primarily for tests)."""
-    user_items = _cache.pop(user_id, None)
-    if user_items:
-        for _content, _mime, _exp, handle in user_items.values():
-            _handles.pop(handle, None)
-    _uploaded.pop(user_id, None)
-
-
-def _purge_expired() -> None:
-    now = time.monotonic()
-    empty_users: list[str] = []
-    for user_id, items in _cache.items():
-        expired_urls: list[str] = []
-        for url, (_c, _m, exp, handle) in items.items():
-            if exp <= now:
-                expired_urls.append(url)
-                _handles.pop(handle, None)
-        for url in expired_urls:
-            del items[url]
-        if not items:
-            empty_users.append(user_id)
-    for user_id in empty_users:
-        del _cache[user_id]

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -184,7 +184,9 @@ async def prepare_media(
             try:
                 media = await download_media(file_id)
                 downloaded_media.append(media)
-                media_staging.stage(user.id, media.original_url, media.content, media.mime_type)
+                await media_staging.stage(
+                    user.id, media.original_url, media.content, media.mime_type
+                )
                 logger.debug("Downloaded media %s (%s)", file_id, _mime_type)
             except Exception:
                 logger.exception("Failed to download media: %s", file_id)
@@ -455,7 +457,9 @@ async def prepare_media_step(ctx: PipelineContext) -> PipelineContext:
     pre_downloaded = list(ctx.downloaded_media)
     if ctx.user is not None:
         for media in pre_downloaded:
-            media_staging.stage(ctx.user.id, media.original_url, media.content, media.mime_type)
+            await media_staging.stage(
+                ctx.user.id, media.original_url, media.content, media.mime_type
+            )
     newly_downloaded, ctx.storage = await prepare_media(
         ctx.user, ctx.message, ctx.media_urls, download_media=ctx.download_media
     )

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -253,6 +253,21 @@ def create_file_tools(
             first_url = next(iter(media_map))
             file_bytes = media_map[first_url]
             original_url = original_url or first_url
+        elif not original_url:
+            # Cross-turn fallback: the agent called upload_to_storage on a
+            # turn with no attachments, so neither ``media_map`` nor
+            # ``resolve_media_ref`` had anything to chew on. Reach into
+            # staging directly and pick the most recently staged photo.
+            # ``_file_factory`` deliberately does NOT pre-load these into
+            # ``media_map`` because that would mean reading every staged
+            # photo off disk on every agent turn, just in case.
+            staged_urls = await media_staging.list_urls_for_user(user.id)
+            if staged_urls:
+                first_staged = staged_urls[0]
+                resolved = await media_staging.resolve_media_ref(user.id, first_staged)
+                if resolved is not None:
+                    _, file_bytes, mime_type = resolved
+                    original_url = first_staged
 
         # The download layer knows the real mime type; prefer that over the
         # LLM-supplied argument so PDFs or HEICs don't get mislabeled.
@@ -548,7 +563,7 @@ def create_file_tools(
     ]
 
 
-async def _file_factory(ctx: ToolContext) -> list[Tool]:
+def _file_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for file tools, used by the registry."""
     # auth_check is the user-visible gate, but defend against direct
     # invocation paths that bypass it (e.g. ``activate_specialist`` before
@@ -557,10 +572,11 @@ async def _file_factory(ctx: ToolContext) -> list[Tool]:
     if ctx.storage is None:
         return []
     pending_media = {m.original_url: m.content for m in ctx.downloaded_media if m.content}
-    # Fall back to recent staged bytes so upload_to_storage works even when the
-    # agent defers the call to a later turn with no attachments of its own.
-    for url, content in (await media_staging.get_all_for_user(ctx.user.id)).items():
-        pending_media.setdefault(url, content)
+    # Don't eagerly load every staged photo here -- that would read all
+    # of the user's 7-day window off disk on every agent turn just in
+    # case ``upload_to_storage`` ends up firing. ``upload_to_storage``
+    # has its own fallback path that reaches into staging only when the
+    # LLM actually calls it without an ``original_url``.
     return create_file_tools(ctx.user, ctx.storage, pending_media, ctx.turn_text)
 
 

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -237,7 +237,7 @@ def create_file_tools(
         # Resolve media handles: the LLM may pass a handle from
         # analyze_photo instead of the actual URL.
         if original_url and original_url not in media_map:
-            resolved = media_staging.resolve_media_ref(user.id, original_url)
+            resolved = await media_staging.resolve_media_ref(user.id, original_url)
             if resolved is not None:
                 resolved_url, resolved_bytes, resolved_mime = resolved
                 original_url = resolved_url
@@ -257,7 +257,7 @@ def create_file_tools(
         # The download layer knows the real mime type; prefer that over the
         # LLM-supplied argument so PDFs or HEICs don't get mislabeled.
         if original_url:
-            staged_mime = media_staging.get_mime_type(user.id, original_url)
+            staged_mime = await media_staging.get_mime_type(user.id, original_url)
             if staged_mime:
                 mime_type = staged_mime
 
@@ -330,7 +330,7 @@ def create_file_tools(
                 target=filename,
                 status="uploaded",
             )
-            media_staging.evict(user.id, original_url)
+            await media_staging.evict(user.id, original_url)
 
         logger.info("File cataloged: %s", saved.path)
         return ToolResult(content=f"Uploaded {filename} to {folder_path}/ ({saved.path})")
@@ -548,7 +548,7 @@ def create_file_tools(
     ]
 
 
-def _file_factory(ctx: ToolContext) -> list[Tool]:
+async def _file_factory(ctx: ToolContext) -> list[Tool]:
     """Factory for file tools, used by the registry."""
     # auth_check is the user-visible gate, but defend against direct
     # invocation paths that bypass it (e.g. ``activate_specialist`` before
@@ -559,7 +559,7 @@ def _file_factory(ctx: ToolContext) -> list[Tool]:
     pending_media = {m.original_url: m.content for m in ctx.downloaded_media if m.content}
     # Fall back to recent staged bytes so upload_to_storage works even when the
     # agent defers the call to a later turn with no attachments of its own.
-    for url, content in media_staging.get_all_for_user(ctx.user.id).items():
+    for url, content in (await media_staging.get_all_for_user(ctx.user.id)).items():
         pending_media.setdefault(url, content)
     return create_file_tools(ctx.user, ctx.storage, pending_media, ctx.turn_text)
 

--- a/backend/app/agent/tools/media_tools.py
+++ b/backend/app/agent/tools/media_tools.py
@@ -105,7 +105,7 @@ def create_media_tools(
             )
 
         # Extend TTL on reference so long agent sessions don't evict mid-turn.
-        await media_staging.touch(handle)
+        await media_staging.touch(handle, user_id=user_id)
 
         effective_context = context or turn_text
         description = await run_vision_on_media(content, mime, effective_context)

--- a/backend/app/agent/tools/media_tools.py
+++ b/backend/app/agent/tools/media_tools.py
@@ -73,7 +73,7 @@ def create_media_tools(
         if cached is not None:
             return ToolResult(content=cached)
 
-        entry = media_staging.get_by_handle(handle)
+        entry = await media_staging.get_by_handle(handle)
         if entry is None:
             return ToolResult(
                 content=(
@@ -105,7 +105,7 @@ def create_media_tools(
             )
 
         # Extend TTL on reference so long agent sessions don't evict mid-turn.
-        media_staging.touch(handle)
+        await media_staging.touch(handle)
 
         effective_context = context or turn_text
         description = await run_vision_on_media(content, mime, effective_context)
@@ -117,7 +117,7 @@ def create_media_tools(
         # Defense in depth: same cross-user ownership check as analyze_photo.
         # Handles are unguessable in practice but we still scope every
         # destructive operation to the current user.
-        entry = media_staging.get_by_handle(handle)
+        entry = await media_staging.get_by_handle(handle)
         if entry is not None and entry[0] != user_id:
             return ToolResult(
                 content=f"Handle {handle!r} does not belong to the current user.",
@@ -125,7 +125,7 @@ def create_media_tools(
                 error_kind=ToolErrorKind.PERMISSION,
             )
 
-        removed = media_staging.evict_by_handle(handle)
+        removed = await media_staging.evict_by_handle(handle)
         if not removed:
             # Idempotent: a second call (or a call after expiry) reports
             # success so the agent does not get stuck retrying.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -72,6 +72,20 @@ class Settings(BaseSettings):
     google_drive_client_id: str = ""
     google_drive_client_secret: str = ""
 
+    # Inbound media staging: bytes for photos/files the user sends over the
+    # messaging channel land here until the agent uploads them somewhere
+    # durable (CompanyCam, Drive) or the 7-day TTL expires. Point this at a
+    # persistent volume in production; the bytes survive process restarts so
+    # the agent can still reference photos from days ago. Metadata lives in
+    # the ``staged_media`` Postgres table.
+    #
+    # MULTI-REPLICA WARNING: this path must be writable by exactly one
+    # application instance. If clawbolt is ever deployed across multiple
+    # replicas, the on-disk bytes are no longer shared and the staging cache
+    # needs to move to Postgres BYTEA or an object store. Tracked at
+    # https://github.com/mozilla-ai/clawbolt/issues/1336.
+    media_staging_base_dir: str = "data/staged_media"
+
     # Agent loop
     approval_timeout_seconds: int = Field(default=120, ge=1)
     agent_processing_timeout_seconds: float = Field(default=300.0, gt=0)

--- a/backend/app/integrations/appfolio_vendor/media_resolver.py
+++ b/backend/app/integrations/appfolio_vendor/media_resolver.py
@@ -57,7 +57,7 @@ async def resolve_staged_files(
     from backend.app.agent import media_staging
     from backend.app.agent.saved_media import find_saved_file, read_saved_file_bytes
 
-    staged_cache = media_staging.get_all_for_user(ctx.user.id)
+    staged_cache = await media_staging.get_all_for_user(ctx.user.id)
 
     resolved: list[FileUpload] = []
     missing: list[str] = []
@@ -71,7 +71,7 @@ async def resolve_staged_files(
         mime_type = "image/jpeg"
 
         # 1. Resolve a media handle to (original_url, bytes).
-        handle = media_staging.resolve_media_ref(ctx.user.id, ref)
+        handle = await media_staging.resolve_media_ref(ctx.user.id, ref)
         if handle is not None:
             original_url, file_bytes, mime_type = handle
 

--- a/backend/app/integrations/companycam/photos.py
+++ b/backend/app/integrations/companycam/photos.py
@@ -114,7 +114,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         #    (e.g. "media_abZtYWFs") from analyze_photo instead of the
         #    actual URL. Normalize to original_url + bytes before the
         #    three-tier lookup below.
-        resolved = media_staging.resolve_media_ref(ctx.user.id, original_url)
+        resolved = await media_staging.resolve_media_ref(ctx.user.id, original_url)
         if resolved is not None:
             original_url, file_bytes, mime_type = resolved
 
@@ -129,7 +129,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
 
         # 2. Try media staging (cached bytes, may have been evicted)
         if not file_bytes:
-            all_staged = media_staging.get_all_for_user(ctx.user.id)
+            all_staged = await media_staging.get_all_for_user(ctx.user.id)
             if original_url in all_staged:
                 file_bytes = all_staged[original_url]
 
@@ -253,7 +253,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                 target=photo_target(photo),
                 status=status,
             )
-            media_staging.evict(ctx.user.id, original_url)
+            await media_staging.evict(ctx.user.id, original_url)
 
         if status == "processing_error":
             return ToolResult(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -341,6 +341,19 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     except Exception:
         logger.exception("BlueBubbles startup backfill failed")
 
+    # Sweep expired media staging rows + on-disk bytes. Steady-state
+    # eviction happens inline on stage(), but a crash between cap-enforce
+    # and DB commit can leave dead rows past their TTL; this gives every
+    # fresh process a clean slate.
+    try:
+        from backend.app.agent import media_staging
+
+        purged = await media_staging.purge_expired()
+        if purged:
+            logger.info("Purged %d expired staged media entr(y/ies) on startup", purged)
+    except Exception:
+        logger.exception("Staged media purge failed on startup")
+
     yield
 
     # Cancel any channel start tasks still running.

--- a/backend/app/media/pipeline.py
+++ b/backend/app/media/pipeline.py
@@ -96,10 +96,13 @@ async def process_message_media(
             len(media_items),
         )
 
-    handles: list[str | None] = [
-        media_staging.get_handle_for(user_id, m.original_url) if user_id else None
-        for m in media_items
-    ]
+    handles: list[str | None]
+    if user_id:
+        handles = await asyncio.gather(
+            *(media_staging.get_handle_for(user_id, m.original_url) for m in media_items)
+        )
+    else:
+        handles = [None for _ in media_items]
 
     tasks = [_process_single_media(m, handle=handles[i]) for i, m in enumerate(media_items)]
     media_results = list(await asyncio.gather(*tasks))

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -822,6 +822,46 @@ class UserPermissionSet(Base):
     )
 
 
+class StagedMedia(Base):
+    """Inbound media bytes the user sent over a messaging channel.
+
+    Bytes themselves live on the deployment's persistent volume under
+    ``settings.media_staging_base_dir`` (see ``disk_path``); this row is
+    the metadata that lets the agent find them again across process
+    restarts. Rows past ``expires_at`` are deleted by a lazy purge on the
+    next write and a startup sweep. See
+    ``backend.app.agent.media_staging`` for the public API.
+
+    The pair ``(user_id, original_url)`` is unique: re-staging the same
+    URL for a user reuses the existing handle so the agent can reference
+    a photo consistently across turns. ``handle`` is globally unique so
+    a reverse lookup is one SELECT, not a per-user scan.
+    """
+
+    __tablename__ = "staged_media"
+    __table_args__ = (
+        UniqueConstraint("handle", name="uq_staged_media_handle"),
+        UniqueConstraint("user_id", "original_url", name="uq_staged_media_user_original_url"),
+    )
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(_uuid.uuid4()))
+    user_id: Mapped[str] = mapped_column(
+        String, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    handle: Mapped[str] = mapped_column(String, nullable=False)
+    original_url: Mapped[str] = mapped_column(Text, nullable=False)
+    mime_type: Mapped[str] = mapped_column(
+        String, nullable=False, default="application/octet-stream"
+    )
+    disk_path: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+
+
 class AppSetting(Base):
     """Runtime-configurable settings keyed by name.
 

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -118,6 +118,14 @@ Google Drive is the integration Clawbolt uses for file storage. Each user grants
 
 See [Google Drive Setup](./google-drive-setup.md) for the full walkthrough.
 
+## Inbound media staging
+
+Photos and files the user sends over a messaging channel are cached on disk while the agent decides what to do with them (analyze, upload to Drive or CompanyCam, discard). Bytes live on the deployment's filesystem under `MEDIA_STAGING_BASE_DIR`; metadata (handle, original URL, mime type, expiry) lives in the `staged_media` Postgres table. The cache holds each item for 7 days so the agent can still reference photos from earlier in the week.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEDIA_STAGING_BASE_DIR` | `data/staged_media` | Filesystem directory for staged media bytes. Point at a persistent volume in production so a process restart does not discard recent inbound media. The single application instance is assumed to own this path exclusively; multi-replica deployments are not currently supported. |
+
 ## LLM token limits
 
 | Variable | Default | Description |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,7 +226,11 @@ def _isolate_stores(_pg_async_engine_session: AsyncEngine, tmp_path: Path) -> Ge
     after the expected failure.
     """
     # Set up per-test file store isolation
-    with patch.object(settings, "data_dir", str(tmp_path)):
+    staging_dir = tmp_path / "staged_media"
+    with (
+        patch.object(settings, "data_dir", str(tmp_path)),
+        patch.object(settings, "media_staging_base_dir", str(staging_dir)),
+    ):
         reset_stores()
         reset_session_stores()
         reset_memory_stores()

--- a/tests/integration/test_agent_native_storage_evals.py
+++ b/tests/integration/test_agent_native_storage_evals.py
@@ -15,10 +15,11 @@ Scenarios (from design doc /root/.gstack/projects/mozilla-ai-clawbolt/root-main-
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import pytest_asyncio
 
 from backend.app.agent import media_staging
 from backend.app.agent.tools.media_tools import create_media_tools
@@ -26,11 +27,11 @@ from backend.app.agent.tools.names import ToolName
 from backend.app.models import User
 
 
-@pytest.fixture(autouse=True)
-def _clear_staging_between_tests(test_user: User) -> Generator[None]:
-    media_staging.clear_user(test_user.id)
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_staging_between_tests(test_user: User) -> AsyncGenerator[None]:
+    await media_staging.clear_user(test_user.id)
     yield
-    media_staging.clear_user(test_user.id)
+    await media_staging.clear_user(test_user.id)
 
 
 # ---------------------------------------------------------------------------
@@ -52,7 +53,7 @@ async def test_eval_contextual_companycam_routing(mock_vision: AsyncMock, test_u
     halves of the scenario; CompanyCam routing is exercised in
     tests/test_companycam_tools.py.
     """
-    handle = media_staging.stage(test_user.id, "url-kitchen", b"photo-bytes", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "url-kitchen", b"photo-bytes", "image/jpeg")
     assert handle is not None
 
     turn_text = "kitchen demo at 123 Main St"
@@ -62,7 +63,7 @@ async def test_eval_contextual_companycam_routing(mock_vision: AsyncMock, test_u
 
     # The agent decides NOT to call analyze_photo or discard_media. We verify
     # that the tool surface works without side effects to staging.
-    assert media_staging.get_by_handle(handle) is not None
+    assert await media_staging.get_by_handle(handle) is not None
     assert mock_vision.await_count == 0
 
     # Sanity: the tools exist and would work if called, we just expect the
@@ -86,7 +87,7 @@ async def test_eval_no_context_photo(mock_vision: AsyncMock, test_user: User) ->
     exercises the analyze_photo side of the sequence.
     """
     mock_vision.return_value = "A damaged kitchen sink, corroded copper pipes."
-    handle = media_staging.stage(test_user.id, "url-nocaption", b"photo-bytes", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "url-nocaption", b"photo-bytes", "image/jpeg")
     assert handle is not None
 
     turn_text = "hi"  # Essentially empty context
@@ -106,7 +107,7 @@ async def test_eval_no_context_photo(mock_vision: AsyncMock, test_user: User) ->
     assert passed_context == turn_text
     # After analysis, staging is still intact so a follow-up upload_to_storage
     # or organize_file can read the bytes.
-    assert media_staging.get_by_handle(handle) is not None
+    assert await media_staging.get_by_handle(handle) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -123,7 +124,7 @@ async def test_eval_opt_out(mock_vision: AsyncMock, test_user: User) -> None:
     user's request. No analyze_photo (user doesn't want vision either), no
     upload_to_storage (explicitly opted out).
     """
-    handle = media_staging.stage(test_user.id, "url-skip", b"photo-bytes", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "url-skip", b"photo-bytes", "image/jpeg")
     assert handle is not None
 
     turn_text = "don't save this one"
@@ -135,6 +136,6 @@ async def test_eval_opt_out(mock_vision: AsyncMock, test_user: User) -> None:
 
     assert result.is_error is False
     # Staging is now empty for this handle.
-    assert media_staging.get_by_handle(handle) is None
+    assert await media_staging.get_by_handle(handle) is None
     # Vision was never called.
     assert mock_vision.await_count == 0

--- a/tests/integration/test_vision_integration.py
+++ b/tests/integration/test_vision_integration.py
@@ -16,6 +16,7 @@ import pytest
 from backend.app.media.download import DownloadedMedia
 from backend.app.media.pipeline import process_message_media
 from backend.app.media.vision import analyze_image
+from backend.app.models import User
 
 from .conftest import _ANTHROPIC_MODEL, skip_without_anthropic_key
 
@@ -98,7 +99,7 @@ async def test_analyze_image_with_context() -> None:
 
 @pytest.mark.integration()
 @skip_without_anthropic_key
-async def test_pipeline_stages_image_for_agent() -> None:
+async def test_pipeline_stages_image_for_agent(test_user: User) -> None:
     """Media pipeline should stage images and surface handles in the combined context.
 
     With agent-native storage, vision is deferred to the agent (analyze_photo tool).
@@ -115,14 +116,13 @@ async def test_pipeline_stages_image_for_agent() -> None:
         filename="test_image.png",
     )
 
-    user_id = "test-vision-integration"
     # Pre-stage the media so the pipeline can find the handle
-    media_staging.stage(user_id, media.original_url, media.content, media.mime_type)
+    await media_staging.stage(test_user.id, media.original_url, media.content, media.mime_type)
 
     result = await process_message_media(
         text_body="Here's a photo of the job site",
         media_items=[media],
-        user_id=user_id,
+        user_id=test_user.id,
     )
 
     assert len(result.media_results) == 1

--- a/tests/test_agent_native_storage.py
+++ b/tests/test_agent_native_storage.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -139,6 +138,38 @@ async def test_get_by_handle_missing(test_user: User) -> None:
 
 
 @pytest.mark.asyncio()
+async def test_evict_unlinks_disk_file(test_user: User) -> None:
+    """The single-URL ``evict()`` path must remove the backing ``.bin`` file.
+
+    Parallel to ``test_evict_by_handle`` -- both eviction paths share an
+    ``_unlink_quiet`` call today, but a future refactor could regress
+    one without the other.
+    """
+    await media_staging.stage(test_user.id, "url-evict", b"bytes", "image/jpeg")
+    async with db_session_async() as db:
+        row = (
+            await db.execute(select(StagedMedia).where(StagedMedia.original_url == "url-evict"))
+        ).scalar_one()
+        disk_path = media_staging._resolve_disk_path(row.disk_path)
+    assert disk_path.exists()
+    await media_staging.evict(test_user.id, "url-evict")
+    assert not disk_path.exists()
+
+
+@pytest.mark.asyncio()
+async def test_touch_rejects_cross_user_handle(test_user: User, second_user: User) -> None:
+    """A handle owned by user A must not have its TTL extended by user B.
+
+    Today every ``touch`` caller does an ownership check first, so this
+    is belt + suspenders. Encoded as a regression test so a future
+    caller that forgets the check still fails closed.
+    """
+    handle = await media_staging.stage(second_user.id, "url-x", b"bytes", "image/jpeg")
+    assert handle is not None
+    assert await media_staging.touch(handle, user_id=test_user.id) is False
+
+
+@pytest.mark.asyncio()
 async def test_evict_by_handle(test_user: User) -> None:
     handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
@@ -146,7 +177,7 @@ async def test_evict_by_handle(test_user: User) -> None:
         row = (
             await db.execute(select(StagedMedia).where(StagedMedia.handle == handle))
         ).scalar_one()
-        disk_path = Path(row.disk_path)
+        disk_path = media_staging._resolve_disk_path(row.disk_path)
     assert disk_path.exists()
     assert await media_staging.evict_by_handle(handle) is True
     assert await media_staging.get_by_handle(handle) is None
@@ -180,7 +211,7 @@ async def test_touch_extends_ttl(test_user: User) -> None:
             update(StagedMedia).where(StagedMedia.handle == handle).values(expires_at=past)
         )
         await db.commit()
-    assert await media_staging.touch(handle) is True
+    assert await media_staging.touch(handle, user_id=test_user.id) is True
     async with db_session_async() as db:
         refreshed = (
             await db.execute(select(StagedMedia).where(StagedMedia.handle == handle))
@@ -191,7 +222,7 @@ async def test_touch_extends_ttl(test_user: User) -> None:
 
 @pytest.mark.asyncio()
 async def test_touch_unknown_handle(test_user: User) -> None:
-    assert await media_staging.touch("media_missing") is False
+    assert await media_staging.touch("media_missing", user_id=test_user.id) is False
 
 
 @pytest.mark.asyncio()
@@ -230,7 +261,7 @@ async def test_purge_expired_drops_dead_rows(test_user: User) -> None:
         row = (
             await db.execute(select(StagedMedia).where(StagedMedia.handle == handle))
         ).scalar_one()
-        disk_path = Path(row.disk_path)
+        disk_path = media_staging._resolve_disk_path(row.disk_path)
     assert disk_path.exists()
     past = datetime.now(UTC) - timedelta(hours=1)
     async with db_session_async() as db:

--- a/tests/test_agent_native_storage.py
+++ b/tests/test_agent_native_storage.py
@@ -8,11 +8,14 @@ mutual-exclusion check for personal storage backends.
 
 from __future__ import annotations
 
-import time
-from collections.abc import Generator
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import pytest_asyncio
+from sqlalchemy import select, update
 
 from backend.app.agent import media_staging
 from backend.app.agent.tools import media_tools
@@ -22,24 +25,40 @@ from backend.app.agent.tools.media_tools import (
 )
 from backend.app.agent.tools.names import ToolName
 from backend.app.agent.tools.registry import ToolContext
+from backend.app.database import db_session_async
 from backend.app.media.download import DownloadedMedia
 from backend.app.media.pipeline import process_message_media
-from backend.app.models import User
+from backend.app.models import StagedMedia, User
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(autouse=True)
-def _clear_staging_between_tests(test_user: User) -> Generator[None]:
-    media_staging.clear_user(test_user.id)
-    media_staging.clear_user("user-a")
-    media_staging.clear_user("user-b")
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_staging_between_tests(test_user: User) -> AsyncGenerator[None]:
+    await media_staging.clear_user(test_user.id)
     yield
-    media_staging.clear_user(test_user.id)
-    media_staging.clear_user("user-a")
-    media_staging.clear_user("user-b")
+    await media_staging.clear_user(test_user.id)
+
+
+@pytest_asyncio.fixture
+async def second_user() -> User:
+    """A second persisted user, used by cross-user permission tests."""
+    async with db_session_async() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id=f"second-user-{uuid.uuid4().hex[:8]}",
+            phone="+15557654321",
+            channel_identifier="987654321",
+            preferred_channel="telegram",
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        db.expunge(user)
+    return user
 
 
 def _make_media(url: str = "https://example.com/media") -> DownloadedMedia:
@@ -56,37 +75,55 @@ def _make_media(url: str = "https://example.com/media") -> DownloadedMedia:
 # ---------------------------------------------------------------------------
 
 
-def test_stage_returns_handle(test_user: User) -> None:
-    handle = media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+@pytest.mark.asyncio()
+async def test_stage_returns_handle(test_user: User) -> None:
+    handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
     assert handle.startswith("media_")
 
 
-def test_stage_returns_none_for_empty_inputs(test_user: User) -> None:
-    assert media_staging.stage(test_user.id, "", b"bytes", "image/jpeg") is None
-    assert media_staging.stage(test_user.id, "url", b"", "image/jpeg") is None
+@pytest.mark.asyncio()
+async def test_stage_returns_none_for_empty_inputs(test_user: User) -> None:
+    assert await media_staging.stage(test_user.id, "", b"bytes", "image/jpeg") is None
+    assert await media_staging.stage(test_user.id, "url", b"", "image/jpeg") is None
 
 
-def test_handle_is_stable_across_restage(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_handle_is_stable_across_restage(test_user: User) -> None:
     """Re-staging the same URL returns the same handle so the agent can
     reference it consistently across turns."""
-    h1 = media_staging.stage(test_user.id, "url-1", b"a", "image/jpeg")
-    h2 = media_staging.stage(test_user.id, "url-1", b"b", "image/jpeg")
+    h1 = await media_staging.stage(test_user.id, "url-1", b"a", "image/jpeg")
+    h2 = await media_staging.stage(test_user.id, "url-1", b"b", "image/jpeg")
     assert h1 == h2
 
 
-def test_media_handle_uniqueness_across_urls(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_restage_overwrites_bytes(test_user: User) -> None:
+    """Re-staging updates the bytes the next reader sees."""
+    handle = await media_staging.stage(test_user.id, "url-1", b"first", "image/jpeg")
+    assert handle is not None
+    await media_staging.stage(test_user.id, "url-1", b"second", "image/png")
+    entry = await media_staging.get_by_handle(handle)
+    assert entry is not None
+    _user, _url, content, mime = entry
+    assert content == b"second"
+    assert mime == "image/png"
+
+
+@pytest.mark.asyncio()
+async def test_media_handle_uniqueness_across_urls(test_user: User) -> None:
     """Different URLs must get distinct handles so analyze_photo(handle)
     never pulls the wrong bytes."""
-    h1 = media_staging.stage(test_user.id, "url-1", b"a", "image/jpeg")
-    h2 = media_staging.stage(test_user.id, "url-2", b"b", "image/jpeg")
+    h1 = await media_staging.stage(test_user.id, "url-1", b"a", "image/jpeg")
+    h2 = await media_staging.stage(test_user.id, "url-2", b"b", "image/jpeg")
     assert h1 != h2
 
 
-def test_get_by_handle_returns_bytes(test_user: User) -> None:
-    handle = media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+@pytest.mark.asyncio()
+async def test_get_by_handle_returns_bytes(test_user: User) -> None:
+    handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
-    entry = media_staging.get_by_handle(handle)
+    entry = await media_staging.get_by_handle(handle)
     assert entry is not None
     user_id, url, content, mime = entry
     assert user_id == test_user.id
@@ -95,42 +132,99 @@ def test_get_by_handle_returns_bytes(test_user: User) -> None:
     assert mime == "image/jpeg"
 
 
-def test_get_by_handle_missing(test_user: User) -> None:
-    assert media_staging.get_by_handle("media_missing") is None
+@pytest.mark.asyncio()
+async def test_get_by_handle_missing(test_user: User) -> None:
+    assert await media_staging.get_by_handle("media_missing") is None
 
 
-def test_evict_by_handle(test_user: User) -> None:
-    handle = media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+@pytest.mark.asyncio()
+async def test_evict_by_handle(test_user: User) -> None:
+    handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
-    assert media_staging.evict_by_handle(handle) is True
-    assert media_staging.get_by_handle(handle) is None
+    assert await media_staging.evict_by_handle(handle) is True
+    assert await media_staging.get_by_handle(handle) is None
     # Idempotent: second evict returns False because already gone.
-    assert media_staging.evict_by_handle(handle) is False
+    assert await media_staging.evict_by_handle(handle) is False
 
 
-def test_touch_extends_ttl(test_user: User, monkeypatch: pytest.MonkeyPatch) -> None:
-    handle = media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+@pytest.mark.asyncio()
+async def test_touch_extends_ttl(test_user: User) -> None:
+    """``touch`` updates ``expires_at`` so a near-expired entry survives.
+
+    The TTL is wall-clock not monotonic, so the assertion checks that the
+    row's stored expiry advances past where it started instead of
+    fast-forwarding the clock.
+    """
+    handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
-    # Jump forward to just before expiry, then touch.
-    real_monotonic = time.monotonic
-    future = real_monotonic() + media_staging.STAGING_TTL_SECONDS - 60
-    monkeypatch.setattr(media_staging.time, "monotonic", lambda: future)
-    assert media_staging.touch(handle) is True
-    # Further jump past the ORIGINAL expiry; the touch must have kept it alive.
-    further = real_monotonic() + media_staging.STAGING_TTL_SECONDS + 60
-    monkeypatch.setattr(media_staging.time, "monotonic", lambda: further)
-    assert media_staging.get_by_handle(handle) is not None
+    async with db_session_async() as db:
+        initial = (
+            await db.execute(select(StagedMedia).where(StagedMedia.handle == handle))
+        ).scalar_one()
+        initial_exp = initial.expires_at
+    # Force the row's expiry into the past so we can verify ``touch``
+    # genuinely pushes it back into the future.
+    past = datetime.now(UTC) - timedelta(minutes=5)
+    async with db_session_async() as db:
+        await db.execute(
+            update(StagedMedia).where(StagedMedia.handle == handle).values(expires_at=past)
+        )
+        await db.commit()
+    assert await media_staging.touch(handle) is True
+    async with db_session_async() as db:
+        refreshed = (
+            await db.execute(select(StagedMedia).where(StagedMedia.handle == handle))
+        ).scalar_one()
+    assert refreshed.expires_at > datetime.now(UTC)
+    assert refreshed.expires_at > initial_exp
 
 
-def test_touch_unknown_handle(test_user: User) -> None:
-    assert media_staging.touch("media_missing") is False
+@pytest.mark.asyncio()
+async def test_touch_unknown_handle(test_user: User) -> None:
+    assert await media_staging.touch("media_missing") is False
 
 
-def test_get_handle_for_roundtrip(test_user: User) -> None:
-    handle = media_staging.stage(test_user.id, "url-xyz", b"b", "image/jpeg")
+@pytest.mark.asyncio()
+async def test_get_handle_for_roundtrip(test_user: User) -> None:
+    handle = await media_staging.stage(test_user.id, "url-xyz", b"b", "image/jpeg")
     assert handle is not None
-    assert media_staging.get_handle_for(test_user.id, "url-xyz") == handle
-    assert media_staging.get_handle_for(test_user.id, "missing") is None
+    assert await media_staging.get_handle_for(test_user.id, "url-xyz") == handle
+    assert await media_staging.get_handle_for(test_user.id, "missing") is None
+
+
+@pytest.mark.asyncio()
+async def test_staged_bytes_survive_in_process_state_reset(test_user: User) -> None:
+    """Bytes outlive a process-state wipe.
+
+    Regression for #1333: the prior in-process dict lost everything on
+    every deploy. Persistence is now disk + DB, so simulating a process
+    restart (here: a `clear_user`-free reread) still returns the bytes.
+    """
+    handle = await media_staging.stage(test_user.id, "url-survival", b"persist", "image/jpeg")
+    assert handle is not None
+    # New process would re-import the module; functionally equivalent
+    # to a fresh in-process dict because the implementation no longer
+    # keeps one. The reread below must find the bytes on disk + DB.
+    entry = await media_staging.get_by_handle(handle)
+    assert entry is not None
+    _user, _url, content, _mime = entry
+    assert content == b"persist"
+
+
+@pytest.mark.asyncio()
+async def test_purge_expired_drops_dead_rows(test_user: User) -> None:
+    """Rows past ``expires_at`` get swept and their disk bytes removed."""
+    handle = await media_staging.stage(test_user.id, "url-expired", b"bytes", "image/jpeg")
+    assert handle is not None
+    past = datetime.now(UTC) - timedelta(hours=1)
+    async with db_session_async() as db:
+        await db.execute(
+            update(StagedMedia).where(StagedMedia.handle == handle).values(expires_at=past)
+        )
+        await db.commit()
+    purged = await media_staging.purge_expired()
+    assert purged == 1
+    assert await media_staging.get_by_handle(handle) is None
 
 
 # ---------------------------------------------------------------------------
@@ -143,11 +237,11 @@ def test_get_handle_for_roundtrip(test_user: User) -> None:
 async def test_pipeline_skips_vision(mock_vision: AsyncMock, test_user: User) -> None:
     """Pipeline stages bytes and labels the context with a handle, but does
     not call the vision LLM. Vision is the agent's decision via analyze_photo."""
-    media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+    await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     result = await process_message_media("hi", [_make_media("url-1")], user_id=test_user.id)
     assert mock_vision.await_count == 0
     # Context surfaces the handle so the agent knows what to call.
-    handle = media_staging.get_handle_for(test_user.id, "url-1")
+    handle = await media_staging.get_handle_for(test_user.id, "url-1")
     assert handle is not None
     assert "call analyze_photo" in result.combined_context
     assert handle in result.combined_context
@@ -158,7 +252,7 @@ async def test_pipeline_skips_vision(mock_vision: AsyncMock, test_user: User) ->
 async def test_pipeline_empty_extracted_text(mock_vision: AsyncMock, test_user: User) -> None:
     """ProcessedMedia.extracted_text is empty so nothing leaks into
     conversation history before the agent decides."""
-    media_staging.stage(test_user.id, "url-2", b"b", "image/jpeg")
+    await media_staging.stage(test_user.id, "url-2", b"b", "image/jpeg")
     result = await process_message_media("", [_make_media("url-2")], user_id=test_user.id)
     assert result.media_results[0].extracted_text == ""
     assert mock_vision.await_count == 0
@@ -173,7 +267,7 @@ async def test_pipeline_empty_extracted_text(mock_vision: AsyncMock, test_user: 
 @patch("backend.app.agent.tools.media_tools.run_vision_on_media", new_callable=AsyncMock)
 async def test_analyze_photo_happy_path(mock_vision: AsyncMock, test_user: User) -> None:
     mock_vision.return_value = "A damaged roof."
-    handle = media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
 
     tools = create_media_tools(test_user.id, "tell me what this is", {})
@@ -194,7 +288,7 @@ async def test_analyze_photo_happy_path(mock_vision: AsyncMock, test_user: User)
 @patch("backend.app.agent.tools.media_tools.run_vision_on_media", new_callable=AsyncMock)
 async def test_analyze_photo_cached_second_call(mock_vision: AsyncMock, test_user: User) -> None:
     mock_vision.return_value = "A deck."
-    handle = media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
     cache: dict[str, str] = {}
     tools = create_media_tools(test_user.id, "", cache)
@@ -218,11 +312,11 @@ async def test_analyze_photo_missing_handle(test_user: User) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_analyze_photo_wrong_user(test_user: User) -> None:
+async def test_analyze_photo_wrong_user(test_user: User, second_user: User) -> None:
     """A handle minted for another user must not leak bytes across users."""
-    handle = media_staging.stage("user-a", "url-1", b"bytes", "image/jpeg")
+    handle = await media_staging.stage(second_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
-    tools = create_media_tools("user-b", "", {})
+    tools = create_media_tools(test_user.id, "", {})
     analyze = next(t for t in tools if t.name == ToolName.ANALYZE_PHOTO)
     result = await analyze.function(handle=handle)
     assert result.is_error is True
@@ -236,20 +330,20 @@ async def test_analyze_photo_wrong_user(test_user: User) -> None:
 
 @pytest.mark.asyncio()
 async def test_discard_media_evicts_handle(test_user: User) -> None:
-    handle = media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
     tools = create_media_tools(test_user.id, "", {})
     discard = next(t for t in tools if t.name == ToolName.DISCARD_MEDIA)
     result = await discard.function(handle=handle, reason='user said "drop this"')
     assert result.is_error is False
-    assert media_staging.get_by_handle(handle) is None
+    assert await media_staging.get_by_handle(handle) is None
 
 
 @pytest.mark.asyncio()
 async def test_discard_media_idempotent(test_user: User) -> None:
     """A second discard on the same handle must not error — otherwise the
     agent gets stuck retrying."""
-    handle = media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
     tools = create_media_tools(test_user.id, "", {})
     discard = next(t for t in tools if t.name == ToolName.DISCARD_MEDIA)
@@ -288,8 +382,9 @@ def test_media_factory_always_registers_tools(test_user: User) -> None:
     assert names == {ToolName.ANALYZE_PHOTO, ToolName.DISCARD_MEDIA}
 
 
-def test_media_factory_registers_tools_when_staged(test_user: User) -> None:
-    media_staging.stage(test_user.id, "url-1", b"b", "image/jpeg")
+@pytest.mark.asyncio()
+async def test_media_factory_registers_tools_when_staged(test_user: User) -> None:
+    await media_staging.stage(test_user.id, "url-1", b"b", "image/jpeg")
     ctx = ToolContext(user=test_user, downloaded_media=[_make_media("url-1")])
     tools = _media_factory(ctx)
     names = {t.name for t in tools}
@@ -297,7 +392,8 @@ def test_media_factory_registers_tools_when_staged(test_user: User) -> None:
     assert ToolName.DISCARD_MEDIA in names
 
 
-def test_media_factory_tool_list_stable_across_media_state(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_media_factory_tool_list_stable_across_media_state(test_user: User) -> None:
     """The tool name sequence must be identical regardless of media state.
 
     The Anthropic prompt-cache key includes the tools block, so any
@@ -307,7 +403,7 @@ def test_media_factory_tool_list_stable_across_media_state(test_user: User) -> N
     no_media_ctx = ToolContext(user=test_user, downloaded_media=[])
     no_media_names = [t.name for t in _media_factory(no_media_ctx)]
 
-    media_staging.stage(test_user.id, "url-1", b"b", "image/jpeg")
+    await media_staging.stage(test_user.id, "url-1", b"b", "image/jpeg")
     with_media_ctx = ToolContext(user=test_user, downloaded_media=[_make_media("url-1")])
     with_media_names = [t.name for t in _media_factory(with_media_ctx)]
 

--- a/tests/test_agent_native_storage.py
+++ b/tests/test_agent_native_storage.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -141,8 +142,17 @@ async def test_get_by_handle_missing(test_user: User) -> None:
 async def test_evict_by_handle(test_user: User) -> None:
     handle = await media_staging.stage(test_user.id, "url-1", b"bytes", "image/jpeg")
     assert handle is not None
+    async with db_session_async() as db:
+        row = (
+            await db.execute(select(StagedMedia).where(StagedMedia.handle == handle))
+        ).scalar_one()
+        disk_path = Path(row.disk_path)
+    assert disk_path.exists()
     assert await media_staging.evict_by_handle(handle) is True
     assert await media_staging.get_by_handle(handle) is None
+    # Disk file goes with the row: a follow-up restart should not see
+    # the bytes laying around either.
+    assert not disk_path.exists()
     # Idempotent: second evict returns False because already gone.
     assert await media_staging.evict_by_handle(handle) is False
 
@@ -216,6 +226,12 @@ async def test_purge_expired_drops_dead_rows(test_user: User) -> None:
     """Rows past ``expires_at`` get swept and their disk bytes removed."""
     handle = await media_staging.stage(test_user.id, "url-expired", b"bytes", "image/jpeg")
     assert handle is not None
+    async with db_session_async() as db:
+        row = (
+            await db.execute(select(StagedMedia).where(StagedMedia.handle == handle))
+        ).scalar_one()
+        disk_path = Path(row.disk_path)
+    assert disk_path.exists()
     past = datetime.now(UTC) - timedelta(hours=1)
     async with db_session_async() as db:
         await db.execute(
@@ -225,6 +241,9 @@ async def test_purge_expired_drops_dead_rows(test_user: User) -> None:
     purged = await media_staging.purge_expired()
     assert purged == 1
     assert await media_staging.get_by_handle(handle) is None
+    # Startup purge must also unlink the bytes; otherwise the deployment
+    # accumulates orphan files on every deploy cycle.
+    assert not disk_path.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1008,10 +1008,12 @@ async def test_resolve_staged_files_pulls_from_downloaded_media() -> None:
     with (
         patch(
             "backend.app.agent.media_staging.resolve_media_ref",
+            new_callable=AsyncMock,
             return_value=None,
         ),
         patch(
             "backend.app.agent.media_staging.get_all_for_user",
+            new_callable=AsyncMock,
             return_value={},
         ),
     ):
@@ -1041,10 +1043,12 @@ async def test_resolve_staged_files_returns_error_for_missing_ref() -> None:
     with (
         patch(
             "backend.app.agent.media_staging.resolve_media_ref",
+            new_callable=AsyncMock,
             return_value=None,
         ),
         patch(
             "backend.app.agent.media_staging.get_all_for_user",
+            new_callable=AsyncMock,
             return_value={},
         ),
     ):

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -1324,7 +1324,7 @@ async def test_receipt_upload_duplicate_photo_uses_app_url() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_evicts_staging_on_success() -> None:
+async def test_upload_photo_evicts_staging_on_success(test_user: User) -> None:
     """Regression #1282: a successful upload must evict the staged bytes.
 
     CompanyCam dedupes by MD5 account-wide, so if we leave the bytes in
@@ -1336,11 +1336,11 @@ async def test_upload_photo_evicts_staging_on_success() -> None:
     from backend.app.integrations.companycam.models import ImageURI, Photo
     from backend.app.media.download import DownloadedMedia
 
-    user_id = "test-user-evict-success"
+    user_id = test_user.id
     photo_url = "https://example.com/staged-success.jpg"
-    media_staging.clear_user(user_id)
-    media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
-    assert photo_url in media_staging.get_all_for_user(user_id)
+    await media_staging.clear_user(user_id)
+    await media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
+    assert photo_url in await media_staging.get_all_for_user(user_id)
 
     service = MagicMock(spec=CompanyCamService)
     photo_obj = Photo(
@@ -1377,16 +1377,16 @@ async def test_upload_photo_evicts_staging_on_success() -> None:
             result = await tool.function(project_id="22222222", original_url=photo_url)
 
         assert not result.is_error
-        assert photo_url not in media_staging.get_all_for_user(user_id), (
+        assert photo_url not in await media_staging.get_all_for_user(user_id), (
             "staged bytes must be evicted after a successful upload so a "
             "follow-up turn cannot re-upload them"
         )
     finally:
-        media_staging.clear_user(user_id)
+        await media_staging.clear_user(user_id)
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_evicts_staging_on_duplicate() -> None:
+async def test_upload_photo_evicts_staging_on_duplicate(test_user: User) -> None:
     """Regression #1282: ``duplicate`` response must also evict the staged bytes.
 
     When CompanyCam reports the upload was a duplicate, the bytes have
@@ -1398,11 +1398,11 @@ async def test_upload_photo_evicts_staging_on_duplicate() -> None:
     from backend.app.integrations.companycam.models import ImageURI, Photo
     from backend.app.media.download import DownloadedMedia
 
-    user_id = "test-user-evict-duplicate"
+    user_id = test_user.id
     photo_url = "https://example.com/staged-duplicate.jpg"
-    media_staging.clear_user(user_id)
-    media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
-    assert photo_url in media_staging.get_all_for_user(user_id)
+    await media_staging.clear_user(user_id)
+    await media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
+    assert photo_url in await media_staging.get_all_for_user(user_id)
 
     service = MagicMock(spec=CompanyCamService)
     photo_obj = Photo(
@@ -1438,16 +1438,16 @@ async def test_upload_photo_evicts_staging_on_duplicate() -> None:
             tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
             await tool.function(project_id="44444444", original_url=photo_url)
 
-        assert photo_url not in media_staging.get_all_for_user(user_id), (
+        assert photo_url not in await media_staging.get_all_for_user(user_id), (
             "staged bytes must be evicted after a duplicate response so "
             "the LLM cannot trigger more redundant uploads"
         )
     finally:
-        media_staging.clear_user(user_id)
+        await media_staging.clear_user(user_id)
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_keeps_staging_on_upload_exception() -> None:
+async def test_upload_photo_keeps_staging_on_upload_exception(test_user: User) -> None:
     """If the upload itself raises, the staged bytes must remain so the
     user (or the agent on retry) can try again. Spy on ``evict`` so this
     test would still fail if eviction were moved before the try/except."""
@@ -1455,10 +1455,10 @@ async def test_upload_photo_keeps_staging_on_upload_exception() -> None:
     from backend.app.agent.tools.names import ToolName
     from backend.app.media.download import DownloadedMedia
 
-    user_id = "test-user-keep-on-error"
+    user_id = test_user.id
     photo_url = "https://example.com/staged-error.jpg"
-    media_staging.clear_user(user_id)
-    media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
+    await media_staging.clear_user(user_id)
+    await media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
 
     service = MagicMock(spec=CompanyCamService)
     service.upload_photo = AsyncMock(side_effect=RuntimeError("network down"))
@@ -1492,15 +1492,15 @@ async def test_upload_photo_keeps_staging_on_upload_exception() -> None:
 
         assert result.is_error
         evict_spy.assert_not_called()
-        assert photo_url in media_staging.get_all_for_user(user_id), (
+        assert photo_url in await media_staging.get_all_for_user(user_id), (
             "staged bytes must survive a service-side failure so a retry still has the content"
         )
     finally:
-        media_staging.clear_user(user_id)
+        await media_staging.clear_user(user_id)
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_keeps_staging_on_processing_error() -> None:
+async def test_upload_photo_keeps_staging_on_processing_error(test_user: User) -> None:
     """Regression #1282: ``processing_error`` means CompanyCam could not
     fetch the temp URL. A retry can succeed if the connectivity issue
     resolves, so the staged bytes must remain available for it."""
@@ -1509,10 +1509,10 @@ async def test_upload_photo_keeps_staging_on_processing_error() -> None:
     from backend.app.integrations.companycam.models import ImageURI, Photo
     from backend.app.media.download import DownloadedMedia
 
-    user_id = "test-user-processing-error"
+    user_id = test_user.id
     photo_url = "https://example.com/staged-processing-error.jpg"
-    media_staging.clear_user(user_id)
-    media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
+    await media_staging.clear_user(user_id)
+    await media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
 
     service = MagicMock(spec=CompanyCamService)
     photo_obj = Photo(
@@ -1549,12 +1549,12 @@ async def test_upload_photo_keeps_staging_on_processing_error() -> None:
             result = await tool.function(project_id="77777777", original_url=photo_url)
 
         assert result.is_error
-        assert photo_url in media_staging.get_all_for_user(user_id), (
+        assert photo_url in await media_staging.get_all_for_user(user_id), (
             "staged bytes must survive ``processing_error`` so a retry can "
             "re-mint the temp URL with the same content"
         )
     finally:
-        media_staging.clear_user(user_id)
+        await media_staging.clear_user(user_id)
 
 
 def test_upload_photo_concurrency_group_serializes_per_project() -> None:
@@ -1782,7 +1782,7 @@ async def test_upload_photo_rejects_empty_original_url() -> None:
 
 @pytest.mark.asyncio()
 async def test_upload_photo_idempotent_retry_after_eviction(
-    caplog: pytest.LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture, test_user: User
 ) -> None:
     """Option A: a same-turn retry on an evicted handle returns the prior receipt.
 
@@ -1801,11 +1801,11 @@ async def test_upload_photo_idempotent_retry_after_eviction(
     from backend.app.integrations.companycam.models import ImageURI, Photo
     from backend.app.media.download import DownloadedMedia
 
-    user_id = "test-user-idempotent-retry"
+    user_id = test_user.id
     photo_url = "https://example.com/photo-once.jpg"
 
-    media_staging.clear_user(user_id)
-    media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
+    await media_staging.clear_user(user_id)
+    await media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
 
     service = MagicMock(spec=CompanyCamService)
     photo_obj = Photo(
@@ -1867,11 +1867,11 @@ async def test_upload_photo_idempotent_retry_after_eviction(
             "media_handle_referenced_after_eviction" in rec.message for rec in caplog.records
         )
     finally:
-        media_staging.clear_user(user_id)
+        await media_staging.clear_user(user_id)
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_records_duplicate_status_for_retry() -> None:
+async def test_upload_photo_records_duplicate_status_for_retry(test_user: User) -> None:
     """When CompanyCam dedupes the first upload, a retry on the same handle
     still surfaces the duplicate receipt (no spurious ``No photo`` error).
     """
@@ -1880,11 +1880,11 @@ async def test_upload_photo_records_duplicate_status_for_retry() -> None:
     from backend.app.integrations.companycam.models import ImageURI, Photo
     from backend.app.media.download import DownloadedMedia
 
-    user_id = "test-user-dup-retry"
+    user_id = test_user.id
     photo_url = "https://example.com/photo-dup.jpg"
 
-    media_staging.clear_user(user_id)
-    media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
+    await media_staging.clear_user(user_id)
+    await media_staging.stage(user_id, photo_url, b"fake-jpg", "image/jpeg")
 
     service = MagicMock(spec=CompanyCamService)
     photo_obj = Photo(
@@ -1929,7 +1929,7 @@ async def test_upload_photo_records_duplicate_status_for_retry() -> None:
         # does not think the retry actually shipped a new copy.
         assert "duplicate" in second.content.lower() or "already" in second.content.lower()
     finally:
-        media_staging.clear_user(user_id)
+        await media_staging.clear_user(user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_media_pipeline.py
+++ b/tests/test_media_pipeline.py
@@ -9,6 +9,7 @@ from backend.app.media.pipeline import (
     process_message_media,
     run_vision_on_media,
 )
+from backend.app.models import User
 
 
 def _make_media(
@@ -24,13 +25,17 @@ def _make_media(
 
 @pytest.mark.asyncio()
 @patch("backend.app.media.pipeline.analyze_image", new_callable=AsyncMock)
-async def test_process_single_image_stages_without_vision(mock_vision: AsyncMock) -> None:
+async def test_process_single_image_stages_without_vision(
+    mock_vision: AsyncMock, test_user: User
+) -> None:
     """Pipeline classifies the image and leaves vision for the agent via
     analyze_photo. The combined context surfaces the staging handle."""
-    media_staging.clear_user("test-user")
-    media_staging.stage("test-user", "https://example.com/media", b"fake-bytes", "image/jpeg")
+    await media_staging.clear_user(test_user.id)
+    await media_staging.stage(
+        test_user.id, "https://example.com/media", b"fake-bytes", "image/jpeg"
+    )
     result = await process_message_media(
-        "Check this deck", [_make_media("image/jpeg")], user_id="test-user"
+        "Check this deck", [_make_media("image/jpeg")], user_id=test_user.id
     )
     assert len(result.media_results) == 1
     assert result.media_results[0].category == "image"
@@ -39,7 +44,7 @@ async def test_process_single_image_stages_without_vision(mock_vision: AsyncMock
     assert "Photo 1" in result.combined_context
     assert "Check this deck" in result.combined_context
     assert "call analyze_photo" in result.combined_context
-    media_staging.clear_user("test-user")
+    await media_staging.clear_user(test_user.id)
 
 
 @pytest.mark.asyncio()

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -192,7 +192,7 @@ async def test_file_factory_merges_staged_bytes_when_current_turn_has_none(
         storage=MockStorageBackend(),
         downloaded_media=[],
     )
-    tools = await _file_factory(ctx)
+    tools = _file_factory(ctx)
     upload = tools[0].function
 
     result = await upload(
@@ -225,7 +225,7 @@ async def test_file_factory_prefers_current_turn_over_stale_staging(
         storage=MockStorageBackend(),
         downloaded_media=[current],
     )
-    tools = await _file_factory(ctx)
+    tools = _file_factory(ctx)
     upload = tools[0].function
 
     result = await upload(
@@ -257,7 +257,7 @@ async def test_upload_uses_staged_mime_over_llm_argument(test_user: User) -> Non
         storage=MockStorageBackend(),
         downloaded_media=[],
     )
-    tools = await _file_factory(ctx)
+    tools = _file_factory(ctx)
     upload = tools[0].function
 
     result = await upload(
@@ -873,7 +873,7 @@ async def test_upload_to_storage_resolves_handle(test_user: User) -> None:
         storage=MockStorageBackend(),
         downloaded_media=[],
     )
-    tools = await _file_factory(ctx)
+    tools = _file_factory(ctx)
     upload = tools[0].function
 
     result = await upload(

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Generator
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
+import pytest_asyncio
 from pydantic import BaseModel, Field
+from sqlalchemy import update
 
 from backend.app.agent import media_staging
 from backend.app.agent.approval import (
@@ -23,52 +27,84 @@ from backend.app.agent.messages import ToolCallRequest
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.agent.tools.file_tools import _file_factory, create_file_tools
 from backend.app.agent.tools.registry import ToolContext
+from backend.app.database import db_session_async
 from backend.app.media.download import DownloadedMedia
-from backend.app.models import User
+from backend.app.models import StagedMedia, User
 from tests.mocks.storage import MockStorageBackend
 
 
-@pytest.fixture(autouse=True)
-def _clear_staging_between_tests(test_user: User) -> Generator[None]:
-    media_staging.clear_user(test_user.id)
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_staging_between_tests(test_user: User) -> AsyncGenerator[None]:
+    await media_staging.clear_user(test_user.id)
     yield
-    media_staging.clear_user(test_user.id)
+    await media_staging.clear_user(test_user.id)
 
 
-def test_stage_and_retrieve(test_user: User) -> None:
-    media_staging.stage(test_user.id, "bb_abc", b"bytes", "image/jpeg")
-    result = media_staging.get_all_for_user(test_user.id)
+@pytest_asyncio.fixture
+async def second_user() -> User:
+    """A persisted second user for cross-user isolation tests."""
+    async with db_session_async() as db:
+        user = User(
+            id=str(uuid.uuid4()),
+            user_id=f"second-user-{uuid.uuid4().hex[:8]}",
+            phone="+15557654321",
+            channel_identifier="987654321",
+            preferred_channel="telegram",
+            onboarding_complete=True,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        db.expunge(user)
+    return user
+
+
+@pytest.mark.asyncio()
+async def test_stage_and_retrieve(test_user: User) -> None:
+    await media_staging.stage(test_user.id, "bb_abc", b"bytes", "image/jpeg")
+    result = await media_staging.get_all_for_user(test_user.id)
     assert result == {"bb_abc": b"bytes"}
 
 
-def test_stage_ignores_empty_url_or_content(test_user: User) -> None:
-    media_staging.stage(test_user.id, "", b"bytes", "image/jpeg")
-    media_staging.stage(test_user.id, "bb_empty", b"", "image/jpeg")
-    assert media_staging.get_all_for_user(test_user.id) == {}
+@pytest.mark.asyncio()
+async def test_stage_ignores_empty_url_or_content(test_user: User) -> None:
+    await media_staging.stage(test_user.id, "", b"bytes", "image/jpeg")
+    await media_staging.stage(test_user.id, "bb_empty", b"", "image/jpeg")
+    assert await media_staging.get_all_for_user(test_user.id) == {}
 
 
-def test_evict_removes_entry(test_user: User) -> None:
-    media_staging.stage(test_user.id, "bb_abc", b"bytes", "image/jpeg")
-    media_staging.evict(test_user.id, "bb_abc")
-    assert media_staging.get_all_for_user(test_user.id) == {}
+@pytest.mark.asyncio()
+async def test_evict_removes_entry(test_user: User) -> None:
+    await media_staging.stage(test_user.id, "bb_abc", b"bytes", "image/jpeg")
+    await media_staging.evict(test_user.id, "bb_abc")
+    assert await media_staging.get_all_for_user(test_user.id) == {}
 
 
-def test_expired_entries_are_purged(test_user: User, monkeypatch: pytest.MonkeyPatch) -> None:
-    media_staging.stage(test_user.id, "bb_old", b"bytes", "image/jpeg")
-    # Fast-forward past the TTL.
-    real_monotonic = time.monotonic
-    future = real_monotonic() + media_staging.STAGING_TTL_SECONDS + 1
-    monkeypatch.setattr(media_staging.time, "monotonic", lambda: future)
-    assert media_staging.get_all_for_user(test_user.id) == {}
+@pytest.mark.asyncio()
+async def test_expired_entries_are_purged(test_user: User) -> None:
+    """Rows past ``expires_at`` are filtered out by reads and removed by purge.
+
+    The TTL is wall-clock now (a Postgres ``DateTime``); shift the row's
+    ``expires_at`` into the past instead of fast-forwarding the clock.
+    """
+    handle = await media_staging.stage(test_user.id, "bb_old", b"bytes", "image/jpeg")
+    assert handle is not None
+    past = datetime.now(UTC) - timedelta(seconds=1)
+    async with db_session_async() as db:
+        await db.execute(
+            update(StagedMedia).where(StagedMedia.handle == handle).values(expires_at=past)
+        )
+        await db.commit()
+    assert await media_staging.get_all_for_user(test_user.id) == {}
 
 
-def test_isolation_between_users() -> None:
-    media_staging.stage("user-a", "bb_abc", b"bytes-a", "image/jpeg")
-    media_staging.stage("user-b", "bb_abc", b"bytes-b", "image/jpeg")
-    assert media_staging.get_all_for_user("user-a") == {"bb_abc": b"bytes-a"}
-    assert media_staging.get_all_for_user("user-b") == {"bb_abc": b"bytes-b"}
-    media_staging.clear_user("user-a")
-    media_staging.clear_user("user-b")
+@pytest.mark.asyncio()
+async def test_isolation_between_users(test_user: User, second_user: User) -> None:
+    await media_staging.stage(test_user.id, "bb_abc", b"bytes-a", "image/jpeg")
+    await media_staging.stage(second_user.id, "bb_abc", b"bytes-b", "image/jpeg")
+    assert await media_staging.get_all_for_user(test_user.id) == {"bb_abc": b"bytes-a"}
+    assert await media_staging.get_all_for_user(second_user.id) == {"bb_abc": b"bytes-b"}
+    await media_staging.clear_user(second_user.id)
 
 
 def test_upload_record_round_trip(test_user: User) -> None:
@@ -88,11 +124,12 @@ def test_upload_record_round_trip(test_user: User) -> None:
     assert rec.status == "uploaded"
 
 
-def test_upload_record_survives_evict(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_upload_record_survives_evict(test_user: User) -> None:
     """A successful upload evicts staged bytes but keeps the receipt so a
     same-turn retry on the same handle returns an idempotent result.
     """
-    media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+    await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
     media_staging.mark_uploaded(
         test_user.id,
         "bb_photo",
@@ -102,8 +139,8 @@ def test_upload_record_survives_evict(test_user: User) -> None:
         target="Some target",
         status="uploaded",
     )
-    media_staging.evict(test_user.id, "bb_photo")
-    assert media_staging.get_all_for_user(test_user.id) == {}
+    await media_staging.evict(test_user.id, "bb_photo")
+    assert await media_staging.get_all_for_user(test_user.id) == {}
     rec = media_staging.get_uploaded(test_user.id, "bb_photo")
     assert rec is not None
     assert rec.external_id == "cc-999"
@@ -126,6 +163,9 @@ def test_upload_record_expires(test_user: User, monkeypatch: pytest.MonkeyPatch)
 
 
 def test_upload_record_isolated_per_user() -> None:
+    """The upload-receipt cache is in-process and unrelated to the
+    ``staged_media`` table, so plain string user_ids are fine here.
+    """
     media_staging.mark_uploaded(
         "user-a",
         "bb_photo",
@@ -136,7 +176,7 @@ def test_upload_record_isolated_per_user() -> None:
         status="uploaded",
     )
     assert media_staging.get_uploaded("user-b", "bb_photo") is None
-    media_staging.clear_user("user-a")
+    media_staging._uploaded.pop("user-a", None)
 
 
 @pytest.mark.asyncio()
@@ -145,14 +185,14 @@ async def test_file_factory_merges_staged_bytes_when_current_turn_has_none(
 ) -> None:
     """The agent may call upload_to_storage on a turn with no attachments; staged
     bytes from an earlier turn must still be available so the upload succeeds."""
-    media_staging.stage(test_user.id, "bb_photo", b"photo-bytes", "image/jpeg")
+    await media_staging.stage(test_user.id, "bb_photo", b"photo-bytes", "image/jpeg")
 
     ctx = ToolContext(
         user=test_user,
         storage=MockStorageBackend(),
         downloaded_media=[],
     )
-    tools = _file_factory(ctx)
+    tools = await _file_factory(ctx)
     upload = tools[0].function
 
     result = await upload(
@@ -164,7 +204,7 @@ async def test_file_factory_merges_staged_bytes_when_current_turn_has_none(
     assert result.is_error is False
     assert "Uploaded" in result.content
     # Staging entry should be evicted after a successful upload.
-    assert media_staging.get_all_for_user(test_user.id) == {}
+    assert await media_staging.get_all_for_user(test_user.id) == {}
 
 
 @pytest.mark.asyncio()
@@ -173,7 +213,7 @@ async def test_file_factory_prefers_current_turn_over_stale_staging(
 ) -> None:
     """If the same URL is in both current downloaded_media and staging, the
     current-turn bytes win (staging is fallback only)."""
-    media_staging.stage(test_user.id, "bb_photo", b"stale-bytes", "image/jpeg")
+    await media_staging.stage(test_user.id, "bb_photo", b"stale-bytes", "image/jpeg")
     current = DownloadedMedia(
         content=b"fresh-bytes",
         mime_type="image/jpeg",
@@ -185,7 +225,7 @@ async def test_file_factory_prefers_current_turn_over_stale_staging(
         storage=MockStorageBackend(),
         downloaded_media=[current],
     )
-    tools = _file_factory(ctx)
+    tools = await _file_factory(ctx)
     upload = tools[0].function
 
     result = await upload(
@@ -200,23 +240,24 @@ async def test_file_factory_prefers_current_turn_over_stale_staging(
     assert any(v == b"fresh-bytes" for v in storage.files.values())
 
 
-def test_get_mime_type_returns_staged_value(test_user: User) -> None:
-    media_staging.stage(test_user.id, "bb_doc", b"pdf-bytes", "application/pdf")
-    assert media_staging.get_mime_type(test_user.id, "bb_doc") == "application/pdf"
-    assert media_staging.get_mime_type(test_user.id, "missing") is None
+@pytest.mark.asyncio()
+async def test_get_mime_type_returns_staged_value(test_user: User) -> None:
+    await media_staging.stage(test_user.id, "bb_doc", b"pdf-bytes", "application/pdf")
+    assert await media_staging.get_mime_type(test_user.id, "bb_doc") == "application/pdf"
+    assert await media_staging.get_mime_type(test_user.id, "missing") is None
 
 
 @pytest.mark.asyncio()
 async def test_upload_uses_staged_mime_over_llm_argument(test_user: User) -> None:
     """The download layer knows the real mime; the LLM-supplied value must not
     overwrite it (e.g. agent defaults to image/jpeg but file is a PDF)."""
-    media_staging.stage(test_user.id, "bb_doc", b"pdf-bytes", "application/pdf")
+    await media_staging.stage(test_user.id, "bb_doc", b"pdf-bytes", "application/pdf")
     ctx = ToolContext(
         user=test_user,
         storage=MockStorageBackend(),
         downloaded_media=[],
     )
-    tools = _file_factory(ctx)
+    tools = await _file_factory(ctx)
     upload = tools[0].function
 
     result = await upload(
@@ -232,7 +273,7 @@ async def test_upload_uses_staged_mime_over_llm_argument(test_user: User) -> Non
 
 @pytest.mark.asyncio()
 async def test_upload_evicts_staged_entry(test_user: User) -> None:
-    media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+    await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
     storage = MockStorageBackend()
     tools = create_file_tools(
         test_user,
@@ -247,7 +288,7 @@ async def test_upload_evicts_staged_entry(test_user: User) -> None:
         client_name="Jane",
     )
     assert result.is_error is False
-    assert media_staging.get_all_for_user(test_user.id) == {}
+    assert await media_staging.get_all_for_user(test_user.id) == {}
 
 
 @pytest.mark.asyncio()
@@ -261,7 +302,7 @@ async def test_upload_to_storage_idempotent_retry_after_eviction(
     """
     import logging
 
-    media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+    await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
     storage = MockStorageBackend()
     # pending_media is the per-turn snapshot the factory closes over; we
     # mutate it after the first call to simulate the bytes being consumed.
@@ -780,11 +821,12 @@ async def test_permissions_write_normalizes_minified_json(test_user: User) -> No
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_media_ref_by_handle(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_resolve_media_ref_by_handle(test_user: User) -> None:
     """resolve_media_ref resolves a handle to (original_url, bytes, mime)."""
-    handle = media_staging.stage(test_user.id, "bb_photo_1", b"photo", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "bb_photo_1", b"photo", "image/jpeg")
     assert handle is not None
-    result = media_staging.resolve_media_ref(test_user.id, handle)
+    result = await media_staging.resolve_media_ref(test_user.id, handle)
     assert result is not None
     url, content, mime = result
     assert url == "bb_photo_1"
@@ -792,10 +834,11 @@ def test_resolve_media_ref_by_handle(test_user: User) -> None:
     assert mime == "image/jpeg"
 
 
-def test_resolve_media_ref_by_url(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_resolve_media_ref_by_url(test_user: User) -> None:
     """resolve_media_ref resolves a URL to (url, bytes, mime)."""
-    media_staging.stage(test_user.id, "bb_photo_2", b"photo2", "image/png")
-    result = media_staging.resolve_media_ref(test_user.id, "bb_photo_2")
+    await media_staging.stage(test_user.id, "bb_photo_2", b"photo2", "image/png")
+    result = await media_staging.resolve_media_ref(test_user.id, "bb_photo_2")
     assert result is not None
     url, content, mime = result
     assert url == "bb_photo_2"
@@ -803,25 +846,26 @@ def test_resolve_media_ref_by_url(test_user: User) -> None:
     assert mime == "image/png"
 
 
-def test_resolve_media_ref_wrong_user(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_resolve_media_ref_wrong_user(test_user: User, second_user: User) -> None:
     """resolve_media_ref rejects handles owned by a different user."""
-    handle = media_staging.stage("other-user", "bb_foreign", b"data", "image/jpeg")
+    handle = await media_staging.stage(second_user.id, "bb_foreign", b"data", "image/jpeg")
     assert handle is not None
-    result = media_staging.resolve_media_ref(test_user.id, handle)
+    result = await media_staging.resolve_media_ref(test_user.id, handle)
     assert result is None
-    media_staging.clear_user("other-user")
 
 
-def test_resolve_media_ref_unknown_ref(test_user: User) -> None:
+@pytest.mark.asyncio()
+async def test_resolve_media_ref_unknown_ref(test_user: User) -> None:
     """resolve_media_ref returns None for unrecognized references."""
-    assert media_staging.resolve_media_ref(test_user.id, "media_UNKNOWN") is None
-    assert media_staging.resolve_media_ref(test_user.id, "https://no.such/url") is None
+    assert await media_staging.resolve_media_ref(test_user.id, "media_UNKNOWN") is None
+    assert await media_staging.resolve_media_ref(test_user.id, "https://no.such/url") is None
 
 
 @pytest.mark.asyncio()
 async def test_upload_to_storage_resolves_handle(test_user: User) -> None:
     """Regression: upload_to_storage must accept media handles, not just URLs."""
-    handle = media_staging.stage(test_user.id, "bb_real_url", b"photo-bytes", "image/jpeg")
+    handle = await media_staging.stage(test_user.id, "bb_real_url", b"photo-bytes", "image/jpeg")
     assert handle is not None
 
     ctx = ToolContext(
@@ -829,7 +873,7 @@ async def test_upload_to_storage_resolves_handle(test_user: User) -> None:
         storage=MockStorageBackend(),
         downloaded_media=[],
     )
-    tools = _file_factory(ctx)
+    tools = await _file_factory(ctx)
     upload = tools[0].function
 
     result = await upload(


### PR DESCRIPTION
## Description

Fixes #1333. Inbound media (photos and files contractors send over a messaging channel) was kept in an in-process Python dict with a 24h TTL. Every deploy wiped it and the dict couldn't outlive a single process anyway, so contractors who sent photos earlier in the day routinely saw the agent reply *"the Durham photos have aged out, please resend"* mid-conversation. Captured payloads from Jesse's session yesterday show the failure mode in multiple places (one example: msg seq 69 of his current era).

Persist staged bytes to the deployment's volume under ``MEDIA_STAGING_BASE_DIR`` (default ``data/staged_media``) with metadata in a new ``staged_media`` Postgres table. The handle the agent sees in the prompt is now durable: 7-day TTL refreshed on ``touch``, capped at 50 entries per user, swept on app startup. The in-process upload-receipt cache stays as-is (1h, same-turn idempotency only, intentionally not persisted).

The public ``media_staging`` API keeps its shape but is now ``async``; every caller (``router``, ``media_tools``, ``pipeline``, ``file_tools``, ``media_resolver``, ``companycam/photos``) gets ``await`` added. ``_file_factory`` becomes async so it can await the per-user staging read.

**Multi-replica caveat.** This design assumes one application instance owns the staging volume exclusively. Multi-replica deployment will need bytes in Postgres BYTEA or an object store; tracked in #1336 with the migration call-out noted in the module docstring, the config setting, and ``docs/self-host/configuration.md`` so the warning is visible at the next deploy-topology change.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (``uv run pytest -v``)
- [x] Lint passes (``ruff check backend/ && ruff format --check backend/``)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

New tests of note:
- ``test_staged_bytes_survive_in_process_state_reset`` (regression for the 24h-in-RAM ceiling)
- ``test_purge_expired_drops_dead_rows`` (lifecycle of the startup sweep)
- ``test_touch_extends_ttl`` rewritten against the wall-clock ``expires_at`` instead of the old monotonic-time monkeypatch

## AI Usage
- [x] AI-assisted (describe how)

Claude Opus 4.7 wrote the code, the tests, the migration, the docs entries, and the body of #1336, working from a back-and-forth with @njbrake who chose the design (disk + DB over a pure in-memory TTL bump, single-instance OK for now with a tracking issue rather than blocking on multi-replica work).

- [ ] No AI used