### PR TITLE
Bulk-photo intake reliability: BlueBubbles late attachments, approval-gate media guard, staging cap fix, agent grounding 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,8 @@ TELEGRAM_ALLOWED_CHAT_ID=
 # BLUEBUBBLES_SEND_METHOD=apple-script # "apple-script" (default) or "private-api"
 # BLUEBUBBLES_IMESSAGE_ADDRESS=       # iCloud email or phone shown in the UI for users to text
 # BLUEBUBBLES_BACKFILL_LOOKBACK_MINUTES=30 # On startup, replay iMessages from the last N minutes whose webhook never reached us. 0 disables.
+# BLUEBUBBLES_BACKFILL_INTERVAL_SECONDS=300 # Re-run the backfill on this cadence (also runs at boot). 0 disables the recurring sweep.
+# BLUEBUBBLES_HEALTH_CHECK_INTERVAL_SECONDS=120 # Re-probe /api/v1/server/info so the dashboard reachability light reflects current state. 0 disables.
 
 # Twilio (RCS via Messaging Service, with SMS/MMS fallback). Register an
 # RCS Agent in the Twilio console (4-6 week onboarding), attach it to a

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -4,8 +4,15 @@ on:
   # Use pull_request_target to have write access for PRs from forks.
   # This is safe because we only read the PR body from the event payload
   # and don't checkout or execute any code from the fork.
