### PR TITLE
feat: add CHAT_WEB_ATTACHMENTS_ENABLED flag for chat upload UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -230,3 +230,10 @@ HEARTBEAT_MAX_DAILY_MESSAGES=5
 
 # -- Observability --
 # LOG_REQUEST_TIMING=false
+
+# -- Web chat UI --
+# Show the paperclip / file-input affordance on the chat page. Set to false
+# behind proxies or CDNs that cap request body size below the typical photo
+# upload (e.g. CloudFront's 1 MB default) so users do not see an attach button
+# that silently 413s. Defaults to true; premium flips this off automatically.
+# CHAT_WEB_ATTACHMENTS_ENABLED=true

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -322,6 +322,14 @@ class Settings(BaseSettings):
     # Observability
     log_request_timing: bool = False  # Set True (or LOG_REQUEST_TIMING=1) to log per-request timing
 
+    # Web chat UI: whether the chat page shows the file attachment affordance
+    # (paperclip button + hidden file input). Defaults to True for OSS, where
+    # uploads land directly on the FastAPI worker. Deployments behind a proxy
+    # or CDN that caps request body size (e.g. CloudFront's 1 MB default on
+    # premium) set this to False until the upload path is fixed, so users do
+    # not see an affordance that silently fails.
+    chat_web_attachments_enabled: bool = True
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from backend.app.database import db_session_async, get_async_engine
 from backend.app.logging_utils import mask_pii
 from backend.app.models import ChannelRoute, User
 from backend.app.routers import (
+    app_config,
     auth,
     health,
     media_temp,
@@ -381,6 +382,7 @@ app.add_middleware(
 )
 
 app.include_router(health.router, prefix="/api")
+app.include_router(app_config.router, prefix="/api")
 app.include_router(auth.router, prefix="/api")
 app.include_router(oauth.router, prefix="/api")
 app.include_router(media_temp.router, prefix="/api")

--- a/backend/app/routers/app_config.py
+++ b/backend/app/routers/app_config.py
@@ -1,0 +1,23 @@
+"""Deployment-level feature flags consumed by the frontend.
+
+A single GET endpoint that returns the set of runtime flags the React app
+needs to know about (e.g. whether the chat page should expose the file
+attachment affordance). The values come from ``Settings`` so a deployment
+can flip them via env vars without a rebuild. No auth required: the
+payload contains nothing sensitive and the frontend fetches it before
+the user is signed in.
+"""
+
+from fastapi import APIRouter
+
+from backend.app.config import settings
+from backend.app.schemas import AppConfigResponse
+
+router = APIRouter()
+
+
+@router.get("/app/config", response_model=AppConfigResponse)
+async def app_config() -> AppConfigResponse:
+    return AppConfigResponse(
+        chat_web_attachments_enabled=settings.chat_web_attachments_enabled,
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -8,6 +8,12 @@ class HealthResponse(BaseModel):
     database: str = "ok"
 
 
+class AppConfigResponse(BaseModel):
+    """Deployment-level feature flags the frontend reads on app load."""
+
+    chat_web_attachments_enabled: bool
+
+
 class MemoryResponse(BaseModel):
     content: str
 

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -195,6 +195,12 @@ Photos and files the user sends over a messaging channel are cached on disk whil
 |----------|---------|-------------|
 | `LOG_REQUEST_TIMING` | `false` | Log method, path, status code, and duration for every HTTP request |
 
+## Web chat UI
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHAT_WEB_ATTACHMENTS_ENABLED` | `true` | Show the paperclip / file-input affordance on the chat page. Set to `false` behind proxies or CDNs that cap request body size below the typical photo upload (e.g. CloudFront's 1 MB default) so users do not see an attach button that silently 413s. Premium flips this off automatically. |
+
 ## OAuth
 
 | Variable | Default | Description |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -43,6 +43,24 @@
         }
       }
     },
+    "/api/app/config": {
+      "get": {
+        "summary": "App Config",
+        "operationId": "app_config_api_app_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/config": {
       "get": {
         "summary": "Auth Config",
@@ -1333,6 +1351,20 @@
   },
   "components": {
     "schemas": {
+      "AppConfigResponse": {
+        "properties": {
+          "chat_web_attachments_enabled": {
+            "type": "boolean",
+            "title": "Chat Web Attachments Enabled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "chat_web_attachments_enabled"
+        ],
+        "title": "AppConfigResponse",
+        "description": "Deployment-level feature flags the frontend reads on app load."
+      },
       "BatchDeleteRequest": {
         "properties": {
           "seqs": {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AppConfigResponse,
   AuthConfig,
   AuthUser,
   ChatAccepted,
@@ -131,6 +132,11 @@ function logout(): void {
 
 const api = {
   getAuthConfig,
+  getAppConfig: async (): Promise<AppConfigResponse> => {
+    const { data, error } = await client.GET('/api/app/config');
+    if (error) _throwApiError(error, 'Failed to get app config');
+    return data as AppConfigResponse;
+  },
   logout,
   tryRestoreSession: _tryRestoreSession as () => Promise<AuthUser | null>,
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -55,6 +55,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/app/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** App Config */
+        get: operations["app_config_api_app_config_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/config": {
         parameters: {
             query?: never;
@@ -875,6 +892,14 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * AppConfigResponse
+         * @description Deployment-level feature flags the frontend reads on app load.
+         */
+        AppConfigResponse: {
+            /** Chat Web Attachments Enabled */
+            chat_web_attachments_enabled: boolean;
+        };
         /** BatchDeleteRequest */
         BatchDeleteRequest: {
             /** Seqs */
@@ -1591,6 +1616,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
+    };
+    app_config_api_app_config_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AppConfigResponse"];
                 };
             };
         };

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -11,6 +11,18 @@ import type {
   DataSharingConsentRequest,
 } from '@/types';
 
+// --- App config (deployment-level feature flags) ---
+
+export function useAppConfig() {
+  return useQuery({
+    queryKey: queryKeys.appConfig,
+    queryFn: () => api.getAppConfig(),
+    // Flags only change on redeploy. Cache aggressively so every page that
+    // gates on a flag does not re-fetch on mount.
+    staleTime: Infinity,
+  });
+}
+
 // --- Profile ---
 
 export function useProfile(opts: { enabled?: boolean } = {}) {

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -1,4 +1,5 @@
 export const queryKeys = {
+  appConfig: ['appConfig'] as const,
   profile: ['profile'] as const,
   dataSharingConsent: ['dataSharingConsent'] as const,
   conversation: {

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -10,6 +10,7 @@ import ChatPage from './ChatPage';
 // Mock the api module
 vi.mock('@/api', () => ({
   default: {
+    getAppConfig: vi.fn().mockResolvedValue({ chat_web_attachments_enabled: true }),
     getConversation: vi.fn(),
     getConversationSystemPrompt: vi.fn(),
     sendChatMessage: vi.fn(),
@@ -407,6 +408,33 @@ describe('ChatPage concurrent messaging', () => {
     // Attach files button should also remain enabled
     const attachButton = screen.getByLabelText('Attach files');
     expect(attachButton).not.toBeDisabled();
+  });
+});
+
+describe('ChatPage attachment affordance gating', () => {
+  it('hides the paperclip and file input when chat_web_attachments_enabled is false', async () => {
+    mockApi.getAppConfig.mockResolvedValueOnce({ chat_web_attachments_enabled: false });
+    mockApi.getConversation.mockResolvedValue({
+      session_id: '',
+      user_id: '1',
+      created_at: '',
+      last_message_at: '',
+      channel: 'webchat',
+      messages: [],
+    });
+
+    const { container } = renderWithRouter(
+      <ChatActivityProvider><ChatPage /></ChatActivityProvider>,
+    );
+
+    // Wait for the page to settle on the disabled-attachments config.
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Attach files')).not.toBeInTheDocument();
+    });
+    expect(container.querySelector('input[type="file"]')).toBeNull();
+
+    // Send button still renders so the user can submit text-only messages.
+    expect(screen.getByLabelText('Send message')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -9,7 +9,7 @@ import { Spinner } from '@heroui/spinner';
 import api from '@/api';
 import { compressImageIfNeeded, shouldCompressImage } from '@/lib/imageCompression';
 import { toast } from '@/lib/toast';
-import { useConversation, useConversationSystemPrompt } from '@/hooks/queries';
+import { useAppConfig, useConversation, useConversationSystemPrompt } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
 import { useChatActivity } from '@/contexts/ChatActivityContext';
 import type { AppShellContext } from '@/layouts/AppShell';
@@ -72,6 +72,12 @@ export default function ChatPage() {
   const isPremium = outletCtx?.isPremium ?? false;
   const isAdmin = outletCtx?.isAdmin ?? false;
   const canSeeSystemPrompt = !isPremium || isAdmin;
+  // Default to enabled while the deployment config is loading so OSS users
+  // (and the test harness that doesn't mock useAppConfig) see the affordance
+  // immediately. Premium flips this off via CHAT_WEB_ATTACHMENTS_ENABLED=false
+  // while CloudFront's body-size cap keeps uploads from reaching the worker.
+  const { data: appConfig } = useAppConfig();
+  const chatAttachmentsEnabled = appConfig?.chat_web_attachments_enabled ?? true;
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [pendingCount, setPendingCount] = useState(0);
@@ -927,14 +933,16 @@ export default function ChatPage() {
       {/* Input area */}
       <div className="pt-3 pb-4 sm:pb-6">
         <form onSubmit={handleSubmit}>
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            accept={ACCEPTED_FILE_TYPES}
-            onChange={handleFileSelect}
-            className="hidden"
-          />
+          {chatAttachmentsEnabled && (
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept={ACCEPTED_FILE_TYPES}
+              onChange={handleFileSelect}
+              className="hidden"
+            />
+          )}
           <div className="flex flex-col gap-2 p-2 bg-panel border border-border rounded-lg">
             <textarea
               ref={inputRef}
@@ -995,17 +1003,21 @@ export default function ChatPage() {
 
             {/* Toolbar row */}
             <div className="flex items-center justify-between">
-              <Tooltip content="Attach files" delay={400} closeDelay={0}>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="text-muted-foreground hover:text-foreground"
-                  aria-label="Attach files"
-                >
-                  <PaperclipIcon />
-                </Button>
-              </Tooltip>
+              {chatAttachmentsEnabled ? (
+                <Tooltip content="Attach files" delay={400} closeDelay={0}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="text-muted-foreground hover:text-foreground"
+                    aria-label="Attach files"
+                  >
+                    <PaperclipIcon />
+                  </Button>
+                </Tooltip>
+              ) : (
+                <span />
+              )}
               <Tooltip content="Send message" delay={400} closeDelay={0}>
                 <Button
                   type="submit"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2,6 +2,7 @@ import type { components } from '@/generated/api';
 
 // --- Backend types (derived from OpenAPI spec, single source of truth) ---
 
+export type AppConfigResponse = components['schemas']['AppConfigResponse'];
 export type UserProfileResponse = components['schemas']['UserProfileResponse'];
 export type UserProfileUpdate = components['schemas']['UserProfileUpdate'];
 export type DataSharingConsentRequest = components['schemas']['DataSharingConsentRequest'];

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from backend.app.config import settings
+
+
+def test_app_config_default(client: TestClient) -> None:
+    """OSS default keeps the chat web upload affordance enabled."""
+    response = client.get("/api/app/config")
+    assert response.status_code == 200
+    assert response.json() == {"chat_web_attachments_enabled": True}
+
+
+def test_app_config_reflects_settings_override(client: TestClient) -> None:
+    """Deployments that flip the flag (e.g. premium under CloudFront) see it."""
+    original = settings.chat_web_attachments_enabled
+    settings.chat_web_attachments_enabled = False
+    try:
+        response = client.get("/api/app/config")
+        assert response.status_code == 200
+        assert response.json() == {"chat_web_attachments_enabled": False}
+    finally:
+        settings.chat_web_attachments_enabled = original


### PR DESCRIPTION
## Description

Adds a deployment-level feature flag (`CHAT_WEB_ATTACHMENTS_ENABLED`,
default `true`) that gates the paperclip / file-input affordance on the
chat page. Deployments behind a proxy or CDN that caps request body size
(e.g. CloudFront's 1 MB default on premium) currently surface a button
that silently 413s on photo-sized uploads; this lets them hide it until
the upload path is fixed.

* New `chat_web_attachments_enabled` setting and `GET /api/app/config`
  endpoint that surfaces it.
* `useAppConfig` hook + ChatPage gating so the paperclip and hidden file
  input only render when the flag is true. A layout placeholder keeps
  the send button right-aligned when the paperclip is hidden.
* `.env.example` and `docs/self-host/configuration.md` document the new
  variable; the existing `test_env_example` checks enforce coverage.

Companion premium PR sets the flag off automatically (with an env-var
escape hatch for local dev).

## Type
- [x] Feature

## Checklist
- [x] Tests pass (`uv run pytest -v`): 2799 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (`tests/test_app_config.py`,
  ChatPage attachment-gating vitest case)
- [x] Bug fixes include regression tests (n/a, feature)

## AI Usage
- [x] AI-assisted: drafted with Claude Code (Opus 4.7) via back-and-forth
  with @njbrake. Design choice (OSS feature flag vs. premium-only
  override) discussed up front; implementation, tests, and docs by
  Claude under review.