### PR TITLE
feat(appfolio): restore work-order status update + undo tools

### DIFF
--- a/backend/app/agent/tools/names.py
+++ b/backend/app/agent/tools/names.py
@@ -74,6 +74,8 @@ class ToolName:
     APPFOLIO_LIST_WORK_ORDERS = "appfolio_list_work_orders"
     APPFOLIO_SEARCH_WORK_ORDERS = "appfolio_search_work_orders"
     APPFOLIO_GET_WORK_ORDER = "appfolio_get_work_order"
+    APPFOLIO_UPDATE_WORK_ORDER_STATUS = "appfolio_update_work_order_status"
+    APPFOLIO_UNDO_WORK_ORDER_STATUS = "appfolio_undo_work_order_status"
     APPFOLIO_LIST_NOTES = "appfolio_list_notes"
     APPFOLIO_ADD_NOTE = "appfolio_add_note"
     APPFOLIO_UPDATE_NOTE = "appfolio_update_note"

--- a/backend/app/integrations/appfolio_vendor/SKILL.md
+++ b/backend/app/integrations/appfolio_vendor/SKILL.md
@@ -1,7 +1,8 @@
 # AppFolio Vendor Portal
 
-Read work orders and notes, add notes (with photos), and create invoices
-on the user's AppFolio Vendor Portal.
+Read work orders and notes, update work-order status (e.g. mark
+complete), add notes (with photos), and create invoices on the user's
+AppFolio Vendor Portal.
 
 ## Tools
 
@@ -11,11 +12,16 @@ on the user's AppFolio Vendor Portal.
 | appfolio_list_work_orders | List work orders, filter by status | Auto |
 | appfolio_search_work_orders | Search by address, number, or text | Auto |
 | appfolio_get_work_order | One work order's details | Auto |
+| appfolio_update_work_order_status | Update the status code (e.g. mark complete) | Ask |
+| appfolio_undo_work_order_status | Revert a recent status change | Ask |
 | appfolio_list_notes | List notes on a work order | Auto |
 | appfolio_add_note | Add a note (with optional photos) | Ask |
 | appfolio_update_note | Edit an existing note | Ask |
 | appfolio_create_invoice | Build a line-itemized invoice with photos | Ask |
 | appfolio_upload_invoice_pdf | Upload a pre-built invoice PDF | Ask |
+
+Common status codes: `0` = new, `4` = in progress, `8` = completed.
+Confirm with the user when uncertain rather than guessing.
 
 ## Photos and documents
 

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -8,7 +8,7 @@ time:
   ``appfolio_connect`` tool. This must stay reachable even when the user
   has no credential, since pasting the token *is* the connect path.
 * ``appfolio_vendor`` (specialist, gated on connection state): the data
-  tools (work-order reads, notes with photos, invoices). When the user
+  tools (work-order reads + status updates, notes with photos, invoices). When the user
   is not yet connected, ``_appfolio_vendor_auth_check`` returns a reason
   string so the registry surfaces it under "Not connected" rather than
   letting the LLM believe AppFolio is ready to use.
@@ -32,6 +32,9 @@ from backend.app.integrations.appfolio_vendor.auth_tools import build_auth_tools
 from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
 from backend.app.integrations.appfolio_vendor.notes import build_note_tools
 from backend.app.integrations.appfolio_vendor.service import build_service
+from backend.app.integrations.appfolio_vendor.work_order_writes import (
+    build_work_order_write_tools,
+)
 from backend.app.integrations.appfolio_vendor.work_orders import build_work_order_tools
 
 if TYPE_CHECKING:
@@ -95,6 +98,7 @@ async def _appfolio_vendor_factory(ctx: ToolContext) -> list[Tool]:
     )
     tools: list[Tool] = []
     tools.extend(build_work_order_tools(service))
+    tools.extend(build_work_order_write_tools(service))
     tools.extend(build_note_tools(service, ctx))
     tools.extend(build_invoice_tools(service, ctx))
     return tools
@@ -144,11 +148,15 @@ def _register() -> None:
         _appfolio_vendor_factory,
         core=False,
         summary=(
-            "AppFolio Vendor Portal: view and search work orders, read and add "
-            "notes (with photos), and create or upload invoices"
+            "AppFolio Vendor Portal: view and search work orders, update their "
+            "status (e.g. mark complete), read and add notes (with photos), "
+            "and create or upload invoices"
         ),
         display_name="AppFolio Vendor Portal",
