### PR TITLE
fix(webchat): memoize file blob URLs + add upload POST timeout

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { _authedFetch } from './api';
+import api, { _authedFetch } from './api';
 import { setAccessToken, setRefreshToken } from './lib/api-client';
 
 function makeJwt(exp: number): string {
@@ -147,5 +147,31 @@ describe('_authedFetch', () => {
     const retryInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
     expect(firstInit.signal).toBe(controller.signal);
     expect(retryInit.signal).toBe(controller.signal);
+  });
+});
+
+describe('sendChatMessage upload timeout (issue #1368)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const NOW_S = Math.floor(Date.now() / 1000);
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setAccessToken(makeJwt(NOW_S + 3600));
+  });
+
+  afterEach(() => {
+    setAccessToken(null);
+    setRefreshToken(null);
+    vi.restoreAllMocks();
+  });
+
+  it('converts a POST AbortSignal.timeout abort into a friendly error', async () => {
+    // Simulate what AbortSignal.timeout throws when its deadline fires.
+    fetchMock.mockImplementation(() => {
+      throw new DOMException('The operation timed out.', 'TimeoutError');
+    });
+
+    await expect(api.sendChatMessage('hi')).rejects.toThrow(/upload timed out/i);
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -490,11 +490,23 @@ const api = {
 
     // Step 1: Submit message to bus. multipart/form-data has to bypass the
     // typed openapi-fetch client, so route through _authedFetch to keep the
-    // proactive-refresh + 401-retry behaviour.
-    const submitRes = await _authedFetch('/api/user/chat', {
-      method: 'POST',
-      body: formData,
-    });
+    // proactive-refresh + 401-retry behaviour. The 2 minute timeout caps how
+    // long a stuck POST can leave the spinner up; once it fires, the catch
+    // block in ChatPage drops the optimistic message so the user sees a
+    // clear failure instead of a hung send. #1368.
+    let submitRes: Response;
+    try {
+      submitRes = await _authedFetch('/api/user/chat', {
+        method: 'POST',
+        body: formData,
+        signal: AbortSignal.timeout(120_000),
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        throw new Error('Upload timed out. Please try again.');
+      }
+      throw err;
+    }
     if (!submitRes.ok) {
       const body = await submitRes.json().catch(() => ({}));
       const b = body as { detail?: string };

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -547,6 +547,53 @@ describe('ChatPage failed-send cleanup (issue #1368)', () => {
   });
 });
 
+describe('ChatPage file attachment blob URLs (issue #1368)', () => {
+  it('creates each preview blob URL once, not on every keystroke', async () => {
+    // Before the fix, the chip rendering called URL.createObjectURL(file)
+    // inline on every render. Typing in the textarea re-renders ChatPage,
+    // so each keystroke leaked a new blob URL. For phone-sized photos that
+    // showed up as visible typing lag.
+    mockApi.getConversation.mockResolvedValue({
+      session_id: '',
+      user_id: '1',
+      created_at: '',
+      last_message_at: '',
+      channel: 'webchat',
+      messages: [],
+    });
+
+    const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test-url');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    try {
+      const { container } = renderWithRouter(
+        <ChatActivityProvider><ChatPage /></ChatActivityProvider>,
+      );
+
+      const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+      const png = new File([new Uint8Array(100)], 'photo.png', { type: 'image/png' });
+      const user = userEvent.setup();
+      await user.upload(fileInput, png);
+
+      // One URL for the freshly attached image.
+      expect(createSpy).toHaveBeenCalledTimes(1);
+
+      // Typing should NOT allocate any new blob URLs.
+      const textarea = await screen.findByPlaceholderText('Type a message...');
+      await user.type(textarea, 'caption text');
+      expect(createSpy).toHaveBeenCalledTimes(1);
+
+      // Removing the chip revokes the URL exactly once.
+      const removeButton = screen.getByRole('button', { name: /remove photo\.png/i });
+      await user.click(removeButton);
+      expect(revokeSpy).toHaveBeenCalledWith('blob:test-url');
+    } finally {
+      createSpy.mockRestore();
+      revokeSpy.mockRestore();
+    }
+  });
+});
+
 describe('ChatPage system prompt panel visibility', () => {
   const sessionWithMessages = (sessionId: string) => ({
     session_id: sessionId,

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -592,6 +592,101 @@ describe('ChatPage file attachment blob URLs (issue #1368)', () => {
       revokeSpy.mockRestore();
     }
   });
+
+  it('revokes a staged chip URL on unmount if the user never sends', async () => {
+    mockApi.getConversation.mockResolvedValue({
+      session_id: '',
+      user_id: '1',
+      created_at: '',
+      last_message_at: '',
+      channel: 'webchat',
+      messages: [],
+    });
+
+    const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:unmount-url');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    try {
+      const { container, unmount } = renderWithRouter(
+        <ChatActivityProvider><ChatPage /></ChatActivityProvider>,
+      );
+
+      const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+      const png = new File([new Uint8Array(100)], 'photo.png', { type: 'image/png' });
+      const user = userEvent.setup();
+      await user.upload(fileInput, png);
+
+      // Sanity: the URL was created and NOT yet revoked.
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      expect(revokeSpy).not.toHaveBeenCalled();
+
+      unmount();
+
+      // Navigating away with a staged file should revoke the URL.
+      expect(revokeSpy).toHaveBeenCalledWith('blob:unmount-url');
+    } finally {
+      createSpy.mockRestore();
+      revokeSpy.mockRestore();
+    }
+  });
+
+  it('revokes optimistic message attachment URLs when the conversation refetches', async () => {
+    // First load: empty session.
+    mockApi.getConversation.mockResolvedValueOnce({
+      session_id: '',
+      user_id: '1',
+      created_at: '',
+      last_message_at: '',
+      channel: 'webchat',
+      messages: [],
+    });
+    // After send + invalidation, the refetch returns a server-side message
+    // (with no previewUrl). Without the revoke, the optimistic message's
+    // URL would leak when the local state is replaced.
+    mockApi.getConversation.mockResolvedValueOnce({
+      session_id: 's1',
+      user_id: '1',
+      created_at: '2025-01-01T00:00:00Z',
+      last_message_at: '2025-01-01T00:01:00Z',
+      channel: 'webchat',
+      messages: [
+        {
+          seq: 1,
+          direction: 'inbound',
+          body: 'check this out',
+          timestamp: '2025-01-01T00:00:00Z',
+          tool_interactions: [],
+        },
+      ],
+    });
+    mockApi.sendChatMessage.mockResolvedValue({ reply: 'got it' });
+
+    const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:refetch-url');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    try {
+      const { container } = renderWithRouter(
+        <ChatActivityProvider><ChatPage /></ChatActivityProvider>,
+      );
+
+      const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+      const png = new File([new Uint8Array(100)], 'photo.png', { type: 'image/png' });
+      const user = userEvent.setup();
+      await user.upload(fileInput, png);
+      const textarea = await screen.findByPlaceholderText('Type a message...');
+      await user.type(textarea, 'check this out');
+      await user.keyboard('{Enter}');
+
+      // sendChatMessage resolves, queryClient invalidates, refetch fires,
+      // useEffect replaces messages; the optimistic URL should be revoked.
+      await waitFor(() => {
+        expect(revokeSpy).toHaveBeenCalledWith('blob:refetch-url');
+      });
+    } finally {
+      createSpy.mockRestore();
+      revokeSpy.mockRestore();
+    }
+  });
 });
 
 describe('ChatPage system prompt panel visibility', () => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -62,7 +62,20 @@ export default function ChatPage() {
   const [pendingCount, setPendingCount] = useState(0);
   const pendingRef = useRef(0);
   const sending = pendingCount > 0;
-  const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([]);
+  // Mirror of selectedFiles. The unmount cleanup reads this ref so it can
+  // revoke chip preview URLs without resubscribing on every render (which
+  // would race against removeFile's own revoke). #1368.
+  const selectedFilesRef = useRef<SelectedFile[]>([]);
+  const [selectedFiles, _setSelectedFiles] = useState<SelectedFile[]>([]);
+  // Wrap setSelectedFiles so selectedFilesRef stays in lockstep with state.
+  // A missed sync would let a staged chip URL leak past navigation.
+  const setSelectedFiles: typeof _setSelectedFiles = useCallback((value) => {
+    _setSelectedFiles((prev) => {
+      const next = typeof value === 'function' ? value(prev) : value;
+      selectedFilesRef.current = next;
+      return next;
+    });
+  }, []);
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const [currentTool, setCurrentTool] = useState<string | null>(null);
   const { agentBusy, activityTool, doneTick } = useChatActivity();
@@ -90,6 +103,20 @@ export default function ChatPage() {
   useEffect(() => {
     mountedRef.current = true;
     return () => { mountedRef.current = false; };
+  }, []);
+
+  // Revoke any staged chip preview URLs when the user navigates away with
+  // an attachment still selected (otherwise those blob URLs leak until page
+  // reload). URLs already transferred to a sent message are owned by the
+  // message and revoked separately on conversation refetch / failed send.
+  // Uses selectedFilesRef so the cleanup sees the latest selection at unmount
+  // time without resubscribing on every render.
+  useEffect(() => {
+    return () => {
+      selectedFilesRef.current.forEach((entry) => {
+        if (entry.previewUrl) URL.revokeObjectURL(entry.previewUrl);
+      });
+    };
   }, []);
 
   // Refresh conversation data when the agent finishes, so replies produced while
@@ -141,7 +168,12 @@ export default function ChatPage() {
     inputRef.current?.focus();
   }, []);
 
-  // Populate messages from conversation history when it loads
+  // Populate messages from conversation history when it loads.
+  // Server messages never carry a previewUrl, so any blob URL on the about-to-
+  // be-replaced local messages came from an optimistic send and has nothing
+  // else holding it alive once we drop the message. Revoke before replacing so
+  // long-lived chat sessions do not accumulate one orphaned blob per uploaded
+  // image. #1368.
   useEffect(() => {
     if (!sessionDetail) return;
     const loaded: ChatMessage[] = sessionDetail.messages.map((m) => ({
@@ -152,7 +184,14 @@ export default function ChatPage() {
       seq: m.seq,
       toolInteractions: m.tool_interactions && m.tool_interactions.length > 0 ? m.tool_interactions : undefined,
     }));
-    setMessages(loaded);
+    setMessages((prev) => {
+      prev.forEach((m) => {
+        m.attachments?.forEach((att) => {
+          if (att.previewUrl) URL.revokeObjectURL(att.previewUrl);
+        });
+      });
+      return loaded;
+    });
   }, [sessionDetail]);
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -20,6 +20,20 @@ interface FileAttachment {
   previewUrl?: string;
 }
 
+/**
+ * A staged file plus its blob preview URL. The URL is created once when the
+ * file is selected and lives until the file is either removed from the chip
+ * row or transferred onto a sent message. Critically, the URL is NOT
+ * regenerated on render; the previous implementation called
+ * URL.createObjectURL() inside the chip JSX, which produced a new blob URL
+ * on every keystroke (since typing re-renders ChatPage) and caused noticeable
+ * input lag for phone-sized photos. #1368.
+ */
+interface SelectedFile {
+  file: File;
+  previewUrl?: string;
+}
+
 interface ChatMessage {
   id: number;
   role: 'user' | 'assistant';
@@ -48,7 +62,7 @@ export default function ChatPage() {
   const [pendingCount, setPendingCount] = useState(0);
   const pendingRef = useRef(0);
   const sending = pendingCount > 0;
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([]);
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const [currentTool, setCurrentTool] = useState<string | null>(null);
   const { agentBusy, activityTool, doneTick } = useChatActivity();
@@ -144,14 +158,24 @@ export default function ChatPage() {
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newFiles = Array.from(e.target.files || []);
     if (newFiles.length > 0) {
-      setSelectedFiles((prev) => [...prev, ...newFiles]);
+      setSelectedFiles((prev) => [
+        ...prev,
+        ...newFiles.map((file) => ({
+          file,
+          previewUrl: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined,
+        })),
+      ]);
     }
     // Reset so the same file can be re-selected
     e.target.value = '';
   };
 
   const removeFile = (index: number) => {
-    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
+    setSelectedFiles((prev) => {
+      const entry = prev[index];
+      if (entry?.previewUrl) URL.revokeObjectURL(entry.previewUrl);
+      return prev.filter((_, i) => i !== index);
+    });
   };
 
   const handleSubmit = async (e: FormEvent) => {
@@ -159,11 +183,15 @@ export default function ChatPage() {
     const text = input.trim();
     if (!text && selectedFiles.length === 0) return;
 
-    // Build attachments for display
-    const attachments: FileAttachment[] = selectedFiles.map((f) => ({
-      name: f.name,
-      type: f.type,
-      previewUrl: f.type.startsWith('image/') ? URL.createObjectURL(f) : undefined,
+    // Build attachments for display. Reuse the blob URLs created at file-select
+    // time so we don't allocate a second one per attachment (the optimistic
+    // message and the chip can share the same URL). After this call the URLs
+    // are owned by the rendered message; the chip row is cleared below
+    // without revoking, so previews remain valid in the chat.
+    const attachments: FileAttachment[] = selectedFiles.map((entry) => ({
+      name: entry.file.name,
+      type: entry.file.type,
+      previewUrl: entry.previewUrl,
     }));
 
     const userMsg: ChatMessage = {
@@ -175,7 +203,8 @@ export default function ChatPage() {
     };
     setMessages((prev) => [...prev, userMsg]);
 
-    const filesToSend = selectedFiles.length > 0 ? [...selectedFiles] : undefined;
+    const filesToSend =
+      selectedFiles.length > 0 ? selectedFiles.map((entry) => entry.file) : undefined;
     setInput('');
     setSelectedFiles([]);
     pendingRef.current++;
@@ -235,8 +264,15 @@ export default function ChatPage() {
       // and then silently vanish on the next successful send (which
       // invalidates the conversation query and replaces local state with
       // what the server has, which never includes a message whose POST
-      // failed). #1368.
-      setMessages((prev) => prev.filter((m) => m.id !== userMsg.id));
+      // failed). Revoke any attachment blob URLs the optimistic message
+      // owned, since nothing else will. #1368.
+      setMessages((prev) => {
+        const removed = prev.find((m) => m.id === userMsg.id);
+        removed?.attachments?.forEach((att) => {
+          if (att.previewUrl) URL.revokeObjectURL(att.previewUrl);
+        });
+        return prev.filter((m) => m.id !== userMsg.id);
+      });
     } finally {
       if (!mountedRef.current) return;
       pendingRef.current--;
@@ -709,28 +745,28 @@ export default function ChatPage() {
             {/* File preview chips */}
             {selectedFiles.length > 0 && (
               <div className="flex flex-wrap gap-1.5 px-1">
-                {selectedFiles.map((file, i) => (
+                {selectedFiles.map((entry, i) => (
                   <div
                     key={i}
                     className="flex items-center gap-1.5 bg-card border border-border text-foreground text-xs px-2 py-1 rounded-md"
                   >
-                    {file.type.startsWith('image/') ? (
+                    {entry.previewUrl ? (
                       <img
-                        src={URL.createObjectURL(file)}
-                        alt={file.name}
+                        src={entry.previewUrl}
+                        alt={entry.file.name}
                         className="w-5 h-5 rounded object-cover"
                       />
                     ) : (
                       <FileIcon />
                     )}
-                    <span className="truncate max-w-[100px]">{file.name}</span>
-                    <Tooltip content={`Remove ${file.name}`} delay={400} closeDelay={0}>
+                    <span className="truncate max-w-[100px]">{entry.file.name}</span>
+                    <Tooltip content={`Remove ${entry.file.name}`} delay={400} closeDelay={0}>
                       <Button
                         variant="ghost"
                         size="icon-sm"
                         onClick={() => removeFile(i)}
                         className="ml-0.5 text-muted-foreground hover:text-foreground"
-                        aria-label={`Remove ${file.name}`}
+                        aria-label={`Remove ${entry.file.name}`}
                       >
                         <CloseIcon />
                       </Button>


### PR DESCRIPTION
## Description

Two follow-ups after the prior #1368 fix did not stop the real-world failure (typing got laggy after attaching an image, the "thinking" spinner stayed up forever, and the message vanished on refresh).

1. **Memoize file preview blob URLs.** The chip row was calling `URL.createObjectURL(file)` inline on every render, so each keystroke in the textarea allocated a new blob URL for every attached image. For phone-sized photos this was the typing lag and leaked one blob URL per keystroke per image. `selectedFiles` now carries `{file, previewUrl}` pairs: the URL is allocated once at file-select time, the chip reads the cached URL, `removeFile` revokes it, and on send the URL is handed off to the rendered message attachment. The failed-message cleanup added in the prior PR also revokes any attachment URLs it drops.

2. **Add an upload POST timeout.** The chat POST had no client-side timeout, so a hung upload left the spinner up forever. Wrap the POST in `AbortSignal.timeout(120_000)` and translate the `TimeoutError` into a user-readable "Upload timed out. Please try again." so the existing optimistic-message cleanup fires and the user sees a clear failure instead of a stuck send.

Does **not** fix the "message gone on refresh" symptom: that's server-side (the message would already be persisted by `session_store.add_message` before the agent pipeline runs, so if the row is missing post-refresh, the POST never reached that line). Without prod logs I cannot pin which earlier step failed. Next move on that front is adding server-side request logging on `/api/user/chat` (start / persisted / dispatched / responded) so the next recurrence tells us where it hung.

Refs #1368.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`npx vitest run src/api.test.ts src/pages/ChatPage.test.tsx` = 28/28)
- [x] Lint passes (typecheck, knip, ruff suite green; no backend changes)
- [x] New tests added for new functionality (createObjectURL called once regardless of typing; revokeObjectURL on chip remove; TimeoutError translates to friendly message)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: Claude Opus 4.7 (Claude Code, 1M context) drafted the refactor, the timeout wiring, the tests, and this PR body via back-and-forth with @njbrake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)