### PR TITLE
feat: instrument list_capabilities to measure SKILL.md delivery

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -654,6 +654,16 @@ class ClawboltAgent:
         tool_name = tc_req.name
         tool_tags = self._get_tool_tags(tool_name)
 
+        # Telemetry: log specialist tool invocations with their category.
+        if self._registry is not None:
+            factory = self._registry.get_specialist_factory_for_tool(tool_name)
+            if factory is not None:
+                logger.info(
+                    "specialist_tool_invocation tool=%s category=%s",
+                    tool_name,
+                    factory,
+                )
+
         await self._emit(ToolExecutionStartEvent(tool_name=tool_name, arguments=validated_args))
         tool_start = time.monotonic()
         result_str = ""

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -187,6 +187,13 @@ def create_list_capabilities_tool(
                     lines.append(f"- {name}: {reason}")
             return ToolResult(content="\n".join(lines))
 
+        # Telemetry: log every list_capabilities lookup with a non-null
+        # category, regardless of whether the category is valid or connected.
+        logger.info(
+            "list_capabilities_lookup category=%s",
+            category,
+        )
+
         if category in _unauthenticated:
             return ToolResult(
                 content=_unauthenticated[category],
@@ -267,6 +274,8 @@ class ToolRegistry:
 
     def __init__(self) -> None:
         self._factories: dict[str, ToolFactory] = {}
+        # Lazy-built reverse mapping: tool name -> specialist factory name
+        self._specialist_tool_to_factory: dict[str, str] | None = None
 
     def register(
         self,
@@ -588,6 +597,26 @@ class ToolRegistry:
             if disabled:
                 result[name] = disabled
         return result
+
+    def get_specialist_factory_for_tool(self, tool_name: str) -> str | None:
+        """Return the specialist factory name that owns *tool_name*, or ``None``.
+
+        Builds a reverse mapping from tool name to factory name for all
+        specialist (non-core) factories. Core tools return ``None`` since
+        they have no associated SKILL.md category.
+
+        The mapping is lazily built on first call and cached so repeated
+        lookups in the same agent turn are O(1) after the initial scan.
+        """
+        if self._specialist_tool_to_factory is None:
+            mapping: dict[str, str] = {}
+            for fname, factory in self._factories.items():
+                if factory.core:
+                    continue
+                for st in factory.sub_tools:
+                    mapping[st.name] = fname
+            self._specialist_tool_to_factory = mapping
+        return self._specialist_tool_to_factory.get(tool_name)
 
     @property
     def specialist_summaries(self) -> dict[str, str]:

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -5,15 +5,22 @@ mechanism: tools for authenticated integrations are loaded on the schema
 from turn 1 (see ``create_ready_specialist_tools``).
 """
 
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from pydantic import BaseModel
 
+from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.messages import ToolCallRequest
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.agent.tools.registry import (
+    SubToolInfo,
     ToolContext,
     ToolRegistry,
     create_list_capabilities_tool,
+    default_registry,
     ensure_tool_modules_imported,
 )
 from backend.app.models import User
@@ -109,8 +116,6 @@ class TestAvailableSpecialistSummaries:
 
     @pytest.mark.asyncio()
     async def test_returns_all_specialists_when_deps_met(self) -> None:
-        from unittest.mock import MagicMock
-
         registry = _build_test_registry()
         ctx = ToolContext(
             user=User(id="1"),
@@ -211,16 +216,12 @@ class TestDefaultRegistryCoreSpecialistSplit:
     """The default registry correctly classifies built-in factories."""
 
     def test_core_factories(self) -> None:
-        from backend.app.agent.tools.registry import default_registry
-
         core = default_registry.core_factory_names
         assert "messaging" in core
         assert "workspace" in core
         assert "heartbeat" in core
 
     def test_specialist_factories(self) -> None:
-        from backend.app.agent.tools.registry import default_registry
-
         specialist = default_registry.specialist_factory_names
         assert "quickbooks" in specialist
         assert "calendar" in specialist
@@ -228,8 +229,6 @@ class TestDefaultRegistryCoreSpecialistSplit:
         assert "heartbeat" not in specialist
 
     def test_no_overlap(self) -> None:
-        from backend.app.agent.tools.registry import default_registry
-
         core = default_registry.core_factory_names
         specialist = default_registry.specialist_factory_names
         assert not core & specialist
@@ -240,8 +239,6 @@ class TestGetSpecialistFactoryForTool:
 
     def _reg_with_subtools(self) -> ToolRegistry:
         """Build a registry where specialist factories declare sub_tools."""
-        from backend.app.agent.tools.registry import SubToolInfo
-
         reg = ToolRegistry()
         reg.register(
             "estimate",
@@ -295,8 +292,6 @@ class TestListCapabilitiesTelemetry:
     async def test_logs_lookup_when_category_provided(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        import logging
-
         caplog.set_level(logging.INFO)
         summaries = {"estimate": "Generate estimates"}
         tool = create_list_capabilities_tool(summaries)
@@ -309,8 +304,6 @@ class TestListCapabilitiesTelemetry:
     async def test_does_not_log_when_category_is_none(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        import logging
-
         caplog.set_level(logging.INFO)
         summaries = {"estimate": "Generate estimates"}
         tool = create_list_capabilities_tool(summaries)
@@ -320,8 +313,6 @@ class TestListCapabilitiesTelemetry:
 
     @pytest.mark.asyncio
     async def test_logs_unknown_category_as_lookup(self, caplog: pytest.LogCaptureFixture) -> None:
-        import logging
-
         caplog.set_level(logging.INFO)
         summaries = {"estimate": "Generate estimates"}
         tool = create_list_capabilities_tool(summaries)
@@ -338,12 +329,6 @@ class TestSpecialistToolInvocationTelemetry:
     @pytest.mark.asyncio
     async def test_logs_specialist_tool_invocation(self) -> None:
         """When a specialist tool is executed, the logger fires with tool and category."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        from pydantic import BaseModel
-
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.tools.registry import SubToolInfo
 
         class _Params(BaseModel):
             pass
@@ -380,8 +365,6 @@ class TestSpecialistToolInvocationTelemetry:
             agent = ClawboltAgent(user=MagicMock(), registry=reg)
             agent.register_tools(tools)
             # Directly invoke _execute_single_tool to trigger the logging
-            from backend.app.agent.messages import ToolCallRequest
-
             tc_req = ToolCallRequest(id="call_1", name="test_tool", arguments={})
             validated_args = {}
             parsed_calls = [tc_req]
@@ -397,12 +380,6 @@ class TestSpecialistToolInvocationTelemetry:
     @pytest.mark.asyncio
     async def test_does_not_log_core_tool_invocation(self) -> None:
         """Core tools do not trigger the specialist telemetry log."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        from pydantic import BaseModel
-
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.tools.registry import SubToolInfo
 
         class _Params(BaseModel):
             pass
@@ -431,8 +408,6 @@ class TestSpecialistToolInvocationTelemetry:
         )
         tools = await reg.create_core_tools(ctx)
         assert len(tools) == 1
-
-        from backend.app.agent.messages import ToolCallRequest
 
         tc_req = ToolCallRequest(id="call_1", name="core_tool", arguments={})
         validated_args = {}

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -233,3 +233,214 @@ class TestDefaultRegistryCoreSpecialistSplit:
         core = default_registry.core_factory_names
         specialist = default_registry.specialist_factory_names
         assert not core & specialist
+
+
+class TestGetSpecialistFactoryForTool:
+    """get_specialist_factory_for_tool maps specialist tool names to their factory."""
+
+    def _reg_with_subtools(self) -> ToolRegistry:
+        """Build a registry where specialist factories declare sub_tools."""
+        from backend.app.agent.tools.registry import SubToolInfo
+
+        reg = ToolRegistry()
+        reg.register(
+            "estimate",
+            lambda ctx: [_make_tool("generate_estimate")],
+            core=False,
+            summary="Generate estimates",
+            sub_tools=[SubToolInfo("generate_estimate", "Generate estimates")],
+        )
+        reg.register(
+            "heartbeat",
+            lambda ctx: [_make_tool("get_heartbeat")],
+            core=False,
+            summary="Heartbeat",
+            sub_tools=[SubToolInfo("get_heartbeat", "Get heartbeat")],
+        )
+        reg.register(
+            "messaging",
+            lambda ctx: [_make_tool("send_media_reply")],
+            sub_tools=[SubToolInfo("send_media_reply", "Send reply")],
+        )
+        return reg
+
+    def test_returns_factory_name_for_specialist_tool(self) -> None:
+        registry = self._reg_with_subtools()
+        factory = registry.get_specialist_factory_for_tool("generate_estimate")
+        assert factory == "estimate"
+
+    def test_returns_none_for_core_tool(self) -> None:
+        registry = self._reg_with_subtools()
+        factory = registry.get_specialist_factory_for_tool("send_media_reply")
+        assert factory is None
+
+    def test_returns_none_for_unknown_tool(self) -> None:
+        registry = self._reg_with_subtools()
+        factory = registry.get_specialist_factory_for_tool("no_such_tool")
+        assert factory is None
+
+    def test_caches_after_first_lookup(self) -> None:
+        registry = self._reg_with_subtools()
+        factory1 = registry.get_specialist_factory_for_tool("generate_estimate")
+        assert factory1 == "estimate"
+        assert registry._specialist_tool_to_factory is not None
+        factory2 = registry.get_specialist_factory_for_tool("get_heartbeat")
+        assert factory2 == "heartbeat"
+
+
+class TestListCapabilitiesTelemetry:
+    """list_capabilities with a non-null category logs a structured event."""
+
+    @pytest.mark.asyncio
+    async def test_logs_lookup_when_category_provided(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        caplog.set_level(logging.INFO)
+        summaries = {"estimate": "Generate estimates"}
+        tool = create_list_capabilities_tool(summaries)
+        result = await tool.function(category="estimate")
+        assert not result.is_error
+        assert "list_capabilities_lookup" in caplog.text
+        assert "category=estimate" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_does_not_log_when_category_is_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        caplog.set_level(logging.INFO)
+        summaries = {"estimate": "Generate estimates"}
+        tool = create_list_capabilities_tool(summaries)
+        result = await tool.function(category=None)
+        assert not result.is_error
+        assert "list_capabilities_lookup" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_unknown_category_as_lookup(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        caplog.set_level(logging.INFO)
+        summaries = {"estimate": "Generate estimates"}
+        tool = create_list_capabilities_tool(summaries)
+        result = await tool.function(category="nonexistent")
+        assert result.is_error
+        # Even though the category is unknown, the lookup event should still fire
+        assert "list_capabilities_lookup" in caplog.text
+        assert "category=nonexistent" in caplog.text
+
+
+class TestSpecialistToolInvocationTelemetry:
+    """Specialist tool invocations log a structured event with the category."""
+
+    @pytest.mark.asyncio
+    async def test_logs_specialist_tool_invocation(self) -> None:
+        """When a specialist tool is executed, the logger fires with tool and category."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from pydantic import BaseModel
+
+        from backend.app.agent.core import ClawboltAgent
+        from backend.app.agent.tools.registry import SubToolInfo
+
+        class _Params(BaseModel):
+            pass
+
+        async def _tool_fn(**_: object) -> ToolResult:
+            return ToolResult(content="done")
+
+        reg = ToolRegistry()
+        reg.register(
+            "test_specialist",
+            lambda ctx: [
+                Tool(
+                    name="test_tool",
+                    description="test specialist tool",
+                    function=_tool_fn,
+                    params_model=_Params,
+                )
+            ],
+            core=False,
+            summary="Test specialist",
+            sub_tools=[SubToolInfo("test_tool", "Test tool")],
+        )
+
+        ctx = ToolContext(
+            user=MagicMock(),
+            storage=MagicMock(),
+            publish_outbound=AsyncMock(),
+        )
+        tools = await reg.create_ready_specialist_tools(ctx)
+        assert len(tools) == 1
+
+        # Patch the logger to verify the call, bypassing the full agent loop
+        with patch("backend.app.agent.core.logger") as mock_logger:
+            agent = ClawboltAgent(user=MagicMock(), registry=reg)
+            agent.register_tools(tools)
+            # Directly invoke _execute_single_tool to trigger the logging
+            from backend.app.agent.messages import ToolCallRequest
+
+            tc_req = ToolCallRequest(id="call_1", name="test_tool", arguments={})
+            validated_args = {}
+            parsed_calls = [tc_req]
+
+            await agent._execute_single_tool(0, tools[0], validated_args, parsed_calls)
+
+            mock_logger.info.assert_called_once()
+            args = mock_logger.info.call_args[0]
+            assert "specialist_tool_invocation" in args[0]
+            assert "test_tool" in str(args)
+            assert "test_specialist" in str(args)
+
+    @pytest.mark.asyncio
+    async def test_does_not_log_core_tool_invocation(self) -> None:
+        """Core tools do not trigger the specialist telemetry log."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from pydantic import BaseModel
+
+        from backend.app.agent.core import ClawboltAgent
+        from backend.app.agent.tools.registry import SubToolInfo
+
+        class _Params(BaseModel):
+            pass
+
+        async def _tool_fn(**_: object) -> ToolResult:
+            return ToolResult(content="done")
+
+        reg = ToolRegistry()
+        reg.register(
+            "core_factory",
+            lambda ctx: [
+                Tool(
+                    name="core_tool",
+                    description="core tool",
+                    function=_tool_fn,
+                    params_model=_Params,
+                )
+            ],
+            sub_tools=[SubToolInfo("core_tool", "Core tool")],
+        )
+
+        ctx = ToolContext(
+            user=MagicMock(),
+            storage=MagicMock(),
+            publish_outbound=AsyncMock(),
+        )
+        tools = await reg.create_core_tools(ctx)
+        assert len(tools) == 1
+
+        from backend.app.agent.messages import ToolCallRequest
+
+        tc_req = ToolCallRequest(id="call_1", name="core_tool", arguments={})
+        validated_args = {}
+        parsed_calls = [tc_req]
+
+        with patch("backend.app.agent.core.logger") as mock_logger:
+            agent = ClawboltAgent(user=MagicMock(), registry=reg)
+            agent.register_tools(tools)
+            await agent._execute_single_tool(0, tools[0], validated_args, parsed_calls)
+
+            mock_logger.info.assert_not_called()


### PR DESCRIPTION
## Description

Add lightweight telemetry counters on `list_capabilities` lookups and specialist-tool invocations, broken down by category. The ratio of `list_capabilities(category=X)` to `first-tool-call(category=X)` per session will validate whether the LLM calls `list_capabilities` before using specialist tools, informing the SKILL.md delivery design.

### Changes

**`backend/app/agent/tools/registry.py`**
- Structured logging on `list_capabilities(category=...)` with a non-null category
- New `get_specialist_factory_for_tool(tool_name)` method on `ToolRegistry` mapping tool names to their specialist category

**`backend/app/agent/core.py`**
- Structured logging on specialist-tool invocations with tool name and category

**`tests/test_select_tools.py`**
- Tests for `get_specialist_factory_for_tool`
- Tests for `list_capabilities` telemetry logging
- Tests for specialist-tool invocation telemetry logging

## Type
- [x] Feature

## Checklist
- [x] Tests pass (\`uv run pytest -v\`)
- [x] Lint passes (\`ruff check backend/ && ruff format --check backend/\`)
- [x] New tests added for new functionality

## AI Usage
- [x] AI-assisted (Claude Code implemented the fix following issue #1388 specification)

Fixes #1388

🤖 Generated by DeepSeek V4 Flash running on [ds4](https://github.com/antirez/ds4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
High-level summary
- Adds lightweight telemetry to measure delivery and use of SKILL.md: list_capabilities calls now log the requested category, and specialist tool invocations log the tool name plus its specialist category when resolvable.
- Introduces a reverse lookup on the tool registry to map sub-tool names to their owning specialist factory, exposed via ToolRegistry.get_specialist_factory_for_tool.
- Expands tests to cover the new telemetry, the specialist-to-factory lookup (including caching), and the core/specialist classification behavior.
- Touches three areas: backend/app/agent/tools/registry.py (telemetry + lookup), backend/app/agent/core.py (invocation telemetry), and tests/test_select_tools.py (new/updated tests).

Technical details
- registry.list_capabilities(category=...) now emits structured info logs that include the category argument (including None).
- ToolRegistry lazily builds and caches a reverse mapping from specialist sub-tool names → specialist factory and exposes get_specialist_factory_for_tool(tool_name) -> str | None.
- ClawboltAgent._execute_single_tool emits structured info logs for specialist tool invocations only when the registry resolves the tool to a specialist category; core/unknown tools are not logged as specialist invocations.
- Tests assert: list_capabilities logging behavior, specialist-tool invocation logging, correct specialist ownership resolution (and caching), and adjust expectations for the default registry split (e.g., heartbeat treated as core).

Benefits
- Enables measuring how often agents request SKILL.md (via list_capabilities) vs. actually invoking specialist tools, allowing data-driven decisions about whether SKILL.md should remain on-demand.
- Low-overhead, structured telemetry makes it straightforward to compute per-session ratios and surface gaps where agents use tools without first requesting guidance.
- Improves specialist-tool resolution performance via a cached reverse lookup and increases test coverage for these behaviors.

Potential follow-ups / improvements
- Add metrics aggregation (counters or monitoring hooks) to complement structured logs for easier production analysis.
- Instrument first-tool-call per session (if not already present) to simplify computing ratios without post-processing session logs.
- Consider telemetry for alternate delivery paths if SKILL.md is auto-injected in the future.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->