### PR TITLE
fix: redirect AppFolio and ServiceTitan credential input from chat to web app

### DIFF
--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -16,6 +16,7 @@ from backend.app.agent.stores import ToolConfigStore
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.integrations.appfolio_vendor import auth as appfolio_auth
+from backend.app.integrations.servicetitan import auth as servicetitan_auth
 from backend.app.services.oauth import get_oauth_config, list_oauth_integrations, oauth_service
 
 if TYPE_CHECKING:
@@ -23,20 +24,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Tool groups that use magic-link / paste-token auth instead of OAuth. These
+# Tool groups that use web-app credential input instead of OAuth. These
 # do not show up in ``list_oauth_integrations()`` but should still be
 # manageable through ``manage_integration`` so the agent has a single
-# discovery surface for "connect <integration>".
-_MAGIC_LINK_INTEGRATIONS: set[str] = {"appfolio_vendor"}
+# discovery surface for "connect <integration>." The connect flow
+# redirects users to the Clawbolt web app where credentials are entered
+# securely, rather than accepting pasted secrets in chat.
+_WEB_CONNECT_INTEGRATIONS: set[str] = {"appfolio_vendor", "servicetitan"}
 
 # Core factories that back a user-facing integration but should not surface
 # in ``manage_integration`` listings or be enable/disable-able on their own.
 # These are visibility-paired with another factory: when the user-facing
 # integration is disabled, the backing factory follows. ``appfolio_auth``
-# holds the magic-link connect tools that must stay on the schema even when
+# holds the connect tools that must stay on the schema even when
 # ``appfolio_vendor`` reports "not connected"; ``servicetitan_auth`` plays
-# the same role for the paste-credentials ``connect_servicetitan`` tool.
-# From the user's perspective each pair is one integration.
+# the same role for the ``connect_servicetitan`` tool. From the user's
+# perspective each pair is one integration.
 _HIDDEN_CORE_FACTORIES: dict[str, str] = {
     "appfolio_auth": "appfolio_vendor",
     "servicetitan_auth": "servicetitan",
@@ -60,7 +63,7 @@ def _display_name_for_oauth(registry: ToolRegistry, oauth_name: str) -> str:
 def _build_available_integrations_hint(registry: ToolRegistry) -> str:
     """Return a sentence enumerating the integrations this deployment supports.
 
-    Built from ``list_oauth_integrations()`` plus ``_MAGIC_LINK_INTEGRATIONS``
+    Built from ``list_oauth_integrations()`` plus ``_WEB_CONNECT_INTEGRATIONS``
     so new integrations surface in the system prompt automatically once
     their factory is wired up. This is the LLM's authoritative signal that
     an integration exists: prior ``manage_integration`` results sitting in
@@ -74,13 +77,13 @@ def _build_available_integrations_hint(registry: ToolRegistry) -> str:
     would reject.
     """
     oauth_targets = sorted(list_oauth_integrations())
-    magic_link_targets = sorted(_MAGIC_LINK_INTEGRATIONS)
+    web_connect_targets = sorted(_WEB_CONNECT_INTEGRATIONS)
 
     display_names = [_display_name_for_oauth(registry, name) for name in oauth_targets]
-    display_names.extend(registry.get_display_name(name) for name in magic_link_targets)
+    display_names.extend(registry.get_display_name(name) for name in web_connect_targets)
     display_names.sort()
 
-    all_targets = sorted({*oauth_targets, *magic_link_targets})
+    all_targets = sorted({*oauth_targets, *web_connect_targets})
     target_tokens = ", ".join(f"'{name}'" for name in all_targets)
 
     return (
@@ -170,8 +173,10 @@ def create_integration_tools(ctx: ToolContext) -> list[Tool]:
                 f"for something they already set up). "
                 f"Call with action='connect' and a target from the list above to "
                 f"generate an OAuth link the user can tap to connect. "
-                f"For 'appfolio_vendor' you'll get magic-link instructions instead "
-                f"of a URL; follow them and then call appfolio_connect directly. "
+                f"For 'appfolio_vendor' and 'servicetitan', the user must navigate"
+                f" to the Clawbolt web app to enter credentials securely; tell"
+                f" them to open Settings > Tools and click Connect on the"
+                f" integration card. "
                 f"Call with action='enable'/'disable' and target=group_name to toggle tools."
             ),
             # Enable/disable and connect/disconnect mutate the per-user
@@ -210,7 +215,7 @@ async def _handle_status(
 
             # Check OAuth connection status. Factories backed by OAuth
             # declare ``oauth_name`` at registration time; an empty value
-            # means the factory is not OAuth-backed (e.g. magic-link or
+            # means the factory is not OAuth-backed (e.g. web-connect or
             # purely local tools).
             oauth_name = factory.oauth_name
             if oauth_name:
@@ -220,8 +225,8 @@ async def _handle_status(
                     status_parts.append("connected" if connected else "not connected")
                 else:
                     status_parts.append("not configured by admin")
-            elif name in _MAGIC_LINK_INTEGRATIONS:
-                connected = await _is_magic_link_connected(name, user_id)
+            elif name in _WEB_CONNECT_INTEGRATIONS:
+                connected = await _is_web_connect_connected(name, user_id)
                 status_parts.append("connected" if connected else "not connected")
 
             integration_lines.append(f"- {name}: {display} ({', '.join(status_parts)})")
@@ -346,7 +351,7 @@ def _resolve_oauth_name(target: str, registry: ToolRegistry) -> str:
 
 
 async def _handle_connect(user_id: str, target: str, registry: ToolRegistry) -> ToolResult:
-    """Generate an OAuth authorization URL for an integration."""
+    """Generate an OAuth authorization URL or web-app connect instructions."""
     # Hidden backing factories are never directly addressable by users; the
     # connect flow goes through the user-facing factory they back.
     if target in _HIDDEN_CORE_FACTORIES:
@@ -356,10 +361,10 @@ async def _handle_connect(user_id: str, target: str, registry: ToolRegistry) -> 
             error_kind=ToolErrorKind.NOT_FOUND,
         )
 
-    # Magic-link integrations have their own connect flow (paste-a-token)
-    # and don't fit the OAuth URL model.
-    if target in _MAGIC_LINK_INTEGRATIONS:
-        return await _handle_magic_link_connect(user_id, target, registry)
+    # Web-connect integrations (AppFolio, ServiceTitan) redirect to the
+    # Clawbolt web app where credentials are entered securely.
+    if target in _WEB_CONNECT_INTEGRATIONS:
+        return await _handle_web_connect(user_id, target, registry)
 
     oauth_name = _resolve_oauth_name(target, registry)
 
@@ -411,8 +416,8 @@ async def _handle_disconnect(user_id: str, target: str, registry: ToolRegistry) 
             error_kind=ToolErrorKind.NOT_FOUND,
         )
 
-    if target in _MAGIC_LINK_INTEGRATIONS:
-        return await _handle_magic_link_disconnect(user_id, target, registry)
+    if target in _WEB_CONNECT_INTEGRATIONS:
+        return await _handle_web_connect_disconnect(user_id, target, registry)
 
     oauth_name = _resolve_oauth_name(target, registry)
 
@@ -445,10 +450,12 @@ async def _handle_disconnect(user_id: str, target: str, registry: ToolRegistry) 
     )
 
 
-async def _is_magic_link_connected(target: str, user_id: str) -> bool:
-    """Dispatch ``is_connected`` lookup for magic-link integrations."""
+async def _is_web_connect_connected(target: str, user_id: str) -> bool:
+    """Dispatch ``is_connected`` lookup for web-connect integrations."""
     if target == "appfolio_vendor":
         return await appfolio_auth.is_connected(user_id)
