### PR TITLE
feat: move channels from sidebar into settings, move approvals from settings into sidebar

### DIFF
--- a/e2e/oss/smoke.spec.ts
+++ b/e2e/oss/smoke.spec.ts
@@ -42,7 +42,7 @@ test.describe('OSS Smoke Tests', () => {
 
     // Primary nav items (visible by default).
     await expect(page.getByRole('link', { name: /chat/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /channels/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /approvals/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /integrations/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /settings/i })).toBeVisible();
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,6 @@ const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
 const HeartbeatPage = lazy(() => import('@/pages/HeartbeatPage'));
 const SoulPage = lazy(() => import('@/pages/SoulPage'));
 const UserPage = lazy(() => import('@/pages/UserPage'));
-const ChannelsPage = lazy(() => import('@/pages/ChannelsPage'));
 const PermissionsPage = lazy(() => import('@/pages/PermissionsPage'));
 const ToolsPage = lazy(() => import('@/pages/ToolsPage'));
 const OAuthCallbackPage = lazy(() => import('@/pages/OAuthCallbackPage'));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ const HeartbeatPage = lazy(() => import('@/pages/HeartbeatPage'));
 const SoulPage = lazy(() => import('@/pages/SoulPage'));
 const UserPage = lazy(() => import('@/pages/UserPage'));
 const ChannelsPage = lazy(() => import('@/pages/ChannelsPage'));
+const PermissionsPage = lazy(() => import('@/pages/PermissionsPage'));
 const ToolsPage = lazy(() => import('@/pages/ToolsPage'));
 const OAuthCallbackPage = lazy(() => import('@/pages/OAuthCallbackPage'));
 const GetStartedPage = lazy(() => import('@/pages/GetStartedPage'));
@@ -88,12 +89,14 @@ export default function App() {
           <Route path="heartbeat" element={<HeartbeatPage />} />
           <Route path="soul" element={<SoulPage />} />
           <Route path="user" element={<UserPage />} />
-          <Route path="channels" element={<ChannelsPage />} />
-          {/* Approvals moved into Settings as a tab; redirect old bookmarks. */}
-          <Route path="permissions" element={<Navigate to="/app/settings/approvals" replace />} />
+          {/* Channels moved into Settings as a tab; redirect old bookmarks. */}
+          <Route path="channels" element={<Navigate to="/app/settings/channels" replace />} />
+          <Route path="permissions" element={<PermissionsPage />} />
           <Route path="tools" element={<ToolsPage />} />
           <Route path="oauth/callback" element={<OAuthCallbackPage />} />
           <Route path="admin" element={<AdminRoute />} />
+          {/* Approvals moved out of Settings to its own sidebar page; redirect old bookmarks. */}
+          <Route path="settings/approvals" element={<Navigate to="/app/permissions" replace />} />
           <Route path="settings/:tab" element={<SettingsPage />} />
           <Route path="settings" element={<Navigate to={`/app/settings/${getDefaultSettingsTab(isPremium)}`} replace />} />
         </Route>

--- a/frontend/src/extensions/settings.tsx
+++ b/frontend/src/extensions/settings.tsx
@@ -14,5 +14,5 @@ export function renderPremiumSettingsTab(_key: string, _isAdmin: boolean): React
 }
 
 export function showOssSettingsTabs(_isPremium: boolean, _isAdmin: boolean): string[] {
-  return ['model', 'heartbeat', 'telegram', 'approvals', 'privacy'];
+  return ['model', 'heartbeat', 'telegram', 'channels', 'privacy'];
 }

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -66,12 +66,12 @@ describe('AppShell', () => {
     await waitFor(() => {
       expect(screen.getByText('Dashboard')).toBeInTheDocument();
     });
-    expect(screen.getByText('Channels')).toBeInTheDocument();
+    expect(screen.getByText('Approvals')).toBeInTheDocument();
     expect(screen.getByText('Integrations')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
     expect(screen.getByText('Chat')).toBeInTheDocument();
     // Knowledge/Priorities/Personality/About You live under the
-    // "Personalize" fold; Approvals moved into Settings tabs.
+    // "Personalize" fold; Channels moved into Settings tabs.
     expect(screen.getByText('Personalize')).toBeInTheDocument();
     expect(screen.queryByText('Knowledge')).not.toBeInTheDocument();
   });
@@ -92,7 +92,7 @@ describe('AppShell', () => {
     expect(screen.getByText('Personality')).toBeInTheDocument();
     expect(screen.getByText('About You')).toBeInTheDocument();
     // Approvals is no longer a sidebar nav item; it's a Settings tab now.
-    expect(screen.queryByText('Approvals')).not.toBeInTheDocument();
+    expect(screen.queryByText('Channels')).not.toBeInTheDocument();
   });
 
   it('renders Dashboard first and Chat last in sidebar', async () => {
@@ -108,6 +108,15 @@ describe('AppShell', () => {
       expect(links[0]?.textContent).toContain('Dashboard');
       expect(links[links.length - 1]?.textContent).toContain('Chat');
     }
+  });
+
+  it('does not render a Channels nav link (moved into Settings tabs)', async () => {
+    renderWithRouter(<AppShell />, { route: '/app' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Approvals')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Channels')).not.toBeInTheDocument();
   });
 
   it('does not render a Conversations nav link', async () => {

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -91,7 +91,7 @@ describe('AppShell', () => {
     expect(screen.getByText('Priorities')).toBeInTheDocument();
     expect(screen.getByText('Personality')).toBeInTheDocument();
     expect(screen.getByText('About You')).toBeInTheDocument();
-    // Approvals is no longer a sidebar nav item; it's a Settings tab now.
+    // Channels is no longer a sidebar nav item; it's a Settings tab now.
     expect(screen.queryByText('Channels')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -29,8 +29,8 @@ const NAV_TOP = [
 ] as const;
 
 const NAV_MAIN = [
-  { to: '/app/channels', label: 'Channels', icon: ChannelsIcon, end: false },
   { to: '/app/tools', label: 'Integrations', icon: ToolsIcon, end: false },
+  { to: '/app/permissions', label: 'Approvals', icon: ApprovalsIcon, end: false },
   { to: '/app/settings', label: 'Settings', icon: SettingsIcon, end: false },
 ] as const;
 
@@ -405,6 +405,14 @@ function ChannelsIcon() {
   return (
     <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+    </svg>
+  );
+}
+
+function ApprovalsIcon() {
+  return (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
     </svg>
   );
 }

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -401,14 +401,6 @@ function UserIcon() {
   );
 }
 
-function ChannelsIcon() {
-  return (
-    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
-    </svg>
-  );
-}
-
 function ApprovalsIcon() {
   return (
     <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -508,7 +508,7 @@ describe('DashboardPage', () => {
     const channelsCard = screen.getByText('Channels').closest('[tabindex]');
     if (channelsCard) {
       await user.click(channelsCard);
-      expect(mockNavigate).toHaveBeenCalledWith('/app/channels');
+      expect(mockNavigate).toHaveBeenCalledWith('/app/settings/channels');
     }
   });
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -199,7 +199,7 @@ export default function DashboardPage() {
           description="Messaging platforms your assistant listens on."
           configured={channelConfigured}
           icon={<ChannelsIcon />}
-          onClick={() => navigate('/app/channels')}
+          onClick={() => navigate('/app/settings/channels')}
           isLoading={channelData.isLoading}
           isError={channelData.isError}
         >

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -248,7 +248,7 @@ export default function GetStartedPage() {
               {selectedChannel === 'none' ? (
                 <p className="text-sm text-muted-foreground mt-1">
                   You can always add a messaging channel later from the{' '}
-                  <button type="button" className="text-primary hover:underline font-medium" onClick={() => navigate('/app/channels')}>
+                  <button type="button" className="text-primary hover:underline font-medium" onClick={() => navigate('/app/settings/channels')}>
                     Channels page
                   </button>
                   .
@@ -332,7 +332,7 @@ export default function GetStartedPage() {
                               <button
                                 type="button"
                                 className="text-primary hover:underline font-medium"
-                                onClick={() => navigate('/app/channels')}
+                                onClick={() => navigate('/app/settings/channels')}
                               >
                                 set up a channel
                               </button>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -11,7 +11,7 @@ import api from '@/api';
 import { toast } from '@/lib/toast';
 import { useModelConfig, useUpdateModelConfig, useUpdateProfile, useChannelConfig, useUpdateChannelConfig } from '@/hooks/queries';
 import DataSharingConsentSection from '@/components/DataSharingConsentSection';
-import PermissionsPage from '@/pages/PermissionsPage';
+import ChannelsPage from '@/pages/ChannelsPage';
 import type { AppShellContext } from '@/layouts/AppShell';
 import {
   getExtraSettingsTabs,
@@ -41,7 +41,7 @@ export default function SettingsPage() {
     { key: 'model', label: 'Model' },
     { key: 'heartbeat', label: 'Heartbeat' },
     { key: 'telegram', label: 'Telegram' },
-    { key: 'approvals', label: 'Approvals' },
+    { key: 'channels', label: 'Channels' },
     { key: 'privacy', label: 'Privacy' },
   ].filter((t) => visibleOssKeys.includes(t.key));
   const allTabs = [...ossTabs, ...extraTabs.map((t) => ({ key: t.key, label: t.label }))];
@@ -57,7 +57,7 @@ export default function SettingsPage() {
       case 'model': return <ModelTab />;
       case 'heartbeat': return profile ? <HeartbeatTab profile={profile} /> : null;
       case 'telegram': return <TelegramTab />;
-      case 'approvals': return <PermissionsPage />;
+      case 'channels': return <ChannelsPage />;
       case 'privacy': return <PrivacyTab />;
       default: return null;
     }


### PR DESCRIPTION
## Description

Moves the Channels page out of the sidebar navigation into the Settings page as a tab, and moves the Approvals page out of Settings into the sidebar as a dedicated nav link. This better aligns with user behavior (channels are configuration, approvals are a frequently-used feature).

Closes #1353

## Changes

### Sidebar (AppShell.tsx)
- **Removed** Channels nav link from NAV_MAIN
- **Added** Approvals nav link to NAV_MAIN (routes to `/app/permissions`)

### Settings (SettingsPage.tsx)
- **Removed** Approvals tab from settings tabs
- **Added** Channels tab that renders ChannelsPage within Settings

### Routing (App.tsx)
- `/app/permissions` now renders PermissionsPage directly (was a redirect to settings)
- `/app/channels` now redirects to `/app/settings/channels` (was a standalone page)
- `/app/settings/approvals` now redirects to `/app/permissions` (was the approvals tab)

### Extension hooks
- `showOssSettingsTabs` returns `channels` instead of `approvals`

### Tests
- Updated AppShell.test.tsx to expect Approvals nav link instead of Channels
- Added regression test: 'does not render a Channels nav link (moved into Settings tabs)'

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`npx vitest run`)
- [x] New tests added for new functionality

## AI Usage
- [x] AI-assisted (implemented by pi coding agent)
