### PR TITLE
chore: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,201 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit configuration for clawbolt.
+# Reference: https://docs.coderabbit.ai/reference/yaml-template
+# Schema:    https://coderabbit.ai/integrations/schema.v2.json
+#
+# Style note: this repo bans em dashes everywhere (see AGENTS.md), including
+# yaml comments. Use commas, semicolons, or rephrase.
+#
+# Philosophy: start small. AGENTS.md is the source of truth; CodeRabbit reads
+# it via knowledge_base.code_guidelines below, so we do not restate its rules
+# here. Pre-merge gates start at `warning` and only graduate to `error` once
+# real PR traffic shows they catch real problems. Tools that CI already runs
+# (ruff, ty, pytest, frontend typecheck) are left to CI to avoid duplicate
+# signal.
+
+language: en-US
+
+tone_instructions: "Review code like a calm, friendly senior engineer. Be clear, constructive, and encouraging. Explain the reasoning behind suggestions, assume good intentions, and occasionally use light, friendly humor when appropriate."
+
+# Beta features can shift under us; stay on stable until we have a reason.
+early_access: false
+enable_free_tier: true
+
+reviews:
+  profile: chill
+
+  # Comment-only reviews; do not auto-request changes from CodeRabbit.
+  request_changes_workflow: false
+
+  high_level_summary: true
+  high_level_summary_instructions: "Provide a concise, high-level summary of the code changes, focusing on the most significant improvements and potential areas for further enhancement. Use clear and concise language, and avoid overly technical jargon. We just want to know what changed, what moved, what was added, what was removed. Not technically. Then you can add technical jargons in another block if needed. Provide the benefits of the PR if you can"
+  high_level_summary_placeholder: "@coderabbitai summary"
+  high_level_summary_in_walkthrough: false
+
+  auto_title_placeholder: "@coderabbitai title"
+  auto_title_instructions: "Generate a short, action-oriented PR title. Start with a verb in the imperative form. Focus only on what changed, not why. Keep it concise and specific"
+
+  review_status: true
+  # Off to stop CodeRabbit from posting a separate per-commit status check.
+  # The walkthrough comment on the PR is enough signal; CI already gates
+  # merges via ruff, ty, pytest, and the frontend typecheck.
+  commit_status: false
+  # Fails the GitHub commit check when CodeRabbit cannot complete a review
+  # (errors, timeouts, service unavailable). It does NOT fail based on review
+  # findings; those are surfaced as comments.
+  fail_commit_status: false
+
+  collapse_walkthrough: false
+  changed_files_summary: true
+  # Auto mermaid on most diffs adds noise; opt back in once we miss it.
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+
+  suggested_labels: true
+  labeling_instructions: []
+  auto_apply_labels: false
+
+  # Leave on so reviewer suggestions work as the maintainer team grows.
+  suggested_reviewers: true
+  auto_assign_reviewers: true
+
+  in_progress_fortune: false
+  poem: false
+
+  enable_prompt_for_ai_agents: true
+
+  path_filters: []
+
+  # Intentionally empty. AGENTS.md and CLAUDE.md are loaded as
+  # knowledge_base.code_guidelines below; restating rules here would create
+  # two sources of truth that drift. Add entries only when CodeRabbit needs
+  # signal that AGENTS.md cannot express.
+  path_instructions: []
+
+  abort_on_close: true
+  disable_cache: false
+
+  auto_review:
+    enabled: true
+    # On. CodeRabbit does proper housekeeping between incremental reviews
+    # (does not keep previous reviews open) and self-caps at roughly 3
+    # follow-up commits per PR before switching to manual review, so the
+    # noise that originally motivated turning this off is bounded.
+    auto_incremental_review: true
+    ignore_title_keywords:
+      - "Dependencies"
+      - "update dependency"
+      - "wip"
+      - "dependabot"
+    labels: []
+    drafts: false
+    base_branches: ["main"]
+    ignore_usernames: []
+
+  # Optional auto-commits CodeRabbit can offer at the end of a review. Each
+  # one is a "click to accept" suggestion; nothing lands without approval.
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
+    simplify:
+      enabled: true
+
+  # Gates that run before merge. Start everything at `warning` so we can
+  # observe real PR traffic before promoting any of these to `error`.
+  pre_merge_checks:
+    docstrings:
+      mode: warning
+      threshold: 80
+    issue_assessment:
+      mode: warning
+    title:
+      mode: warning
+      requirements: |
+        PR titles should start with a Conventional Commit prefix: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`, `perf:`, or `ci:`.
+        Use imperative mood. Keep the title under ~70 chars and let the body carry the detail.
+    description:
+      mode: warning
+
+  tools:
+    # CI already runs `uv run ruff check`, `uv run ty check`, and `uv run
+    # pytest`; leaving the equivalent CodeRabbit tools off avoids duplicate
+    # signal in PR comments. The frontend has no eslint config (typecheck and
+    # knip run in CI), so eslint stays off too.
+    ruff:
+      enabled: false
+    eslint:
+      enabled: false
+    # Things CI does not cover and that are cheap to surface inline.
+    gitleaks:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    # Off by default; opt back in once we know what kind of noise they make.
+    shellcheck:
+      enabled: false
+    languagetool:
+      enabled: false
+    checkov:
+      enabled: false
+    actionlint:
+      enabled: false
+    semgrep:
+      enabled: false
+    dotenvLint:
+      enabled: false
+
+chat:
+  art: true
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    # AGENTS.md is the canonical rule set; CLAUDE.md is a symlink to it but
+    # we list both since the symlink may not be resolved by the scanner.
+    # DESIGN.md carries visual rules referenced by AGENTS.md.
+    filePatterns:
+      - "**/AGENTS.md"
+      - "**/CLAUDE.md"
+      - "**/DESIGN.md"
+  # `auto` keeps learnings per-repo unless the same content shows up in a
+  # sibling repo. clawbolt and clawbolt-premium share an open-core codebase
+  # and conventions, so cross-repo learning is welcome. Switch to `global`
+  # deliberately if the shared rule set grows.
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto
+  mcp:
+    usage: enabled
+
+code_generation:
+  docstrings:
+    language: en-US
+
+# Issue enrichment intentionally disabled for now. Revisit once we have a
+# clearer sense of CodeRabbit's baseline behavior on real PRs.
+issue_enrichment:
+  auto_enrich:
+    enabled: false
+  planning:
+    enabled: false
+    auto_planning:
+      enabled: false
+      labels: []


