### PR TITLE
fix(frontend): wrap long URLs inside chat message bubble

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -283,6 +283,43 @@ describe('ChatPage tool interaction expand/collapse', () => {
   });
 });
 
+describe('ChatPage message body wrapping', () => {
+  it('wraps long unbreakable strings (e.g. URLs) inside the message bubble', async () => {
+    const sessionId = '1_3000';
+    const longUrl =
+      'https://example.com/oauth/connect?state=' + 'a'.repeat(200) + '&redirect=https://app.example.com/callback';
+    mockApi.getConversation.mockResolvedValue({
+      session_id: sessionId,
+      user_id: '1',
+      created_at: '2025-01-01T00:00:00Z',
+      last_message_at: '2025-01-01T00:01:00Z',
+      channel: 'webchat',
+      initial_system_prompt: '',
+      messages: [
+        {
+          seq: 1,
+          direction: 'inbound',
+          body: 'Connect my calendar',
+          timestamp: '2025-01-01T00:00:00Z',
+          tool_interactions: [],
+        },
+        {
+          seq: 2,
+          direction: 'outbound',
+          body: longUrl,
+          timestamp: '2025-01-01T00:01:00Z',
+          tool_interactions: [],
+        },
+      ],
+    });
+
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>, { route: `/app/chat?session=${sessionId}` });
+
+    const body = await screen.findByText(longUrl);
+    expect(body.className).toContain('break-words');
+  });
+});
+
 describe('ChatPage conversation auto-load', () => {
   it('loads the user conversation on mount', async () => {
     mockApi.getConversation.mockResolvedValue({

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -473,7 +473,7 @@ export default function ChatPage() {
                     </div>
                   )}
                   {msg.body && (
-                    <p className="text-sm whitespace-pre-wrap">{msg.body}</p>
+                    <p className="text-sm whitespace-pre-wrap break-words">{msg.body}</p>
                   )}
 
                   {msg.toolInteractions && msg.toolInteractions.length > 0 && (

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -541,7 +541,7 @@ export default function ChatPage() {
                             </button>
                             {isExpanded && (
                               <div className="px-2 pb-2 space-y-2">
-                                <div className="font-mono text-[14px] whitespace-pre-wrap max-h-60 overflow-y-auto bg-panel/50 rounded px-2 py-1.5">
+                                <div className="font-mono text-[14px] whitespace-pre-wrap break-words max-h-60 overflow-y-auto bg-panel/50 rounded px-2 py-1.5">
                                   {result || 'No result'}
                                 </div>
                                 {hasArgs && (
@@ -549,7 +549,7 @@ export default function ChatPage() {
                                     <span className="text-xs font-medium opacity-70">
                                       Args
                                     </span>
-                                    <pre className="font-mono text-[14px] whitespace-pre-wrap max-h-40 overflow-y-auto bg-panel/50 rounded px-2 py-1.5 mt-0.5">
+                                    <pre className="font-mono text-[14px] whitespace-pre-wrap break-words max-h-40 overflow-y-auto bg-panel/50 rounded px-2 py-1.5 mt-0.5">
                                       {(() => { try { return JSON.stringify(args, null, 2); } catch { return String(args); } })()}
                                     </pre>
                                   </div>


### PR DESCRIPTION
## Description
Long URLs (e.g. an OAuth "connect" link) overflowed the chat bubble in the web chat UI. The message body `<p>` used `whitespace-pre-wrap`, which preserves newlines and wraps on whitespace but does not break long unbreakable tokens. The parent bubble is `max-w-[80%]`, so a URL with no spaces pushed past its edge.

Fix: add Tailwind `break-words` (`overflow-wrap: break-word`) to the body `<p>`. Long URLs now wrap inside the bubble; normal prose continues to wrap on spaces as before. This keeps the web view consistent with how iMessage/SMS render long URLs inline (no autolinking, per the issue note).

Fixes #1367

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Frontend-only change. Verified locally:
- `npx vitest run src/pages/ChatPage.test.tsx`: 15/15 pass (including new regression test)
- `npm run typecheck`: clean
- `npm run deadcode` (knip): clean

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Diagnosed and fixed by Claude via back-and-forth with @njbrake.