-        dashboard_description="View work orders, add notes, and create invoices in AppFolio Vendor Portal",
+        dashboard_description=(
+            "View work orders, update status, add notes, and create invoices "
+            "in AppFolio Vendor Portal"
+        ),
         dashboard_group="Integrations",
         dashboard_group_order=2,
         sub_tools=[
@@ -166,6 +174,16 @@ def _register() -> None:
                 ToolName.APPFOLIO_GET_WORK_ORDER,
                 "Get full details for one AppFolio work order",
                 default_permission="always",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UPDATE_WORK_ORDER_STATUS,
+                "Update the status code on an AppFolio work order",
+                default_permission="ask",
+            ),
+            SubToolInfo(
+                ToolName.APPFOLIO_UNDO_WORK_ORDER_STATUS,
+                "Revert a recent AppFolio work order status change",
+                default_permission="ask",
             ),
             SubToolInfo(
                 ToolName.APPFOLIO_LIST_NOTES,

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -60,6 +60,27 @@ class AppFolioGetWorkOrderParams(BaseModel):
     work_order_id: str = Field(description="AppFolio work order ID.")
 
 
+class AppFolioUpdateWorkOrderStatusParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID to update.")
+    status_code: int = Field(
+        description=(
+            "Numeric status code AppFolio expects. Common values:"
+            " 0=new, 4=in progress, 8=completed."
+            " Confirm with the user when uncertain rather than guessing."
+        ),
+    )
+
+
+class AppFolioUndoWorkOrderStatusParams(BaseModel):
+    work_order_id: str = Field(description="AppFolio work order ID.")
+    previous_status: str = Field(
+        description=(
+            "The status the work order should revert to. Pass the prior"
+            " status code or label as returned by appfolio_get_work_order."
+        ),
+    )
+
+
 class AppFolioListNotesParams(BaseModel):
     work_order_id: str = Field(description="AppFolio work order ID.")
 

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -492,6 +492,37 @@ class AppFolioVendorService:
         self._credential.customer_ids = ids
         return ids[0]
 
+    async def update_work_order_status(
+        self,
+        work_order_id: str,
+        *,
+        status_code: int,
+        customer_id: str | None = None,
+    ) -> Any:
+        """PATCH a work order's status code.
+
+        SPA-verified shape: ``{"work_order": {"status_code": N}, "customer_id": "..."}``.
+        snake_case throughout; ``customer_id`` is required.
+        """
+        cid = customer_id or await self._resolve_primary_customer_id()
+        return await self.patch(
+            f"/maintenance/api/work_orders/{work_order_id}",
+            json_body={"work_order": {"status_code": status_code}, "customer_id": cid},
+        )
+
+    async def undo_work_order_status(
+        self,
+        work_order_id: str,
+        *,
+        previous_status: int | str,
+        customer_id: str | None = None,
+    ) -> Any:
+        cid = customer_id or await self._resolve_primary_customer_id()
+        return await self.patch(
+            f"/maintenance/api/work_orders/{work_order_id}/undo_status",
+            json_body={"work_order": {"status": previous_status}, "customer_id": cid},
+        )
+
     # ------------------------------------------------------------------
     # Work-order notes
     # ------------------------------------------------------------------

--- a/backend/app/integrations/appfolio_vendor/work_order_writes.py
+++ b/backend/app/integrations/appfolio_vendor/work_order_writes.py
@@ -1,0 +1,100 @@
+"""Write tools for AppFolio work-order status.
+
+Limited surface: status update and undo. Note writes live in
+:mod:`notes`; invoice writes in :mod:`invoices`. The accept/schedule
+and tenant-messaging tools that previously lived here were dropped in
+#1331 ("trim tool surface to reads, notes, and invoices") and are not
+restored.
+
+Brought back the status tools after vendor feedback: marking a work
+order complete from inside the assistant is the one write the trim
+left without a workaround, and users now have to flip status in the
+AppFolio UI by hand.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.tools.base import Tool, ToolReceipt, ToolResult
+from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+from backend.app.integrations.appfolio_vendor.params import (
+    AppFolioUndoWorkOrderStatusParams,
+    AppFolioUpdateWorkOrderStatusParams,
+)
+from backend.app.integrations.appfolio_vendor.service import AppFolioVendorService
+
+logger = logging.getLogger(__name__)
+
+
+def build_work_order_write_tools(service: AppFolioVendorService) -> list[Tool]:
+    """Return the work-order status-write Tool instances."""
+
+    async def appfolio_update_work_order_status(work_order_id: str, status_code: int) -> ToolResult:
+        try:
+            await service.update_work_order_status(work_order_id, status_code=status_code)
+        except Exception as exc:
+            return service_error_to_tool_result("updating work order status", exc)
+        return ToolResult(
+            content=f"Updated work order {work_order_id} status to {status_code}.",
+            receipt=ToolReceipt(
+                action="Updated AppFolio work order status",
+                target=f"#{work_order_id} → {status_code}",
+            ),
+        )
+
+    async def appfolio_undo_work_order_status(
+        work_order_id: str, previous_status: str
+    ) -> ToolResult:
+        # AppFolio accepts either the int code or the string label; pass
+        # whichever the agent supplied through unchanged so the API-side
+        # validation is the canonical check rather than us guessing.
+        try:
+            await service.undo_work_order_status(work_order_id, previous_status=previous_status)
+        except Exception as exc:
+            return service_error_to_tool_result("undoing work order status", exc)
+        return ToolResult(
+            content=f"Reverted work order {work_order_id} status to {previous_status}.",
+            receipt=ToolReceipt(
+                action="Reverted AppFolio work order status",
+                target=f"#{work_order_id} → {previous_status}",
+            ),
+        )
+
+    return [
+        Tool(
+            name=ToolName.APPFOLIO_UPDATE_WORK_ORDER_STATUS,
+            description="Update the status code on an AppFolio work order.",
+            function=appfolio_update_work_order_status,
+            params_model=AppFolioUpdateWorkOrderStatusParams,
+            usage_hint=(
+                "Use to mark a job in-progress, completed, or back to needs-action."
+                " Confirm the target status with the user when uncertain."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Update AppFolio work order #{args.get('work_order_id', '?')}"
+                    f" status to {args.get('status_code', '?')}"
+                ),
+            ),
+        ),
+        Tool(
+            name=ToolName.APPFOLIO_UNDO_WORK_ORDER_STATUS,
+            description="Revert a recent status change on an AppFolio work order.",
+            function=appfolio_undo_work_order_status,
+            params_model=AppFolioUndoWorkOrderStatusParams,
+            usage_hint=(
+                "Use only when the user explicitly asks to undo a status change they just made."
+            ),
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                description_builder=lambda args: (
+                    f"Revert AppFolio work order #{args.get('work_order_id', '?')}"
+                    f" status to {args.get('previous_status', '?')}"
+                ),
+            ),
+        ),
+    ]

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -687,6 +687,103 @@ async def test_resolve_customer_id_raises_when_profile_has_none() -> None:
             await service.add_work_order_note("999001", body_text="x")
 
 
+@pytest.mark.asyncio()
+async def test_update_work_order_status_sends_patch_with_customer_id() -> None:
+    """``update_work_order_status`` must PATCH the work-order endpoint with
+    the SPA-verified body shape: ``{"work_order": {"status_code": N},
+    "customer_id": "..."}``. ``customer_id`` is required by AppFolio; the
+    service falls back to the cached credential value (or resolves from
+    ``/profiles/me``) when not passed explicitly.
+
+    Regression: status updates were dropped in #1331 and reinstated when
+    vendors flagged they had lost the "mark complete" path.
+    """
+    cred = AppFolioCredential(
+        user_id="u1",
+        jwt="jwt-1",
+        fingerprint="fp-1",
+        customer_ids=["cust-9001"],
+        extra={},
+    )
+    service = AppFolioVendorService(cred, api_base="https://api.test")
+    response = _mock_response(json_data={"id": 999001, "status_code": 8})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.update_work_order_status("999001", status_code=8)
+
+    args, kwargs = client.request.call_args
+    assert args[0] == "PATCH"
+    assert args[1].endswith("/maintenance/api/work_orders/999001")
+    assert kwargs["json"] == {
+        "work_order": {"status_code": 8},
+        "customer_id": "cust-9001",
+    }
+
+
+@pytest.mark.asyncio()
+async def test_undo_work_order_status_sends_patch_to_undo_endpoint() -> None:
+    """``undo_work_order_status`` must PATCH the dedicated ``/undo_status``
+    sub-route with ``{"work_order": {"status": <prev>}, "customer_id":
+    "..."}``. AppFolio accepts either the int code or the string label for
+    ``previous_status``; the service passes through whatever the caller
+    supplied so the API-side validation stays canonical.
+    """
+    cred = AppFolioCredential(
+        user_id="u1",
+        jwt="jwt-1",
+        fingerprint="fp-1",
+        customer_ids=["cust-9001"],
+        extra={},
+    )
+    service = AppFolioVendorService(cred, api_base="https://api.test")
+    response = _mock_response(json_data={"id": 999001, "status_code": 4})
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.undo_work_order_status("999001", previous_status="in_progress")
+
+    args, kwargs = client.request.call_args
+    assert args[0] == "PATCH"
+    assert args[1].endswith("/maintenance/api/work_orders/999001/undo_status")
+    assert kwargs["json"] == {
+        "work_order": {"status": "in_progress"},
+        "customer_id": "cust-9001",
+    }
+
+
+def test_appfolio_vendor_factory_registers_status_write_tools() -> None:
+    """Registry must surface ``appfolio_update_work_order_status`` and
+    ``appfolio_undo_work_order_status`` as sub-tools of the
+    ``appfolio_vendor`` factory at ``ask`` permission.
+
+    Without these entries the LLM cannot see the tool on its schema,
+    cannot call it, and falls back to telling the user to flip status
+    manually in AppFolio — the exact regression that motivated bringing
+    these back.
+    """
+    from backend.app.agent.tools.names import ToolName
+    from backend.app.agent.tools.registry import default_registry, ensure_tool_modules_imported
+
+    ensure_tool_modules_imported()
+    sub_tools = default_registry.get_factory_sub_tools("appfolio_vendor")
+    by_name = {st.name: st for st in sub_tools}
+    update_st = by_name.get(ToolName.APPFOLIO_UPDATE_WORK_ORDER_STATUS)
+    undo_st = by_name.get(ToolName.APPFOLIO_UNDO_WORK_ORDER_STATUS)
+    assert update_st is not None, "update_work_order_status sub-tool missing from registry"
+    assert undo_st is not None, "undo_work_order_status sub-tool missing from registry"
+    assert update_st.default_permission == "ask"
+    assert undo_st.default_permission == "ask"
+
+
 def test_client_version_header_is_opaque_hex() -> None:
     """The ``X-Vendor-Portal-Web-Client`` header value must not identify
     Clawbolt to AppFolio. Match the SPA's git-SHA shape (40-char hex)."""


### PR DESCRIPTION
## Description

The trim in #1331 dropped every AppFolio write tool except notes and invoices. Vendor feedback: marking a work order complete inside the assistant is a daily need (the typical end-of-job flow is *added photos → created invoice → mark complete*), and there's no workaround except manually opening the AppFolio UI. The agent ended up telling users *"You'll need to flip that to complete in AppFolio manually"* — correct but a sharp capability regression for vendors who relied on it.

This brings back only the status surface (update + undo). The accept / schedule / message_tenant / payments / estimates / profile tools that #1331 also dropped stay out unless similar feedback surfaces.

### What's restored

| Tool | Permission | What it does |
|------|------------|--------------|
| `appfolio_update_work_order_status` | Ask | PATCH `/maintenance/api/work_orders/{id}` with `{"work_order": {"status_code": N}, "customer_id": "..."}`. Common codes: 0=new, 4=in progress, 8=complete. |
| `appfolio_undo_work_order_status` | Ask | PATCH `/maintenance/api/work_orders/{id}/undo_status` with the prior status. Accepts int code or string label; passes through unchanged. |

### Files

- `backend/app/integrations/appfolio_vendor/work_order_writes.py` — new module, scoped to the two status tools only.
- `backend/app/integrations/appfolio_vendor/params.py`, `service.py`, `factory.py`, `SKILL.md` — restore the entries #1331 removed for status tools.
- `backend/app/agent/tools/names.py` — re-add the two `ToolName` constants.
- `tests/test_appfolio_vendor.py` — three regression tests: PATCH body shape for update + undo, and registry-side wiring at `ask` permission.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — local Postgres unavailable in my sandbox; new tests are unit-level (`patch httpx.AsyncClient`) and registry-level; CI will exercise them.
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality — three regression tests covering the SPA-verified PATCH body shape, the dedicated `/undo_status` route, and the factory wiring.
- [x] Bug fixes include regression tests — n/a but covered by the new tests above.

## AI Usage
- [x] AI-assisted — diagnosed and prepared by Claude Code after a vendor reported "Marshall can't complete work orders in appfolio anymore. That's a new feature." The investigation walked from the user's complaint → approval-events audit log → identifying #1331 as the commit that removed the tool, then scoped the restoration to the minimum surface that addresses the feedback.
- [ ] No AI used