### PR TITLE
docs(skills): expand companycam coverage, fix calendar gap, add SKILL.md template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ The agent's capabilities are extended by adding tools. Tools follow a factory/re
 
 7. **Write tests** at `tests/test_<name>_tools.py`. Call the factory function directly (e.g., `_create_calculator_tools()`) and invoke the tool function. No database needed for stateless tools.
 
-8. **(Specialist only) Add a SKILL.md** at `backend/app/agent/skills/<name>/SKILL.md` if the tool has complex workflows the LLM needs guidance on. This markdown is injected into the conversation when the LLM activates the category via `list_capabilities`. Core tools do not need SKILL.md; their `description` and `usage_hint` fields in the Python code serve the same purpose.
+8. **(Specialist only) Add a SKILL.md** at `backend/app/agent/skills/<name>/SKILL.md` if the tool has complex workflows the LLM needs guidance on. This markdown is injected into the conversation when the LLM activates the category via `list_capabilities`. Core tools do not need SKILL.md; their `description` and `usage_hint` fields in the Python code serve the same purpose. See "SKILL.md structure for specialist tools" below for the expected skeleton.
 
 ### Key files
 
@@ -224,6 +224,22 @@ The agent's capabilities are extended by adding tools. Tools follow a factory/re
 - **Cut padding.** Phrases like "Use this whenever ...", "If a field is listed here, the entity has it ...", "It is important to ..." are framing the structure already implies. Delete the sentence; if the meaning is intact, it was redundant.
 
 After editing, read the diff and ask: did I add a new fact, or restate an old one? Restated facts double the prompt without doubling agent behavior.
+
+### SKILL.md structure for specialist tools
+
+A specialist SKILL.md is injected only when the agent calls `list_capabilities("<name>")`, so it pays its cost in one place. Aim for 60-150 lines covering what tool descriptions and `usage_hint` strings cannot carry on their own.
+
+Use this skeleton; drop sections that do not apply:
+
+1. **Lead paragraph.** Name the platform, the entities that live in it, and the scope of this integration's coverage.
+2. **Available Tools table.** Group by domain when the surface is wide (e.g. Projects / Photos / Checklists). Columns: tool name in backticks, purpose, approval (`Auto` or `Ask`). Every registered tool gets a row.
+3. **Entity vocabulary.** Bullets defining each first-class entity (id, key fields, relationships). Include enum literals (status values, type codes) verbatim; the agent has no other way to know them.
+4. **Failure-mode rules.** Per-topic sections (e.g. `## Photo handles`, `## Dates`) stating non-obvious constraints at the place they apply, plus the consequence of breaking them.
+5. **Common Workflows.** `### Named workflow` subsections with numbered steps, one tool call or one decision per step. Cover the multi-tool recipes the agent cannot infer from individual tool descriptions.
+6. **Companion integrations.** Bullets pointing to other integrations the agent may compose with (e.g. "X customer ids are not Y project ids"). Reciprocate when another SKILL.md cross-references this one.
+7. **Connecting.** OAuth flow, paste-token, or magic-link steps. Note what happens if the connection lapses.
+
+Reference implementations: `backend/app/integrations/servicetitan/SKILL.md` (clean, mid-sized) and `backend/app/integrations/companycam/SKILL.md` (wider tool surface).
 
 ## Definition of Done
 

--- a/backend/app/integrations/calendar/SKILL.md
+++ b/backend/app/integrations/calendar/SKILL.md
@@ -6,6 +6,7 @@ You now have access to Google Calendar tools. Here is how to use them effectivel
 
 | Tool | Purpose | Approval |
 |------|---------|----------|
+| `calendar_list_calendars` | List enabled calendars with access roles and per-tool permissions | Auto |
 | `calendar_list_events` | List events in a date range | Auto |
 | `calendar_create_event` | Create a new event | Asks user |
 | `calendar_update_event` | Update an existing event | Asks user |
