### PR TITLE
fix(storage): resolve files by canonical clawbolt_path appProperty

### DIFF
--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -429,7 +429,7 @@ class GoogleDriveStorage(StorageBackend):
             from_parent_ids = list(payload.get("parents") or [])
         if file_id is None:
             # Fallback: locate the file via its folder + name. Source folder
-            # must already exist -- never auto-create it, that would just
+            # must already exist. Never auto-create it, that would just
             # silently pollute the user's Drive with empty folders on a
             # NOT_FOUND.
             from_folder_id = await self._resolve_existing_path(from_path)
@@ -589,7 +589,7 @@ class GoogleDriveStorage(StorageBackend):
 
         canonical = f"/{normalized}"
         # Primary: canonical clawbolt_path lookup. Same robustness story as
-        # get_file -- a file whose folder was renamed still downloads.
+        # get_file: a file whose folder was renamed still downloads.
         payload = await self._find_by_app_path(canonical)
         file_id: str | None = payload.get("id") if payload is not None else None
         service = self._get_service()

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -276,6 +276,36 @@ class GoogleDriveStorage(StorageBackend):
 
         return current_id
 
+    async def _find_by_app_path(self, path: str) -> dict[str, Any] | None:
+        """Look up a file by its canonical ``clawbolt_path`` appProperty.
+
+        Drive's appProperties query supports exact-match on (key, value)
+        pairs, which makes this the natural way to resolve a path that
+        was minted by :meth:`upload_file` or :meth:`move_file`. Independent
+        of folder structure, folder name case, and the in-process
+        ``_folder_cache`` state, so it succeeds for files whose containing
+        folder was renamed or whose parent the folder cache forgot about.
+        Returns the raw payload (so callers can read ``parents`` for a
+        precise move) or ``None`` when no file is tagged with that path.
+        """
+        if not path:
+            return None
+        service = self._get_service()
+        normalized = path if path.startswith("/") else f"/{path.strip('/')}"
+        safe_value = normalized.replace("\\", "\\\\").replace("'", "\\'")
+        query = (
+            f"appProperties has {{ key='{_DRIVE_PATH_PROPERTY}' and value='{safe_value}' }}"
+            " and trashed=false"
+        )
+        result = await self._execute_with_retry(
+            lambda: service.files().list(
+                q=query, fields=f"files({_DRIVE_FILE_FIELDS})", pageSize=1
+            ),
+            op="find_by_app_path",
+        )
+        files = result.get("files", [])
+        return files[0] if files else None
+
     async def _resolve_existing_path(self, path: str) -> str | None:
         """Translate a human-readable path to an existing Google Drive folder ID."""
         parts = [p for p in path.strip("/").split("/") if p]
@@ -386,32 +416,60 @@ class GoogleDriveStorage(StorageBackend):
     async def move_file(
         self, from_path: str, from_filename: str, to_path: str, to_filename: str
     ) -> SavedFile:
-        from_folder_id = await self._resolve_path(from_path)
+        # Primary lookup by canonical clawbolt_path. Returns the file's
+        # actual current parents, so the removeParents we pass to update()
+        # matches reality even if the source folder was renamed or the
+        # folder cache is stale.
+        canonical_from = self._normalized_path(from_path, from_filename)
+        payload = await self._find_by_app_path(canonical_from)
+        from_parent_ids: list[str] = []
+        file_id: str | None = None
+        if payload is not None:
+            file_id = payload.get("id")
+            from_parent_ids = list(payload.get("parents") or [])
+        if file_id is None:
+            # Fallback: locate the file via its folder + name. Source folder
+            # must already exist -- never auto-create it, that would just
+            # silently pollute the user's Drive with empty folders on a
+            # NOT_FOUND.
+            from_folder_id = await self._resolve_existing_path(from_path)
+            if from_folder_id is None:
+                msg = f"File not found: {from_filename} in {from_path}"
+                raise FileNotFoundError(msg)
+            service = self._get_service()
+            safe_name = from_filename.replace("\\", "\\\\").replace("'", "\\'")
+            query = f"name='{safe_name}' and '{from_folder_id}' in parents and trashed=false"
+            result = await self._execute_with_retry(
+                lambda: service.files().list(q=query, fields="files(id,name,parents)"),
+                op="move_file.list",
+            )
+            files = result.get("files", [])
+            if not files:
+                msg = f"File not found: {from_filename} in {from_path}"
+                raise FileNotFoundError(msg)
+            file_id = files[0]["id"]
+            from_parent_ids = list(files[0].get("parents") or [from_folder_id])
+
         to_folder_id = await self._resolve_path(to_path)
