### PR TITLE
fix(integrations): surface real errors instead of canned guesses (gmail, calendar, companycam)

### DIFF
--- a/backend/app/integrations/_google_errors.py
+++ b/backend/app/integrations/_google_errors.py
@@ -1,0 +1,59 @@
+"""Shared helpers for Google REST API error responses.
+
+Gmail and Google Calendar return the same JSON error envelope:
+
+    {"error": {"code": ..., "message": "...", "errors": [{"reason": "..."}]}}
+
+Both integrations need the same logic to extract the human-readable message
+and the machine-readable reason so callers can render the actual cause to
+the user instead of a hardcoded guess. Lives at the ``integrations/`` level
+(not inside one integration) so neither integration owns the other's helper.
+"""
+
+from __future__ import annotations
+
+import json
+
+# Cap the message text we surface so a verbose 403 (which can include a
+# console URL and several sentences) doesn't blow past a reasonable agent
+# reply. 500 fits Gmail's real accessNotConfigured message in full, including
+# the "wait a few minutes for propagation" sentence that matters right after
+# the operator enables the API.
+GOOGLE_MAX_MESSAGE_CHARS = 500
+
+
+def parse_google_api_error(body: str) -> tuple[str, str]:
+    """Return ``(message, reason)`` from a Google REST API JSON error body.
+
+    Returns empty strings when the body is missing, not JSON, or lacks the
+    expected shape so callers can fall through to a generic message.
+    """
+    if not body:
+        return "", ""
+    try:
+        data = json.loads(body)
+    except (ValueError, TypeError):
+        return "", ""
+    err = data.get("error") if isinstance(data, dict) else None
+    if not isinstance(err, dict):
+        return "", ""
+    message = err.get("message") or ""
+    reason = ""
+    errors = err.get("errors")
+    if isinstance(errors, list) and errors and isinstance(errors[0], dict):
+        reason = errors[0].get("reason") or ""
+    return message, reason
+
+
+def format_google_api_message(message: str, max_chars: int = GOOGLE_MAX_MESSAGE_CHARS) -> str:
+    """Truncate a Google error message for inclusion in a ToolResult."""
+    if len(message) <= max_chars:
+        return message
+    return message[:max_chars].rstrip() + "..."
+
+
+__all__ = [
+    "GOOGLE_MAX_MESSAGE_CHARS",
+    "format_google_api_message",
+    "parse_google_api_error",
+]

--- a/backend/app/integrations/calendar/factory.py
+++ b/backend/app/integrations/calendar/factory.py
@@ -18,6 +18,10 @@ from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolR
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
 from backend.app.database import AsyncSessionLocal