@@ -45,6 +46,10 @@ Before creating an event, check for existing events in the same time range:
 1. Use `calendar_list_events` for the target date range
 2. Look for events with similar titles or times
 3. If a match exists, ask the user: "There's already an event at that time. Update it instead?"
+
+## Multi-calendar setups
+
+When `calendar_list_calendars` returns more than one row, check the target calendar's `access_role` before mutating. Read-only roles (`reader`, `freeBusyReader`) reject create, update, and delete. Pass `calendar_id` explicitly on `calendar_create_event`, `calendar_update_event`, and `calendar_delete_event` rather than letting the tool default.
 
 ## Common Workflows
 

--- a/backend/app/integrations/companycam/SKILL.md
+++ b/backend/app/integrations/companycam/SKILL.md
@@ -1,34 +1,98 @@
 # CompanyCam
 
-You now have access to CompanyCam tools for managing job site photo documentation.
+CompanyCam is a photo documentation platform for the trades. Projects, photos, comments, tags, checklists, and documents live in the account; this integration covers the full project lifecycle, photo upload with deduplication, comments and tags, and checklist management.
 
 ## Available Tools
 
+### Projects
 | Tool | Purpose | Approval |
 |------|---------|----------|
-| companycam_search_projects | Search projects by name or address | Auto |
-| companycam_upload_photo | Upload a photo to a project | Asks user |
-| companycam_create_project | Create a new project | Asks user |
-| companycam_update_project | Rename a project or update its address | Asks user |
+| `companycam_search_projects` | Search projects by name or address | Auto |
+| `companycam_get_project` | Fetch full details for one project | Auto |
+| `companycam_list_documents` | List contracts, specs, and files on a project | Auto |
+| `companycam_create_project` | Create a new project | Ask |
+| `companycam_update_project` | Rename a project or update its address | Ask |
+| `companycam_update_notepad` | Add or update project notes | Ask |
+| `companycam_archive_project` | Archive a completed project | Ask |
+| `companycam_delete_project` | Permanently delete a project (cannot be undone) | Ask |
 
-## Workflow: Uploading a Photo
+### Photos and Comments
+| Tool | Purpose | Approval |
+|------|---------|----------|
+| `companycam_search_photos` | Search photos by project or date range | Auto |
+| `companycam_list_comments` | List comments on a project or photo | Auto |
+| `companycam_upload_photo` | Upload a photo to a project | Ask |
+| `companycam_add_comment` | Add a comment to a project or photo | Ask |
+| `companycam_tag_photo` | Add tags to a photo | Ask |
+| `companycam_delete_photo` | Permanently delete a photo (cannot be undone) | Ask |
 
-When the user sends a photo with job context (client name, address, work type):
+### Checklists
+| Tool | Purpose | Approval |
+|------|---------|----------|
+| `companycam_list_checklists` | List checklists on a project | Auto |
+| `companycam_get_checklist` | View full checklist with task completion | Auto |
+| `companycam_create_checklist` | Create a checklist on a project from a template | Ask |
 
-1. Search for the CompanyCam project: `companycam_search_projects(query="123 Main St")`
-2. If no project found, create one: `companycam_create_project(name="Smith - 123 Main St", address="123 Main St")`
-3. Upload the photo, passing the handle shown in the conversation context: `companycam_upload_photo(project_id="...", original_url="media_XXXXXX", tags=["kitchen", "demo"], description="Kitchen demolition progress")`. One call per photo, one handle per call.
-4. Summarize what you assumed (project, tags) in one short line so the user can amend.
+## Entity vocabulary
 
