### PR TITLE
fix: deliver OAuth connect link via ToolReceipt so the LLM cannot drop it

### DIFF
--- a/backend/app/agent/tools/integration_tools.py
+++ b/backend/app/agent/tools/integration_tools.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel, Field
 
 from backend.app.agent.stores import ToolConfigStore
-from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.integrations.appfolio_vendor import auth as appfolio_auth
 from backend.app.services.oauth import get_oauth_config, list_oauth_integrations, oauth_service
@@ -393,12 +393,22 @@ async def _handle_connect(user_id: str, target: str, registry: ToolRegistry) -> 
 
     url = oauth_service.get_authorization_url(config, user_id, source="chat")
     logger.info("User %s requested OAuth connect link for '%s' via chat", user_id, oauth_name)
+    # The URL lives ONLY in the ToolReceipt, never in ``content``. The receipt
+    # is rendered server-side by ``tool_summary.append_receipts`` and appended
+    # to the outbound verbatim, so the link reaches the user deterministically
+    # instead of depending on the LLM to echo a 400-char OAuth URL it tends to
+    # paraphrase away ("Tap the link" with no link -- the original bug). Keeping
+    # the URL out of ``content`` also closes the duplication trap the calendar /
+    # qb receipts hit: when the rich value is echoed to the LLM too, the model
+    # restates it and the user sees the link twice. Same pattern as
+    # ``calendar/factory.py`` create_event.
     return ToolResult(
         content=(
-            f"To connect {display}, open this link:\n\n{url}\n\n"
-            "After you approve access, the connection will be ready "
-            "the next time you message me."
+            f"Connect link for {display} generated. It is shown to the user as a "
+            "tappable link below your reply, so just tell them to tap it, approve "
+            "access, then message you back. Do not write out or repeat the URL."
         ),
+        receipt=ToolReceipt(action="Tap to connect", target=display, url=url),
     )
 
 

--- a/tests/test_integration_tools.py
+++ b/tests/test_integration_tools.py
@@ -291,7 +291,11 @@ async def test_connect_returns_oauth_url(test_user: User) -> None:
 
         result = await _call(test_user, "connect", "google_calendar")
         assert not result.is_error
-        assert "https://accounts.google.com" in result.content
+        # The URL is delivered via the ToolReceipt (rendered server-side),
+        # never echoed in content, so the LLM can neither drop nor duplicate it.
+        assert result.receipt is not None
+        assert result.receipt.url == "https://accounts.google.com/o/oauth2/auth?client_id=test"
+        assert "https://accounts.google.com" not in result.content
         mock_oauth.get_authorization_url.assert_called_once_with(
             mock_config, test_user.id, source="chat"
         )
@@ -320,7 +324,77 @@ async def test_connect_via_tool_group_name(test_user: User) -> None:
 
         result = await _call(test_user, "connect", "calendar")
         assert not result.is_error
-        assert "https://example.com/auth" in result.content
+        assert result.receipt is not None
+        assert result.receipt.url == "https://example.com/auth"
+        assert "https://example.com/auth" not in result.content
+
+
+@pytest.mark.asyncio()
+async def test_connect_link_survives_llm_dropping_it(test_user: User) -> None:
+    """Regression: the OAuth connect URL reaches the user even when the LLM's
+    prose omits it.
+
+    The original bug: a user asked to connect Gmail, the tool returned the
+    URL inside ``content``, and the model paraphrased the tool result into
+    "Tap the link, approve access, then message me back" -- with no link.
+    The fix moves the URL into a ToolReceipt so ``append_receipts`` renders
+    it server-side, independent of whatever the model wrote. This test
+    reproduces the model dropping the URL and asserts the user still gets it.
+    """
+    from backend.app.agent.context import StoredToolInteraction, StoredToolReceipt
+    from backend.app.agent.tool_summary import append_receipts
+
+    mock_config = OAuthConfig(
+        integration="gmail",
+        client_id="test-id",
+        client_secret="test-secret",
+        authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+    )
+    full_url = (
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=abc.apps."
+        "googleusercontent.com&redirect_uri=https%3A%2F%2Fclawbolt.ai%2Fapi"
+        "%2Foauth%2Fcallback&response_type=code&scope=gmail.readonly&state=xyz"
+    )
+    with (
+        patch(
+            "backend.app.agent.tools.integration_tools.get_oauth_config",
+            return_value=mock_config,
+        ),
+        patch("backend.app.agent.tools.integration_tools.oauth_service") as mock_oauth,
+    ):
+        mock_oauth.is_connected = AsyncMock(return_value=False)
+        mock_oauth.get_authorization_url.return_value = full_url
+
+        result = await _call(test_user, "connect", "gmail")
+
+    # The tool hands the URL off via the receipt, not the LLM-facing content.
+    assert not result.is_error
+    assert result.receipt is not None
+    assert result.receipt.url == full_url
+    assert full_url not in result.content
+
+    # Now simulate the model dropping the link in its prose, exactly like the
+    # original incident. append_receipts must still surface the URL.
+    stored = StoredToolInteraction(
+        name=ToolName.MANAGE_INTEGRATION,
+        result=result.content,
+        is_error=False,
+        receipt=StoredToolReceipt(
+            action=result.receipt.action,
+            target=result.receipt.target,
+            url=result.receipt.url,
+        ),
+    )
+    llm_prose = "Tap the link, approve access, then message me back."
+    outbound = append_receipts(llm_prose, [stored])
+
+    # The full URL (sans https://, the receipt renderer's compact form) is in
+    # the message the user actually receives, and only once.
+    assert "accounts.google.com/o/oauth2/v2/auth?client_id=abc" in outbound
+    assert outbound.count("accounts.google.com/o/oauth2/v2/auth?client_id=abc") == 1
+    assert "Tap the link" in outbound
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

When a user asks the agent to connect an OAuth integration (e.g. "let's connect Gmail"), `_handle_connect` in `integration_tools.py` returned the authorization URL inside `ToolResult.content`. That content flows back through the LLM, which composes the user-facing reply. The model paraphrased the tool result and dropped the ~400-char OAuth URL, replying "Tap the link, approve access, then message me back" with no link.

This was reproduced from a real production conversation (consented transcript): the same tool content produced the link only on a later retry, so the failure is probabilistic LLM elision of a long, token-heavy URL.

### Fix

Move the URL out of `content` and into a `ToolReceipt(action, target, url)`. `tool_summary.append_receipts` renders the receipt server-side and appends it to the outbound verbatim, so the link reaches the user deterministically regardless of what the model writes. `content` is now minimal and tells the model not to repeat the URL.

Keeping the URL out of `content` also closes the duplication trap already documented in `calendar/factory.py` create_event and the qb_send / qb_create fixes: when the rich value is echoed to the LLM too, the model restates it and the user sees it twice. This change reuses that established pattern rather than adding a new delivery path.

Rendered result, even when the model omits the link in its prose:

```
Tap the link, approve access, then message me back.

- Tap to connect Gmail
  accounts.google.com/o/oauth2/v2/auth?client_id=...&state=xyz
```

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (investigation, fix, and tests via Claude Code, reviewed by @njbrake)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)