### PR TITLE
fix(media-staging): persist UploadRecord onto staged_media

### DIFF
--- a/alembic/versions/036_staged_media_upload_record.py
+++ b/alembic/versions/036_staged_media_upload_record.py
@@ -1,0 +1,51 @@
+"""Add upload-record columns to ``staged_media``.
+
+Until this revision, ``media_staging.mark_uploaded`` wrote receipts to an
+in-process dict that did not survive a worker restart. A same-handle
+retry across a restart (deploy, OOM) bypassed the idempotency check in
+``upload_to_storage`` and wrote a second Drive copy with the same
+content. The bytes were durable; the receipt was not.
+
+This revision moves the receipt onto the ``staged_media`` row itself so
+its lifetime matches the bytes: same TTL, same uniqueness key, same
+purge. All columns nullable; an unset upload-row means "no upload yet"
+which is the correct semantics for existing rows.
+
+See issue #1347 for the failure scenario and design discussion.
+
+Revision ID: 036
+Revises: 035
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "036"
+down_revision: str = "035"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("staged_media", sa.Column("upload_service", sa.String(), nullable=True))
+    op.add_column("staged_media", sa.Column("upload_external_id", sa.Text(), nullable=True))
+    op.add_column("staged_media", sa.Column("upload_url", sa.Text(), nullable=True))
+    op.add_column("staged_media", sa.Column("upload_target", sa.Text(), nullable=True))
+    op.add_column("staged_media", sa.Column("upload_status", sa.String(), nullable=True))
+    op.add_column(
+        "staged_media",
+        sa.Column("uploaded_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("staged_media", "uploaded_at")
+    op.drop_column("staged_media", "upload_status")
+    op.drop_column("staged_media", "upload_target")
+    op.drop_column("staged_media", "upload_url")
+    op.drop_column("staged_media", "upload_external_id")
+    op.drop_column("staged_media", "upload_service")

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -590,42 +590,54 @@ async def mark_uploaded(
     """Record that ``original_url`` was successfully shipped to *service*.
 
     ``original_url`` may be either the canonical URL the channel layer
-    staged under or the short handle the LLM sees; the UPDATE matches
+    staged under or the short handle the LLM sees; the lookup matches
     either form. No-op when no ``staged_media`` row matches (e.g. the
     tool was called with a URL that was never staged, like a direct
     ``downloaded_media`` entry from a channel that does not stage).
+
+    The OR-keyed match can in principle hit more than one row when a
+    user happens to have one row whose ``original_url`` equals the ref
+    and a different row whose ``handle`` equals it. We scope the UPDATE
+    to a single id (most recently staged) so a stray match never writes
+    a misleading receipt onto an unrelated row.
     """
     if not original_url:
         return
     now = datetime.now(UTC)
     async with db_session_async() as db:
-        result = cast(
-            "CursorResult[object]",
+        target_row_id = (
             await db.execute(
-                update(StagedMedia)
+                select(StagedMedia.id)
                 .where(
                     StagedMedia.user_id == user_id,
                     (StagedMedia.original_url == original_url)
                     | (StagedMedia.handle == original_url),
                     StagedMedia.expires_at > now,
                 )
-                .values(
-                    upload_service=service,
-                    upload_external_id=external_id,
-                    upload_url=url,
-                    upload_target=target,
-                    upload_status=status,
-                    uploaded_at=now,
-                )
-            ),
-        )
-        await db.commit()
-        if result.rowcount == 0:
+                .order_by(StagedMedia.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if target_row_id is None:
             logger.debug(
                 "mark_uploaded: no staged_media row for user=%s ref=%s; receipt not persisted",
                 user_id,
                 original_url,
             )
+            return
+        await db.execute(
+            update(StagedMedia)
+            .where(StagedMedia.id == target_row_id)
+            .values(
+                upload_service=service,
+                upload_external_id=external_id,
+                upload_url=url,
+                upload_target=target,
+                upload_status=status,
+                uploaded_at=now,
+            )
+        )
+        await db.commit()
 
 
 async def get_uploaded(user_id: str, original_url: str) -> UploadRecord | None:
@@ -634,6 +646,13 @@ async def get_uploaded(user_id: str, original_url: str) -> UploadRecord | None:
     ``ref`` may be the staged handle (``media_XYZ``) or the original URL.
     Returns ``None`` when no row matches, the row has no recorded
     upload, or the row has expired.
+
+    The OR-clause can in principle match more than one row (row A's
+    ``original_url`` matches the ref while a different row B's
+    ``handle`` matches it). The chance is near-zero given handles are
+    48 bits of url-safe randomness behind a ``media_`` prefix, but we
+    pick the most recently staged row deterministically rather than
+    raising, so a benign retry never surfaces as a crash.
     """
     if not original_url:
         return None
