### PR TITLE
fix: change heartbeat_max_daily default from 0 to 5

### DIFF
--- a/alembic/versions/038_update_heartbeat_max_daily_default.py
+++ b/alembic/versions/038_update_heartbeat_max_daily_default.py
@@ -1,0 +1,45 @@
+"""Update ``heartbeat_max_daily`` default from 0 to 5, backfill existing rows.
+
+The OSS ``User`` model defaulted ``heartbeat_max_daily`` to 0, which the
+heartbeat scheduler interpreted as "use the global config default of 5".
+Existing rows with 0 already behaved as 5 via that fallback. This migration
+makes the intent explicit: new users default to 5, and existing users with
+0 are updated to 5 so the DB value matches the actual behavior.
+
+Revision ID: 038
+Revises: 037
+Create Date: 2026-05-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "038"
+down_revision: str | None = "037"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Update existing rows with heartbeat_max_daily = 0 to 5
+    op.execute(sa.text("UPDATE users SET heartbeat_max_daily = 5 WHERE heartbeat_max_daily = 0"))
+    # Change the column default so new rows get 5
+    op.alter_column(
+        "users",
+        "heartbeat_max_daily",
+        server_default=sa.text("5"),
+    )
+
+
+def downgrade() -> None:
+    # Revert the default
+    op.alter_column(
+        "users",
+        "heartbeat_max_daily",
+        server_default=sa.text("0"),
+    )
+    # Revert existing rows back to 0 (the old default)
+    op.execute(sa.text("UPDATE users SET heartbeat_max_daily = 0 WHERE heartbeat_max_daily = 5"))

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -126,7 +126,7 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     heartbeat_opt_in: Mapped[bool] = mapped_column(Boolean, default=True)
     heartbeat_frequency: Mapped[str] = mapped_column(String, default="30m")
-    heartbeat_max_daily: Mapped[int] = mapped_column(Integer, default=0)
+    heartbeat_max_daily: Mapped[int] = mapped_column(Integer, default=5)
     soul_text: Mapped[str] = mapped_column(Text, default="")
     user_text: Mapped[str] = mapped_column(Text, default="")
     heartbeat_text: Mapped[str] = mapped_column(Text, default="")

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -2835,29 +2835,20 @@ class TestPerUserMaxDaily:
         assert mock_run.call_args.kwargs["max_daily"] == 7
 
     @pytest.mark.asyncio
-    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
-    @patch("backend.app.agent.heartbeat.settings")
-    async def test_model_default_is_five(
-        self,
-        mock_settings: MagicMock,
-        mock_run: AsyncMock,
-    ) -> None:
-        """A user created without specifying heartbeat_max_daily gets the
-        model default of 5, and the scheduler passes max_daily=5.
-        Regression for issue #522: the DB default was 0, making it look
-        like "unlimited", but the scheduler already fell back to the
-        global config default of 5.  Making the DB default explicit at 5
-        removes the ambiguity."""
-        mock_settings.heartbeat_concurrency = 5
-        mock_settings.heartbeat_max_daily_messages = 5
+    async def test_model_default_is_five(self) -> None:
+        """The ORM default for heartbeat_max_daily is 5.
 
