### PR TITLE
feat(frontend): add renderHeaderBadge extension hook

### DIFF
--- a/frontend/src/extensions/header-badge.tsx
+++ b/frontend/src/extensions/header-badge.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Extension hook for rendering a small badge next to the Clawbolt logo
+ * (sidebar logo + mobile header). OSS returns null; premium overrides to
+ * tag the hosted deployment with status like "Beta".
+ */
+export function renderHeaderBadge(): ReactNode {
+  return null;
+}

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -29,3 +29,4 @@ export type {
 export { QuotaBanner, OnboardingBanner, isQuotaError } from './quota';
 export { renderSidebarFooter } from './sidebar-footer';
 export type { SidebarFooterProps } from './sidebar-footer';
+export { renderHeaderBadge } from './header-badge';

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -10,7 +10,7 @@ import { ChatActivityProvider } from '@/contexts/ChatActivityContext';
 import { Tooltip } from '@heroui/tooltip';
 import { Link } from '@heroui/link';
 import { Divider } from '@heroui/divider';
-import { getFeatureRequestUrl, getReportIssueUrl, getDocsUrl, getExtraNavItems, renderSidebarFooter } from '@/extensions';
+import { getFeatureRequestUrl, getReportIssueUrl, getDocsUrl, getExtraNavItems, renderSidebarFooter, renderHeaderBadge } from '@/extensions';
 import useSwipeSidebar from '@/hooks/useSwipeSidebar';
 import { useProfile } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
@@ -135,6 +135,7 @@ export default function AppShell() {
           <div className="flex items-center gap-2">
             <img src="/clawbolt.png" alt="" className="w-7 h-7" />
             <h1 className="text-lg font-bold font-display text-foreground">Clawbolt</h1>
+            {renderHeaderBadge()}
           </div>
         </div>
 
@@ -324,6 +325,7 @@ export default function AppShell() {
           </Tooltip>
           <img src="/clawbolt.png" alt="" className="w-6 h-6" />
           <h1 className="text-lg font-bold font-display text-foreground">Clawbolt</h1>
+          {renderHeaderBadge()}
         </header>
 
         <main className="flex-1 min-h-0 overflow-y-auto p-4 sm:p-6 max-w-7xl w-full mx-auto">


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds a small extension hook, `renderHeaderBadge()`, that downstream layers (clawbolt-premium) can overlay to tag the Clawbolt logo with a status badge. OSS returns `null`, so the in-app shell is visually unchanged for OSS users.

Two call sites in `AppShell.tsx`: next to the sidebar logo and next to the mobile-header logo.

Same additive pattern as the existing `renderSidebarFooter` and `getExtraNavItems` hooks, so premium can ship a "Beta" pill (or any future tag) without forking the layout.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [ ] Tests pass (`uv run pytest -v`)
- [ ] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

Frontend-only change; no backend tests touched. Hook returns `null` in OSS so no behavioral change here.

## AI Usage
- [x] AI-assisted (Claude Code drafted the hook and call sites under @njbrake's direction; visually verified via Playwright against a local premium build)
- [ ] No AI used