### PR TITLE
fix: sort integration tools alphabetically by display name in Web UI

### DIFF
--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -582,4 +582,43 @@ describe('DashboardPage', () => {
     expect(screen.queryByText('AI model and provider configuration.')).not.toBeInTheDocument();
     expect(mockGetModelConfig).not.toHaveBeenCalled();
   });
+
+  it('sorts integration tools alphabetically by display name', async () => {
+    // Regression: tools from different providers should appear grouped
+    // together rather than scattered by factory name order.
+    setupMocks({
+      tools: {
+        tools: [
+          { name: 'file', description: 'Google Drive storage', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_drive', always_enabled: true },
+          { name: 'calendar', description: 'Google Calendar integration', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_calendar', always_enabled: false },
+          { name: 'gmail', description: 'Gmail integration', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'gmail', always_enabled: false },
+          { name: 'servicetitan', description: 'ServiceTitan integration', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '', always_enabled: false },
+          { name: 'quickbooks', description: 'QuickBooks integration', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'quickbooks', always_enabled: false },
+        ],
+      },
+      oauth: {
+        integrations: [
+          { integration: 'google_drive', connected: true, configured: true },
+          { integration: 'google_calendar', connected: true, configured: true },
+          { integration: 'gmail', connected: true, configured: true },
+          { integration: 'quickbooks', connected: true, configured: true },
+        ],
+      },
+    });
+    renderWithRouter(<DashboardPage />);
+
+    await waitFor(() => {
+      // Collect all spans in DOM order, filter to the known display names.
+      const spans = document.querySelectorAll('span');
+      const toolNames: string[] = [];
+      for (const span of spans) {
+        const text = span.textContent ?? '';
+        if (['Gmail', 'Google Calendar', 'Google Drive', 'QuickBooks', 'ServiceTitan'].includes(text)) {
+          toolNames.push(text);
+        }
+      }
+
+      expect(toolNames).toEqual(['Gmail', 'Google Calendar', 'Google Drive', 'QuickBooks', 'ServiceTitan']);
+    });
+  });
 });

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -127,7 +127,11 @@ export default function DashboardPage() {
   // Mirror the ToolsPage filter: integrations group plus OAuth-backed
   // always-on tools (Google Drive). Keeps the dashboard card in sync with
   // what the Settings page actually renders.
-  const integrationTools = allTools.filter((t) => t.category === 'domain' || !!t.oauth_name);
+  // Sort alphabetically by display name so integrations from the same
+  // provider (e.g. Google Calendar, Google Drive, Gmail) appear together.
+  const integrationTools = allTools
+    .filter((t) => t.category === 'domain' || !!t.oauth_name)
+    .sort((a, b) => toolDisplayName(a.name).localeCompare(toolDisplayName(b.name)));
   const integrations = oauth.data?.integrations ?? [];
   const oauthMap = Object.fromEntries(integrations.map((i) => [i.integration, i]));
   const enabledCalendars = calendarConfig.data?.calendars ?? [];

--- a/frontend/src/pages/PermissionsPage.test.tsx
+++ b/frontend/src/pages/PermissionsPage.test.tsx
@@ -156,4 +156,48 @@ describe('PermissionsPage', () => {
     });
     expect(screen.queryByText('Google Drive')).not.toBeInTheDocument();
   });
+
+  it('sorts domain tools alphabetically by display name', async () => {
+    // Regression: domain tools should appear in alphabetical display-name
+    // order rather than factory-name order.
+    mockGetToolConfig.mockResolvedValue({
+      tools: [
+        tool({ name: 'quickbooks', category: 'domain', oauth_name: 'quickbooks', sub_tools: [
+          { name: 'qb_query', permission_level: 'ask', hidden_in_permissions: false },
+        ] }),
+        tool({ name: 'calendar', category: 'domain', oauth_name: 'google_calendar', sub_tools: [
+          { name: 'calendar_list_events', permission_level: 'ask', hidden_in_permissions: false },
+        ] }),
+        tool({ name: 'gmail', category: 'domain', oauth_name: 'gmail', sub_tools: [
+          { name: 'gmail_send', permission_level: 'ask', hidden_in_permissions: false },
+        ] }),
+        tool({ name: 'servicetitan', category: 'domain', sub_tools: [
+          { name: 'st_action', permission_level: 'ask', hidden_in_permissions: false },
+        ] }),
+      ],
+    });
+    mockGetOAuthStatus.mockResolvedValue({
+      integrations: [
+        { integration: 'quickbooks', connected: true, configured: true },
+        { integration: 'google_calendar', connected: true, configured: true },
+        { integration: 'gmail', connected: true, configured: true },
+      ],
+    });
+
+    renderWithRouter(<PermissionsPage />);
+
+    await waitFor(() => {
+      // Collect font-medium spans (the tool display names) in DOM order.
+      const spans = document.querySelectorAll('span.font-medium');
+      const toolNames: string[] = [];
+      for (const span of spans) {
+        const text = span.textContent ?? '';
+        if (['Gmail', 'Google Calendar', 'QuickBooks', 'ServiceTitan'].includes(text)) {
+          toolNames.push(text);
+        }
+      }
+
+      expect(toolNames).toEqual(['Gmail', 'Google Calendar', 'QuickBooks', 'ServiceTitan']);
+    });
+  });
 });