-`original_url` is required: pass the handle exactly as it appears in `[Photo N, handle=media_XXXXXX]`. Do not retry an upload whose receipt is already in the conversation; a retry on the same handle returns the prior receipt, not a fresh upload.
+- **Project**: a job site or property. Has `id`, `name`, `address`, `status`, `notepad`, primary contact. Photos, documents, checklists, and comments hang off the project.
+- **Photo**: an uploaded image. Has `id`, optional `description`, tags, and a CompanyCam-side `processing_status` (`pending`, `processed`, `duplicate`, `processing_error`).
+- **Checklist**: a task list bound to a project, instantiated from a template. Sections contain tasks; each task carries a `completed_at` timestamp when done.
+
+## Photo handles
+
+`companycam_upload_photo` requires an `original_url` handle. Pass the value exactly as it appears in the conversation context (`handle=media_XXXXXX`). A blank handle is rejected; do not call the tool without one.
+
+The handle is idempotent within the staging TTL: a retry with the same handle returns the prior receipt rather than re-uploading. If the user actually wants a fresh upload, they need to send the photo again to get a new handle.
+
+CompanyCam may report two non-success outcomes:
+- `duplicate`: the same image bytes (MD5) already exist on the project. Surface this so the user knows a re-send was a no-op.
+- `processing_error`: CompanyCam could not fetch the temporary URL. The upload is not recorded; a fresh retry on the same handle will try again.
+
+## Dates
+
+`companycam_search_photos` takes ISO 8601 dates for `start_date` and `end_date` (`2026-05-11` or `2026-05-11T08:00:00`). End-of-day is applied automatically to `end_date`.
 
 ## Tags
 
-Derive tags from the conversation context:
-- Room or area: "kitchen", "bathroom", "exterior", "roof"
-- Work type: "demo", "framing", "finish", "inspection"
-- Stage: "before", "during", "after"
+Derive tags from the conversation context. Common dimensions:
+- Room or area: `kitchen`, `bathroom`, `exterior`, `roof`
+- Work type: `demo`, `framing`, `finish`, `inspection`
+- Stage: `before`, `during`, `after`
 
-## Connection
+Tags are trimmed at 50 chars and capped at 10 per call.
 
-Users connect via OAuth. Use `manage_integration(action='connect', target='companycam')` to start the authorization flow. The user will be redirected to CompanyCam to grant access.
+## Common Workflows
+
+### Upload a photo with job context
+1. `companycam_search_projects(query="<address or client>")`.
+2. If no match, `companycam_create_project(name="<Client - Address>", address="<address>")`.
+3. `companycam_upload_photo(project_id="...", original_url="media_XXXXXX", tags=[...], description="...")`. One call per photo, one handle per call.
+4. Summarize what you assumed (project, tags) in one line so the user can amend.
+
+### Document progress on existing photos
+1. After upload, if the user adds context ("this is the finished kitchen"), use `companycam_tag_photo` or `companycam_add_comment(target_type="photo", target_id="...", content="...")`.
+2. Use project-level comments (`target_type="project"`) for site-wide notes, not photo-specific observations.
+
+### Project handoff or close-out
+1. `companycam_get_project(project_id="...")` to confirm address, contact, status.
+2. `companycam_list_documents(project_id="...")` for attached contracts or specs.
+3. `companycam_archive_project(project_id="...")` when the job is complete. Use `companycam_delete_project` only on explicit request.
+
+### Work a checklist
+1. `companycam_list_checklists(project_id="...")` to see what exists.
+2. `companycam_get_checklist(project_id="...", checklist_id="...")` for task-by-task progress.
+3. `companycam_create_checklist` requires a `template_id`; ask the user which template to use rather than guessing.
+
+### Find recent work across projects
+`companycam_search_photos(start_date="2026-05-01", end_date="2026-05-15")` browses recent photos across all projects. Constrain to one project with `project_id`.
+
+## Companion integrations
+
+- **ServiceTitan**: CompanyCam projects for an ST job are keyed by the customer's address. Resolve the address via `st_get_customer` before `companycam_search_projects`. ServiceTitan customer ids are not CompanyCam project ids.
+- **QuickBooks**: cross-link customers by name plus address; the IDs are not interchangeable. Reference uploaded photos in invoice or estimate notes by their CompanyCam URL.
+- **AppFolio Vendor**: both tools accept `media_XXXXXX` handles directly. A photo already staged for one can be attached to the other in the same conversation without re-sending.
+
+## Connecting
+
+CompanyCam uses OAuth 2.0 authorization code flow. Use `manage_integration(action='connect', target='companycam')` to start the flow; the user is redirected to CompanyCam to grant access. Until that runs, the tools stay surfaced under "Not connected" in `list_capabilities` and refuse to execute.

