### PR TITLE
fix(tools): tighten ToolResult content to stop receipt-mimicry duplicates

### DIFF
--- a/backend/app/agent/tools/file_tools.py
+++ b/backend/app/agent/tools/file_tools.py
@@ -445,8 +445,11 @@ def create_file_tools(
             )
 
         logger.info("File cataloged: %s", saved.path)
+        # Content terse and data-only; the auto-appended receipt is the
+        # user-facing render. Keeps the LLM from mimicking
+        # "Uploaded {file} to {folder}" as prose right before the receipt.
         return ToolResult(
-            content=f"Uploaded {filename} to {normalized_folder} ({saved.path})",
+            content=f"ok | path: {saved.path}",
             receipt=ToolReceipt(
                 action="Uploaded file to Drive",
                 target=saved.path,
@@ -524,7 +527,7 @@ def create_file_tools(
 
         logger.info("File moved: %s -> %s", current_path, moved.path)
         return ToolResult(
-            content=f"Moved {old_filename} to {moved.path}",
+            content=f"ok | path: {moved.path}",
             receipt=ToolReceipt(
                 action="Moved file in Drive",
                 target=moved.path,

--- a/backend/app/agent/tools/servicetitan_tools.py
+++ b/backend/app/agent/tools/servicetitan_tools.py
@@ -382,8 +382,12 @@ def build_servicetitan_tools(service: ServiceTitanService) -> list[Tool]:
         # dict; the createdOn timestamp confirms the write landed.
         created_on = payload.get("createdOn") if isinstance(payload, dict) else None
         timestamp_phrase = f" at {created_on}" if created_on else ""
+        # Content terse and data-only; the auto-appended receipt carries
+        # the user-facing rendering. Avoids the LLM bullet-pointing
+        # "Added note to ServiceTitan job X" right before the receipt
+        # renders the same action.
         return ToolResult(
-            content=f"Added note to ServiceTitan job {job_id}{pinned_phrase}{timestamp_phrase}.",
+            content=f"ok | job: {job_id}{pinned_phrase}{timestamp_phrase}",
             receipt=ToolReceipt(
                 action="Added ServiceTitan job note",
                 target=f"job #{job_id}{pinned_phrase}",

--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -329,11 +329,11 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
             invoice_id = str(result.get("id") or result.get("invoice", {}).get("id") or "")
         total = _line_items_total(typed_items)
         photo_phrase = f" with {len(files)} attachment(s)" if files else ""
+        invoice_phrase = f" | invoice Id: {invoice_id}" if invoice_id else ""
         return ToolResult(
             content=(
-                f"Created invoice on work order {work_order_id} for ${total:.2f}"
-                f" ({len(typed_items)} line item(s)){photo_phrase}"
-                + (f" (invoice id {invoice_id})." if invoice_id else ".")
+                f"ok | work order: #{work_order_id} | total: ${total:.2f}"
+                f" | line items: {len(typed_items)}{photo_phrase}{invoice_phrase}"
             ),
             receipt=ToolReceipt(
                 action="Created AppFolio invoice",
@@ -381,11 +381,9 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
         invoice_id = ""
         if isinstance(result, dict):
             invoice_id = str(result.get("id") or "")
+        invoice_phrase = f" | invoice Id: {invoice_id}" if invoice_id else ""
         return ToolResult(
-            content=(
-                f"Uploaded {len(files)} file(s) as an invoice on work order"
-                f" {work_order_id}" + (f" (invoice id {invoice_id})." if invoice_id else ".")
-            ),
+            content=(f"ok | work order: #{work_order_id} | files: {len(files)}{invoice_phrase}"),
             receipt=ToolReceipt(
                 action="Uploaded AppFolio invoice",
                 target=f"#{work_order_id} ({len(files)} file)",

--- a/backend/app/integrations/appfolio_vendor/notes.py
+++ b/backend/app/integrations/appfolio_vendor/notes.py
@@ -139,7 +139,7 @@ def build_note_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[T
         photo_count = len(files)
         photo_phrase = f", added {photo_count} photo(s)" if photo_count else ""
         return ToolResult(
-            content=f"Updated note {note_id}{photo_phrase}.",
+            content=f"ok | work order: #{work_order_id} | note: {note_id}{photo_phrase}",
             receipt=ToolReceipt(
                 action="Updated AppFolio work order note",
                 target=f"#{work_order_id} note {note_id}{photo_phrase}",

--- a/backend/app/integrations/calendar/factory.py
+++ b/backend/app/integrations/calendar/factory.py
@@ -533,10 +533,13 @@ def create_calendar_tools(
         # Minimal content. The rich record (title, start, end) lives only in
         # the ToolReceipt below, which is rendered server-side and shown to
         # the user. Don't echo title/dates back to the LLM here: when we did,
-        # the model pattern-matched the formatted "field | field | field"
-        # layout into a fabricated bullet ("- Created Google Calendar event:
-        # Lunch with Tam\n  Thu Apr 30, 12:00 PM") that doubled the receipt
-        # block in the outbound. Same shape as the qb_send / qb_create fix.
+        # the model pattern-matched the rich content into a fabricated bullet
+        # ("- Created Google Calendar event: Lunch with Tam\n  Thu Apr 30,
+        # 12:00 PM") that doubled the receipt block in the outbound. Same
+        # shape as the qb_send / qb_create fix. Calendar uses parens instead
+        # of pipes (`ok ({id})` not `ok | id: {id}`) because the existing
+        # `test_*_event_content_is_minimal` tests guard against pipes in
+        # calendar content for that same mimic shape.
         return ToolResult(
             content=f"ok ({event.id})",
             receipt=ToolReceipt(

--- a/backend/app/integrations/calendar/factory.py
+++ b/backend/app/integrations/calendar/factory.py
@@ -536,9 +536,9 @@ def create_calendar_tools(
         # the model pattern-matched the formatted "field | field | field"
         # layout into a fabricated bullet ("- Created Google Calendar event:
         # Lunch with Tam\n  Thu Apr 30, 12:00 PM") that doubled the receipt
-        # block in the outbound. Matches the CompanyCam convention.
+        # block in the outbound. Same shape as the qb_send / qb_create fix.
         return ToolResult(
-            content=f"Event created (id={event.id}).",
+            content=f"ok ({event.id})",
             receipt=ToolReceipt(
                 action="Scheduled calendar event",
                 target=(f"{event.title} on {event.start.strftime('%Y-%m-%d %H:%M')}"),
@@ -615,7 +615,7 @@ def create_calendar_tools(
         # Minimal content. See calendar_create_event above for why the rich
         # record stays in the receipt and not in content.
         return ToolResult(
-            content=f"Event updated (id={event.id}).",
+            content=f"ok ({event.id})",
             receipt=ToolReceipt(
                 action="Updated calendar event",
                 target=(f"{event.title} on {event.start.strftime('%Y-%m-%d %H:%M')}"),
@@ -656,7 +656,7 @@ def create_calendar_tools(
             )
 
         return ToolResult(
-            content=f"Event {event_id} deleted.",
+            content=f"ok ({event_id} deleted)",
             receipt=ToolReceipt(
                 action="Canceled calendar event",
                 target=event_id,

--- a/backend/app/integrations/companycam/checklists.py
+++ b/backend/app/integrations/companycam/checklists.py
@@ -95,10 +95,7 @@ def build_checklist_tools(service: CompanyCamService) -> list[Tool]:
                 error_kind=ToolErrorKind.SERVICE,
             )
         return ToolResult(
-            content=(
-                f"Created checklist '{cl.name or 'Untitled'}' (ID: {cl.id}) "
-                f"on project {project_id}."
-            ),
+            content=f"ok | checklist Id: {cl.id} | project: {project_id}",
             receipt=ToolReceipt(
                 action="Created CompanyCam checklist",
                 target=_sanitize(cl.name or "", 40) or "checklist",

--- a/backend/app/integrations/companycam/photos.py
+++ b/backend/app/integrations/companycam/photos.py
@@ -265,7 +265,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
 
         if status == "duplicate":
             return ToolResult(
-                content=f"CompanyCam detected this as a duplicate photo (ID: {photo.id}).",
+                content=f"ok | duplicate | photo Id: {photo.id}",
                 receipt=ToolReceipt(
                     action="Photo already in CompanyCam",
                     target=photo_target(photo),
@@ -277,7 +277,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
         if status == "pending":
             status_note = " (still processing, may take a moment to appear)"
         return ToolResult(
-            content=f"Photo uploaded to CompanyCam project {project_id}{status_note}.",
+            content=f"ok | photo Id: {photo.id} | project: {project_id}{status_note}",
             receipt=ToolReceipt(
                 action="Uploaded photo to CompanyCam",
                 target=photo_target(photo),
@@ -311,7 +311,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             )
         parent_url = project_url(target_id) if target_type == "project" else photo_url(target_id)
         return ToolResult(
-            content=f"Comment added to {target_type} {target_id} (ID: {comment.id}).",
+            content=f"ok | {target_type} Id: {target_id} | comment Id: {comment.id}",
             receipt=ToolReceipt(
                 action=f"Commented on CompanyCam {target_type}",
                 target=comment_target(content),
@@ -382,7 +382,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             )
         tag_names = [t.display_value or t.value or "?" for t in result_tags]
         return ToolResult(
-            content=f"Tagged photo {photo_id} with: {', '.join(tag_names)}",
+            content=f"ok | photo Id: {photo_id} | tags: {', '.join(tag_names)}",
             receipt=ToolReceipt(
                 action="Tagged CompanyCam photo",
                 target=tags_target(tag_names),
@@ -402,7 +402,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
                 error_kind=ToolErrorKind.SERVICE,
             )
         return ToolResult(
-            content=f"Photo {photo_id} permanently deleted.",
+            content=f"ok | photo Id: {photo_id} (deleted)",
             receipt=ToolReceipt(
                 action="Deleted CompanyCam photo",
                 target=photo_target(None),

--- a/backend/app/integrations/companycam/projects.py
+++ b/backend/app/integrations/companycam/projects.py
@@ -74,7 +74,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             )
 
         return ToolResult(
-            content=(f"Created CompanyCam project: {project.name or name} (ID: {project.id})"),
+            content=f"ok | project Id: {project.id}",
             receipt=ToolReceipt(
                 action="Created CompanyCam project",
                 target=project_target(project),
@@ -109,7 +109,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             )
 
         return ToolResult(
-            content=f"Updated CompanyCam project: {project.name or ''} (ID: {project_id})",
+            content=f"ok | project Id: {project_id}",
             receipt=ToolReceipt(
                 action="Updated CompanyCam project",
                 target=project_target(project),
@@ -163,7 +163,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
                 error_kind=ToolErrorKind.SERVICE,
             )
         return ToolResult(
-            content=f"Project {project_id} archived successfully.",
+            content=f"ok | project Id: {project_id}",
             receipt=ToolReceipt(
                 action="Archived CompanyCam project",
                 target=project_target(None),
@@ -183,7 +183,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
                 error_kind=ToolErrorKind.SERVICE,
             )
         return ToolResult(
-            content=f"Project {project_id} permanently deleted.",
+            content=f"ok | project Id: {project_id} (deleted)",
             receipt=ToolReceipt(
                 action="Deleted CompanyCam project",
                 target=project_target(None),
@@ -205,7 +205,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
                 error_kind=ToolErrorKind.SERVICE,
             )
         return ToolResult(
-            content=f"Notepad updated on project {project_id}.",
+            content=f"ok | project Id: {project_id}",
             receipt=ToolReceipt(
                 action="Updated notepad on CompanyCam project",
                 target=project_target(None),

--- a/backend/app/integrations/gmail/factory.py
+++ b/backend/app/integrations/gmail/factory.py
@@ -300,8 +300,10 @@ def create_gmail_tools(service: GmailService) -> list[Tool]:
 
         # Receipt strings get rendered to the user, so keep them short.
         receipt_target = f"reply to {reply_to_message_id}" if reply_to_message_id else ", ".join(to)
+        # Content stays terse and data-only so the model has no
+        # receipt-shaped phrasing to bullet-point in its reply.
         return ToolResult(
-            content=f"Message sent (id={result.id}, thread={result.thread_id}).",
+            content=f"ok | id: {result.id} | thread: {result.thread_id}",
             receipt=ToolReceipt(
                 action="Sent email via Gmail",
                 target=receipt_target,

--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -567,7 +567,11 @@ def create_quickbooks_tools(
         total = result.get("TotalAmt")
         display_name = result.get("DisplayName", "")
 
-        parts = [f"{entity_type} created in QuickBooks.", f"Id: {entity_id}"]
+        # LLM-facing content stays terse and data-only so the model has no
+        # receipt-shaped phrasing to bullet-point back to the user. The
+        # auto-appended ToolReceipt is the canonical user-facing rendering
+        # (see regression test guarding ``qb_send`` content).
+        parts = ["ok", f"Id: {entity_id}"]
         if doc_num:
             parts.append(f"DocNumber: {doc_num}")
         if total is not None:
@@ -613,7 +617,7 @@ def create_quickbooks_tools(
         total = result.get("TotalAmt")
         display_name = result.get("DisplayName", "")
 
-        parts = [f"{entity_type} updated in QuickBooks.", f"Id: {entity_id}"]
+        parts = ["ok", f"Id: {entity_id}"]
         if doc_num:
             parts.append(f"DocNumber: {doc_num}")
         if total is not None:
@@ -654,8 +658,13 @@ def create_quickbooks_tools(
                 error_kind=ToolErrorKind.SERVICE,
             )
 
+        # Drop the verb + recipient from the LLM-facing content: that
+        # phrasing was getting bullet-pointed in prose right before the
+        # auto-receipt rendered the same action structurally, producing
+        # a double-bullet for one underlying call. Bug observed in
+        # production 2026-05-13 on a contractor's invoice send.
         return ToolResult(
-            content=f"{entity_type} {entity_id} sent to {email} via QuickBooks.",
+            content=f"ok | {entity_type} Id: {entity_id}",
             receipt=ToolReceipt(
                 action=f"Emailed QuickBooks {entity_type.lower()} to",
                 target=email,

--- a/tests/test_calendar_tools.py
+++ b/tests/test_calendar_tools.py
@@ -422,7 +422,7 @@ async def test_create_event_auto_select_single_calendar() -> None:
         end="2026-03-28T17:00:00",
     )
     assert result.is_error is False
-    assert "Event created" in result.content
+    assert result.content.startswith("ok")
 
 
 @pytest.mark.asyncio()
@@ -556,7 +556,7 @@ async def test_create_event_happy_path(cal_tools: list[Tool]) -> None:
         calendar_id="primary",
     )
     assert result.is_error is False
-    assert "Event created" in result.content
+    assert result.content.startswith("ok")
     # Title and times are intentionally NOT in content -- they live in the
     # ToolReceipt below to stop the LLM from pattern-matching the structured
     # content into a fabricated bullet that doubles the receipt block.
@@ -737,7 +737,7 @@ async def test_update_event_happy_path() -> None:
         title="Job: Smith Kitchen Remodel (Revised)",
     )
     assert result.is_error is False
-    assert "Event updated" in result.content
+    assert result.content.startswith("ok")
     # Title is intentionally NOT in content; it lives in the receipt only.
     assert "Revised" not in result.content
     assert result.receipt is not None
@@ -1102,7 +1102,7 @@ async def test_create_event_auto_selects_allowed_calendar() -> None:
         end="2026-03-28T17:00:00",
     )
     assert result.is_error is False
-    assert "Event created" in result.content
+    assert result.content.startswith("ok")
 
 
 @pytest.mark.asyncio()
@@ -1238,7 +1238,7 @@ async def test_read_only_calendar_blocks_write_tools() -> None:
         end="2026-03-28T17:00:00",
     )
     assert result.is_error is False
-    assert "Event created" in result.content
+    assert result.content.startswith("ok")
 
 
 @pytest.mark.asyncio()

--- a/tests/test_file_cataloging.py
+++ b/tests/test_file_cataloging.py
@@ -146,7 +146,7 @@ async def test_upload_writes_file_to_caller_supplied_folder(
     )
 
     assert result.is_error is False
-    assert "Uploaded" in result.content
+    assert result.content.startswith("ok")
     assert "damaged_deck_railing_001.jpg" in result.content
     assert any("Johnson - 123 Main Streetreet/photos" in key for key in storage.files)
 
@@ -298,7 +298,7 @@ async def test_upload_uses_first_media_if_no_url(
     upload = tools[0].function
 
     result = await upload(folder_path="/Inbox", description="Auto selected")
-    assert "Uploaded" in result.content
+    assert result.content.startswith("ok")
     assert result.is_error is False
     assert len(storage.files) == 1
 
@@ -436,7 +436,7 @@ async def test_move_file_relocates_to_named_folder(
     )
 
     assert result.is_error is False
-    assert "Moved" in result.content
+    assert result.content.startswith("ok")
     assert "John Smith - 123 Main Streetreet/photos/file_001.jpg" in result.content
     assert "Inbox/file_001.jpg" not in storage.files
     assert any("John Smith" in k for k in storage.files)
@@ -550,7 +550,7 @@ async def test_move_file_normalizes_missing_leading_slash(
         to_folder_path="/Ralph Smith/photos",
     )
     assert result.is_error is False
-    assert "Moved" in result.content
+    assert result.content.startswith("ok")
 
 
 @pytest.mark.asyncio()
@@ -574,7 +574,7 @@ async def test_move_file_from_drive_root(
     )
 
     assert result.is_error is False
-    assert "Moved" in result.content
+    assert result.content.startswith("ok")
     assert any("Acme/photos/stray.jpg" in key for key in storage.files)
 
 

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -336,7 +336,7 @@ async def test_file_factory_merges_staged_bytes_when_current_turn_has_none(
     )
 
     assert result.is_error is False
-    assert "Uploaded" in result.content
+    assert result.content.startswith("ok")
     # Staging entry stays for the TTL so cross-tool reuse works.
     assert "bb_photo" in await media_staging.get_all_for_user(test_user.id)
 
@@ -1006,4 +1006,4 @@ async def test_upload_to_storage_resolves_handle(test_user: User) -> None:
         original_url=handle,
     )
     assert result.is_error is False
-    assert "Uploaded" in result.content
+    assert result.content.startswith("ok")

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -89,8 +89,10 @@ async def test_qb_create_customer() -> None:
     )
 
     assert result.is_error is False
-    assert "Customer created" in result.content
-    assert "New Customer LLC" in result.content
+    # Content is terse and data-only (no "Customer created in QuickBooks"
+    # phrasing that the LLM would bullet-point alongside the receipt).
+    assert result.content.startswith("ok")
+    assert "Name: New Customer LLC" in result.content
     assert len(svc.created) == 1
     entity_type, body = svc.created[0]
     assert entity_type == "Customer"
@@ -150,7 +152,7 @@ async def test_qb_create_estimate() -> None:
     )
 
     assert result.is_error is False
-    assert "Estimate created" in result.content
+    assert result.content.startswith("ok")
     assert "$600.00" in result.content
     assert len(svc.created) == 1
     entity_type, body = svc.created[0]
@@ -187,7 +189,7 @@ async def test_qb_create_invoice() -> None:
     )
 
     assert result.is_error is False
-    assert "Invoice created" in result.content
+    assert result.content.startswith("ok")
     assert "$350.00" in result.content
     entity_type, body = svc.created[0]
     assert entity_type == "Invoice"
@@ -218,7 +220,7 @@ async def test_qb_create_invoice_with_linked_estimate() -> None:
     )
 
     assert result.is_error is False
-    assert "Invoice created" in result.content
+    assert result.content.startswith("ok")
     _, body = svc.created[0]
     assert body["LinkedTxn"][0]["TxnId"] == "42"
     assert body["LinkedTxn"][0]["TxnType"] == "Estimate"
@@ -287,7 +289,7 @@ async def test_qb_update_estimate() -> None:
     )
 
     assert result.is_error is False
-    assert "Estimate updated" in result.content
+    assert result.content.startswith("ok")
     assert "Id: 2001" in result.content
     assert "$600.00" in result.content
     assert len(svc.updated) == 1
@@ -315,8 +317,8 @@ async def test_qb_update_customer() -> None:
     )
 
     assert result.is_error is False
-    assert "Customer updated" in result.content
-    assert "John Smith" in result.content
+    assert result.content.startswith("ok")
+    assert "Name: John Smith" in result.content
     _, body = svc.updated[0]
     assert body["PrimaryPhone"]["FreeFormNumber"] == "555-9999"
 
@@ -423,7 +425,11 @@ async def test_qb_send_invoice_success() -> None:
     result = await fn(entity_type="Invoice", entity_id="42", email="client@example.com")
 
     assert result.is_error is False
-    assert "Invoice 42 sent to client@example.com" in result.content
+    # Content stays terse and data-only; the recipient and action verb
+    # live in the ToolReceipt, not in the LLM-facing content. Pinned by
+    # the dedicated anti-mimicry test below.
+    assert result.content.startswith("ok")
+    assert "Id: 42" in result.content
     assert svc.sent == [("Invoice", "42", "client@example.com")]
 
 
@@ -436,8 +442,57 @@ async def test_qb_send_estimate_success() -> None:
     result = await fn(entity_type="Estimate", entity_id="2001", email="client@example.com")
 
     assert result.is_error is False
-    assert "Estimate 2001 sent to client@example.com" in result.content
+    assert result.content.startswith("ok")
+    assert "Id: 2001" in result.content
     assert svc.sent == [("Estimate", "2001", "client@example.com")]
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_content_does_not_invite_receipt_mimicry() -> None:
+    """The LLM-facing content for qb_send must not carry the action verb
+    or recipient that the auto-receipt already renders.
+
+    Regression for a 2026-05-13 production observation: a contractor's
+    invoice email turned into a double-bullet in the iMessage reply.
+
+    Final body shipped:
+        Sent.
+
+        - Sent QuickBooks invoice 573 to <email>
+
+        - Emailed QuickBooks invoice to <email>
+          app.qbo.intuit.com/app/invoice?txnId=573
+
+    The first bullet was LLM-fabricated prose mimicking the tool result
+    text (``"Invoice 573 sent to <email> via QuickBooks."``); the second
+    was the auto-appended ToolReceipt. Mirrors the CompanyCam
+    anti-mimicry guard from #1069 but expands it to the recipient and
+    action verb, since those (not the URL) were the mimic trigger here.
+    """
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_send")
+
+    result = await fn(entity_type="Invoice", entity_id="573", email="paula@example.com")
+    assert result.is_error is False
+    assert result.receipt is not None
+
+    # The receipt's URL must not appear in content (the existing #1069
+    # guard, now a per-tool invariant). FakeQBService omits the URL, so
+    # only assert when a URL is actually rendered.
+    if result.receipt.url is not None:
+        assert result.receipt.url not in result.content, (
+            f"content leaked receipt URL: {result.content!r}"
+        )
+    # The recipient (target) must not appear in content. Inlining the
+    # email teaches the model to bullet-point it in prose.
+    assert "paula@example.com" not in result.content, (
+        f"content leaked recipient email: {result.content!r}"
+    )
+    # The action verb ("Emailed" / "sent") must not appear in content.
+    lowered = result.content.lower()
+    for verb in ("sent", "emailed"):
+        assert verb not in lowered, f"content uses receipt-shaped verb {verb!r}: {result.content!r}"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description

Production observation 2026-05-13: a contractor's QuickBooks invoice send rendered with a duplicate bullet in the iMessage reply. The shipped body was:

> Sent.
>
> - Sent QuickBooks invoice 573 to <email>
>
> - Emailed QuickBooks invoice to <email>
>   app.qbo.intuit.com/app/invoice?txnId=573

The first bullet was LLM-fabricated prose mimicking the tool's `content` string (`"Invoice 573 sent to <email> via QuickBooks."`). The second was the auto-appended `ToolReceipt`, which is the canonical user-facing render. Same root cause as #1069 (CompanyCam URL mimic), but #1069 only stripped the URL since that was the original mimic trigger; this case proved the verb + recipient are equally mimickable.

This PR audits every mutating tool that pairs `content` + `ToolReceipt` and tightens the LLM-facing content to a terse, data-only payload (`"ok | Id: X"`-style). The receipts are unchanged.

Tools touched:
- `quickbooks`: qb_create, qb_update, qb_send (root-cause site)
- `gmail`: gmail_send
- `servicetitan`: servicetitan_add_job_note
- `file_tools`: upload_to_storage, move_file
- `companycam`: 5 project tools, 5 photo tools
- `appfolio_vendor`: appfolio_update_note
- `calendar`: create_event, update_event, delete_event

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

New regression: `test_qb_send_content_does_not_invite_receipt_mimicry` asserts that the receipt's URL, recipient email, and action verb stay out of the LLM-facing content. Existing content-shape assertions across `test_quickbooks_write.py`, `test_file_cataloging.py`, `test_calendar_tools.py`, and `test_media_staging.py` updated to the new terse format.

## AI Usage
- [x] AI-assisted (describe how)

Investigation, audit, and code drafted by Claude Opus 4.7 via back-and-forth with @njbrake. The reasoning, scope, and decisions are his; the prose is Claude's.