--- a/frontend/src/pages/PermissionsPage.tsx
+++ b/frontend/src/pages/PermissionsPage.tsx
@@ -80,7 +80,7 @@ export default function PermissionsPage() {
     [visibleTools],
   );
   const domainTools = useMemo(
-    () => visibleTools.filter((t) => t.category === 'domain'),
+    () => visibleTools.filter((t) => t.category === 'domain').sort((a, b) => displayName(a.name).localeCompare(displayName(b.name))),
     [visibleTools],
   );
 

--- a/frontend/src/pages/ToolsPage.test.tsx
+++ b/frontend/src/pages/ToolsPage.test.tsx
@@ -183,4 +183,44 @@ describe('ToolsPage', () => {
     });
     expect(screen.getByText('Connected')).toBeInTheDocument();
   });
+
+  it('sorts integration tools alphabetically by display name', async () => {
+    // Regression: tools from different providers (e.g. Google Calendar,
+    // Google Drive, Gmail) should appear grouped together rather than
+    // scattered by factory name order.
+    setupMocks({
+      tools: {
+        tools: [
+          { name: 'file', description: 'Google Drive storage', category: 'core', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_drive', always_enabled: true },
+          { name: 'calendar', description: 'Google Calendar integration', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'google_calendar', always_enabled: false },
+          { name: 'gmail', description: 'Gmail integration', category: 'domain', enabled: true, domain_group: 'Integrations', domain_group_order: 2, oauth_name: 'gmail', always_enabled: false },
+          { name: 'servicetitan', description: 'ServiceTitan integration', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: '', always_enabled: false },
+          { name: 'quickbooks', description: 'QuickBooks integration', category: 'domain', enabled: true, domain_group: '', domain_group_order: 0, oauth_name: 'quickbooks', always_enabled: false },
+        ],
+      },
+      oauth: {
+        integrations: [
+          { integration: 'google_drive', connected: true, configured: true },
+          { integration: 'google_calendar', connected: true, configured: true },
+          { integration: 'gmail', connected: true, configured: true },
+          { integration: 'quickbooks', connected: true, configured: true },
+        ],
+      },
+    });
+    renderWithRouter(<ToolsPage />);
+
+    await waitFor(() => {
+      // Collect font-medium spans (the tool display names) in DOM order.
+      const spans = document.querySelectorAll('span.font-medium');
+      const toolNames: string[] = [];
+      for (const span of spans) {
+        const text = span.textContent ?? '';
+        if (['Gmail', 'Google Calendar', 'Google Drive', 'QuickBooks', 'ServiceTitan'].includes(text)) {
+          toolNames.push(text);
+        }
+      }
+
+      expect(toolNames).toEqual(['Gmail', 'Google Calendar', 'Google Drive', 'QuickBooks', 'ServiceTitan']);
+    });
+  });
 });

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -117,9 +117,11 @@ export default function ToolsPage() {
   // (``category === 'domain'``) plus any OAuth-backed tool that is rendered
   // as always-on in Settings (e.g. Google Drive). The latter has no toggle
   // but still needs Connect / Disconnect.
-  const integrationTools = tools.filter(
-    (t: ToolConfigEntryResponse) => t.category === 'domain' || !!t.oauth_name,
-  );
+  // Sort alphabetically by display name so integrations from the same
+  // provider (e.g. Google Calendar, Google Drive, Gmail) appear together.
+  const integrationTools = tools
+    .filter((t: ToolConfigEntryResponse) => t.category === 'domain' || !!t.oauth_name)
+    .sort((a, b) => displayName(a.name).localeCompare(displayName(b.name)));
 
   return (
     <div>


### PR DESCRIPTION
## Description

Integration tools (e.g. Google Calendar, Google Drive, Gmail) were rendered in factory-name order, scattering tools from the same provider apart. This PR sorts the tools alphabetically by display name so related integrations appear together.

### Changes
- frontend/src/pages/ToolsPage.tsx: Added .sort() by displayName after the integration tools filter
- frontend/src/pages/DashboardPage.tsx: Same sort applied to the dashboard integration tools list
- frontend/src/pages/PermissionsPage.tsx: Same sort applied to the domain tools list
- frontend/src/pages/ToolsPage.test.tsx: Added regression test verifying alphabetical display-name order
- frontend/src/pages/DashboardPage.test.tsx: Added regression test for dashboard integration tools order
- frontend/src/pages/PermissionsPage.test.tsx: Added regression test for domain tools order

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (uv run pytest -v) - frontend tests pass (pre-existing failure unrelated)
- [x] Lint passes (ruff check backend/ && ruff format --check backend/)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by DeepSeek V4 Flash)

Fixes #1370

🤖 Generated by DeepSeek V4 Flash running on ds4 (https://github.com/antirez/ds4)