### PR DESCRIPTION
## Description
Adds a `.coderabbit.yaml` to configure CodeRabbit reviews for this repo. Adapted from the [agent-of-empires config](https://github.com/agent-of-empires/agent-of-empires/blob/main/.coderabbit.yaml) and tuned for clawbolt:

- Repo-specific header, philosophy, and comments.
- Tools that CI already runs (`ruff`, `ty`, `pytest`, frontend `typecheck`/`knip`) are left off CodeRabbit to avoid duplicate signal; `eslint` stays off since the frontend has no eslint config.
- `knowledge_base.code_guidelines` points at `AGENTS.md` / `CLAUDE.md` (symlink) / `DESIGN.md` so AGENTS.md stays the single source of truth instead of restating rules here.
- `learnings.scope: auto` note reflects the open-core sibling relationship between clawbolt and clawbolt-premium.
- Pre-merge gates start at `warning` so we can watch real PR traffic before promoting any to `error`.

## Type
- [x] CI/CD

## Checklist
- [ ] Tests pass (`uv run pytest -v`)
- [ ] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

Config-only change; no code paths affected. YAML validated locally.

## AI Usage
- [x] AI-assisted (Claude drafted the config and PR by adapting the agent-of-empires template for this repo)
- [ ] No AI used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established repository-wide configuration for automated code review processes, including review behaviour standards, quality check tool settings, and pre-merge verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->