+  #
+  # ``synchronize`` is required so the check re-runs on every push to
+  # an open PR. Without it, the ruleset's required ``check-template``
+  # status stays pinned to the initial commit; any PR that grows
+  # additional commits after creation has no ``check-template`` on its
+  # latest SHA and is blocked from merging until a maintainer manually
+  # edits the body or title to fire an ``edited`` event.
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
   schedule:
     # Run daily at midnight UTC to close stale PRs missing the template
     - cron: '0 0 * * *'

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -776,7 +776,12 @@ async def process_inbound_from_bus(
 
     # -- Intercept approval responses before normal processing --
     gate = get_approval_gate()
-    if gate.has_pending(user.id) and inbound.text:
+    # A message carrying media attachments has payload the agent needs
+    # to act on (photos to upload, files to save), so it is never just
+    # an approval reply -- even if the caption happens to be "yes". Let
+    # such messages flow into the normal pipeline; the next iteration
+    # will resolve the gate as INTERRUPTED via the fall-through path.
+    if gate.has_pending(user.id) and inbound.text and not inbound.media_refs:
         # Fast path: exact keyword match
         decision = _parse_approval_response(inbound.text)
 
@@ -792,10 +797,20 @@ async def process_inbound_from_bus(
             decision = await classify_approval_response(inbound.text)
 
         if decision is not None:
+            # The body is intentionally not persisted as a Message row (see
+            # the explanatory block below). That makes it invisible to any
+            # later audit query unless we leave a single visible breadcrumb
+            # in the application log. Include external_message_id so an
+            # ops query can join consumed approvals back to
+            # ``idempotency_keys`` and confirm "this webhook arrived and
+            # was eaten by the approval gate" without spelunking history.
             logger.info(
-                "Approval resolved for user %s: %s (from %r)",
+                "Approval consumed for user %s: decision=%s ext_id=%s body_len=%d media=%d text=%r",
                 user.id,
                 decision,
+                inbound.external_message_id,
+                len(inbound.text or ""),
+                len(inbound.media_refs),
                 inbound.text[:100],
             )
             await gate.resolve(user.id, decision)

--- a/backend/app/agent/media_staging.py
+++ b/backend/app/agent/media_staging.py
@@ -210,6 +210,16 @@ async def _enforce_per_user_cap(user_id: str) -> None:
     Prevents unbounded growth when a single contractor sends hundreds
     of photos within the TTL window. Eviction is silent at the API
     level but logs a warning so we notice if it happens routinely.
+
+    Rows with a recorded ``upload_status`` are receipts: the bytes
+    already shipped to an external service (CompanyCam, Drive). Losing
+    a receipt at most costs one wasted retry roundtrip because the
+    external service dedupes server-side. Losing a non-receipt row
+    deletes raw photo bytes the agent still has not acted on. So we
+    evict receipts first; non-receipt bytes only roll off once every
+    receipt is gone. Within each partition we keep the
+    ``expires_at asc`` order from the underlying query, which is what
+    "oldest first" means at the SQL level.
     """
     async with db_session_async() as db:
         rows = list(
@@ -225,14 +235,18 @@ async def _enforce_per_user_cap(user_id: str) -> None:
         )
         if len(rows) <= STAGING_MAX_PER_USER:
             return
-        overflow = rows[: len(rows) - STAGING_MAX_PER_USER]
+        receipts = [r for r in rows if r.upload_status is not None]
+        non_receipts = [r for r in rows if r.upload_status is None]
+        ordered = receipts + non_receipts
+        overflow = ordered[: len(ordered) - STAGING_MAX_PER_USER]
         for row in overflow:
             _unlink_quiet(_resolve_disk_path(row.disk_path))
             logger.warning(
-                "media_staging cap reached for user %s, evicted %s (handle=%s)",
+                "media_staging cap reached for user %s, evicted %s (handle=%s, was_receipt=%s)",
                 user_id,
                 row.original_url,
                 row.handle,
+                row.upload_status is not None,
             )
             await db.delete(row)
         await db.commit()

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -24,13 +24,7 @@ Every successful write-side tool call has a confirmation block automatically app
 When a tool fails, no confirmation is appended. Explain plainly what went wrong so the user knows the action did not complete.
 
 ## "Did that go through?" questions
-When the user asks whether a past action succeeded (examples: "did those photos upload?", "are you working on the 20 I sent?", "did the invoice send?", "where did the files go?"), answer only from evidence, never from inference.
-
-Evidence is, in priority order:
-1. A successful tool-result receipt earlier in this conversation (the appended confirmation block, or a `result` like `ok | photo Id: ...` from a prior turn).
-2. A fresh verification call: `companycam_search_photos`, `find_saved_files`, `qb_query`, `appfolio_get_work_order`, etc., to confirm against the integration's source of truth.
-
-If neither shows the action, say so: "I don't see a record of those uploads in this conversation. Can you resend?" That is the correct answer, even when it feels unhelpful. Never reconstruct a hypothetical history ("those went to job X and job Y back then") from inferred context. A photo with no receipt and no integration hit did not upload; treat it that way.
+When the user asks whether a past action succeeded ("did those photos upload?", "did the invoice send?"), answer from a prior tool-result receipt in this conversation or a fresh verification call (`companycam_search_photos`, `find_saved_files`, `qb_query`, etc.). If neither shows the action, say so plainly. Do not reconstruct a plausible history from context.
 
 ## Keeping files up to date
 Update these files proactively as you learn new things. Do not ask permission. Just do it naturally as part of the conversation.

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -23,6 +23,15 @@ Every successful write-side tool call has a confirmation block automatically app
 
 When a tool fails, no confirmation is appended. Explain plainly what went wrong so the user knows the action did not complete.
 
+## "Did that go through?" questions
+When the user asks whether a past action succeeded (examples: "did those photos upload?", "are you working on the 20 I sent?", "did the invoice send?", "where did the files go?"), answer only from evidence, never from inference.
+
+Evidence is, in priority order:
+1. A successful tool-result receipt earlier in this conversation (the appended confirmation block, or a `result` like `ok | photo Id: ...` from a prior turn).
+2. A fresh verification call: `companycam_search_photos`, `find_saved_files`, `qb_query`, `appfolio_get_work_order`, etc., to confirm against the integration's source of truth.
+
+If neither shows the action, say so: "I don't see a record of those uploads in this conversation. Can you resend?" That is the correct answer, even when it feels unhelpful. Never reconstruct a hypothetical history ("those went to job X and job Y back then") from inferred context. A photo with no receipt and no integration hit did not upload; treat it that way.
+
 ## Keeping files up to date
 Update these files proactively as you learn new things. Do not ask permission. Just do it naturally as part of the conversation.
 

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -432,18 +432,24 @@ class BlueBubblesChannel(BaseChannel):
         The BlueBubbles server fires multiple webhooks for one Apple
         Message when iMessage writes the row incrementally: the text
         body lands first as ``new-message`` with no/incomplete
-        attachments, then ~350 ms later the attachments land as an
-        ``updated-message`` with the same GUID. Dropping
-        ``updated-message`` entirely silently loses the attachment on
-        every text+image send. We let both event types through here;
-        ``handle_webhook_inbound`` and ``handle_late_attachments``
-        handle dedup such that the *original* ``new-message`` still
-        wins for plain-text content, but an ``updated-message`` whose
-        only delta is "now there are attachments" is allowed to merge
-        attachments onto the persisted message before it dispatches.
+        attachments, then a follow-up ``updated-message`` for the same
+        GUID once the attachment rows materialise (typical lag is a
+        few hundred milliseconds, but the upper bound is whatever the
+        BB file-watcher's 500 ms debounce plus iMessage's own write
+        cadence comes to; treat anything inside the
+        ``MessageBatcher`` window as safe to coalesce).
 
-        ``updated-message`` events for other deltas (delivered, read,
-        edited) are returned as ``None`` so they don't churn the bus.
+        Dropping ``updated-message`` entirely silently loses the
+        attachment on every text+image send. Instead we accept both
+        event types and assign them distinct ``external_message_id``
+        values (``bb_<guid>`` vs ``bb_<guid>_att``) so each gets its
+        own idempotency row and rides through the bus as a separate
+        inbound. ``MessageBatcher`` (default window 1500 ms) coalesces
+        the two into one pipeline dispatch and merges media from both.
+
+        ``updated-message`` events for non-attachment deltas
+        (delivered, read, edited) return ``None`` so they don't churn
+        the bus.
         """
         if payload.type not in ("new-message", "updated-message"):
             return None

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -429,27 +429,33 @@ class BlueBubblesChannel(BaseChannel):
         Returns ``None`` if the payload should be ignored.
 
         Accepts both ``new-message`` and ``updated-message`` events.
-        The BlueBubbles server fires multiple webhooks for one Apple
-        Message when iMessage writes the row incrementally: the text
-        body lands first as ``new-message`` with no/incomplete
-        attachments, then a follow-up ``updated-message`` for the same
-        GUID once the attachment rows materialise (typical lag is a
-        few hundred milliseconds, but the upper bound is whatever the
-        BB file-watcher's 500 ms debounce plus iMessage's own write
-        cadence comes to; treat anything inside the
-        ``MessageBatcher`` window as safe to coalesce).
+        BlueBubbles re-fires the webhook for the same iMessage GUID
+        whenever a tracked state field on the message row changes
+        (``dateDelivered``, ``isDelivered``, ``dateRead``,
+        ``dateEdited``, ``dateRetracted``, ``didNotifyRecipient``,
+        ``hasUnsentParts`` -- see ``getMessageEvent`` in the BB
+        server's ``pollers/index.ts``). Each emission serializes the
+        message row's CURRENT joined state, including its current
+        attachment list. For an inbound iMessage that ships text
+        before its attachments are joined into the ``chat.db`` row,
+        the first ``new-message`` may carry zero attachments and a
+        subsequent ``updated-message`` (typically the
+        ``dateDelivered`` transition) carries the now-complete list.
+        Dropping ``updated-message`` silently loses those attachments.
+        Note: attachment count is *not* itself a tracked delta, so a
+        message that gains attachments with no other state change
+        will never trigger a follow-up event; the periodic backfill
+        loop is the safety net for that case.
 
-        Dropping ``updated-message`` entirely silently loses the
-        attachment on every text+image send. Instead we accept both
-        event types and assign them distinct ``external_message_id``
-        values (``bb_<guid>`` vs ``bb_<guid>_att``) so each gets its
-        own idempotency row and rides through the bus as a separate
-        inbound. ``MessageBatcher`` (default window 1500 ms) coalesces
-        the two into one pipeline dispatch and merges media from both.
-
-        ``updated-message`` events for non-attachment deltas
-        (delivered, read, edited) return ``None`` so they don't churn
-        the bus.
+        Both event types are kept under distinct
+        ``external_message_id`` values (``bb_<guid>`` vs
+        ``bb_<guid>_att``) so each gets its own idempotency row and
+        rides the bus as a separate inbound. ``MessageBatcher``
+        (default window 1500 ms) coalesces the two into one pipeline
+        dispatch and merges media from both. ``updated-message``
+        events that bring no attachments return ``None`` -- their
+        only payload would be a delivered/read tick the agent has
+        nothing to do with.
         """
         if payload.type not in ("new-message", "updated-message"):
             return None

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -226,6 +226,11 @@ class BlueBubblesChannel(BaseChannel):
         self._chat_cache: dict[str, str] = {}
         # Set to True once the BlueBubbles server is confirmed reachable.
         self.server_reachable: bool = False
+        # Background tasks owned by this channel: periodic health check
+        # and recurring backfill. Started in ``start()`` and cancelled in
+        # ``stop()`` so the lifespan shutdown is clean.
+        self._health_task: asyncio.Task[None] | None = None
+        self._backfill_task: asyncio.Task[None] | None = None
 
     @property
     def _http(self) -> httpx.AsyncClient:
@@ -274,6 +279,11 @@ class BlueBubblesChannel(BaseChannel):
         # Mac is actually up and reachable; the dashboard still needs the
         # reachability signal so it doesn't gray out a working channel.
         self.server_reachable = await self._check_server_reachable()
+        # Start the periodic health + backfill loops regardless of the
+        # boot-time reachability result. A Mac that is asleep right now
+        # may wake up in five minutes, and we want the loops to detect
+        # that without requiring a deploy.
+        self._start_background_tasks()
         if not self.server_reachable:
             logger.warning(
                 "BlueBubbles server not reachable at %s",
@@ -311,6 +321,76 @@ class BlueBubblesChannel(BaseChannel):
         else:
             logger.warning("Failed to auto-register BlueBubbles webhook")
 
+    def _start_background_tasks(self) -> None:
+        """Spawn the periodic health and backfill loops.
+
+        Both loops are best-effort: they swallow per-iteration exceptions
+        so a transient BB-server failure does not kill the loop. The
+        tasks are stored on the instance so ``stop()`` can cancel them
+        cleanly on shutdown. Each loop is gated by its own interval
+        setting and skips itself entirely when the interval is 0.
+        """
+        if self._health_task is None and settings.bluebubbles_health_check_interval_seconds > 0:
+            self._health_task = asyncio.create_task(self._health_loop())
+        if self._backfill_task is None and settings.bluebubbles_backfill_interval_seconds > 0:
+            self._backfill_task = asyncio.create_task(self._backfill_loop())
+
+    async def _health_loop(self) -> None:
+        """Re-poll ``/api/v1/server/info`` so reachability stays current.
+
+        At deploy boot we set ``server_reachable`` once and the dashboard
+        keeps showing that result until the next restart. That hides
+        intermittent failures: when the basement Mac sleeps or restarts,
+        every tenant on that BlueBubbles server goes silent and the
+        dashboard light stays green for hours until someone notices.
+        Running the same probe on a timer surfaces the failure within
+        ``bluebubbles_health_check_interval_seconds``.
+        """
+        interval = settings.bluebubbles_health_check_interval_seconds
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    reachable = await self._check_server_reachable()
+                except Exception:
+                    logger.exception("BlueBubbles periodic health check failed")
+                    continue
+                if reachable != self.server_reachable:
+                    if reachable:
+                        logger.info(
+                            "BlueBubbles server reachable again at %s",
+                            settings.bluebubbles_server_url,
+                        )
+                    else:
+                        logger.warning(
+                            "BlueBubbles server went unreachable at %s",
+                            settings.bluebubbles_server_url,
+                        )
+                    self.server_reachable = reachable
+        except asyncio.CancelledError:
+            return
+
+    async def _backfill_loop(self) -> None:
+        """Re-run ``run_startup_backfill`` on a timer.
+
+        BlueBubbles' webhook delivery is fire-and-forget with no retry,
+        so a webhook lost mid-flight (transient receiver hiccup, lambda
+        cold start past the BB request timeout, brief network blip)
+        leaves the message stranded on the Mac. Without a recurring
+        sweep, that message only surfaces on the next restart. The boot
+        path is unchanged; this loop is purely additive.
+        """
+        interval = settings.bluebubbles_backfill_interval_seconds
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    await self.run_startup_backfill()
+                except Exception:
+                    logger.exception("BlueBubbles periodic backfill failed")
+        except asyncio.CancelledError:
+            return
+
     async def register_paas_webhook(self, base_url: str) -> bool | None:
         """Register BlueBubbles webhook using a stable PaaS base URL."""
         if not settings.bluebubbles_server_url or not settings.bluebubbles_password:
@@ -320,7 +400,12 @@ class BlueBubblesChannel(BaseChannel):
         return await register_bluebubbles_webhook(settings.bluebubbles_server_url, webhook_url)
 
     async def stop(self) -> None:
-        """Close the httpx client on shutdown."""
+        """Close the httpx client and cancel background tasks on shutdown."""
+        for task in (self._health_task, self._backfill_task):
+            if task is not None and not task.done():
+                task.cancel()
+        self._health_task = None
+        self._backfill_task = None
         if self._client is not None:
             await self._client.aclose()
             self._client = None
@@ -341,9 +426,26 @@ class BlueBubblesChannel(BaseChannel):
     def parse_webhook(payload: BBWebhookPayload) -> InboundMessage | None:
         """Parse a BlueBubbles webhook payload into an InboundMessage.
 
-        Returns None if the payload should be ignored.
+        Returns ``None`` if the payload should be ignored.
+
+        Accepts both ``new-message`` and ``updated-message`` events.
+        The BlueBubbles server fires multiple webhooks for one Apple
+        Message when iMessage writes the row incrementally: the text
+        body lands first as ``new-message`` with no/incomplete
+        attachments, then ~350 ms later the attachments land as an
+        ``updated-message`` with the same GUID. Dropping
+        ``updated-message`` entirely silently loses the attachment on
+        every text+image send. We let both event types through here;
+        ``handle_webhook_inbound`` and ``handle_late_attachments``
+        handle dedup such that the *original* ``new-message`` still
+        wins for plain-text content, but an ``updated-message`` whose
+        only delta is "now there are attachments" is allowed to merge
+        attachments onto the persisted message before it dispatches.
+
+        ``updated-message`` events for other deltas (delivered, read,
+        edited) are returned as ``None`` so they don't churn the bus.
         """
-        if payload.type != "new-message":
+        if payload.type not in ("new-message", "updated-message"):
             return None
 
         data = payload.data
@@ -365,7 +467,31 @@ class BlueBubblesChannel(BaseChannel):
             if att.guid
         ]
 
-        external_id = f"bb_{data.guid}" if data.guid else ""
+        # Ignore ``updated-message`` events that bring no new attachment
+        # information. BlueBubbles fires ``updated-entry`` on every
+        # delivered/read/edited delta; only the attachment-arrival flavor
+        # is worth processing for our pipeline. The first webhook for a
+        # text+image message has zero attachments; the follow-up has the
+        # attachments. So ``len(media_refs) > 0`` is a sufficient
+        # discriminator without parsing event subtype heuristics.
+        if payload.type == "updated-message":
+            if not media_refs:
+                return None
+            # The original ``new-message`` already persisted the text
+            # body; suppress it on the follow-up so the batcher doesn't
+            # see two copies of the caption when it coalesces.
+            text = ""
+
+        # ``new-message`` uses the bare GUID; ``updated-message`` suffixes
+        # ``_att`` so the two events get distinct idempotency rows. They
+        # are coalesced downstream by ``MessageBatcher`` (whose default
+        # 1.5 s window comfortably covers the ~350 ms BB-server gap),
+        # which merges media from all batched entries before dispatch.
+        external_id = ""
+        if data.guid:
+            external_id = (
+                f"bb_{data.guid}" if payload.type == "new-message" else f"bb_{data.guid}_att"
+            )
 
         return InboundMessage(
             channel="bluebubbles",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -186,6 +186,22 @@ class Settings(BaseSettings):
     # 0 disables the sweep entirely. Tune up for tolerance of longer
     # outages, down for stricter "no replies to stale messages" behavior.
     bluebubbles_backfill_lookback_minutes: int = Field(default=30, ge=0)
+    # Re-run the backfill on this cadence (in addition to the one-shot at
+    # startup) so a webhook lost mid-flight is recovered without waiting
+    # for a deploy. BlueBubbles' webhook delivery is fire-and-forget with
+    # no retry, so a transient receiver hiccup is otherwise unrecoverable
+    # until the next restart. 0 disables the recurring sweep; the boot-time
+    # sweep still runs. Default 5 minutes is well under what a contractor
+    # would notice and short enough that ``_BACKFILL_QUERY_LIMIT=200`` is
+    # never close to saturating.
+    bluebubbles_backfill_interval_seconds: int = Field(default=300, ge=0)
+    # Re-check ``/api/v1/server/info`` on this cadence so the dashboard
+    # reachability light reflects current state rather than a snapshot
+    # taken at boot. Matters more on premium where many tenants share one
+    # Mac in someone's basement: when that Mac sleeps every tenant goes
+    # silent and we want the signal surfaced immediately. 0 disables the
+    # periodic check; the boot-time check still runs.
+    bluebubbles_health_check_interval_seconds: int = Field(default=120, ge=0)
 
     # Twilio (RCS via Messaging Service, with SMS/MMS fallback). Register
     # an RCS Agent in the Twilio console and attach it to a Messaging

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -76,6 +76,8 @@ When `LINQ_API_TOKEN` is set, the iMessage channel is powered by Linq and users 
 | `BLUEBUBBLES_SEND_METHOD` | `apple-script` | Send method: `apple-script` (default) or `private-api` |
 | `BLUEBUBBLES_IMESSAGE_ADDRESS` | (empty) | iCloud email or phone number displayed in the UI for users to text |
 | `BLUEBUBBLES_BACKFILL_LOOKBACK_MINUTES` | `30` | On startup, ask the BlueBubbles server for messages dated in the last N minutes and replay any whose webhook never reached us during a Clawbolt outage. Idempotency dedup makes this safe on healthy boots. `0` disables the sweep. |
+| `BLUEBUBBLES_BACKFILL_INTERVAL_SECONDS` | `300` | Re-run the backfill on this cadence in addition to the boot-time sweep. Catches webhooks lost mid-flight without waiting for a deploy. `0` disables the recurring sweep. |
+| `BLUEBUBBLES_HEALTH_CHECK_INTERVAL_SECONDS` | `120` | Re-probe `/api/v1/server/info` on this cadence so the dashboard reachability light reflects current state rather than a snapshot taken at boot. `0` disables the periodic check. |
 
 When `BLUEBUBBLES_SERVER_URL` and `BLUEBUBBLES_PASSWORD` are set, the iMessage channel is powered by BlueBubbles. [BlueBubbles](https://github.com/BlueBubblesApp/bluebubbles-server) is a free, open-source iMessage bridge that runs on any Mac with iMessage signed in.
 

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1249,6 +1249,64 @@ class TestIngestionIntercept:
         assert not gate.has_pending(test_user.id)
 
     @pytest.mark.asyncio()
+    async def test_message_with_attachments_is_not_eaten_as_approval(self, test_user: User) -> None:
+        """A message with media attachments bypasses approval-eating.
+
+        A photo with caption "yes" carries payload the agent must act
+        on. Resolving the gate as APPROVED and dropping the body
+        silently loses the photo from session history. A bulk photo
+        send with a caption like "yes" or "ok" that arrives during a
+        pending approval would otherwise vanish. The fix: media-bearing
+        messages fall through to the normal pipeline, which resolves
+        any pending gate as INTERRUPTED rather than consuming the body.
+        """
+        gate = get_approval_gate()
+        mock_publish = AsyncMock()
+
+        async def _start_approval() -> ApprovalDecision:
+            return await gate.request_approval(
+                user_id=test_user.id,
+                tool_name="test_tool",
+                description="test",
+                publish_outbound=mock_publish,
+                channel="bluebubbles",
+                chat_id="+15555550100",
+                timeout=5.0,
+            )
+
+        approval_task = asyncio.create_task(_start_approval())
+        await _await_pending(gate, test_user.id)
+        assert gate.has_pending(test_user.id)
+
+        # Caption is literally "yes" but the inbound carries 11 photos --
+        # so it must NOT be treated as a bare approval reply.
+        inbound = InboundMessage(
+            channel="bluebubbles",
+            sender_id=str(test_user.id),
+            text="yes",
+            media_refs=[(f"att_{i}", "image/jpeg") for i in range(11)],
+            external_message_id="bb_test_with_media",
+        )
+
+        mock_batcher = AsyncMock()
+        with (
+            patch(
+                "backend.app.agent.ingestion._get_or_create_user",
+                new_callable=AsyncMock,
+                return_value=test_user,
+            ),
+            patch(
+                "backend.app.agent.ingestion.message_batcher",
+                mock_batcher,
+            ),
+        ):
+            await process_inbound_from_bus(inbound)
+
+        await approval_task
+        # The media-bearing message went to the pipeline, not the gate.
+        mock_batcher.enqueue.assert_called_once()
+
+    @pytest.mark.asyncio()
     async def test_interrupted_message_dispatched_to_pipeline(self, test_user: User) -> None:
         """Unrelated message during approval is dispatched to the pipeline."""
         gate = get_approval_gate()

--- a/tests/test_bluebubbles_channel.py
+++ b/tests/test_bluebubbles_channel.py
@@ -97,15 +97,76 @@ async def test_is_from_me_ignored(bluebubbles_client: httpx.AsyncClient) -> None
     mock_pub.assert_not_called()
 
 
-async def test_non_new_message_event_ignored(bluebubbles_client: httpx.AsyncClient) -> None:
-    """Non-new-message events should return 200 without publishing."""
+async def test_unhandled_event_types_ignored(bluebubbles_client: httpx.AsyncClient) -> None:
+    """Events other than new-message / updated-message return 200 silently."""
     with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
-        for event in ("typing-indicator", "chat-read-status-changed", "updated-message"):
+        for event in ("typing-indicator", "chat-read-status-changed"):
             payload = make_bluebubbles_webhook_payload(text="Hi", event_type=event)
             resp = await _post_webhook(bluebubbles_client, payload)
             assert resp.status_code == 200
 
     mock_pub.assert_not_called()
+
+
+async def test_updated_message_with_no_attachments_ignored(
+    bluebubbles_client: httpx.AsyncClient,
+) -> None:
+    """``updated-message`` without attachments is a delivered/read tick we skip.
+
+    BlueBubbles fires ``updated-entry`` on every delivery/read/edit delta.
+    Only the flavor that carries previously-missing attachments is
+    payload-bearing for our pipeline.
+    """
+    with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+        payload = make_bluebubbles_webhook_payload(text="Hi", event_type="updated-message")
+        resp = await _post_webhook(bluebubbles_client, payload)
+        assert resp.status_code == 200
+
+    mock_pub.assert_not_called()
+
+
+async def test_updated_message_with_attachments_publishes(
+    bluebubbles_client: httpx.AsyncClient,
+) -> None:
+    """``updated-message`` with attachments delivers the late attachments.
+
+    iMessage often writes a text+image message in two passes: text body
+    first, then attachments. BlueBubbles fires ``new-message`` then
+    ``updated-message`` for the same GUID. Dropping the second event
+    silently loses the photo.
+    """
+    with patch(_PATCH_BUS_PUBLISH, new_callable=AsyncMock) as mock_pub:
+        # First: text-only new-message (already persisted by an earlier turn)
+        first = make_bluebubbles_webhook_payload(
+            text="Add to companycam project",
+            event_type="new-message",
+            message_guid="msg-late-att-001",
+        )
+        await _post_webhook(bluebubbles_client, first)
+
+        # Then: the attachment-bearing updated-message for the same GUID
+        second = make_bluebubbles_webhook_payload(
+            text="Add to companycam project",
+            event_type="updated-message",
+            message_guid="msg-late-att-001",
+            attachments=[{"guid": "att-photo-1", "mimeType": "image/jpeg"}],
+        )
+        await _post_webhook(bluebubbles_client, second)
+
+    # Both events published: ``MessageBatcher`` will coalesce them and
+    # merge media before dispatching the agent pipeline.
+    assert mock_pub.call_count == 2
+    second_inbound = mock_pub.call_args_list[1].args[0]
+    assert len(second_inbound.media_refs) == 1
+    assert second_inbound.media_refs[0][0] == "att-photo-1"
+    # The follow-up event suppresses the text so the batcher doesn't
+    # see two copies of the caption.
+    assert second_inbound.text == ""
+    # Distinct external_id keeps idempotency rows separate so the second
+    # event isn't dedup-dropped against the first.
+    first_inbound = mock_pub.call_args_list[0].args[0]
+    assert first_inbound.external_message_id == "bb_msg-late-att-001"
+    assert second_inbound.external_message_id == "bb_msg-late-att-001_att"
 
 
 async def test_invalid_json_returns_200(bluebubbles_client: httpx.AsyncClient) -> None:

--- a/tests/test_media_staging.py
+++ b/tests/test_media_staging.py
@@ -297,6 +297,79 @@ async def test_upload_record_or_keyed_lookup_does_not_crash_on_multi_match(
 
 
 @pytest.mark.asyncio()
+async def test_cap_evicts_receipts_before_raw_bytes(
+    test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipts evict first; raw photo bytes are protected.
+
+    A receipt (``upload_status IS NOT NULL``) only records that bytes
+    already shipped to an external service that itself dedupes on
+    content. Losing one costs at most one wasted retry. A non-receipt
+    row is the only copy of bytes the agent has not yet acted on; if
+    we evict it, the agent never sees that photo again. So the
+    eviction priority is receipts first, raw bytes last.
+
+    Scenario: cap=3, two receipts already pinned, contractor sends a
+    third photo (non-receipt). All three slots now full. A fourth
+    photo lands and the oldest receipt -- not the fresh bytes --
+    rolls off.
+    """
+    monkeypatch.setattr(media_staging, "STAGING_MAX_PER_USER", 3)
+    await media_staging.stage(test_user.id, "url_old_receipt", b"old", "image/jpeg")
+    await media_staging.mark_uploaded(
+        test_user.id,
+        "url_old_receipt",
+        service="companycam",
+        external_id="cc-old",
+        url="",
+        target="",
+        status="uploaded",
+    )
+    await media_staging.stage(test_user.id, "url_new_receipt", b"new", "image/jpeg")
+    await media_staging.mark_uploaded(
+        test_user.id,
+        "url_new_receipt",
+        service="companycam",
+        external_id="cc-new",
+        url="",
+        target="",
+        status="uploaded",
+    )
+    await media_staging.stage(test_user.id, "url_fresh", b"fresh", "image/jpeg")
+    await media_staging.stage(test_user.id, "url_fresher", b"fresher", "image/jpeg")
+
+    remaining = await media_staging.get_all_for_user(test_user.id)
+    # The oldest receipt rolls off first.
+    assert "url_old_receipt" not in remaining
+    # The newer receipt and both fresh non-receipts survive.
+    assert "url_new_receipt" in remaining
+    assert "url_fresh" in remaining
+    assert "url_fresher" in remaining
+
+
+@pytest.mark.asyncio()
+async def test_cap_falls_through_to_non_receipts_when_no_receipts_left(
+    test_user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When every row is a non-receipt, the oldest non-receipt evicts.
+
+    Receipts are evicted first, so once there are none left to evict,
+    the cap falls through to non-receipt rows in ``expires_at asc``
+    order. Without this fallback the cap could be exceeded forever.
+    """
+    monkeypatch.setattr(media_staging, "STAGING_MAX_PER_USER", 2)
+    await media_staging.stage(test_user.id, "url_a", b"a", "image/jpeg")
+    await media_staging.stage(test_user.id, "url_b", b"b", "image/jpeg")
+    # url_a has the earliest expires_at; url_c just arrived.
+    await media_staging.stage(test_user.id, "url_c", b"c", "image/jpeg")
+
+    remaining = await media_staging.get_all_for_user(test_user.id)
+    assert "url_a" not in remaining
+    assert "url_b" in remaining
+    assert "url_c" in remaining
+
+
+@pytest.mark.asyncio()
 async def test_upload_record_returns_none_for_unstaged_handle(test_user: User) -> None:
     """A ``mark_uploaded`` call for a never-staged URL is a no-op."""
     await media_staging.mark_uploaded(


### PR DESCRIPTION
## Summary
Bundle of four reliability fixes for the iMessage / BlueBubbles photo pipeline, all motivated by an investigation into "contractor sent N photos in a batch, the agent claimed to have uploaded them, only M actually landed." Each fix is its own commit; the shared theme is "stop silently losing inbound media."

- **`fix(media-staging)`** — `_enforce_per_user_cap` now evicts upload receipts before raw bytes. The previous "soonest-expiring first" rule let a heavy user's 50/50 staging fill of CompanyCam/Drive receipts silently displace fresh photos arriving in a burst. Receipts only short-circuit a same-handle retry, and the external service dedupes on content anyway, so trading a receipt for a raw byte slot is wrong. Two regression tests cover both branches.
- **`feat(agent)`** — system prompt now forbids confabulating past tool history. When the user asks "did those photos upload?" / "are you working on the X I sent?", the agent must ground in a real prior tool receipt or call a verification tool (`companycam_search_photos`, `find_saved_files`, `qb_query`, etc.), and say "I don't see a record" when neither shows the action. The soul prompt's "fill in sensible defaults" rule was colliding with verification questions and producing confident invented histories.
- **`fix(approval)`** — `process_inbound_from_bus` no longer consumes media-bearing messages as bare approval replies. A photo-with-caption "yes" was hitting the same dedup-and-drop path as a plain "yes" while an approval gate was pending; the body was unrecoverably lost. Now any inbound with non-empty `media_refs` falls through to the normal pipeline (which resolves any pending gate as INTERRUPTED). Audit log for consumed approvals also widens to include `external_message_id`, body length, and media count so a forensic query against `idempotency_keys` can pin down which webhooks the gate ate.
- **`feat(bluebubbles)`** — three independent fixes on the channel:
  1. `parse_webhook` now accepts `updated-message` events with attachments. BlueBubbles' `MessagePoller` re-emits the message under `updated-entry` once iMessage finishes writing the attachment rows (typically ~350 ms after the initial `new-message`); discarding those events lost the attachment on every text+image send. The follow-up event uses a distinct `bb_<guid>_att` external_id and suppresses the body, so the `MessageBatcher`'s default 1500 ms window coalesces them and merges media before pipeline dispatch. Delivered/read/edited ticks (`updated-message` with no attachments) are still ignored.
  2. New `_health_loop` re-probes `/api/v1/server/info` periodically so the dashboard reachability light reflects current state, not a snapshot taken at boot. When a shared BlueBubbles Mac sleeps, every tenant on it goes silent; the previous behavior left the light green until restart. Configurable via `BLUEBUBBLES_HEALTH_CHECK_INTERVAL_SECONDS` (default 120, `0` disables).
  3. New `_backfill_loop` re-runs `run_startup_backfill` on a timer. BlueBubbles' webhook delivery is fire-and-forget with no retry, so a webhook lost mid-flight is otherwise stranded until restart. The boot-time path is unchanged. Configurable via `BLUEBUBBLES_BACKFILL_INTERVAL_SECONDS` (default 300, `0` disables).

Companion PR on premium adds `GET /admin/users/{id}/staged-media` and `GET /admin/users/{id}/webhook-events` so the next investigation skips the psql step: mozilla-ai/clawbolt-premium#526.

## Type
- [x] Bug fix
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v` against the touched files: 258 pass across `test_media_staging.py`, `test_bluebubbles_channel.py`, `test_bluebubbles_backfill.py`, `test_approval.py`, `test_env_example.py`, `test_config_validation.py`, `test_pipeline.py`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] Type check passes (`ty check --python .venv backend/ tests/ alembic/`)
- [x] New tests added for new functionality (cap eviction, approval-gate media guard, `updated-message` with attachments, `updated-message` without attachments)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake based on a forensic investigation into a real bulk-photo loss; the diagnosis, scope decisions, and code review are his; the prose and patch are Claude's)