@@ -642,12 +661,15 @@ async def get_uploaded(user_id: str, original_url: str) -> UploadRecord | None:
     try:
         row = (
             await db.execute(
-                select(StagedMedia).where(
+                select(StagedMedia)
+                .where(
                     StagedMedia.user_id == user_id,
                     (StagedMedia.original_url == original_url)
                     | (StagedMedia.handle == original_url),
                     StagedMedia.expires_at > now,
                 )
+                .order_by(StagedMedia.created_at.desc())
+                .limit(1)
             )
         ).scalar_one_or_none()
     finally:

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -13,14 +13,13 @@ can reference the bytes without passing raw channel URLs through the
 prompt. Both lookup styles work; the handle-based API is what the agent
 sees.
 
-This module also tracks a short-lived ``recently_uploaded`` record for
-each ``(user_id, original_url)``. After a tool successfully ships the
-bytes to an external service (CompanyCam, etc.) it both ``evict``s the
-bytes and ``mark_uploaded``s an ``UploadRecord`` so a same-turn retry
-on the same handle can return an idempotent "already uploaded" result
-instead of the generic "No photo available" error. The receipt cache
-stays in-process and is intentionally short-lived (1 h); its job is
-only to absorb same-turn / same-day retries within one worker.
+This module also records an upload receipt on each row. After a tool
+ships the bytes to an external service (CompanyCam, Drive, etc.) it
+calls ``mark_uploaded`` to populate ``upload_*`` columns on the
+matching ``staged_media`` row. A same-handle retry then surfaces an
+idempotent receipt via ``get_uploaded`` instead of writing a second
+copy. The receipt shares the row's TTL, so it survives worker
+restarts and ages out alongside the bytes.
 
 MULTI-REPLICA WARNING: this module assumes a single application
 instance with exclusive write access to ``media_staging_base_dir``. If
@@ -36,7 +35,6 @@ from __future__ import annotations
 
 import logging
 import secrets
-import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -59,30 +57,20 @@ logger = logging.getLogger(__name__)
 STAGING_TTL_SECONDS = 604800
 STAGING_MAX_PER_USER = 50  # Cap memory growth: oldest-expiring entry is evicted on overflow
 
-# Recently-uploaded receipt cache. Matches the staging TTL so a handle
-# whose bytes are still on disk always has a corresponding receipt: the
-# tools no longer evict on success (bytes coexist with the permanent
-# home for the staging window), so the receipt is the only mechanism
-# preventing a same-handle retry from writing a second Drive copy.
-# Drive does not dedupe by content the way CompanyCam does, so without
-# this guard a 2h-later retry on the same handle would land a duplicate.
-# The cache is in-process: a worker restart inside the staging window
-# can still produce a duplicate Drive file (no data loss). Persisting
-# this record onto ``staged_media`` would close that gap; tracked for
-# a follow-up.
-UPLOAD_RECORD_TTL_SECONDS = STAGING_TTL_SECONDS  # 7 days
-UPLOAD_RECORD_MAX_PER_USER = 200
-
 
 @dataclass(frozen=True)
 class UploadRecord:
-    """A receipt of a successful external upload, scoped to a (user, handle).
+    """A receipt of a successful external upload, scoped to a staged handle.
 
-    Returned by :func:`get_uploaded` so a tool that finds its staged bytes
-    already evicted can re-emit the same external receipt instead of an
-    error. Tools should populate ``service`` with a short identifier
-    (e.g. ``"companycam"``) so a future cross-service handle reuse cannot
+    Returned by :func:`get_uploaded` so a tool with a same-handle retry
+    can re-emit the same external receipt instead of writing a second
+    copy. Tools populate ``service`` with a short identifier (e.g.
+    ``"companycam"``) so a future cross-service handle reuse cannot
     surface the wrong receipt.
+
+    Persisted as columns on the ``staged_media`` row that the handle
+    points at, so the receipt shares the bytes' TTL and survives worker
+    restarts.
     """
 
     service: str
@@ -90,10 +78,6 @@ class UploadRecord:
     url: str
     target: str
     status: str  # "uploaded", "duplicate", "pending", "processing_error"
-
-
-# user_id -> {original_url: (UploadRecord, expires_at)} recently-uploaded receipts
-_uploaded: dict[str, dict[str, tuple[UploadRecord, float]]] = {}
 
 
 def _staging_root() -> Path:
@@ -540,7 +524,10 @@ async def evict_by_handle(handle: str) -> bool:
 
 
 async def clear_user(user_id: str) -> None:
-    """Drop all staged media and upload records for a user (primarily for tests)."""
+    """Drop all staged media and upload records for a user (primarily for tests).
+
+    Upload receipts live on the same rows, so a single DELETE clears both.
+    """
     async with db_session_async() as db:
         rows = list(
             (await db.execute(select(StagedMedia).where(StagedMedia.user_id == user_id)))
@@ -551,7 +538,6 @@ async def clear_user(user_id: str) -> None:
             _unlink_quiet(_resolve_disk_path(row.disk_path))
         await db.execute(delete(StagedMedia).where(StagedMedia.user_id == user_id))
         await db.commit()
-    _uploaded.pop(user_id, None)
 
 
 async def purge_expired() -> int:
@@ -578,18 +564,20 @@ async def purge_expired() -> int:
 
 
 # ---------------------------------------------------------------------------
-# In-process upload-receipt cache
+# DB-backed upload receipts
 # ---------------------------------------------------------------------------
 #
 # A handle that already shipped to an external service needs an idempotent
-# answer on retry so the tool does not write a second copy. Bytes are
-# preserved across the staging TTL (no longer evicted on success), so the
-# receipt has to age alongside them: anything still resolvable as bytes
-# must also be resolvable as a receipt. Worker-local; persisting onto the
-# ``staged_media`` row is a follow-up that would survive restarts.
+# answer on retry so the tool does not write a second copy. The receipt
+# lives on the same ``staged_media`` row as the bytes it describes, so
+# both share the same TTL and survive worker restarts. The lookup key
+# matches either form of reference (URL or handle), mirroring
+# :func:`resolve_media_ref`: the LLM is given handles in the prompt but
+# tools call ``mark_uploaded`` after resolving to the URL, so the two
+# sides of the idempotency contract must agree across both shapes.
 
 
-def mark_uploaded(
+async def mark_uploaded(
     user_id: str,
     original_url: str,
     *,
@@ -599,56 +587,77 @@ def mark_uploaded(
     target: str,
     status: str,
 ) -> None:
-    """Record that ``original_url`` was successfully shipped to *service*."""
+    """Record that ``original_url`` was successfully shipped to *service*.
+
+    ``original_url`` may be either the canonical URL the channel layer
+    staged under or the short handle the LLM sees; the UPDATE matches
+    either form. No-op when no ``staged_media`` row matches (e.g. the
+    tool was called with a URL that was never staged, like a direct
+    ``downloaded_media`` entry from a channel that does not stage).
+    """
     if not original_url:
         return
-    _purge_expired_uploads()
-    expires_at = time.monotonic() + UPLOAD_RECORD_TTL_SECONDS
-    record = UploadRecord(
-        service=service,
-        external_id=external_id,
-        url=url,
-        target=target,
-        status=status,
+    now = datetime.now(UTC)
+    async with db_session_async() as db:
+        result = cast(
+            "CursorResult[object]",
+            await db.execute(
+                update(StagedMedia)
+                .where(
+                    StagedMedia.user_id == user_id,
+                    (StagedMedia.original_url == original_url)
+                    | (StagedMedia.handle == original_url),
+                    StagedMedia.expires_at > now,
+                )
+                .values(
+                    upload_service=service,
+                    upload_external_id=external_id,
+                    upload_url=url,
+                    upload_target=target,
+                    upload_status=status,
+                    uploaded_at=now,
+                )
+            ),
+        )
+        await db.commit()
+        if result.rowcount == 0:
+            logger.debug(
+                "mark_uploaded: no staged_media row for user=%s ref=%s; receipt not persisted",
+                user_id,
+                original_url,
+            )
+
+
+async def get_uploaded(user_id: str, original_url: str) -> UploadRecord | None:
+    """Return the recorded upload receipt for ``(user_id, ref)``, if any.
+
+    ``ref`` may be the staged handle (``media_XYZ``) or the original URL.
+    Returns ``None`` when no row matches, the row has no recorded
+    upload, or the row has expired.
+    """
+    if not original_url:
+        return None
+    now = datetime.now(UTC)
+    db = AsyncSessionLocal()
+    try:
+        row = (
+            await db.execute(
+                select(StagedMedia).where(
+                    StagedMedia.user_id == user_id,
+                    (StagedMedia.original_url == original_url)
+                    | (StagedMedia.handle == original_url),
+                    StagedMedia.expires_at > now,
+                )
+            )
+        ).scalar_one_or_none()
+    finally:
+        await db.close()
+    if row is None or row.upload_service is None:
+        return None
+    return UploadRecord(
+        service=row.upload_service,
+        external_id=row.upload_external_id or "",
+        url=row.upload_url or "",
+        target=row.upload_target or "",
+        status=row.upload_status or "",
     )
-    user_records = _uploaded.setdefault(user_id, {})
-    user_records[original_url] = (record, expires_at)
-    _enforce_upload_record_cap(user_id)
-
-
-def get_uploaded(user_id: str, original_url: str) -> UploadRecord | None:
-    """Return the recently-uploaded receipt for ``(user_id, original_url)``."""
-    if not original_url:
-        return None
-    user_records = _uploaded.get(user_id)
-    if not user_records:
-        return None
-    entry = user_records.get(original_url)
-    if entry is None:
-        return None
-    record, expires_at = entry
-    if expires_at <= time.monotonic():
-        return None
-    return record
-
-
-def _enforce_upload_record_cap(user_id: str) -> None:
-    user_records = _uploaded.get(user_id)
-    if not user_records or len(user_records) <= UPLOAD_RECORD_MAX_PER_USER:
-        return
-    while len(user_records) > UPLOAD_RECORD_MAX_PER_USER:
-        oldest_url = min(user_records, key=lambda url: user_records[url][1])
-        user_records.pop(oldest_url, None)
-
-
-def _purge_expired_uploads() -> None:
-    now = time.monotonic()
-    empty_users: list[str] = []
-    for user_id, records in _uploaded.items():
-        expired = [url for url, (_rec, exp) in records.items() if exp <= now]
-        for url in expired:
-            del records[url]
-        if not records:
-            empty_users.append(user_id)
-    for user_id in empty_users:
-        del _uploaded[user_id]

--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -325,9 +325,11 @@ def create_file_tools(
         # second copy. Drive does not dedupe by content, so the receipt
         # cache is what prevents duplicate Drive files on retried LLM tool
         # calls now that bytes are no longer evicted after a successful
-        # upload.
+        # upload. The lookup is DB-backed (column on the staged_media row),
+        # so a worker restart inside the staging TTL does not lose the
+        # idempotency guarantee.
         if original_url:
-            prior = media_staging.get_uploaded(user.id, original_url)
+            prior = await media_staging.get_uploaded(user.id, original_url)
             if prior is not None and prior.service == "storage":
                 logger.info(
                     "upload_to_storage idempotent hit: user=%s handle=%s path=%s",
@@ -432,7 +434,7 @@ def create_file_tools(
             # Bytes intentionally stay in staging: keeps cross-tool flow
             # simple (``companycam_upload_photo`` can still find them) at
             # the cost of ~2x storage for the staging window.
-            media_staging.mark_uploaded(
+            await media_staging.mark_uploaded(
                 user.id,
                 original_url,
                 service="storage",

--- a/backend/app/integrations/companycam/photos.py
+++ b/backend/app/integrations/companycam/photos.py
@@ -114,8 +114,9 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         # the staging TTL, return the recorded receipt rather than POSTing the
         # same bytes again. CompanyCam dedupes by MD5 server-side so a missed
         # idempotency check is only a wasted roundtrip, but skipping it keeps
-        # the flow clean.
-        prior = media_staging.get_uploaded(ctx.user.id, original_url)
+        # the flow clean. Receipt lives on the staged_media row, so the
+        # check survives a worker restart inside the staging window.
+        prior = await media_staging.get_uploaded(ctx.user.id, original_url)
         if prior is not None and prior.service == "companycam":
             return ToolResult(
                 content=(
@@ -240,7 +241,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         # CompanyCam could not fetch our temp URL, and we want a retry to
         # be a fresh attempt rather than a no-op receipt.
         if original_url and status != "processing_error":
-            media_staging.mark_uploaded(
+            await media_staging.mark_uploaded(
                 ctx.user.id,
                 original_url,
                 service="companycam",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -860,6 +860,16 @@ class StagedMedia(Base):
     expires_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, index=True
     )
+    # Upload receipt: where this handle's bytes were shipped, populated by
+    # ``media_staging.mark_uploaded`` after a successful tool call. Lives on
+    # the same row as the staged bytes so it shares their TTL and survives
+    # worker restarts. ``service`` is None until the bytes are uploaded.
+    upload_service: Mapped[str | None] = mapped_column(String, nullable=True)
+    upload_external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    upload_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    upload_target: Mapped[str | None] = mapped_column(Text, nullable=True)
+    upload_status: Mapped[str | None] = mapped_column(String, nullable=True)
+    uploaded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class AppSetting(Base):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import NullPool
 
 import backend.app.database as _db_module
-from backend.app.agent import media_staging as _media_staging
 from backend.app.agent.approval import reset_approval_gate
 from backend.app.agent.file_store import SessionState, StoredMessage, reset_stores
 from backend.app.agent.memory_db import reset_memory_stores
@@ -236,11 +235,6 @@ def _isolate_stores(_pg_async_engine_session: AsyncEngine, tmp_path: Path) -> Ge
         reset_session_stores()
         reset_memory_stores()
         reset_approval_gate()
-        # In-memory upload-receipt cache survives across tests by design
-        # (matches the 7-day staging TTL in production). Clear it per
-        # test so a prior test's mark_uploaded does not short-circuit a
-        # later test that reuses the same (user_id, original_url) pair.
-        _media_staging._uploaded.clear()
         yield
 
     async def _truncate() -> None:
@@ -257,7 +251,6 @@ def _isolate_stores(_pg_async_engine_session: AsyncEngine, tmp_path: Path) -> Ge
     reset_session_stores()
     reset_memory_stores()
     reset_approval_gate()
-    _media_staging._uploaded.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -1383,7 +1383,7 @@ async def test_upload_photo_keeps_staging_on_success(test_user: User) -> None:
             "staged bytes must stay available after success so cross-tool "
             "reuse works within the staging TTL"
         )
-        prior = media_staging.get_uploaded(user_id, photo_url)
+        prior = await media_staging.get_uploaded(user_id, photo_url)
         assert prior is not None and prior.service == "companycam", (
             "the upload receipt must be recorded so a same-handle retry "
             "short-circuits via the top-of-tool idempotency check"
@@ -1736,7 +1736,7 @@ async def test_upload_photo_finds_staged_bytes_after_prior_storage_upload(
 
     # Simulate the prior ``upload_to_storage`` call: receipt recorded,
     # bytes NOT evicted (the new model).
-    media_staging.mark_uploaded(
+    await media_staging.mark_uploaded(
         user_id,
         handle,
         service="storage",
@@ -1792,7 +1792,7 @@ async def test_upload_photo_idempotent_on_same_handle_retry(test_user: User) -> 
     handle = "media_dup_handle"
     await media_staging.clear_user(user_id)
     await media_staging.stage(user_id, handle, b"jpg-bytes", "image/jpeg")
-    media_staging.mark_uploaded(
+    await media_staging.mark_uploaded(
         user_id,
         handle,
         service="companycam",

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
@@ -107,8 +106,11 @@ async def test_isolation_between_users(test_user: User, second_user: User) -> No
     await media_staging.clear_user(second_user.id)
 
 
-def test_upload_record_round_trip(test_user: User) -> None:
-    media_staging.mark_uploaded(
+@pytest.mark.asyncio()
+async def test_upload_record_round_trip(test_user: User) -> None:
+    """``mark_uploaded`` writes onto the staged row and ``get_uploaded`` reads it back."""
+    await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+    await media_staging.mark_uploaded(
         test_user.id,
         "bb_photo",
         service="companycam",
@@ -117,7 +119,7 @@ def test_upload_record_round_trip(test_user: User) -> None:
         target="123 Main St",
         status="uploaded",
     )
-    rec = media_staging.get_uploaded(test_user.id, "bb_photo")
+    rec = await media_staging.get_uploaded(test_user.id, "bb_photo")
     assert rec is not None
     assert rec.service == "companycam"
     assert rec.external_id == "cc-123"
@@ -125,16 +127,56 @@ def test_upload_record_round_trip(test_user: User) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_upload_record_survives_evict(test_user: User) -> None:
-    """The receipt cache is independent of the bytes cache.
+async def test_upload_record_resolvable_by_either_handle_or_url(test_user: User) -> None:
+    """``get_uploaded`` accepts either the staged handle or the original URL.
 
-    Tools no longer evict bytes after a successful upload, but the eviction
-    function itself is still used (e.g. for ``discard_media``). Verify the
-    two caches age independently: a manual ``evict`` drops the bytes but
-    leaves the receipt intact for the receipt cache's own TTL.
+    Production path: the channel layer stages bytes under a real URL and
+    mints a short ``media_*`` handle. The LLM sees the handle, so a
+    top-of-tool idempotency check is keyed on the handle. ``mark_uploaded``
+    fires after the tool has resolved the handle to the URL. Both forms
+    must hit the same row so the receipt is findable on retry.
+    """
+    handle = await media_staging.stage(
+        test_user.id,
+        "https://channel.example.com/photo.jpg",
+        b"bytes",
+        "image/jpeg",
+    )
+    assert handle is not None
+    # Receipt recorded against the URL form (what mark_uploaded sees
+    # post-resolve in the real tools).
+    await media_staging.mark_uploaded(
+        test_user.id,
+        "https://channel.example.com/photo.jpg",
+        service="storage",
+        external_id="/Inbox/photo_001.jpg",
+        url="https://drive.google.com/file/d/abc/view",
+        target="/Inbox/photo_001.jpg",
+        status="uploaded",
+    )
+    # Lookup by handle (what the LLM passes on retry) hits the same row.
+    rec = await media_staging.get_uploaded(test_user.id, handle)
+    assert rec is not None
+    assert rec.external_id == "/Inbox/photo_001.jpg"
+    # Lookup by URL also works.
+    rec_by_url = await media_staging.get_uploaded(
+        test_user.id, "https://channel.example.com/photo.jpg"
+    )
+    assert rec_by_url is not None
+    assert rec_by_url.external_id == "/Inbox/photo_001.jpg"
+
+
+@pytest.mark.asyncio()
+async def test_upload_record_dropped_with_evict(test_user: User) -> None:
+    """Eviction drops the staged row entirely, so the receipt goes with it.
+
+    The lifetime alignment is intentional: if the bytes are gone (and
+    therefore the bytes cannot be re-uploaded as the same content), the
+    receipt no longer guards anything and there is nothing to be
+    idempotent about. Matches the bytes' TTL.
     """
     await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
-    media_staging.mark_uploaded(
+    await media_staging.mark_uploaded(
         test_user.id,
         "bb_photo",
         service="companycam",
@@ -145,33 +187,15 @@ async def test_upload_record_survives_evict(test_user: User) -> None:
     )
     await media_staging.evict(test_user.id, "bb_photo")
     assert await media_staging.get_all_for_user(test_user.id) == {}
-    rec = media_staging.get_uploaded(test_user.id, "bb_photo")
-    assert rec is not None
-    assert rec.external_id == "cc-999"
+    assert await media_staging.get_uploaded(test_user.id, "bb_photo") is None
 
 
-def test_upload_record_expires(test_user: User, monkeypatch: pytest.MonkeyPatch) -> None:
-    media_staging.mark_uploaded(
+@pytest.mark.asyncio()
+async def test_upload_record_isolated_per_user(test_user: User, second_user: User) -> None:
+    """One user's receipt does not surface for a different user with the same handle."""
+    await media_staging.stage(test_user.id, "bb_photo", b"bytes-a", "image/jpeg")
+    await media_staging.mark_uploaded(
         test_user.id,
-        "bb_photo",
-        service="companycam",
-        external_id="cc-1",
-        url="https://app.companycam.com/photos/cc-1",
-        target="t",
-        status="uploaded",
-    )
-    real_monotonic = time.monotonic
-    future = real_monotonic() + media_staging.UPLOAD_RECORD_TTL_SECONDS + 1
-    monkeypatch.setattr(media_staging.time, "monotonic", lambda: future)
-    assert media_staging.get_uploaded(test_user.id, "bb_photo") is None
-
-
-def test_upload_record_isolated_per_user() -> None:
-    """The upload-receipt cache is in-process and unrelated to the
-    ``staged_media`` table, so plain string user_ids are fine here.
-    """
-    media_staging.mark_uploaded(
-        "user-a",
         "bb_photo",
         service="companycam",
         external_id="cc-a",
@@ -179,8 +203,73 @@ def test_upload_record_isolated_per_user() -> None:
         target="t",
         status="uploaded",
     )
-    assert media_staging.get_uploaded("user-b", "bb_photo") is None
-    media_staging._uploaded.pop("user-a", None)
+    assert await media_staging.get_uploaded(second_user.id, "bb_photo") is None
+
+
+@pytest.mark.asyncio()
+async def test_upload_record_survives_simulated_worker_restart(test_user: User) -> None:
+    """Regression for #1347: receipts must survive a process restart.
+
+    The pre-fix in-memory dict was lost on any worker restart, which let
+    a same-handle retry write a duplicate Drive copy. Simulate a restart
+    by reading the receipt through a fresh ``AsyncSessionLocal`` after
+    the write session committed; the DB row is the source of truth so
+    the read must succeed.
+    """
+    from sqlalchemy import select as _select
+
+    from backend.app.database import AsyncSessionLocal as _Sess
+    from backend.app.models import StagedMedia as _SM
+
+    await media_staging.stage(test_user.id, "bb_photo", b"bytes", "image/jpeg")
+    await media_staging.mark_uploaded(
+        test_user.id,
+        "bb_photo",
+        service="storage",
+        external_id="/Inbox/photo_001.jpg",
+        url="https://drive.google.com/file/d/abc/view",
+        target="/Inbox/photo_001.jpg",
+        status="uploaded",
+    )
+
+    # Cross-session read: a different DB session sees the committed row,
+    # which is what a post-restart process would see.
+    sess = _Sess()
+    try:
+        row = (
+            await sess.execute(
+                _select(_SM).where(_SM.user_id == test_user.id, _SM.original_url == "bb_photo")
+            )
+        ).scalar_one_or_none()
+    finally:
+        await sess.close()
+    assert row is not None
+    assert row.upload_service == "storage"
+    assert row.upload_external_id == "/Inbox/photo_001.jpg"
+
+    # And the public API surfaces the receipt as a UploadRecord.
+    rec = await media_staging.get_uploaded(test_user.id, "bb_photo")
+    assert rec is not None
+    assert rec.service == "storage"
+    assert rec.external_id == "/Inbox/photo_001.jpg"
+
+
+@pytest.mark.asyncio()
+async def test_upload_record_returns_none_for_unstaged_handle(test_user: User) -> None:
+    """A ``mark_uploaded`` call for a never-staged URL is a no-op."""
+    await media_staging.mark_uploaded(
+        test_user.id,
+        "https://never-staged.example.com/x.jpg",
+        service="storage",
+        external_id="/Inbox/x.jpg",
+        url="",
+        target="/Inbox/x.jpg",
+        status="uploaded",
+    )
+    assert (
+        await media_staging.get_uploaded(test_user.id, "https://never-staged.example.com/x.jpg")
+        is None
+    )
 
 
 @pytest.mark.asyncio()
@@ -298,7 +387,7 @@ async def test_upload_keeps_staged_entry(test_user: User) -> None:
     # Bytes stay in staging.
     assert "bb_photo" in await media_staging.get_all_for_user(test_user.id)
     # Receipt was recorded for the top-of-tool idempotency check.
-    rec = media_staging.get_uploaded(test_user.id, "bb_photo")
+    rec = await media_staging.get_uploaded(test_user.id, "bb_photo")
     assert rec is not None and rec.service == "storage"
 
 

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -255,6 +255,48 @@ async def test_upload_record_survives_simulated_worker_restart(test_user: User) 
 
 
 @pytest.mark.asyncio()
+async def test_upload_record_or_keyed_lookup_does_not_crash_on_multi_match(
+    test_user: User,
+) -> None:
+    """A user with two staged rows where the lookup ref matches both columns
+    must NOT raise; ``get_uploaded`` deterministically picks the latest row.
+
+    Contrived in production (handles are 48 bits of random url-safe data
+    behind a ``media_`` prefix) but observable when a test reuses a
+    string that looks like a handle as an ``original_url``. The defense
+    is in production code; this test pins the behavior.
+    """
+    # Row A: original_url is some real URL, mint a server handle.
+    handle_a = await media_staging.stage(
+        test_user.id, "https://example.com/photo-a.jpg", b"a", "image/jpeg"
+    )
+    assert handle_a is not None
+    # Row B: original_url happens to equal Row A's handle (the OR-clause
+    # multi-match case). Distinct row because (user_id, original_url)
+    # is unique but A and B differ on that column.
+    handle_b = await media_staging.stage(test_user.id, handle_a, b"b", "image/jpeg")
+    assert handle_b is not None and handle_b != handle_a
+
+    # Receipt recorded for Row B (the one whose original_url is handle_a).
+    await media_staging.mark_uploaded(
+        test_user.id,
+        handle_a,
+        service="storage",
+        external_id="/Inbox/photo_B.jpg",
+        url="https://drive.google.com/file/d/B/view",
+        target="/Inbox/photo_B.jpg",
+        status="uploaded",
+    )
+
+    # Lookup must not raise even though two rows match the OR clause.
+    rec = await media_staging.get_uploaded(test_user.id, handle_a)
+    assert rec is not None
+    # The most recently staged row (Row B) wins; mark_uploaded keyed on
+    # the latest matching row, so the returned receipt is the one we set.
+    assert rec.external_id == "/Inbox/photo_B.jpg"
+
+
+@pytest.mark.asyncio()
 async def test_upload_record_returns_none_for_unstaged_handle(test_user: User) -> None:
     """A ``mark_uploaded`` call for a never-staged URL is a no-op."""
     await media_staging.mark_uploaded(


### PR DESCRIPTION
## Description

Closes #1347.

Idempotency for `upload_to_storage` and `companycam_upload_photo` used to live in an in-process dict (`media_staging._uploaded`) seeded by `mark_uploaded`. Staged bytes, in contrast, are durable: the file on the persistent volume and the `staged_media` row both survive a process restart. That asymmetry let a same-handle retry after a deploy or OOM bypass the idempotency check and write a duplicate Drive copy. CompanyCam was protected by server-side MD5 dedupe; Drive has no such guard.

Move the receipt onto the row whose bytes it describes:

- **Migration 036** adds six nullable columns to `staged_media`: `upload_service`, `upload_external_id`, `upload_url`, `upload_target`, `upload_status`, `uploaded_at`. No backfill; an unset row means "no upload yet", which is the correct semantics for existing rows. Round-trips cleanly under `alembic upgrade head` and `alembic downgrade -1`.
- `StagedMedia` ORM grows matching `Mapped[... | None]` columns.
- `mark_uploaded` becomes async and writes an UPDATE keyed on `staged_media`. `get_uploaded` becomes async and reads from the same row.
- Both lookups match **either** `original_url` **or** `handle`, mirroring `resolve_media_ref`. This also closes a latent asymmetry from #1346 where the top-of-tool idempotency check in `companycam_upload_photo` was keyed on the unresolved handle while `mark_uploaded` recorded the resolved URL, so the two sides of the contract did not agree.
- The in-process `_uploaded` dict, its TTL constants, the purge helper, and the per-user cap are deleted. Eviction now drops the receipt with the row (lifetime alignment is intentional: if the bytes are gone there is nothing to be idempotent about).
- Callers in `file_tools.upload_to_storage` and `companycam.photos.companycam_upload_photo` `await` the new async API.
- The test conftest no longer needs the per-test `_uploaded.clear()` reset (DB truncation handles it now).

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -n auto`, 2751 passed, 2 skipped; premium downstream: 607 passed, 4 skipped)
- [x] Lint passes (`ruff check`, `ruff format --check`, `ty check`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

### Regression test

`test_upload_record_survives_simulated_worker_restart` (in `tests/test_media_staging.py`): writes a receipt via `mark_uploaded`, then reads it through a fresh `AsyncSessionLocal` to simulate a post-restart process. Pre-fix this would return `None`; the DB read now finds the receipt.

Other new coverage:
- `test_upload_record_resolvable_by_either_handle_or_url`: writes via the URL form, reads via the handle. Guards the latent asymmetry from #1346 against future regressions.
- `test_upload_record_dropped_with_evict`: explicit assertion that evicting the row drops the receipt with it (lifetime alignment).
- `test_upload_record_returns_none_for_unstaged_handle`: `mark_uploaded` is a no-op when there is no row to UPDATE.

## AI Usage
- [x] AI-assisted: investigated the failure scenario described in #1347, designed the schema migration and DB-backed lookup, and folded in the handle-or-URL keying fix after spotting the latent asymmetry while reading my own #1346 code.