### PR TITLE
refactor(frontend): collapse desktop GetStartedPage to one setup card

### DIFF
--- a/frontend/src/pages/GetStartedPage.test.tsx
+++ b/frontend/src/pages/GetStartedPage.test.tsx
@@ -86,93 +86,103 @@ vi.mock('@/api', () => ({
   },
 }));
 
+// Default channel config used by every test unless explicitly overridden.
+// Encapsulated so beforeEach can re-pin it: ``mockResolvedValue`` overrides
+// inside individual tests are otherwise sticky and bleed into the next test.
+const defaultChannelConfig = {
+  telegram_bot_token_set: false,
+  telegram_allowed_chat_id: '',
+  linq_api_token_set: true,
+  linq_from_number: '+15559876543',
+  linq_allowed_numbers: '',
+  linq_preferred_service: 'iMessage',
+  bluebubbles_configured: false,
+  bluebubbles_allowed_numbers: '',
+  imessage_backend: 'linq',
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockIsPremium = false;
+  mockGetChannelConfig.mockResolvedValue(defaultChannelConfig);
+  mockGetChannelRoutes.mockResolvedValue({ routes: [] });
+  mockToggleChannelRoute.mockResolvedValue({
+    channel: 'linq', channel_identifier: '', enabled: true, created_at: '',
+  });
 });
 
 describe('GetStartedPage', () => {
-  it('renders the get started heading and channel selection step', () => {
+  it('renders the get started heading and intro copy', () => {
     renderWithRouter(<GetStartedPage />);
 
     expect(screen.getByText('Get Started')).toBeInTheDocument();
-    expect(screen.getByText('Choose your messaging channel')).toBeInTheDocument();
-    expect(screen.getByText('Send a message')).toBeInTheDocument();
-    expect(screen.getByText("You're off to the races")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Clawbolt is your AI assistant for the trades/),
+    ).toBeInTheDocument();
   });
 
-  it('renders channel selection radio options for configured channels only', async () => {
-    // Default fixture has telegram_bot_token_set=false and imessage_backend=linq.
-    // After issues #1029 and #1040, Telegram is hidden when not configured.
+  it('does not show the legacy four-step wizard copy', async () => {
+    // The collapsed one-card layout drops the Step 1-4 framing. If any of
+    // these reappear, the wizard regressed.
     renderWithRouter(<GetStartedPage />);
 
     await waitFor(() => {
-      expect(screen.getAllByText('iMessage')).toHaveLength(1);
+      expect(screen.getByPlaceholderText('e.g. +15551234567')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Telegram')).not.toBeInTheDocument();
-    expect(screen.queryByText(/Text Messaging/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/BlueBubbles/)).not.toBeInTheDocument();
-    expect(screen.getByText('None')).toBeInTheDocument();
+    expect(screen.queryByText('Choose your messaging channel')).not.toBeInTheDocument();
+    expect(screen.queryByText('Send a message')).not.toBeInTheDocument();
+    expect(screen.queryByText("You're off to the races")).not.toBeInTheDocument();
+    // No "None" radio either; the bottom-of-page "Use web chat instead" link
+    // covers users who want to skip messaging setup.
+    expect(screen.queryByDisplayValue('none')).not.toBeInTheDocument();
   });
 
-  it('shows Telegram as a radio option when the bot token is set', async () => {
-    mockGetChannelConfig.mockResolvedValueOnce({
+  it('auto-renders the sole configured channel form without a chooser', async () => {
+    // Default fixture has only Linq configured. With one channel visible,
+    // the toggle is skipped and the form is rendered directly.
+    renderWithRouter(<GetStartedPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('e.g. +15551234567')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('tab', { name: 'iMessage' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Telegram' })).not.toBeInTheDocument();
+  });
+
+  it('shows a channel toggle when iMessage and Telegram are both configured', async () => {
+    // ``mockResolvedValue`` (sticky) instead of ``mockResolvedValueOnce`` so
+    // the auto-select mutation's ``invalidateQueries(channels)`` refetch sees
+    // the same multi-channel config. ``beforeEach`` resets it next test.
+    mockGetChannelConfig.mockResolvedValue({
+      ...defaultChannelConfig,
       telegram_bot_token_set: true,
-      telegram_allowed_chat_id: '',
-      linq_api_token_set: true,
-      linq_from_number: '+15559876543',
-      linq_allowed_numbers: '',
-      linq_preferred_service: 'iMessage',
-      bluebubbles_configured: false,
-      bluebubbles_allowed_numbers: '',
-      imessage_backend: 'linq',
     });
 
     renderWithRouter(<GetStartedPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Telegram')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'iMessage' })).toBeInTheDocument();
     });
+    expect(screen.getByRole('tab', { name: 'Telegram' })).toBeInTheDocument();
   });
 
-  it('renders the dismiss button defaulting to chat when no channel selected', () => {
+  it('shows the dashboard dismiss button once a channel is auto-selected', async () => {
     renderWithRouter(<GetStartedPage />);
-    expect(screen.getByText('Got it, take me to chat')).toBeInTheDocument();
-  });
-
-  it('shows dashboard dismiss button when a messaging channel is selected', async () => {
-    renderWithRouter(<GetStartedPage />);
-    const user = userEvent.setup();
-
-    const linqRadio = await screen.findByDisplayValue('linq');
-    await user.click(linqRadio);
 
     await waitFor(() => {
       expect(screen.getByText('Got it, take me to the dashboard')).toBeInTheDocument();
     });
   });
 
-  it('shows "Configure your channel" placeholder when no channel is selected', () => {
+  it('renders the OSS linq config form when only Linq is configured', async () => {
     renderWithRouter(<GetStartedPage />);
-    expect(screen.getByText('Configure your channel')).toBeInTheDocument();
-    expect(screen.getByText('Select a channel above to configure it.')).toBeInTheDocument();
-  });
-
-  it('shows the shared OSS linq config form when text messaging is selected', async () => {
-    renderWithRouter(<GetStartedPage />);
-    const user = userEvent.setup();
-
-    const linqRadio = await screen.findByDisplayValue('linq');
-    await user.click(linqRadio);
 
     await waitFor(() => {
-      expect(screen.getByText(/Configure iMessage/)).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g. +15551234567')).toBeInTheDocument();
     });
-    // The shared OssLinqForm shows "Allowed Phone Number" field
-    expect(screen.getByPlaceholderText('e.g. +15551234567')).toBeInTheDocument();
   });
 
-  it('shows the shared telegram config form when telegram is selected', async () => {
+  it('swaps to the telegram form when the user picks Telegram in the toggle', async () => {
     mockGetChannelConfig.mockResolvedValue({
       telegram_bot_token_set: true,
       telegram_allowed_chat_id: '',
@@ -188,31 +198,19 @@ describe('GetStartedPage', () => {
     renderWithRouter(<GetStartedPage />);
     const user = userEvent.setup();
 
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('telegram')).not.toBeDisabled();
-    });
-
-    await user.click(screen.getByDisplayValue('telegram'));
+    const telegramTab = await screen.findByRole('tab', { name: 'Telegram' });
+    await user.click(telegramTab);
 
     await waitFor(() => {
-      expect(screen.getByText(/Configure Telegram/)).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g. 123456789')).toBeInTheDocument();
     });
-    // The shared OssTelegramForm shows "Your Telegram User ID" field
-    expect(screen.getByPlaceholderText('e.g. 123456789')).toBeInTheDocument();
   });
 
   it('saves linq config via the shared form (updateChannelConfig)', async () => {
     renderWithRouter(<GetStartedPage />);
     const user = userEvent.setup();
 
-    const linqRadio = await screen.findByDisplayValue('linq');
-    await user.click(linqRadio);
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('e.g. +15551234567')).toBeInTheDocument();
-    });
-
-    const input = screen.getByPlaceholderText('e.g. +15551234567');
+    const input = await screen.findByPlaceholderText('e.g. +15551234567');
     await user.type(input, '+15551234567');
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -221,22 +219,18 @@ describe('GetStartedPage', () => {
     });
   });
 
-  it('shows QR code and from-number when linq is configured and text messaging selected', async () => {
+  it('shows QR code and from-number when linq is configured', async () => {
     renderWithRouter(<GetStartedPage />);
-    const user = userEvent.setup();
-
-    const linqRadio = await screen.findByDisplayValue('linq');
-    await user.click(linqRadio);
 
     await waitFor(() => {
-      // From-number appears in both the config form and Step 3
+      // From-number appears in both the config form and the QR card
       const matches = screen.getAllByText('+15559876543');
       expect(matches.length).toBeGreaterThanOrEqual(1);
     });
     expect(screen.getByText(/Send an iMessage to this address to get started/)).toBeInTheDocument();
   });
 
-  it('shows fallback messaging when no iMessage backend is configured', async () => {
+  it('shows the empty-state card when no channels are configured', async () => {
     mockGetChannelConfig.mockResolvedValueOnce({
       telegram_bot_token_set: false,
       telegram_allowed_chat_id: '',
@@ -252,56 +246,50 @@ describe('GetStartedPage', () => {
     renderWithRouter(<GetStartedPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No messaging channel is configured yet/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/No messaging channels are configured on the server yet/),
+      ).toBeInTheDocument();
     });
-  });
-
-  it('calls toggleChannelRoute when selecting a channel', async () => {
-    mockGetChannelConfig.mockResolvedValue({
-      telegram_bot_token_set: true,
-      telegram_allowed_chat_id: '',
-      linq_api_token_set: true,
-      linq_from_number: '+15559876543',
-      linq_allowed_numbers: '',
-      linq_preferred_service: 'iMessage',
-      bluebubbles_configured: false,
-      bluebubbles_allowed_numbers: '',
-      imessage_backend: 'linq',
-    });
-
-    renderWithRouter(<GetStartedPage />);
-    const user = userEvent.setup();
-
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('telegram')).not.toBeDisabled();
-    });
-
-    await user.click(screen.getByDisplayValue('telegram'));
-
-    await waitFor(() => {
-      expect(mockToggleChannelRoute).toHaveBeenCalledWith('telegram', true);
-    });
-  });
-
-  it('renders a clickable "None" option for web chat only', async () => {
-    renderWithRouter(<GetStartedPage />);
-    const user = userEvent.setup();
-
-    const noneRadio = screen.getByDisplayValue('none');
-    expect(noneRadio).toBeInTheDocument();
-    expect(noneRadio).not.toBeDisabled();
-
-    await user.click(noneRadio);
-
-    await waitFor(() => {
-      expect(screen.getByText('No setup needed')).toBeInTheDocument();
-    });
-    expect(screen.getByText('Use the chat in the sidebar to talk to your assistant.')).toBeInTheDocument();
-    // "None" keeps the chat-oriented dismiss button
+    // No channel form rendered.
+    expect(screen.queryByPlaceholderText('e.g. +15551234567')).not.toBeInTheDocument();
+    // Dismiss button stays on the chat-oriented copy because no channel is selected.
     expect(screen.getByText('Got it, take me to chat')).toBeInTheDocument();
   });
 
-  it('pre-populates selection from active channel route', async () => {
+  it('auto-selects the first visible channel and enables its route', async () => {
+    // Sanity check: the one-card flow fires toggleChannelRoute for the
+    // auto-picked channel so the user does not have to click anything to
+    // start filling out the form.
+    renderWithRouter(<GetStartedPage />);
+
+    await waitFor(() => {
+      expect(mockToggleChannelRoute).toHaveBeenCalledWith('linq', true);
+    });
+  });
+
+  it('keeps the data-sharing consent card visible on desktop', async () => {
+    renderWithRouter(<GetStartedPage />);
+
+    // ``findByRole`` waits for the consent query to resolve. ``getByText``
+    // on "Help improve Clawbolt" alone passes during the loading state and
+    // races the checkbox check.
+    expect(
+      await screen.findByRole('checkbox', { name: /share my chat history/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Help improve Clawbolt')).toBeInTheDocument();
+  });
+
+  it('renders a "Use web chat instead" link that navigates to chat', async () => {
+    renderWithRouter(<GetStartedPage />);
+    const user = userEvent.setup();
+
+    const link = await screen.findByRole('button', { name: 'Use web chat instead' });
+    await user.click(link);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/chat');
+  });
+
+  it('pre-populates the toggle selection from an active channel route', async () => {
     mockGetChannelConfig.mockResolvedValue({
       telegram_bot_token_set: true,
       telegram_allowed_chat_id: '123',
@@ -320,11 +308,11 @@ describe('GetStartedPage', () => {
     renderWithRouter(<GetStartedPage />);
 
     await waitFor(() => {
-      const telegramRadio = screen.getByDisplayValue('telegram') as HTMLInputElement;
-      expect(telegramRadio.checked).toBe(true);
+      expect(
+        screen.getByRole('tab', { name: 'Telegram', selected: true }),
+      ).toBeInTheDocument();
     });
-    // Should show the telegram config form since it's pre-selected
-    expect(screen.getByText(/Configure Telegram/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('e.g. 123456789')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/GetStartedPage.test.tsx
+++ b/frontend/src/pages/GetStartedPage.test.tsx
@@ -219,6 +219,102 @@ describe('GetStartedPage', () => {
     });
   });
 
+  it('does NOT enable the route on mount; defers to form save', async () => {
+    // Auto-pick only sets display state. The channel route stays disabled
+    // until the user commits via Save, so a user who lands on the page
+    // and bails via "Use web chat instead" never silently flips a route.
+    renderWithRouter(<GetStartedPage />);
+
+    await screen.findByPlaceholderText('e.g. +15551234567');
+    // Settle any pending microtasks just to be sure.
+    await waitFor(() => {
+      expect(mockGetChannelConfig).toHaveBeenCalled();
+    });
+    expect(mockToggleChannelRoute).not.toHaveBeenCalled();
+  });
+
+  it('enables the channel route when the user saves the form', async () => {
+    renderWithRouter(<GetStartedPage />);
+    const user = userEvent.setup();
+
+    const input = await screen.findByPlaceholderText('e.g. +15551234567');
+    await user.type(input, '+15551234567');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockToggleChannelRoute).toHaveBeenCalledWith('linq', true);
+    });
+  });
+
+  it('disables the previously enabled channel when the user saves a different one', async () => {
+    // Land with Telegram already enabled; switch to iMessage via the tab
+    // toggle; save the iMessage form. The save should both disable Telegram
+    // and enable Linq, leaving exactly one active messaging route.
+    mockGetChannelConfig.mockResolvedValue({
+      ...defaultChannelConfig,
+      telegram_bot_token_set: true,
+      telegram_allowed_chat_id: '123',
+    });
+    mockGetChannelRoutes.mockResolvedValue({
+      routes: [{ channel: 'telegram', channel_identifier: '123', enabled: true, created_at: '' }],
+    });
+
+    renderWithRouter(<GetStartedPage />);
+    const user = userEvent.setup();
+
+    const imessageTab = await screen.findByRole('tab', { name: 'iMessage' });
+    await user.click(imessageTab);
+
+    const input = await screen.findByPlaceholderText('e.g. +15551234567');
+    await user.type(input, '+15551234567');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockToggleChannelRoute).toHaveBeenCalledWith('telegram', false);
+    });
+    expect(mockToggleChannelRoute).toHaveBeenCalledWith('linq', true);
+  });
+
+  it('does not re-toggle when saving the already-active channel', async () => {
+    // ``pre-populates the toggle selection`` confirms the form pre-fills
+    // for the active route. Re-saving that same channel should not fire a
+    // redundant enable on a route that is already enabled.
+    mockGetChannelRoutes.mockResolvedValue({
+      routes: [{ channel: 'linq', channel_identifier: '+15551234567', enabled: true, created_at: '' }],
+    });
+
+    renderWithRouter(<GetStartedPage />);
+    const user = userEvent.setup();
+
+    const input = await screen.findByPlaceholderText('e.g. +15551234567');
+    await user.type(input, '+15551234567');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockUpdateChannelConfig).toHaveBeenCalled();
+    });
+    expect(mockToggleChannelRoute).not.toHaveBeenCalled();
+  });
+
+  it('does not fire any route mutation when the user just switches tabs', async () => {
+    // Clicking between tabs is a display-only action; nothing hits the
+    // backend until the user commits via Save.
+    mockGetChannelConfig.mockResolvedValue({
+      ...defaultChannelConfig,
+      telegram_bot_token_set: true,
+    });
+
+    renderWithRouter(<GetStartedPage />);
+    const user = userEvent.setup();
+
+    const telegramTab = await screen.findByRole('tab', { name: 'Telegram' });
+    await user.click(telegramTab);
+    const imessageTab = screen.getByRole('tab', { name: 'iMessage' });
+    await user.click(imessageTab);
+
+    expect(mockToggleChannelRoute).not.toHaveBeenCalled();
+  });
+
   it('shows QR code and from-number when linq is configured', async () => {
     renderWithRouter(<GetStartedPage />);
 
@@ -254,17 +350,6 @@ describe('GetStartedPage', () => {
     expect(screen.queryByPlaceholderText('e.g. +15551234567')).not.toBeInTheDocument();
     // Dismiss button stays on the chat-oriented copy because no channel is selected.
     expect(screen.getByText('Got it, take me to chat')).toBeInTheDocument();
-  });
-
-  it('auto-selects the first visible channel and enables its route', async () => {
-    // Sanity check: the one-card flow fires toggleChannelRoute for the
-    // auto-picked channel so the user does not have to click anything to
-    // start filling out the form.
-    renderWithRouter(<GetStartedPage />);
-
-    await waitFor(() => {
-      expect(mockToggleChannelRoute).toHaveBeenCalledWith('linq', true);
-    });
   });
 
   it('keeps the data-sharing consent card visible on desktop', async () => {

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -100,17 +100,6 @@ export default function GetStartedPage() {
     (ch) => routes.some((r) => r.channel === ch.key && r.enabled),
   )?.key ?? null;
 
-  // Pre-populate selection from active route on initial data load
-  const prePopulated = useRef(false);
-  useEffect(() => {
-    if (prePopulated.current || !channelConfig || !routesData) return;
-    prePopulated.current = true;
-    if (activeChannelKey) {
-      setSelectedChannel(activeChannelKey);
-      setConfirmedChannel(activeChannelKey);
-    }
-  }, [channelConfig, routesData, activeChannelKey]);
-
   const handleSelectChannel = useCallback((channel: Selection) => {
     setSelectedChannel(channel);
 
@@ -146,6 +135,24 @@ export default function GetStartedPage() {
       },
     );
   }, [activeChannelKey, confirmedChannel, toggleChannelRoute]);
+
+  // Pre-populate selection from active route on initial data load. The
+  // desktop one-card flow also auto-picks the first visible channel when
+  // nothing is enabled yet so the setup form is in front of the user
+  // immediately, mirroring how mobile drops the user straight into the
+  // phone-number input.
+  const prePopulated = useRef(false);
+  useEffect(() => {
+    if (prePopulated.current || !channelConfig || !routesData) return;
+    prePopulated.current = true;
+    if (activeChannelKey) {
+      setSelectedChannel(activeChannelKey);
+      setConfirmedChannel(activeChannelKey);
+    } else if (!isMobile) {
+      const first = visibleChannels[0];
+      if (first) handleSelectChannel(first.key);
+    }
+  }, [channelConfig, routesData, activeChannelKey, isMobile, visibleChannels, handleSelectChannel]);
 
   const handleConfigSaved = (key: ChannelKey) => {
     if (isPremium) {
@@ -187,13 +194,6 @@ export default function GetStartedPage() {
     );
   }
 
-  // Determine Step 2 heading based on selection
-  const step2Label = selectedChannel === 'none'
-    ? 'No setup needed'
-    : selectedChannel
-      ? `Configure ${visibleChannels.find((c) => c.key === selectedChannel)?.label ?? selectedChannel}`
-      : 'Configure your channel';
-
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-8">
@@ -205,248 +205,127 @@ export default function GetStartedPage() {
       </div>
 
       <div className="grid gap-4">
-        {/* Step 1: Choose messaging channel */}
-        <Card>
-          <div className="flex items-start gap-4">
-            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-primary-light text-primary shrink-0">
-              <ChannelIcon />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
-                <span className="text-xs font-medium text-muted-foreground">Step 1</span>
-              </div>
-              <h3 className="text-sm font-semibold font-display">Choose your messaging channel</h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                Pick how you want to talk to Clawbolt. You can change this later.
-              </p>
-              <div className="mt-3 grid gap-2" role="radiogroup" aria-label="Messaging channel">
+        {visibleChannels.length === 0 ? (
+          <Card>
+            <p className="text-sm text-muted-foreground">
+              No messaging channels are configured on the server yet.
+              Use web chat for now, or ask your admin to enable iMessage or Telegram.
+            </p>
+          </Card>
+        ) : (
+          <Card>
+            {visibleChannels.length > 1 && (
+              <div
+                role="tablist"
+                aria-label="Messaging channel"
+                className="flex gap-1 p-1 bg-panel rounded-xl mb-4"
+              >
                 {visibleChannels.map(({ key, label }) => (
-                  <ChannelRadioItem
+                  <button
                     key={key}
-                    value={key}
-                    label={label}
-                    isSelected={selectedChannel === key}
-                    isConfirmed={confirmedChannel === key}
-                    isSwitching={toggleChannelRoute.isPending && selectedChannel === key && confirmedChannel !== key}
-                    isMutating={toggleChannelRoute.isPending}
-                    onSelect={() => handleSelectChannel(key)}
-                  />
-                ))}
-
-                <ChannelRadioItem
-                  value="none"
-                  label="None"
-                  description="Web chat only, no external messaging channel"
-                  isSelected={selectedChannel === 'none'}
-                  isConfirmed={confirmedChannel === 'none'}
-                  isSwitching={toggleChannelRoute.isPending && selectedChannel === 'none' && confirmedChannel !== 'none'}
-                  isMutating={toggleChannelRoute.isPending}
-                  onSelect={() => handleSelectChannel('none')}
-                />
-                {visibleChannels.length === 0 && (
-                  <p className="text-xs text-muted-foreground italic px-3 py-2">
-                    No messaging channels are configured on the server yet.
-                    Use web chat for now, or ask your admin to enable iMessage or Telegram.
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
-        </Card>
-
-        {/* Step 2: Channel-specific setup */}
-        <Card>
-          <div className="flex items-start gap-4">
-            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-primary-light text-primary shrink-0">
-              <SettingsIcon />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
-                <span className="text-xs font-medium text-muted-foreground">Step 2</span>
-              </div>
-              <h3 className="text-sm font-semibold font-display">{step2Label}</h3>
-              {selectedChannel === 'none' ? (
-                <p className="text-sm text-muted-foreground mt-1">
-                  You can always add a messaging channel later from the{' '}
-                  <button type="button" className="text-primary hover:underline font-medium" onClick={() => navigate('/app/settings/channels')}>
-                    Channels page
+                    type="button"
+                    role="tab"
+                    aria-selected={selectedChannel === key}
+                    onClick={() => handleSelectChannel(key)}
+                    disabled={toggleChannelRoute.isPending}
+                    className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
+                      selectedChannel === key
+                        ? 'bg-card text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {label}
                   </button>
-                  .
-                </p>
-              ) : selectedChannel ? (
-                <div className="mt-3">
-                  <ChannelConfigForm
-                    channelKey={selectedChannel}
-                    isPremium={isPremium}
-                    channelConfig={channelConfig}
-                    telegramLinkData={telegramLinkData}
-                    premiumLinkData={linkDataMap[selectedChannel] ?? null}
-                    onSaved={() => handleConfigSaved(selectedChannel)}
-                    triggerWelcome={isPremium && isWelcomeChannel(selectedChannel)}
-                    onWelcomeSent={(ch) => {
-                      setWelcomeSentAt((prev) => ({ ...prev, [ch]: Date.now() }));
-                      setWelcomeFailedAt((prev) => ({ ...prev, [ch]: undefined }));
-                    }}
-                    onWelcomeFailed={(ch) =>
-                      setWelcomeFailedAt((prev) => ({ ...prev, [ch]: Date.now() }))
-                    }
-                  />
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground mt-1">
-                  Select a channel above to configure it.
-                </p>
-              )}
-            </div>
-          </div>
-        </Card>
-
-        {/* Step 3: Send a message */}
-        <Card>
-          <div className="flex items-start gap-4">
-            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-primary-light text-primary shrink-0">
-              <ChatIcon />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
-                <span className="text-xs font-medium text-muted-foreground">Step 3</span>
+                ))}
               </div>
-              <h3 className="text-sm font-semibold font-display">
-                {isPremium && isWelcomeChannel(selectedChannel)
-                  ? 'Get your first text'
-                  : 'Send a message'}
-              </h3>
-              {isPremium && isWelcomeChannel(selectedChannel) ? (
-                // ``key`` includes ``welcomeSentAt`` so a successful Step 2
-                // save+send remounts this with ``startInSentState=true``
-                // and the cooldown ticking from zero. Switching channels
-                // in Step 1 also remounts (key includes channel), which
-                // resets a prior channel's 'sent' state.
-                <DesktopWelcomeStep
-                  key={`${selectedChannel}-${welcomeSentAt[selectedChannel] ?? 0}-${welcomeFailedAt[selectedChannel] ?? 0}`}
-                  channel={selectedChannel}
-                  destination={linkDataMap[selectedChannel]?.identifier ?? ''}
-                  isConnected={linkDataMap[selectedChannel]?.connected ?? false}
-                  startInSentState={Boolean(welcomeSentAt[selectedChannel])}
-                  startInFailedState={Boolean(welcomeFailedAt[selectedChannel])}
-                  fallbackAddress={
-                    selectedChannel === 'linq'
-                      ? fromNumber
-                      : selectedChannel === 'bluebubbles'
-                        ? bbAddress
-                        : twilioAddress
+            )}
+
+            {selectedChannel && selectedChannel !== 'none' && (
+              <div className="grid gap-4">
+                <ChannelConfigForm
+                  channelKey={selectedChannel}
+                  isPremium={isPremium}
+                  channelConfig={channelConfig}
+                  telegramLinkData={telegramLinkData}
+                  premiumLinkData={linkDataMap[selectedChannel] ?? null}
+                  onSaved={() => handleConfigSaved(selectedChannel)}
+                  triggerWelcome={isPremium && isWelcomeChannel(selectedChannel)}
+                  onWelcomeSent={(ch) => {
+                    setWelcomeSentAt((prev) => ({ ...prev, [ch]: Date.now() }));
+                    setWelcomeFailedAt((prev) => ({ ...prev, [ch]: undefined }));
+                  }}
+                  onWelcomeFailed={(ch) =>
+                    setWelcomeFailedAt((prev) => ({ ...prev, [ch]: Date.now() }))
                   }
                 />
-              ) : selectedChannel === 'linq' && linqConfigured && fromNumber ? (
-                <div className="mt-2 grid gap-2">
+
+                {isPremium && isWelcomeChannel(selectedChannel) ? (
+                  // ``key`` includes ``welcomeSentAt`` so a successful save
+                  // remounts this with ``startInSentState=true`` and the
+                  // cooldown ticking from zero. Switching channels via the
+                  // toggle also remounts (key includes channel), which
+                  // resets a prior channel's 'sent' state.
+                  <DesktopWelcomeStep
+                    key={`${selectedChannel}-${welcomeSentAt[selectedChannel] ?? 0}-${welcomeFailedAt[selectedChannel] ?? 0}`}
+                    channel={selectedChannel}
+                    destination={linkDataMap[selectedChannel]?.identifier ?? ''}
+                    isConnected={linkDataMap[selectedChannel]?.connected ?? false}
+                    startInSentState={Boolean(welcomeSentAt[selectedChannel])}
+                    startInFailedState={Boolean(welcomeFailedAt[selectedChannel])}
+                    fallbackAddress={
+                      selectedChannel === 'linq'
+                        ? fromNumber
+                        : selectedChannel === 'bluebubbles'
+                          ? bbAddress
+                          : twilioAddress
+                    }
+                  />
+                ) : selectedChannel === 'linq' && linqConfigured && fromNumber ? (
                   <TextAssistantCard
                     fromNumber={fromNumber}
                     subtitle="Send an iMessage to this address to get started."
                     qrSize={120}
                   />
-                </div>
-              ) : selectedChannel === 'bluebubbles' && bbConfigured && bbAddress ? (
-                <div className="mt-2 grid gap-2">
+                ) : selectedChannel === 'bluebubbles' && bbConfigured && bbAddress ? (
                   <TextAssistantCard
                     fromNumber={bbAddress}
                     subtitle="Send an iMessage to this address to get started."
                     qrSize={120}
                   />
-                </div>
-              ) : selectedChannel === 'twilio' && twilioAddress ? (
-                <div className="mt-2 grid gap-2">
+                ) : selectedChannel === 'twilio' && twilioAddress ? (
                   <TextAssistantCard
                     fromNumber={twilioAddress}
                     subtitle="Text this number to chat with your assistant."
                     qrSize={120}
                   />
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground mt-1">
-                  {selectedChannel === 'none'
-                    ? 'Use the chat in the sidebar to talk to your assistant.'
-                    : selectedChannel === 'telegram'
-                      ? 'Open Telegram and send a message to your bot to get started.'
-                      : selectedChannel === 'linq' || selectedChannel === 'bluebubbles'
-                        ? 'Send an iMessage to your assistant to get started.'
-                        : selectedChannel === 'twilio'
-                          ? 'Text your Twilio number from your personal phone to get started.'
-                          : (
-                            <>
-                              No messaging channel is configured yet. You can also{' '}
-                              <button
-                                type="button"
-                                className="text-primary hover:underline font-medium"
-                                onClick={() => navigate('/app/chat')}
-                              >
-                                chat from the web
-                              </button>
-                              {' '}or{' '}
-                              <button
-                                type="button"
-                                className="text-primary hover:underline font-medium"
-                                onClick={() => navigate('/app/settings/channels')}
-                              >
-                                set up a channel
-                              </button>
-                              .
-                            </>
-                          )}
-                </p>
-              )}
-            </div>
-          </div>
-        </Card>
-
-        {/* Step 4: You're off to the races */}
-        <Card>
-          <div className="flex items-start gap-4">
-            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-primary-light text-primary shrink-0">
-              <RocketIcon />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
-                <span className="text-xs font-medium text-muted-foreground">Step 4</span>
+                ) : selectedChannel === 'telegram' ? (
+                  <p className="text-sm text-muted-foreground">
+                    Once saved, open Telegram and send a message to your bot to get started.
+                  </p>
+                ) : null}
               </div>
-              <h3 className="text-sm font-semibold font-display">You're off to the races</h3>
-              {selectedChannel && selectedChannel !== 'none' ? (
-                <p className="text-sm text-muted-foreground mt-1">
-                  That's it. From here, just text your assistant directly.
-                  Clawbolt learns about you and your business as you chat,
-                  and you can set up integrations, approve tool access, and
-                  adjust settings all from the conversation.
-                </p>
-              ) : (
-                <p className="text-sm text-muted-foreground mt-1">
-                  That's it. Clawbolt learns about you and your business as you chat.
-                  You can always fine-tune settings later from the sidebar.
-                </p>
-              )}
-            </div>
-          </div>
-        </Card>
+            )}
+          </Card>
+        )}
 
-        {/* Privacy: optional opt-in. Not numbered, not blocking — first-run is the natural
-            moment to ask, but the same toggle lives on the User page so people can change
-            their mind any time. Default off; the API stamps a timestamp on every flip so
-            consent history is reconstructable from data_sharing_consent_at. */}
+        {/* Privacy: optional opt-in. First-run is the natural moment to ask;
+            the same toggle lives on the User page so people can change their
+            mind any time. Default off; the API stamps a timestamp on every
+            flip so consent history is reconstructable. */}
         <Card>
-          <div className="flex items-start gap-4">
-            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-primary-light text-primary shrink-0">
-              <ShieldIcon />
-            </div>
-            <div className="flex-1 min-w-0">
-              <DataSharingConsentSection variant="compact" />
-            </div>
-          </div>
+          <DataSharingConsentSection variant="compact" />
         </Card>
       </div>
 
-      <div className="mt-8 flex justify-center">
-        <Button
-          variant="primary"
-          onClick={handleDismiss}
+      <div className="mt-8 flex items-center justify-between gap-4">
+        <button
+          type="button"
+          className="text-sm text-primary hover:underline"
+          onClick={() => navigate('/app/chat')}
         >
+          Use web chat instead
+        </button>
+        <Button variant="primary" onClick={handleDismiss}>
           {selectedChannel && selectedChannel !== 'none'
             ? 'Got it, take me to the dashboard'
             : 'Got it, take me to chat'}
@@ -1041,106 +920,3 @@ function MobileTelegramFlow({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Shared bits
-// ---------------------------------------------------------------------------
-
-function ChannelRadioItem({
-  value,
-  label,
-  description,
-  isSelected,
-  isConfirmed,
-  isSwitching,
-  isMutating,
-  onSelect,
-}: {
-  value: string;
-  label: string;
-  description?: string;
-  isSelected: boolean;
-  isConfirmed: boolean;
-  isSwitching: boolean;
-  isMutating: boolean;
-  onSelect: () => void;
-}) {
-  return (
-    <label
-      className={`flex items-center gap-3 p-3 rounded-xl border transition-colors ${
-        isSelected
-          ? 'border-primary bg-primary-light cursor-pointer'
-          : 'border-border hover:border-primary/40 cursor-pointer'
-      }`}
-    >
-      {isSwitching ? (
-        <span className="w-4 h-4 shrink-0 flex items-center justify-center" aria-busy="true">
-          <span className="w-3.5 h-3.5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-        </span>
-      ) : (
-        <input
-          type="radio"
-          name="onboarding-channel"
-          value={value}
-          checked={isSelected}
-          onChange={onSelect}
-          disabled={isMutating}
-          className="accent-primary w-4 h-4 shrink-0"
-        />
-      )}
-      <div className="flex-1">
-        <span className="text-sm font-medium">{label}</span>
-        {description && <p className="text-xs text-muted-foreground">{description}</p>}
-      </div>
-      {isConfirmed && (
-        <span className="text-xs text-success flex items-center gap-1" aria-label="Confirmed">
-          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
-          </svg>
-        </span>
-      )}
-    </label>
-  );
-}
-
-// --- Step icons (inline SVG) ---
-
-function ChannelIcon() {
-  return (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
-    </svg>
-  );
-}
-
-function SettingsIcon() {
-  return (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-    </svg>
-  );
-}
-
-function ChatIcon() {
-  return (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
-    </svg>
-  );
-}
-
-function RocketIcon() {
-  return (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.63 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.841M3.75 21h.008v.008H3.75V21z" />
-    </svg>
-  );
-}
-
-function ShieldIcon() {
-  return (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12.75 11.25 15 15 9.75M21 12c0 4.97-3.582 9-8 9s-8-4.03-8-9c0-1.07.166-2.097.473-3.06A11.95 11.95 0 0 0 12 5.25a11.95 11.95 0 0 0 7.527-1.31A9.954 9.954 0 0 1 21 12Z" />
-    </svg>
-  );
-}

--- a/frontend/src/pages/GetStartedPage.tsx
+++ b/frontend/src/pages/GetStartedPage.tsx
@@ -124,6 +124,20 @@ export default function GetStartedPage() {
       return;
     }
 
+    // Already the confirmed channel? Nothing to mutate.
+    if (confirmedChannel === channel) return;
+
+    // Switching to a new channel: disable the previously-enabled one so the
+    // user does not end up with two messaging channels routed to their
+    // account at once. ``_enforce_single_channel`` covers any stragglers,
+    // but doing it client-side keeps the UI honest.
+    if (confirmedChannel && confirmedChannel !== 'none') {
+      toggleChannelRoute.mutate(
+        { channel: confirmedChannel, enabled: false },
+        { onError: (e) => toast.error(e.message) },
+      );
+    }
+
     toggleChannelRoute.mutate(
       { channel, enabled: true },
       {
@@ -140,7 +154,10 @@ export default function GetStartedPage() {
   // desktop one-card flow also auto-picks the first visible channel when
   // nothing is enabled yet so the setup form is in front of the user
   // immediately, mirroring how mobile drops the user straight into the
-  // phone-number input.
+  // phone-number input. Auto-pick only updates display state; the actual
+  // ``toggleChannelRoute`` mutation fires from ``handleConfigSaved`` so a
+  // user who lands here and bails via "Use web chat instead" does not
+  // silently enable a channel route they never committed to.
   const prePopulated = useRef(false);
   useEffect(() => {
     if (prePopulated.current || !channelConfig || !routesData) return;
@@ -150,11 +167,17 @@ export default function GetStartedPage() {
       setConfirmedChannel(activeChannelKey);
     } else if (!isMobile) {
       const first = visibleChannels[0];
-      if (first) handleSelectChannel(first.key);
+      if (first) setSelectedChannel(first.key);
     }
-  }, [channelConfig, routesData, activeChannelKey, isMobile, visibleChannels, handleSelectChannel]);
+  }, [channelConfig, routesData, activeChannelKey, isMobile, visibleChannels]);
 
   const handleConfigSaved = (key: ChannelKey) => {
+    // The form save is the user's commitment to this channel: now enable
+    // its route (and disable any prior one). ``handleSelectChannel``
+    // no-ops when ``confirmedChannel`` already matches, so resaving an
+    // existing channel does not fire a redundant toggle.
+    handleSelectChannel(key);
+
     if (isPremium) {
       if (key === 'telegram') api.getTelegramLink().then(setTelegramLinkData).catch(() => {});
       const fetchers: Partial<Record<ChannelKey, () => Promise<{ phone_number: string | null; connected: boolean }>>> = {
@@ -226,8 +249,7 @@ export default function GetStartedPage() {
                     type="button"
                     role="tab"
                     aria-selected={selectedChannel === key}
-                    onClick={() => handleSelectChannel(key)}
-                    disabled={toggleChannelRoute.isPending}
+                    onClick={() => setSelectedChannel(key)}
                     className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
                       selectedChannel === key
                         ? 'bg-card text-foreground shadow-sm'


### PR DESCRIPTION
## Description

Desktop onboarding stacked five cards (Step 1 channel chooser, Step 2 form, Step 3 welcome state, Step 4 "off to the races", privacy) while mobile already used a one-screen flow. This collapses desktop to mirror mobile.

Specifically:

- One setup card with the channel-config form and the post-save state (welcome-sent / QR / fallback) inline. No more separate Step 2 and Step 3 cards.
- A tab toggle replaces the Step 1 radio group, and only renders when more than one channel is configured. With a single channel (the common case) the form is shown directly.
- Auto-pick the sole visible channel on mount so the user lands on a ready-to-fill form, mirroring how mobile drops users straight into the phone-number input.
- Step 4 "off to the races" card removed. The dismiss button and the welcome-sent state already convey closure.
- "None" radio removed. A "Use web chat instead" link beside the dismiss button covers the same intent without occupying a card slot.
- Privacy opt-in card kept; no behavior change.
- Per-step icons (Channel/Settings/Chat/Rocket/Shield) and the ChannelRadioItem helper dropped along with their callers.

Mobile flow untouched.

## Type
- [x] Refactor

## Checklist
- [x] Tests pass (frontend vitest: 24/24 in `GetStartedPage.test.tsx`; full suite 241/242, the one failure is in `ToolsPage.test.tsx` and pre-exists on main)
- [x] Lint passes (`tsc --noEmit` clean; project does not run ruff/eslint on frontend)
- [x] New tests added (desktop suite rewritten for the new tablist + auto-select; regression checks for the dropped Step 1-4 copy and for the kept data-sharing card; "Use web chat instead" navigation check)
- [x] Bug fixes include regression tests (n/a, this is a refactor)

## AI Usage
- [x] AI-assisted (drafted by Claude via back-and-forth with @njbrake; design choices, scope, and review are his, prose and code are Claude's)