### PR TITLE
fix(storage,companycam): three saved-file regressions from the Drive cutover

### DIFF
--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -59,11 +59,18 @@ logger = logging.getLogger(__name__)
 STAGING_TTL_SECONDS = 604800
 STAGING_MAX_PER_USER = 50  # Cap memory growth: oldest-expiring entry is evicted on overflow
 
-# Recently-uploaded receipt cache. Shorter TTL than staging because its
-# job is only to absorb same-turn / same-day retries on a handle the
-# model already shipped. Anything older than this should not look like
-# a fresh success on retry; the tool can return its normal NOT_FOUND.
-UPLOAD_RECORD_TTL_SECONDS = 3600  # 1h
+# Recently-uploaded receipt cache. Matches the staging TTL so a handle
+# whose bytes are still on disk always has a corresponding receipt: the
+# tools no longer evict on success (bytes coexist with the permanent
+# home for the staging window), so the receipt is the only mechanism
+# preventing a same-handle retry from writing a second Drive copy.
+# Drive does not dedupe by content the way CompanyCam does, so without
+# this guard a 2h-later retry on the same handle would land a duplicate.
+# The cache is in-process: a worker restart inside the staging window
+# can still produce a duplicate Drive file (no data loss). Persisting
+# this record onto ``staged_media`` would close that gap; tracked for
+# a follow-up.
+UPLOAD_RECORD_TTL_SECONDS = STAGING_TTL_SECONDS  # 7 days
 UPLOAD_RECORD_MAX_PER_USER = 200
 
 
@@ -574,12 +581,12 @@ async def purge_expired() -> int:
 # In-process upload-receipt cache
 # ---------------------------------------------------------------------------
 #
