### PR TITLE
fix(session): clamp last_trim_seq when per-seq delete orphans the watermark

### DIFF
--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -33,6 +33,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.agent.dto import SessionState, StoredMessage
 from backend.app.agent.store_cache import StoreCache
@@ -194,6 +195,28 @@ def _delete_all_messages_for_session(cs_id: int) -> Delete[tuple[Message]]:
         .where(Message.session_id == cs_id)
         .execution_options(synchronize_session="fetch")
     )
+
+
+async def _reset_trim_watermark_if_orphaned(db: AsyncSession, cs: ChatSession) -> None:
+    """Reset ``last_trim_seq`` to None when nothing above the watermark remains.
+
+    ``load_conversation_history`` filters to ``seq > last_trim_seq``, and new
+    inserts pick the next seq via ``max(seq) + 1`` (which is 1 when the table
+    is empty). If a partial delete (via :meth:`SessionStore.delete_message_async`
+    or :meth:`SessionStore.delete_messages_by_seqs_async`) removes every row
+    above the watermark, the watermark becomes a permanent ceiling: every
+    future inserted message satisfies ``seq <= last_trim_seq`` and is silently
+    filtered out of LLM context. Same failure mode the docstring on
+    ``delete_messages_async`` warns about, just via the per-seq paths.
+
+    Resetting here drops the watermark only when there is nothing left for it
+    to protect; trimmed facts already live in MEMORY.md / USER.md / SOUL.md.
+    """
+    if cs.last_trim_seq is None:
+        return
+    max_seq = (await db.execute(_select_max_seq(cs.id))).scalar()
+    if max_seq is None or max_seq <= cs.last_trim_seq:
+        cs.last_trim_seq = None
 
 
 # ---------------------------------------------------------------------------
@@ -622,6 +645,8 @@ class SessionStore:
                 return False
             result = await db.execute(_delete_message_by_seq(cs.id, seq))
             count: int = cast("CursorResult[object]", result).rowcount
+            if count > 0:
+                await _reset_trim_watermark_if_orphaned(db, cs)
             await db.commit()
             return count > 0
 
@@ -642,6 +667,8 @@ class SessionStore:
                 return 0
             result = await db.execute(_delete_messages_by_seqs(cs.id, seqs))
             count: int = cast("CursorResult[object]", result).rowcount
+            if count > 0:
+                await _reset_trim_watermark_if_orphaned(db, cs)
             await db.commit()
             return count
 

--- a/tests/test_session_db_async.py
+++ b/tests/test_session_db_async.py
@@ -372,6 +372,104 @@ async def test_delete_messages_async_resets_trim_watermark(
         assert cs.last_trim_seq is None
 
 
+async def test_delete_message_async_resets_orphaned_trim_watermark(
+    async_db: async_sessionmaker,
+) -> None:
+    """Per-seq delete that orphans the watermark must reset it.
+
+    Production repro: a session was compacted up to seq=335 (so
+    ``last_trim_seq=335``), then the user deleted every remaining row
+    via the per-seq endpoint. Future inserts started at seq=1 again
+    (``_select_max_seq`` returns 0 on an empty table), but
+    ``load_conversation_history`` kept filtering them all out because
+    ``seq > 335`` was never true. The LLM saw only the live inbound,
+    losing every prior turn, including freshly attached media.
+    """
+    user_id = await _create_user(async_db)
+    store = SessionStore(user_id)
+    session, _ = await store.get_or_create_session_async()
+    await store.add_message_async(session, direction="inbound", body="a")
+
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).where(ChatSession.user_id == user_id))
+        ).scalar_one()
+        cs.last_trim_seq = 199
+        await db.commit()
+
+    assert await store.delete_message_async(session.session_id, 1) is True
+
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).where(ChatSession.user_id == user_id))
+        ).scalar_one()
+        assert cs.last_trim_seq is None
+
+
+async def test_delete_message_async_preserves_live_trim_watermark(
+    async_db: async_sessionmaker,
+) -> None:
+    """Per-seq delete that leaves rows above the watermark must keep it.
+
+    Trimmed facts already live in MEMORY.md / USER.md / SOUL.md;
+    re-feeding pre-watermark rows to the LLM would duplicate the
+    extracted memory. Only clear the watermark when the delete leaves
+    nothing above it.
+    """
+    user_id = await _create_user(async_db)
+    store = SessionStore(user_id)
+    session, _ = await store.get_or_create_session_async()
+    for body in ("a", "b", "c"):
+        await store.add_message_async(session, direction="inbound", body=body)
+
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).where(ChatSession.user_id == user_id))
+        ).scalar_one()
+        cs.last_trim_seq = 1
+        await db.commit()
+
+    assert await store.delete_message_async(session.session_id, 2) is True
+
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).where(ChatSession.user_id == user_id))
+        ).scalar_one()
+        assert cs.last_trim_seq == 1
+
+
+async def test_delete_messages_by_seqs_async_resets_orphaned_trim_watermark(
+    async_db: async_sessionmaker,
+) -> None:
+    """Batch-seq delete that orphans the watermark must reset it.
+
+    Same failure mode as the per-seq path: deleting every live row in a
+    single batch call leaves an orphan watermark that silently filters
+    every future insert.
+    """
+    user_id = await _create_user(async_db)
+    store = SessionStore(user_id)
+    session, _ = await store.get_or_create_session_async()
+    for body in ("a", "b"):
+        await store.add_message_async(session, direction="inbound", body=body)
+
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).where(ChatSession.user_id == user_id))
+        ).scalar_one()
+        cs.last_trim_seq = 50
+        await db.commit()
+
+    deleted = await store.delete_messages_by_seqs_async(session.session_id, [1, 2])
+    assert deleted == 2
+
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).where(ChatSession.user_id == user_id))
+        ).scalar_one()
+        assert cs.last_trim_seq is None
+
+
 # ---------------------------------------------------------------------------
 # last-timestamp helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description
The per-seq and batch-seq message delete paths (`delete_message_async` and `delete_messages_by_seqs_async`) did not touch `sessions.last_trim_seq`. If a caller deletes every row above the watermark via those endpoints, the session is left with an orphan ceiling: `max(seq)` becomes `<= last_trim_seq`, new inserts start at `seq=1` again (`max(seq)+1` on an empty table), and `load_conversation_history` filters every future message out with `seq > last_trim_seq`. Symptom in prod: the LLM sees only the live inbound on every turn and behaves as if the conversation just started, losing all prior context including freshly staged media (e.g. a photo from the previous turn never reached the agent on a follow-up "save to GDrive" request).

The clear-all path (`delete_messages_async`) already resets the watermark and explicitly documents this failure mode. This change adds a shared helper, `_reset_trim_watermark_if_orphaned`, and calls it from both partial-delete paths after a successful delete. The helper resets `last_trim_seq` to `None` only when nothing remains above it; trimmed facts already live in `MEMORY.md` / `USER.md` / `SOUL.md`, so dropping the watermark when its job is over is the correct call.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude diagnosed the prod symptom from captured LLM payload + admin conversation API, located the missing reset in the per-seq delete paths, wrote the helper + tests, and verified the full OSS suite green.)
- [ ] No AI used