### PR TITLE
fix(frontend): unify Heartbeat settings into the Priorities page

### DIFF
--- a/frontend/src/extensions/routes.tsx
+++ b/frontend/src/extensions/routes.tsx
@@ -11,7 +11,7 @@ export function getLoginPageElement(): ReactNode {
 }
 
 export function getDefaultSettingsTab(_isPremium: boolean): string {
-  return 'heartbeat';
+  return 'model';
 }
 
 export function shouldRedirectRootToApp(_isPremium: boolean): boolean {

--- a/frontend/src/extensions/settings.tsx
+++ b/frontend/src/extensions/settings.tsx
@@ -14,5 +14,5 @@ export function renderPremiumSettingsTab(_key: string, _isAdmin: boolean): React
 }
 
 export function showOssSettingsTabs(_isPremium: boolean, _isAdmin: boolean): string[] {
-  return ['model', 'heartbeat', 'telegram', 'channels', 'privacy'];
+  return ['model', 'telegram', 'channels', 'privacy'];
 }

--- a/frontend/src/pages/HeartbeatPage.test.tsx
+++ b/frontend/src/pages/HeartbeatPage.test.tsx
@@ -16,6 +16,7 @@ const mockProfile = {
   channel_identifier: '',
   heartbeat_opt_in: true,
   heartbeat_frequency: 'daily',
+  heartbeat_max_daily: 0,
   onboarding_complete: true,
   is_active: true,
   created_at: '2025-01-01T00:00:00Z',
@@ -48,6 +49,7 @@ const mockApi = vi.mocked(api);
 beforeEach(() => {
   vi.clearAllMocks();
   mockApi.getProfile.mockResolvedValue(mockProfile as never);
+  mockApi.updateProfile.mockResolvedValue(mockProfile as never);
 });
 
 describe('HeartbeatPage', () => {
@@ -60,12 +62,10 @@ describe('HeartbeatPage', () => {
 
     // Should show Edit button, not Save
     expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
   });
 
   it('switches to textarea on Edit click and saves on Save click', async () => {
-    mockApi.updateProfile.mockResolvedValue(mockProfile as never);
-
     renderWithRouter(<HeartbeatPage />, { route: '/app/heartbeat' });
 
     await waitFor(() => {
@@ -81,7 +81,7 @@ describe('HeartbeatPage', () => {
 
     // Modify and save
     fireEvent.change(textarea, { target: { value: 'Updated notes' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
     await waitFor(() => {
       expect(mockApi.updateProfile).toHaveBeenCalled();
@@ -110,5 +110,37 @@ describe('HeartbeatPage', () => {
       expect(screen.getByRole('listitem')).toHaveTextContent('Follow up with new leads');
     });
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('renders check-in settings on the Priorities page', async () => {
+    renderWithRouter(<HeartbeatPage />, { route: '/app/heartbeat' });
+
+    await waitFor(() => {
+      expect(screen.getByText(/enable proactive check-ins/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/max daily check-ins/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save check-in settings/i })).toBeInTheDocument();
+  });
+
+  it('saves the current check-in settings when Save is clicked', async () => {
+    renderWithRouter(<HeartbeatPage />, { route: '/app/heartbeat' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save check-in settings/i })).toBeInTheDocument();
+    });
+
+    const maxDailyInput = screen.getByPlaceholderText('0') as HTMLInputElement;
+    fireEvent.change(maxDailyInput, { target: { value: '5' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save check-in settings/i }));
+
+    await waitFor(() => {
+      expect(mockApi.updateProfile).toHaveBeenCalled();
+      expect(mockApi.updateProfile.mock.calls[0]?.[0]).toEqual({
+        heartbeat_opt_in: true,
+        heartbeat_frequency: 'daily',
+        heartbeat_max_daily: 5,
+      });
+    });
   });
 });

--- a/frontend/src/pages/HeartbeatPage.tsx
+++ b/frontend/src/pages/HeartbeatPage.tsx
@@ -1,10 +1,29 @@
-import { useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { Spinner } from '@heroui/spinner';
 import { toast } from '@/lib/toast';
 import { useUpdateProfile } from '@/hooks/queries';
 import MarkdownEditor from '@/components/ui/MarkdownEditor';
+import Card from '@/components/ui/card';
+import Input from '@/components/ui/input';
+import Select from '@/components/ui/select';
+import Button from '@/components/ui/button';
+import Checkbox from '@/components/ui/checkbox';
+import Field from '@/components/ui/field';
 import type { AppShellContext } from '@/layouts/AppShell';
+import type { UserProfileResponse } from '@/types';
+
+const HEARTBEAT_PRESETS = [
+  { value: '15m', label: 'Every 15 minutes' },
+  { value: '30m', label: 'Every 30 minutes' },
+  { value: '1h', label: 'Every hour' },
+  { value: '2h', label: 'Every 2 hours' },
+  { value: '4h', label: 'Every 4 hours' },
+  { value: '8h', label: 'Every 8 hours' },
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekdays', label: 'Weekdays only' },
+  { value: 'weekly', label: 'Weekly' },
+] as const;
 
 export default function HeartbeatPage() {
   const { profile, reloadProfile } = useOutletContext<AppShellContext>();
@@ -14,12 +33,12 @@ export default function HeartbeatPage() {
     reloadProfile();
   }, [reloadProfile]);
 
-  const handleSave = useCallback(
+  const handleSaveText = useCallback(
     async (text: string) => {
       await updateProfile.mutateAsync(
         { heartbeat_text: text },
         {
-          onSuccess: () => toast.success('Heartbeat updated'),
+          onSuccess: () => toast.success('Priorities updated'),
           onError: (e) => toast.error(e.message),
         },
       );
@@ -40,16 +59,128 @@ export default function HeartbeatPage() {
       <div className="mb-4">
         <h2 className="text-xl font-semibold font-display">Priorities</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Your assistant reads this to stay aware of what you're working on.
+          Track what you are working on and how often you want a proactive check-in from your assistant.
         </p>
       </div>
-      <MarkdownEditor
-        value={profile.heartbeat_text}
-        onSave={handleSave}
-        isSaving={updateProfile.isPending}
-        placeholder="Track tasks and priorities in markdown format, e.g. - [ ] Follow up with new leads"
-        emptyMessage="No priorities yet. Click Edit to track what you're working on."
-      />
+      <div className="grid gap-6">
+        <CheckInSettings profile={profile} />
+        <div>
+          <h3 className="text-sm font-medium mb-2">What you are working on</h3>
+          <p className="text-xs text-muted-foreground mb-3">
+            Your assistant reads this to stay aware of your active priorities.
+          </p>
+          <MarkdownEditor
+            value={profile.heartbeat_text}
+            onSave={handleSaveText}
+            isSaving={updateProfile.isPending}
+            placeholder="Track tasks and priorities in markdown format, e.g. - [ ] Follow up with new leads"
+            emptyMessage="No priorities yet. Click Edit to track what you're working on."
+          />
+        </div>
+      </div>
     </div>
+  );
+}
+
+function CheckInSettings({ profile }: { profile: UserProfileResponse }) {
+  const updateProfile = useUpdateProfile();
+  const isPreset = HEARTBEAT_PRESETS.some((p) => p.value === profile.heartbeat_frequency);
+  const [form, setForm] = useState({
+    heartbeat_opt_in: profile.heartbeat_opt_in,
+    heartbeat_frequency: isPreset ? profile.heartbeat_frequency : 'custom',
+    custom_frequency: isPreset ? '' : profile.heartbeat_frequency,
+    heartbeat_max_daily: profile.heartbeat_max_daily,
+  });
+
+  useEffect(() => {
+    const preset = HEARTBEAT_PRESETS.some((p) => p.value === profile.heartbeat_frequency);
+    setForm({
+      heartbeat_opt_in: profile.heartbeat_opt_in,
+      heartbeat_frequency: preset ? profile.heartbeat_frequency : 'custom',
+      custom_frequency: preset ? '' : profile.heartbeat_frequency,
+      heartbeat_max_daily: profile.heartbeat_max_daily,
+    });
+  }, [profile.heartbeat_opt_in, profile.heartbeat_frequency, profile.heartbeat_max_daily]);
+
+  const effectiveFrequency = form.heartbeat_frequency === 'custom'
+    ? form.custom_frequency
+    : form.heartbeat_frequency;
+
+  const handleSave = () => {
+    updateProfile.mutate(
+      {
+        heartbeat_opt_in: form.heartbeat_opt_in,
+        heartbeat_frequency: effectiveFrequency,
+        heartbeat_max_daily: form.heartbeat_max_daily,
+      },
+      {
+        onSuccess: () => toast.success('Check-in settings updated'),
+        onError: (e) => toast.error(e.message),
+      },
+    );
+  };
+
+  return (
+    <Card>
+      <h3 className="text-sm font-medium mb-3">Proactive check-ins</h3>
+      <div className="grid gap-4">
+        <div className="flex items-center gap-3">
+          <Checkbox
+            id="heartbeat-opt-in"
+            checked={form.heartbeat_opt_in}
+            onChange={(e) => setForm((prev) => ({ ...prev, heartbeat_opt_in: e.target.checked }))}
+          />
+          <label htmlFor="heartbeat-opt-in" className="text-sm">
+            Enable proactive check-ins
+          </label>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          When enabled, your assistant will reach out with reminders and updates based on the priorities below.
+        </p>
+        <Field label="Frequency">
+          <Select
+            value={form.heartbeat_frequency}
+            onChange={(e) => setForm((prev) => ({ ...prev, heartbeat_frequency: e.target.value }))}
+            disabled={!form.heartbeat_opt_in}
+          >
+            {HEARTBEAT_PRESETS.map((p) => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+            <option value="custom">Custom interval</option>
+          </Select>
+        </Field>
+        {form.heartbeat_frequency === 'custom' && (
+          <Field label="Custom Interval">
+            <Input
+              value={form.custom_frequency}
+              onChange={(e) => setForm((prev) => ({ ...prev, custom_frequency: e.target.value }))}
+              disabled={!form.heartbeat_opt_in}
+              placeholder="e.g. 45m, 3h, 2d"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Use a number followed by m (minutes), h (hours), or d (days).
+            </p>
+          </Field>
+        )}
+        <Field label="Max daily check-ins">
+          <Input
+            type="number"
+            min={0}
+            value={form.heartbeat_max_daily}
+            onChange={(e) => setForm((prev) => ({ ...prev, heartbeat_max_daily: parseInt(e.target.value, 10) || 0 }))}
+            disabled={!form.heartbeat_opt_in}
+            placeholder="0"
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Maximum check-ins per day. Set to 0 to use the server default.
+          </p>
+        </Field>
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={updateProfile.isPending} isLoading={updateProfile.isPending}>
+            Save check-in settings
+          </Button>
+        </div>
+      </div>
+    </Card>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,11 +5,10 @@ import Input from '@/components/ui/input';
 import Button from '@/components/ui/button';
 import Select from '@/components/ui/select';
 import { Tabs, Tab } from '@heroui/tabs';
-import Checkbox from '@/components/ui/checkbox';
 import Field from '@/components/ui/field';
 import api from '@/api';
 import { toast } from '@/lib/toast';
-import { useModelConfig, useUpdateModelConfig, useUpdateProfile, useChannelConfig, useUpdateChannelConfig } from '@/hooks/queries';
+import { useModelConfig, useUpdateModelConfig, useChannelConfig, useUpdateChannelConfig } from '@/hooks/queries';
 import DataSharingConsentSection from '@/components/DataSharingConsentSection';
 import ChannelsPage from '@/pages/ChannelsPage';
 import type { AppShellContext } from '@/layouts/AppShell';
@@ -22,7 +21,7 @@ import {
 export default function SettingsPage() {
   const { tab } = useParams<{ tab: string }>();
   const navigate = useNavigate();
-  const { profile, reloadProfile, isPremium, isAdmin } = useOutletContext<AppShellContext>();
+  const { reloadProfile, isPremium, isAdmin } = useOutletContext<AppShellContext>();
 
   // Refresh profile whenever the settings page is opened.
   useEffect(() => {
@@ -39,7 +38,6 @@ export default function SettingsPage() {
   const visibleOssKeys = showOssSettingsTabs(isPremium, isAdmin);
   const ossTabs = [
     { key: 'model', label: 'Model' },
-    { key: 'heartbeat', label: 'Heartbeat' },
     { key: 'telegram', label: 'Telegram' },
     { key: 'channels', label: 'Channels' },
     { key: 'privacy', label: 'Privacy' },
@@ -55,7 +53,6 @@ export default function SettingsPage() {
     if (premiumContent) return premiumContent;
     switch (activeTab) {
       case 'model': return <ModelTab />;
-      case 'heartbeat': return profile ? <HeartbeatTab profile={profile} /> : null;
       case 'telegram': return <TelegramTab />;
       case 'channels': return <ChannelsPage />;
       case 'privacy': return <PrivacyTab />;
@@ -360,128 +357,6 @@ function ModelTab() {
         </Button>
       </div>
     </div>
-  );
-}
-
-// --- Storage Tab ---
-
-// --- Heartbeat Tab ---
-
-const HEARTBEAT_PRESETS = [
-  { value: '15m', label: 'Every 15 minutes' },
-  { value: '30m', label: 'Every 30 minutes' },
-  { value: '1h', label: 'Every hour' },
-  { value: '2h', label: 'Every 2 hours' },
-  { value: '4h', label: 'Every 4 hours' },
-  { value: '8h', label: 'Every 8 hours' },
-  { value: 'daily', label: 'Daily' },
-  { value: 'weekdays', label: 'Weekdays only' },
-  { value: 'weekly', label: 'Weekly' },
-] as const;
-
-function HeartbeatTab({
-  profile,
-}: {
-  profile: { heartbeat_opt_in: boolean; heartbeat_frequency: string; heartbeat_max_daily: number };
-}) {
-  const isPreset = HEARTBEAT_PRESETS.some((p) => p.value === profile.heartbeat_frequency);
-  const [form, setForm] = useState({
-    heartbeat_opt_in: profile.heartbeat_opt_in,
-    heartbeat_frequency: isPreset ? profile.heartbeat_frequency : 'custom',
-    custom_frequency: isPreset ? '' : profile.heartbeat_frequency,
-    heartbeat_max_daily: profile.heartbeat_max_daily,
-  });
-  const updateProfile = useUpdateProfile();
-
-  useEffect(() => {
-    const preset = HEARTBEAT_PRESETS.some((p) => p.value === profile.heartbeat_frequency);
-    setForm({
-      heartbeat_opt_in: profile.heartbeat_opt_in,
-      heartbeat_frequency: preset ? profile.heartbeat_frequency : 'custom',
-      custom_frequency: preset ? '' : profile.heartbeat_frequency,
-      heartbeat_max_daily: profile.heartbeat_max_daily,
-    });
-  }, [profile.heartbeat_opt_in, profile.heartbeat_frequency, profile.heartbeat_max_daily]);
-
-  const effectiveFrequency = form.heartbeat_frequency === 'custom'
-    ? form.custom_frequency
-    : form.heartbeat_frequency;
-
-  const handleSave = () => {
-    updateProfile.mutate(
-      {
-        heartbeat_opt_in: form.heartbeat_opt_in,
-        heartbeat_frequency: effectiveFrequency,
-        heartbeat_max_daily: form.heartbeat_max_daily,
-      },
-      {
-        onSuccess: () => toast.success('Heartbeat settings updated'),
-        onError: (e) => toast.error(e.message),
-      },
-    );
-  };
-
-  return (
-    <Card>
-      <div className="grid gap-4">
-        <div className="flex items-center gap-3">
-          <Checkbox
-            id="heartbeat-opt-in"
-            checked={form.heartbeat_opt_in}
-            onChange={(e) => setForm((prev) => ({ ...prev, heartbeat_opt_in: e.target.checked }))}
-          />
-          <label htmlFor="heartbeat-opt-in" className="text-sm">
-            Enable heartbeat check-ins
-          </label>
-        </div>
-        <p className="text-xs text-muted-foreground">
-          When enabled, your assistant will proactively send you reminders and updates based on your heartbeat items.
-        </p>
-        <Field label="Frequency">
-          <Select
-            value={form.heartbeat_frequency}
-            onChange={(e) => setForm((prev) => ({ ...prev, heartbeat_frequency: e.target.value }))}
-            disabled={!form.heartbeat_opt_in}
-          >
-            {HEARTBEAT_PRESETS.map((p) => (
-              <option key={p.value} value={p.value}>{p.label}</option>
-            ))}
-            <option value="custom">Custom interval</option>
-          </Select>
-        </Field>
-        {form.heartbeat_frequency === 'custom' && (
-          <Field label="Custom Interval">
-            <Input
-              value={form.custom_frequency}
-              onChange={(e) => setForm((prev) => ({ ...prev, custom_frequency: e.target.value }))}
-              disabled={!form.heartbeat_opt_in}
-              placeholder="e.g. 45m, 3h, 2d"
-            />
-            <p className="text-xs text-muted-foreground mt-1">
-              Use a number followed by m (minutes), h (hours), or d (days).
-            </p>
-          </Field>
-        )}
-        <Field label="Max daily check-ins">
-          <Input
-            type="number"
-            min={0}
-            value={form.heartbeat_max_daily}
-            onChange={(e) => setForm((prev) => ({ ...prev, heartbeat_max_daily: parseInt(e.target.value, 10) || 0 }))}
-            disabled={!form.heartbeat_opt_in}
-            placeholder="0"
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            Maximum number of heartbeat messages per day. Set to 0 to use the server default.
-          </p>
-        </Field>
-        <div className="flex justify-end">
-          <Button onClick={handleSave} disabled={updateProfile.isPending} isLoading={updateProfile.isPending}>
-            Save Heartbeat Settings
-          </Button>
-        </div>
-      </div>
-    </Card>
   );
 }
 


### PR DESCRIPTION
## Description

The Settings tab had a "Heartbeat" entry that exposed proactive check-in
controls (opt-in, frequency, max daily) under the assistant-internal
"heartbeat" name, which a new user would not understand. This PR moves
those controls into the existing Priorities page (`/app/heartbeat`) as a
"Proactive check-ins" card above the priorities markdown editor, and
drops the standalone Heartbeat tab from Settings.

The Priorities page is the natural home for these knobs: it is where
you write down what you want the assistant to check in about, so it
should also be where you decide how often it does so.

Related: mozilla-ai/clawbolt-premium#524 (the issue lives on the premium
repo because that is where the change was originally requested; the
premium counterpart drops the same tab from premium's overlay).

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

`HeartbeatPage.test.tsx` gains two new tests covering that the
check-in settings render and that clicking "Save check-in settings"
calls `updateProfile` with the right payload.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Drafted with Claude Code: identified the UI rearrangement scope, wrote
the merged page, removed the dead tab and its now-unused imports, and
extended the existing test file with regression coverage. Author
reviewed the diff before pushing.