### PR TITLE
fix(webchat): auth-retry chat upload + drop failed optimistic message

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -120,4 +120,32 @@ describe('_authedFetch', () => {
     expect(res.status).toBe(403);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('passes init fields through (signal, method, etc.) to fetch', async () => {
+    // Long-lived SSE callers rely on signal propagation so abort() actually
+    // tears down the connection. Verify init flows through verbatim on both
+    // the original request and the retry path.
+    setAccessToken(makeJwt(NOW_S + 3600));
+    const controller = new AbortController();
+
+    fetchMock
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: makeJwt(NOW_S + 3600),
+            refresh_token: 'rt-new',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await _authedFetch('/api/user/chat/activity', { signal: controller.signal });
+
+    const firstInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const retryInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect(firstInit.signal).toBe(controller.signal);
+    expect(retryInit.signal).toBe(controller.signal);
+  });
 });

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { _authedFetch } from './api';
+import { setAccessToken, setRefreshToken } from './lib/api-client';
+
+function makeJwt(exp: number): string {
+  const b64 = (s: string): string =>
+    btoa(s).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  return `${b64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))}.${b64(JSON.stringify({ exp, sub: 'test-user' }))}.signature`;
+}
+
+describe('_authedFetch', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const NOW_S = Math.floor(Date.now() / 1000);
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    localStorage.setItem('clawbolt_refresh_token', 'rt-test');
+  });
+
+  afterEach(() => {
+    setAccessToken(null);
+    setRefreshToken(null);
+    vi.restoreAllMocks();
+  });
+
+  it('attaches the current bearer token to outgoing requests', async () => {
+    setAccessToken(makeJwt(NOW_S + 3600));
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    await _authedFetch('/api/whatever', { method: 'POST' });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toMatch(/^Bearer eyJ/);
+  });
+
+  it('proactively refreshes when the access token is within the leeway window', async () => {
+    // Token expires in 10s, leeway is 30s, so refresh should fire BEFORE the
+    // actual request goes out.
+    setAccessToken(makeJwt(NOW_S + 10));
+
+    // Refresh response first, then the actual request.
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: makeJwt(NOW_S + 3600),
+            refresh_token: 'rt-new',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await _authedFetch('/api/user/chat', { method: 'POST', body: new FormData() });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('/api/auth/refresh');
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('/api/user/chat');
+    // Second call carries the fresh token.
+    const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>).Authorization).toMatch(/^Bearer /);
+  });
+
+  it('does not refresh proactively when the token has plenty of life left', async () => {
+    setAccessToken(makeJwt(NOW_S + 3600));
+    fetchMock.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await _authedFetch('/api/user/chat', { method: 'POST' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/user/chat');
+  });
+
+  it('refreshes once and retries on a 401 response', async () => {
+    setAccessToken(makeJwt(NOW_S + 3600));
+
+    fetchMock
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: makeJwt(NOW_S + 3600),
+            refresh_token: 'rt-new',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const res = await _authedFetch('/api/user/chat', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // Original, refresh, retry.
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/user/chat');
+    expect(fetchMock.mock.calls[1]?.[0]).toContain('/api/auth/refresh');
+    expect(fetchMock.mock.calls[2]?.[0]).toBe('/api/user/chat');
+  });
+
+  it('returns the 401 response without retry when refresh fails', async () => {
+    setAccessToken(makeJwt(NOW_S + 3600));
+
+    fetchMock
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(new Response('', { status: 401 }));
+
+    const res = await _authedFetch('/api/user/chat', { method: 'POST' });
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on non-401 failures (e.g. 403)', async () => {
+    setAccessToken(makeJwt(NOW_S + 3600));
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 403 }));
+
+    const res = await _authedFetch('/api/user/chat', { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -407,12 +407,12 @@ const api = {
 
     const connect = (): void => {
       if (controller.signal.aborted) return;
-      const token = getAccessToken();
 
-      fetch('/api/user/chat/activity', {
-        headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) },
-        signal: controller.signal,
-      })
+      // _authedFetch refreshes once on 401 and retries, so a token that ages
+      // out mid-stream no longer terminates the activity feed; only a
+      // refresh-also-fails 401 (or a real 403) still trips the auth-stop
+      // branch below.
+      _authedFetch('/api/user/chat/activity', { signal: controller.signal })
         .then((res) => {
           if (!res.ok || !res.body) {
             if (res.status === 401 || res.status === 403) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -25,7 +25,14 @@ import type {
   ToolConfigResponse,
   ToolConfigUpdateEntry,
 } from '@/types';
-import client, { getAccessToken, setAccessToken, setRefreshToken } from '@/lib/api-client';
+import client, {
+  _getAccessTokenExp,
+  _shouldProactivelyRefresh,
+  getAccessToken,
+  setAccessToken,
+  setRefreshToken,
+  tryRefresh,
+} from '@/lib/api-client';
 import { tryRestoreSession as _tryRestoreSession } from '@/extensions';
 
 // --- Shared helpers ---
@@ -36,6 +43,36 @@ function _getAuthHeaders(): Record<string, string> {
     return { Authorization: `Bearer ${token}` };
   }
   return {};
+}
+
+/**
+ * fetch() wrapper that mirrors the openapi-fetch auth middleware:
+ *   - Proactively refreshes the access token when it is within 30s of expiry,
+ *     so the request goes out with a fresh credential.
+ *   - On a 401 response, refreshes once and retries the original request.
+ *
+ * Use this for endpoints that have to bypass the typed openapi-fetch client
+ * (multipart/form-data uploads, SSE streams). Without it, those endpoints
+ * skip the auth-retry path entirely and a token expiring mid-session
+ * surfaces as a user-visible error instead of a silent refresh-and-retry.
+ * #1368.
+ */
+export async function _authedFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const buildInit = (): RequestInit => ({
+    ...init,
+    headers: { ...(init.headers as Record<string, string> | undefined), ..._getAuthHeaders() },
+  });
+
+  if (getAccessToken() && _shouldProactivelyRefresh(_getAccessTokenExp())) {
+    await tryRefresh();
+  }
+
+  const res = await fetch(input, buildInit());
+  if (res.status !== 401) return res;
+
+  const refreshed = await tryRefresh();
+  if (!refreshed) return res;
+  return fetch(input, buildInit());
 }
 
 /** Error with an HTTP status attached, so callers can distinguish 404 from other failures. */
@@ -451,10 +488,11 @@ const api = {
       }
     }
 
-    // Step 1: Submit message to bus (raw fetch for multipart/form-data)
-    const submitRes = await fetch('/api/user/chat', {
+    // Step 1: Submit message to bus. multipart/form-data has to bypass the
+    // typed openapi-fetch client, so route through _authedFetch to keep the
+    // proactive-refresh + 401-retry behaviour.
+    const submitRes = await _authedFetch('/api/user/chat', {
       method: 'POST',
-      headers: _getAuthHeaders(),
       body: formData,
     });
     if (!submitRes.ok) {
@@ -467,13 +505,12 @@ const api = {
 
     // Step 2: Open SSE connection to receive the reply
     return new Promise<ChatResponse>((resolve, reject) => {
-      const token = getAccessToken();
       const url = `/api/user/chat/events/${encodeURIComponent(accepted.request_id)}`;
 
-      // EventSource does not support custom headers, so we use fetch + ReadableStream
-      fetch(url, {
-        headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) },
-      })
+      // EventSource does not support custom headers, so we use fetch + ReadableStream.
+      // Route through _authedFetch so an expired access token refreshes once
+      // and retries instead of surfacing as a 401 to the user.
+      _authedFetch(url)
         .then((res) => {
           if (!res.ok) {
             reject(new Error(`SSE request failed: ${res.status}`));

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -527,3 +527,33 @@ describe('ChatPage current system prompt panel', () => {
     expect(screen.getByText(/onboarding/i)).toBeInTheDocument();
   });
 });
+
+describe('ChatPage failed-send cleanup (issue #1368)', () => {
+  it('removes the optimistic user message when sendChatMessage rejects', async () => {
+    // Empty conversation so the only visible user message is the one we send.
+    mockApi.getConversation.mockResolvedValue({
+      session_id: '',
+      user_id: '1',
+      created_at: '',
+      last_message_at: '',
+      channel: 'webchat',
+      initial_system_prompt: '',
+      messages: [],
+    });
+    mockApi.sendChatMessage.mockRejectedValue(new Error('Request failed: 403'));
+
+    renderWithRouter(<ChatActivityProvider><ChatPage /></ChatActivityProvider>);
+
+    const textarea = await screen.findByPlaceholderText('Type a message...');
+    const user = userEvent.setup();
+    await user.type(textarea, 'check this out');
+    await user.keyboard('{Enter}');
+
+    // The optimistic message appears briefly, then is removed when the POST
+    // rejects. Without the cleanup it would linger until the next successful
+    // send wiped it via a conversation refetch.
+    await waitFor(() => {
+      expect(screen.queryByText('check this out')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -220,6 +220,12 @@ export default function ChatPage() {
       if (!mountedRef.current) return;
       const msg = err instanceof Error ? err.message : 'Failed to send message';
       toast.error(msg);
+      // Drop the optimistic user message so it does not linger in the chat
+      // and then silently vanish on the next successful send (which
+      // invalidates the conversation query and replaces local state with
+      // what the server has, which never includes a message whose POST
+      // failed). #1368.
+      setMessages((prev) => prev.filter((m) => m.id !== userMsg.id));
     } finally {
       if (!mountedRef.current) return;
       pendingRef.current--;


### PR DESCRIPTION
## Description

Two related quirks made web chat file uploads feel broken (#1368):

1. **Chat POST and SSE GET bypassed the auth-retry path.** The typed openapi-fetch client has middleware that proactively refreshes the access token within 30s of expiry and retries once on 401 after a refresh. The chat POST (multipart/form-data) and the SSE GET (raw fetch + ReadableStream) had to bypass that client, so they skipped the retry path entirely. A token that aged out mid-session surfaced as a toast instead of a silent retry. New `_authedFetch` helper mirrors the middleware; both endpoints go through it.

2. **Failed optimistic messages lingered then silently disappeared.** When a send failed, the user bubble (with the image preview) stayed in local state until the next successful send invalidated the conversation query, which replaced local state with the server's view, which never includes a message whose POST failed. Result: the image vanished one message later, which is the UI quirk the issue called out. Drop the optimistic message in the catch path so the failure is immediate and obvious.

This is a defensive fix. I could not pin the exact 403 source from code alone, but if 403s persist after this the next step is capturing the actual Network response (status + body + which request) to target the real code path.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`npx vitest run src/api.test.ts src/pages/ChatPage.test.tsx` = 22/22; full vitest 197 pass, 1 pre-existing ToolsPage failure unrelated)
- [x] Lint passes (`ruff check`, `ruff format --check`, `ty check` on backend all green; no backend changes)
- [x] New tests added for new functionality (6 tests for `_authedFetch`, 1 for failed-message cleanup)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: Claude Opus 4.7 (Claude Code, 1M context) drafted the helper, the cleanup edit, the tests, and this PR body via back-and-forth with @njbrake.

Fixes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)