### PR TITLE
fix(frontend): hide disconnected integrations on Approvals page

### DIFF
--- a/frontend/src/pages/PermissionsPage.test.tsx
+++ b/frontend/src/pages/PermissionsPage.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '@/test/test-utils';
+import PermissionsPage from './PermissionsPage';
+
+const mockGetToolConfig = vi.fn();
+const mockGetPermissions = vi.fn();
+const mockGetOAuthStatus = vi.fn();
+
+vi.mock('@/api', () => ({
+  default: {
+    getToolConfig: (...args: unknown[]) => mockGetToolConfig(...args),
+    getPermissions: (...args: unknown[]) => mockGetPermissions(...args),
+    updatePermissions: vi.fn().mockResolvedValue({}),
+    getOAuthStatus: (...args: unknown[]) => mockGetOAuthStatus(...args),
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    authState: 'ready',
+    currentAuthUser: { id: 1, name: 'Test User' },
+    authConfig: { required: true, method: 'oidc' },
+    isPremium: false,
+    handleLogin: vi.fn(),
+    handleLogout: vi.fn(),
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useOutletContext: () => ({ profile: {}, reloadProfile: vi.fn() }),
+  };
+});
+
+function tool(overrides: Record<string, unknown>) {
+  return {
+    name: 'demo',
+    description: '',
+    category: 'core',
+    domain_group: '',
+    domain_group_order: 0,
+    enabled: true,
+    configured: true,
+    auth_message: '',
+    oauth_name: '',
+    always_enabled: false,
+    sub_tools: [{ name: 'demo_action', permission_level: 'ask', hidden_in_permissions: false }],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetPermissions.mockResolvedValue({ content: '{}' });
+});
+
+describe('PermissionsPage', () => {
+  it('hides OAuth integrations that are not connected', async () => {
+    mockGetToolConfig.mockResolvedValue({
+      tools: [
+        tool({ name: 'workspace', category: 'core' }),
+        tool({
+          name: 'calendar',
+          category: 'domain',
+          oauth_name: 'google_calendar',
+          sub_tools: [
+            { name: 'calendar_list_events', permission_level: 'ask', hidden_in_permissions: false },
+          ],
+        }),
+      ],
+    });
+    mockGetOAuthStatus.mockResolvedValue({
+      integrations: [{ integration: 'google_calendar', connected: false, configured: true }],
+    });
+
+    renderWithRouter(<PermissionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Workspace')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Google Calendar')).not.toBeInTheDocument();
+  });
+
+  it('shows OAuth integrations once they are connected', async () => {
+    mockGetToolConfig.mockResolvedValue({
+      tools: [
+        tool({
+          name: 'calendar',
+          category: 'domain',
+          oauth_name: 'google_calendar',
+          sub_tools: [
+            { name: 'calendar_list_events', permission_level: 'ask', hidden_in_permissions: false },
+          ],
+        }),
+      ],
+    });
+    mockGetOAuthStatus.mockResolvedValue({
+      integrations: [{ integration: 'google_calendar', connected: true, configured: true }],
+    });
+
+    renderWithRouter(<PermissionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Google Calendar')).toBeInTheDocument();
+    });
+  });
+
+  it('hides non-OAuth tools whose backend reports configured=false', async () => {
+    mockGetToolConfig.mockResolvedValue({
+      tools: [
+        tool({
+          name: 'supplier_pricing',
+          category: 'domain',
+          configured: false,
+          sub_tools: [
+            { name: 'search_supplier', permission_level: 'ask', hidden_in_permissions: false },
+          ],
+        }),
+      ],
+    });
+    mockGetOAuthStatus.mockResolvedValue({ integrations: [] });
+
+    renderWithRouter(<PermissionsPage />);
+
+    await waitFor(() => {
+      expect(mockGetToolConfig).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Pricing Tools')).not.toBeInTheDocument();
+  });
+
+  it('hides OAuth-backed core tools (e.g. Google Drive) when not connected', async () => {
+    mockGetToolConfig.mockResolvedValue({
+      tools: [
+        tool({
+          name: 'file',
+          category: 'core',
+          oauth_name: 'google_drive',
+          always_enabled: true,
+          sub_tools: [
+            { name: 'save_file', permission_level: 'ask', hidden_in_permissions: false },
+          ],
+        }),
+      ],
+    });
+    mockGetOAuthStatus.mockResolvedValue({
+      integrations: [{ integration: 'google_drive', connected: false, configured: true }],
+    });
+
+    renderWithRouter(<PermissionsPage />);
+
+    await waitFor(() => {
+      expect(mockGetToolConfig).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Google Drive')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/PermissionsPage.test.tsx
+++ b/frontend/src/pages/PermissionsPage.test.tsx
@@ -126,7 +126,7 @@ describe('PermissionsPage', () => {
     renderWithRouter(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(mockGetToolConfig).toHaveBeenCalled();
+      expect(screen.getByText(/Control which actions/i)).toBeInTheDocument();
     });
     expect(screen.queryByText('Pricing Tools')).not.toBeInTheDocument();
   });
@@ -152,7 +152,7 @@ describe('PermissionsPage', () => {
     renderWithRouter(<PermissionsPage />);
 
     await waitFor(() => {
-      expect(mockGetToolConfig).toHaveBeenCalled();
+      expect(screen.getByText(/Control which actions/i)).toBeInTheDocument();
     });
     expect(screen.queryByText('Google Drive')).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/PermissionsPage.tsx
+++ b/frontend/src/pages/PermissionsPage.tsx
@@ -2,23 +2,37 @@ import { useState, useCallback, useMemo } from 'react';
 import { Spinner } from '@heroui/spinner';
 import { Tooltip } from '@heroui/tooltip';
 import { toast } from '@/lib/toast';
-import { useToolConfig, usePermissions, useUpdatePermissions } from '@/hooks/queries';
-import { displayName, subToolDisplayName } from '@/lib/tool-utils';
+import {
+  useToolConfig,
+  usePermissions,
+  useUpdatePermissions,
+  useOAuthStatus,
+} from '@/hooks/queries';
+import { displayName, subToolDisplayName, getToolOAuthStatus } from '@/lib/tool-utils';
 import PermissionSelector, {
   PERM_OPTIONS,
   PERM_ACTIVE_STYLES,
   type PermLevel,
 } from '@/components/PermissionSelector';
-import type { ToolConfigEntryResponse, SubToolEntryResponse } from '@/types';
+import type { ToolConfigEntryResponse, OAuthStatusEntry, SubToolEntryResponse } from '@/types';
 
 export default function PermissionsPage() {
   const { data: toolData, isPending: toolsPending, isError } = useToolConfig();
   const { data: permData, isPending: permsPending } = usePermissions();
+  const { data: oauthData } = useOAuthStatus();
   const updateMutation = useUpdatePermissions();
   const [collapsedTools, setCollapsedTools] = useState<Set<string>>(new Set());
 
   const tools = toolData?.tools ?? [];
   const rawContent = permData?.content ?? '';
+
+  const oauthMap = useMemo<Record<string, OAuthStatusEntry>>(() => {
+    const map: Record<string, OAuthStatusEntry> = {};
+    for (const entry of oauthData?.integrations ?? []) {
+      map[entry.integration] = entry;
+    }
+    return map;
+  }, [oauthData]);
 
   const resourcesByTool = useMemo<Record<string, Record<string, PermLevel>>>(() => {
     try {
@@ -42,14 +56,21 @@ export default function PermissionsPage() {
 
   const visibleTools = useMemo(() => {
     // Exclude sub-tools flagged hidden_in_permissions (e.g. send_reply) and
-    // then drop any tool group left without visible sub-tools.
+    // then drop any tool group left without visible sub-tools. Also hide
+    // integrations the user has not connected: OAuth-backed tools without
+    // an active grant, and non-OAuth tools whose backend reports
+    // configured=false (e.g. missing API key). Mirrors the Tools page logic.
     return tools
       .map((t) => ({
         ...t,
         sub_tools: (t.sub_tools ?? []).filter((st) => !st.hidden_in_permissions),
       }))
-      .filter((t) => t.sub_tools.length > 0);
-  }, [tools]);
+      .filter((t) => t.sub_tools.length > 0)
+      .filter((t) => {
+        const { isConnected } = getToolOAuthStatus(t.oauth_name ?? '', oauthMap, t.configured);
+        return isConnected;
+      });
+  }, [tools, oauthMap]);
   const coreTools = useMemo(
     () => visibleTools.filter((t) => t.category === 'core'),
     [visibleTools],

--- a/frontend/src/pages/PermissionsPage.tsx
+++ b/frontend/src/pages/PermissionsPage.tsx
@@ -19,7 +19,7 @@ import type { ToolConfigEntryResponse, OAuthStatusEntry, SubToolEntryResponse } 
 export default function PermissionsPage() {
   const { data: toolData, isPending: toolsPending, isError } = useToolConfig();
   const { data: permData, isPending: permsPending } = usePermissions();
-  const { data: oauthData } = useOAuthStatus();
+  const { data: oauthData, isPending: oauthPending } = useOAuthStatus();
   const updateMutation = useUpdatePermissions();
   const [collapsedTools, setCollapsedTools] = useState<Set<string>>(new Set());
 
@@ -59,7 +59,11 @@ export default function PermissionsPage() {
     // then drop any tool group left without visible sub-tools. Also hide
     // integrations the user has not connected: OAuth-backed tools without
     // an active grant, and non-OAuth tools whose backend reports
-    // configured=false (e.g. missing API key). Mirrors the Tools page logic.
+    // configured=false (e.g. missing API key). Mirrors the Tools page logic
+    // for the "connected" check, but diverges intentionally on the rendering
+    // choice: Tools page dims disconnected cards to surface "Connect" CTAs,
+    // while Approvals page hides them outright because there are no approval
+    // settings to manage for a tool that cannot run yet (issue #521).
     return tools
       .map((t) => ({
         ...t,
@@ -160,7 +164,9 @@ export default function PermissionsPage() {
     [rawContent, updateMutation],
   );
 
-  if (toolsPending && !toolData) {
+  // Wait for both queries so OAuth-backed tools do not briefly render
+  // hidden before the OAuth status arrives.
+  if ((toolsPending && !toolData) || (oauthPending && !oauthData)) {
     return (
       <div className="flex justify-center py-12">
         <Spinner color="primary" size="md" aria-label="Loading" />


### PR DESCRIPTION
## Description

The Approvals page renders approval settings for every domain tool plus any OAuth-backed core tool, even when the user has not connected the integration. That clutters the page with controls the user cannot act on yet and exposes sub-tools for integrations that were never configured.

This change reuses the same `getToolOAuthStatus` helper the Tools page already uses to filter `visibleTools`:

- OAuth-backed tools must have an active grant in `/oauth/status`
- Non-OAuth tools must report `configured=true` (so for example `supplier_pricing` without `SERPAPI_API_KEY` is hidden)

Once a user connects an integration the approval controls appear automatically because `react-query` invalidates the OAuth status cache on connect/disconnect.

Fixes mozilla-ai/clawbolt-premium#521

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) - frontend only, no Python touched; `npx vitest run` on the new test passes (4/4). The full vitest run has 1 unrelated pre-existing `ToolsPage.test.tsx` failure that reproduces on `main`.
- [x] Lint passes - `npm run typecheck` and `npm run deadcode` both clean
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests (`frontend/src/pages/PermissionsPage.test.tsx` with 4 cases: hidden when OAuth not connected, shown when connected, hidden when non-OAuth `configured=false`, hidden for OAuth-backed core tools like Google Drive when not connected)

## AI Usage
- [x] AI-assisted (Claude Code drafted the filter + test scaffolding from the existing `ToolsPage` pattern; review and decisions by @njbrake)
- [ ] No AI used