### PR TITLE
fix(frontend): merge save+welcome into one click on GetStartedPage

### DIFF
--- a/frontend/src/components/ChannelConfigForm.tsx
+++ b/frontend/src/components/ChannelConfigForm.tsx
@@ -24,16 +24,39 @@ interface ChannelConfigFormProps {
   telegramLinkData: TelegramLinkData | null;
   premiumLinkData: PremiumLinkData | null;
   onSaved: () => void;
+  // When true and the channel supports outbound welcome texts (linq /
+  // twilio / bluebubbles), saving also fires ``POST /channels/{x}/welcome``
+  // in the same handler so a brand-new user gets texted with one click
+  // instead of two. Opt-in: the settings page leaves it off so updating
+  // a stored number does not re-send a welcome on every save.
+  triggerWelcome?: boolean;
+  onWelcomeSent?: (channel: ChannelKey) => void;
+  onWelcomeFailed?: (channel: ChannelKey) => void;
 }
 
-export function ChannelConfigForm({ channelKey, isPremium, ...rest }: ChannelConfigFormProps) {
+export function ChannelConfigForm({
+  channelKey,
+  isPremium,
+  triggerWelcome,
+  onWelcomeSent,
+  onWelcomeFailed,
+  ...rest
+}: ChannelConfigFormProps) {
   if (channelKey === 'telegram') {
     return isPremium ? <PremiumTelegramForm {...rest} /> : <OssTelegramForm {...rest} />;
   }
   if (isPremium) {
     const config = PREMIUM_LINK_CONFIGS[channelKey];
     if (config) {
-      return <PremiumChannelLinkForm config={config} {...rest} />;
+      return (
+        <PremiumChannelLinkForm
+          config={config}
+          triggerWelcome={triggerWelcome}
+          onWelcomeSent={onWelcomeSent}
+          onWelcomeFailed={onWelcomeFailed}
+          {...rest}
+        />
+      );
     }
   }
   if (channelKey === 'twilio') {
@@ -47,6 +70,11 @@ export function ChannelConfigForm({ channelKey, isPremium, ...rest }: ChannelCon
   }
   return null;
 }
+
+// Channels that can deliver a welcome text on save. Mirrors the backend
+// ``POST /api/channels/{x}/welcome`` route set. Telegram is excluded
+// because bots cannot message a user who has not /start-ed them first.
+const WELCOME_CHANNELS = new Set<ChannelKey>(['linq', 'twilio', 'bluebubbles']);
 
 // ---------------------------------------------------------------------------
 // Generic premium link form (data-driven)
@@ -95,13 +123,22 @@ function PremiumChannelLinkForm({
   config,
   premiumLinkData,
   onSaved,
-}: { config: PremiumLinkConfig } & Omit<ChannelConfigFormProps, 'channelKey' | 'isPremium'>) {
+  triggerWelcome,
+  onWelcomeSent,
+  onWelcomeFailed,
+}: {
+  config: PremiumLinkConfig;
+  triggerWelcome?: boolean;
+  onWelcomeSent?: (channel: ChannelKey) => void;
+  onWelcomeFailed?: (channel: ChannelKey) => void;
+} & Omit<ChannelConfigFormProps, 'channelKey' | 'isPremium' | 'triggerWelcome' | 'onWelcomeSent' | 'onWelcomeFailed'>) {
   const [identifier, setIdentifier] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const displayedValue = identifier ?? premiumLinkData?.identifier ?? '';
   const isPhoneInput = config.inputMode === 'tel';
+  const supportsWelcome = Boolean(triggerWelcome) && WELCOME_CHANNELS.has(config.channelKey);
 
   const handleSave = async () => {
     setError(null);
@@ -110,15 +147,44 @@ function PremiumChannelLinkForm({
       setError(PHONE_FORMAT_ERROR);
       return;
     }
-    if (premiumLinkData && normalized === (premiumLinkData.identifier ?? '')) {
+    const valueUnchanged =
+      premiumLinkData !== null && normalized === (premiumLinkData.identifier ?? '');
+    // When triggerWelcome is on, allow re-clicking after a successful
+    // link to fire just the welcome text. Without this, a user whose
+    // value is already saved (e.g. they refreshed mid-flow) would be
+    // stuck on "No changes to save".
+    if (valueUnchanged && !supportsWelcome) {
       toast.error('No changes to save');
       return;
     }
     setSaving(true);
     try {
-      await config.setLink(normalized);
-      setIdentifier(null);
-      toast.success(`${config.displayName} settings updated`);
+      if (!valueUnchanged) {
+        await config.setLink(normalized);
+        setIdentifier(null);
+      }
+      if (supportsWelcome) {
+        try {
+          await api.sendWelcomeText(
+            config.channelKey as 'linq' | 'twilio' | 'bluebubbles',
+          );
+          toast.success(`Saved. We just texted ${normalized}.`);
+          onWelcomeSent?.(config.channelKey);
+        } catch (e) {
+          // Save succeeded (or wasn't needed); only the text delivery
+          // failed. Keep onSaved so the parent refreshes link data,
+          // and surface a fallback signal so Step 3 can render the
+          // "text us yourself" affordance.
+          toast.error(
+            e instanceof Error
+              ? `${e.message} You can still text us yourself.`
+              : 'Saved, but the welcome text could not be sent. You can still text us yourself.',
+          );
+          onWelcomeFailed?.(config.channelKey);
+        }
+      } else {
+        toast.success(`${config.displayName} settings updated`);
+      }
       onSaved();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to save');
@@ -126,6 +192,8 @@ function PremiumChannelLinkForm({
       setSaving(false);
     }
   };
+
+  const buttonLabel = supportsWelcome ? 'Save and text me to start' : 'Save';
 
   return (
     <div className="grid gap-4">
@@ -149,7 +217,7 @@ function PremiumChannelLinkForm({
       </Field>
       <div className="flex justify-end">
         <Button onClick={handleSave} disabled={saving || premiumLinkData === null} isLoading={saving}>
-          Save
+          {buttonLabel}
         </Button>
       </div>
     </div>

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -46,6 +46,17 @@ export default function GetStartedPage() {
   const [telegramLinkData, setTelegramLinkData] = useState<TelegramLinkData | null>(null);
   const [linkDataMap, setLinkDataMap] = useState<Partial<Record<ChannelKey, PremiumLinkData | null>>>({});
 
+  // Tracks per-channel welcome-text outcome from Step 2's save+send. When
+  // Step 2 fires the welcome successfully, the timestamp here drives Step
+  // 3's DesktopWelcomeStep to remount in its 'sent' state with the resend
+  // cooldown ticking. ``failedAt`` flips Step 3 into the legacy
+  // "text us yourself" fallback so a delivery error does not leave the
+  // user stranded.
+  const [welcomeSentAt, setWelcomeSentAt] = useState<Partial<Record<ChannelKey, number>>>({});
+  const [welcomeFailedAt, setWelcomeFailedAt] = useState<Partial<Record<ChannelKey, number>>>({});
+
+
+
   useEffect(() => {
     if (isPremium) {
       api.getTelegramLink().then(setTelegramLinkData).catch(() => {});
@@ -271,6 +282,14 @@ export default function GetStartedPage() {
                     telegramLinkData={telegramLinkData}
                     premiumLinkData={linkDataMap[selectedChannel] ?? null}
                     onSaved={() => handleConfigSaved(selectedChannel)}
+                    triggerWelcome={isPremium && isWelcomeChannel(selectedChannel)}
+                    onWelcomeSent={(ch) => {
+                      setWelcomeSentAt((prev) => ({ ...prev, [ch]: Date.now() }));
+                      setWelcomeFailedAt((prev) => ({ ...prev, [ch]: undefined }));
+                    }}
+                    onWelcomeFailed={(ch) =>
+                      setWelcomeFailedAt((prev) => ({ ...prev, [ch]: Date.now() }))
+                    }
                   />
                 </div>
               ) : (
@@ -293,20 +312,23 @@ export default function GetStartedPage() {
                 <span className="text-xs font-medium text-muted-foreground">Step 3</span>
               </div>
               <h3 className="text-sm font-semibold font-display">
-                {isPremium && isWelcomeChannel(selectedChannel) && linkDataMap[selectedChannel]?.connected
+                {isPremium && isWelcomeChannel(selectedChannel)
                   ? 'Get your first text'
                   : 'Send a message'}
               </h3>
-              {isPremium && isWelcomeChannel(selectedChannel) && linkDataMap[selectedChannel]?.connected ? (
-                // ``key={selectedChannel}`` forces a remount when the user
-                // switches channels in Step 1. Without it, React reuses the
-                // same component instance and its ``status='sent'`` state
-                // carries over to the new channel, rendering "We just
-                // texted you" at the prior channel's destination.
+              {isPremium && isWelcomeChannel(selectedChannel) ? (
+                // ``key`` includes ``welcomeSentAt`` so a successful Step 2
+                // save+send remounts this with ``startInSentState=true``
+                // and the cooldown ticking from zero. Switching channels
+                // in Step 1 also remounts (key includes channel), which
+                // resets a prior channel's 'sent' state.
                 <DesktopWelcomeStep
-                  key={selectedChannel}
+                  key={`${selectedChannel}-${welcomeSentAt[selectedChannel] ?? 0}-${welcomeFailedAt[selectedChannel] ?? 0}`}
                   channel={selectedChannel}
                   destination={linkDataMap[selectedChannel]?.identifier ?? ''}
+                  isConnected={linkDataMap[selectedChannel]?.connected ?? false}
+                  startInSentState={Boolean(welcomeSentAt[selectedChannel])}
+                  startInFailedState={Boolean(welcomeFailedAt[selectedChannel])}
                   fallbackAddress={
                     selectedChannel === 'linq'
                       ? fromNumber
@@ -441,21 +463,34 @@ export default function GetStartedPage() {
 function DesktopWelcomeStep({
   channel,
   destination,
+  isConnected,
+  startInSentState,
+  startInFailedState,
   fallbackAddress,
 }: {
   channel: WelcomeChannel;
   destination: string;
+  isConnected: boolean;
+  startInSentState: boolean;
+  startInFailedState: boolean;
   fallbackAddress: string;
 }) {
   type Status = 'idle' | 'sent' | 'failed';
-  const [status, setStatus] = useState<Status>('idle');
-  const [sending, setSending] = useState(false);
-  const [resendCooldown, setResendCooldown] = useState(0);
-
   // Mirrors the backend WELCOME_COOLDOWN_SECONDS. Surfaced in the UI so
   // a user clicking "Resend" before the backend would accept it sees a
   // disabled button instead of a 429 toast.
   const COOLDOWN_SECONDS = 60;
+
+  const initialStatus: Status = startInFailedState
+    ? 'failed'
+    : startInSentState
+      ? 'sent'
+      : 'idle';
+  const [status, setStatus] = useState<Status>(initialStatus);
+  const [sending, setSending] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(
+    startInSentState ? COOLDOWN_SECONDS : 0,
+  );
 
   useEffect(() => {
     if (resendCooldown <= 0) return;
@@ -480,6 +515,21 @@ function DesktopWelcomeStep({
       setSending(false);
     }
   };
+
+  // Not linked yet: Step 2 is the trigger, so Step 3 just describes
+  // what's about to happen. Discoverability fix: previously this branch
+  // fell through to the legacy QR card, making the new flow invisible
+  // until after a save.
+  if (!isConnected) {
+    return (
+      <div className="mt-3 grid gap-2">
+        <p className="text-sm text-muted-foreground">
+          Enter your phone number above and click "Save and text me to start".
+          We'll text you right away and you reply from there.
+        </p>
+      </div>
+    );
+  }
 
   if (status === 'sent') {
     return (
@@ -523,6 +573,8 @@ function DesktopWelcomeStep({
     );
   }
 
+  // Linked but no welcome has been sent (e.g. user revisits Get Started
+  // after onboarding, or Step 2 saved without firing welcome).
   return (
     <div className="mt-3 grid gap-2">
       <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Description

Discoverability fix for the onboarding "Text me to start" flow shipped in #1390.

**Before:** Step 2's Save button only persisted the channel route. Step 3 only showed the new "Text me to start" button when `linkDataMap[channel].connected === true`. For a new user with no route yet, Step 3 fell through to the legacy `TextAssistantCard` (QR + "Send an iMessage to this address"). Admins who'd previously linked saw the new flow; new users saw the old one and would have to click Save, wait for refetch, and then click again. Result: the welcome flow was hidden behind a step it was meant to replace.

**After:**

- Step 2 passes a new `triggerWelcome` prop to `ChannelConfigForm`. When set, the save button reads "Save and text me to start" and fires `api.sendWelcomeText` in the same handler. Matches the mobile flow, which was already single-click.
- Step 3 always renders `DesktopWelcomeStep` for premium iMessage/SMS users, with three states:
  - **not yet linked**: explanatory copy pointing back at Step 2
  - **just saved + welcome sent**: "We just texted you at +X" with a 60s resend countdown (driven by `welcomeSentAt` state lifted to `GetStartedPage`, which forces a remount with `startInSentState=true`)
  - **send failed**: falls back to the `TextAssistantCard` "text us yourself" affordance so the user can still bootstrap
- Settings page (`ChannelsPage`) continues to use `ChannelConfigForm` without `triggerWelcome`, so editing a stored number doesn't re-send a welcome on every save.
- Mobile `MobileImessageFlow` was already single-click and unchanged.

## Type

- [x] Bug fix (the previous shape made the new affordance invisible to new users)

## Checklist

- [x] Tests pass (`vitest src/pages/GetStartedPage.test.tsx`: 23/23, plus ChannelsPage 19/19)
- [x] `tsc --noEmit` clean
- [x] Bug fixes include regression tests (existing component tests cover the linked/unlinked branches; tests of the new save+send merged path would need the OSS test scaffolding extended, flagged as a follow-up)

## AI Usage

- [x] AI-assisted. Claude diagnosed the discoverability bug (new users vs admins seeing different flows) and refactored. Decisions and review by @njbrake.