-        service = self._get_service()
-        safe_name = from_filename.replace("\\", "\\\\").replace("'", "\\'")
-        query = f"name='{safe_name}' and '{from_folder_id}' in parents and trashed=false"
-        result = await self._execute_with_retry(
-            lambda: service.files().list(q=query, fields="files(id,name)"),
-            op="move_file.list",
-        )
-        files = result.get("files", [])
-        if not files:
-            msg = f"File not found: {from_filename} in {from_path}"
-            raise FileNotFoundError(msg)
-        file_id = files[0]["id"]
         new_path = self._normalized_path(to_path, to_filename)
+        service = self._get_service()
+        # Drop every current parent so the file lands cleanly under the new
+        # one. Passing the cached from_folder_id alone would be a no-op when
+        # the file's real parent differs from what the caller assumed.
+        remove_parents = ",".join(from_parent_ids) if from_parent_ids else None
+        update_kwargs: dict[str, Any] = {
+            "fileId": file_id,
+            "body": {
+                "name": to_filename,
+                "appProperties": {_DRIVE_PATH_PROPERTY: new_path},
+            },
+            "addParents": to_folder_id,
+            "fields": _DRIVE_FILE_FIELDS,
+        }
+        if remove_parents:
+            update_kwargs["removeParents"] = remove_parents
         update_result = await self._execute_with_retry(
-            lambda: service.files().update(
-                fileId=file_id,
-                body={
-                    "name": to_filename,
-                    "appProperties": {_DRIVE_PATH_PROPERTY: new_path},
-                },
-                addParents=to_folder_id,
-                removeParents=from_folder_id,
-                fields=_DRIVE_FILE_FIELDS,
-            ),
+            lambda: service.files().update(**update_kwargs),
             op="move_file.update",
         )
         return self._from_drive_file(update_result, fallback_path=new_path)
@@ -436,7 +494,16 @@ class GoogleDriveStorage(StorageBackend):
         return files
 
     async def get_file(self, path: str) -> SavedFile | None:
-        normalized = path.strip("/")
+        canonical = path if path.startswith("/") else f"/{path.strip('/')}"
+        # Primary: exact-match the canonical ``clawbolt_path`` appProperty.
+        # Robust to folder renames in Drive and to ``_folder_cache`` misses
+        # that would otherwise turn an existing file into a NOT_FOUND.
+        payload = await self._find_by_app_path(canonical)
+        if payload is not None:
+            return self._from_drive_file(payload, fallback_path=canonical)
+        # Fallback: legacy folder-walk + name match. Catches files whose
+        # appProperty was never set (pre-cutover uploads) or got cleared.
+        normalized = canonical.strip("/")
         if not normalized or "/" not in normalized:
             folder_path, filename = "", normalized
         else:
@@ -456,7 +523,7 @@ class GoogleDriveStorage(StorageBackend):
         files = result.get("files", [])
         if not files:
             return None
-        return self._from_drive_file(files[0], fallback_path=f"/{normalized}")
+        return self._from_drive_file(files[0], fallback_path=canonical)
 
     async def search_files(self, query: str = "", limit: int = 10) -> list[SavedFile]:
         bounded = max(1, min(limit, 100))
@@ -520,25 +587,31 @@ class GoogleDriveStorage(StorageBackend):
             msg = "Cannot download a folder path from Google Drive."
             raise FileNotFoundError(msg)
 
-        folder_path, filename = normalized.rsplit("/", 1) if "/" in normalized else ("", normalized)
-        folder_id = await self._resolve_existing_path(folder_path)
-        if folder_id is None:
-            msg = f"Google Drive folder not found for {path!r}"
-            raise FileNotFoundError(msg)
-
+        canonical = f"/{normalized}"
+        # Primary: canonical clawbolt_path lookup. Same robustness story as
+        # get_file -- a file whose folder was renamed still downloads.
+        payload = await self._find_by_app_path(canonical)
+        file_id: str | None = payload.get("id") if payload is not None else None
         service = self._get_service()
