### PR TITLE
feat(webchat): compress images before upload; delay Thinking spinner

### DIFF
--- a/frontend/src/lib/imageCompression.test.ts
+++ b/frontend/src/lib/imageCompression.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { compressImageIfNeeded, shouldCompressImage } from './imageCompression';
+
+describe('shouldCompressImage', () => {
+  it('returns true for a multi-MB JPEG', () => {
+    const file = new File([new Uint8Array(2_000_000)], 'photo.jpg', { type: 'image/jpeg' });
+    expect(shouldCompressImage(file)).toBe(true);
+  });
+
+  it('returns true for a multi-MB PNG', () => {
+    const file = new File([new Uint8Array(2_000_000)], 'shot.png', { type: 'image/png' });
+    expect(shouldCompressImage(file)).toBe(true);
+  });
+
+  it('returns true for HEIC (iPhone default)', () => {
+    const file = new File([new Uint8Array(2_000_000)], 'IMG.heic', { type: 'image/heic' });
+    expect(shouldCompressImage(file)).toBe(true);
+  });
+
+  it('returns false for tiny images below the threshold', () => {
+    const file = new File([new Uint8Array(50_000)], 'icon.png', { type: 'image/png' });
+    expect(shouldCompressImage(file)).toBe(false);
+  });
+
+  it('returns false for GIFs (would lose animation)', () => {
+    const file = new File([new Uint8Array(2_000_000)], 'anim.gif', { type: 'image/gif' });
+    expect(shouldCompressImage(file)).toBe(false);
+  });
+
+  it('returns false for SVGs', () => {
+    const file = new File([new Uint8Array(2_000_000)], 'icon.svg', { type: 'image/svg+xml' });
+    expect(shouldCompressImage(file)).toBe(false);
+  });
+
+  it('returns false for non-image files', () => {
+    const file = new File([new Uint8Array(2_000_000)], 'doc.pdf', { type: 'application/pdf' });
+    expect(shouldCompressImage(file)).toBe(false);
+  });
+});
+
+describe('compressImageIfNeeded', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the original file unchanged when compression is not warranted', async () => {
+    const file = new File([new Uint8Array(50_000)], 'icon.png', { type: 'image/png' });
+    const out = await compressImageIfNeeded(file);
+    expect(out).toBe(file);
+  });
+
+  it('returns the original file if createImageBitmap throws (unsupported format)', async () => {
+    vi.stubGlobal('createImageBitmap', () => {
+      throw new TypeError('Unsupported source');
+    });
+    const file = new File([new Uint8Array(2_000_000)], 'IMG.heic', { type: 'image/heic' });
+    const out = await compressImageIfNeeded(file);
+    expect(out).toBe(file);
+  });
+
+  it('returns the original file if the re-encoded blob is larger', async () => {
+    const fakeBitmap = { width: 100, height: 100, close: vi.fn() };
+    vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(fakeBitmap));
+    // Spy toBlob to return a larger blob than the source.
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(function (
+      this: HTMLCanvasElement,
+      cb: BlobCallback,
+    ) {
+      cb(new Blob([new Uint8Array(5_000_000)], { type: 'image/jpeg' }));
+    });
+    const file = new File([new Uint8Array(2_000_000)], 'photo.jpg', { type: 'image/jpeg' });
+    const out = await compressImageIfNeeded(file);
+    expect(out).toBe(file);
+  });
+
+  it('returns a smaller JPEG when the round-trip beats the source', async () => {
+    const fakeBitmap = { width: 4000, height: 3000, close: vi.fn() };
+    vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(fakeBitmap));
+    // happy-dom's canvas getContext('2d') returns null by default; stub it
+    // so the compression path isn't short-circuited.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(function (
+      this: HTMLCanvasElement,
+      cb: BlobCallback,
+    ) {
+      cb(new Blob([new Uint8Array(300_000)], { type: 'image/jpeg' }));
+    });
+    const file = new File([new Uint8Array(2_000_000)], 'photo.heic', { type: 'image/heic' });
+    const out = await compressImageIfNeeded(file);
+    expect(out).not.toBe(file);
+    expect(out.name).toBe('photo.jpg');
+    expect(out.type).toBe('image/jpeg');
+    expect(out.size).toBeLessThan(file.size);
+  });
+});