--- a/backend/app/integrations/companycam/SKILL.md
+++ b/backend/app/integrations/companycam/SKILL.md
@@ -36,7 +36,7 @@ CompanyCam is a photo documentation platform for the trades. Projects, photos, c
 ## Entity vocabulary
 
 - **Project**: a job site or property. Has `id`, `name`, `address`, `status`, `notepad`, primary contact. Photos, documents, checklists, and comments hang off the project.
-- **Photo**: an uploaded image. Has `id`, optional `description`, tags, and a CompanyCam-side `processing_status` (`pending`, `processed`, `duplicate`, `processing_error`).
+- **Photo**: an uploaded image. Has `id`, optional `description`, tags, and a CompanyCam-side `processing_status` (`pending`, `processing`, `processed`, `duplicate`, `processing_error`).
 - **Checklist**: a task list bound to a project, instantiated from a template. Sections contain tasks; each task carries a `completed_at` timestamp when done.
 
 ## Photo handles


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Three related documentation changes that all land under the SKILL.md system.

### 1. CompanyCam SKILL.md rewrite (commits 81e54db, f03326f)

The CompanyCam SKILL.md previously documented only 4 of the 17 tools registered in `backend/app/integrations/companycam/factory.py`. Photo upload outcomes (`duplicate`, `processing_error`) were undocumented despite the handler returning them.

Rewrite the file against the bar set by `servicetitan/SKILL.md` and `calendar/SKILL.md`:

- Full tool table (17 tools) grouped by Projects / Photos and Comments / Checklists
- Entity vocabulary (Project / Photo / Checklist) modeled on ServiceTitan, with the full `processing_status` enum
- `## Photo handles` section consolidating the `media_XXXXXX` rule, idempotency within the staging TTL, and the two non-success outcomes the handler can return
- `## Common Workflows` with 5 named recipes (upload, document progress, project close-out, checklist, find recent work)
- `## Companion integrations` reciprocating the ServiceTitan cross-reference and adding QuickBooks and AppFolio Vendor pointers

### 2. Calendar SKILL.md gap (commit a62348c)

An audit of the other SKILL.md files (QuickBooks, Calendar, ServiceTitan, AppFolio) surfaced one additional gap: `calendar_list_calendars` was registered in `calendar/factory.py` but missing from `calendar/SKILL.md`, even though several other tools' descriptions tell the LLM to "check calendar_list_calendars first". Add the missing row and a brief Multi-calendar setups section noting that read-only access roles reject mutations.

### 3. AGENTS.md SKILL.md template (commit aac2c76)

Codify the structure the strongest existing SKILL.md files follow (lead paragraph, tool table, entity vocabulary, failure-mode rules, common workflows, companion integrations, connecting) so the next integration does not drift the way CompanyCam's did. The template lives under "Editing prompt files" alongside the existing token-cost guidance.

Documentation only. No tool code, factory registrations, or tests changed.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`). Verified locally on the relevant subset: `tests/test_skill_loader.py` (10 passed), `tests/test_tool_registry.py` (9 passed), `tests/test_companycam_tools.py` plus `tests/test_companycam_receipts.py` (121 passed), `tests/test_calendar_tools.py` (78 passed).
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`). No Python files touched.
- [ ] New tests added for new functionality. N/A, doc-only change.
- [ ] Bug fixes include regression tests. N/A, not a bug fix.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Drafted end-to-end by Claude during a discussion about whether the existing SKILL.md design needed restructuring. The gap analysis (CompanyCam coverage, `duplicate` / `processing_error` semantics, missing reciprocal companion-integrations section, calendar_list_calendars omission) and the resulting content and template were produced via that back-and-forth.