### PR TITLE
fix(receipts): stop the LLM's appended receipts from contaminating next-turn history

### DIFF
--- a/alembic/versions/037_add_llm_reply_text_to_messages.py
+++ b/alembic/versions/037_add_llm_reply_text_to_messages.py
@@ -1,0 +1,51 @@
+"""Add envelope-encrypted ``llm_reply_text`` column to messages.
+
+Captures the LLM's pre-receipt prose for outbound messages. Today,
+``messages.body`` stores the dispatched body (LLM prose plus the
+deterministic receipt block appended by ``append_receipts``). The same
+column is then read back when reconstructing conversation history for the
+LLM, which trains the model on its own past output including the receipt
+block. The model treats that as the canonical reply shape and reproduces
+the receipt bullet on its next turn, forcing a post-hoc grep dedup to
+clean up. ``llm_reply_text`` captures the LLM's prose *before* the
+receipt block is appended so the rebuild path can feed the LLM its own
+text without the feedback loop.
+
+Empty for inbound rows and for outbound rows persisted before this
+migration (``load_conversation_history`` falls back to ``body`` when the
+column is empty, preserving behavior for legacy rows).
+
+Encrypted at rest under ``EncryptedString`` like the rest of the
+user-authored content on this table: the LLM reply quotes user content
+back and would expose the same PII as ``body`` if left in plaintext.
+
+NOT NULL with a server default of empty string so existing rows
+backfill cleanly and raw-SQL inserts in older migration tests (which
+omit the column) keep working.
+
+Revision ID: 037
+Revises: 036
+Create Date: 2026-05-19
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "037"
+down_revision: str = "036"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "messages",
+        sa.Column("llm_reply_text", sa.Text(), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("messages", "llm_reply_text")

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -314,8 +314,20 @@ def _stored_messages_to_agent_messages(messages: list[Any]) -> list[AgentMessage
     history: list[AgentMessage] = []
     last_was_approval_prompt = False
     for msg in messages:
-        # Prefer processed context (includes media descriptions) over raw body
-        content = msg.processed_context if msg.processed_context else msg.body
+        if msg.direction == MessageDirection.OUTBOUND:
+            # Feed the LLM its pre-receipt prose, not the dispatched body.
+            # The dispatched body has the deterministic receipt block
+            # appended by ``append_receipts``; reading it back here on the
+            # next turn would train the model on its own appended
+            # receipts, after which it reproduces the bullet on the next
+            # write turn and the receipt grep has to clean it up
+            # post-hoc. ``llm_reply_text`` is populated by
+            # ``persist_outbound``; legacy rows (before migration 037)
+            # have it empty and fall back to ``body``.
+            content = msg.llm_reply_text or msg.body
+        else:
+            # Prefer processed context (includes media descriptions) over raw body
+            content = msg.processed_context if msg.processed_context else msg.body
         if msg.direction == MessageDirection.INBOUND:
             # Rapid-fire attachment-only messages can be batched so the
             # placeholder row is persisted with no body and no processed

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -682,7 +682,11 @@ class ClawboltAgent:
                 # this" preview hoping the LLM would skip restating it;
                 # the LLM restated it anyway and ``append_receipts``
                 # then added a second copy at dispatch, doubling every
-                # receipt block in the outbound message.
+                # receipt block in the outbound message. Migration 037
+                # also closes the cross-turn version of this loop by
+                # storing the LLM's pre-receipt prose in
+                # ``messages.llm_reply_text`` so the history rebuilder
+                # does not train the model on its own appended receipts.
             record = StoredToolInteraction(
                 tool_call_id=tc_req.id,
                 name=tool_name,

--- a/backend/app/agent/dto.py
+++ b/backend/app/agent/dto.py
@@ -55,6 +55,7 @@ class StoredMessage(BaseModel):
     processed_context: str = ""
     tool_interactions_json: str = ""
     thinking_text: str = ""
+    llm_reply_text: str = ""
     external_message_id: str = ""
     media_urls_json: str = "[]"
     timestamp: str = Field(default_factory=lambda: datetime.datetime.now(datetime.UTC).isoformat())

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -1088,12 +1088,18 @@ async def run_heartbeat_for_user(
 
         session, _ = await get_or_create_conversation(user.id)
         session_store = get_session_store(user.id)
+        # Heartbeats do not run through ``dispatch_reply_step`` so no
+        # receipt block is appended; ``body`` and ``llm_reply_text`` are
+        # the same prose. Writing both anyway keeps the column populated
+        # so the history rebuilder never has to fall back to ``body`` for
+        # heartbeat-driven turns.
         await session_store.add_message(
             session=session,
             direction=MessageDirection.OUTBOUND,
             body=reply_text,
             tool_interactions_json=tool_interactions,
             thinking_text=response.thinking_text if response else "",
+            llm_reply_text=reply_text,
         )
 
         # Record heartbeat log for persistent rate limiting

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -19,7 +19,7 @@ When a request needs several pieces of information (an estimate, a calendar even
 - Treat "estimate reasonable X" or "you decide" as explicit permission to act, not an invitation to read the values back as questions.
 
 ## After a tool performs an action
-When a tool result shows a line noting what has been appended to the user's reply, that confirmation is the source of truth for the action. Do not repeat its content in your own text. Use your reply only for what the confirmation does not carry: a next-step offer, a caveat, or a follow-up question. If the action is the whole answer, reply with a short acknowledgement or stay silent.
+Every successful write-side tool call has a confirmation block automatically appended to your reply (one line per action, formatted like "- Sent email via Gmail recipient@example.com"). The block is rendered from the tool's actual API response, not by you, so it is the source of truth for the action. Do not restate it in your prose: a bullet like "- Sent email to recipient@example.com" duplicates the appended block. Use your reply only for what the block does not carry: a next-step offer, a caveat, a follow-up question. If the action is the whole answer, reply with a short acknowledgement or stay silent.
 
 When a tool fails, no confirmation is appended. Explain plainly what went wrong so the user knows the action did not complete.
 

--- a/backend/app/agent/router.py
+++ b/backend/app/agent/router.py
@@ -426,11 +426,17 @@ async def persist_outbound(
     if response.tool_calls:
         tool_interactions = json.dumps([tc.model_dump(mode="json") for tc in response.tool_calls])
 
-    # Store the body that was actually dispatched to the user (LLM prose +
-    # any receipt block) so the DB matches what the user saw. Falls back to
-    # ``reply_text`` for code paths that bypass ``dispatch_reply_step``
-    # (heartbeats, error fallbacks).
+    # ``body`` is what the user saw (LLM prose + receipt block); falls back
+    # to ``reply_text`` for code paths that bypass ``dispatch_reply_step``
+    # (heartbeats, error fallbacks). ``llm_reply_text`` is the LLM's prose
+    # *before* the receipt block was appended, kept around so the history
+    # rebuild on the next turn can feed the LLM its own text without the
+    # receipt block (see ``backend/app/agent/context.py``). When the two
+    # are identical (no receipt was appended), we still write
+    # ``llm_reply_text`` so legacy-row fallback can distinguish "no LLM
+    # reply persisted" from "LLM reply equals body".
     body = response.dispatched_body or response.reply_text
+    llm_reply_text = response.reply_text
 
     session_store = get_session_store(user_id)
     await session_store.add_message(
@@ -439,6 +445,7 @@ async def persist_outbound(
         body=body,
         tool_interactions_json=tool_interactions,
         thinking_text=response.thinking_text,
+        llm_reply_text=llm_reply_text,
     )
 
 

--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -61,6 +61,7 @@ def _msg_to_stored(msg: Message) -> StoredMessage:
         processed_context=msg.processed_context,
         tool_interactions_json=msg.tool_interactions_json,
         thinking_text=msg.thinking_text,
+        llm_reply_text=msg.llm_reply_text,
         external_message_id=msg.external_message_id,
         media_urls_json=msg.media_urls_json,
         timestamp=ts,
@@ -230,6 +231,7 @@ _MESSAGE_UPDATABLE_FIELDS: frozenset[str] = frozenset(
         "processed_context",
         "tool_interactions_json",
         "thinking_text",
+        "llm_reply_text",
         "external_message_id",
         "media_urls_json",
     }
@@ -387,6 +389,7 @@ class SessionStore:
         processed_context: str = "",
         tool_interactions_json: str = "",
         thinking_text: str = "",
+        llm_reply_text: str = "",
         channel: str = "",
     ) -> StoredMessage:
         """Deprecated alias of :meth:`add_message_async`."""
@@ -399,6 +402,7 @@ class SessionStore:
             processed_context=processed_context,
             tool_interactions_json=tool_interactions_json,
             thinking_text=thinking_text,
+            llm_reply_text=llm_reply_text,
             channel=channel,
         )
 
@@ -412,6 +416,7 @@ class SessionStore:
         processed_context: str = "",
         tool_interactions_json: str = "",
         thinking_text: str = "",
+        llm_reply_text: str = "",
         channel: str = "",
     ) -> StoredMessage:
         """Insert a message into the database and update the in-memory session."""
@@ -444,6 +449,7 @@ class SessionStore:
                 processed_context=processed_context,
                 tool_interactions_json=tool_interactions_json,
                 thinking_text=thinking_text,
+                llm_reply_text=llm_reply_text,
                 external_message_id=external_message_id,
                 media_urls_json=media_urls_json,
                 timestamp=now,
@@ -462,6 +468,7 @@ class SessionStore:
                 processed_context=processed_context,
                 tool_interactions_json=tool_interactions_json,
                 thinking_text=thinking_text,
+                llm_reply_text=llm_reply_text,
                 external_message_id=external_message_id,
                 media_urls_json=media_urls_json,
                 timestamp=now.isoformat(),
@@ -488,6 +495,7 @@ class SessionStore:
         processed_context: str = "",
         tool_interactions_json: str = "",
         thinking_text: str = "",
+        llm_reply_text: str = "",
         channel: str = "",
     ) -> StoredMessage:
         """Deprecated alias of :meth:`add_message_by_session_id_async`."""
@@ -500,6 +508,7 @@ class SessionStore:
             processed_context=processed_context,
             tool_interactions_json=tool_interactions_json,
             thinking_text=thinking_text,
+            llm_reply_text=llm_reply_text,
             channel=channel,
         )
 
@@ -513,6 +522,7 @@ class SessionStore:
         processed_context: str = "",
         tool_interactions_json: str = "",
         thinking_text: str = "",
+        llm_reply_text: str = "",
         channel: str = "",
     ) -> StoredMessage:
         """Insert a message using only the session_id (no SessionState needed).
