### PR TITLE
feat(frontend): "Update available" banner when new service worker is ready

### DIFF
--- a/frontend/src/components/UpdateAvailableBanner.test.tsx
+++ b/frontend/src/components/UpdateAvailableBanner.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UpdateAvailableBanner from './UpdateAvailableBanner';
+
+type Setter<T> = (v: T | ((prev: T) => T)) => void;
+
+let mockNeedRefresh = false;
+const mockSetNeedRefresh = vi.fn<Setter<boolean>>();
+const mockUpdateServiceWorker = vi.fn<(reload?: boolean) => Promise<void>>();
+const mockUseRegisterSW = vi.fn();
+
+vi.mock('virtual:pwa-register/react', () => ({
+  useRegisterSW: (options?: unknown) => mockUseRegisterSW(options),
+}));
+
+beforeEach(() => {
+  mockNeedRefresh = false;
+  mockSetNeedRefresh.mockReset();
+  mockUpdateServiceWorker.mockReset();
+  mockUpdateServiceWorker.mockResolvedValue(undefined);
+  mockUseRegisterSW.mockReset();
+  mockUseRegisterSW.mockImplementation(() => ({
+    needRefresh: [mockNeedRefresh, mockSetNeedRefresh],
+    offlineReady: [false, vi.fn()],
+    updateServiceWorker: mockUpdateServiceWorker,
+  }));
+});
+
+describe('UpdateAvailableBanner', () => {
+  it('renders nothing when no update is waiting', () => {
+    mockNeedRefresh = false;
+    const { container } = render(<UpdateAvailableBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the banner with Update and Later buttons when an update is waiting', () => {
+    mockNeedRefresh = true;
+    render(<UpdateAvailableBanner />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/new version of Clawbolt is available/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /dismiss update notification/i })).toBeInTheDocument();
+  });
+
+  it('calls updateServiceWorker(true) when Update is clicked', async () => {
+    mockNeedRefresh = true;
+    const user = userEvent.setup();
+    render(<UpdateAvailableBanner />);
+    await user.click(screen.getByRole('button', { name: 'Update' }));
+    expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
+  });
+
+  it('hides the banner via setNeedRefresh(false) when Later is clicked', async () => {
+    mockNeedRefresh = true;
+    const user = userEvent.setup();
+    render(<UpdateAvailableBanner />);
+    await user.click(screen.getByRole('button', { name: /dismiss update notification/i }));
+    expect(mockSetNeedRefresh).toHaveBeenCalledWith(false);
+  });
+
+  it('schedules a periodic update poll inside onRegisteredSW', () => {
+    vi.useFakeTimers();
+    try {
+      mockNeedRefresh = false;
+      const update = vi.fn().mockResolvedValue(undefined);
+      const registration = { installing: null, update } as unknown as ServiceWorkerRegistration;
+      mockUseRegisterSW.mockImplementation((options: { onRegisteredSW?: (url: string, r: ServiceWorkerRegistration) => void }) => {
+        options.onRegisteredSW?.('/sw.js', registration);
+        return {
+          needRefresh: [false, mockSetNeedRefresh],
+          offlineReady: [false, vi.fn()],
+          updateServiceWorker: mockUpdateServiceWorker,
+        };
+      });
+      render(<UpdateAvailableBanner />);
+      expect(update).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(60 * 60 * 1000);
+      expect(update).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(60 * 60 * 1000);
+      expect(update).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/components/UpdateAvailableBanner.tsx
+++ b/frontend/src/components/UpdateAvailableBanner.tsx
@@ -1,0 +1,53 @@
+import { useRegisterSW } from 'virtual:pwa-register/react';
+
+/**
+ * Polls the SW for a new build on a fixed interval. Browsers only auto-check
+ * for SW updates on navigation, which rarely happens in a SPA / installed PWA,
+ * so without this users would not see a fresh build until they reopen the app.
+ */
+const UPDATE_POLL_INTERVAL_MS = 60 * 60 * 1000;
+
+export default function UpdateAvailableBanner() {
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return;
+      const tick = () => {
+        if (registration.installing || !navigator.onLine) return;
+        void registration.update();
+      };
+      setInterval(tick, UPDATE_POLL_INTERVAL_MS);
+    },
+  });
+
+  if (!needRefresh) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="fixed top-0 inset-x-0 z-[100] flex items-center justify-center gap-3 bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm"
+    >
+      <span>A new version of Clawbolt is available.</span>
+      <button
+        type="button"
+        onClick={() => {
+          void updateServiceWorker(true);
+        }}
+        className="rounded-md bg-white/95 px-3 py-1 text-xs font-semibold text-primary shadow-sm transition-colors can-hover:hover:bg-white"
+      >
+        Update
+      </button>
+      <button
+        type="button"
+        onClick={() => setNeedRefresh(false)}
+        aria-label="Dismiss update notification"
+        className="rounded-md px-2 py-1 text-xs font-medium text-white/80 transition-colors can-hover:hover:text-white"
+      >
+        Later
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/query-client';
 import { AuthProvider } from '@/contexts/AuthContext';
 import App from '@/App';
+import UpdateAvailableBanner from '@/components/UpdateAvailableBanner';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
@@ -14,6 +15,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
           <AuthProvider>
+            <UpdateAvailableBanner />
             <App />
           </AuthProvider>
         </BrowserRouter>

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -9,10 +9,13 @@ declare const self: ServiceWorkerGlobalScope
 cleanupOutdatedCaches()
 precacheAndRoute(self.__WB_MANIFEST)
 
-// Activate new SW immediately and take control of all open tabs.
-// skipWaiting() bypasses the waiting phase; clients.claim() ensures the
-// new SW controls existing tabs without requiring a second navigation.
-// Combined with autoUpdate registration mode, this triggers a page reload
-// via the controllerchange event so users always get the latest deploy.
-self.skipWaiting()
+// The new SW stays in the waiting state until the page sends SKIP_WAITING,
+// which the in-app "Update" banner triggers via vite-plugin-pwa's
+// updateServiceWorker(). clients.claim() on activate lets the new SW take
+// over open tabs immediately so the post-update reload renders the new build.
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})
 self.addEventListener('activate', () => self.clients.claim())

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,7 +12,11 @@ export default defineConfig({
       strategies: 'injectManifest',
       srcDir: 'src',
       filename: 'sw.ts',
-      registerType: 'autoUpdate',
+      // 'prompt' (instead of 'autoUpdate') keeps the new SW in the waiting
+      // state until the user taps the in-app "Update" banner, so we never
+      // reload mid-conversation and cancel an in-flight chat send.
+      // See src/components/UpdateAvailableBanner.tsx.
+      registerType: 'prompt',
       injectManifest: {
         globPatterns: ['**/*.{js,css,html,svg,png,woff2}'],
         globIgnores: [


### PR DESCRIPTION
## Description

Surfaces a small in-app banner when a new build is waiting to install, replacing the previous silent auto-update that could reload mid-conversation. Tap **Update** to activate the new SW and reload cleanly; tap **Later** to dismiss for the session.

Also adds an hourly `registration.update()` poll because browsers only auto-check for SW updates on navigation, which rarely fires in SPAs / installed PWAs, so without it users would not discover a new build until they fully closed the app.

### How it works

1. `vite.config.ts`: `registerType: 'autoUpdate'` → `'prompt'`. New SW now stays in the waiting state.
2. `sw.ts`: removed unconditional `self.skipWaiting()`; added a message handler that calls `skipWaiting()` only when the page posts `{type: 'SKIP_WAITING'}`.
3. `UpdateAvailableBanner.tsx`: new component using `useRegisterSW` from `virtual:pwa-register/react`. Fixed amber banner with Update / Later. Polls every 60 min in `onRegisteredSW`.
4. Mounted in `main.tsx` at the top of the tree so logged-out and logged-in users both see it.

Fixes #1384

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (no backend changes; frontend `npm test` for the new component passes 5/5)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (`UpdateAvailableBanner.test.tsx`, 5 cases)
- [x] Bug fixes include regression tests (n/a, this is a feature)

## AI Usage
- [x] AI-assisted (Claude wrote the code via back-and-forth with @njbrake; reasoning, scope, and final review by him)
- [ ] No AI used

## Follow-up

Premium overlays its own `frontend/src/vite-env.d.ts` on top of OSS. After this lands and we cut an OSS release, the premium OSS_REF bump PR also needs to add the `vite-plugin-pwa/react` reference to premium's vite-env.d.ts, otherwise the premium frontend build will fail on the new `useRegisterSW` import.