+    if target == "servicetitan":
+        return await servicetitan_auth.is_connected(user_id)
     return False
 
 
@@ -456,9 +463,9 @@ async def get_user_connected_integrations(user_id: str) -> dict[str, bool]:
     """Return a mapping of integration name to ``connected`` flag for *user_id*.
 
     Covers OAuth integrations from :func:`list_oauth_integrations` plus the
-    magic-link integrations enumerated in ``_MAGIC_LINK_INTEGRATIONS``.
+    web-connect integrations enumerated in ``_WEB_CONNECT_INTEGRATIONS``.
     Integrations the operator has not configured on this deployment (no
-    OAuth credentials, no magic-link backend) are omitted entirely, so the
+    OAuth credentials, no web-connect backend) are omitted entirely, so the
     caller does not have to distinguish "not connected by this user" from
     "not available on this deployment".
 
@@ -474,21 +481,17 @@ async def get_user_connected_integrations(user_id: str) -> dict[str, bool]:
         if config is None or not config.is_configured:
             continue
         result[name] = await oauth_service.is_connected(user_id, name)
-    for name in _MAGIC_LINK_INTEGRATIONS:
-        result[name] = await _is_magic_link_connected(name, user_id)
+    for name in _WEB_CONNECT_INTEGRATIONS:
+        result[name] = await _is_web_connect_connected(name, user_id)
     return result
 
 
-async def _handle_magic_link_connect(
-    user_id: str, target: str, registry: ToolRegistry
-) -> ToolResult:
-    """Return paste-token instructions for a magic-link integration.
+async def _handle_web_connect(user_id: str, target: str, registry: ToolRegistry) -> ToolResult:
+    """Return web-app navigation instructions for a web-connect integration.
 
-    These integrations cannot be connected with a single URL: the user
-    has to request a magic link from the vendor's web UI and paste it
-    back. We return that recipe so the agent can guide the user, then
-    rely on the integration's own auth tool (e.g. ``appfolio_connect``)
-    to finish the flow.
+    These integrations require the user to enter credentials in the
+    Clawbolt web app rather than pasting them in chat. The agent
+    instructs the user to navigate to the Tools page and click Connect.
     """
     if target == "appfolio_vendor":
         display = registry.get_display_name(target)
@@ -499,34 +502,52 @@ async def _handle_magic_link_connect(
                 ),
             )
         logger.info(
-            "User %s requested magic-link connect instructions for '%s' via chat",
+            "User %s requested web-app connect instructions for '%s' via chat",
             user_id,
             target,
         )
         return ToolResult(
             content=(
-                f"{display} uses magic-link auth (no OAuth URL). "
-                "Walk the user through these steps: "
-                "(1) open vendor.appfolio.com on their phone or laptop, "
-                "(2) enter their email and request a sign-in link, "
-                "(3) when the email arrives, copy only the token from "
-                "the link's URL (everything after 'magic_link_token='), "
-                "not the full URL. iMessage and other SMS clients strip "
-                "query params from pasted links. Then call "
-                "appfolio_connect with the pasted token."
+                f"To connect {display}, open your Clawbolt web app and navigate"
+                f" to Settings > Tools. Click 'Connect' on the {display} card"
+                f" and paste your magic link there. The magic link comes from"
+                f" vendor.appfolio.com - request a sign-in link and copy the"
+                f" token from the URL."
+            ),
+        )
+    if target == "servicetitan":
+        display = registry.get_display_name(target)
+        if await servicetitan_auth.is_connected(user_id):
+            return ToolResult(
+                content=(
+                    f"{display} is already connected. Use action='disconnect' first to reconnect."
+                ),
+            )
+        logger.info(
+            "User %s requested web-app connect instructions for '%s' via chat",
+            user_id,
+            target,
+        )
+        return ToolResult(
+            content=(
+                f"To connect {display}, open your Clawbolt web app and navigate"
+                f" to Settings > Tools. Click 'Connect' on the {display} card"
+                f" and enter your Tenant ID, Client ID, and Client Secret."
+                f" These come from ServiceTitan > Settings > Integrations >"
+                f" API Application Access."
             ),
         )
     return ToolResult(
-        content=f"No magic-link connect flow registered for '{target}'.",
+        content=f"No web-app connect flow registered for '{target}'.",
         is_error=True,
         error_kind=ToolErrorKind.VALIDATION,
     )
 
 
-async def _handle_magic_link_disconnect(
+async def _handle_web_connect_disconnect(
     user_id: str, target: str, registry: ToolRegistry
 ) -> ToolResult:
-    """Clear stored credentials for a magic-link integration."""
+    """Clear stored credentials for a web-connect integration."""
     if target == "appfolio_vendor":
         display = registry.get_display_name(target)
         if not await appfolio_auth.is_connected(user_id):
@@ -537,7 +558,27 @@ async def _handle_magic_link_disconnect(
             )
         await appfolio_auth.clear_credential(user_id)
         logger.info(
-            "User %s disconnected magic-link integration '%s' via chat",
+            "User %s disconnected web-connect integration '%s' via chat",
+            user_id,
+            target,
+        )
+        return ToolResult(
+            content=(
+                f"Disconnected {display}. "
+                "The tools are still enabled but won't work until you reconnect."
+            ),
+        )
+    if target == "servicetitan":
+        display = registry.get_display_name(target)
+        if not await servicetitan_auth.is_connected(user_id):
+            return ToolResult(
+                content=f"{display} is not currently connected.",
+                is_error=True,
+                error_kind=ToolErrorKind.NOT_FOUND,
+            )
+        await servicetitan_auth.clear_credentials(user_id)
+        logger.info(
+            "User %s disconnected web-connect integration '%s' via chat",
             user_id,
             target,
         )
@@ -548,7 +589,7 @@ async def _handle_magic_link_disconnect(
             ),
         )
     return ToolResult(
-        content=f"No magic-link disconnect flow registered for '{target}'.",
+        content=f"No web-app disconnect flow registered for '{target}'.",
         is_error=True,
         error_kind=ToolErrorKind.VALIDATION,
     )

--- a/backend/app/integrations/appfolio_vendor/auth_tools.py
+++ b/backend/app/integrations/appfolio_vendor/auth_tools.py
@@ -1,9 +1,14 @@
 """AppFolio Vendor Portal authentication tools.
 
-``appfolio_connect`` is the only tool here: it accepts a magic-link URL,
-exchanges it for a Bearer JWT via the OAuth2 token endpoint, and persists
-the credential. It lives separately from the data tools because it runs
-*before* a credential exists.
+``appfolio_connect`` is the only tool here. It no longer accepts a
+magic-link URL in chat; instead it instructs the user to navigate to
+the Clawbolt web app to enter their magic link securely. The tool
+lives separately from the data tools because it must run *before* a
+credential exists.
+
+Credential input moved to the web UI per issue #1337: pasting secure
+secrets in chat (iMessage, Telegram) leaves them permanently in chat
+history. The web app provides a controlled form for magic-link entry.
 """
 
 from __future__ import annotations
@@ -11,19 +16,9 @@ from __future__ import annotations
 import logging
 
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
-from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
-from backend.app.integrations.appfolio_vendor.auth import (
-    MagicLinkError,
-    extract_magic_link_token,
-    save_credential,
-    upsert_fingerprint,
-)
 from backend.app.integrations.appfolio_vendor.params import AppFolioConnectParams
