### PR TITLE
fix: gate system prompt UI and stop exposing initial_system_prompt

### DIFF
--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -50,7 +50,6 @@ def _empty_conversation(user_id: str) -> SessionDetailResponse:
         created_at="",
         last_message_at="",
         channel="",
-        initial_system_prompt="",
         messages=[],
     )
 
@@ -103,7 +102,6 @@ async def get_conversation(
         created_at=session.created_at,
         last_message_at=session.last_message_at,
         channel=session.channel,
-        initial_system_prompt=session.initial_system_prompt,
         messages=messages,
     )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -127,7 +127,6 @@ class SessionDetailResponse(BaseModel):
     created_at: str
     last_message_at: str
     channel: str = ""
-    initial_system_prompt: str = ""
     messages: list[SessionMessage]
 
 
@@ -135,11 +134,11 @@ class SessionSystemPromptResponse(BaseModel):
     """Live system prompt that would be sent to the LLM on the next turn.
 
     Reconstructed on demand from current user state (memory, profile,
-    onboarding status, available tools) rather than pulled from the
-    session's frozen ``initial_system_prompt`` column. Use this when
-    the UI needs the current prompt; use ``initial_system_prompt`` on
-    ``SessionDetailResponse`` when the historical first-turn prompt is
-    what's wanted.
+    onboarding status, available tools). The historical first-turn
+    snapshot lives on the ``ChatSession.initial_system_prompt`` column
+    for forensics but is intentionally not exposed via the public API,
+    since it reveals the operator's preamble and tool wiring. Premium
+    deployments additionally gate this endpoint behind an admin guard.
     """
 
     session_id: str

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2427,11 +2427,6 @@
             "title": "Channel",
             "default": ""
           },
-          "initial_system_prompt": {
-            "type": "string",
-            "title": "Initial System Prompt",
-            "default": ""
-          },
           "messages": {
             "items": {
               "$ref": "#/components/schemas/SessionMessage"
@@ -2508,7 +2503,7 @@
           "is_onboarding"
         ],
         "title": "SessionSystemPromptResponse",
-        "description": "Live system prompt that would be sent to the LLM on the next turn.\n\nReconstructed on demand from current user state (memory, profile,\nonboarding status, available tools) rather than pulled from the\nsession's frozen ``initial_system_prompt`` column. Use this when\nthe UI needs the current prompt; use ``initial_system_prompt`` on\n``SessionDetailResponse`` when the historical first-turn prompt is\nwhat's wanted."
+        "description": "Live system prompt that would be sent to the LLM on the next turn.\n\nReconstructed on demand from current user state (memory, profile,\nonboarding status, available tools). The historical first-turn\nsnapshot lives on the ``ChatSession.initial_system_prompt`` column\nfor forensics but is intentionally not exposed via the public API,\nsince it reveals the operator's preamble and tool wiring. Premium\ndeployments additionally gate this endpoint behind an admin guard."
       },
       "SubToolEntryResponse": {
         "properties": {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1304,11 +1304,6 @@ export interface components {
              * @default
              */
             channel: string;
-            /**
-             * Initial System Prompt
-             * @default
-             */
-            initial_system_prompt: string;
             /** Messages */
             messages: components["schemas"]["SessionMessage"][];
         };
@@ -1335,11 +1330,11 @@ export interface components {
          * @description Live system prompt that would be sent to the LLM on the next turn.
          *
          *     Reconstructed on demand from current user state (memory, profile,
-         *     onboarding status, available tools) rather than pulled from the
-         *     session's frozen ``initial_system_prompt`` column. Use this when
-         *     the UI needs the current prompt; use ``initial_system_prompt`` on
-         *     ``SessionDetailResponse`` when the historical first-turn prompt is
-         *     what's wanted.
+         *     onboarding status, available tools). The historical first-turn
+         *     snapshot lives on the ``ChatSession.initial_system_prompt`` column
+         *     for forensics but is intentionally not exposed via the public API,
+         *     since it reveals the operator's preamble and tool wiring. Premium
+         *     deployments additionally gate this endpoint behind an admin guard.
          */
         SessionSystemPromptResponse: {
             /** Session Id */

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { Outlet, Route, Routes } from 'react-router-dom';
 import { renderWithRouter } from '@/test/test-utils';
 import { ChatActivityProvider } from '@/contexts/ChatActivityContext';
 import ChatPage from './ChatPage';
@@ -557,3 +559,115 @@ describe('ChatPage failed-send cleanup (issue #1368)', () => {
     });
   });
 });
