### PR TITLE
refactor(frontend): extract admin nav item into a shared module

### DIFF
--- a/frontend/src/extensions/admin-nav-item.ts
+++ b/frontend/src/extensions/admin-nav-item.ts
@@ -1,0 +1,34 @@
+import { createElement, type ComponentType } from 'react';
+
+export interface NavExtensionItem {
+  to: string;
+  label: string;
+  icon: ComponentType;
+  /** Fired in addition to navigation, so extensions can reset internal state (e.g. hash-routed tabs). */
+  onClick?: () => void;
+}
+
+function AdminIcon() {
+  return createElement(
+    'svg',
+    {
+      className: 'w-5 h-5 shrink-0',
+      fill: 'none',
+      stroke: 'currentColor',
+      viewBox: '0 0 24 24',
+    },
+    createElement('path', {
+      strokeLinecap: 'round',
+      strokeLinejoin: 'round',
+      strokeWidth: 1.5,
+      d: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
+    }),
+  );
+}
+
+/** Shared admin nav item. Premium imports this and adds an isAdmin gate. */
+export const ADMIN_NAV_ITEM: NavExtensionItem = {
+  to: '/app/admin',
+  label: 'Admin',
+  icon: AdminIcon,
+};

--- a/frontend/src/extensions/nav.test.tsx
+++ b/frontend/src/extensions/nav.test.tsx
@@ -1,21 +1,26 @@
 import { render } from '@testing-library/react';
+import { ADMIN_NAV_ITEM } from '@/extensions/admin-nav-item';
 import { getExtraNavItems } from '@/extensions/nav';
 
 const APPROVALS_SHIELD_CHECK_PATH_PREFIX = 'M9 12l2 2 4-4';
 
-describe('getExtraNavItems', () => {
-  it('returns an Admin nav item pointing at /app/admin', () => {
-    const items = getExtraNavItems(false, true);
-    expect(items).toHaveLength(1);
-    expect(items[0]).toMatchObject({ to: '/app/admin', label: 'Admin' });
+describe('ADMIN_NAV_ITEM', () => {
+  it('points at /app/admin and is labeled Admin', () => {
+    expect(ADMIN_NAV_ITEM).toMatchObject({ to: '/app/admin', label: 'Admin' });
   });
 
-  it('renders the Admin icon with a different SVG path than the Approvals shield-check', () => {
-    const items = getExtraNavItems(false, true);
-    const Icon = items[0]!.icon;
+  it('renders an icon whose SVG path is not the Approvals shield-check', () => {
+    const Icon = ADMIN_NAV_ITEM.icon;
     const { container } = render(<Icon />);
     const path = container.querySelector('path')?.getAttribute('d') ?? '';
     expect(path).not.toBe('');
     expect(path.startsWith(APPROVALS_SHIELD_CHECK_PATH_PREFIX)).toBe(false);
+  });
+});
+
+describe('getExtraNavItems', () => {
+  it('returns the shared admin nav item', () => {
+    const items = getExtraNavItems(false, true);
+    expect(items).toEqual([ADMIN_NAV_ITEM]);
   });
 });

--- a/frontend/src/extensions/nav.ts
+++ b/frontend/src/extensions/nav.ts
@@ -1,34 +1,10 @@
-import { createElement, type ComponentType } from 'react';
+import { ADMIN_NAV_ITEM, type NavExtensionItem } from './admin-nav-item';
 
-export interface NavExtensionItem {
-  to: string;
-  label: string;
-  icon: ComponentType;
-  /** Fired in addition to navigation, so extensions can reset internal state (e.g. hash-routed tabs). */
-  onClick?: () => void;
-}
-
-function AdminIcon() {
-  return createElement(
-    'svg',
-    {
-      className: 'w-5 h-5 shrink-0',
-      fill: 'none',
-      stroke: 'currentColor',
-      viewBox: '0 0 24 24',
-    },
-    createElement('path', {
-      strokeLinecap: 'round',
-      strokeLinejoin: 'round',
-      strokeWidth: 1.5,
-      d: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
-    }),
-  );
-}
+export type { NavExtensionItem };
 
 export function getExtraNavItems(
   _isPremium: boolean,
   _isAdmin: boolean,
 ): NavExtensionItem[] {
-  return [{ to: '/app/admin', label: 'Admin', icon: AdminIcon }];
+  return [ADMIN_NAV_ITEM];
 }


### PR DESCRIPTION
## Description

Pre-work for fixing issue #1357 on the premium side too. After PR #1360 swapped OSS's Admin icon to a user-group glyph, the premium overlay still ships its own near-verbatim copy of `nav.ts` (with the original shield-with-check). The fix didn't reach the audience the issue actually targets (premium admins) because of that duplication.

This PR pulls the shared parts of OSS's nav extension into a new module so premium can import them instead of re-declaring:

- New `frontend/src/extensions/admin-nav-item.ts`
  - `NavExtensionItem` interface (moved here from `nav.ts`)
  - private `AdminIcon` (the user-group SVG)
  - exported `ADMIN_NAV_ITEM` constant
- `frontend/src/extensions/nav.ts`
  - re-exports `NavExtensionItem` (unchanged public API via `extensions/index.ts`)
  - `getExtraNavItems` now returns `[ADMIN_NAV_ITEM]`
- `frontend/src/extensions/nav.test.tsx`
  - adds two tests covering `ADMIN_NAV_ITEM` directly (label/route, rendered SVG path)
  - tightens the existing `getExtraNavItems` test to assert it returns the shared item

No runtime behavior change in OSS. The followup premium PR bumps `OSS_REF`, deletes the duplicated `ShieldIcon` + `NavExtensionItem`, and imports `ADMIN_NAV_ITEM`, which is what visibly fixes #1357 for premium admins.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Authored via Claude Code: drove the design (split the shared icon/interface into its own module so premium can import instead of duplicating), implemented, ran frontend DoD (typecheck, deadcode, vitest) locally.