### PR TITLE
feat(observer): add LLM response capture hook

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -27,7 +27,9 @@ from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessa
 from backend.app.agent.observer import (
     PURPOSE_COMPACTION,
     LLMRequestPayload,
+    LLMResponsePayload,
     emit_llm_request,
+    emit_llm_response,
 )
 from backend.app.agent.prompts import load_prompt
 from backend.app.agent.stores import HeartbeatStore
@@ -180,6 +182,52 @@ def _parse_compaction_response(raw: str) -> CompactionResult:
     )
 
 
+async def _emit_compaction_response(
+    response: MessageResponse,
+    *,
+    user_id: str,
+    model: str,
+    provider: str,
+    started_at: datetime.datetime,
+) -> None:
+    """Build and dispatch an ``LLMResponsePayload`` for the compaction call.
+
+    Mirrors ``ClawboltAgent._emit_response`` for the agent-loop side; the
+    same serialization rules apply (plain dicts via ``model_dump``, per-block
+    try/except so a single unexpected block shape cannot break the dispatch).
+    Compaction's session_id / request_id are ``None`` because compaction
+    runs on a synthetic prompt outside the session-aware path.
+    """
+    content_blocks: list[dict[str, Any]] = []
+    for block in response.content:
+        try:
+            content_blocks.append(block.model_dump(mode="json"))
+        except Exception:
+            logger.exception(
+                "Failed to serialize compaction response content block; skipping for observer"
+            )
+    usage = response.usage
+    await emit_llm_response(
+        LLMResponsePayload(
+            schema_version=1,
+            purpose=PURPOSE_COMPACTION,
+            user_id=user_id,
+            session_id=None,
+            request_id=None,
+            model=model,
+            provider=provider,
+            content_blocks=content_blocks,
+            stop_reason=response.stop_reason,
+            input_tokens=usage.input_tokens if usage else None,
+            output_tokens=usage.output_tokens if usage else None,
+            cache_creation_input_tokens=(usage.cache_creation_input_tokens if usage else None),
+            cache_read_input_tokens=(usage.cache_read_input_tokens if usage else None),
+            started_at=started_at,
+            completed_at=datetime.datetime.now(UTC),
+        )
+    )
+
+
 async def compact_session(
     user_id: str,
     trimmed_messages: list[AgentMessage],
@@ -278,6 +326,7 @@ async def compact_session(
     compaction_system = prepare_system_with_caching(COMPACTION_SYSTEM_PROMPT)
     compaction_thinking = reasoning_effort_to_thinking(settings.reasoning_effort)
 
+    started_at = datetime.datetime.now(UTC)
     try:
         await emit_llm_request(
             LLMRequestPayload(
@@ -298,7 +347,7 @@ async def compact_session(
                 # text, not on a session-aware message history. The
                 # era-marker field has no meaning here.
                 min_message_seq_in_prompt=None,
-                started_at=datetime.datetime.now(UTC),
+                started_at=started_at,
             )
         )
         response = cast(
@@ -316,6 +365,13 @@ async def compact_session(
     except Exception:
         logger.exception("Compaction LLM call failed for user %s", user_id)
         return "", None
+    await _emit_compaction_response(
+        response,
+        user_id=user_id,
+        model=model,
+        provider=provider,
+        started_at=started_at,
+    )
 
     await log_llm_usage(user_id, model, response, purpose="compaction", provider=provider)
 

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -55,8 +55,10 @@ from backend.app.agent.observer import (
     PURPOSE_AGENT_FOLLOWUP,
     PURPOSE_AGENT_MAIN,
     LLMRequestPayload,
+    LLMResponsePayload,
     compute_min_message_seq,
     emit_llm_request,
+    emit_llm_response,
 )
 from backend.app.agent.system_prompt import build_agent_system_prompt, build_time_user_context
 from backend.app.agent.tool_errors import (
@@ -404,6 +406,59 @@ class ClawboltAgent:
             current_session_id=self._session_id,
         )
 
+    async def _emit_response(
+        self,
+        response: MessageResponse,
+        *,
+        purpose: str,
+        model: str,
+        provider: str,
+        started_at: datetime,
+    ) -> None:
+        """Build and dispatch an ``LLMResponsePayload`` for a single LLM round.
+
+        Paired with the ``emit_llm_request`` call that fired just before
+        the corresponding ``amessages`` call. Observers see the request
+        first, then the response; ``request_id`` and ``started_at`` echo
+        the request so consumers can pair them without depending on call
+        ordering across concurrent agent loops.
+
+        Content blocks are serialized to plain dicts so observers can
+        store them as JSON without holding references to pydantic types
+        from the any-llm provider package.
+        """
+        content_blocks: list[dict[str, Any]] = []
+        for block in response.content:
+            try:
+                content_blocks.append(block.model_dump(mode="json"))
+            except Exception:
+                # Defensive: a provider returning an unexpected block shape
+                # must not break the agent turn. Logged once per occurrence;
+                # the observer just sees a partial content list.
+                logger.exception(
+                    "Failed to serialize response content block; skipping for observer"
+                )
+        usage = response.usage
+        await emit_llm_response(
+            LLMResponsePayload(
+                schema_version=1,
+                purpose=purpose,
+                user_id=self.user.id,
+                session_id=self._session_id or None,
+                request_id=self._request_id or None,
+                model=model,
+                provider=provider,
+                content_blocks=content_blocks,
+                stop_reason=response.stop_reason,
+                input_tokens=usage.input_tokens if usage else None,
+                output_tokens=usage.output_tokens if usage else None,
+                cache_creation_input_tokens=(usage.cache_creation_input_tokens if usage else None),
+                cache_read_input_tokens=(usage.cache_read_input_tokens if usage else None),
+                started_at=started_at,
+                completed_at=datetime.now(UTC),
+            )
+        )
+
     async def _call_llm_with_retry(
         self,
         messages: list[AgentMessage],
@@ -440,6 +495,7 @@ class ClawboltAgent:
             tool_count,
             effective_max_tokens,
         )
+        started_at = datetime.now(UTC)
         await emit_llm_request(
             LLMRequestPayload(
                 schema_version=1,
@@ -455,12 +511,12 @@ class ClawboltAgent:
                 messages=msg_dicts,
                 tools=tool_schemas,
                 min_message_seq_in_prompt=compute_min_message_seq(messages),
-                started_at=datetime.now(UTC),
+                started_at=started_at,
             )
         )
         for attempt in range(LLM_MAX_RETRIES):
             try:
-                return cast(
+                response = cast(
                     MessageResponse,
                     await amessages(
                         model=effective_model,
@@ -473,6 +529,14 @@ class ClawboltAgent:
                         thinking=thinking,
                     ),
                 )
+                await self._emit_response(
+                    response,
+                    purpose=PURPOSE_AGENT_MAIN,
+                    model=effective_model,
+                    provider=effective_provider,
+                    started_at=started_at,
+                )
+                return response
             except RateLimitError:
                 if attempt == LLM_MAX_RETRIES - 1:
                     raise
@@ -501,6 +565,7 @@ class ClawboltAgent:
                     if retry_system_str is not None
                     else None
                 )
+                followup_started_at = datetime.now(UTC)
                 await emit_llm_request(
                     LLMRequestPayload(
                         schema_version=1,
@@ -516,10 +581,10 @@ class ClawboltAgent:
                         messages=trimmed_dicts,
                         tools=tool_schemas,
                         min_message_seq_in_prompt=compute_min_message_seq(trim_result.messages),
-                        started_at=datetime.now(UTC),
+                        started_at=followup_started_at,
                     )
                 )
-                return cast(
+                followup_response = cast(
                     MessageResponse,
                     await amessages(
                         model=effective_model,
@@ -532,6 +597,14 @@ class ClawboltAgent:
                         thinking=thinking,
                     ),
                 )
+                await self._emit_response(
+                    followup_response,
+                    purpose=PURPOSE_AGENT_FOLLOWUP,
+                    model=effective_model,
+                    provider=effective_provider,
+                    started_at=followup_started_at,
+                )
+                return followup_response
             except ContentFilterError:
                 logger.warning("Content blocked by provider safety filter")
                 raise

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -36,7 +36,9 @@ from backend.app.agent.llm_parsing import get_response_text, parse_tool_calls
 from backend.app.agent.observer import (
     PURPOSE_HEARTBEAT_DECISION,
     LLMRequestPayload,
+    LLMResponsePayload,
     emit_llm_request,
+    emit_llm_response,
 )
 from backend.app.agent.session_db import get_session_store
 from backend.app.agent.stores import HeartbeatStore
@@ -466,6 +468,7 @@ async def evaluate_heartbeat_need(
     ]
     heartbeat_tools = [HEARTBEAT_DECISION_TOOL]
     heartbeat_thinking = reasoning_effort_to_thinking(settings.reasoning_effort)
+    started_at = datetime.datetime.now(datetime.UTC)
     await emit_llm_request(
         LLMRequestPayload(
             schema_version=1,
@@ -483,7 +486,7 @@ async def evaluate_heartbeat_need(
             # Heartbeat sends a synthetic single-message prompt -- there
             # is no session history to derive an era marker from.
             min_message_seq_in_prompt=None,
-            started_at=datetime.datetime.now(datetime.UTC),
+            started_at=started_at,
         )
     )
     for attempt in range(max_retries):
@@ -517,11 +520,64 @@ async def evaluate_heartbeat_need(
         raise RuntimeError("Heartbeat LLM retry loop exited without response")
 
     await log_llm_usage(user.id, model, response, "heartbeat_decision", provider=provider)
+    await _emit_heartbeat_response(
+        response,
+        user_id=user.id,
+        model=model,
+        provider=provider,
+        started_at=started_at,
+    )
     decision = _parse_decision_response(response)
     if response.usage:
         decision.input_tokens = response.usage.input_tokens or 0
         decision.output_tokens = response.usage.output_tokens or 0
     return decision
+
+
+async def _emit_heartbeat_response(
+    response: MessageResponse,
+    *,
+    user_id: str,
+    model: str,
+    provider: str,
+    started_at: datetime.datetime,
+) -> None:
+    """Build and dispatch an ``LLMResponsePayload`` for the heartbeat decision.
+
+    Mirrors ``ClawboltAgent._emit_response`` for the agent-loop side and
+    ``_emit_compaction_response`` for the compaction side. Heartbeat's
+    session_id / request_id are ``None`` because the heartbeat decider
+    runs on a synthetic single-message prompt outside the session-aware
+    path.
+    """
+    content_blocks: list[dict[str, Any]] = []
+    for block in response.content:
+        try:
+            content_blocks.append(block.model_dump(mode="json"))
+        except Exception:
+            logger.exception(
+                "Failed to serialize heartbeat response content block; skipping for observer"
+            )
+    usage = response.usage
+    await emit_llm_response(
+        LLMResponsePayload(
+            schema_version=1,
+            purpose=PURPOSE_HEARTBEAT_DECISION,
+            user_id=user_id,
+            session_id=None,
+            request_id=None,
+            model=model,
+            provider=provider,
+            content_blocks=content_blocks,
+            stop_reason=response.stop_reason,
+            input_tokens=usage.input_tokens if usage else None,
+            output_tokens=usage.output_tokens if usage else None,
+            cache_creation_input_tokens=(usage.cache_creation_input_tokens if usage else None),
+            cache_read_input_tokens=(usage.cache_read_input_tokens if usage else None),
+            started_at=started_at,
+            completed_at=datetime.datetime.now(datetime.UTC),
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/observer.py
+++ b/backend/app/agent/observer.py
@@ -1,15 +1,23 @@
-"""Observer hook for LLM requests dispatched by the agent layer.
+"""Observer hooks for LLM requests and responses dispatched by the agent layer.
 
 Mirrors the module-level setter pattern used by ``set_pipeline_override``
 in ``backend.app.agent.router``. Premium (or other plugins) can register
-a single async callback that receives a versioned snapshot of every LLM
-request the agent layer dispatches (main agent loop, compaction,
-heartbeat decision), for telemetry and token-efficiency analysis.
+async callbacks that receive a versioned snapshot of every LLM request
+and the matching response dispatched by the agent layer (main agent
+loop, compaction, heartbeat decision), for telemetry, token-efficiency
+analysis, and post-incident forensics.
 
-The observer runs inline with the LLM call but its exceptions are caught
-and logged, so it never crashes the caller. Observers should return
-quickly (e.g. by enqueueing work onto a background task) to avoid adding
-latency to the user-facing response.
+Both observers run inline with the LLM call but their exceptions are
+caught and logged, so they never crash the caller. Observers should
+return quickly (e.g. by enqueueing work onto a background task) to
+avoid adding latency to the user-facing response.
+
+Request / response pairing: the response payload echoes the request's
+``request_id`` and ``started_at`` so downstream consumers can correlate
+them without depending on observer call ordering. Capture the request
+first; if the response observer fires without a matching request row,
+the request was either dropped (size cap, opt-out) or arrived
+out-of-order due to retry logic.
 """
 
 import logging
@@ -139,3 +147,86 @@ async def emit_llm_request(payload: LLMRequestPayload) -> None:
         await observer(payload)
     except Exception:
         logger.exception("LLM request observer raised; payload dropped")
+
+
+# ---------------------------------------------------------------------------
+# Response side
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LLMResponsePayload:
+    """Versioned snapshot of an LLM response paired with its request.
+
+    Same forward-compatibility rules as :class:`LLMRequestPayload`:
+    observers read fields by name and tolerate unknown ones via
+    ``getattr(payload, "field", default)``.
+
+    ``content_blocks`` is the model's literal output as a list of
+    Anthropic-style content blocks (``text``, ``tool_use``, ``thinking``,
+    etc.). For agent-loop calls this is what lets us tell a single model
+    round emitting N tool_use blocks apart from N rounds emitting one
+    block each: the persisted ``tool_interactions_json`` column flattens
+    rounds, but the raw response preserves round boundaries.
+
+    ``request_id`` and ``started_at`` mirror the matching
+    :class:`LLMRequestPayload` so observers can pair the two without
+    relying on call ordering. ``completed_at`` is the wall-clock moment
+    the response payload was built (after ``amessages`` returned).
+
+    ``stop_reason`` is the provider's terminal signal ("end_turn",
+    "tool_use", "max_tokens", "stop_sequence", ...). Useful for spotting
+    truncation events without scanning every captured response.
+    """
+
+    schema_version: int
+    purpose: str
+    user_id: str
+    session_id: str | None
+    request_id: str | None
+    model: str
+    provider: str
+    content_blocks: list[dict[str, Any]]
+    stop_reason: str | None
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_creation_input_tokens: int | None
+    cache_read_input_tokens: int | None
+    started_at: datetime
+    completed_at: datetime
+
+
+LLMResponseObserver = Callable[[LLMResponsePayload], Awaitable[None]]
+
+_response_observer: LLMResponseObserver | None = None
+
+
+def set_llm_response_observer(observer: LLMResponseObserver | None) -> None:
+    """Register the (single) observer that receives each LLM response.
+
+    Pass ``None`` to clear. Same single-observer semantics as
+    :func:`set_llm_request_observer`.
+    """
+    global _response_observer
+    _response_observer = observer
+
+
+def get_llm_response_observer() -> LLMResponseObserver | None:
+    """Return the registered response observer, or ``None`` if none is set."""
+    return _response_observer
+
+
+async def emit_llm_response(payload: LLMResponsePayload) -> None:
+    """Dispatch ``payload`` to the registered response observer, swallowing errors.
+
+    No-op when no observer is registered. Same error-handling contract as
+    :func:`emit_llm_request`: exceptions are logged and swallowed so a
+    misbehaving observer cannot break a user-facing turn.
+    """
+    observer = _response_observer
+    if observer is None:
+        return
+    try:
+        await observer(payload)
+    except Exception:
+        logger.exception("LLM response observer raised; payload dropped")

--- a/tests/test_llm_observer.py
+++ b/tests/test_llm_observer.py
@@ -21,10 +21,14 @@ from backend.app.agent.observer import (
     PURPOSE_AGENT_FOLLOWUP,
     PURPOSE_AGENT_MAIN,
     LLMRequestPayload,
+    LLMResponsePayload,
     compute_min_message_seq,
     emit_llm_request,
+    emit_llm_response,
     get_llm_request_observer,
+    get_llm_response_observer,
     set_llm_request_observer,
+    set_llm_response_observer,
 )
 from backend.app.models import User
 from tests.mocks.llm import make_text_response
@@ -35,8 +39,10 @@ def _reset_observer() -> Iterator[None]:
     """Clear any registered observer between tests so module-level state does
     not leak across cases."""
     set_llm_request_observer(None)
+    set_llm_response_observer(None)
     yield
     set_llm_request_observer(None)
+    set_llm_response_observer(None)
 
 
 def _make_payload() -> LLMRequestPayload:
@@ -304,5 +310,197 @@ async def test_observer_exception_does_not_crash_agent_loop(
             await agent.process_message("still ok")
     finally:
         set_llm_request_observer(None)
+
+    assert any("observer raised" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Response observer (unit tests, no agent integration)
+# ---------------------------------------------------------------------------
+
+
+def _make_response_payload() -> LLMResponsePayload:
+    started = datetime.now(UTC)
+    return LLMResponsePayload(
+        schema_version=1,
+        purpose=PURPOSE_AGENT_MAIN,
+        user_id="user-1",
+        session_id="sess-1",
+        request_id="req-1",
+        model="claude-test",
+        provider="anthropic",
+        content_blocks=[{"type": "text", "text": "hi"}],
+        stop_reason="end_turn",
+        input_tokens=10,
+        output_tokens=2,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        started_at=started,
+        completed_at=started,
+    )
+
+
+def test_response_payload_schema_version_is_one() -> None:
+    """Pin the response-payload schema version, same rationale as the
+    request payload: bumps must be coordinated with every observer."""
+    assert _make_response_payload().schema_version == 1
+
+
+def test_default_response_observer_is_none() -> None:
+    assert get_llm_response_observer() is None
+
+
+def test_set_and_get_response_observer() -> None:
+    async def obs(_: LLMResponsePayload) -> None:
+        return None
+
+    set_llm_response_observer(obs)
+    assert get_llm_response_observer() is obs
+
+    set_llm_response_observer(None)
+    assert get_llm_response_observer() is None
+
+
+@pytest.mark.asyncio()
+async def test_emit_response_calls_registered_observer() -> None:
+    received: list[LLMResponsePayload] = []
+
+    async def obs(payload: LLMResponsePayload) -> None:
+        received.append(payload)
+
+    set_llm_response_observer(obs)
+    payload = _make_response_payload()
+    await emit_llm_response(payload)
+    assert received == [payload]
+
+
+@pytest.mark.asyncio()
+async def test_emit_response_is_noop_when_no_observer() -> None:
+    # Must not raise.
+    await emit_llm_response(_make_response_payload())
+
+
+@pytest.mark.asyncio()
+async def test_emit_response_swallows_observer_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A misbehaving response observer cannot break the agent turn."""
+
+    async def boom(_: LLMResponsePayload) -> None:
+        raise RuntimeError("observer blew up")
+
+    set_llm_response_observer(boom)
+    with caplog.at_level(logging.ERROR, logger="backend.app.agent.observer"):
+        await emit_llm_response(_make_response_payload())
+    assert any("observer raised" in rec.message for rec in caplog.records)
+    # Still registered after failure: a transient observer issue does
+    # not silently deregister it.
+    assert get_llm_response_observer() is boom
+
+
+# ---------------------------------------------------------------------------
+# Response observer (integration: fires from inside _call_llm_with_retry)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_response_observer_fires_from_agent_loop(
+    mock_amessages: MagicMock,
+    test_user: User,
+) -> None:
+    """The response observer fires after each ``amessages`` call returns,
+    with the same ``request_id`` / ``started_at`` that went into the
+    matching request payload so observers can pair the two without
+    relying on call ordering across concurrent agent loops."""
+    mock_amessages.return_value = make_text_response("hello back")
+
+    requests: list[LLMRequestPayload] = []
+    responses: list[LLMResponsePayload] = []
+
+    async def req_obs(p: LLMRequestPayload) -> None:
+        requests.append(p)
+
+    async def resp_obs(p: LLMResponsePayload) -> None:
+        responses.append(p)
+
+    set_llm_request_observer(req_obs)
+    set_llm_response_observer(resp_obs)
+    try:
+        agent = ClawboltAgent(user=test_user, session_id="sess-rsp", request_id="req-rsp")
+        await agent.process_message("hi")
+    finally:
+        set_llm_request_observer(None)
+        set_llm_response_observer(None)
+
+    assert requests, "request observer should have fired"
+    assert responses, "response observer should have fired"
+    req = requests[0]
+    resp = responses[0]
+    # Pairing fields echo across both payloads.
+    assert resp.request_id == req.request_id == "req-rsp"
+    assert resp.session_id == req.session_id == "sess-rsp"
+    assert resp.user_id == req.user_id == test_user.id
+    assert resp.started_at == req.started_at
+    # Purpose carries through unchanged.
+    assert resp.purpose == req.purpose == PURPOSE_AGENT_MAIN
+    # Content blocks are serialized to plain dicts (no pydantic objects).
+    for block in resp.content_blocks:
+        assert isinstance(block, dict)
+        assert "type" in block
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_response_observer_purpose_followup_after_trim_retry(
+    mock_amessages: MagicMock,
+    test_user: User,
+) -> None:
+    """When the first round is rejected by the provider for
+    ``ContextLengthExceeded`` the retry's request is tagged
+    ``PURPOSE_AGENT_FOLLOWUP``. The matching response payload must use the
+    same purpose so observers can pair them by request_id without
+    fixing up the label."""
+    mock_amessages.side_effect = [
+        ContextLengthExceededError("too big"),
+        make_text_response("ok after trim"),
+    ]
+
+    responses: list[LLMResponsePayload] = []
+
+    async def resp_obs(p: LLMResponsePayload) -> None:
+        responses.append(p)
+
+    set_llm_response_observer(resp_obs)
+    try:
+        agent = ClawboltAgent(user=test_user)
+        await agent.process_message("hi")
+    finally:
+        set_llm_response_observer(None)
+
+    assert any(r.purpose == PURPOSE_AGENT_FOLLOWUP for r in responses)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_response_observer_exception_does_not_crash_agent_loop(
+    mock_amessages: MagicMock,
+    test_user: User,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Same safety guarantee as the request observer: a raising response
+    observer cannot break the user-facing turn."""
+    mock_amessages.return_value = make_text_response("ok")
+
+    async def boom(_: LLMResponsePayload) -> None:
+        raise RuntimeError("response observer blew up")
+
+    set_llm_response_observer(boom)
+    try:
+        with caplog.at_level(logging.ERROR, logger="backend.app.agent.observer"):
+            agent = ClawboltAgent(user=test_user)
+            await agent.process_message("still ok")
+    finally:
+        set_llm_response_observer(None)
 
     assert any("observer raised" in rec.message for rec in caplog.records)

--- a/tests/test_llm_observer.py
+++ b/tests/test_llm_observer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Iterator
 from datetime import UTC, datetime
@@ -504,3 +505,88 @@ async def test_response_observer_exception_does_not_crash_agent_loop(
         set_llm_response_observer(None)
 
     assert any("observer raised" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.compaction.amessages")
+async def test_response_observer_fires_from_compaction(
+    mock_amessages: MagicMock,
+    test_user: User,
+) -> None:
+    """Compaction also dispatches an LLM call; the response observer must
+    fire there too so post-incident forensics have parity with the
+    request observer."""
+    import json
+
+    from backend.app.agent.compaction import compact_session
+    from backend.app.agent.messages import UserMessage as AgentUserMessage
+
+    mock_amessages.return_value = make_text_response(
+        json.dumps({"memory_update": "ok", "summary": ""})
+    )
+
+    received: list[LLMResponsePayload] = []
+
+    async def obs(payload: LLMResponsePayload) -> None:
+        received.append(payload)
+
+    set_llm_response_observer(obs)
+    try:
+        await compact_session(
+            test_user.id,
+            [AgentUserMessage(content="hi", seq=1)],
+        )
+    finally:
+        set_llm_response_observer(None)
+
+    assert any(p.purpose == "compaction" for p in received)
+    payload = next(p for p in received if p.purpose == "compaction")
+    assert payload.user_id == test_user.id
+    assert payload.session_id is None
+    # Content is serialized as plain dicts.
+    assert payload.content_blocks
+    for block in payload.content_blocks:
+        assert isinstance(block, dict)
+        assert "type" in block
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.heartbeat.amessages")
+async def test_response_observer_fires_from_heartbeat_decision(
+    mock_amessages: MagicMock,
+    test_user: User,
+) -> None:
+    """Heartbeat decision is the third LLM dispatch site (alongside agent
+    loop and compaction). Pair the request observer's coverage with
+    response-side coverage so we never have a half-instrumented
+    purpose."""
+    from backend.app.agent.heartbeat import evaluate_heartbeat_need
+
+    # The heartbeat decider parses a plain text response into a no-send
+    # decision when no tool_use is present; the parser tolerates an
+    # empty / "skip" reply so the dispatch path completes without us
+    # standing up a fake tool_use block.
+    mock_amessages.return_value = make_text_response("skip")
+
+    received: list[LLMResponsePayload] = []
+
+    async def obs(payload: LLMResponsePayload) -> None:
+        received.append(payload)
+
+    set_llm_response_observer(obs)
+    try:
+        # We only care that the observer fired before any downstream
+        # parsing or store interaction; the rest of the heartbeat path
+        # is exercised by ``test_heartbeat.py``. Suppress any parse-time
+        # failure raised by the synthetic mock response.
+        with contextlib.suppress(Exception):
+            await evaluate_heartbeat_need(test_user)
+    finally:
+        set_llm_response_observer(None)
+
+    assert any(p.purpose == "heartbeat_decision" for p in received), (
+        "response observer must fire for heartbeat decision"
+    )
+    payload = next(p for p in received if p.purpose == "heartbeat_decision")
+    assert payload.user_id == test_user.id
+    assert payload.session_id is None


### PR DESCRIPTION
## Description

Adds a response-side observer hook mirroring the existing `emit_llm_request` infrastructure. Plugins (e.g. premium) can now register an async callback that receives the model's raw output per LLM round: content_blocks, stop_reason, usage, and pairing fields that match the corresponding request.

### Why

Today we capture only the prompt sent to the model. The model's literal output is parsed in-process and persisted only in already-flattened form: `Message.tool_interactions_json` concatenates tool calls across multiple rounds within a single user turn into one DB row. That flattening makes it impossible to tell after the fact whether a single model round emitted N tool_use blocks or N rounds each emitted one. Capturing the raw response per round resolves the ambiguity for post-incident forensic analysis.

### What changes

- **`LLMResponsePayload`** dataclass in `backend/app/agent/observer.py` with the model's `content_blocks`, `stop_reason`, `usage`, and the pairing fields (`request_id` / `started_at`) that echo the matching request.
- **`set_llm_response_observer`** / **`emit_llm_response`** follow the same single-observer, swallow-errors-and-log contract as the request side. A misbehaving observer cannot break a user-facing turn.
- **`ClawboltAgent._emit_response`** in `backend/app/agent/core.py` serializes `response.content` via `block.model_dump(mode='json')` so observers see plain dicts (no pydantic objects from the any-llm provider package leak into storage).
- Wired into both `amessages` call sites inside `_call_llm_with_retry` (the main path and the post-trim retry path), so the response purpose matches the request purpose (AGENT_MAIN vs AGENT_FOLLOWUP).

### Out of scope / follow-up

This PR adds the OSS hook only. The premium-side capture (storing responses alongside the existing request captures, admin export) lands as a separate PR in `mozilla-ai/clawbolt-premium`.

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests (N/A: feature add)

Tests cover the unit surface (set/get/emit/error-swallowing) and the integration paths (response fires after a main-loop call, follow-up purpose label after a context-trim retry, raising observer is non-fatal, pairing fields ``request_id`` / ``session_id`` / ``started_at`` match across the request and response observers).

## AI Usage
- [x] AI-assisted (claude code drafted the diff and tests; reviewed line-by-line before commit)