### PR TITLE
fix(integrations): add absence-claim guard to QuickBooks, Calendar, ServiceTitan, AppFolio Vendor SKILL.md

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -654,6 +654,16 @@ class ClawboltAgent:
         tool_name = tc_req.name
         tool_tags = self._get_tool_tags(tool_name)
 
+        # Telemetry: log specialist tool invocations with their category.
+        if self._registry is not None:
+            factory = self._registry.get_specialist_factory_for_tool(tool_name)
+            if factory is not None:
+                logger.info(
+                    "specialist_tool_invocation tool=%s category=%s",
+                    tool_name,
+                    factory,
+                )
+
         await self._emit(ToolExecutionStartEvent(tool_name=tool_name, arguments=validated_args))
         tool_start = time.monotonic()
         result_str = ""

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -187,6 +187,13 @@ def create_list_capabilities_tool(
                     lines.append(f"- {name}: {reason}")
             return ToolResult(content="\n".join(lines))
 
+        # Telemetry: log every list_capabilities lookup with a non-null
+        # category, regardless of whether the category is valid or connected.
+        logger.info(
+            "list_capabilities_lookup category=%s",
+            category,
+        )
+
         if category in _unauthenticated:
             return ToolResult(
                 content=_unauthenticated[category],
@@ -267,6 +274,8 @@ class ToolRegistry:
 
     def __init__(self) -> None:
         self._factories: dict[str, ToolFactory] = {}
+        # Lazy-built reverse mapping: tool name -> specialist factory name
+        self._specialist_tool_to_factory: dict[str, str] | None = None
 
     def register(
         self,
@@ -588,6 +597,26 @@ class ToolRegistry:
             if disabled:
                 result[name] = disabled
         return result
+
+    def get_specialist_factory_for_tool(self, tool_name: str) -> str | None:
+        """Return the specialist factory name that owns *tool_name*, or ``None``.
+
+        Builds a reverse mapping from tool name to factory name for all
+        specialist (non-core) factories. Core tools return ``None`` since
+        they have no associated SKILL.md category.
+
+        The mapping is lazily built on first call and cached so repeated
+        lookups in the same agent turn are O(1) after the initial scan.
+        """
+        if self._specialist_tool_to_factory is None:
+            mapping: dict[str, str] = {}
+            for fname, factory in self._factories.items():
+                if factory.core:
+                    continue
+                for st in factory.sub_tools:
+                    mapping[st.name] = fname
+            self._specialist_tool_to_factory = mapping
+        return self._specialist_tool_to_factory.get(tool_name)
 
     @property
     def specialist_summaries(self) -> dict[str, str]:

--- a/backend/app/integrations/appfolio_vendor/SKILL.md
+++ b/backend/app/integrations/appfolio_vendor/SKILL.md
@@ -23,6 +23,14 @@ AppFolio Vendor Portal.
 Common status codes: `0` = new, `4` = in progress, `8` = completed.
 Confirm with the user when uncertain rather than guessing.
 
+## Finding a work order
+
+A work order you have not searched this session is unknown, not absent. Never
+tell the user a work order does not exist until
+`appfolio_search_work_orders` has returned no match for the address, number,
+or text they gave. A work order ID you already resolved this session can be
+reused without re-searching.
+
 ## Photos and documents
 
 See the ``analyze_photo`` tool description for the ``media_XXXXXX`` handle

--- a/backend/app/integrations/calendar/SKILL.md
+++ b/backend/app/integrations/calendar/SKILL.md
@@ -33,6 +33,14 @@ Examples:
 - `Job: Smith - Kitchen Remodel` at `123 Oak St, Portland OR`
 - `Job: Jones - Roof Repair` at `456 Elm Ave, Seattle WA`
 
+## Finding an event
+
+An event you have not listed this session is unknown, not absent. Never tell
+the user an event does not exist, and never create a duplicate event, until
+`calendar_list_events` has returned no match for the time range or search
+criteria they gave. An event ID you already resolved this session can be
+reused without re-listing.
+
 ## Availability Checking
 
 Always check availability before suggesting times or creating events:

--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -35,6 +35,13 @@ SELECT <fields> FROM <Entity> [WHERE <conditions>] [ORDERBY <field> DESC] [MAXRE
 - Not all fields support all operators. For example, Estimate TxnStatus does not support IN or LIKE. If a query returns a 400 error, simplify the WHERE clause and filter results yourself.
 - String comparisons are case-sensitive in QBO queries.
 
+## Finding a customer, invoice, or estimate
+
+An entity you have not queried this session is unknown, not absent. Never tell
+the user a customer, invoice, or estimate does not exist, and never create a
+new one, until `qb_query` has returned no match for the identifier they gave.
+An ID you already resolved this session can be reused without re-querying.
+
 ## Creating Entities (qb_create)
 
 Pass `entity_type` (Customer, Estimate, or Invoice) and `data` (the QBO API payload).
@@ -155,8 +162,9 @@ This is the primary workflow for users who dictate job details from the field:
 9. When user says it's ready: `qb_send` Estimate to the client's email
 
 ### New customer job
-1. `qb_create` Customer
-2. `qb_create` Estimate with the new customer's Id
+1. `qb_query` Customer to check if the client exists (see "Finding a customer, invoice, or estimate")
+2. If new client: `qb_create` Customer
+3. `qb_create` Estimate with the new customer's Id
 3. User approves the estimate
 4. Convert estimate to invoice (see below)
 5. `qb_send` the invoice

--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -165,9 +165,9 @@ This is the primary workflow for users who dictate job details from the field:
 1. `qb_query` Customer to check if the client exists (see "Finding a customer, invoice, or estimate")
 2. If new client: `qb_create` Customer
 3. `qb_create` Estimate with the new customer's Id
-3. User approves the estimate
-4. Convert estimate to invoice (see below)
-5. `qb_send` the invoice
+4. User approves the estimate
+5. Convert estimate to invoice (see below)
+6. `qb_send` the invoice
 
 ### Recovering a customer email
 1. `qb_query`: `SELECT * FROM Customer WHERE Id = '<customer_id>'` and check `PrimaryEmailAddr.Address`. If it's set, use it.

--- a/backend/app/integrations/servicetitan/SKILL.md
+++ b/backend/app/integrations/servicetitan/SKILL.md
@@ -11,6 +11,15 @@ ServiceTitan is a field-service management platform for HVAC, plumbing, and elec
 | `st_list_appointments` | List appointments in a date window, optionally by status | Auto |
 | `st_add_job_note` | Post a plain-text note to a job, optionally pinned | Ask |
 
+## Finding a customer or job
+
+A customer or job you have not searched this session is unknown, not absent.
+Never tell the user a customer or job does not exist until
+`st_search_customers` has returned no match for the name or phone they gave.
+Search the bare name first; a guessed extra token can narrow a name match to
+zero. A customer ID you already resolved this session can be reused without
+re-searching.
+
 ## Entity vocabulary
 
 - **Customer**: the billable party. Has `id`, `name`, `type`, `address`, `contacts`, `balance`, and flags (`active`, `doNotMail`, `doNotService`).

--- a/tests/test_appfolio_vendor_skill_md.py
+++ b/tests/test_appfolio_vendor_skill_md.py
@@ -1,0 +1,52 @@
+"""Doc-lint tests for the AppFolio Vendor SKILL.md.
+
+Regression for the "claimed a work order does not exist without searching"
+bug (issue #1403): the agent told a user a work order was absent without
+calling ``appfolio_search_work_orders`` first. Work orders are created
+upstream by property managers, so there is no duplicate-create risk, but the
+agent can still wrongly claim there is no work order for an address. The same
+bug class as the CompanyCam fix in #1402 (project absence claimed without
+searching).
+
+These tests pin the guard so the guidance does not drift out of the file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL_MD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "backend"
+    / "app"
+    / "integrations"
+    / "appfolio_vendor"
+    / "SKILL.md"
+)
+
+
+def test_skill_md_has_finding_work_order_section() -> None:
+    """SKILL.md must carry a dedicated 'Finding a work order' guard section."""
+    content = SKILL_MD_PATH.read_text()
+    assert "## Finding a work order" in content, (
+        "SKILL.md should include a 'Finding a work order' section instructing "
+        "the agent to search before claiming a work order is absent."
+    )
+
+
+def test_skill_md_requires_search_before_claiming_absence() -> None:
+    """The guard must tell the agent not to assert absence before searching.
+
+    Without this, the agent answers from its in-context work-order cache: an
+    address it has not searched this session reads as 'does not exist', so it
+    tells the user there is no work order.
+    """
+    content = SKILL_MD_PATH.read_text()
+    lowered = content.lower()
+    # The search tool the guard ties together.
+    assert "appfolio_search_work_orders" in content
+    # The core framing: not-searched is not the same as not-existing.
+    assert "unknown, not absent" in lowered, (
+        "The guard should state that an unsearched work order is 'unknown, not "
+        "absent' so the agent searches before claiming it does not exist."
+    )

--- a/tests/test_calendar_skill_md.py
+++ b/tests/test_calendar_skill_md.py
@@ -1,0 +1,51 @@
+"""Doc-lint tests for the Calendar SKILL.md.
+
+Regression for the "claimed an event does not exist without listing" bug
+(issue #1403): the agent told a user an event was absent without calling
+``calendar_list_events`` first, or created a duplicate event because it did
+not check existing events. The same bug class as the CompanyCam fix in #1402
+(project absence claimed without searching).
+
+These tests pin the guard so the guidance does not drift out of the file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL_MD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "backend"
+    / "app"
+    / "integrations"
+    / "calendar"
+    / "SKILL.md"
+)
+
+
+def test_skill_md_has_finding_event_section() -> None:
+    """SKILL.md must carry a dedicated 'Finding an event' guard section."""
+    content = SKILL_MD_PATH.read_text()
+    assert "## Finding an event" in content, (
+        "SKILL.md should include a 'Finding an event' section instructing the "
+        "agent to list events before claiming an event is absent."
+    )
+
+
+def test_skill_md_requires_list_before_claiming_absence() -> None:
+    """The guard must tell the agent not to assert absence before listing events.
+
+    Without this, the agent answers from its in-context event cache: an event
+    it has not listed this session reads as 'does not exist', so it creates a
+    duplicate or claims an event to update/delete is absent.
+    """
+    content = SKILL_MD_PATH.read_text()
+    lowered = content.lower()
+    # The two tools the guard ties together.
+    assert "calendar_list_events" in content
+    assert "calendar_create_event" in content
+    # The core framing: not-listed is not the same as not-existing.
+    assert "unknown, not absent" in lowered, (
+        "The guard should state that an unlisted event is 'unknown, not "
+        "absent' so the agent lists events before claiming it does not exist."
+    )

--- a/tests/test_quickbooks_skill_md.py
+++ b/tests/test_quickbooks_skill_md.py
@@ -1,18 +1,17 @@
 """Doc-lint tests for the QuickBooks SKILL.md.
 
-The agent treats any field omitted from SKILL.md's "Queryable entities and useful
-fields" section as if it does not exist on the entity. That has caused real
-regressions (issue #1131: agent claimed QuickBooks does not store the recipient
-email on past invoices, because BillEmail was not listed). These tests pin the
-field list so future drift surfaces in CI.
+Regression for the "claimed an entity does not exist without querying" bug
+(issue #1403): the agent told a user a customer, invoice, or estimate was
+absent without calling ``qb_query`` first. The same bug class as issue #1131
+(fields treated as absent because SKILL.md did not list them) and the
+CompanyCam fix in #1402 (project absence claimed without searching).
+
+These tests pin the guard so the guidance does not drift out of the file.
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
-
-import pytest
 
 SKILL_MD_PATH = (
     Path(__file__).resolve().parent.parent
@@ -23,137 +22,44 @@ SKILL_MD_PATH = (
     / "SKILL.md"
 )
 
-# Fields each queryable entity must list. Covers the audit in issue #1131:
-# anything the agent has been observed to need (or is likely to need) when
-# answering questions about prior transactions, customers, items, and bills.
-_REQUIRED_QUERYABLE_FIELDS: dict[str, list[str]] = {
-    "Invoice": [
-        "Id",
-        "SyncToken",
-        "DocNumber",
-        "CustomerRef",
-        "TotalAmt",
-        "Balance",
-        "DueDate",
-        "TxnDate",
-        "EmailStatus",
-        "BillEmail",
-        "Line",
-        "CustomerMemo",
-        "PrivateNote",
-        "BillAddr",
-        "ShipAddr",
-        "LinkedTxn",
-    ],
-    "Estimate": [
-        "Id",
-        "SyncToken",
-        "DocNumber",
-        "CustomerRef",
-        "TotalAmt",
-        "TxnDate",
-        "ExpirationDate",
-        "TxnStatus",
-        "BillEmail",
-        "Line",
-        "CustomerMemo",
-        "PrivateNote",
-        "LinkedTxn",
-    ],
-    "Customer": [
-        "Id",
-        "SyncToken",
-        "DisplayName",
-        "CompanyName",
-        "PrimaryEmailAddr",
-        "PrimaryPhone",
-        "BillAddr",
-        "Balance",
-        "Active",
-        "Notes",
-    ],
-    "Item": [
-        "Id",
-        "Name",
-        "Sku",
-        "Description",
-        "UnitPrice",
-        "Type",
-        "Active",
-        "QtyOnHand",
-    ],
-    "Payment": [
-        "Id",
-        "CustomerRef",
-        "TotalAmt",
-        "TxnDate",
-        "Line",
-    ],
-    "Bill": [
-        "Id",
-        "VendorRef",
-        "DocNumber",
-        "TotalAmt",
-        "DueDate",
-        "TxnDate",
-        "Line",
-    ],
-}
 
-
-def _entity_field_line(content: str, entity: str) -> str:
-    """Return the bullet line that lists fields for ``entity``."""
-    pattern = re.compile(rf"^- {entity}: (.+)$", re.MULTILINE)
-    match = pattern.search(content)
-    if not match:
-        raise AssertionError(
-            f"SKILL.md is missing a queryable-fields bullet for {entity!r}. "
-            "Expected a line like `- Invoice: Id, SyncToken, ...`."
-        )
-    return match.group(1)
-
-
-@pytest.mark.parametrize(("entity", "fields"), list(_REQUIRED_QUERYABLE_FIELDS.items()))
-def test_skill_md_lists_required_queryable_fields(entity: str, fields: list[str]) -> None:
-    """Every entity in SKILL.md must list the fields the agent is expected to know about."""
+def test_skill_md_has_finding_entity_section() -> None:
+    """SKILL.md must carry a dedicated 'Finding a customer, invoice, or estimate' guard section."""
     content = SKILL_MD_PATH.read_text()
-    listed = _entity_field_line(content, entity)
-    missing = [f for f in fields if not re.search(rf"\b{re.escape(f)}\b", listed)]
-    assert not missing, (
-        f"SKILL.md's {entity} field list is missing: {missing}. "
-        f"Without these, the agent treats the data as 'not stored' and refuses to query for it. "
-        f"Current line: {listed}"
+    assert "## Finding a customer, invoice, or estimate" in content, (
+        "SKILL.md should include a 'Finding a customer, invoice, or estimate' section "
+        "instructing the agent to query before claiming an entity is absent."
     )
 
 
-def test_skill_md_invoice_lists_billemail() -> None:
-    """Regression test for issue #1131.
+def test_skill_md_requires_query_before_claiming_absence() -> None:
+    """The guard must tell the agent not to assert absence before querying.
 
-    The agent answered 'QuickBooks does not store the recipient email on past
-    invoices' because BillEmail was not in SKILL.md. Pin it explicitly so
-    nobody accidentally drops it.
+    Without this, the agent answers from its in-context entity cache: a name
+    it has not queried this session reads as 'does not exist', so it creates a
+    duplicate of a customer that is already there, or claims an invoice does
+    not exist.
     """
     content = SKILL_MD_PATH.read_text()
-    invoice_line = _entity_field_line(content, "Invoice")
-    assert "BillEmail" in invoice_line, (
-        "Invoice queryable fields must include BillEmail (the recipient email "
-        "address recorded on a sent or unsent invoice). See issue #1131."
+    lowered = content.lower()
+    # The two tools the guard ties together.
+    assert "qb_query" in content
+    assert "qb_create" in content
+    # The core framing: not-queried is not the same as not-existing.
+    assert "unknown, not absent" in lowered, (
+        "The guard should state that an unqueried entity is 'unknown, not "
+        "absent' so the agent queries before claiming it does not exist."
     )
 
 
-def test_skill_md_documents_email_recovery_workflow() -> None:
-    """SKILL.md must describe how to recover a customer email before asking the user.
+def test_skill_md_new_customer_job_queries_first() -> None:
+    """The 'New customer job' workflow must query Customer before creating.
 
-    qb_send needs a recipient email. If SKILL.md does not document the
-    PrimaryEmailAddr -> Invoice.BillEmail fallback, the agent will either
-    interrupt the user for an email it could have looked up, or claim the
-    data is unavailable. See issue #1131.
+    The original workflow jumped straight to qb_create Customer, risking a
+    duplicate. Reinforce that the agent searches first.
     """
     content = SKILL_MD_PATH.read_text()
-    assert "Recovering a customer email" in content, (
-        "SKILL.md should include a 'Recovering a customer email' workflow under Common Workflows."
+    assert "qb_query" in content, (
+        "The New customer job workflow should include a qb_query step to "
+        "check if the customer exists before creating."
     )
-    # The workflow must reference both the Customer-level and Invoice-level fallbacks
-    # so the agent knows where to look before asking.
-    assert "PrimaryEmailAddr" in content
-    assert "BillEmail" in content

--- a/tests/test_quickbooks_skill_md.py
+++ b/tests/test_quickbooks_skill_md.py
@@ -162,6 +162,7 @@ def test_skill_md_documents_email_recovery_workflow() -> None:
 
 # --- #1403 guard tests --------------------------------------------------------
 
+
 def test_skill_md_has_finding_entity_section() -> None:
     """SKILL.md must carry a dedicated 'Finding a customer, invoice, or estimate' guard section."""
     content = SKILL_MD_PATH.read_text()

--- a/tests/test_quickbooks_skill_md.py
+++ b/tests/test_quickbooks_skill_md.py
@@ -1,17 +1,19 @@
 """Doc-lint tests for the QuickBooks SKILL.md.
 
-Regression for the "claimed an entity does not exist without querying" bug
-(issue #1403): the agent told a user a customer, invoice, or estimate was
-absent without calling ``qb_query`` first. The same bug class as issue #1131
-(fields treated as absent because SKILL.md did not list them) and the
-CompanyCam fix in #1402 (project absence claimed without searching).
-
-These tests pin the guard so the guidance does not drift out of the file.
+Covers two related regression classes:
+- Issue #1131: agent claims a field does not exist because SKILL.md does not
+  list it (e.g. BillEmail on Invoice). The field-list pinning tests prevent
+  that drift.
+- Issue #1403: agent claims a customer, invoice, or estimate is absent
+  without calling ``qb_query`` first. The guard tests prevent that drift.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+import pytest
 
 SKILL_MD_PATH = (
     Path(__file__).resolve().parent.parent
@@ -22,6 +24,143 @@ SKILL_MD_PATH = (
     / "SKILL.md"
 )
 
+# Fields each queryable entity must list. Covers the audit in issue #1131:
+# anything the agent has been observed to need (or is likely to need) when
+# answering questions about prior transactions, customers, items, and bills.
+_REQUIRED_QUERYABLE_FIELDS: dict[str, list[str]] = {
+    "Invoice": [
+        "Id",
+        "SyncToken",
+        "DocNumber",
+        "CustomerRef",
+        "TotalAmt",
+        "Balance",
+        "DueDate",
+        "TxnDate",
+        "EmailStatus",
+        "BillEmail",
+        "Line",
+        "CustomerMemo",
+        "PrivateNote",
+        "BillAddr",
+        "ShipAddr",
+        "LinkedTxn",
+    ],
+    "Estimate": [
+        "Id",
+        "SyncToken",
+        "DocNumber",
+        "CustomerRef",
+        "TotalAmt",
+        "TxnDate",
+        "ExpirationDate",
+        "TxnStatus",
+        "BillEmail",
+        "Line",
+        "CustomerMemo",
+        "PrivateNote",
+        "LinkedTxn",
+    ],
+    "Customer": [
+        "Id",
+        "SyncToken",
+        "DisplayName",
+        "CompanyName",
+        "PrimaryEmailAddr",
+        "PrimaryPhone",
+        "BillAddr",
+        "Balance",
+        "Active",
+        "Notes",
+    ],
+    "Item": [
+        "Id",
+        "Name",
+        "Sku",
+        "Description",
+        "UnitPrice",
+        "Type",
+        "Active",
+        "QtyOnHand",
+    ],
+    "Payment": [
+        "Id",
+        "CustomerRef",
+        "TotalAmt",
+        "TxnDate",
+        "Line",
+    ],
+    "Bill": [
+        "Id",
+        "VendorRef",
+        "DocNumber",
+        "TotalAmt",
+        "DueDate",
+        "TxnDate",
+        "Line",
+    ],
+}
+
+
+def _entity_field_line(content: str, entity: str) -> str:
+    """Return the bullet line that lists fields for ``entity``."""
+    pattern = re.compile(rf"^- {entity}: (.+)$", re.MULTILINE)
+    match = pattern.search(content)
+    if not match:
+        raise AssertionError(
+            f"SKILL.md is missing a queryable-fields bullet for {entity!r}. "
+            "Expected a line like `- Invoice: Id, SyncToken, ...`."
+        )
+    return match.group(1)
+
+
+@pytest.mark.parametrize(("entity", "fields"), list(_REQUIRED_QUERYABLE_FIELDS.items()))
+def test_skill_md_lists_required_queryable_fields(entity: str, fields: list[str]) -> None:
+    """Every entity in SKILL.md must list the fields the agent is expected to know about."""
+    content = SKILL_MD_PATH.read_text()
+    listed = _entity_field_line(content, entity)
+    missing = [f for f in fields if not re.search(rf"\b{re.escape(f)}\b", listed)]
+    assert not missing, (
+        f"SKILL.md's {entity} field list is missing: {missing}. "
+        f"Without these, the agent treats the data as 'not stored' and refuses to query for it. "
+        f"Current line: {listed}"
+    )
+
+
+def test_skill_md_invoice_lists_billemail() -> None:
+    """Regression test for issue #1131.
+
+    The agent answered 'QuickBooks does not store the recipient email on past
+    invoices' because BillEmail was not in SKILL.md. Pin it explicitly so
+    nobody accidentally drops it.
+    """
+    content = SKILL_MD_PATH.read_text()
+    invoice_line = _entity_field_line(content, "Invoice")
+    assert "BillEmail" in invoice_line, (
+        "Invoice queryable fields must include BillEmail (the recipient email "
+        "address recorded on a sent or unsent invoice). See issue #1131."
+    )
+
+
+def test_skill_md_documents_email_recovery_workflow() -> None:
+    """SKILL.md must describe how to recover a customer email before asking the user.
+
+    qb_send needs a recipient email. If SKILL.md does not document the
+    PrimaryEmailAddr -> Invoice.BillEmail fallback, the agent will either
+    interrupt the user for an email it could have looked up, or claim the
+    data is unavailable. See issue #1131.
+    """
+    content = SKILL_MD_PATH.read_text()
+    assert "Recovering a customer email" in content, (
+        "SKILL.md should include a 'Recovering a customer email' workflow under Common Workflows."
+    )
+    # The workflow must reference both the Customer-level and Invoice-level fallbacks
+    # so the agent knows where to look before asking.
+    assert "PrimaryEmailAddr" in content
+    assert "BillEmail" in content
+
+
+# --- #1403 guard tests --------------------------------------------------------
 
 def test_skill_md_has_finding_entity_section() -> None:
     """SKILL.md must carry a dedicated 'Finding a customer, invoice, or estimate' guard section."""

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -5,15 +5,22 @@ mechanism: tools for authenticated integrations are loaded on the schema
 from turn 1 (see ``create_ready_specialist_tools``).
 """
 
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from pydantic import BaseModel
 
+from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.messages import ToolCallRequest
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.agent.tools.registry import (
+    SubToolInfo,
     ToolContext,
     ToolRegistry,
     create_list_capabilities_tool,
+    default_registry,
     ensure_tool_modules_imported,
 )
 from backend.app.models import User
@@ -109,8 +116,6 @@ class TestAvailableSpecialistSummaries:
 
     @pytest.mark.asyncio()
     async def test_returns_all_specialists_when_deps_met(self) -> None:
-        from unittest.mock import MagicMock
-
         registry = _build_test_registry()
         ctx = ToolContext(
             user=User(id="1"),
@@ -211,16 +216,12 @@ class TestDefaultRegistryCoreSpecialistSplit:
     """The default registry correctly classifies built-in factories."""
 
     def test_core_factories(self) -> None:
-        from backend.app.agent.tools.registry import default_registry
-
         core = default_registry.core_factory_names
         assert "messaging" in core
         assert "workspace" in core
         assert "heartbeat" in core
 
     def test_specialist_factories(self) -> None:
-        from backend.app.agent.tools.registry import default_registry
-
         specialist = default_registry.specialist_factory_names
         assert "quickbooks" in specialist
         assert "calendar" in specialist
@@ -228,8 +229,6 @@ class TestDefaultRegistryCoreSpecialistSplit:
         assert "heartbeat" not in specialist
 
     def test_no_overlap(self) -> None:
-        from backend.app.agent.tools.registry import default_registry
-
         core = default_registry.core_factory_names
         specialist = default_registry.specialist_factory_names
         assert not core & specialist
@@ -240,8 +239,6 @@ class TestGetSpecialistFactoryForTool:
 
     def _reg_with_subtools(self) -> ToolRegistry:
         """Build a registry where specialist factories declare sub_tools."""
-        from backend.app.agent.tools.registry import SubToolInfo
-
         reg = ToolRegistry()
         reg.register(
             "estimate",
@@ -295,8 +292,6 @@ class TestListCapabilitiesTelemetry:
     async def test_logs_lookup_when_category_provided(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        import logging
-
         caplog.set_level(logging.INFO)
         summaries = {"estimate": "Generate estimates"}
         tool = create_list_capabilities_tool(summaries)
@@ -309,8 +304,6 @@ class TestListCapabilitiesTelemetry:
     async def test_does_not_log_when_category_is_none(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        import logging
-
         caplog.set_level(logging.INFO)
         summaries = {"estimate": "Generate estimates"}
         tool = create_list_capabilities_tool(summaries)
@@ -320,8 +313,6 @@ class TestListCapabilitiesTelemetry:
 
     @pytest.mark.asyncio
     async def test_logs_unknown_category_as_lookup(self, caplog: pytest.LogCaptureFixture) -> None:
-        import logging
-
         caplog.set_level(logging.INFO)
         summaries = {"estimate": "Generate estimates"}
         tool = create_list_capabilities_tool(summaries)
@@ -338,12 +329,6 @@ class TestSpecialistToolInvocationTelemetry:
     @pytest.mark.asyncio
     async def test_logs_specialist_tool_invocation(self) -> None:
         """When a specialist tool is executed, the logger fires with tool and category."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        from pydantic import BaseModel
-
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.tools.registry import SubToolInfo
 
         class _Params(BaseModel):
             pass
@@ -380,8 +365,6 @@ class TestSpecialistToolInvocationTelemetry:
             agent = ClawboltAgent(user=MagicMock(), registry=reg)
             agent.register_tools(tools)
             # Directly invoke _execute_single_tool to trigger the logging
-            from backend.app.agent.messages import ToolCallRequest
-
             tc_req = ToolCallRequest(id="call_1", name="test_tool", arguments={})
             validated_args = {}
             parsed_calls = [tc_req]
@@ -397,12 +380,6 @@ class TestSpecialistToolInvocationTelemetry:
     @pytest.mark.asyncio
     async def test_does_not_log_core_tool_invocation(self) -> None:
         """Core tools do not trigger the specialist telemetry log."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        from pydantic import BaseModel
-
-        from backend.app.agent.core import ClawboltAgent
-        from backend.app.agent.tools.registry import SubToolInfo
 
         class _Params(BaseModel):
             pass
@@ -431,8 +408,6 @@ class TestSpecialistToolInvocationTelemetry:
         )
         tools = await reg.create_core_tools(ctx)
         assert len(tools) == 1
-
-        from backend.app.agent.messages import ToolCallRequest
 
         tc_req = ToolCallRequest(id="call_1", name="core_tool", arguments={})
         validated_args = {}

--- a/tests/test_select_tools.py
+++ b/tests/test_select_tools.py
@@ -233,3 +233,214 @@ class TestDefaultRegistryCoreSpecialistSplit:
         core = default_registry.core_factory_names
         specialist = default_registry.specialist_factory_names
         assert not core & specialist
+
+
+class TestGetSpecialistFactoryForTool:
+    """get_specialist_factory_for_tool maps specialist tool names to their factory."""
+
+    def _reg_with_subtools(self) -> ToolRegistry:
+        """Build a registry where specialist factories declare sub_tools."""
+        from backend.app.agent.tools.registry import SubToolInfo
+
+        reg = ToolRegistry()
+        reg.register(
+            "estimate",
+            lambda ctx: [_make_tool("generate_estimate")],
+            core=False,
+            summary="Generate estimates",
+            sub_tools=[SubToolInfo("generate_estimate", "Generate estimates")],
+        )
+        reg.register(
+            "heartbeat",
+            lambda ctx: [_make_tool("get_heartbeat")],
+            core=False,
+            summary="Heartbeat",
+            sub_tools=[SubToolInfo("get_heartbeat", "Get heartbeat")],
+        )
+        reg.register(
+            "messaging",
+            lambda ctx: [_make_tool("send_media_reply")],
+            sub_tools=[SubToolInfo("send_media_reply", "Send reply")],
+        )
+        return reg
+
+    def test_returns_factory_name_for_specialist_tool(self) -> None:
+        registry = self._reg_with_subtools()
+        factory = registry.get_specialist_factory_for_tool("generate_estimate")
+        assert factory == "estimate"
+
+    def test_returns_none_for_core_tool(self) -> None:
+        registry = self._reg_with_subtools()
+        factory = registry.get_specialist_factory_for_tool("send_media_reply")
+        assert factory is None
+
+    def test_returns_none_for_unknown_tool(self) -> None:
+        registry = self._reg_with_subtools()
+        factory = registry.get_specialist_factory_for_tool("no_such_tool")
+        assert factory is None
+
+    def test_caches_after_first_lookup(self) -> None:
+        registry = self._reg_with_subtools()
+        factory1 = registry.get_specialist_factory_for_tool("generate_estimate")
+        assert factory1 == "estimate"
+        assert registry._specialist_tool_to_factory is not None
+        factory2 = registry.get_specialist_factory_for_tool("get_heartbeat")
+        assert factory2 == "heartbeat"
+
+
+class TestListCapabilitiesTelemetry:
+    """list_capabilities with a non-null category logs a structured event."""
+
+    @pytest.mark.asyncio
+    async def test_logs_lookup_when_category_provided(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        caplog.set_level(logging.INFO)
+        summaries = {"estimate": "Generate estimates"}
+        tool = create_list_capabilities_tool(summaries)
+        result = await tool.function(category="estimate")
+        assert not result.is_error
+        assert "list_capabilities_lookup" in caplog.text
+        assert "category=estimate" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_does_not_log_when_category_is_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        caplog.set_level(logging.INFO)
+        summaries = {"estimate": "Generate estimates"}
+        tool = create_list_capabilities_tool(summaries)
+        result = await tool.function(category=None)
+        assert not result.is_error
+        assert "list_capabilities_lookup" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_unknown_category_as_lookup(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        caplog.set_level(logging.INFO)
+        summaries = {"estimate": "Generate estimates"}
+        tool = create_list_capabilities_tool(summaries)
+        result = await tool.function(category="nonexistent")
+        assert result.is_error
+        # Even though the category is unknown, the lookup event should still fire
+        assert "list_capabilities_lookup" in caplog.text
+        assert "category=nonexistent" in caplog.text
+
+
+class TestSpecialistToolInvocationTelemetry:
+    """Specialist tool invocations log a structured event with the category."""
+
+    @pytest.mark.asyncio
+    async def test_logs_specialist_tool_invocation(self) -> None:
+        """When a specialist tool is executed, the logger fires with tool and category."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from pydantic import BaseModel
+
+        from backend.app.agent.core import ClawboltAgent
+        from backend.app.agent.tools.registry import SubToolInfo
+
+        class _Params(BaseModel):
+            pass
+
+        async def _tool_fn(**_: object) -> ToolResult:
+            return ToolResult(content="done")
+
+        reg = ToolRegistry()
+        reg.register(
+            "test_specialist",
+            lambda ctx: [
+                Tool(
+                    name="test_tool",
+                    description="test specialist tool",
+                    function=_tool_fn,
+                    params_model=_Params,
+                )
+            ],
+            core=False,
+            summary="Test specialist",
+            sub_tools=[SubToolInfo("test_tool", "Test tool")],
+        )
+
+        ctx = ToolContext(
+            user=MagicMock(),
+            storage=MagicMock(),
+            publish_outbound=AsyncMock(),
+        )
+        tools = await reg.create_ready_specialist_tools(ctx)
+        assert len(tools) == 1
+
+        # Patch the logger to verify the call, bypassing the full agent loop
+        with patch("backend.app.agent.core.logger") as mock_logger:
+            agent = ClawboltAgent(user=MagicMock(), registry=reg)
+            agent.register_tools(tools)
+            # Directly invoke _execute_single_tool to trigger the logging
+            from backend.app.agent.messages import ToolCallRequest
+
+            tc_req = ToolCallRequest(id="call_1", name="test_tool", arguments={})
+            validated_args = {}
+            parsed_calls = [tc_req]
+
+            await agent._execute_single_tool(0, tools[0], validated_args, parsed_calls)
+
+            mock_logger.info.assert_called_once()
+            args = mock_logger.info.call_args[0]
+            assert "specialist_tool_invocation" in args[0]
+            assert "test_tool" in str(args)
+            assert "test_specialist" in str(args)
+
+    @pytest.mark.asyncio
+    async def test_does_not_log_core_tool_invocation(self) -> None:
+        """Core tools do not trigger the specialist telemetry log."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from pydantic import BaseModel
+
+        from backend.app.agent.core import ClawboltAgent
+        from backend.app.agent.tools.registry import SubToolInfo
+
+        class _Params(BaseModel):
+            pass
+
+        async def _tool_fn(**_: object) -> ToolResult:
+            return ToolResult(content="done")
+
+        reg = ToolRegistry()
+        reg.register(
+            "core_factory",
+            lambda ctx: [
+                Tool(
+                    name="core_tool",
+                    description="core tool",
+                    function=_tool_fn,
+                    params_model=_Params,
+                )
+            ],
+            sub_tools=[SubToolInfo("core_tool", "Core tool")],
+        )
+
+        ctx = ToolContext(
+            user=MagicMock(),
+            storage=MagicMock(),
+            publish_outbound=AsyncMock(),
+        )
+        tools = await reg.create_core_tools(ctx)
+        assert len(tools) == 1
+
+        from backend.app.agent.messages import ToolCallRequest
+
+        tc_req = ToolCallRequest(id="call_1", name="core_tool", arguments={})
+        validated_args = {}
+        parsed_calls = [tc_req]
+
+        with patch("backend.app.agent.core.logger") as mock_logger:
+            agent = ClawboltAgent(user=MagicMock(), registry=reg)
+            agent.register_tools(tools)
+            await agent._execute_single_tool(0, tools[0], validated_args, parsed_calls)
+
+            mock_logger.info.assert_not_called()

--- a/tests/test_servicetitan_skill_md.py
+++ b/tests/test_servicetitan_skill_md.py
@@ -1,0 +1,54 @@
+"""Doc-lint tests for the ServiceTitan SKILL.md.
+
+Regression for the "claimed a customer or job does not exist without
+searching" bug (issue #1403): the agent told a user a customer or job was
+absent without calling ``st_search_customers`` first. ServiceTitan is
+read-only, so there is no duplicate-create risk, but the agent can still
+falsely tell the user an entity does not exist and fail to target
+``st_add_job_note``. The same bug class as the CompanyCam fix in #1402
+(project absence claimed without searching).
+
+These tests pin the guard so the guidance does not drift out of the file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL_MD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "backend"
+    / "app"
+    / "integrations"
+    / "servicetitan"
+    / "SKILL.md"
+)
+
+
+def test_skill_md_has_finding_customer_section() -> None:
+    """SKILL.md must carry a dedicated 'Finding a customer or job' guard section."""
+    content = SKILL_MD_PATH.read_text()
+    assert "## Finding a customer or job" in content, (
+        "SKILL.md should include a 'Finding a customer or job' section "
+        "instructing the agent to search before claiming a customer or job is "
+        "absent."
+    )
+
+
+def test_skill_md_requires_search_before_claiming_absence() -> None:
+    """The guard must tell the agent not to assert absence before searching.
+
+    Without this, the agent answers from its in-context customer cache: a name
+    it has not searched this session reads as 'does not exist', so it tells
+    the user there is no such customer and fails to add a job note.
+    """
+    content = SKILL_MD_PATH.read_text()
+    lowered = content.lower()
+    # The search tool the guard ties together.
+    assert "st_search_customers" in content
+    # The core framing: not-searched is not the same as not-existing.
+    assert "unknown, not absent" in lowered, (
+        "The guard should state that an unsearched customer or job is "
+        "'unknown, not absent' so the agent searches before claiming it does "
+        "not exist."
+    )


### PR DESCRIPTION
## Description

The agent claimed entities were absent without calling the search/query tool first, across all integrations. Same bug class as #1402 (CompanyCam) and #1131 (QuickBooks fields). Added a failure-mode guard section to each SKILL.md and a doc-lint regression test pinning the guard.

### Changes

- **QuickBooks**: added "Finding a customer, invoice, or estimate" guard; reinforced "New customer job" workflow to `qb_query` before `qb_create`
- **Calendar**: added "Finding an event" guard
- **ServiceTitan**: added "Finding a customer or job" guard
- **AppFolio Vendor**: added "Finding a work order" guard
- **Tests**: rewrote `test_quickbooks_skill_md.py` from field-listing tests to guard tests; created `test_calendar_skill_md.py`, `test_servicetitan_skill_md.py`, `test_appfolio_vendor_skill_md.py`

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] CI/CD
- [x] Documentation

## Checklist

- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage

- [x] AI-assisted (Claude investigated the captured conversation, identified the root cause, and drafted the SKILL.md guards and regression tests via back-and-forth with @njbrake)
- [ ] No AI used

Fixes #1403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a recurring agent-safety bug where integrations could claim entities were absent or offer to create them without first calling the integration-specific search/query tool. It adds explicit "failure-mode" guard guidance to SKILL.md for QuickBooks, Calendar, ServiceTitan, and AppFolio Vendor, updates workflows to query before create where needed, and pins those guards with new doc-lint tests. Additionally, it adds telemetry around tool listing/specialist invocation and improves related test organization.

### What changed (high-level)
- Added "Finding ..." guard sections to SKILL.md for:
  - QuickBooks: "Finding a customer, invoice, or estimate" (and changed the "New customer job" workflow to query before creating)
  - Calendar: "Finding an event"
  - ServiceTitan: "Finding a customer or job"
  - AppFolio Vendor: "Finding a work order"
- New/updated tests:
  - Rewrote QuickBooks SKILL.md tests to check for both field-list and absence-claim guards
  - Added doc-lint tests for Calendar, ServiceTitan, and AppFolio Vendor SKILL.md
  - Expanded tests around tool registry/telemetry and consolidated imports in test_select_tools.py
- Telemetry and registry changes:
  - ToolRegistry: added get_specialist_factory_for_tool(tool_name) and reverse lookup caching
  - list_capabilities now emits telemetry when called with a category
  - Agent tool execution emits specialist invocation telemetry when applicable

### Technical details (brief)
- SKILL.md updates: added guard wording that unsearched entities are "unknown, not absent," require the integration-specific search tool to return no matches before claiming absence or creating duplicates, and allow reusing IDs already resolved in-session.
- Tests: new pytest modules validate presence and exact phrasing of the guards; QuickBooks tests were expanded to preserve field-listing checks alongside the new absence-claim guards.
- Agent/registry: ClawboltAgent now conditionally logs structured telemetry for specialist tool invocations; ToolRegistry provides a cached reverse map from sub-tool to specialist factory to support that telemetry.

### Benefits
- Safety: Prevents incorrect user-facing assertions and duplicate-creation bugs by enforcing search-before-claim rules.
- Observability: Adds telemetry to monitor tool discovery and specialist tool usage.
- Reliability: Doc-lint tests lock in guard text to prevent regressions.
- Maintainability: Consolidated tests and preserved field-list coverage keep both bug classes tested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🤖 Generated by DeepSeek V4 Flash running on [ds4](https://github.com/antirez/ds4)