### PR TITLE
fix(frontend): let error toast titles wrap instead of truncating

### DIFF
--- a/frontend/src/lib/toast.test.ts
+++ b/frontend/src/lib/toast.test.ts
@@ -23,6 +23,7 @@ describe('toast deduplication', () => {
       title: 'Saved',
       color: 'success',
       timeout: 4000,
+      classNames: { title: 'whitespace-normal break-words' },
     });
   });
 
@@ -32,7 +33,22 @@ describe('toast deduplication', () => {
       title: 'Network error',
       color: 'danger',
       timeout: 8000,
+      classNames: { title: 'whitespace-normal break-words' },
     });
+  });
+
+  it('passes a wrapping classNames override so long titles are not truncated', () => {
+    // Regression for clawbolt-premium#554: HeroUI's default toast title slot
+    // applies `truncate`, hiding most of long error messages with no expand
+    // affordance. The wrapper must override that with wrapping classes.
+    const longMessage =
+      'Failed to send message: the server returned an unexpectedly long error '
+      + 'that previously got clipped after roughly 40 characters with no way to '
+      + 'expand it.';
+    toast.error(longMessage);
+    const call = mockAddToast.mock.calls[0]?.[0] as { classNames?: { title?: string } };
+    expect(call.classNames?.title).toContain('whitespace-normal');
+    expect(call.classNames?.title).toContain('break-words');
   });
 
   it('suppresses duplicate success toasts', () => {

--- a/frontend/src/lib/toast.ts
+++ b/frontend/src/lib/toast.ts
@@ -16,8 +16,7 @@ function dedupKey(title: string, color: ToastColor): string {
 
 // HeroUI's default toast styles apply `truncate` to the title slot, which
 // silently clips longer error messages with no way to expand. Override the
-// title slot so the text wraps onto multiple lines instead. (issue #554 in
-// clawbolt-premium)
+// title slot so the text wraps onto multiple lines instead.
 const TITLE_CLASS_NAMES = { title: 'whitespace-normal break-words' } as const;
 
 function showToast(title: string, color: ToastColor): void {

--- a/frontend/src/lib/toast.ts
+++ b/frontend/src/lib/toast.ts
@@ -14,11 +14,17 @@ function dedupKey(title: string, color: ToastColor): string {
   return `${color}:${title}`;
 }
 
+// HeroUI's default toast styles apply `truncate` to the title slot, which
+// silently clips longer error messages with no way to expand. Override the
+// title slot so the text wraps onto multiple lines instead. (issue #554 in
+// clawbolt-premium)
+const TITLE_CLASS_NAMES = { title: 'whitespace-normal break-words' } as const;
+
 function showToast(title: string, color: ToastColor): void {
   const key = dedupKey(title, color);
   if (activeToasts.has(key)) return;
   const duration = DURATIONS[color];
-  addToast({ title, color, timeout: duration });
+  addToast({ title, color, timeout: duration, classNames: TITLE_CLASS_NAMES });
   const timer = setTimeout(() => {
     activeToasts.delete(key);
   }, duration);


### PR DESCRIPTION
## Description

HeroUI's toast theme applies `truncate` to the title slot (`@heroui/theme/dist/components/toast.js:381`), so longer error messages (server failures, upload errors, etc.) got clipped at the right edge of the 356px toast with no way to expand them. The OSS toast helper passes the entire message as `title`, so this hit every `toast.error()` call in the app.

This PR makes `showToast` pass a per-call `classNames.title` override of `whitespace-normal break-words`. `whitespace-normal` overrides `truncate`'s `whitespace-nowrap`, and `break-words` keeps long unbreakable error strings (URLs, stack lines, etc.) from blowing out the toast width. The toast height grows naturally; no max-height in the surrounding slots constrains it.

Fixes mozilla-ai/clawbolt-premium#554

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) - frontend only; vitest passes for `src/lib/toast.test.ts` (10/10). The pre-existing `ToolsPage.test.tsx` failure reproduces on `origin/main` without these changes.
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) - no backend changes.
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests - `toast.test.ts` gains a regression test that pins `whitespace-normal` and `break-words` in the `classNames.title` override.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Drafted by Claude (Opus 4.7) via back-and-forth with @njbrake; reasoning and decisions are his, prose is Claude's.