-        safe_name = filename.replace("\\", "\\\\").replace("'", "\\'")
-        query = f"name='{safe_name}' and '{folder_id}' in parents and trashed=false"
-        result = await self._execute_with_retry(
-            lambda: service.files().list(q=query, fields="files(id)", pageSize=1),
-            op="download_file.list",
-        )
-        files = result.get("files", [])
-        if not files:
-            msg = f"File not found in Google Drive: {path}"
-            raise FileNotFoundError(msg)
-
-        file_id = files[0]["id"]
+        if file_id is None:
+            folder_path, filename = (
+                normalized.rsplit("/", 1) if "/" in normalized else ("", normalized)
+            )
+            folder_id = await self._resolve_existing_path(folder_path)
+            if folder_id is None:
+                msg = f"Google Drive folder not found for {path!r}"
+                raise FileNotFoundError(msg)
+            safe_name = filename.replace("\\", "\\\\").replace("'", "\\'")
+            query = f"name='{safe_name}' and '{folder_id}' in parents and trashed=false"
+            result = await self._execute_with_retry(
+                lambda: service.files().list(q=query, fields="files(id)", pageSize=1),
+                op="download_file.list",
+            )
+            files = result.get("files", [])
+            if not files:
+                msg = f"File not found in Google Drive: {path}"
+                raise FileNotFoundError(msg)
+            file_id = files[0]["id"]
         try:
             data = await self._execute_with_retry(
                 lambda: service.files().get_media(fileId=file_id),

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -268,7 +268,7 @@ async def test_gdrive_get_file_falls_back_to_app_property_when_folder_walk_fails
     s._service = mock_drive_service
     s._folder_cache[ROOT_FOLDER_NAME] = "root-folder-id"
     # Cache is empty for the client folder, and the folder-walk query is
-    # rigged to find nothing -- the renamed-in-Drive case.
+    # rigged to find nothing, mirroring the renamed-in-Drive case.
     file_payload = {
         "id": "file-xyz",
         "name": "receipt_001.jpg",
@@ -300,7 +300,7 @@ async def test_gdrive_move_file_uses_actual_parents_for_remove(
 
     When a folder gets renamed (or the from_path resolves to a stale
     folder id), passing the cached ``from_folder_id`` as ``removeParents``
-    is a silent no-op -- the file ends up in both the old AND the new
+    is a silent no-op, and the file ends up in both the old AND the new
     folder. Using the file's actual current parents (read from the
     appProperty lookup) keeps the move atomic.
     """

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -250,6 +250,116 @@ async def test_gdrive_move_file_not_found(
 
 
 @pytest.mark.asyncio()
+async def test_gdrive_get_file_falls_back_to_app_property_when_folder_walk_fails(
+    mock_drive_service: MagicMock,
+) -> None:
+    """Folder rename (or any folder-walk miss) must not turn an existing file into NOT_FOUND.
+
+    Regression for issue #1364: a user moved their folder around in Drive
+    (or the per-turn ``_folder_cache`` never learned about it), and the
+    legacy ``get_file`` -> ``_resolve_existing_path`` -> ``_find_folder``
+    chain returned ``None`` even though the file was still tagged with the
+    canonical ``clawbolt_path`` appProperty. ``move_file`` then surfaced
+    "File not found at <path>" through the pre-check in ``file_tools``.
+    Looking up by appProperty first uses the same handle the upload wrote,
+    so the file resolves regardless of folder structure drift.
+    """
+    s = GoogleDriveStorage(_drive_credentials())
+    s._service = mock_drive_service
+    s._folder_cache[ROOT_FOLDER_NAME] = "root-folder-id"
+    # Cache is empty for the client folder, and the folder-walk query is
+    # rigged to find nothing -- the renamed-in-Drive case.
+    file_payload = {
+        "id": "file-xyz",
+        "name": "receipt_001.jpg",
+        "parents": ["renamed-parent-id"],
+        "appProperties": {"clawbolt_path": "/John Smith - 123 Main/documents/receipt_001.jpg"},
+        "webViewLink": "https://drive.google.com/file/d/xyz/view",
+    }
+
+    def list_side_effect(*, q: str, **_kwargs: object) -> object:
+        if "appProperties has" in q and "receipt_001.jpg" in q:
+            return MagicMock(execute=MagicMock(return_value={"files": [file_payload]}))
+        # Every folder-walk / name-match query misses.
+        return MagicMock(execute=MagicMock(return_value={"files": []}))
+
+    mock_drive_service.files.return_value.list.side_effect = list_side_effect
+
+    saved = await s.get_file("/John Smith - 123 Main/documents/receipt_001.jpg")
+    assert saved is not None
+    assert saved.path == "/John Smith - 123 Main/documents/receipt_001.jpg"
+    assert saved.name == "receipt_001.jpg"
+    assert saved.metadata.get("id") == "file-xyz"
+
+
+@pytest.mark.asyncio()
+async def test_gdrive_move_file_uses_actual_parents_for_remove(
+    mock_drive_service: MagicMock,
+) -> None:
+    """removeParents must come from the file's real Drive metadata, not the cached source folder.
+
+    When a folder gets renamed (or the from_path resolves to a stale
+    folder id), passing the cached ``from_folder_id`` as ``removeParents``
+    is a silent no-op -- the file ends up in both the old AND the new
+    folder. Using the file's actual current parents (read from the
+    appProperty lookup) keeps the move atomic.
+    """
+    s = GoogleDriveStorage(_drive_credentials())
+    s._service = mock_drive_service
+    s._folder_cache[ROOT_FOLDER_NAME] = "root-folder-id"
+    s._folder_cache[f"{ROOT_FOLDER_NAME}/dest-folder"] = "dest-folder-id"
+    file_payload = {
+        "id": "file-abc",
+        "name": "file_001.jpg",
+        "parents": ["actual-parent-id"],
+        "appProperties": {"clawbolt_path": "/src-folder/file_001.jpg"},
+    }
+
+    def list_side_effect(*, q: str, **_kwargs: object) -> object:
+        if "appProperties has" in q:
+            return MagicMock(execute=MagicMock(return_value={"files": [file_payload]}))
+        return MagicMock(execute=MagicMock(return_value={"files": []}))
+
+    mock_drive_service.files.return_value.list.side_effect = list_side_effect
+    mock_drive_service.files.return_value.update.return_value.execute.return_value = {
+        "id": "file-abc",
+        "webViewLink": "https://drive.google.com/file/d/abc/view",
+    }
+
+    moved = await s.move_file("src-folder", "file_001.jpg", "dest-folder", "file_001.jpg")
+
+    assert moved.metadata.get("id") == "file-abc"
+    update_call = mock_drive_service.files.return_value.update.call_args
+    assert update_call is not None
+    # removeParents pulls from the payload's ``parents``, not the cached
+    # source folder id we never had to begin with.
+    assert update_call.kwargs.get("removeParents") == "actual-parent-id"
+    assert update_call.kwargs.get("addParents") == "dest-folder-id"
+
+
+@pytest.mark.asyncio()
+async def test_gdrive_download_file_falls_back_to_app_property(
+    mock_drive_service: MagicMock,
+) -> None:
+    """download_file must reach files whose folder walk fails but appProperty is intact."""
+    s = GoogleDriveStorage(_drive_credentials())
+    s._service = mock_drive_service
+    s._folder_cache[ROOT_FOLDER_NAME] = "root-folder-id"
+
+    def list_side_effect(*, q: str, **_kwargs: object) -> object:
+        if "appProperties has" in q:
+            return MagicMock(execute=MagicMock(return_value={"files": [{"id": "file-xyz"}]}))
+        return MagicMock(execute=MagicMock(return_value={"files": []}))
+
+    mock_drive_service.files.return_value.list.side_effect = list_side_effect
+
+    content = await s.download_file("/Client/photo.jpg")
+
+    assert content == b"drive-bytes"
+    mock_drive_service.files.return_value.get_media.assert_called_once_with(fileId="file-xyz")
+
+
+@pytest.mark.asyncio()
 async def test_gdrive_resolve_path_caches_results(
     gdrive_storage: GoogleDriveStorage, mock_drive_service: MagicMock
 ) -> None:


### PR DESCRIPTION
## Description

Fixes #1364: ``move_file`` consistently returned ``File not found at <path>`` for paths the agent had just quoted from ``find_saved_files``. Confirmed against a production transcript where ``find_saved_files`` listed three saved files and ``move_file`` then failed every retry against the same path.

Root cause: ``find_saved_files`` matches files via the ``clawbolt_path`` appProperty (the canonical handle every upload/move writes), but ``get_file`` resolved paths by walking the folder tree and matching by name. Those two paths diverge whenever the folder tree no longer matches the shape the appProperty recorded: a folder rename, a manual move in the Drive UI, or even a sibling-name collision is enough to break the second lookup while the first keeps working.

Fix: query Drive by ``appProperties has { key='clawbolt_path' and value=<path> }`` first in ``get_file``, ``move_file``, and ``download_file``. Folder-walk + name-match stays as the fallback for any pre-cutover files whose appProperty was never set. ``move_file`` additionally reads the file's current parents from the Drive payload and passes them as ``removeParents``, so a file the user dragged in the Drive UI still detaches cleanly from its real parent instead of no-opping the remove against a stale folder id. The folder-walk fallback in ``move_file`` also switches to ``_resolve_existing_path`` on the source side so a NOT_FOUND no longer leaves an empty pollutant folder in the user's Drive.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (``uv run pytest -v``) // 2792 passed, 2 skipped, 13 deselected
- [x] Lint passes (``ruff check backend/ && ruff format --check backend/``)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Regression tests in ``tests/test_storage_service.py``:
- ``test_gdrive_get_file_falls_back_to_app_property_when_folder_walk_fails`` (cites #1364)
- ``test_gdrive_move_file_uses_actual_parents_for_remove``
- ``test_gdrive_download_file_falls_back_to_app_property``

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

_Note: this PR was drafted by Claude via back-and-forth with @njbrake, including pulling the failing transcript out of the admin shared-data API to confirm the failure mode. The reasoning and decisions are his; the prose and the diff are Claude's._