--- a/frontend/src/lib/imageCompression.ts
+++ b/frontend/src/lib/imageCompression.ts
@@ -1,0 +1,88 @@
+/**
+ * Client-side image compression before upload.
+ *
+ * Phone photos are routinely 5-10 MB at full resolution, but the agent's
+ * vision pipeline downsamples them to ~1600px anyway (see backend
+ * media/download.py compression step). Shipping the original over the
+ * wire is pure overhead, and on a typical home connection it dominates
+ * end-to-end latency. Resizing to ``MAX_DIMENSION`` and re-encoding as
+ * JPEG at ``JPEG_QUALITY`` typically cuts size by 5-10x with no
+ * visible quality loss at the size the user sees in the chat. #1368.
+ *
+ * The compressed file is always JPEG (we re-encode through a canvas),
+ * regardless of the input format. EXIF is stripped as a side effect,
+ * which is desirable for a chat upload anyway (drops GPS, camera serial,
+ * etc.).
+ */
+
+const MAX_DIMENSION = 1600;
+const JPEG_QUALITY = 0.85;
+// Don't bother compressing files this small: the canvas round-trip would
+// likely produce a similar or larger blob and we'd add latency for nothing.
+const MIN_COMPRESS_BYTES = 200 * 1024;
+
+const COMPRESSIBLE_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
+/** Return true when the file is worth attempting to compress. */
+export function shouldCompressImage(file: File): boolean {
+  if (!COMPRESSIBLE_TYPES.has(file.type)) return false;
+  if (file.size < MIN_COMPRESS_BYTES) return false;
+  return true;
+}
+
+/**
+ * Compress *file* if it's an image worth shrinking; otherwise return the
+ * original. Never throws: any failure (unsupported format, OOM, canvas
+ * blocked, …) returns the original so the upload still goes through.
+ */
+export async function compressImageIfNeeded(file: File): Promise<File> {
+  if (!shouldCompressImage(file)) return file;
+  try {
+    return await _compressImage(file);
+  } catch {
+    return file;
+  }
+}
+
+async function _compressImage(file: File): Promise<File> {
+  const bitmap = await createImageBitmap(file);
+  try {
+    const { width, height } = bitmap;
+    const maxSide = Math.max(width, height);
+    // Already at or below the target resolution: only worth re-encoding if
+    // a high-quality JPEG round-trip noticeably beats the source bytes.
+    // For PNG screenshots and HEIC this can still help, so we don't bail
+    // early on dimensions alone.
+    const scale = maxSide > MAX_DIMENSION ? MAX_DIMENSION / maxSide : 1;
+    const targetW = Math.max(1, Math.round(width * scale));
+    const targetH = Math.max(1, Math.round(height * scale));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = targetW;
+    canvas.height = targetH;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return file;
+    ctx.drawImage(bitmap, 0, 0, targetW, targetH);
+
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, 'image/jpeg', JPEG_QUALITY);
+    });
+    if (!blob) return file;
+    // Never substitute a larger file: simple PNGs of solid color and
+    // already-aggressively-compressed JPEGs sometimes round-trip larger
+    // than the source.
+    if (blob.size >= file.size) return file;
+
+    const baseName = file.name.replace(/\.[^.]+$/, '');
+    return new File([blob], `${baseName}.jpg`, { type: 'image/jpeg' });
+  } finally {
+    bitmap.close();
+  }
+}

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -806,6 +806,45 @@ describe('ChatPage upload progress + cancel + retry (issue #1368)', () => {
     expect(secondCallFiles).toHaveLength(1);
     expect(secondCallFiles[0]?.name).toBe('photo.png');
   });
