### PR TITLE
ci(pr-template): also fire on synchronize so later commits keep check-template green

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -4,8 +4,14 @@ on:
   # Use pull_request_target to have write access for PRs from forks.
   # This is safe because we only read the PR body from the event payload
   # and don't checkout or execute any code from the fork.
+  #
+  # ``synchronize`` is required so the check re-runs on every push to a
+  # PR branch. Without it, the ruleset's "check-template" requirement
+  # stays satisfied on the initial commit but never refreshes on later
+  # SHAs, leaving any PR that adds commits after creation unable to
+  # merge until a maintainer manually edits the body to force a re-fire.
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
   schedule:
     # Run daily at midnight UTC to close stale PRs missing the template
     - cron: '0 0 * * *'


### PR DESCRIPTION
## Summary
The repository ruleset requires ``check-template`` on the head SHA of every PR, but the workflow only listens for ``pull_request_target: [opened, edited]``. Any PR that adds commits after creation has its ``check-template`` status pinned to the initial commit; the latest SHA then has no ``check-template`` run, and the merge is blocked with `Required status check "check-template" is expected`.

The escape hatch today is "edit the PR body or title to fire ``edited``." That works from the GitHub UI, but API-driven edits via fine-grained PATs do not reliably fire ``pull_request_target`` workflows, so automated tooling cannot recover.

Adding ``synchronize`` to the trigger types means every push to a PR branch re-runs the check, matching what the rest of the CI workflows already do.

## Type
- [x] CI/CD

## Checklist
- [x] Tests pass (N/A: workflow trigger change)
- [x] Lint passes (workflow file is YAML; ruff doesn't lint it)
- [x] New tests added for new functionality (N/A)
- [x] Bug fixes include regression tests (N/A: meta-CI fix)

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake after the same dead-end blocked mozilla-ai/clawbolt#1372)