### PR TITLE
fix: search CompanyCam before claiming a project is absent

### DIFF
--- a/backend/app/integrations/companycam/SKILL.md
+++ b/backend/app/integrations/companycam/SKILL.md
@@ -39,6 +39,10 @@ CompanyCam is a photo documentation platform for the trades. Projects, photos, c
 - **Photo**: an uploaded image. Has `id`, optional `description`, tags, and a CompanyCam-side `processing_status` (`pending`, `processing`, `processed`, `duplicate`, `processing_error`).
 - **Checklist**: a task list bound to a project, instantiated from a template. Sections contain tasks; each task carries a `completed_at` timestamp when done.
 
+## Finding a project
+
+A project you have not searched this session is unknown, not absent. Never tell the user a project does not exist, and never offer `companycam_create_project`, until `companycam_search_projects` has returned no match for the name they gave. Search the bare name first; adding a guessed token (an address you are not sure of) can narrow a name match to zero. A project ID you already resolved this session can be reused without re-searching.
+
 ## Photo handles
 
 See the ``analyze_photo`` tool description for the ``media_XXXXXX`` handle convention.
@@ -63,8 +67,8 @@ Tags are trimmed at 50 chars and capped at 10 per call.
 ## Common Workflows
 
 ### Upload a photo with job context
-1. `companycam_search_projects(query="<address or client>")`.
-2. If no match, `companycam_create_project(name="<Client - Address>", address="<address>")`.
+1. `companycam_search_projects(query="<address or client>")`. Required even when the user names a project you do not recognize: see "Finding a project".
+2. If the search returns no match, `companycam_create_project(name="<Client - Address>", address="<address>")`.
 3. `companycam_upload_photo(project_id="...", original_url="media_XXXXXX", tags=[...], description="...")`. One call per photo, one handle per call.
 4. Summarize what you assumed (project, tags) in one line so the user can amend.
 

--- a/tests/test_companycam_skill_md.py
+++ b/tests/test_companycam_skill_md.py
@@ -1,0 +1,52 @@
+"""Doc-lint tests for the CompanyCam SKILL.md.
+
+Regression for the "claimed a project did not exist without searching" bug:
+the agent told a user it had no CompanyCam project for a name it had never
+looked up this session, and offered to create one, instead of calling
+``companycam_search_projects`` first. The project existed. The agent had been
+reusing project IDs it resolved earlier in the session and generalized that
+cache into a belief that its in-context set of projects was complete.
+
+These tests pin the guard so the guidance does not drift out of the file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL_MD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "backend"
+    / "app"
+    / "integrations"
+    / "companycam"
+    / "SKILL.md"
+)
+
+
+def test_skill_md_has_finding_a_project_section() -> None:
+    """SKILL.md must carry a dedicated "Finding a project" guard section."""
+    content = SKILL_MD_PATH.read_text()
+    assert "## Finding a project" in content, (
+        "SKILL.md should include a 'Finding a project' section instructing the "
+        "agent to search before claiming a project is absent."
+    )
+
+
+def test_skill_md_requires_search_before_claiming_absence() -> None:
+    """The guard must tell the agent not to assert absence before searching.
+
+    Without this, the agent answers from its in-context project cache: a name
+    it has not searched this session reads as 'does not exist', so it offers to
+    create a duplicate of a project that is already there.
+    """
+    content = SKILL_MD_PATH.read_text()
+    lowered = content.lower()
+    # The two tools the guard ties together.
+    assert "companycam_search_projects" in content
+    assert "companycam_create_project" in content
+    # The core framing: not-searched is not the same as not-existing.
+    assert "unknown, not absent" in lowered, (
+        "The guard should state that an unsearched project is 'unknown, not "
+        "absent' so the agent searches before claiming it does not exist."
+    )


### PR DESCRIPTION
## Description

The agent claimed it had no CompanyCam project for a name the user gave, and offered to create one, without ever calling `companycam_search_projects`. The project existed. Earlier in the same session the agent had searched for and cached a couple of project IDs, then reused those IDs for many uploads. It generalized that cache into a belief that its in-context set of projects was complete, so a name it had never searched read as "does not exist". Only after the user pushed back did it search and find the project immediately.

Root cause is prompt guidance: nothing in the CompanyCam `SKILL.md` told the agent that an unsearched project is unknown, not absent. This is the same bug class as the QuickBooks SKILL.md fix for issue #1131 (agent treated unlisted data as nonexistent).

Changes:
- Add a "Finding a project" guard to `backend/app/integrations/companycam/SKILL.md`: never claim a project is absent, and never offer `companycam_create_project`, until `companycam_search_projects` returns no match. Search the bare name first; a guessed extra token can narrow a name match to zero.
- Reinforce step 1 of the "Upload a photo with job context" workflow.
- Add `tests/test_companycam_skill_md.py`, a doc-lint regression test pinning the guard (mirrors `tests/test_quickbooks_skill_md.py`).

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude investigated the captured conversation, identified the root cause, and drafted the SKILL.md guard and regression test via back-and-forth with @njbrake)
- [ ] No AI used