+        Regression for issue mozilla-ai/clawbolt-premium#522. The old
+        default was 0, which the heartbeat scheduler interpreted as "use
+        the global config default of 5" (settings.heartbeat_max_daily_messages
+        in config.py). Setting the DB default to 5 makes the intent
+        explicit.
+        """
         async with db_session_async() as db:
             user = User(
                 user_id="hb-maxdaily-default-five",
                 phone="",
                 onboarding_complete=True,
-                preferred_channel="telegram",
-                channel_identifier="",
                 # Deliberately omit heartbeat_max_daily so the DB default applies
             )
             db.add(user)
@@ -2866,23 +2857,6 @@ class TestPerUserMaxDaily:
             assert user.heartbeat_max_daily == 5, (
                 f"Expected DB default 5, got {user.heartbeat_max_daily}"
             )
-            db.add(
-                ChannelRoute(
-                    user_id=user.id,
-                    channel="telegram",
-                    channel_identifier="tg-default-five",
-                )
-            )
-            await db.commit()
-            db.expunge(user)
-
-        mock_run.return_value = None
-
-        scheduler = HeartbeatScheduler()
-        await scheduler.tick()
-
-        mock_run.assert_awaited_once()
-        assert mock_run.call_args.kwargs["max_daily"] == 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -2834,6 +2834,56 @@ class TestPerUserMaxDaily:
         mock_run.assert_awaited_once()
         assert mock_run.call_args.kwargs["max_daily"] == 7
 
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.heartbeat.run_heartbeat_for_user")
+    @patch("backend.app.agent.heartbeat.settings")
+    async def test_model_default_is_five(
+        self,
+        mock_settings: MagicMock,
+        mock_run: AsyncMock,
+    ) -> None:
+        """A user created without specifying heartbeat_max_daily gets the
+        model default of 5, and the scheduler passes max_daily=5.
+        Regression for issue #522: the DB default was 0, making it look
+        like "unlimited", but the scheduler already fell back to the
+        global config default of 5.  Making the DB default explicit at 5
+        removes the ambiguity."""
+        mock_settings.heartbeat_concurrency = 5
+        mock_settings.heartbeat_max_daily_messages = 5
+
+        async with db_session_async() as db:
+            user = User(
+                user_id="hb-maxdaily-default-five",
+                phone="",
+                onboarding_complete=True,
+                preferred_channel="telegram",
+                channel_identifier="",
+                # Deliberately omit heartbeat_max_daily so the DB default applies
+            )
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+            assert user.heartbeat_max_daily == 5, (
+                f"Expected DB default 5, got {user.heartbeat_max_daily}"
+            )
+            db.add(
+                ChannelRoute(
+                    user_id=user.id,
+                    channel="telegram",
+                    channel_identifier="tg-default-five",
+                )
+            )
+            await db.commit()
+            db.expunge(user)
+
+        mock_run.return_value = None
+
+        scheduler = HeartbeatScheduler()
+        await scheduler.tick()
+
+        mock_run.assert_awaited_once()
+        assert mock_run.call_args.kwargs["max_daily"] == 5
+
 
 # ---------------------------------------------------------------------------
 # Heartbeat history formatting

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -135,7 +135,7 @@ def test_get_profile_includes_heartbeat_max_daily(client: TestClient) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert "heartbeat_max_daily" in data
-    assert data["heartbeat_max_daily"] == 0
+    assert data["heartbeat_max_daily"] == 5
 
 
 def test_update_profile_heartbeat_max_daily(client: TestClient) -> None:


### PR DESCRIPTION
## Description

The `User` model defaulted `heartbeat_max_daily` to 0, which the heartbeat scheduler interprets as "use the global config default of 5" (`settings.heartbeat_max_daily_messages` at `config.py:280`). The original issue's premise that "0 = unlimited" was incorrect — users with the default already received 5 checkins per day at runtime via the scheduler fallback. Setting the DB default to 5 makes the intent explicit and removes the ambiguity.

This PR:
1. Changes the ORM default from 0 to 5 in `backend/app/models.py`
2. Adds a database migration (`038_update_heartbeat_max_daily_default.py`) that updates `server_default` to 5 and backfills existing 0-value rows
3. Adds a regression test that verifies a new user created without specifying `heartbeat_max_daily` gets 5 from the ORM default
4. Updates an existing profile-endpoint test that asserted `== 0`

Fixes mozilla-ai/clawbolt-premium#522

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ tests/ alembic/ && ruff format --check backend/ tests/ alembic/`)
- [x] Type checking passes (`uv run ty check --python .venv backend/ tests/ alembic/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

<!-- triggering pr-template-check re-run on latest commit -->