-from backend.app.integrations.appfolio_vendor.service import (
-    AppFolioError,
-    exchange_magic_link,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -32,51 +27,26 @@ def build_auth_tools(user_id: str) -> list[Tool]:
     """Return the AppFolio connect tool bound to one user."""
 
     async def appfolio_connect(magic_link: str) -> ToolResult:
-        """Exchange a pasted magic link for a Bearer JWT and persist it."""
-        try:
-            token = extract_magic_link_token(magic_link)
-        except MagicLinkError as exc:
-            return ToolResult(
-                content=f"Could not read magic link: {exc}",
-                is_error=True,
-                error_kind=ToolErrorKind.VALIDATION,
-                hint=(
-                    "Ask the user to paste only the magic-link token"
-                    " (the long string after 'magic_link_token=' in the"
-                    " AppFolio email URL), not the full URL. iMessage"
-                    " and other SMS clients strip query params from"
-                    " pasted links."
-                ),
-            )
+        """
+        Instruct the user to connect via the Clawbolt web app.
 
-        fingerprint = await upsert_fingerprint(user_id)
-        try:
-            result = await exchange_magic_link(magic_link_token=token)
-        except AppFolioError as exc:
-            logger.warning("AppFolio OAuth exchange failed: %s", exc)
-            return ToolResult(
-                content=f"AppFolio rejected the magic link: {exc}",
-                is_error=True,
-                error_kind=ToolErrorKind.AUTH,
-                hint=(
-                    "Magic links can only be used once and expire quickly."
-                    " Request a fresh link from vendor.appfolio.com and try again."
-                ),
-            )
-
-        await save_credential(
-            user_id=user_id,
-            jwt=result.jwt,
-            fingerprint=fingerprint,
-            customer_ids=result.customer_ids,
-            refresh_token=result.refresh_token,
-        )
-
+        Credentials are no longer accepted in chat to avoid leaking
+        secure secrets into permanent chat history. The user must
+        navigate to the Clawbolt web app to enter their magic link.
+        """
         return ToolResult(
-            content="AppFolio connected. Tools are now available.",
-            receipt=ToolReceipt(
-                action="Connected AppFolio Vendor Portal",
-                target="vendor account",
+            content=(
+                "AppFolio Vendor Portal connection now requires the Clawbolt"
+                " web app. Please navigate to Settings > Tools > AppFolio"
+                " Vendor Portal and click Connect to enter your magic link"
+                " securely."
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.AUTH,
+            hint=(
+                "Ask the user to open the Clawbolt web app, go to Settings"
+                " > Tools > AppFolio Vendor Portal, and click Connect."
+                " The web form will accept their magic link securely."
             ),
         )
 
@@ -84,17 +54,20 @@ def build_auth_tools(user_id: str) -> list[Tool]:
         Tool(
             name=ToolName.APPFOLIO_CONNECT,
             description=(
-                "Connect AppFolio Vendor Portal with the magic-link token"
-                " from the user's AppFolio email."
+                "Connect AppFolio Vendor Portal. The user must navigate to"
+                " the Clawbolt web app (Settings > Tools > AppFolio Vendor"
+                " Portal) to enter their magic link securely. Chat-based"
+                " credential input is disabled for security reasons."
             ),
             function=appfolio_connect,
             params_model=AppFolioConnectParams,
             usage_hint=(
                 "Use when the user wants to start using AppFolio tools."
-                " Tell them: open vendor.appfolio.com, request a magic link,"
-                " then paste only the token from the URL (everything after"
-                " 'magic_link_token='), not the full URL. iMessage and"
-                " other SMS clients strip query params from pasted links."
+                " Tell them: open the Clawbolt web app, go to Settings"
+                " > Tools > AppFolio Vendor Portal, click Connect, and"
+                " paste their magic link there. The link comes from"
+                " vendor.appfolio.com - request a magic link and copy"
+                " the token from the URL."
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ALWAYS,

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -122,8 +122,8 @@ async def _appfolio_vendor_auth_check(ctx: ToolContext) -> str | None:
     return (
         "AppFolio Vendor Portal is not connected. Use "
         "manage_integration(action='connect', target='appfolio_vendor') "
-        "for the magic-link recipe, then call appfolio_connect with the "
-        "URL the user pastes."
+        "for instructions, then navigate to the Clawbolt web app "
+        "(Settings > Tools) to enter your magic link securely."
     )
 
 

--- a/backend/app/integrations/servicetitan/auth_tools.py
+++ b/backend/app/integrations/servicetitan/auth_tools.py
@@ -1,11 +1,15 @@
 """ServiceTitan authentication tool.
 
-``connect_servicetitan`` accepts the three values a user pastes during
-onboarding (Tenant ID, Client ID, Client Secret), validates them by
-minting a bearer token against the configured token endpoint, and
-persists the credential. It lives separately from the (empty for now)
-data-tools surface because it must remain reachable before any
-credential exists, mirroring the AppFolio ``appfolio_connect`` split.
+``connect_servicetitan`` no longer accepts credentials pasted in chat.
+Instead it instructs the user to navigate to the Clawbolt web app to
+enter their Tenant ID, Client ID, and Client Secret securely. The tool
+lives separately from the data-tools surface because it must remain
+reachable before any credential exists, mirroring the AppFolio
+``appfolio_connect`` split.
+
+Credential input moved to the web UI per issue #1337: pasting secure
+secrets in chat (iMessage, Telegram) leaves them permanently in chat
+history. The web app provides a controlled form for credential entry.
 """
 
 from __future__ import annotations
@@ -13,14 +17,8 @@ from __future__ import annotations
 import logging
 
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
-from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
-from backend.app.config import settings
-from backend.app.integrations.servicetitan.auth import (
-    ServiceTitanAuthError,
-    mint_access_token,
-    save_credentials,
-)
 from backend.app.integrations.servicetitan.params import ServiceTitanConnectParams
 
 logger = logging.getLogger(__name__)
@@ -34,62 +32,28 @@ def build_auth_tools(user_id: str) -> list[Tool]:
         client_id: str,
         client_secret: str,
     ) -> ToolResult:
-        """Validate the three pasted values, then persist them."""
-        tenant_id = tenant_id.strip()
-        client_id = client_id.strip()
-        client_secret = client_secret.strip()
-        if not tenant_id or not client_id or not client_secret:
-            return ToolResult(
-                content=("Tenant ID, Client ID, and Client Secret are all required."),
-                is_error=True,
-                error_kind=ToolErrorKind.VALIDATION,
-                hint=(
-                    "Have the user paste all three values from ServiceTitan's"
-                    " Settings -> Integrations -> API Application Access page."
-                ),
-            )
-        if not settings.servicetitan_app_key:
-            return ToolResult(
-                content=(
-                    "ServiceTitan is not configured: the deployment is missing"
-                    " an App Key. Ask the operator to set SERVICETITAN_APP_KEY."
-                ),
-                is_error=True,
-                error_kind=ToolErrorKind.AUTH,
-            )
+        """
+        Instruct the user to connect via the Clawbolt web app.
 
-        try:
-            access_token, expires_at = await mint_access_token(
-                client_id=client_id,
-                client_secret=client_secret,
-            )
-        except ServiceTitanAuthError as exc:
-            logger.warning("ServiceTitan connect failed for user=%s: %s", user_id, exc)
-            return ToolResult(
-                content=f"ServiceTitan rejected the credentials: {exc}",
-                is_error=True,
-                error_kind=ToolErrorKind.AUTH,
-                hint=(
-                    "Double-check the Tenant ID, Client ID, and Client Secret."
-                    " Regenerate the secret in ServiceTitan if it was lost."
-                ),
-            )
-
-        await save_credentials(
-            user_id,
-            tenant_id=tenant_id,
-            client_id=client_id,
-            client_secret=client_secret,
-            app_key=settings.servicetitan_app_key,
-            access_token=access_token,
-            expires_at=expires_at,
-        )
-
+        Credentials are no longer accepted in chat to avoid leaking
+        secure secrets into permanent chat history. The user must
+        navigate to the Clawbolt web app to enter their Tenant ID,
+        Client ID, and Client Secret.
+        """
         return ToolResult(
-            content="ServiceTitan connected. Tools are now available.",
-            receipt=ToolReceipt(
-                action="Connected ServiceTitan",
-                target=f"tenant {tenant_id}",
+            content=(
+                "ServiceTitan connection now requires the Clawbolt web app."
+                " Please navigate to Settings > Tools > ServiceTitan and"
+                " click Connect to enter your Tenant ID, Client ID, and"
+                " Client Secret securely."
+            ),
+            is_error=True,
+            error_kind=ToolErrorKind.AUTH,
+            hint=(
+                "Ask the user to open the Clawbolt web app, go to Settings"
+                " > Tools > ServiceTitan, and click Connect. The web form"
+                " will accept their Tenant ID, Client ID, and Client Secret"
+                " securely."
             ),
         )
 
@@ -97,19 +61,21 @@ def build_auth_tools(user_id: str) -> list[Tool]:
         Tool(
             name=ToolName.SERVICETITAN_CONNECT,
             description=(
-                "Connect a ServiceTitan tenant by pasting the Tenant ID, Client"
-                " ID, and Client Secret from the ServiceTitan API Application"
-                " Access settings."
+                "Connect a ServiceTitan tenant. The user must navigate to"
+                " the Clawbolt web app (Settings > Tools > ServiceTitan)"
+                " to enter their Tenant ID, Client ID, and Client Secret"
+                " securely. Chat-based credential input is disabled for"
+                " security reasons."
             ),
             function=connect_servicetitan,
             params_model=ServiceTitanConnectParams,
             usage_hint=(
                 "Use when the user wants to start using ServiceTitan tools."
-                " Walk them through: (1) open ServiceTitan -> Settings ->"
-                " Integrations -> API Application Access, (2) create or"
-                " open an application and copy the Client ID and Client"
-                " Secret, (3) read the Tenant ID off the same page, then"
-                " paste all three values back to you."
+                " Tell them: open the Clawbolt web app, go to Settings"
+                " > Tools > ServiceTitan, click Connect, and enter their"
+                " Tenant ID, Client ID, and Client Secret. These come from"
+                " ServiceTitan -> Settings -> Integrations -> API"
+                " Application Access."
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ALWAYS,

--- a/backend/app/integrations/servicetitan/factory.py
+++ b/backend/app/integrations/servicetitan/factory.py
@@ -87,9 +87,11 @@ async def _servicetitan_auth_check(ctx: ToolContext) -> str | None:
     if await is_connected(ctx.user.id):
         return None
     return (
-        "ServiceTitan is not connected. Ask the user to paste their Tenant ID,"
-        " Client ID, and Client Secret, then call connect_servicetitan to"
-        " validate and persist them."
+        "ServiceTitan is not connected. Use "
+        "manage_integration(action='connect', target='servicetitan') "
+        "for instructions, then navigate to the Clawbolt web app "
+        "(Settings > Tools) to enter your Tenant ID, Client ID, and "
+        "Client Secret securely."
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from backend.app.models import ChannelRoute, User
 from backend.app.routers import (
     auth,
     health,
+    integrations,
     media_temp,
     oauth,
     user_calendar,
@@ -395,6 +396,7 @@ app.include_router(user_memory.router, prefix="/api")
 app.include_router(user_permissions.router, prefix="/api")
 app.include_router(user_tools.router, prefix="/api")
 app.include_router(user_calendar.router, prefix="/api")
+app.include_router(integrations.router, prefix="/api")
 
 # ---------------------------------------------------------------------------
 # Static file serving (built frontend)

--- a/backend/app/routers/integrations.py
+++ b/backend/app/routers/integrations.py
@@ -1,0 +1,218 @@
+"""Web-based credential input endpoints for non-OAuth integrations.
+
+AppFolio Vendor Portal and ServiceTitan use credential-paste flows that
+should happen in the Clawbolt web app rather than in chat, so users
+never paste secure secrets (magic-link tokens, Client IDs, Client
+Secrets) into an iMessage thread where they would persist in chat
+history.
+
+These endpoints accept the credential values from a web form, process
+them identically to the (now deprecated) chat-based auth tools, and
+persist the resulting tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from backend.app.auth.dependencies import get_current_user
+from backend.app.config import settings
+from backend.app.integrations.appfolio_vendor.auth import (
+    MagicLinkError,
+    extract_magic_link_token,
+    save_credential,
+    upsert_fingerprint,
+)
+from backend.app.integrations.appfolio_vendor.service import (
+    AppFolioError,
+    exchange_magic_link,
+)
+from backend.app.integrations.servicetitan.auth import (
+    ServiceTitanAuthError,
+    mint_access_token,
+    save_credentials,
+)
+from backend.app.models import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# AppFolio Vendor Portal - web-based magic-link connect
+# ---------------------------------------------------------------------------
+
+
+class AppFolioConnectRequest(BaseModel):
+    """Request body for connecting AppFolio via the web UI.
+
+    The user pastes the magic-link URL they received from AppFolio email;
+    the backend extracts the token, exchanges it for a Bearer JWT, and
+    persists the credential.
+    """
+
+    magic_link: str = Field(
+        description="The full magic-link URL from AppFolio email, or just the token"
+    )
+
+
+class ConnectResponse(BaseModel):
+    """Response for a successful web-based connect."""
+
+    status: str = "connected"
+    message: str = ""
+
+
+@router.post("/integrations/appfolio_vendor/connect")
+async def appfolio_web_connect(
+    body: AppFolioConnectRequest,
+    current_user: User = Depends(get_current_user),
+) -> ConnectResponse:
+    """Connect AppFolio Vendor Portal via a magic link pasted in the web UI.
+
+    Extracts the magic-link token from the user's input, exchanges it
+    for a Bearer JWT via the AppFolio OAuth2 token endpoint, and
+    persists the credential so the agent's AppFolio tools become
+    available.
+    """
+    try:
+        token = extract_magic_link_token(body.magic_link)
+    except MagicLinkError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not read magic link: {exc}",
+        ) from exc
+
+    fingerprint = await upsert_fingerprint(current_user.id)
+    try:
+        result = await exchange_magic_link(magic_link_token=token)
+    except AppFolioError as exc:
+        logger.warning("AppFolio OAuth exchange failed for user %s: %s", current_user.id, exc)
+        raise HTTPException(
+            status_code=400,
+            detail=f"AppFolio rejected the magic link: {exc}",
+        ) from exc
+
+    await save_credential(
+        user_id=current_user.id,
+        jwt=result.jwt,
+        fingerprint=fingerprint,
+        customer_ids=result.customer_ids,
+        refresh_token=result.refresh_token,
+    )
+
+    logger.info("User %s connected AppFolio Vendor Portal via web UI", current_user.id)
+    return ConnectResponse(
+        status="connected",
+        message="AppFolio Vendor Portal connected successfully.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ServiceTitan - web-based credential connect
+# ---------------------------------------------------------------------------
+
+
+class ServiceTitanConnectRequest(BaseModel):
+    """Request body for connecting ServiceTitan via the web UI.
+
+    The user enters the Tenant ID, Client ID, and Client Secret from
+    ServiceTitan's Settings -> Integrations -> API Application Access page.
+    """
+
+    tenant_id: str = Field(description="ServiceTitan Tenant ID")
+    client_id: str = Field(description="ServiceTitan Client ID")
+    client_secret: str = Field(description="ServiceTitan Client Secret")
+
+
+@router.post("/integrations/servicetitan/connect")
+async def servicetitan_web_connect(
+    body: ServiceTitanConnectRequest,
+    current_user: User = Depends(get_current_user),
+) -> ConnectResponse:
+    """Connect ServiceTitan via credentials entered in the web UI.
+
+    Validates the three credential values by minting a bearer token
+    against the ServiceTitan token endpoint, then persists everything
+    so the agent's ServiceTitan tools become available.
+    """
+    tenant_id = body.tenant_id.strip()
+    client_id = body.client_id.strip()
+    client_secret = body.client_secret.strip()
+
+    if not tenant_id or not client_id or not client_secret:
+        raise HTTPException(
+            status_code=400,
+            detail="Tenant ID, Client ID, and Client Secret are all required.",
+        )
+
+    if not settings.servicetitan_app_key:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "ServiceTitan is not configured: the deployment is missing"
+                " an App Key. Ask the operator to set SERVICETITAN_APP_KEY."
+            ),
+        )
+
+    try:
+        access_token, expires_at = await mint_access_token(
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    except ServiceTitanAuthError as exc:
+        logger.warning("ServiceTitan connect failed for user=%s: %s", current_user.id, exc)
+        raise HTTPException(
+            status_code=400,
+            detail=f"ServiceTitan rejected the credentials: {exc}",
+        ) from exc
+
+    await save_credentials(
+        current_user.id,
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+        app_key=settings.servicetitan_app_key,
+        access_token=access_token,
+        expires_at=expires_at,
+    )
+
+    logger.info("User %s connected ServiceTitan via web UI", current_user.id)
+    return ConnectResponse(
+        status="connected",
+        message="ServiceTitan connected successfully.",
+    )
+
+
+@router.delete("/integrations/appfolio_vendor/disconnect")
+async def appfolio_web_disconnect(
+    current_user: User = Depends(get_current_user),
+) -> ConnectResponse:
+    """Disconnect AppFolio Vendor Portal by removing stored credentials."""
+    from backend.app.integrations.appfolio_vendor.auth import clear_credential
+
+    await clear_credential(current_user.id)
+    logger.info("User %s disconnected AppFolio Vendor Portal via web UI", current_user.id)
+    return ConnectResponse(
+        status="disconnected",
+        message="AppFolio Vendor Portal disconnected.",
+    )
+
+
+@router.delete("/integrations/servicetitan/disconnect")
+async def servicetitan_web_disconnect(
+    current_user: User = Depends(get_current_user),
+) -> ConnectResponse:
+    """Disconnect ServiceTitan by removing stored credentials."""
+    from backend.app.integrations.servicetitan.auth import clear_credentials
+
+    await clear_credentials(current_user.id)
+    logger.info("User %s disconnected ServiceTitan via web UI", current_user.id)
+    return ConnectResponse(
+        status="disconnected",
+        message="ServiceTitan disconnected.",
+    )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -251,6 +251,31 @@ const api = {
     });
     if (error) _throwApiError(error, 'Failed to disconnect OAuth');
   },
+
+  // Web-based integration connect (AppFolio, ServiceTitan)
+  connectAppfolio: async (magicLink: string) => {
+    const { data, error } = await client.POST('/api/integrations/appfolio_vendor/connect', {
+      body: { magic_link: magicLink },
+    });
+    if (error) _throwApiError(error, 'Failed to connect AppFolio');
+    return data as { status: string; message: string };
+  },
+  connectServiceTitan: async (tenantId: string, clientId: string, clientSecret: string) => {
+    const { data, error } = await client.POST('/api/integrations/servicetitan/connect', {
+      body: { tenant_id: tenantId, client_id: clientId, client_secret: clientSecret },
+    });
+    if (error) _throwApiError(error, 'Failed to connect ServiceTitan');
+    return data as { status: string; message: string };
+  },
+  disconnectAppfolio: async () => {
+    const { error } = await client.DELETE('/api/integrations/appfolio_vendor/disconnect');
+    if (error) _throwApiError(error, 'Failed to disconnect AppFolio');
+  },
+  disconnectServiceTitan: async () => {
+    const { error } = await client.DELETE('/api/integrations/servicetitan/disconnect');
+    if (error) _throwApiError(error, 'Failed to disconnect ServiceTitan');
+  },
+
   // Calendar config
   getCalendarList: async () => {
     const { data, error } = await client.GET('/api/user/calendar/calendars');

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -6,6 +6,8 @@ import { toast } from '@/lib/toast';
 import { displayName, subToolDisplayName, getToolOAuthStatus } from '@/lib/tool-utils';
 import { IntegrationIcon } from '@/components/integration-icons';
 import PermissionSelector, { PERM_OPTIONS, type PermLevel } from '@/components/PermissionSelector';
+import Field from '@/components/ui/field';
+import Input from '@/components/ui/input';
 
 const PERM_LEVEL_CLASSNAMES: Record<PermLevel, string> = {
   always: 'text-success',
@@ -28,6 +30,10 @@ import { useToolConfig, useUpdateToolConfig, useOAuthStatus, useOAuthDisconnect,
 import api from '@/api';
 import type { ToolConfigEntryResponse, OAuthStatusEntry, SubToolEntryResponse } from '@/types';
 
+// Integrations that use web-app credential input instead of OAuth.
+// These show a Connect button that opens a credential form in the web UI.
+const WEB_CONNECT_INTEGRATIONS = new Set(['appfolio_vendor', 'servicetitan']);
+
 export default function ToolsPage() {
   const { data, isPending } = useToolConfig();
   const updateMutation = useUpdateToolConfig();
@@ -35,6 +41,16 @@ export default function ToolsPage() {
   const disconnectMutation = useOAuthDisconnect();
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const [connectingIntegration, setConnectingIntegration] = useState<string | null>(null);
+
+  // State for web-connect credential forms (AppFolio, ServiceTitan)
+  const [showAppfolioForm, setShowAppfolioForm] = useState(false);
+  const [appfolioMagicLink, setAppfolioMagicLink] = useState('');
+  const [appfolioConnecting, setAppfolioConnecting] = useState(false);
+  const [showServiceTitanForm, setShowServiceTitanForm] = useState(false);
+  const [stTenantId, setStTenantId] = useState('');
+  const [stClientId, setStClientId] = useState('');
+  const [stClientSecret, setStClientSecret] = useState('');
+  const [stConnecting, setStConnecting] = useState(false);
 
   const tools = data?.tools ?? [];
   const oauthMap: Record<string, OAuthStatusEntry> = {};
@@ -102,6 +118,46 @@ export default function ToolsPage() {
     });
   };
 
+  const handleAppfolioConnect = async () => {
+    if (!appfolioMagicLink.trim()) {
+      toast.error('Please enter the magic link from your AppFolio email.');
+      return;
+    }
+    setAppfolioConnecting(true);
+    try {
+      await api.connectAppfolio(appfolioMagicLink.trim());
+      toast.success('AppFolio Vendor Portal connected successfully.');
+      setShowAppfolioForm(false);
+      setAppfolioMagicLink('');
+    } catch (e) {
+      const err = e instanceof Error ? e.message : 'Failed to connect AppFolio';
+      toast.error(err);
+    } finally {
+      setAppfolioConnecting(false);
+    }
+  };
+
+  const handleServiceTitanConnect = async () => {
+    if (!stTenantId.trim() || !stClientId.trim() || !stClientSecret.trim()) {
+      toast.error('Tenant ID, Client ID, and Client Secret are all required.');
+      return;
+    }
+    setStConnecting(true);
+    try {
+      await api.connectServiceTitan(stTenantId.trim(), stClientId.trim(), stClientSecret.trim());
+      toast.success('ServiceTitan connected successfully.');
+      setShowServiceTitanForm(false);
+      setStTenantId('');
+      setStClientId('');
+      setStClientSecret('');
+    } catch (e) {
+      const err = e instanceof Error ? e.message : 'Failed to connect ServiceTitan';
+      toast.error(err);
+    } finally {
+      setStConnecting(false);
+    }
+  };
+
   if (isPending && !data) {
     return (
       <div>
@@ -131,6 +187,7 @@ export default function ToolsPage() {
             {integrationTools.map((tool) => {
               const oauthIntegration = tool.oauth_name;
               const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(oauthIntegration, oauthMap, tool.configured);
+              const isWebConnect = WEB_CONNECT_INTEGRATIONS.has(tool.name);
 
               return (
                 <Card key={tool.name}>
@@ -145,7 +202,7 @@ export default function ToolsPage() {
                               <span className={`size-1.5 rounded-full inline-block shrink-0 ${
                                 isConnected ? 'bg-success' : 'bg-warning'
                               }`} />
-                              {needsOAuth ? (isConnected ? 'Connected' : 'Not connected') : 'Available'}
+                              {(needsOAuth || isWebConnect) ? (isConnected ? 'Connected' : 'Not connected') : 'Available'}
                             </span>
                           ) : (
                             <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -176,6 +233,26 @@ export default function ToolsPage() {
                           onClick={() => void handleConnect(oauthIntegration)}
                           disabled={connectingIntegration === oauthIntegration}
                           isLoading={connectingIntegration === oauthIntegration}
+                        >
+                          Connect
+                        </Button>
+                      )}
+                      {isWebConnect && isConnected && (
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => void handleDisconnect('', tool.name)}
+                        >
+                          Disconnect
+                        </Button>
+                      )}
+                      {isWebConnect && !isConnected && (
+                        <Button
+                          size="sm"
+                          onClick={() => {
+                            if (tool.name === 'appfolio_vendor') setShowAppfolioForm(true);
+                            else if (tool.name === 'servicetitan') setShowServiceTitanForm(true);
+                          }}
                         >
                           Connect
                         </Button>
@@ -225,6 +302,122 @@ export default function ToolsPage() {
         </section>
       )}
 
+      {/* AppFolio connect modal */}
+      {showAppfolioForm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+          onClick={(e) => {
+            // Close when clicking the overlay backdrop, not the modal content
+            if (e.target === e.currentTarget) setShowAppfolioForm(false);
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="appfolio-modal-title"
+        >
+          <div className="bg-card border border-border rounded-lg shadow-lg w-full max-w-sm mx-4 p-5 animate-message-in">
+            <h3 id="appfolio-modal-title" className="text-base font-semibold font-display text-foreground">
+              Connect AppFolio Vendor Portal
+            </h3>
+            <div className="mt-3 space-y-3">
+              <p className="text-xs text-muted-foreground">
+                Paste the magic link from your AppFolio email. Open vendor.appfolio.com,
+                request a sign-in link, and copy the token from the URL.
+              </p>
+              <Field label="Magic Link URL or Token">
+                <Input
+                  value={appfolioMagicLink}
+                  onChange={(e) => setAppfolioMagicLink(e.target.value)}
+                  placeholder="e.g. https://vendor.appfolio.com/?magic_link_token=..."
+                />
+              </Field>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowAppfolioForm(false)}
+                disabled={appfolioConnecting}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleAppfolioConnect}
+                disabled={appfolioConnecting}
+                isLoading={appfolioConnecting}
+              >
+                Connect
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ServiceTitan connect modal */}
+      {showServiceTitanForm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+          onClick={(e) => {
+            // Close when clicking the overlay backdrop, not the modal content
+            if (e.target === e.currentTarget) setShowServiceTitanForm(false);
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="st-modal-title"
+        >
+          <div className="bg-card border border-border rounded-lg shadow-lg w-full max-w-sm mx-4 p-5 animate-message-in">
+            <h3 id="st-modal-title" className="text-base font-semibold font-display text-foreground">
+              Connect ServiceTitan
+            </h3>
+            <div className="mt-3 space-y-3">
+              <p className="text-xs text-muted-foreground">
+                Enter your ServiceTitan credentials from Settings > Integrations >
+                API Application Access.
+              </p>
+              <Field label="Tenant ID">
+                <Input
+                  value={stTenantId}
+                  onChange={(e) => setStTenantId(e.target.value)}
+                  placeholder="e.g. 1234567"
+                />
+              </Field>
+              <Field label="Client ID">
+                <Input
+                  value={stClientId}
+                  onChange={(e) => setStClientId(e.target.value)}
+                  placeholder="e.g. my-client-id"
+                />
+              </Field>
+              <Field label="Client Secret">
+                <Input
+                  type="password"
+                  value={stClientSecret}
+                  onChange={(e) => setStClientSecret(e.target.value)}
+                  placeholder="Enter client secret"
+                />
+              </Field>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowServiceTitanForm(false)}
+                disabled={stConnecting}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleServiceTitanConnect}
+                disabled={stConnecting}
+                isLoading={stConnecting}
+              >
+                Connect
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "Pillow>=10.0",
     "simpleeval>=1.0",
     "genai-prices>=0.0.57,<0.1",
+    "ruff>=0.15.4",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+    "psycopg>=3.3.3",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1879,51 +1879,31 @@ async def test_4xx_log_summarizes_base64_files(caplog: Any) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_appfolio_connect_message_omits_customer_count(async_test_user: Any) -> None:
-    """Regression for #1275: connect must not surface 'customer' counts.
-
-    The OAuth2 migration in #1269 stopped populating ``customer_ids`` on
-    the exchange result, leaving the receipt forever rendering "0
-    customer(s)". Rather than backfill via /profiles/me just to print a
-    number that vendors don't think in, we drop the framing entirely.
+async def test_appfolio_connect_redirects_to_web_app(async_test_user: Any) -> None:
+    """The auth tool now redirects to the Clawbolt web app instead of
+    accepting credentials in chat. Issue #1337.
     """
     from backend.app.agent.tools.names import ToolName
     from backend.app.integrations.appfolio_vendor.auth_tools import build_auth_tools
-    from backend.app.integrations.appfolio_vendor.service import AccessExchangeResult
 
     user_id = async_test_user.id
     tools = build_auth_tools(user_id)
     connect = next(t for t in tools if t.name == ToolName.APPFOLIO_CONNECT)
 
-    fake_result = AccessExchangeResult(
-        jwt="jwt-1",
-        customer_ids=[],
-        raw={},
-        refresh_token="rt-1",
-    )
-    with patch(
-        "backend.app.integrations.appfolio_vendor.auth_tools.exchange_magic_link",
-        new=AsyncMock(return_value=fake_result),
-    ):
-        result = await connect.function(magic_link="eyJ.fake.token")
+    result = await connect.function(magic_link="any_input")
 
-    assert result.is_error is False
-    assert result.content == "AppFolio connected. Tools are now available."
-    assert "customer" not in result.content.lower()
-    assert result.receipt is not None
-    assert "customer" not in (result.receipt.target or "").lower()
+    assert result.is_error is True
+    assert "Clawbolt web app" in result.content
+    assert "Settings > Tools" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_appfolio_connect_parse_failure_hint_steers_to_token_paste(
+async def test_appfolio_connect_hint_steers_to_web_app(
     async_test_user: Any,
 ) -> None:
-    """Regression for #1297: parse-failure hint must mention the iMessage gotcha.
+    """The hint should tell the agent to navigate to the Clawbolt web app.
 
-    When the user pastes a full magic-link URL over iMessage, the SMS
-    client strips the query params and the token never reaches us. The
-    validation hint has to tell the agent to ask for the token alone, not
-    the full URL, so the next attempt actually succeeds.
+    Credentials are no longer accepted in chat per issue #1337.
     """
     from backend.app.agent.tools.names import ToolName
     from backend.app.integrations.appfolio_vendor.auth_tools import build_auth_tools
@@ -1931,13 +1911,12 @@ async def test_appfolio_connect_parse_failure_hint_steers_to_token_paste(
     tools = build_auth_tools(async_test_user.id)
     connect = next(t for t in tools if t.name == ToolName.APPFOLIO_CONNECT)
 
-    # Empty input triggers MagicLinkError -> the validation hint we care about.
     result = await connect.function(magic_link="")
 
     assert result.is_error is True
     assert result.hint is not None
-    assert "magic_link_token=" in result.hint
-    assert "iMessage" in result.hint
+    assert "Clawbolt web app" in result.hint
+    assert "Settings > Tools" in result.hint
 
 
 @pytest.mark.asyncio()

--- a/tests/test_integration_tools.py
+++ b/tests/test_integration_tools.py
@@ -134,14 +134,14 @@ async def test_usage_hint_lists_current_oauth_integrations(test_user: User) -> N
             f"missing '{oauth_name}'"
         )
 
-    # Magic-link integrations (paste-token auth, e.g. appfolio_vendor) are
+    # Web-connect integrations (web-app auth, e.g. appfolio_vendor, servicetitan) are
     # also routed through manage_integration and so must appear in the hint
     # for the same staleness-override reason as OAuth integrations.
-    from backend.app.agent.tools.integration_tools import _MAGIC_LINK_INTEGRATIONS
+    from backend.app.agent.tools.integration_tools import _WEB_CONNECT_INTEGRATIONS
 
-    for magic_link_name in _MAGIC_LINK_INTEGRATIONS:
-        assert magic_link_name in tool.usage_hint, (
-            f"usage_hint should reference every magic-link integration; missing '{magic_link_name}'"
+    for web_connect_name in _WEB_CONNECT_INTEGRATIONS:
+        assert web_connect_name in tool.usage_hint, (
+            f"usage_hint should reference every web-connect integration; missing '{web_connect_name}'"
         )
 
     # Human-readable labels render for at least one well-known integration.
@@ -460,13 +460,13 @@ async def test_set_enabled_updates_existing_row(test_user: User) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Magic-link integrations (AppFolio Vendor Portal)
+# Web-connect integrations (AppFolio Vendor Portal, ServiceTitan)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio()
 async def test_status_lists_appfolio_with_connection_state(test_user: User) -> None:
-    """Status should surface AppFolio's magic-link connection state.
+    """Status should surface AppFolio's connection state.
 
     Regression for the dev.clawbolt.ai bug where the agent told the user
     "AppFolio is listed as an integration but it's not set up yet on the
@@ -500,15 +500,12 @@ async def test_status_marks_appfolio_connected(test_user: User) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_connect_appfolio_returns_magic_link_instructions(test_user: User) -> None:
-    """Connect with target='appfolio_vendor' should return paste-token instructions.
+async def test_connect_appfolio_returns_web_app_instructions(test_user: User) -> None:
+    """Connect with target='appfolio_vendor' should return web-app instructions.
 
-    The agent-facing message must mention vendor.appfolio.com (so the
-    agent can guide the user to the right site) and appfolio_connect (so
-    the agent knows which tool finishes the flow). It must also tell the
-    agent to ask the user for the token only (not the full URL), because
-    iMessage strips query params from pasted links and the token gets
-    lost. Regression for issue #1297.
+    The agent-facing message must mention the Clawbolt web app and guide
+    the user to Settings > Tools to enter their magic link securely.
+    Credentials are no longer accepted in chat per issue #1337.
     """
     with patch(
         "backend.app.agent.tools.integration_tools.appfolio_auth.is_connected",
@@ -517,12 +514,13 @@ async def test_connect_appfolio_returns_magic_link_instructions(test_user: User)
         result = await _call(test_user, "connect", "appfolio_vendor")
     assert not result.is_error
     assert "vendor.appfolio.com" in result.content
-    assert "appfolio_connect" in result.content
+    assert "Clawbolt web app" in result.content
+    assert "Settings > Tools" in result.content
     # Should NOT claim AppFolio "does not use OAuth" or look like a rejection.
     assert "does not use OAuth" not in result.content
-    # Must steer the agent toward the token-only paste flow.
-    assert "magic_link_token=" in result.content
-    assert "iMessage" in result.content
+    # Must NOT mention chat-based paste flow anymore.
+    assert "magic_link_token=" not in result.content
+    assert "iMessage" not in result.content
 
 
 @pytest.mark.asyncio()
@@ -571,8 +569,8 @@ async def test_disconnect_appfolio_when_not_connected(test_user: User) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_appfolio_usage_hint_mentions_magic_link(test_user: User) -> None:
-    """The usage_hint should tell the agent that AppFolio uses magic-link auth.
+async def test_appfolio_usage_hint_mentions_web_app(test_user: User) -> None:
+    """The usage_hint should tell the agent that AppFolio uses web-app auth.
 
     Without this guidance the agent would assume a connect URL is coming
     back and either stall or pass the instructions through verbatim.
@@ -583,7 +581,8 @@ async def test_appfolio_usage_hint_mentions_magic_link(test_user: User) -> None:
     assert tool.usage_hint is not None
     hint = tool.usage_hint.lower()
     assert "appfolio" in hint
-    assert "magic-link" in hint or "magic link" in hint
+    assert "servicetitan" in hint
+    assert "Clawbolt web app" in hint or "Clawbolt web app" in hint.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -716,7 +715,7 @@ async def test_status_renders_registry_display_names_for_every_integration(
 
 
 def test_user_facing_integrations_declare_display_names() -> None:
-    """Every user-facing OAuth or magic-link integration must declare a
+    """Every user-facing OAuth or web-connect integration must declare a
     ``display_name`` at registration so manage_integration never falls
     back to the raw factory key in agent output.
 
@@ -726,7 +725,7 @@ def test_user_facing_integrations_declare_display_names() -> None:
     silently leaking ``companycam`` / ``google_drive`` style raw keys
     into chat.
     """
-    from backend.app.agent.tools.integration_tools import _MAGIC_LINK_INTEGRATIONS
+    from backend.app.agent.tools.integration_tools import _WEB_CONNECT_INTEGRATIONS
     from backend.app.services.oauth import list_oauth_integrations
 
     # Every OAuth integration must be reachable through some factory's
@@ -745,13 +744,13 @@ def test_user_facing_integrations_declare_display_names() -> None:
             f"a display_name in its registry.register() call"
         )
 
-    # Magic-link integrations share the factory name with the target.
-    for target in _MAGIC_LINK_INTEGRATIONS:
+    # Web-connect integrations share the factory name with the target.
+    for target in _WEB_CONNECT_INTEGRATIONS:
         factory = default_registry.get_factory(target)
         assert factory is not None, (
-            f"Magic-link integration {target!r} must be registered as a factory"
+            f"Web-connect integration {target!r} must be registered as a factory"
         )
-        assert factory.display_name, f"Magic-link factory {target!r} must declare a display_name"
+        assert factory.display_name, f"Web-connect factory {target!r} must declare a display_name"
 
 
 @pytest.mark.asyncio()
@@ -831,7 +830,7 @@ async def test_get_user_connected_integrations_skips_unconfigured_oauth() -> Non
         ),
         patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth_service,
         patch(
-            "backend.app.agent.tools.integration_tools._is_magic_link_connected",
+            "backend.app.agent.tools.integration_tools._is_web_connect_connected",
             new_callable=AsyncMock,
             return_value=False,
         ),
@@ -842,8 +841,8 @@ async def test_get_user_connected_integrations_skips_unconfigured_oauth() -> Non
     # gmail is unconfigured -> not in the dict at all.
     assert "gmail" not in result
     assert result["google_drive"] is True
-    # Magic-link integrations still appear: they have no separate
-    # "configured" check; the magic-link plumbing is always available
+    # Web-connect integrations still appear: they have no separate
+    # "configured" check; the web-connect plumbing is always available
     # when the integration is registered.
     assert "appfolio_vendor" in result
 
@@ -878,7 +877,7 @@ async def test_get_user_connected_integrations_reflects_per_user_state() -> None
         ),
         patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth_service,
         patch(
-            "backend.app.agent.tools.integration_tools._is_magic_link_connected",
+            "backend.app.agent.tools.integration_tools._is_web_connect_connected",
             new_callable=AsyncMock,
             return_value=False,
         ),

--- a/tests/test_servicetitan_factory.py
+++ b/tests/test_servicetitan_factory.py
@@ -19,7 +19,6 @@ from backend.app.agent.tools.registry import ToolContext, default_registry
 from backend.app.integrations.servicetitan import _fake as fake_module
 from backend.app.integrations.servicetitan.auth import (
     is_connected,
-    load_credentials,
     save_credentials,
 )
 from backend.app.integrations.servicetitan.auth_tools import build_auth_tools
@@ -185,7 +184,9 @@ async def test_data_factory_returns_all_tools_when_connected(async_test_user: An
 
 
 @pytest.mark.asyncio()
-async def test_connect_servicetitan_persists_credentials(async_test_user: Any) -> None:
+async def test_connect_servicetitan_redirects_to_web_app(async_test_user: Any) -> None:
+    """The auth tool now redirects to the Clawbolt web app instead of
+    accepting credentials in chat. Issue #1337."""
     user_id = async_test_user.id
     tools = build_auth_tools(user_id)
     assert len(tools) == 1
@@ -197,24 +198,20 @@ async def test_connect_servicetitan_persists_credentials(async_test_user: Any) -
         client_id="my-client-id",
         client_secret="my-secret",
     )
-    assert result.is_error is False
-    assert "connected" in result.content.lower()
-    assert result.receipt is not None
-    assert "1234567" in result.receipt.target
+    assert result.is_error is True
+    assert "Clawbolt web app" in result.content
+    assert "Settings > Tools" in result.content
+    assert "ServiceTitan" in result.content
 
-    assert await is_connected(user_id) is True
-    cred = await load_credentials(user_id)
-    assert cred is not None
-    assert cred.tenant_id == "1234567"
-    assert cred.client_id == "my-client-id"
-    assert cred.client_secret == "my-secret"
-    assert cred.app_key == "fake-st-app-key"
-    assert cred.access_token == fake_module.FAKE_TOKEN_VALUE
-    assert cred.expires_at > time.time()
+    # No credentials should have been persisted.
+    assert await is_connected(user_id) is False
 
 
 @pytest.mark.asyncio()
-async def test_connect_servicetitan_rejects_empty_fields(async_test_user: Any) -> None:
+async def test_connect_servicetitan_redirects_even_with_empty_fields(
+    async_test_user: Any,
+) -> None:
+    """The tool now always redirects to web app regardless of input."""
     user_id = async_test_user.id
     tools = build_auth_tools(user_id)
     connect_tool = tools[0]
@@ -225,15 +222,14 @@ async def test_connect_servicetitan_rejects_empty_fields(async_test_user: Any) -
         client_secret="csec",
     )
     assert result.is_error is True
-    assert result.error_kind is not None
-    assert "required" in result.content.lower()
+    assert "Clawbolt web app" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_connect_servicetitan_errors_without_app_key(
+async def test_connect_servicetitan_redirects_regardless_of_app_key(
     async_test_user: Any,
 ) -> None:
-    """When the operator has not set the App Key, connect must fail loudly."""
+    """The tool now always redirects to web app regardless of App Key config."""
     from backend.app.config import settings as _settings
 
     user_id = async_test_user.id
@@ -246,14 +242,14 @@ async def test_connect_servicetitan_errors_without_app_key(
             client_secret="csec",
         )
     assert result.is_error is True
-    assert "SERVICETITAN_APP_KEY" in result.content
+    assert "Clawbolt web app" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_connect_servicetitan_strips_and_rejects_blank_client_secret(
+async def test_connect_servicetitan_redirects_even_with_blank_secret(
     async_test_user: Any,
 ) -> None:
-    """A whitespace-only Client Secret must surface as a validation error."""
+    """The tool now always redirects to web app regardless of input."""
     user_id = async_test_user.id
     tools = build_auth_tools(user_id)
     connect_tool = tools[0]
@@ -261,22 +257,17 @@ async def test_connect_servicetitan_strips_and_rejects_blank_client_secret(
     result = await connect_tool.function(
         tenant_id="t",
         client_id="cid",
-        client_secret="   ",  # stripped to empty before the mint call
+        client_secret="   ",
     )
     assert result.is_error is True
-    assert "required" in result.content.lower()
+    assert "Clawbolt web app" in result.content
 
 
 @pytest.mark.asyncio()
-async def test_connect_servicetitan_surfaces_token_endpoint_failure(
+async def test_connect_servicetitan_redirects_regardless_of_token_failure(
     async_test_user: Any,
 ) -> None:
-    """When the fake rejects the credentials, the tool surfaces an AUTH error.
-
-    Patches the mint helper to raise so this test actually exercises the
-    failure-path branch in the connect tool, not the local validation
-    branch that catches blank fields up front.
-    """
+    """The tool now always redirects to web app regardless of token state."""
     user_id = async_test_user.id
     tools = build_auth_tools(user_id)
     connect_tool = tools[0]
@@ -296,5 +287,4 @@ async def test_connect_servicetitan_surfaces_token_endpoint_failure(
             client_secret="csec",
         )
     assert result.is_error is True
-    assert "rejected" in result.content.lower()
-    assert result.error_kind is not None
+    assert "Clawbolt web app" in result.content

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-04T13:13:44.80209309Z"
+exclude-newer = "2026-05-15T13:13:18.062096967Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -654,10 +654,14 @@ dependencies = [
     { name = "google-auth-oauthlib" },
     { name = "httpx" },
     { name = "pillow" },
+    { name = "psycopg" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "python-multipart" },
     { name = "python-telegram-bot" },
+    { name = "ruff" },
     { name = "simpleeval" },
     { name = "sqlalchemy" },
     { name = "twilio" },
@@ -699,16 +703,20 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
+    { name = "psycopg", specifier = ">=3.3.3" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'alembic'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "python-telegram-bot", specifier = ">=22.0" },
+    { name = "ruff", specifier = ">=0.15.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "simpleeval", specifier = ">=1.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },


### PR DESCRIPTION

Closes #1337

AppFolio magic-link tokens and ServiceTitan Tenant ID/Client ID/Client Secret must not be pastable in iMessage or Telegram chat, where secrets persist in chat history. Instead, both integrations now redirect users to the Clawbolt web app (Settings > Tools) to enter credentials securely.

### Backend changes
- New `POST /api/integrations/appfolio_vendor/connect` endpoint accepts magic link from web form
- New `POST /api/integrations/servicetitan/connect` endpoint accepts credentials from web form
- New DELETE disconnect endpoints for both integrations
- Updated auth_tools.py for both integrations: tools now return a redirect message pointing to the web app
- Renamed `_MAGIC_LINK_INTEGRATIONS` to `_WEB_CONNECT_INTEGRATIONS`, added `_handle_web_connect` / `_handle_web_connect_disconnect` handlers
- Updated factory auth_check messages to point to web app

### Frontend changes
- Added `connectAppfolio`, `connectServiceTitan`, `disconnectAppfolio`, `disconnectServiceTitan` API calls
- Added modal forms for credential input in ToolsPage.tsx
- Connect/Disconnect buttons for web-connect integrations

### Test changes
- Updated all test assertions to expect web app redirect messages instead of chat paste instructions
