### PR TITLE
refactor: hoist message_bus import to top of main.py

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from sqlalchemy import select, text
 from backend.app.agent.approval import cleanup_orphaned_approvals
 from backend.app.agent.heartbeat import heartbeat_scheduler
 from backend.app.agent.inbound_recovery import recover_orphan_inbound_messages
+from backend.app.bus import message_bus
 from backend.app.channels import get_manager, register_channel
 from backend.app.channels.bluebubbles import BlueBubblesChannel
 from backend.app.channels.linq import LinqChannel
@@ -309,8 +310,6 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     # Notify users whose approval requests were in flight when the previous
     # worker died. Runs after channels are up so outbound delivery works.
     try:
-        from backend.app.bus import message_bus
-
         recovered = await cleanup_orphaned_approvals(message_bus.publish_outbound)
         if recovered:
             logger.info("Recovered %d orphaned approval request(s) on startup", recovered)


### PR DESCRIPTION
## Description

Hoists the inline `from backend.app.bus import message_bus` from inside the orphaned-approval try/except block to the top-level imports block. OSS AGENTS.md forbids inline/deferred imports (only `TYPE_CHECKING`-guarded imports are allowed). This is a pre-existing violation in the lifespan function.

### Breadth note

There are many other inline `message_bus` imports across the codebase (manager.py, router.py, core.py, ingestion.py, oauth.py, etc.). Fixing all of them is out of scope for this PR; this fix only addresses the one in `main.py` that the AGENTS.md rule most directly governs.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run ruff check && uv run ruff format --check && uv run ty check`)
- [x] Lint passes
- [ ] New tests added for new functionality (N/A — pure refactor)
- [ ] Bug fixes include regression tests (N/A — not a bug fix)

## AI Usage
- [x] AI-assisted (implemented by DeepSeek V4 Flash)

🤖 Generated by DeepSeek V4 Flash running on ds4 (https://github.com/antirez/ds4)