+
+describe('ChatPage system prompt panel visibility', () => {
+  const sessionWithMessages = (sessionId: string) => ({
+    session_id: sessionId,
+    user_id: '1',
+    created_at: '2025-01-01T00:00:00Z',
+    last_message_at: '2025-01-01T00:01:00Z',
+    channel: 'webchat' as const,
+    initial_system_prompt: '',
+    messages: [
+      {
+        seq: 1,
+        direction: 'inbound' as const,
+        body: 'Hi',
+        timestamp: '2025-01-01T00:00:00Z',
+        tool_interactions: [],
+      },
+      {
+        seq: 2,
+        direction: 'outbound' as const,
+        body: 'Hello!',
+        timestamp: '2025-01-01T00:01:00Z',
+        tool_interactions: [],
+      },
+    ],
+  });
+
+  it('hides the panel for non-admin users on a premium deployment', async () => {
+    const sessionId = '1_5100';
+    mockApi.getConversation.mockResolvedValue(sessionWithMessages(sessionId));
+
+    const { unmount } = renderWithRouter(
+      <ChatActivityProvider>
+        <OutletCtxProvider value={{ isPremium: true, isAdmin: false }}>
+          <ChatPage />
+        </OutletCtxProvider>
+      </ChatActivityProvider>,
+      { route: `/app/chat?session=${sessionId}` },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello!')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /current system prompt/i })).not.toBeInTheDocument();
+    expect(mockApi.getConversationSystemPrompt).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('shows the panel for admin users on a premium deployment', async () => {
+    const sessionId = '1_5101';
+    mockApi.getConversation.mockResolvedValue(sessionWithMessages(sessionId));
+    mockApi.getConversationSystemPrompt.mockResolvedValue({
+      session_id: sessionId,
+      system_prompt: 'ADMIN-VISIBLE PROMPT',
+      is_onboarding: false,
+    });
+
+    renderWithRouter(
+      <ChatActivityProvider>
+        <OutletCtxProvider value={{ isPremium: true, isAdmin: true }}>
+          <ChatPage />
+        </OutletCtxProvider>
+      </ChatActivityProvider>,
+      { route: `/app/chat?session=${sessionId}` },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello!')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /current system prompt/i })).toBeInTheDocument();
+  });
+
+  it('shows the panel on OSS standalone (no premium auth)', async () => {
+    const sessionId = '1_5102';
+    mockApi.getConversation.mockResolvedValue(sessionWithMessages(sessionId));
+
+    renderWithRouter(
+      <ChatActivityProvider>
+        <OutletCtxProvider value={{ isPremium: false, isAdmin: false }}>
+          <ChatPage />
+        </OutletCtxProvider>
+      </ChatActivityProvider>,
+      { route: `/app/chat?session=${sessionId}` },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello!')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /current system prompt/i })).toBeInTheDocument();
+  });
+});
+
+/** Test helper that injects an outlet context value into the React tree. */
+function OutletCtxProvider({
+  value,
+  children,
+}: {
+  value: { isPremium: boolean; isAdmin: boolean };
+  children: ReactNode;
+}) {
+  return (
+    <Routes>
+      <Route element={<Outlet context={value} />}>
+        <Route path="*" element={children} />
+      </Route>
+    </Routes>
+  );
+}

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -49,7 +49,6 @@ describe('ChatPage tool interactions', () => {
       created_at: '2025-01-01T00:00:00Z',
       last_message_at: '2025-01-01T00:01:00Z',
       channel: 'webchat',
-      initial_system_prompt: '',
       messages: [
         {
           seq: 1,
@@ -90,7 +89,6 @@ describe('ChatPage tool interactions', () => {
       created_at: '2025-01-01T00:00:00Z',
       last_message_at: '2025-01-01T00:01:00Z',
       channel: 'webchat',
-      initial_system_prompt: '',
       messages: [
         {
           seq: 1,
@@ -130,7 +128,6 @@ describe('ChatPage tool interaction expand/collapse', () => {
       created_at: '2025-01-01T00:00:00Z',
       last_message_at: '2025-01-01T00:01:00Z',
       channel: 'webchat',
-      initial_system_prompt: '',
       messages: [
         {
           seq: 1,
@@ -296,7 +293,6 @@ describe('ChatPage message body wrapping', () => {
       created_at: '2025-01-01T00:00:00Z',
       last_message_at: '2025-01-01T00:01:00Z',
       channel: 'webchat',
-      initial_system_prompt: '',
       messages: [
         {
           seq: 1,
@@ -330,7 +326,6 @@ describe('ChatPage conversation auto-load', () => {
       created_at: '2025-01-01T00:00:00Z',
       last_message_at: '2025-01-01T00:01:00Z',
       channel: 'webchat',
-      initial_system_prompt: '',
       messages: [
         {
           seq: 1,
@@ -368,7 +363,6 @@ describe('ChatPage conversation auto-load', () => {
       created_at: '',
       last_message_at: '',
       channel: '',
-      initial_system_prompt: '',
       messages: [],
     });
 
@@ -425,7 +419,6 @@ describe('ChatPage current system prompt panel', () => {
       created_at: '2025-01-01T00:00:00Z',
       last_message_at: '2025-01-01T00:01:00Z',
       channel: 'webchat',
-      initial_system_prompt: 'STALE FIRST-TURN PROMPT',
       messages: [
         {
           seq: 1,
@@ -464,10 +457,6 @@ describe('ChatPage current system prompt panel', () => {
     expect(toggle).toBeInTheDocument();
     expect(mockApi.getConversationSystemPrompt).not.toHaveBeenCalled();
 
-    // We must NOT show the stale frozen snapshot. Even before opening
-    // the panel, the old initial_system_prompt text should be absent.
-    expect(screen.queryByText('STALE FIRST-TURN PROMPT')).not.toBeInTheDocument();
-
     // Expanding triggers a single fetch with the active session id and
     // renders the live prompt body.
     const user = userEvent.setup();
@@ -487,7 +476,6 @@ describe('ChatPage current system prompt panel', () => {
       created_at: '2025-01-01T00:00:00Z',
       last_message_at: '2025-01-01T00:01:00Z',
       channel: 'webchat',
-      initial_system_prompt: '',
       messages: [
         {
           seq: 1,
@@ -539,7 +527,6 @@ describe('ChatPage failed-send cleanup (issue #1368)', () => {
       created_at: '',
       last_message_at: '',
       channel: 'webchat',
-      initial_system_prompt: '',
       messages: [],
     });
     mockApi.sendChatMessage.mockRejectedValue(new Error('Request failed: 403'));
@@ -567,7 +554,6 @@ describe('ChatPage system prompt panel visibility', () => {
     created_at: '2025-01-01T00:00:00Z',
     last_message_at: '2025-01-01T00:01:00Z',
     channel: 'webchat' as const,
-    initial_system_prompt: '',
     messages: [
       {
         seq: 1,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback, type FormEvent } from 'react';
+import { useOutletContext } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import Button from '@/components/ui/button';
 import ConfirmModal from '@/components/ui/confirm-modal';
@@ -10,6 +11,7 @@ import { toast } from '@/lib/toast';
 import { useConversation, useConversationSystemPrompt } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
 import { useChatActivity } from '@/contexts/ChatActivityContext';
+import type { AppShellContext } from '@/layouts/AppShell';
 import type { ToolInteraction } from '@/types';
 
 interface FileAttachment {
@@ -32,6 +34,15 @@ const ACCEPTED_FILE_TYPES = 'image/*,audio/*,application/pdf';
 
 export default function ChatPage() {
   const queryClient = useQueryClient();
+  // The system prompt panel exposes the operator's preamble and tool wiring,
+  // so on multi-tenant premium deployments it is admin-only. OSS standalone
+  // (single-tenant) has no admin/user split, so the panel is visible there.
+  // useOutletContext is undefined under MemoryRouter in tests; default both
+  // flags to false so the OSS standalone branch (panel visible) is taken.
+  const outletCtx = useOutletContext<AppShellContext | undefined>();
+  const isPremium = outletCtx?.isPremium ?? false;
+  const isAdmin = outletCtx?.isAdmin ?? false;
+  const canSeeSystemPrompt = !isPremium || isAdmin;
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [pendingCount, setPendingCount] = useState(0);
@@ -96,7 +107,7 @@ export default function ChatPage() {
     data: systemPromptData,
     isFetching: systemPromptFetching,
     isError: systemPromptError,
-  } = useConversationSystemPrompt({ enabled: systemPromptOpen && hasConversation });
+  } = useConversationSystemPrompt({ enabled: canSeeSystemPrompt && systemPromptOpen && hasConversation });
 
   // Use scrollTop instead of scrollIntoView to avoid iOS Safari viewport zoom
   // bug that occurs when scrollIntoView fires during keyboard dismissal.
@@ -385,7 +396,7 @@ export default function ChatPage() {
           </div>
         ) : (
           <div className="space-y-3">
-            {hasConversation && (
+            {hasConversation && canSeeSystemPrompt && (
               <div className="border border-border rounded-lg overflow-hidden">
                 <button
                   type="button"

--- a/tests/test_session_debug_info.py
+++ b/tests/test_session_debug_info.py
@@ -1,4 +1,11 @@
-"""Tests for session debug info: initial_system_prompt."""
+"""Tests for the ``initial_system_prompt`` capture column.
+
+The column is written by ``persist_system_prompt_step`` for forensics
+and intentionally **not** exposed via the public conversation API,
+since it reveals the operator preamble and tool wiring. The store
+behaviour is exercised below; the API-level negative assertion lives
+alongside the conversation endpoint tests.
+"""
 
 from datetime import UTC, datetime
 
@@ -93,8 +100,15 @@ async def test_system_prompt_not_overwritten(test_user: User) -> None:
     assert loaded.initial_system_prompt == "Original prompt"
 
 
-async def test_api_includes_system_prompt(client: TestClient, test_user: User) -> None:
-    """GET /api/user/conversation includes initial_system_prompt."""
+async def test_api_does_not_leak_initial_system_prompt(client: TestClient, test_user: User) -> None:
+    """GET /api/user/conversation must not expose the frozen system prompt.
+
+    The capture column stores the operator's preamble and tool wiring at
+    the first turn. The dedicated ``/system-prompt`` endpoint is the
+    sanctioned read path (premium gates that one behind admin auth). The
+    conversation endpoint, which is callable by every authenticated user,
+    must not return the field on the wire.
+    """
     await _create_session_with_prompt(
         test_user,
         "debug-sess-1",
@@ -107,20 +121,7 @@ async def test_api_includes_system_prompt(client: TestClient, test_user: User) -
     resp = client.get("/api/user/conversation")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["initial_system_prompt"] == "You are a trades assistant."
-
-
-async def test_api_empty_prompt_for_new_session(client: TestClient, test_user: User) -> None:
-    """Sessions without a system prompt return empty string."""
-    await _create_session_with_prompt(
-        test_user,
-        "debug-sess-2",
-        messages=[
-            {"direction": "inbound", "body": "Hey", "timestamp": "2025-01-15T10:01:00", "seq": 1},
-        ],
-    )
-
-    resp = client.get("/api/user/conversation")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["initial_system_prompt"] == ""
+    assert "initial_system_prompt" not in data
+    # Belt-and-suspenders: even if the field name is ever re-introduced
+    # by accident, make sure the value isn't echoing the stored prompt.
+    assert "You are a trades assistant." not in resp.text

--- a/tests/test_session_endpoints.py
+++ b/tests/test_session_endpoints.py
@@ -524,7 +524,10 @@ async def test_delete_conversation_history(client: TestClient, test_user: User) 
     resp = client.get("/api/user/conversation")
     detail = resp.json()
     assert detail["messages"] == []
-    assert detail["initial_system_prompt"] == ""
+    # The conversation endpoint intentionally does not expose
+    # ``initial_system_prompt``. Store-level coverage of "delete clears
+    # the prompt" lives in ``test_session_db_async.py``.
+    assert "initial_system_prompt" not in detail
 
 
 async def test_delete_conversation_history_preserves_memory(


### PR DESCRIPTION
## Description

The Current System Prompt panel on the Chat page reveals the operator's preamble, tool guidance, and connected integrations. On multi-tenant premium deployments that operational detail should be admin-only.

`ChatPage` now reads `isPremium`/`isAdmin` from `AppShellContext` and gates the panel rendering plus the lazy fetch with `canSeeSystemPrompt = !isPremium || isAdmin`. OSS standalone (single-tenant, no premium auth) is unaffected: `isPremium=false`, so the panel stays visible.

Paired with a premium-side admin guard on `GET /api/user/conversation/system-prompt` (mozilla-ai/clawbolt-premium#529) so non-admins can't bypass the UI hide by calling the endpoint directly.

Tracks mozilla-ai/clawbolt-premium#519.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`npx vitest run src/pages/ChatPage.test.tsx`)
- [x] Type checking passes (`npm run typecheck`)
- [x] Dead code check passes (`npm run deadcode`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implementation drafted with Claude Code: surveyed the existing `AppShellContext` / `useOutletContext` pattern used by `SettingsPage`, added the `canSeeSystemPrompt` gate to `ChatPage`, and added three vitest cases covering non-admin premium (hidden + no fetch), admin premium (visible), and OSS standalone (visible).