-# Same-turn retries on a handle that already shipped to an external
-# service need a positive idempotent answer instead of "no bytes found".
-# This is short-lived (1h) and intentionally not persisted: by the time
-# a retry happens >1h later, the agent should just succeed via the
-# normal staged-bytes path. Keeping it in-memory avoids extra DB writes
-# on every successful upload.
+# A handle that already shipped to an external service needs an idempotent
+# answer on retry so the tool does not write a second copy. Bytes are
+# preserved across the staging TTL (no longer evicted on success), so the
+# receipt has to age alongside them: anything still resolvable as bytes
+# must also be resolvable as a receipt. Worker-local; persisting onto the
+# ``staged_media`` row is a follow-up that would survive restarts.
 
 
 def mark_uploaded(

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -286,6 +286,14 @@ def create_file_tools(
     # Per-turn cache: same closure lifetime as the tool list, so a saved file
     # analyzed twice in one turn only pays the vision cost once.
     saved_analysis_cache: dict[str, str] = {}
+    # Per-turn registry of filenames already minted by this tool list, keyed by
+    # destination folder. Drive's ``files.list`` is eventually consistent, so a
+    # file just written by ``upload_file`` may not appear in the next
+    # ``list_folder`` call. Without this set, two upload calls in the same turn
+    # against the same folder would both see ``existing=[photo_001]`` and both
+    # mint ``photo_002.jpg``, silently shadowing each other. The set is
+    # populated post-write so it reflects what we know has succeeded.
+    recent_uploads_by_folder: dict[str, set[str]] = {}
 
     async def upload_to_storage(
         folder_path: str | None = None,
@@ -389,11 +397,22 @@ def create_file_tools(
             len(file_bytes),
         )
 
-        # Pick the next sequence number from the destination folder.
+        # Pick the next sequence number from the destination folder. Union the
+        # backend listing with names this tool list has already minted this turn
+        # so concurrent or rapid serial uploads cannot collide on the same
+        # index when Drive's eventually-consistent ``files.list`` has not yet
+        # observed the prior write.
         extension = _extension_from_mime(mime_type)
         await storage.create_folder(normalized_folder)
         existing = await storage.list_folder(normalized_folder)
-        filename = _build_filename(description, index=len(existing) + 1, extension=extension)
+        recent_for_folder = recent_uploads_by_folder.setdefault(normalized_folder, set())
+        taken_names = {f.name for f in existing} | recent_for_folder
+        index = len(existing) + 1
+        while True:
+            filename = _build_filename(description, index=index, extension=extension)
+            if filename not in taken_names:
+                break
+            index += 1
 
         saved = await storage.upload_file(
             file_bytes,
@@ -402,6 +421,7 @@ def create_file_tools(
             mime_type=mime_type,
             description=description,
         )
+        recent_for_folder.add(filename)
 
         if original_url:
             # Record the receipt before evicting so a same-turn retry on the
@@ -464,10 +484,12 @@ def create_file_tools(
         # Pick the target filename: caller override if provided, otherwise
         # keep the original. Add a numeric suffix if there is already a
         # file of that name in the destination so the move never silently
-        # overwrites.
+        # overwrites. Union the backend listing with same-turn writes for
+        # the same reason ``upload_to_storage`` does.
         await storage.create_folder(normalized_folder)
         target_existing = await storage.list_folder(normalized_folder)
-        existing_names = {f.name for f in target_existing}
+        recent_for_dest = recent_uploads_by_folder.setdefault(normalized_folder, set())
+        existing_names = {f.name for f in target_existing} | recent_for_dest
         if new_filename and new_filename.strip():
             target_filename = new_filename.strip()
         else:
@@ -491,6 +513,7 @@ def create_file_tools(
                 is_error=True,
                 error_kind=ToolErrorKind.NOT_FOUND,
             )
+        recent_for_dest.add(target_filename)
 
         logger.info("File moved: %s -> %s", current_path, moved.path)
         return ToolResult(

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -320,6 +320,33 @@ def create_file_tools(
                 media_map.setdefault(resolved_url, resolved_bytes)
                 mime_type = resolved_mime
 
+        # Idempotency: if this handle was already filed to Drive within the
+        # staging TTL, return the recorded receipt rather than writing a
+        # second copy. Drive does not dedupe by content, so the receipt
+        # cache is what prevents duplicate Drive files on retried LLM tool
+        # calls now that bytes are no longer evicted after a successful
+        # upload.
+        if original_url:
+            prior = media_staging.get_uploaded(user.id, original_url)
+            if prior is not None and prior.service == "storage":
+                logger.info(
+                    "upload_to_storage idempotent hit: user=%s handle=%s path=%s",
+                    user.id,
+                    original_url,
+                    prior.external_id,
+                )
+                return ToolResult(
+                    content=(
+                        f"File {original_url} was already uploaded to "
+                        f"{prior.external_id}. Not re-uploading."
+                    ),
+                    receipt=ToolReceipt(
+                        action="File already in Drive",
+                        target=prior.target,
+                        url=prior.url or None,
+                    ),
+                )
+
         # Determine file content
         file_bytes = b""
         if original_url and original_url in media_map:
@@ -353,31 +380,6 @@ def create_file_tools(
                 mime_type = staged_mime
 
         if not file_bytes:
-            # A prior tool call in this turn already shipped this handle to
-            # storage and ``evict``ed the bytes. Surface the prior receipt
-            # so the model doesn't read this as a failure and retry. Mirrors
-            # the CompanyCam idempotency in ``companycam_upload_photo``.
-            if original_url:
-                prior = media_staging.get_uploaded(user.id, original_url)
-                if prior is not None and prior.service == "storage":
-                    logger.warning(
-                        "media_handle_referenced_after_eviction service=storage "
-                        "user=%s handle=%s prior_path=%s",
-                        user.id,
-                        original_url,
-                        prior.external_id,
-                    )
-                    return ToolResult(
-                        content=(
-                            f"File {original_url} was already uploaded earlier in "
-                            f"this turn to {prior.external_id}. Not re-uploading."
-                        ),
-                        receipt=ToolReceipt(
-                            action="File already in Drive",
-                            target=prior.target,
-                            url=prior.url or None,
-                        ),
-                    )
             logger.warning("upload_to_storage called but no file content available")
             return ToolResult(
                 content=(
@@ -424,18 +426,21 @@ def create_file_tools(
         recent_for_folder.add(filename)
 
         if original_url:
-            # Record the receipt before evicting so a same-turn retry on the
-            # same handle hits an idempotent result instead of NOT_FOUND.
+            # Record the receipt so a later same-handle retry within the
+            # staging TTL short-circuits via the idempotency check at the
+            # top of this tool instead of writing a second Drive copy.
+            # Bytes intentionally stay in staging: keeps cross-tool flow
+            # simple (``companycam_upload_photo`` can still find them) at
+            # the cost of ~2x storage for the staging window.
             media_staging.mark_uploaded(
                 user.id,
                 original_url,
                 service="storage",
                 external_id=saved.path,
                 url=saved.web_view_link or "",
-                target=filename,
+                target=saved.path,
                 status="uploaded",
             )
-            await media_staging.evict(user.id, original_url)
 
         logger.info("File cataloged: %s", saved.path)
         return ToolResult(

--- a/backend/app/integrations/companycam/photos.py
+++ b/backend/app/integrations/companycam/photos.py
@@ -110,22 +110,24 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         mime_type = "image/jpeg"
         photo_uri = ""
 
-        # 0. Translate a handle that this conversation already wrote to Drive
-        #    into the storage path that ``upload_to_storage`` recorded. After a
-        #    successful upload_to_storage, the staged bytes are evicted (see
-        #    ``file_tools.upload_to_storage``) and the handle no longer
-        #    resolves via ``resolve_media_ref``; without this hop the staging
-        #    miss would surface as NOT_FOUND even though the file is sitting
-        #    in Drive ready to ship. Only ``service="storage"`` is translated;
-        #    a prior CompanyCam upload of the same handle still falls through
-        #    to the idempotent receipt branch below.
-        prior_upload = media_staging.get_uploaded(ctx.user.id, original_url)
-        if (
-            prior_upload is not None
-            and prior_upload.service == "storage"
-            and prior_upload.external_id
-        ):
-            original_url = prior_upload.external_id
+        # Idempotency: if this handle was already shipped to CompanyCam within
+        # the staging TTL, return the recorded receipt rather than POSTing the
+        # same bytes again. CompanyCam dedupes by MD5 server-side so a missed
+        # idempotency check is only a wasted roundtrip, but skipping it keeps
+        # the flow clean.
+        prior = media_staging.get_uploaded(ctx.user.id, original_url)
+        if prior is not None and prior.service == "companycam":
+            return ToolResult(
+                content=(
+                    f"Photo {original_url} was already uploaded to CompanyCam "
+                    f"(status={prior.status}, ID {prior.external_id}). Not re-uploading."
+                ),
+                receipt=ToolReceipt(
+                    action="Photo already in CompanyCam",
+                    target=prior.target,
+                    url=prior.url,
+                ),
+            )
 
         # 1. Resolve media handles: the LLM may pass a handle
         #    (e.g. "media_abZtYWFs") from analyze_photo instead of the
@@ -135,7 +137,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         if resolved is not None:
             original_url, file_bytes, mime_type = resolved
 
-        # 1. Try downloaded_media (current message, not yet evicted)
+        # 2. Try downloaded_media (current message)
         if not file_bytes:
             for media in ctx.downloaded_media:
                 if media.original_url != original_url:
@@ -144,16 +146,17 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                 mime_type = media.mime_type or "image/jpeg"
                 break
 
-        # 2. Try media staging (cached bytes, may have been evicted)
+        # 3. Try media staging by URL (rare: the LLM passed the original URL
+        #    rather than the ``media_*`` handle that Tier 1 already handles).
         if not file_bytes:
             all_staged = await media_staging.get_all_for_user(ctx.user.id)
             if original_url in all_staged:
                 file_bytes = all_staged[original_url]
 
-        # 3. Fall back to a saved file in Drive. The agent quotes a storage
-        #    path (e.g. /Astro Home/photos/foo.jpg) when it wants to push a
-        #    previously saved file into CompanyCam, or step 0 translated a
-        #    same-conversation handle into a storage path.
+        # 4. Fall back to a saved file in Drive. The agent quotes a storage
+        #    path (e.g. /Astro Home/photos/foo.jpg) when pushing a
+        #    previously saved file (older than the staging TTL, or the
+        #    agent simply prefers the explicit path) into CompanyCam.
         #
         #    Always download the bytes; do NOT hand CompanyCam a Drive
         #    ``webViewLink``. Files written under ``drive.file`` scope are
@@ -173,33 +176,6 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                     logger.warning("Saved media missing from storage: %s", saved.path)
 
         if not file_bytes and not photo_uri:
-            # Option A: a prior tool call in this turn already shipped
-            # this handle to CompanyCam, then evict() dropped the bytes.
-            # Surface the prior receipt instead of an error so the model
-            # doesn't read this as "the upload failed" and retry again.
-            prior = media_staging.get_uploaded(ctx.user.id, original_url)
-            if prior is not None and prior.service == "companycam":
-                logger.warning(
-                    "media_handle_referenced_after_eviction service=companycam "
-                    "user=%s handle=%s project=%s prior_status=%s",
-                    ctx.user.id,
-                    original_url,
-                    project_id,
-                    prior.status,
-                )
-                content = (
-                    f"Photo {original_url} was already uploaded to CompanyCam "
-                    f"earlier in this turn (status={prior.status}, ID {prior.external_id}). "
-                    f"Not re-uploading."
-                )
-                return ToolResult(
-                    content=content,
-                    receipt=ToolReceipt(
-                        action="Photo already in CompanyCam",
-                        target=prior.target,
-                        url=prior.url,
-                    ),
-                )
             return ToolResult(
                 content=(
                     "No photo available to upload. Send a photo in the "
@@ -256,15 +232,13 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             app_url,
         )
 
-        # CompanyCam dedupes by MD5 across the whole account, so re-uploading
-        # the same staged bytes in a later turn comes back as ``duplicate``.
-        # Drop the staged copy now that CompanyCam has accepted it, mirroring
-        # the post-upload eviction in ``file_tools.upload_to_storage``. Skip
-        # on ``processing_error``: that status means CompanyCam could not
-        # fetch our temp URL, so a retry can still source bytes from staging.
-        # Before evicting, leave a recently-uploaded record so a same-turn
-        # retry on the same handle hits an idempotent receipt instead of
-        # NOT_FOUND.
+        # Record the upload so a later same-handle retry within the staging
+        # TTL short-circuits via the idempotency check at the top of this
+        # tool. Bytes intentionally stay in staging: CompanyCam dedupes by
+        # MD5 server-side, so even a missed idempotency check is only a
+        # wasted roundtrip. Skip on ``processing_error``: that status means
+        # CompanyCam could not fetch our temp URL, and we want a retry to
+        # be a fresh attempt rather than a no-op receipt.
         if original_url and status != "processing_error":
             media_staging.mark_uploaded(
                 ctx.user.id,
@@ -275,7 +249,6 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                 target=photo_target(photo),
                 status=status,
             )
-            await media_staging.evict(ctx.user.id, original_url)
 
         if status == "processing_error":
             return ToolResult(

--- a/backend/app/integrations/companycam/photos.py
+++ b/backend/app/integrations/companycam/photos.py
@@ -110,7 +110,24 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         mime_type = "image/jpeg"
         photo_uri = ""
 
-        # 0. Resolve media handles: the LLM may pass a handle
+        # 0. Translate a handle that this conversation already wrote to Drive
+        #    into the storage path that ``upload_to_storage`` recorded. After a
+        #    successful upload_to_storage, the staged bytes are evicted (see
+        #    ``file_tools.upload_to_storage``) and the handle no longer
+        #    resolves via ``resolve_media_ref``; without this hop the staging
+        #    miss would surface as NOT_FOUND even though the file is sitting
+        #    in Drive ready to ship. Only ``service="storage"`` is translated;
+        #    a prior CompanyCam upload of the same handle still falls through
+        #    to the idempotent receipt branch below.
+        prior_upload = media_staging.get_uploaded(ctx.user.id, original_url)
+        if (
+            prior_upload is not None
+            and prior_upload.service == "storage"
+            and prior_upload.external_id
+        ):
+            original_url = prior_upload.external_id
+
+        # 1. Resolve media handles: the LLM may pass a handle
         #    (e.g. "media_abZtYWFs") from analyze_photo instead of the
         #    actual URL. Normalize to original_url + bytes before the
         #    three-tier lookup below.
@@ -135,20 +152,25 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
 
         # 3. Fall back to a saved file in Drive. The agent quotes a storage
         #    path (e.g. /Astro Home/photos/foo.jpg) when it wants to push a
-        #    previously saved file into CompanyCam.
+        #    previously saved file into CompanyCam, or step 0 translated a
+        #    same-conversation handle into a storage path.
+        #
+        #    Always download the bytes; do NOT hand CompanyCam a Drive
+        #    ``webViewLink``. Files written under ``drive.file`` scope are
+        #    private, and the link itself is an HTML preview page that
+        #    302-redirects to ``accounts.google.com`` for an unauthenticated
+        #    fetcher. CompanyCam's ingest pulls the URL anonymously and
+        #    would either store HTML or fail. Routing through the temp
+        #    media tunnel below is the same path that handle-staged
+        #    photos take and is battle-tested.
         if not file_bytes and ctx.storage is not None:
             saved = await find_saved_file(ctx.storage, original_url)
             if saved is not None:
                 mime_type = saved.mime_type or "image/jpeg"
-                # Cloud storage: prefer the shareable URL; CompanyCam can
-                # download Drive ``webViewLink``s without a presigned URL.
-                if saved.web_view_link:
-                    photo_uri = saved.web_view_link
-                else:
-                    try:
-                        file_bytes = await read_saved_file_bytes(ctx.storage, saved)
-                    except FileNotFoundError:
-                        logger.warning("Saved media missing from storage: %s", saved.path)
+                try:
+                    file_bytes = await read_saved_file_bytes(ctx.storage, saved)
+                except FileNotFoundError:
+                    logger.warning("Saved media missing from storage: %s", saved.path)
 
         if not file_bytes and not photo_uri:
             # Option A: a prior tool call in this turn already shipped

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -461,8 +461,9 @@ class GoogleDriveStorage(StorageBackend):
     async def search_files(self, query: str = "", limit: int = 10) -> list[SavedFile]:
         bounded = max(1, min(limit, 100))
         service = self._get_service()
+        tokens = _search_tokens(query)
         clauses = ["trashed=false", "mimeType!='application/vnd.google-apps.folder'"]
-        for token in _search_tokens(query):
+        for token in tokens:
             safe = token.replace("\\", "\\\\").replace("'", "\\'")
             clauses.append(f"(name contains '{safe}' or fullText contains '{safe}')")
         q = " and ".join(clauses)
@@ -475,7 +476,41 @@ class GoogleDriveStorage(StorageBackend):
             ),
             op="search_files",
         )
-        return [self._from_drive_file(payload) for payload in result.get("files", [])]
+        native_payloads = result.get("files", [])
+        matches = [self._from_drive_file(payload) for payload in native_payloads]
+        if not tokens or len(matches) >= bounded:
+            return matches
+
+        # The Drive query only matches filename and indexed full-text content;
+        # the human-readable storage path lives in ``appProperties.clawbolt_path``
+        # which Drive's query DSL only supports as an exact-match operator. To
+        # let users search by folder (e.g. ``"Catch All"`` for files saved
+        # under ``/Catch All/photos/``), fall back to a broader list and
+        # filter client-side. Capped at a recent slice so accounts with many
+        # files don't pay an unbounded scan cost on every search.
+        broad_result = await self._execute_with_retry(
+            lambda: service.files().list(
+                q="trashed=false and mimeType!='application/vnd.google-apps.folder'",
+                fields=f"files({_DRIVE_FILE_FIELDS})",
+                pageSize=max(bounded * 5, 50),
+                orderBy="modifiedTime desc",
+            ),
+            op="search_files.path_fallback",
+        )
+        lower_tokens = [t.lower() for t in tokens]
+        seen_ids: set[str] = {(p.get("id") or "") for p in native_payloads if p.get("id")}
+        for payload in broad_result.get("files", []):
+            file_id = payload.get("id") or ""
+            if file_id in seen_ids:
+                continue
+            path_value = (payload.get("appProperties") or {}).get(_DRIVE_PATH_PROPERTY, "")
+            if not path_value:
+                continue
+            if all(token in path_value.lower() for token in lower_tokens):
+                matches.append(self._from_drive_file(payload))
+                if len(matches) >= bounded:
+                    break
+        return matches
 
     async def download_file(self, path: str) -> bytes:
         from googleapiclient.errors import HttpError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import NullPool
 
 import backend.app.database as _db_module
+from backend.app.agent import media_staging as _media_staging
 from backend.app.agent.approval import reset_approval_gate
 from backend.app.agent.file_store import SessionState, StoredMessage, reset_stores
 from backend.app.agent.memory_db import reset_memory_stores
@@ -235,6 +236,11 @@ def _isolate_stores(_pg_async_engine_session: AsyncEngine, tmp_path: Path) -> Ge
         reset_session_stores()
         reset_memory_stores()
         reset_approval_gate()
+        # In-memory upload-receipt cache survives across tests by design
+        # (matches the 7-day staging TTL in production). Clear it per
+        # test so a prior test's mark_uploaded does not short-circuit a
+        # later test that reuses the same (user_id, original_url) pair.
+        _media_staging._uploaded.clear()
         yield
 
     async def _truncate() -> None:
@@ -251,6 +257,7 @@ def _isolate_stores(_pg_async_engine_session: AsyncEngine, tmp_path: Path) -> Ge
     reset_session_stores()
     reset_memory_stores()
     reset_approval_gate()
+    _media_staging._uploaded.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -1637,9 +1637,9 @@ async def test_upload_photo_strips_dict_description() -> None:
 async def test_upload_photo_can_reuse_saved_file_from_storage(test_user: User) -> None:
     """Saved photos should be reusable when the agent quotes their storage path.
 
-    Mock storage exposes a ``web_view_link`` for every saved file, so the
-    companycam tool routes through that URL and never touches the
-    presigned tunnel URL.
+    The bytes are read from storage and served through the temp media tunnel;
+    Drive ``webViewLink``s are not handed to CompanyCam because they require
+    Google auth and would 302 to a login page for an anonymous fetcher.
     """
     from backend.app.agent.tools.names import ToolName
     from backend.app.integrations.companycam.models import ImageURI, Photo
@@ -1668,11 +1668,105 @@ async def test_upload_photo_can_reuse_saved_file_from_storage(test_user: User) -
     ctx.downloaded_media = []
     ctx.storage = storage
 
-    tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
-    result = await tool.function(project_id="94772883", original_url=saved.path)
+    with (
+        patch(
+            "backend.app.services.webhook.discover_tunnel_url",
+            new_callable=AsyncMock,
+            return_value="https://tunnel.example.com",
+        ),
+        patch(
+            "backend.app.routers.media_temp.create_temp_media_url",
+            return_value="https://tunnel.example.com/media/tmp/saved",
+        ) as create_temp,
+    ):
+        tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+        result = await tool.function(project_id="94772883", original_url=saved.path)
 
     assert result.is_error is False
-    assert service.upload_photo.call_args.kwargs["photo_uri"] == saved.web_view_link
+    sent_uri = service.upload_photo.call_args.kwargs["photo_uri"]
+    assert sent_uri == "https://tunnel.example.com/media/tmp/saved"
+    assert sent_uri != saved.web_view_link, (
+        "must not send Drive webViewLink to CompanyCam: "
+        "drive.file-scope files require auth and the link 302s to Google login"
+    )
+    # The bytes shipped to the tunnel must be the saved-file bytes.
+    assert create_temp.call_args.args[0] == b"saved-jpg"
+
+
+@pytest.mark.asyncio()
+async def test_upload_photo_resolves_handle_after_prior_storage_upload(
+    test_user: User,
+) -> None:
+    """A handle whose bytes were already filed to Drive must still ship to CompanyCam.
+
+    Reproduces nathan's 2026-05-13 ``/Catch All/photos/`` flow: agent
+    uploads three photos to Drive via ``upload_to_storage`` (which evicts
+    the staged bytes), then in a later turn the LLM asks to push the
+    same ``media_*`` handles to CompanyCam. Before this fix, the staging
+    miss + the idempotent receipt branch (which only triggered for prior
+    CompanyCam uploads, not prior storage uploads) surfaced NOT_FOUND.
+    """
+    from backend.app.agent import media_staging
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.integrations.companycam.models import ImageURI, Photo
+    from tests.mocks.storage import MockStorageBackend
+
+    service = MagicMock(spec=CompanyCamService)
+    service.upload_photo = AsyncMock(
+        return_value=Photo(
+            id="42",
+            description="",
+            processing_status="processed",
+            uris=[ImageURI(type="original", uri="https://img.companycam.com/x.jpg")],
+        )
+    )
+
+    storage = MockStorageBackend()
+    saved = await storage.upload_file(
+        b"persisted-bytes",
+        "/Catch All/photos",
+        "photo_002.jpg",
+        mime_type="image/jpeg",
+    )
+
+    ctx = MagicMock()
+    ctx.user.id = test_user.id
+    ctx.downloaded_media = []
+    ctx.storage = storage
+
+    handle = "media_evicted_xyz"
+    media_staging.mark_uploaded(
+        ctx.user.id,
+        handle,
+        service="storage",
+        external_id=saved.path,
+        url=saved.web_view_link,
+        target="photo_002.jpg",
+        status="uploaded",
+    )
+    try:
+        with (
+            patch(
+                "backend.app.services.webhook.discover_tunnel_url",
+                new_callable=AsyncMock,
+                return_value="https://tunnel.example.com",
+            ),
+            patch(
+                "backend.app.routers.media_temp.create_temp_media_url",
+                return_value="https://tunnel.example.com/media/tmp/persisted",
+            ) as create_temp,
+        ):
+            tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+            result = await tool.function(project_id="94772883", original_url=handle)
+
+        assert result.is_error is False, result.content
+        assert create_temp.call_args.args[0] == b"persisted-bytes"
+        assert (
+            service.upload_photo.call_args.kwargs["photo_uri"]
+            == "https://tunnel.example.com/media/tmp/persisted"
+        )
+    finally:
+        await media_staging.clear_user(ctx.user.id)
 
 
 @pytest.mark.asyncio()

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -1324,12 +1324,14 @@ async def test_receipt_upload_duplicate_photo_uses_app_url() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_evicts_staging_on_success(test_user: User) -> None:
-    """Regression #1282: a successful upload must evict the staged bytes.
+async def test_upload_photo_keeps_staging_on_success(test_user: User) -> None:
+    """A successful upload must NOT evict the staged bytes.
 
-    CompanyCam dedupes by MD5 account-wide, so if we leave the bytes in
-    media_staging the next turn's upload tool can re-grab them and trip
-    a spurious ``duplicate`` flag against a photo we just uploaded.
+    Bytes stay in staging for the full TTL so cross-tool flows
+    (``upload_to_storage`` -> ``companycam_upload_photo``, or vice versa)
+    can find them without bookkeeping hops. Idempotency on a same-handle
+    retry is provided by the ``mark_uploaded`` receipt cache, which the
+    top-of-tool check honors before re-POSTing.
     """
     from backend.app.agent import media_staging
     from backend.app.agent.tools.names import ToolName
@@ -1377,21 +1379,27 @@ async def test_upload_photo_evicts_staging_on_success(test_user: User) -> None:
             result = await tool.function(project_id="22222222", original_url=photo_url)
 
         assert not result.is_error
-        assert photo_url not in await media_staging.get_all_for_user(user_id), (
-            "staged bytes must be evicted after a successful upload so a "
-            "follow-up turn cannot re-upload them"
+        assert photo_url in await media_staging.get_all_for_user(user_id), (
+            "staged bytes must stay available after success so cross-tool "
+            "reuse works within the staging TTL"
+        )
+        prior = media_staging.get_uploaded(user_id, photo_url)
+        assert prior is not None and prior.service == "companycam", (
+            "the upload receipt must be recorded so a same-handle retry "
+            "short-circuits via the top-of-tool idempotency check"
         )
     finally:
         await media_staging.clear_user(user_id)
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_evicts_staging_on_duplicate(test_user: User) -> None:
-    """Regression #1282: ``duplicate`` response must also evict the staged bytes.
+async def test_upload_photo_keeps_staging_on_duplicate(test_user: User) -> None:
+    """``duplicate`` response from CompanyCam must NOT evict the staged bytes.
 
-    When CompanyCam reports the upload was a duplicate, the bytes have
-    still been delivered. Keeping them staged invites another redundant
-    upload on the next turn.
+    CompanyCam dedupes by MD5, so a duplicate result means the photo
+    already exists on their side. Either way the bytes stay in staging
+    for the TTL so other tools (e.g. ``upload_to_storage``) can still
+    use them.
     """
     from backend.app.agent import media_staging
     from backend.app.agent.tools.names import ToolName
@@ -1438,9 +1446,9 @@ async def test_upload_photo_evicts_staging_on_duplicate(test_user: User) -> None
             tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
             await tool.function(project_id="44444444", original_url=photo_url)
 
-        assert photo_url not in await media_staging.get_all_for_user(user_id), (
-            "staged bytes must be evicted after a duplicate response so "
-            "the LLM cannot trigger more redundant uploads"
+        assert photo_url in await media_staging.get_all_for_user(user_id), (
+            "staged bytes must stay available after a duplicate result so "
+            "cross-tool reuse works within the staging TTL"
         )
     finally:
         await media_staging.clear_user(user_id)
@@ -1449,8 +1457,9 @@ async def test_upload_photo_evicts_staging_on_duplicate(test_user: User) -> None
 @pytest.mark.asyncio()
 async def test_upload_photo_keeps_staging_on_upload_exception(test_user: User) -> None:
     """If the upload itself raises, the staged bytes must remain so the
-    user (or the agent on retry) can try again. Spy on ``evict`` so this
-    test would still fail if eviction were moved before the try/except."""
+    user (or the agent on retry) can try again. The eviction spy is kept
+    as a guardrail in case a future refactor reintroduces an
+    evict-on-success pattern that accidentally fires on the error path."""
     from backend.app.agent import media_staging
     from backend.app.agent.tools.names import ToolName
     from backend.app.media.download import DownloadedMedia
@@ -1694,22 +1703,21 @@ async def test_upload_photo_can_reuse_saved_file_from_storage(test_user: User) -
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_resolves_handle_after_prior_storage_upload(
+async def test_upload_photo_finds_staged_bytes_after_prior_storage_upload(
     test_user: User,
 ) -> None:
-    """A handle whose bytes were already filed to Drive must still ship to CompanyCam.
+    """A handle filed to Drive must still ship to CompanyCam.
 
-    Reproduces nathan's 2026-05-13 ``/Catch All/photos/`` flow: agent
-    uploads three photos to Drive via ``upload_to_storage`` (which evicts
-    the staged bytes), then in a later turn the LLM asks to push the
-    same ``media_*`` handles to CompanyCam. Before this fix, the staging
-    miss + the idempotent receipt branch (which only triggered for prior
-    CompanyCam uploads, not prior storage uploads) surfaced NOT_FOUND.
+    Nathan's 2026-05-13 ``/Catch All/photos/`` flow: agent calls
+    ``upload_to_storage`` for a handle, then in a later turn the LLM
+    asks to push the same handle to CompanyCam. With eviction dropped,
+    the bytes stay in staging for the full TTL and the normal Tier 1
+    lookup picks them up. Idempotency on a same-handle CompanyCam retry
+    is handled by the top-of-tool receipt check (covered separately).
     """
     from backend.app.agent import media_staging
     from backend.app.agent.tools.names import ToolName
     from backend.app.integrations.companycam.models import ImageURI, Photo
-    from tests.mocks.storage import MockStorageBackend
 
     service = MagicMock(spec=CompanyCamService)
     service.upload_photo = AsyncMock(
@@ -1721,29 +1729,28 @@ async def test_upload_photo_resolves_handle_after_prior_storage_upload(
         )
     )
 
-    storage = MockStorageBackend()
-    saved = await storage.upload_file(
-        b"persisted-bytes",
-        "/Catch All/photos",
-        "photo_002.jpg",
-        mime_type="image/jpeg",
-    )
+    user_id = test_user.id
+    handle = "media_persisted_xyz"
+    await media_staging.clear_user(user_id)
+    await media_staging.stage(user_id, handle, b"persisted-bytes", "image/jpeg")
 
-    ctx = MagicMock()
-    ctx.user.id = test_user.id
-    ctx.downloaded_media = []
-    ctx.storage = storage
-
-    handle = "media_evicted_xyz"
+    # Simulate the prior ``upload_to_storage`` call: receipt recorded,
+    # bytes NOT evicted (the new model).
     media_staging.mark_uploaded(
-        ctx.user.id,
+        user_id,
         handle,
         service="storage",
-        external_id=saved.path,
-        url=saved.web_view_link,
+        external_id="/Catch All/photos/photo_002.jpg",
+        url="https://drive.google.com/file/d/abc/view",
         target="photo_002.jpg",
         status="uploaded",
     )
+
+    ctx = MagicMock()
+    ctx.user.id = user_id
+    ctx.downloaded_media = []
+    ctx.storage = None
+
     try:
         with (
             patch(
@@ -1766,7 +1773,57 @@ async def test_upload_photo_resolves_handle_after_prior_storage_upload(
             == "https://tunnel.example.com/media/tmp/persisted"
         )
     finally:
-        await media_staging.clear_user(ctx.user.id)
+        await media_staging.clear_user(user_id)
+
+
+@pytest.mark.asyncio()
+async def test_upload_photo_idempotent_on_same_handle_retry(test_user: User) -> None:
+    """A second CompanyCam upload for the same handle returns the existing receipt.
+
+    Without eviction, the bytes are still available on retry; without
+    the top-of-tool receipt check, we would POST the same photo to
+    CompanyCam twice and rely on their MD5 dedupe. Cheaper to short-circuit.
+    """
+    from backend.app.agent import media_staging
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.media.download import DownloadedMedia
+
+    user_id = test_user.id
+    handle = "media_dup_handle"
+    await media_staging.clear_user(user_id)
+    await media_staging.stage(user_id, handle, b"jpg-bytes", "image/jpeg")
+    media_staging.mark_uploaded(
+        user_id,
+        handle,
+        service="companycam",
+        external_id="cc-existing-99",
+        url="https://app.companycam.com/photos/cc-existing-99",
+        target="123 Main",
+        status="uploaded",
+    )
+
+    service = MagicMock(spec=CompanyCamService)
+    service.upload_photo = AsyncMock()  # must NOT be called
+
+    ctx = MagicMock()
+    ctx.user.id = user_id
+    ctx.downloaded_media = [
+        DownloadedMedia(
+            content=b"jpg-bytes",
+            mime_type="image/jpeg",
+            original_url=handle,
+            filename="x.jpg",
+        )
+    ]
+
+    try:
+        tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
+        result = await tool.function(project_id="123", original_url=handle)
+        assert result.is_error is False
+        assert "cc-existing-99" in result.content
+        service.upload_photo.assert_not_called()
+    finally:
+        await media_staging.clear_user(user_id)
 
 
 @pytest.mark.asyncio()
@@ -1875,21 +1932,20 @@ async def test_upload_photo_rejects_empty_original_url() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_upload_photo_idempotent_retry_after_eviction(
-    caplog: pytest.LogCaptureFixture, test_user: User
+async def test_upload_photo_idempotent_retry_after_first_upload(
+    test_user: User,
 ) -> None:
-    """Option A: a same-turn retry on an evicted handle returns the prior receipt.
+    """A same-handle retry returns the prior receipt without re-POSTing.
 
     Two parallel ``companycam_upload_photo`` calls from one LLM round on
     the same handle previously raced: the first evicted the staged bytes
-    on success, the second fell through to NOT_FOUND ("No photo available
-    to upload"). The model read the error as a failed upload and retried,
-    causing the upload-storm pattern seen in production. This test pins
-    the new behavior: the second call must surface the prior receipt
-    instead.
+    on success, the second fell through to NOT_FOUND. With eviction
+    removed, bytes survive the first call and the second call would
+    happily re-POST the same content to CompanyCam (which dedupes by
+    MD5 but it's still a wasted roundtrip). The top-of-tool receipt
+    check catches this: the second call returns the prior receipt
+    without calling ``service.upload_photo`` a second time.
     """
-    import logging
-
     from backend.app.agent import media_staging
     from backend.app.agent.tools.names import ToolName
     from backend.app.integrations.companycam.models import ImageURI, Photo
@@ -1935,31 +1991,16 @@ async def test_upload_photo_idempotent_retry_after_eviction(
         ):
             tool = _get_tool(build_photo_tools(service, ctx), ToolName.COMPANYCAM_UPLOAD_PHOTO)
             first = await tool.function(project_id="44444444", original_url=photo_url)
-            # Simulate the second-in-turn race: downloaded_media empty
-            # (the prior call consumed and evicted), staging evicted, but
-            # the model retries with the same handle.
-            ctx.downloaded_media = []
-
-            with caplog.at_level(logging.WARNING):
-                second = await tool.function(project_id="44444444", original_url=photo_url)
+            second = await tool.function(project_id="44444444", original_url=photo_url)
 
         assert first.is_error is False
         # Service was only hit once; the retry did not re-upload.
         service.upload_photo.assert_called_once()
 
-        assert second.is_error is False, (
-            "retry on an evicted handle must return a soft idempotent receipt, "
-            "not NOT_FOUND -- otherwise the model reads it as a failure and "
-            "retries again"
-        )
+        assert second.is_error is False
         assert second.receipt is not None
         assert "photos/33333333" in second.receipt.url
         assert "already uploaded" in second.content.lower()
-        # Telemetry: the retry-after-eviction signal must be emitted so we
-        # can measure the pattern across users.
-        assert any(
-            "media_handle_referenced_after_eviction" in rec.message for rec in caplog.records
-        )
     finally:
         await media_staging.clear_user(user_id)
 

--- a/tests/test_file_cataloging.py
+++ b/tests/test_file_cataloging.py
@@ -351,6 +351,65 @@ async def test_upload_creates_folder(
     assert "/photos" in storage.folders[0]
 
 
+@pytest.mark.asyncio()
+async def test_upload_picks_distinct_filenames_when_list_folder_is_stale(
+    test_user: User,
+) -> None:
+    """Serial uploads to the same folder must not collide on the same index
+    when ``list_folder`` returns stale results.
+
+    Drive's ``files.list`` is eventually consistent: a file just written by
+    ``upload_file`` may not appear in the next ``list_folder`` call. Before
+    the per-turn ``recent_uploads_by_folder`` registry, three uploads to
+    the same folder in one turn all read ``existing=[]`` and all minted
+    ``photo_001.jpg``, silently shadowing one another in Drive (issue
+    surfaced on nathan's 2026-05-13 ``/Catch All/photos/`` upload trio).
+    """
+    storage = MockStorageBackend()
+
+    # Simulate the Drive eventual-consistency lag: ``list_folder`` always
+    # returns whatever was visible at the time of the FIRST call this turn.
+    # Subsequent uploads append to ``storage.files`` but the listing stays
+    # frozen. Mirrors what Drive's search index does in production.
+    stale_snapshot: list = []
+    captured = {"first": False}
+    real_list_folder = storage.list_folder
+
+    async def stale_list_folder(path: str) -> list:
+        if not captured["first"]:
+            stale_snapshot[:] = await real_list_folder(path)
+            captured["first"] = True
+        return list(stale_snapshot)
+
+    storage.list_folder = stale_list_folder  # type: ignore[method-assign]
+
+    tools = create_file_tools(
+        test_user,
+        storage,
+        pending_media={
+            "https://example.com/a.jpg": b"aaa",
+            "https://example.com/b.jpg": b"bbb",
+            "https://example.com/c.jpg": b"ccc",
+        },
+    )
+    upload = tools[0].function
+
+    r1 = await upload(folder_path="/Catch All/photos", original_url="https://example.com/a.jpg")
+    r2 = await upload(folder_path="/Catch All/photos", original_url="https://example.com/b.jpg")
+    r3 = await upload(folder_path="/Catch All/photos", original_url="https://example.com/c.jpg")
+
+    assert not (r1.is_error or r2.is_error or r3.is_error), (r1.content, r2.content, r3.content)
+    written = sorted(k for k in storage.files if k.startswith("Catch All/photos/"))
+    assert len(written) == 3
+    # Three distinct sequence numbers, no duplicates.
+    assert len({k for k in written}) == 3, f"duplicate filenames written: {written}"
+    assert written == [
+        "Catch All/photos/file_001.jpg",
+        "Catch All/photos/file_002.jpg",
+        "Catch All/photos/file_003.jpg",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # move_file tool tests
 # ---------------------------------------------------------------------------

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -126,8 +126,12 @@ def test_upload_record_round_trip(test_user: User) -> None:
 
 @pytest.mark.asyncio()
 async def test_upload_record_survives_evict(test_user: User) -> None:
-    """A successful upload evicts staged bytes but keeps the receipt so a
-    same-turn retry on the same handle returns an idempotent result.
+    """The receipt cache is independent of the bytes cache.
+
+    Tools no longer evict bytes after a successful upload, but the eviction
+    function itself is still used (e.g. for ``discard_media``). Verify the
+    two caches age independently: a manual ``evict`` drops the bytes but
+    leaves the receipt intact for the receipt cache's own TTL.
     """
     await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
     media_staging.mark_uploaded(
@@ -202,8 +206,8 @@ async def test_file_factory_merges_staged_bytes_when_current_turn_has_none(
 
     assert result.is_error is False
     assert "Uploaded" in result.content
-    # Staging entry should be evicted after a successful upload.
-    assert await media_staging.get_all_for_user(test_user.id) == {}
+    # Staging entry stays for the TTL so cross-tool reuse works.
+    assert "bb_photo" in await media_staging.get_all_for_user(test_user.id)
 
 
 @pytest.mark.asyncio()
@@ -269,7 +273,14 @@ async def test_upload_uses_staged_mime_over_llm_argument(test_user: User) -> Non
 
 
 @pytest.mark.asyncio()
-async def test_upload_evicts_staged_entry(test_user: User) -> None:
+async def test_upload_keeps_staged_entry(test_user: User) -> None:
+    """A successful storage upload must NOT evict the staged bytes.
+
+    The staging cache and the permanent home coexist for the staging TTL
+    so other tools (e.g. ``companycam_upload_photo``) can find the bytes
+    via the same handle without bookkeeping hops. Idempotency on retry
+    is handled by the recorded ``UploadRecord``.
+    """
     await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
     storage = MockStorageBackend()
     tools = create_file_tools(
@@ -284,50 +295,41 @@ async def test_upload_evicts_staged_entry(test_user: User) -> None:
         original_url="bb_photo",
     )
     assert result.is_error is False
-    assert await media_staging.get_all_for_user(test_user.id) == {}
+    # Bytes stay in staging.
+    assert "bb_photo" in await media_staging.get_all_for_user(test_user.id)
+    # Receipt was recorded for the top-of-tool idempotency check.
+    rec = media_staging.get_uploaded(test_user.id, "bb_photo")
+    assert rec is not None and rec.service == "storage"
 
 
 @pytest.mark.asyncio()
-async def test_upload_to_storage_idempotent_retry_after_eviction(
-    test_user: User, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Regression for the same upload-storm pattern that hit CompanyCam:
-    a same-turn retry on an evicted handle previously returned NOT_FOUND,
-    which the model read as failure and retried. Now the second call
-    surfaces the prior upload's path as an idempotent receipt.
-    """
-    import logging
+async def test_upload_to_storage_idempotent_on_same_handle_retry(test_user: User) -> None:
+    """A second ``upload_to_storage`` for the same handle returns the existing receipt.
 
+    With bytes preserved across the staging TTL, the only thing
+    preventing a second Drive copy is the top-of-tool idempotency check
+    that consults ``media_staging.get_uploaded``. Verify the check
+    short-circuits before the upload runs.
+    """
     await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
     storage = MockStorageBackend()
-    # pending_media is the per-turn snapshot the factory closes over; we
-    # mutate it after the first call to simulate the bytes being consumed.
-    pending = {"bb_photo": b"bytes"}
-    tools = create_file_tools(test_user, storage, pending_media=pending)
+    tools = create_file_tools(test_user, storage, pending_media={"bb_photo": b"bytes"})
     upload = tools[0].function
 
-    first = await upload(
-        folder_path="/Jane/photos",
-        original_url="bb_photo",
-    )
+    first = await upload(folder_path="/Jane/photos", original_url="bb_photo")
     assert first.is_error is False
+    assert first.receipt is not None
+    first_path = first.receipt.target
+    drive_writes_after_first = len(storage.files)
 
-    # Simulate the second call in the same turn: bytes are gone from
-    # pending_media (we just popped them, which mirrors what eviction
-    # does to the closure-held map) and from staging.
-    pending.pop("bb_photo", None)
-
-    with caplog.at_level(logging.WARNING, logger="backend.app.agent.tools.file_tools"):
-        second = await upload(
-            folder_path="/Jane/photos",
-            original_url="bb_photo",
-        )
-
-    assert second.is_error is False, (
-        "second upload on the same handle must return an idempotent receipt, not NOT_FOUND"
-    )
+    # Same call again on the same handle. The receipt should short-circuit.
+    second = await upload(folder_path="/Jane/photos", original_url="bb_photo")
+    assert second.is_error is False
+    assert second.receipt is not None
+    assert second.receipt.target == first_path, "second call must surface the prior path"
     assert "already uploaded" in second.content.lower()
-    assert any("media_handle_referenced_after_eviction" in rec.message for rec in caplog.records)
+    # No additional Drive write happened.
+    assert len(storage.files) == drive_writes_after_first
 
 
 class _FakeUploadParams(BaseModel):

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -300,6 +300,86 @@ async def test_gdrive_root_folder_created_on_first_resolve(
     assert s._folder_cache[f"{ROOT_FOLDER_NAME}/Unsorted"] == "unsorted-id"
 
 
+@pytest.mark.asyncio()
+async def test_gdrive_search_files_matches_storage_path_tokens(
+    gdrive_storage: GoogleDriveStorage, mock_drive_service: MagicMock
+) -> None:
+    """``search_files`` must surface files whose ``clawbolt_path`` contains the query.
+
+    Drive's query DSL has no substring operator on ``appProperties.value``, so
+    a search for ``"Catch All"`` returns nothing from the native
+    ``name contains 'Catch' and name contains 'All'`` query when the files
+    are all named ``photo_002.jpg``. ``search_files`` must fall back to a
+    broader list and client-side filter on the path appProperty.
+    """
+
+    def list_side_effect(*, q: str, **_kwargs: object) -> object:
+        # Native name/fullText query: returns nothing (the bug case).
+        if "name contains" in q or "fullText contains" in q:
+            return MagicMock(execute=MagicMock(return_value={"files": []}))
+        # Broad fallback: return three files whose appProperties carry the
+        # storage path.
+        return MagicMock(
+            execute=MagicMock(
+                return_value={
+                    "files": [
+                        {
+                            "id": "f1",
+                            "name": "photo_002.jpg",
+                            "webViewLink": "https://drive.google.com/f1",
+                            "appProperties": {"clawbolt_path": "/Catch All/photos/photo_002.jpg"},
+                        },
+                        {
+                            "id": "f2",
+                            "name": "photo_001.jpg",
+                            "webViewLink": "https://drive.google.com/f2",
+                            "appProperties": {"clawbolt_path": "/Catch All/photos/photo_001.jpg"},
+                        },
+                        {
+                            "id": "f3",
+                            "name": "unrelated.jpg",
+                            "appProperties": {"clawbolt_path": "/Other/folder/unrelated.jpg"},
+                        },
+                    ]
+                }
+            )
+        )
+
+    mock_drive_service.files.return_value.list.side_effect = list_side_effect
+
+    results = await gdrive_storage.search_files(query="Catch All", limit=10)
+
+    returned_paths = [r.path for r in results]
+    assert "/Catch All/photos/photo_002.jpg" in returned_paths
+    assert "/Catch All/photos/photo_001.jpg" in returned_paths
+    assert "/Other/folder/unrelated.jpg" not in returned_paths
+
+
+@pytest.mark.asyncio()
+async def test_gdrive_search_files_skips_fallback_when_native_query_returns_enough(
+    gdrive_storage: GoogleDriveStorage, mock_drive_service: MagicMock
+) -> None:
+    """When the native query already returns ``limit`` files, no fallback scan.
+
+    Keeps the common case cheap: only pay for the broad list when the
+    name/fullText query is empty or short, which is the bug-fix case.
+    """
+    mock_drive_service.files.return_value.list.return_value.execute.return_value = {
+        "files": [
+            {
+                "id": f"f{i}",
+                "name": f"invoice_{i}.pdf",
+                "appProperties": {"clawbolt_path": f"/Inbox/invoice_{i}.pdf"},
+            }
+            for i in range(5)
+        ]
+    }
+    results = await gdrive_storage.search_files(query="invoice", limit=5)
+    assert len(results) == 5
+    # Single list call total: native query satisfied the bounded request.
+    assert mock_drive_service.files.return_value.list.call_count == 1
+
+
 # ---------------------------------------------------------------------------
 # Thread-safety + transient retry (issue: Durham receipt SSL/timeout storm)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Investigation into a CompanyCam upload failure surfaced four tangled regressions and one inherited assumption that all pointed at the same root cause: the cross-tool model after PR #1262 dropped the `media_files` manifest. This PR fixes the bugs and simplifies the model so the same class of issue is harder to introduce again.

### Bugs fixed

1. **Filename collision in `upload_to_storage`.** Indexed off `storage.list_folder + 1`, which under Drive's eventually-consistent `files.list` lets three uploads in one turn all pick the same `photo_NNN.jpg`. Fix: union the listing with a per-tool-list registry of filenames already minted this turn. Same pattern applied to `move_file`.

2. **`companycam_upload_photo` could not follow a handle that had been filed to Drive.** Eviction dropped the staged bytes, every lookup tier missed, NOT_FOUND.

3. **Drive `webViewLink` shortcut shipped HTML to CompanyCam.** Verified by live HTTP probe: the link 302s to `accounts.google.com/ServiceLogin` for an unauthenticated fetcher, and `drive.file`-scoped files are private. Removed; always download bytes and ship through the temp media tunnel.

4. **`find_saved_files` could not match files by folder.** Drive query DSL has no substring operator on `appProperties.value`. Added a bounded broad-list fallback that filters client-side on `clawbolt_path` containing all tokens.

### Simplification

While fixing the above, the eviction model itself was the source of the cross-tool bookkeeping. Dropped it: staging bytes now live for the full 7-day TTL alongside the permanent home. The cross-tool flow becomes a straight handle lookup.

- Top-of-tool idempotency check on the recorded `UploadRecord` replaces the post-eviction bookkeeping branches.
- `UPLOAD_RECORD_TTL_SECONDS` bumped from 1h to match `STAGING_TTL_SECONDS` (7 days). 200/user cap keeps in-process memory bounded.
- Cost: roughly 2x storage for the staging window (bytes coexist with the permanent home).
- Known gap: `UploadRecord` is still worker-local. Worker restart inside the staging window can let a same-handle retry write a duplicate Drive file (no data loss). Persisting the receipt onto `staged_media` would close this; left as follow-up.

## Type
- [x] Bug fix
- [x] Refactor

## Checklist
- [x] Tests pass (`uv run pytest -v`, 2749 passed, 2 skipped; premium downstream: 607 passed, 4 skipped)
- [x] Lint passes (`ruff check`, `ruff format --check`, `ty check`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

### New / updated tests

- `test_upload_picks_distinct_filenames_when_list_folder_is_stale` (new)
- `test_gdrive_search_files_matches_storage_path_tokens` (new)
- `test_gdrive_search_files_skips_fallback_when_native_query_returns_enough` (new)
- `test_upload_to_storage_idempotent_on_same_handle_retry` (new)
- `test_upload_photo_idempotent_on_same_handle_retry` (new)
- `test_upload_photo_finds_staged_bytes_after_prior_storage_upload` (new)
- `test_upload_photo_can_reuse_saved_file_from_storage` (updated: asserts bytes flow through the tunnel, not `webViewLink`)
- `test_upload_photo_keeps_staging_on_success` and `test_upload_photo_keeps_staging_on_duplicate` (inverted from previous evict-on-success assertions)
- `test_upload_keeps_staged_entry` (inverted from previous evict-on-success assertion)
- `test_upload_photo_idempotent_retry_after_first_upload` (replaces the eviction-flavored variant)

## AI Usage
- [x] AI-assisted: investigated the failing conversation via the admin LLM-payload export, traced through `file_tools.py`, `photos.py`, `storage_service.py`, and `media_staging.py` with Claude, verified the `webViewLink` claim with a live HTTP probe before deleting that branch, and walked through the eviction-drop tradeoff (extra storage vs. simpler cross-tool model) before agreeing on the refactor.