@@ -540,6 +550,7 @@ class SessionStore:
                 processed_context=processed_context,
                 tool_interactions_json=tool_interactions_json,
                 thinking_text=thinking_text,
+                llm_reply_text=llm_reply_text,
                 external_message_id=external_message_id,
                 media_urls_json=media_urls_json,
                 timestamp=now,
@@ -556,6 +567,7 @@ class SessionStore:
                 processed_context=processed_context,
                 tool_interactions_json=tool_interactions_json,
                 thinking_text=thinking_text,
+                llm_reply_text=llm_reply_text,
                 external_message_id=external_message_id,
                 media_urls_json=media_urls_json,
                 timestamp=now.isoformat(),

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -271,8 +271,11 @@ def append_receipts(reply_text: str, tool_calls: list[StoredToolInteraction]) ->
 # "saved", "added", "set", "moved", "named", "organized") to avoid
 # stripping legitimate user-facing prose like "Saved $5k by switching
 # estimate templates" or "Added 3 hours to the labor estimate".
-# In prod we only saw the LLM fabricate with "Created", "Scheduled",
-# "Deleted"; the rest are receipt-flavored siblings of those.
+#
+# The verb set is intentionally global rather than auto-derived from the
+# receipts in scope: the LLM frequently uses a synonym for the receipt's
+# verb (receipt says "Scheduled calendar event", LLM bullet says
+# "Created calendar event"), and the strip should catch that.
 _FABRICATED_RECEIPT_VERBS: frozenset[str] = frozenset(
     {
         "archived",
@@ -280,46 +283,76 @@ _FABRICATED_RECEIPT_VERBS: frozenset[str] = frozenset(
         "cancelled",
         "created",
         "deleted",
+        "emailed",
+        "filed",
         "modified",
+        "posted",
         "removed",
+        "replied",
         "scheduled",
+        "sent",
+        "submitted",
         "tagged",
         "updated",
         "uploaded",
     }
 )
 
-# Subject nouns the LLM uses when it fabricates a receipt-shaped bullet
-# for a calendar/photo/job/accounting action. The bullet must mention
-# at least one of these to qualify for stripping; this keeps the filter
-# conservative (an unrelated bullet like "- Saved progress for next
-# time" stays put because none of these nouns appear).
-_FABRICATED_RECEIPT_NOUNS: frozenset[str] = frozenset(
+# Stopwords pulled from receipt action strings before they become strip
+# nouns. Keeps "Sent email via Gmail" from contributing "via" as a noun.
+_RECEIPT_ACTION_STOPWORDS: frozenset[str] = frozenset(
     {
-        "appointment",
-        "bill",
-        "calendar",
-        "checklist",
-        "comment",
-        "customer",
-        "document",
-        "estimate",
-        "event",
-        "file",
-        "image",
-        "invoice",
-        "meeting",
-        "memo",
-        "note",
-        "photo",
-        "project",
-        "reminder",
-        "tag",
+        "a",
+        "an",
+        "and",
+        "as",
+        "at",
+        "by",
+        "for",
+        "from",
+        "in",
+        "of",
+        "on",
+        "or",
+        "the",
+        "to",
+        "via",
+        "with",
     }
 )
 
 _BULLET_RE = re.compile(r"^\s*-\s+(\w+)(.*)$")
 _INDENT_RE = re.compile(r"^\s{2,}\S")
+_WORD_SPLIT_RE = re.compile(r"[^\w]+")
+
+
+def _strip_nouns_from_receipts(tool_calls: list[StoredToolInteraction]) -> set[str]:
+    """Pull strip-eligible nouns out of this turn's actual receipts.
+
+    Each receipt's ``action`` string is split into words; the first word
+    is the verb and is dropped (the verb set is global, see above), and
+    the remainder contributes content nouns. Stopwords ("via", "to",
+    "for") and short tokens are filtered. Lowercased. Empty when the
+    turn produced no real receipts.
+
+    Auto-derivation replaces the hand-maintained noun list this filter
+    used to ship. New integrations (a Gmail ``Sent email via Gmail``
+    action, a future Slack ``Posted message to channel`` action) get
+    coverage for free: their action verbiage IS the strip vocabulary
+    for that turn. Conservative by construction because the match is
+    only valid against actions that actually fired in this turn, so an
+    unrelated bullet using the same noun in a non-receipt turn is left
+    alone (the outer strip is already gated on ``has_real_receipt``).
+    """
+    nouns: set[str] = set()
+    for tc in tool_calls:
+        if tc.is_error or tc.receipt is None or not tc.receipt.action:
+            continue
+        words = [w.lower() for w in _WORD_SPLIT_RE.split(tc.receipt.action) if w]
+        for word in words[1:]:  # skip the verb
+            if len(word) >= 3 and word not in _RECEIPT_ACTION_STOPWORDS:
+                nouns.add(word)
+    return nouns
 
 
 def _strip_fabricated_receipts(
@@ -332,17 +365,18 @@ def _strip_fabricated_receipts(
     receipt, so on tool-less responses (or read-only tool turns) we never
     touch the LLM's output. A bullet qualifies for stripping when it
     starts with ``-`` followed by a known write-side action verb AND
-    mentions a known subject noun (``event``, ``photo``, ``project``,
-    etc.). Any indented continuation line immediately after a stripped
-    bullet (the LLM's "Thu Apr 30, 12:00 PM" date line) is also dropped.
+    mentions a noun pulled from a real receipt that fired this turn
+    (see :func:`_strip_nouns_from_receipts`). Any indented continuation
+    line immediately after a stripped bullet (the LLM's "Thu Apr 30,
+    12:00 PM" date line) is also dropped.
 
     Trailing blank lines created by the strip are collapsed so the
     canonical receipt block joins cleanly afterward.
     """
     if not reply_text:
         return reply_text
-    has_real_receipt = any(not tc.is_error and tc.receipt is not None for tc in tool_calls)
-    if not has_real_receipt:
+    nouns = _strip_nouns_from_receipts(tool_calls)
+    if not nouns:
         return reply_text
 
     lines = reply_text.split("\n")
@@ -357,9 +391,7 @@ def _strip_fabricated_receipts(
         if match:
             verb = match.group(1).lower()
             rest = match.group(2).lower()
-            if verb in _FABRICATED_RECEIPT_VERBS and any(
-                noun in rest for noun in _FABRICATED_RECEIPT_NOUNS
-            ):
+            if verb in _FABRICATED_RECEIPT_VERBS and any(noun in rest for noun in nouns):
                 drop_indented = True
                 continue
         kept.append(line)

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -326,6 +326,17 @@ _INDENT_RE = re.compile(r"^\s{2,}\S")
 _WORD_SPLIT_RE = re.compile(r"[^\w]+")
 
 
+def _bullet_words(rest: str) -> set[str]:
+    """Lowercased word tokens from the part of a bullet after the verb.
+
+    Word-boundary tokenization keeps "Sent emails out" from matching a
+    strip noun "email" (substring) when the LLM's "emails" is a different
+    word about a different action. Mirrors the splitter used for receipt
+    actions so both sides see the same notion of "a word".
+    """
+    return {w.lower() for w in _WORD_SPLIT_RE.split(rest) if w}
+
+
 def _strip_nouns_from_receipts(tool_calls: list[StoredToolInteraction]) -> set[str]:
     """Pull strip-eligible nouns out of this turn's actual receipts.
 
@@ -390,8 +401,8 @@ def _strip_fabricated_receipts(
         match = _BULLET_RE.match(line)
         if match:
             verb = match.group(1).lower()
-            rest = match.group(2).lower()
-            if verb in _FABRICATED_RECEIPT_VERBS and any(noun in rest for noun in nouns):
+            rest_words = _bullet_words(match.group(2))
+            if verb in _FABRICATED_RECEIPT_VERBS and not rest_words.isdisjoint(nouns):
                 drop_indented = True
                 continue
         kept.append(line)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -282,18 +282,25 @@ class Message(Base):
     """A single message in a conversation, inbound or outbound.
 
     User-authored content (``body``, ``processed_context``,
-    ``tool_interactions_json``, ``thinking_text``) is envelope-encrypted
-    at rest via ``EncryptedString``. ``body`` is the raw text the user /
-    channel sent; ``processed_context`` is the same content after media
-    transcription / OCR / preprocessing; ``tool_interactions_json``
-    holds tool call args / results that frequently embed customer
-    names, phone numbers, and addresses passed to QuickBooks /
-    CompanyCam / calendar tools. ``thinking_text`` holds the LLM's
-    extended-thinking blocks for outbound messages (empty for inbound),
-    which can quote user content back at length and so receives the
-    same encryption treatment. The decrypt path runs transparently on
-    every ORM read, so application code keeps reading
-    ``msg.tool_interactions_json`` and gets plaintext JSON.
+    ``llm_reply_text``, ``tool_interactions_json``, ``thinking_text``)
+    is envelope-encrypted at rest via ``EncryptedString``. ``body`` is
+    the raw text the user / channel sent; ``processed_context`` is the
+    same content after media transcription / OCR / preprocessing;
+    ``tool_interactions_json`` holds tool call args / results that
+    frequently embed customer names, phone numbers, and addresses
+    passed to QuickBooks / CompanyCam / calendar tools.
+    ``thinking_text`` holds the LLM's extended-thinking blocks for
+    outbound messages (empty for inbound), which can quote user content
+    back at length and so receives the same encryption treatment.
+    ``llm_reply_text`` holds the LLM's outbound prose *before* the
+    deterministic receipt block was appended; ``body`` is the dispatched
+    text the user saw. The history rebuilder feeds ``llm_reply_text`` to
+    the LLM on the next turn so the model never trains on its own
+    appended receipts (see ``backend/app/agent/context.py``). Empty for
+    inbound rows and for outbound rows persisted before migration 037.
+    The decrypt path runs transparently on every ORM read, so
+    application code keeps reading ``msg.tool_interactions_json`` and
+    gets plaintext JSON.
 
     Other text columns intentionally left plaintext:
 
@@ -321,6 +328,11 @@ class Message(Base):
     )
     thinking_text: Mapped[str] = mapped_column(
         EncryptedString(table="messages", column="thinking_text"),
+        default="",
+        server_default="",
+    )
+    llm_reply_text: Mapped[str] = mapped_column(
+        EncryptedString(table="messages", column="llm_reply_text"),
         default="",
         server_default="",
     )

--- a/tests/test_conversation_continuity.py
+++ b/tests/test_conversation_continuity.py
@@ -105,6 +105,55 @@ async def test_load_history_prefers_processed_context(
 
 
 @pytest.mark.asyncio()
+async def test_load_history_outbound_uses_llm_reply_text_when_set(
+    conversation: SessionState,
+) -> None:
+    """Outbound history should feed the LLM its pre-receipt prose, not the
+    dispatched body.
+
+    The dispatched body includes the deterministic receipt block. Reading
+    it back next turn would train the model on its own appended receipts
+    and force the post-hoc grep dedup to clean up the imitation. Storing
+    ``llm_reply_text`` separately and preferring it here closes the loop.
+    """
+    conversation.messages.append(
+        StoredMessage(
+            direction="outbound",
+            body="Sent.\n\n- Sent email via Gmail jane.doe@example.com",
+            llm_reply_text="Sent.",
+            seq=1,
+        )
+    )
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=2))
+
+    history = await load_conversation_history(conversation)
+    assert len(history) == 1
+    assert history[0].content == "Sent."
+
+
+@pytest.mark.asyncio()
+async def test_load_history_outbound_falls_back_to_body_for_legacy_rows(
+    conversation: SessionState,
+) -> None:
+    """Rows persisted before migration 037 have an empty ``llm_reply_text``;
+    the rebuild path must fall back to ``body`` so legacy conversations
+    keep loading. New turns will fix forward as they get persisted."""
+    conversation.messages.append(
+        StoredMessage(
+            direction="outbound",
+            body="Got it.",
+            llm_reply_text="",
+            seq=1,
+        )
+    )
+    conversation.messages.append(StoredMessage(direction="inbound", body="Current", seq=2))
+
+    history = await load_conversation_history(conversation)
+    assert len(history) == 1
+    assert history[0].content == "Got it."
+
+
+@pytest.mark.asyncio()
 async def test_load_history_skips_blank_inbound_placeholder_rows(
     conversation: SessionState,
 ) -> None:

--- a/tests/test_session_db_async.py
+++ b/tests/test_session_db_async.py
@@ -193,6 +193,37 @@ async def test_add_message_async_round_trips_thinking_text(
     )
 
 
+async def test_add_message_async_round_trips_llm_reply_text(
+    async_db: async_sessionmaker,
+) -> None:
+    """Outbound messages persist and re-read the pre-receipt LLM prose.
+
+    ``body`` and ``llm_reply_text`` are stored independently so the
+    history rebuilder can feed the LLM its own pre-receipt text on the
+    next turn without the appended receipt block contaminating its
+    context (see ``backend/app/agent/context.py``). This test pins both:
+    the column survives the round-trip through ``EncryptedString``, and
+    the DTO carries the value back to callers without a reload.
+    """
+    user_id = await _create_user(async_db)
+    store = SessionStore(user_id)
+    session, _ = await store.get_or_create_session_async()
+
+    saved = await store.add_message_async(
+        session,
+        direction="outbound",
+        body="Sent.\n\n- Sent email via Gmail jane.doe@example.com",
+        llm_reply_text="Sent.",
+    )
+    assert saved.body == "Sent.\n\n- Sent email via Gmail jane.doe@example.com"
+    assert saved.llm_reply_text == "Sent."
+
+    reloaded = await store.load_session_async(session.session_id)
+    assert reloaded is not None
+    assert reloaded.messages[-1].body == ("Sent.\n\n- Sent email via Gmail jane.doe@example.com")
+    assert reloaded.messages[-1].llm_reply_text == "Sent."
+
+
 async def test_add_message_by_session_id_async_assigns_seq_independently(
     async_db: async_sessionmaker,
 ) -> None:

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -224,6 +224,66 @@ def test_append_strips_multiple_fabricated_bullets() -> None:
     assert body.startswith("Both reminders are set.")
 
 
+def test_append_strips_gmail_fabricated_bullet() -> None:
+    """Regression: Jesse's transcript shipped "- Sent email to X" right next
+    to the canonical "- Sent email via Gmail X" because "sent" / "email"
+    weren't in the hand-maintained strip vocabulary. After switching to
+    auto-derived nouns (and adding "sent" to the global verb set), the
+    fabricated bullet gets caught."""
+    body = append_receipts(
+        ("Sent.\n\n- Sent email to jane.doe@example.com"),
+        [
+            _tc_with_receipt(
+                "gmail_send",
+                action="Sent email via Gmail",
+                target="jane.doe@example.com",
+            )
+        ],
+    )
+    assert "- Sent email to jane.doe@example.com" not in body
+    assert body.count("- Sent email via Gmail jane.doe@example.com") == 1
+    assert body.startswith("Sent.")
+
+
+def test_strip_nouns_auto_derive_from_novel_action() -> None:
+    """A brand-new write-side tool with an unfamiliar action verb / noun
+    pair still gets a working strip on its first occurrence. No
+    per-integration maintenance on the strip vocabulary required."""
+    body = append_receipts(
+        ("Done.\n\n- Posted update to project channel #remodel-jobs"),
+        [
+            _tc_with_receipt(
+                "slack_post",
+                action="Posted Slack channel update",
+                target="#remodel-jobs",
+            )
+        ],
+    )
+    # Auto-derived nouns from "Posted Slack channel update" include
+    # "channel" and "update", and "posted" is in the verb set.
+    assert "- Posted update to project channel" not in body
+    assert "- Posted Slack channel update #remodel-jobs" in body
+
+
+def test_strip_skips_stopwords_in_receipt_action() -> None:
+    """Stopwords ("via", "to") in the receipt action must not become
+    strip nouns. Otherwise a bullet like "- Created a quick note for the
+    team" would be stripped just because "for" appeared in the action
+    "Sent email via Gmail" or similar."""
+    body = append_receipts(
+        ("All set.\n\n- Created a quick note for the team"),
+        [
+            _tc_with_receipt(
+                "gmail_send",
+                action="Sent email via Gmail",
+                target="team@example.com",
+            )
+        ],
+    )
+    # The bullet stays — "for" is a stopword, not a strip noun.
+    assert "- Created a quick note for the team" in body
+
+
 def test_append_strips_delete_fabricated_bullet() -> None:
     """The LLM also fabricates "Deleted Google Calendar event:" lines for
     cancellations. Same scrub should catch them."""

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -280,8 +280,31 @@ def test_strip_skips_stopwords_in_receipt_action() -> None:
             )
         ],
     )
-    # The bullet stays — "for" is a stopword, not a strip noun.
+    # The bullet stays, "for" is a stopword, not a strip noun.
     assert "- Created a quick note for the team" in body
+
+
+def test_strip_uses_word_boundaries_not_substring() -> None:
+    """A bullet whose words only substring-match a strip noun must
+    survive. Auto-derived nouns can be short (e.g. "email"), so substring
+    matching would falsely strip a legitimate caveat like "- Sent emails
+    to the team yesterday" (plural "emails" contains "email") whenever a
+    Gmail receipt fires this turn.
+    """
+    body = append_receipts(
+        ("Sent.\n\n- Sent emails to the team yesterday already"),
+        [
+            _tc_with_receipt(
+                "gmail_send",
+                action="Sent email via Gmail",
+                target="jane.doe@example.com",
+            )
+        ],
+    )
+    # Bullet stays: "emails" is a distinct word from the strip noun "email".
+    assert "- Sent emails to the team yesterday already" in body
+    # And the canonical receipt is still appended below.
+    assert "- Sent email via Gmail jane.doe@example.com" in body
 
 
 def test_append_strips_delete_fabricated_bullet() -> None:


### PR DESCRIPTION
## Description

A user on clawbolt.ai received this reply after asking the agent to send an email via Gmail:

```
Sent.

- Sent email to jane.doe@example.com

- Sent email via Gmail jane.doe@example.com
```

Two near-identical bullets, one fabricated by the LLM, one the canonical receipt block appended by `append_receipts`. Tracing why revealed two issues stacked on each other:

1. **In-context-learning feedback loop.** `messages.body` was doubling as (a) what the user saw and (b) what the LLM saw on the next turn for context rebuild. Outbound rows had the deterministic receipt block appended before being persisted, so on every subsequent turn the LLM was trained on its own appended receipts and reproduced the bullet on the next write turn. The grep-based `_strip_fabricated_receipts` then had to clean up the imitation post-hoc.
2. **Brittle strip vocabulary.** The strip relied on hand-maintained `_FABRICATED_RECEIPT_VERBS` and `_FABRICATED_RECEIPT_NOUNS` constants. Neither included "sent" or "email", so Gmail's `"Sent email via Gmail"` action sailed through the filter. Every new write-side tool needs a manual update to both lists.

This PR addresses both.

### 1. Split `body` and `llm_reply_text`

Migration 037 adds an encrypted `llm_reply_text` column to `messages`. `persist_outbound` writes both fields: `body` is the dispatched text the user saw, `llm_reply_text` is the LLM's prose before `append_receipts` ran. `_stored_messages_to_agent_messages` feeds `llm_reply_text` (falling back to `body` for pre-migration rows) on the rebuild path, so the LLM never trains on its own appended receipts again.

User-facing paths (admin views, outbound bus, replay) keep reading `body`. No change there.

### 2. Auto-derive strip nouns from this turn's receipts

`_FABRICATED_RECEIPT_NOUNS` is deleted. A new helper pulls content nouns out of each `ToolReceipt.action` string (stopwords filtered, short tokens dropped). New write-side tools get coverage for free without touching this file.

The verb list stays global because the LLM uses verb synonyms ("Created" for a "Scheduled" receipt was the original calendar regression in #1078). `"sent"`, `"emailed"`, `"posted"`, `"replied"`, `"submitted"`, `"filed"` added.

A follow-up commit on this branch switches the bullet match from substring to word-boundary tokenization. Auto-derived nouns can be short (e.g. "email") and a substring match would falsely strip "- Sent emails to the team" when the strip noun was "email".

### 3. `instructions.md` cleanup

The "When a tool result shows a line noting what has been appended..." line referenced a feature that was removed in #1078. Rewritten to describe what actually happens (a server-rendered confirmation block gets appended) and the failure mode it's trying to prevent.

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`), 2778 passed / 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

New tests:
- `test_session_db_async.py` round-trip for the new column
- `test_conversation_continuity.py` outbound history uses `llm_reply_text`, plus legacy-row fallback to `body`
- `test_tool_summary.py` Jesse's exact Gmail fabrication is stripped, a novel "Posted Slack channel update" action auto-derives a working strip, stopwords in receipt actions don't bleed into the strip vocabulary, word-boundary tokenization keeps "- Sent emails" alone when the strip noun is "email"

## AI Usage
- [x] AI-assisted (Claude Opus drafted the implementation and tests; design decisions and review by @njbrake)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)