### PR TITLE
fix(tests): drop stale 'concise' assertion after instructions prompt rewording

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -35,7 +35,6 @@ def test_load_prompt_strips_whitespace() -> None:
 
 def test_load_prompt_content_sanity() -> None:
     """Verify key substrings are present in a few prompts."""
-    assert "concise" in load_prompt("instructions")
     assert "JSON" in load_prompt("compaction")
     assert "tradesperson" in load_prompt("bootstrap")
 

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -188,7 +188,6 @@ class TestSectionBuilders:
     def test_build_instructions_section(self) -> None:
         """Should contain core behavioral rules."""
         result = build_instructions_section()
-        assert "concise" in result
         assert "only communicate via this chat" in result
 
     def test_build_instructions_section_no_trade_guidance(self) -> None:


### PR DESCRIPTION
## Description

PR #1404 reworded `backend/app/agent/prompts/instructions.md` and dropped the "Be concise and practical." / "Keep replies concise." / "Be helpful and direct..." bullets. Two tests still asserted `"concise"` was present in the loaded prompt and in `build_instructions_section()`, so main CI has been red since #1404 landed (2026-06-01 10:54 UTC).

Both tests are otherwise covered by their remaining assertions (`"JSON"` / `"tradesperson"` / `"only communicate via this chat"`). This drops only the two now-stale lines.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (locally pytest can't run here, but the change is a strict removal of two assert lines whose subject no longer exists in the source string)
- [x] Lint passes (no code added, only deletions)
- [ ] New tests added for new functionality - N/A (test fix, not new behavior)
- [x] Bug fixes include regression tests - N/A (the bug *is* the test; deleting the stale assertion is the fix)

## AI Usage
- [x] AI-assisted (Claude Code orchestrator wrote the two-line fix directly; not delegated to deepseek because the change is smaller than the delegation overhead)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes two stale test assertions that were checking for the word "concise" in the instructions prompt—assertions that became invalid when PR `#1404` removed that phrase from the instructions. Specifically:

- **tests/test_prompts.py**: Removed the assertion checking that the `instructions` prompt contains `"concise"`
- **tests/test_system_prompt.py**: Removed the assertion checking for `"concise"` in `TestSectionBuilders.test_build_instructions_section`, replacing it with an assertion for `"only communicate via this chat"`

The changes are **deletion-only** (−2 lines total). The affected tests retain coverage through their remaining assertions (e.g., checking for `"JSON"`, `"tradesperson"`, etc.), ensuring they remain meaningful.

### Benefits

- **Fixes broken CI**: Resolves test failures that have been blocking the main branch since PR `#1404` landed
- **Maintains test integrity**: Tests remain functionally covered by other assertions while aligning with the current prompt content
- **Minimal scope**: Pure cleanup with no side effects or additional logic changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->