+
+  it('does not show Thinking... until onAccepted fires (upload finished)', async () => {
+    // Hang sendChatMessage indefinitely without calling onAccepted: the
+    // POST is still in flight from the caller's perspective.
+    mockApi.sendChatMessage.mockImplementation(() => new Promise(() => {}));
+
+    await attachAndSend();
+
+    // The chip + upload overlay show up, but no "Thinking..." yet.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /cancel upload/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/thinking/i)).not.toBeInTheDocument();
+  });
+
+  it('shows Thinking... once the upload completes (onAccepted fires)', async () => {
+    let acceptedCb: (() => void) | undefined;
+    mockApi.sendChatMessage.mockImplementation(
+      (_msg, _files, _onEvent, onAccepted) => {
+        acceptedCb = onAccepted as (() => void) | undefined;
+        // Promise that resolves only after a manual trigger; in this test
+        // we never trigger it, so the agent stays in the "thinking"
+        // window for the assertion.
+        return new Promise(() => {});
+      },
+    );
+
+    await attachAndSend();
+    await waitFor(() => expect(acceptedCb).toBeDefined());
+
+    // Simulate the POST returning a request_id.
+    act(() => {
+      acceptedCb!();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/thinking/i)).toBeInTheDocument();
+    });
+  });
 });
 
 describe('ChatPage system prompt panel visibility', () => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from '@heroui/checkbox';
 import { Tooltip } from '@heroui/tooltip';
 import { Spinner } from '@heroui/spinner';
 import api from '@/api';
+import { compressImageIfNeeded, shouldCompressImage } from '@/lib/imageCompression';
 import { toast } from '@/lib/toast';
 import { useConversation, useConversationSystemPrompt } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
@@ -32,6 +33,11 @@ interface FileAttachment {
 interface SelectedFile {
   file: File;
   previewUrl?: string;
+  // True while a background compression pass is replacing `file` with a
+  // smaller JPEG re-encoding. The chip stays in the row throughout; on
+  // submit we await any in-flight compressions so the upload uses the
+  // shrunken bytes. #1368.
+  compressing?: boolean;
 }
 
 interface ChatMessage {
@@ -71,6 +77,12 @@ export default function ChatPage() {
   const [pendingCount, setPendingCount] = useState(0);
   const pendingRef = useRef(0);
   const sending = pendingCount > 0;
+  // Separate from `pendingCount`: only counts messages whose POST already
+  // landed (onAccepted fired) and that are now waiting on the agent's
+  // reply. Drives the "Thinking..." spinner so it doesn't appear while the
+  // user is still watching their image bytes go up. #1368.
+  const [thinkingCount, setThinkingCount] = useState(0);
+  const thinking = thinkingCount > 0;
   // Mirror of selectedFiles. The unmount cleanup reads this ref so it can
   // revoke chip preview URLs without resubscribing on every render (which
   // would race against removeFile's own revoke). #1368.
@@ -107,6 +119,11 @@ export default function ChatPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const nextId = useRef(1);
   const mountedRef = useRef(true);
+  // In-flight image compressions kicked off from handleFileSelect. Awaited
+  // in handleSubmit so the upload always uses the shrunken bytes, even if
+  // the user hits send within the ~few-hundred-ms compression window for a
+  // phone-sized photo. #1368.
+  const compressionPromisesRef = useRef<Set<Promise<unknown>>>(new Set());
 
   // Track mounted state to prevent state updates after unmount
   useEffect(() => {
@@ -205,15 +222,41 @@ export default function ChatPage() {
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newFiles = Array.from(e.target.files || []);
-    if (newFiles.length > 0) {
-      setSelectedFiles((prev) => [
-        ...prev,
-        ...newFiles.map((file) => ({
-          file,
-          previewUrl: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined,
-        })),
-      ]);
+    if (newFiles.length === 0) {
+      e.target.value = '';
+      return;
     }
+
+    const newEntries: SelectedFile[] = newFiles.map((file) => {
+      const willCompress = shouldCompressImage(file);
+      return {
+        file,
+        previewUrl: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined,
+        compressing: willCompress,
+      };
+    });
+    setSelectedFiles((prev) => [...prev, ...newEntries]);
+
+    // Kick off compression in the background. Each promise lands in the
+    // ref so handleSubmit can await any still in flight at submit time.
+    newEntries.forEach((entry) => {
+      if (!entry.compressing) return;
+      const original = entry.file;
+      const promise = (async () => {
+        const compressed = await compressImageIfNeeded(original);
+        if (!mountedRef.current) return;
+        setSelectedFiles((prev) =>
+          prev.map((e) =>
+            e.file === original ? { ...e, file: compressed, compressing: false } : e,
+          ),
+        );
+      })();
+      compressionPromisesRef.current.add(promise);
+      promise.finally(() => {
+        compressionPromisesRef.current.delete(promise);
+      });
+    });
+
     // Reset so the same file can be re-selected
     e.target.value = '';
   };
@@ -279,6 +322,10 @@ export default function ChatPage() {
 
       pendingRef.current++;
       setPendingCount((c) => c + 1);
+      // Tracks whether onAccepted fired for this call, so the finally
+      // block knows whether to decrement thinkingCount (which was only
+      // incremented in onAccepted, not on send-click).
+      let thinkingIncremented = false;
 
       try {
         const toolNames: string[] = [];
@@ -306,7 +353,16 @@ export default function ChatPage() {
               setWaitingForApproval(true);
             }
           },
-          undefined,
+          () => {
+            // POST succeeded with a request_id, i.e. the upload bytes are
+            // safely on the server and the agent is now the bottleneck.
+            // Flip the spinner on here, not at send-click, so users
+            // watching an upload aren't told "Thinking..." until thinking
+            // actually starts.
+            if (!mountedRef.current) return;
+            thinkingIncremented = true;
+            setThinkingCount((c) => c + 1);
+          },
           hasFiles
             ? {
                 signal: abort.signal,
@@ -384,6 +440,9 @@ export default function ChatPage() {
         if (!mountedRef.current) return;
         pendingRef.current--;
         setPendingCount((c) => c - 1);
+        if (thinkingIncremented) {
+          setThinkingCount((c) => Math.max(0, c - 1));
+        }
         // Only clear indicators when all pending requests are done
         if (pendingRef.current === 0) {
           setCurrentTool(null);
@@ -398,8 +457,18 @@ export default function ChatPage() {
     e.preventDefault();
     const text = input.trim();
     if (!text && selectedFiles.length === 0) return;
+
+    // Wait for any still-running compressions before sampling File handles,
+    // so the upload always uses the compressed bytes.
+    if (compressionPromisesRef.current.size > 0) {
+      await Promise.all([...compressionPromisesRef.current]);
+      if (!mountedRef.current) return;
+    }
+
     const files =
-      selectedFiles.length > 0 ? selectedFiles.map((entry) => entry.file) : undefined;
+      selectedFilesRef.current.length > 0
+        ? selectedFilesRef.current.map((entry) => entry.file)
+        : undefined;
     setInput('');
     setSelectedFiles([]);
     await sendChatMessage(text, files);
@@ -799,10 +868,10 @@ export default function ChatPage() {
               );
             })}
 
-            {sending && !waitingForApproval && (
+            {thinking && !waitingForApproval && (
               <ToolUseIndicator toolName={currentTool ?? undefined} />
             )}
-            {!sending && agentBusy && (
+            {!thinking && agentBusy && (
               <ToolUseIndicator toolName={activityTool ?? undefined} />
             )}
           </div>


### PR DESCRIPTION
## Description

Two follow-ups to the upload-progress feature based on real-world testing in prod.

**1. Compress images client-side before upload.** Phone photos run 5-10 MB at full resolution but the agent's vision pipeline already downsamples them to ~1600px (see `backend/app/media/download.py`), so shipping the originals is pure end-to-end latency. New `lib/imageCompression.ts` resizes to `MAX_DIMENSION=1600` and re-encodes as JPEG at 0.85 quality; typically 5-10x smaller with no visible quality loss. Skipped for files under 200 KB, for GIFs and SVGs (would lose animation / no benefit), for non-image types, and silently falls back to the original on any failure (unsupported codec, OOM, …). EXIF is stripped as a side effect.

Compression runs as a background task fired from `handleFileSelect` so the chip pops up instantly with the original preview URL; the `compressing` flag tracks each entry while a promise is in flight. `handleSubmit` awaits any pending compressions before sampling the file handles, so the bytes that actually go up are always the shrunken ones.

**2. Move the "Thinking..." spinner from send-click to onAccepted.** Currently the spinner appears the instant the user hits send, which is wrong while a multi-MB image is still uploading: the agent isn't thinking yet, the bytes haven't reached the server. New `thinkingCount` state is driven by the `onAccepted` callback (which fires when the POST returns a `request_id`, i.e. the upload bytes are safely on the server), and `ToolUseIndicator` switches from gating on `sending` to gating on `thinking`. For text-only sends `onAccepted` is effectively immediate, so user-visible behavior there is unchanged.

Refs #1368.

## Type
- [x] Feature
- [x] Bug fix

## Checklist
- [x] Tests pass (`npx vitest run src/lib/imageCompression.test.ts src/pages/ChatPage.test.tsx src/api.test.ts` = 47/47)
- [x] Lint passes (typecheck, knip; no backend changes)
- [x] New tests added for new functionality (7 compression unit tests + 2 ChatPage tests for spinner timing)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: Claude Opus 4.7 (Claude Code, 1M context) drafted the compression helper, the spinner-timing rewire, the tests, and this PR body via back-and-forth with @njbrake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)