+from backend.app.integrations._google_errors import (
+    format_google_api_message,
+    parse_google_api_error,
+)
 from backend.app.integrations.calendar.provider import (
     CalendarEventCreate,
     CalendarEventUpdate,
@@ -882,7 +886,7 @@ def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
     status = exc.response.status_code
     body = ""
     with contextlib.suppress(Exception):
-        body = exc.response.text[:500]
+        body = exc.response.text[:1000]
     logger.warning(
         "Calendar HTTP %d during %s: url=%s body=%s",
         status,
@@ -890,21 +894,32 @@ def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
         str(exc.request.url) if exc.request else "unknown",
         body,
     )
+    message, _reason = parse_google_api_error(body)
     if status == 401:
         return ToolResult(
             content="Calendar disconnected. Please reconnect Google Calendar in Settings.",
             is_error=True,
-            error_kind=ToolErrorKind.SERVICE,
+            error_kind=ToolErrorKind.AUTH,
         )
     if status == 403:
+        # 403 has many causes for Calendar: forbidden (read-only calendar
+        # under the granted scope), accessNotConfigured (Calendar API
+        # disabled in the GCP project), domainPolicy (Workspace admin
+        # block), insufficientPermissions (missing scope), etc. We surface
+        # Google's own message verbatim so the user sees the actual cause
+        # instead of a "this calendar is read-only" guess that's wrong
+        # whenever the real cause is operator-side config.
+        if message:
+            content = (
+                f"Calendar denied the request while trying to {action}: "
+                f"{format_google_api_message(message)}"
+            )
+        else:
+            content = f"Calendar denied the request while trying to {action} (HTTP 403)."
         return ToolResult(
-            content=(
-                f"Permission denied while trying to {action}. "
-                "This calendar is likely read-only. "
-                "Use calendar_list_calendars to check which calendars allow writes."
-            ),
+            content=content,
             is_error=True,
-            error_kind=ToolErrorKind.VALIDATION,
+            error_kind=ToolErrorKind.PERMISSION,
         )
     if status == 404:
         return ToolResult(

--- a/backend/app/integrations/companycam/checklists.py
+++ b/backend/app/integrations/companycam/checklists.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import logging
 
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
-from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.base import Tool, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.companycam.errors import classify_companycam_error
 from backend.app.integrations.companycam.params import (
     CompanyCamCreateChecklistParams,
     CompanyCamGetChecklistParams,
@@ -38,7 +39,7 @@ def build_checklist_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         if not checklists:
             return ToolResult(content="No checklists found on this project.")
@@ -60,7 +61,7 @@ def build_checklist_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         status = "completed" if cl.completed_at else "in progress"
         lines = [f"Checklist: {cl.name or 'Untitled'} (ID: {cl.id}) [{status}]"]
@@ -92,7 +93,7 @@ def build_checklist_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         return ToolResult(
             content=f"ok | checklist Id: {cl.id} | project: {project_id}",

--- a/backend/app/integrations/companycam/errors.py
+++ b/backend/app/integrations/companycam/errors.py
@@ -1,0 +1,39 @@
+"""HTTP error classification for CompanyCam tools.
+
+CompanyCam tools wrap every service call in a broad ``except Exception`` so
+the agent gets a structured ToolResult instead of a raw traceback. The
+default classification (``SERVICE``) is the right hint for connection
+errors and 5xx, but misleads the agent on 401/403/404 by suggesting
+"try a different approach" when the real fix is "reconnect", "this
+operation is not permitted", or "the resource doesn't exist".
+
+This module deliberately does not parse CompanyCam's response body. The
+caller already renders ``f"CompanyCam error: {exc}"`` which surfaces the
+real exception string verbatim; the only thing we need from the status
+code is the right ``ToolErrorKind`` so the LLM hint matches the cause.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from backend.app.agent.tools.base import ToolErrorKind
+
+
+def classify_companycam_error(exc: BaseException) -> ToolErrorKind:
+    """Map a raised exception to the right ``ToolErrorKind``.
+
+    Non-HTTP exceptions and 5xx responses fall through to ``SERVICE``.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        if status == 401:
+            return ToolErrorKind.AUTH
+        if status == 403:
+            return ToolErrorKind.PERMISSION
+        if status == 404:
+            return ToolErrorKind.NOT_FOUND
+    return ToolErrorKind.SERVICE
+
+
+__all__ = ["classify_companycam_error"]

--- a/backend/app/integrations/companycam/photos.py
+++ b/backend/app/integrations/companycam/photos.py
@@ -20,6 +20,7 @@ from backend.app.agent.saved_media import (
 )
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.companycam.errors import classify_companycam_error
 from backend.app.integrations.companycam.params import (
     CompanyCamAddCommentParams,
     CompanyCamDeletePhotoParams,
@@ -208,7 +209,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             return ToolResult(
                 content=f"CompanyCam upload error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
 
         # Poll for processing status (CompanyCam downloads the image async)
@@ -307,7 +308,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         parent_url = project_url(target_id) if target_type == "project" else photo_url(target_id)
         return ToolResult(
@@ -341,7 +342,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         if not comments:
             return ToolResult(content=f"No comments on this {target_type}.")
@@ -378,7 +379,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         tag_names = [t.display_value or t.value or "?" for t in result_tags]
         return ToolResult(
@@ -399,7 +400,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         return ToolResult(
             content=f"ok | photo Id: {photo_id} (deleted)",
@@ -451,7 +452,7 @@ def build_photo_tools(service: CompanyCamService, ctx: ToolContext) -> list[Tool
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         if not photos:
             return ToolResult(content="No photos found matching the criteria.")

--- a/backend/app/integrations/companycam/projects.py
+++ b/backend/app/integrations/companycam/projects.py
@@ -12,6 +12,7 @@ import logging
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.companycam.errors import classify_companycam_error
 from backend.app.integrations.companycam.params import (
     CompanyCamArchiveProjectParams,
     CompanyCamCreateProjectParams,
@@ -47,7 +48,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam search error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
 
         if not projects:
@@ -70,7 +71,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error creating project: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
 
         return ToolResult(
@@ -105,7 +106,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error updating project: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
 
         return ToolResult(
@@ -126,7 +127,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
 
         lines = [f"Project: {project.name or 'Untitled'} (ID: {project.id})"]
@@ -160,7 +161,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         return ToolResult(
             content=f"ok | project Id: {project_id}",
@@ -180,7 +181,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         return ToolResult(
             content=f"ok | project Id: {project_id} (deleted)",
@@ -202,7 +203,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         return ToolResult(
             content=f"ok | project Id: {project_id}",
@@ -225,7 +226,7 @@ def build_project_tools(service: CompanyCamService) -> list[Tool]:
             return ToolResult(
                 content=f"CompanyCam error: {exc}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=classify_companycam_error(exc),
             )
         if not docs:
             return ToolResult(content="No documents found on this project.")

--- a/backend/app/integrations/gmail/factory.py
+++ b/backend/app/integrations/gmail/factory.py
@@ -175,9 +175,11 @@ def _parse_gmail_error(body: str) -> tuple[str, str]:
 
 
 # Cap Gmail's message text so a verbose 403 (which can include a console URL
-# and several sentences) doesn't blow past a reasonable line length when the
-# LLM renders it back to the user.
-_MAX_GMAIL_MESSAGE_CHARS = 300
+# and several sentences) doesn't blow past a reasonable agent reply. 500 fits
+# Gmail's real accessNotConfigured message in full, including the "wait a few
+# minutes for propagation" sentence that matters right after the operator
+# enables the API.
+_MAX_GMAIL_MESSAGE_CHARS = 500
 
 
 def _format_gmail_message(message: str) -> str:

--- a/backend/app/integrations/gmail/factory.py
+++ b/backend/app/integrations/gmail/factory.py
@@ -15,6 +15,7 @@ Gmail OAuth client, matching the Calendar pattern.
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -148,11 +149,48 @@ def _format_message(m: GmailMessage) -> str:
     return "\n".join(lines)
 
 
+def _parse_gmail_error(body: str) -> tuple[str, str]:
+    """Return ``(message, reason)`` from a Gmail JSON error body.
+
+    Gmail's REST error shape is
+    ``{"error": {"code": ..., "message": "...", "errors": [{"reason": "..."}]}}``.
+    Returns empty strings when the body is missing, not JSON, or lacks the
+    expected shape so callers can fall through to a generic message.
+    """
+    if not body:
+        return "", ""
+    try:
+        data = json.loads(body)
+    except (ValueError, TypeError):
+        return "", ""
+    err = data.get("error") if isinstance(data, dict) else None
+    if not isinstance(err, dict):
+        return "", ""
+    message = err.get("message") or ""
+    reason = ""
+    errors = err.get("errors")
+    if isinstance(errors, list) and errors and isinstance(errors[0], dict):
+        reason = errors[0].get("reason") or ""
+    return message, reason
+
+
+# Cap Gmail's message text so a verbose 403 (which can include a console URL
+# and several sentences) doesn't blow past a reasonable line length when the
+# LLM renders it back to the user.
+_MAX_GMAIL_MESSAGE_CHARS = 300
+
+
+def _format_gmail_message(message: str) -> str:
+    if len(message) <= _MAX_GMAIL_MESSAGE_CHARS:
+        return message
+    return message[:_MAX_GMAIL_MESSAGE_CHARS].rstrip() + "..."
+
+
 def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
     status = exc.response.status_code
     body = ""
     with contextlib.suppress(Exception):
-        body = exc.response.text[:500]
+        body = exc.response.text[:1000]
     logger.warning(
         "Gmail HTTP %d during %s: url=%s body=%s",
         status,
@@ -160,21 +198,37 @@ def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
         str(exc.request.url) if exc.request else "unknown",
         body,
     )
+    message, reason = _parse_gmail_error(body)
     if status == 401:
         return ToolResult(
             content="Gmail disconnected. Please reconnect Gmail in Settings.",
             is_error=True,
-            error_kind=ToolErrorKind.SERVICE,
+            error_kind=ToolErrorKind.AUTH,
         )
     if status == 403:
-        return ToolResult(
-            content=(
+        # 403 has many causes: insufficientPermissions (real scope problem,
+        # reconnect helps), accessNotConfigured (Gmail API disabled in the
+        # GCP project, operator must enable it), domainPolicy (Workspace
+        # admin block), failedPrecondition, etc. We surface Gmail's own
+        # message verbatim so the user sees the actual cause instead of a
+        # canned "reconnect" guess that's wrong most of the time.
+        if reason == "insufficientPermissions":
+            content = (
                 f"Permission denied while trying to {action}. "
-                "The Gmail integration may be missing the required scope; "
+                "The Gmail integration is missing a required scope; "
                 "disconnect and reconnect Gmail to grant the missing permissions."
-            ),
+            )
+        elif message:
+            content = (
+                f"Gmail denied the request while trying to {action}: "
+                f"{_format_gmail_message(message)}"
+            )
+        else:
+            content = f"Gmail denied the request while trying to {action} (HTTP 403)."
+        return ToolResult(
+            content=content,
             is_error=True,
-            error_kind=ToolErrorKind.VALIDATION,
+            error_kind=ToolErrorKind.PERMISSION,
         )
     if status == 404:
         return ToolResult(

--- a/backend/app/integrations/gmail/factory.py
+++ b/backend/app/integrations/gmail/factory.py
@@ -15,7 +15,6 @@ Gmail OAuth client, matching the Calendar pattern.
 from __future__ import annotations
 
 import contextlib
-import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -26,6 +25,10 @@ from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.config import settings
+from backend.app.integrations._google_errors import (
+    format_google_api_message,
+    parse_google_api_error,
+)
 from backend.app.integrations.gmail.service import (
     GmailMessage,
     GmailMessageSummary,
@@ -149,45 +152,6 @@ def _format_message(m: GmailMessage) -> str:
     return "\n".join(lines)
 
 
-def _parse_gmail_error(body: str) -> tuple[str, str]:
-    """Return ``(message, reason)`` from a Gmail JSON error body.
-
-    Gmail's REST error shape is
-    ``{"error": {"code": ..., "message": "...", "errors": [{"reason": "..."}]}}``.
-    Returns empty strings when the body is missing, not JSON, or lacks the
-    expected shape so callers can fall through to a generic message.
-    """
-    if not body:
-        return "", ""
-    try:
-        data = json.loads(body)
-    except (ValueError, TypeError):
-        return "", ""
-    err = data.get("error") if isinstance(data, dict) else None
-    if not isinstance(err, dict):
-        return "", ""
-    message = err.get("message") or ""
-    reason = ""
-    errors = err.get("errors")
-    if isinstance(errors, list) and errors and isinstance(errors[0], dict):
-        reason = errors[0].get("reason") or ""
-    return message, reason
-
-
-# Cap Gmail's message text so a verbose 403 (which can include a console URL
-# and several sentences) doesn't blow past a reasonable agent reply. 500 fits
-# Gmail's real accessNotConfigured message in full, including the "wait a few
-# minutes for propagation" sentence that matters right after the operator
-# enables the API.
-_MAX_GMAIL_MESSAGE_CHARS = 500
-
-
-def _format_gmail_message(message: str) -> str:
-    if len(message) <= _MAX_GMAIL_MESSAGE_CHARS:
-        return message
-    return message[:_MAX_GMAIL_MESSAGE_CHARS].rstrip() + "..."
-
-
 def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
     status = exc.response.status_code
     body = ""
@@ -200,7 +164,7 @@ def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
         str(exc.request.url) if exc.request else "unknown",
         body,
     )
-    message, reason = _parse_gmail_error(body)
+    message, reason = parse_google_api_error(body)
     if status == 401:
         return ToolResult(
             content="Gmail disconnected. Please reconnect Gmail in Settings.",
@@ -223,7 +187,7 @@ def _handle_http_error(exc: httpx.HTTPStatusError, action: str) -> ToolResult:
         elif message:
             content = (
                 f"Gmail denied the request while trying to {action}: "
-                f"{_format_gmail_message(message)}"
+                f"{format_google_api_message(message)}"
             )
         else:
             content = f"Gmail denied the request while trying to {action} (HTTP 403)."

--- a/tests/test_calendar_tools.py
+++ b/tests/test_calendar_tools.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from backend.app.agent.approval import PermissionLevel
@@ -12,6 +14,7 @@ from backend.app.agent.tools.names import ToolName
 from backend.app.agent.tools.registry import ToolContext
 from backend.app.integrations.calendar.factory import (
     _calendar_factory,
+    _handle_http_error,
     _parse_dt,
     _resolve_tz,
     create_calendar_tools,
@@ -1301,17 +1304,59 @@ async def test_free_busy_reader_blocks_writes() -> None:
     assert "No calendars allow create event" in result.content
 
 
-@pytest.mark.asyncio()
-async def test_403_error_mentions_permissions() -> None:
-    """A 403 from Google should tell the agent it's a permissions issue."""
-    import httpx
+def _make_http_error(status: int, body: str = "") -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://www.googleapis.com/calendar/v3/calendars/x/events")
+    response = httpx.Response(status, request=request, text=body)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
 
-    from backend.app.integrations.calendar.factory import _handle_http_error
 
-    request = httpx.Request("POST", "https://example.com/calendars/test/events")
-    response = httpx.Response(403, request=request, text="Forbidden")
-    exc = httpx.HTTPStatusError("Forbidden", request=request, response=response)
-    result = _handle_http_error(exc, "create event")
+def test_401_is_auth_kind_not_service() -> None:
+    """401 should classify as AUTH so the LLM hint tells the user to reconnect,
+    not "try a different approach" (SERVICE hint)."""
+    result = _handle_http_error(_make_http_error(401), "create event")
     assert result.is_error is True
-    assert "Permission denied" in result.content
-    assert "read-only" in result.content
+    assert result.error_kind == ToolErrorKind.AUTH
+    assert "disconnected" in result.content.lower()
+
+
+def test_403_surfaces_google_message_not_read_only_guess() -> None:
+    """403 with a non-read-only cause (Calendar API disabled in GCP) must
+    surface Google's actual message, not the canned "read-only" guess.
+
+    Sibling regression to the Gmail accessNotConfigured bug: the calendar
+    factory was the original template the Gmail factory was copied from,
+    and carried the same VALIDATION-misclassification + canned-guess shape.
+    """
+    google_message = (
+        "Google Calendar API has not been used in project 1033137896781 before "
+        "or it is disabled. Enable it by visiting https://console.developers."
+        "google.com/apis/api/calendar-json.googleapis.com/overview?project="
+        "1033137896781 then retry."
+    )
+    body = json.dumps(
+        {
+            "error": {
+                "code": 403,
+                "message": google_message,
+                "errors": [{"reason": "accessNotConfigured", "message": google_message}],
+            }
+        }
+    )
+    result = _handle_http_error(_make_http_error(403, body), "create event")
+
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.PERMISSION
+    # Google's real message round-trips so the user sees the actual cause.
+    assert google_message in result.content
+    # The canned "read-only calendar" guess MUST NOT appear for this 403.
+    assert "read-only" not in result.content.lower()
+
+
+def test_403_with_unparseable_body_falls_back() -> None:
+    result = _handle_http_error(
+        _make_http_error(403, "<html>upstream proxy noise</html>"), "create event"
+    )
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.PERMISSION
+    assert "HTTP 403" in result.content
+    assert "read-only" not in result.content.lower()

--- a/tests/test_companycam_tools.py
+++ b/tests/test_companycam_tools.py
@@ -8,6 +8,8 @@ import httpx
 import pytest
 from pydantic import ValidationError
 
+from backend.app.agent.tools.base import ToolErrorKind
+from backend.app.integrations.companycam.errors import classify_companycam_error
 from backend.app.integrations.companycam.params import (
     CompanyCamTagPhotoParams,
     CompanyCamUploadPhotoParams,
@@ -2325,3 +2327,39 @@ async def test_two_photo_upload_renders_each_url_exactly_once() -> None:
     # renderer, so we count the host+path.
     assert final.count("app.companycam.com/photos/3136949848") == 1
     assert final.count("app.companycam.com/photos/3136949871") == 1
+
+
+# ---------------------------------------------------------------------------
+# classify_companycam_error
+# ---------------------------------------------------------------------------
+
+
+def _make_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://api.companycam.com/v2/projects")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+
+
+def test_classify_401_is_auth() -> None:
+    """401 must be AUTH so the LLM tells the user to reconnect, not "try
+    a different approach" (the SERVICE hint that would have fired before)."""
+    assert classify_companycam_error(_make_status_error(401)) == ToolErrorKind.AUTH
+
+
+def test_classify_403_is_permission() -> None:
+    assert classify_companycam_error(_make_status_error(403)) == ToolErrorKind.PERMISSION
+
+
+def test_classify_404_is_not_found() -> None:
+    assert classify_companycam_error(_make_status_error(404)) == ToolErrorKind.NOT_FOUND
+
+
+def test_classify_500_falls_through_to_service() -> None:
+    assert classify_companycam_error(_make_status_error(500)) == ToolErrorKind.SERVICE
+
+
+def test_classify_non_http_exception_is_service() -> None:
+    """Connection errors, JSON errors, and other non-HTTP exceptions stay
+    SERVICE so the agent still gets the "try a different approach" hint."""
+    assert classify_companycam_error(ConnectionError("boom")) == ToolErrorKind.SERVICE
+    assert classify_companycam_error(ValueError("bad json")) == ToolErrorKind.SERVICE

--- a/tests/test_gmail_integration.py
+++ b/tests/test_gmail_integration.py
@@ -553,8 +553,93 @@ async def test_gmail_search_tool_handles_401_as_disconnected() -> None:
         result = await tool.function("q", 5)
 
     assert result.is_error is True
-    assert result.error_kind == ToolErrorKind.SERVICE
+    # AUTH (not SERVICE) so the LLM hint tells the user to reauthenticate
+    # via the dashboard instead of suggesting a transient retry.
+    assert result.error_kind == ToolErrorKind.AUTH
     assert "disconnected" in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_gmail_search_tool_403_surfaces_gmail_message() -> None:
+    """403 with a non-scope cause (Gmail API disabled in GCP) must surface the
+    actual Gmail message, not the canned 'missing scope, reconnect' guess.
+
+    Regression for the production incident where a real ``accessNotConfigured``
+    error was rendered as "missing the required scope; disconnect and reconnect"
+    AND tagged ``error_kind=VALIDATION``, which made the agent append the
+    misleading "[Check the expected parameter format...]" hint.
+    """
+    service = _make_service()
+    body = (
+        '{"error": {"code": 403, '
+        '"message": "Gmail API has not been used in project 1033137896781 '
+        "before or it is disabled. Enable it by visiting "
+        "https://console.developers.google.com/apis/api/gmail.googleapis.com/"
+        'overview?project=1033137896781 then retry.", '
+        '"errors": [{"reason": "accessNotConfigured", '
+        '"message": "Gmail API has not been used in project..."}]}}'
+    )
+    err = httpx.HTTPStatusError(
+        "403",
+        request=httpx.Request("GET", "https://gmail.googleapis.com/gmail/v1/users/me/messages"),
+        response=httpx.Response(403, text=body),
+    )
+    with patch.object(service, "search_messages", new_callable=AsyncMock, side_effect=err):
+        tools = create_gmail_tools(service)
+        tool = _get_tool(tools, ToolName.GMAIL_SEARCH)
+        result = await tool.function("q", 5)
+
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.PERMISSION
+    assert "Gmail API has not been used" in result.content
+    # The canned scope-reconnect guess MUST NOT appear for this 403.
+    assert "missing" not in result.content.lower()
+    assert "reconnect" not in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_gmail_search_tool_403_insufficient_permissions_keeps_reconnect_hint() -> None:
+    """When Gmail's reason is genuinely ``insufficientPermissions`` the
+    "disconnect and reconnect to grant scopes" advice IS the right fix, so we
+    keep it for that specific reason."""
+    service = _make_service()
+    body = (
+        '{"error": {"code": 403, "message": "Insufficient Permission", '
+        '"errors": [{"reason": "insufficientPermissions", '
+        '"message": "Insufficient Permission"}]}}'
+    )
+    err = httpx.HTTPStatusError(
+        "403",
+        request=httpx.Request("GET", "https://gmail.googleapis.com/gmail/v1/users/me/messages"),
+        response=httpx.Response(403, text=body),
+    )
+    with patch.object(service, "search_messages", new_callable=AsyncMock, side_effect=err):
+        tools = create_gmail_tools(service)
+        tool = _get_tool(tools, ToolName.GMAIL_SEARCH)
+        result = await tool.function("q", 5)
+
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.PERMISSION
+    assert "missing a required scope" in result.content
+    assert "reconnect" in result.content.lower()
+
+
+@pytest.mark.asyncio()
+async def test_gmail_search_tool_403_with_unparseable_body_falls_back() -> None:
+    service = _make_service()
+    err = httpx.HTTPStatusError(
+        "403",
+        request=httpx.Request("GET", "https://gmail.googleapis.com/gmail/v1/users/me/messages"),
+        response=httpx.Response(403, text="<html>upstream proxy noise</html>"),
+    )
+    with patch.object(service, "search_messages", new_callable=AsyncMock, side_effect=err):
+        tools = create_gmail_tools(service)
+        tool = _get_tool(tools, ToolName.GMAIL_SEARCH)
+        result = await tool.function("q", 5)
+
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.PERMISSION
+    assert "HTTP 403" in result.content
 
 
 @pytest.mark.asyncio()

--- a/tests/test_gmail_integration.py
+++ b/tests/test_gmail_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -570,14 +571,30 @@ async def test_gmail_search_tool_403_surfaces_gmail_message() -> None:
     misleading "[Check the expected parameter format...]" hint.
     """
     service = _make_service()
-    body = (
-        '{"error": {"code": 403, '
-        '"message": "Gmail API has not been used in project 1033137896781 '
-        "before or it is disabled. Enable it by visiting "
-        "https://console.developers.google.com/apis/api/gmail.googleapis.com/"
-        'overview?project=1033137896781 then retry.", '
-        '"errors": [{"reason": "accessNotConfigured", '
-        '"message": "Gmail API has not been used in project..."}]}}'
+    # The message field is the exact text Gmail returned in prod for this
+    # bug. The full sentence ("If you enabled this API recently, wait a few
+    # minutes for the action to propagate...") must round-trip untruncated,
+    # because that's the actionable hint right after the operator hits Enable.
+    gmail_message = (
+        "Gmail API has not been used in project 1033137896781 before or it is "
+        "disabled. Enable it by visiting https://console.developers.google.com/"
+        "apis/api/gmail.googleapis.com/overview?project=1033137896781 then "
+        "retry. If you enabled this API recently, wait a few minutes for the "
+        "action to propagate to our systems and retry."
+    )
+    body = json.dumps(
+        {
+            "error": {
+                "code": 403,
+                "message": gmail_message,
+                "errors": [
+                    {
+                        "reason": "accessNotConfigured",
+                        "message": "Gmail API has not been used in project...",
+                    }
+                ],
+            }
+        }
     )
     err = httpx.HTTPStatusError(
         "403",
@@ -591,7 +608,11 @@ async def test_gmail_search_tool_403_surfaces_gmail_message() -> None:
 
     assert result.is_error is True
     assert result.error_kind == ToolErrorKind.PERMISSION
-    assert "Gmail API has not been used" in result.content
+    # Full message round-trips, including the trailing "wait a few minutes"
+    # sentence that the previous 300-char cap dropped.
+    assert gmail_message in result.content
+    assert "wait a few minutes" in result.content
+    assert "..." not in result.content
     # The canned scope-reconnect guess MUST NOT appear for this 403.
     assert "missing" not in result.content.lower()
     assert "reconnect" not in result.content.lower()

--- a/tests/test_gmail_integration.py
+++ b/tests/test_gmail_integration.py
@@ -608,11 +608,11 @@ async def test_gmail_search_tool_403_surfaces_gmail_message() -> None:
 
     assert result.is_error is True
     assert result.error_kind == ToolErrorKind.PERMISSION
-    # Full message round-trips, including the trailing "wait a few minutes"
-    # sentence that the previous 300-char cap dropped.
+    # Full message round-trips (substring match also fails on truncation,
+    # since the cap would replace the tail with "..."). Explicit assert on
+    # the previously-dropped propagation-wait sentence locks down the bug.
     assert gmail_message in result.content
     assert "wait a few minutes" in result.content
-    assert "..." not in result.content
     # The canned scope-reconnect guess MUST NOT appear for this 403.
     assert "missing" not in result.content.lower()
     assert "reconnect" not in result.content.lower()


### PR DESCRIPTION
## Description

Three integrations were giving the agent the wrong error hint when an external API failed, so users got "reconnect Gmail" / "this calendar is read-only" / "try a different approach" guidance for failures whose real causes were operator-side config (Gmail API disabled in GCP), unrelated 403 reasons (workspace policy, accessNotConfigured), or token expiry. This PR fixes all three.

### Gmail (original incident)

In prod, a real Gmail `accessNotConfigured` error (Gmail API disabled in the GCP project that owns `GMAIL_CLIENT_ID`) was rendered as "missing scope, disconnect and reconnect" because the 403 handler hardcoded that message for every 403, regardless of Gmail's actual reason. The handler also tagged the result `ToolErrorKind.VALIDATION`, which made the agent runner append the misleading hint `[Check the expected parameter format and try again with corrected arguments.]`.

- Parse Gmail's JSON error body for `message` + `reason`.
- 403 -> `PERMISSION`, surfaces Gmail's own message verbatim (capped at 500 chars). The "reconnect to grant scopes" wording is reserved for the `insufficientPermissions` reason.
- 401 -> `AUTH` (was `SERVICE`).
- Three regression tests covering `accessNotConfigured`, `insufficientPermissions`, and an unparseable body.

### Google Calendar (same bug, copy-pasted)

The Gmail factory's docstring says "The factory mirrors `calendar/factory.py`" — so Gmail copied the bug from Calendar. Calendar still had it: 403 -> `VALIDATION` with hardcoded "this calendar is likely read-only" guess, 401 -> `SERVICE`. Same fix as Gmail, sharing a common Google-API helper.

- New `backend/app/integrations/_google_errors.py` with `parse_google_api_error` / `format_google_api_message` since Gmail and Calendar consume the identical Google JSON error envelope.
- Calendar 401 -> `AUTH`, 403 -> `PERMISSION` with Google's actual message.
- Drop the obsolete read-only assertion test; add three regression tests mirroring the Gmail set.

### CompanyCam (conservative classification fix)

CompanyCam already surfaces real errors (every handler renders `f"CompanyCam error: {exc}"`) so it wasn't lying about causes. But every HTTP error was classified `ToolErrorKind.SERVICE`, which tells the LLM `[An external service is temporarily unavailable. Try a different approach...]` — wrong hint for a 401 (the user should reconnect) or a 404 (the resource doesn't exist).

- `classify_companycam_error()` in `companycam/errors.py`: 401 -> `AUTH`, 403 -> `PERMISSION`, 404 -> `NOT_FOUND`, everything else falls through to `SERVICE`.
- Applied at every `except Exception` handler across `photos.py`, `projects.py`, `checklists.py`.
- Error message content is **unchanged**. The existing `f"CompanyCam error: {exc}"` already surfaces the real exception verbatim; deliberately no new content parsing here, to avoid introducing new ways to deceive.
- One standalone SERVICE case in `photos.py` (the `processing_error` upload status, which is not in an `except` block and has no exception to classify) stays as-is.
- Five classifier regression tests.

### Reference table — what 403 actually means

| Reason | Operator action needed |
|---|---|
| `insufficientPermissions` | User reconnects to grant the missing scope. |
| `accessNotConfigured` | Operator enables the API in GCP. Reconnect does nothing. |
| `domainPolicy` | Workspace admin allowlists the OAuth client. Reconnect does nothing. |
| `failedPrecondition` | Depends on the precondition. |
| Read-only calendar (Calendar only) | User asks for a different calendar; reconnect does nothing. |

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (263 tests in the affected files: `tests/test_gmail_integration.py`, `tests/test_calendar_tools.py`, `tests/test_companycam_tools.py`, `tests/test_tool_registry.py`, `tests/test_integration_tools.py`)
- [x] Lint passes (`ruff check backend/ tests/ alembic/`)
- [x] Format passes (`ruff format --check backend/ tests/ alembic/`)
- [x] Type check passes (`ty check --python .venv backend/ tests/ alembic/`)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: Investigation, audit of sibling integrations, and PR drafted by Claude in collaboration with @njbrake. The Gmail bug was surfaced by a real user-reported "the error is lying" report; root cause was confirmed against prod logs via the admin API before any code was changed. The Calendar and CompanyCam audits came from a follow-up "are there other masks like this?" sweep. Reasoning, decisions, and review are Nathan's; the prose and patch are Claude's.