### PR TITLE
fix(frontend): differentiate Admin sidebar icon from Approvals

### DIFF
--- a/frontend/src/extensions/nav.test.tsx
+++ b/frontend/src/extensions/nav.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import { createElement } from 'react';
 import { getExtraNavItems } from '@/extensions/nav';
 
 const APPROVALS_SHIELD_CHECK_PATH_PREFIX = 'M9 12l2 2 4-4';
@@ -14,7 +13,7 @@ describe('getExtraNavItems', () => {
   it('renders the Admin icon with a different SVG path than the Approvals shield-check', () => {
     const items = getExtraNavItems(false, true);
     const Icon = items[0]!.icon;
-    const { container } = render(createElement(Icon));
+    const { container } = render(<Icon />);
     const path = container.querySelector('path')?.getAttribute('d') ?? '';
     expect(path).not.toBe('');
     expect(path.startsWith(APPROVALS_SHIELD_CHECK_PATH_PREFIX)).toBe(false);

--- a/frontend/src/extensions/nav.test.tsx
+++ b/frontend/src/extensions/nav.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+import { getExtraNavItems } from '@/extensions/nav';
+
+const APPROVALS_SHIELD_CHECK_PATH_PREFIX = 'M9 12l2 2 4-4';
+
+describe('getExtraNavItems', () => {
+  it('returns an Admin nav item pointing at /app/admin', () => {
+    const items = getExtraNavItems(false, true);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ to: '/app/admin', label: 'Admin' });
+  });
+
+  it('renders the Admin icon with a different SVG path than the Approvals shield-check', () => {
+    const items = getExtraNavItems(false, true);
+    const Icon = items[0]!.icon;
+    const { container } = render(createElement(Icon));
+    const path = container.querySelector('path')?.getAttribute('d') ?? '';
+    expect(path).not.toBe('');
+    expect(path.startsWith(APPROVALS_SHIELD_CHECK_PATH_PREFIX)).toBe(false);
+  });
+});

--- a/frontend/src/extensions/nav.ts
+++ b/frontend/src/extensions/nav.ts
@@ -8,7 +8,7 @@ export interface NavExtensionItem {
   onClick?: () => void;
 }
 
-function ShieldIcon() {
+function AdminIcon() {
   return createElement(
     'svg',
     {
@@ -21,7 +21,7 @@ function ShieldIcon() {
       strokeLinecap: 'round',
       strokeLinejoin: 'round',
       strokeWidth: 1.5,
-      d: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+      d: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
     }),
   );
 }
@@ -30,5 +30,5 @@ export function getExtraNavItems(
   _isPremium: boolean,
   _isAdmin: boolean,
 ): NavExtensionItem[] {
-  return [{ to: '/app/admin', label: 'Admin', icon: ShieldIcon }];
+  return [{ to: '/app/admin', label: 'Admin', icon: AdminIcon }];
 }


### PR DESCRIPTION
## Description

The Admin nav extension (`frontend/src/extensions/nav.ts`) and the Approvals nav item (`frontend/src/layouts/AppShell.tsx`) both rendered the exact same shield-with-check SVG path. Admins saw two visually identical glyphs side-by-side in the sidebar.

This PR swaps the Admin icon to a user-group glyph (Heroicons outline) so the two items are clearly distinct at nav size. Approvals keeps the shield-with-check, which still reads as "verified/approved". Includes a regression test that pins the rendered SVG path away from the shield-check prefix so a future revert would fail the suite.

Note: `clawbolt-premium/frontend/src/extensions/nav.ts` is a near-verbatim copy that fully overrides `getExtraNavItems`, so premium will need a parallel change (or, better, the nav extension should be lifted into OSS and imported, per CLAUDE.md's no-duplication rule). Filing that as a follow-up rather than bundling here.

Fixes #1357

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Authored via Claude Code: explored the OSS frontend to locate both icons, picked a distinct user-group glyph for Admin, added a unit test that asserts the rendered SVG path differs from the shield-check signature, and visually verified both glyphs side-by-side via a Playwright screenshot.