### PR TITLE
feat: add QuickBooks Item entity support to qb_create and qb_update

### DIFF
--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -7,8 +7,8 @@ You now have access to QuickBooks Online tools. Here is how to use them effectiv
 | Tool | Purpose |
 |------|---------|
 | `qb_query` | Run read-only queries using QBO query language |
-| `qb_create` | Create a Customer, Estimate, or Invoice |
-| `qb_update` | Update an existing Customer, Estimate, or Invoice |
+| `qb_create` | Create a Customer, Estimate, Invoice, or Item |
+| `qb_update` | Update an existing Customer, Estimate, Invoice, or Item |
 | `qb_send` | Email an invoice or estimate to a customer |
 
 ## Query Guide (qb_query)
@@ -44,7 +44,7 @@ An ID you already resolved this session can be reused without re-querying.
 
 ## Creating Entities (qb_create)
 
-Pass `entity_type` (Customer, Estimate, or Invoice) and `data` (the QBO API payload).
+Pass `entity_type` (Customer, Estimate, Invoice, or Item) and `data` (the QBO API payload).
 
 ### Customer payload
 
@@ -92,6 +92,38 @@ Optional fields:
 - `CustomerMemo`: `{"value": "notes text"}`
 - `TxnDate`: "YYYY-MM-DD" (defaults to today)
 - `LinkedTxn`: array of linked transactions (used when converting an estimate)
+
+### Item payload
+
+Required fields:
+- `Name` (string, must be unique in QB)
+- `Type` (string): "Inventory", "Service", or "OtherCharge"
+
+Optional fields:
+- `Description`: string
+- `UnitPrice`: number
+- `IncomeAccountRef`: `{"value": "<account_id>", "name": "<account_name>"}`
+- `Active`: boolean (defaults to true)
+- `Sku`: string (stock-keeping unit code)
+- `ParentRef`: `{"value": "<parent_item_id>"}`
+- `PurchaseDesc`: string
+- `PurchaseCost`: number
+- `QtyOnHand`: number (for Inventory items)
+
+Example:
+```json
+{
+  "entity_type": "Item",
+  "data": {
+    "Name": "Materials",
+    "Type": "Service",
+    "IncomeAccountRef": {
+      "value": "1",
+      "name": "Services"
+    }
+  }
+}
+```
 
 ### Line item format
 

--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -68,10 +68,10 @@ _ENTITY_LABELS: dict[str, str] = {
 }
 
 # Entity types that qb_create is allowed to create.
-_CREATABLE_ENTITIES = {"Customer", "Estimate", "Invoice"}
+_CREATABLE_ENTITIES = {"Customer", "Estimate", "Invoice", "Item"}
 
 # Entity types that qb_update is allowed to update.
-_UPDATABLE_ENTITIES = {"Customer", "Estimate", "Invoice"}
+_UPDATABLE_ENTITIES = {"Customer", "Estimate", "Invoice", "Item"}
 
 # Entity types that qb_send is allowed to send via email.
 _SENDABLE_ENTITIES = {"Invoice", "Estimate"}
@@ -189,7 +189,7 @@ class QBCreateParams(BaseModel):
     """Parameters for the qb_create tool."""
 
     entity_type: str = Field(
-        description="QBO entity type to create: Customer, Estimate, or Invoice"
+        description="QBO entity type to create: Customer, Estimate, Invoice, or Item"
     )
     data: dict[str, Any] = Field(
         description=(
@@ -204,7 +204,7 @@ class QBUpdateParams(BaseModel):
     """Parameters for the qb_update tool."""
 
     entity_type: str = Field(
-        description="QBO entity type to update: Customer, Estimate, or Invoice"
+        description="QBO entity type to update: Customer, Estimate, Invoice, or Item"
     )
     data: dict[str, Any] = Field(
         description=(
@@ -477,6 +477,9 @@ def _receipt_target(entity_type: str, result: dict[str, Any]) -> str:
         return ", ".join(bits)
     if entity_type == "Customer":
         return name or f"ID {entity_id}"
+    if entity_type == "Item":
+        item_name = result.get("Name") or ""
+        return item_name or f"ID {entity_id}"
     return name or doc_num or f"ID {entity_id}"
 
 
@@ -566,6 +569,7 @@ def create_quickbooks_tools(
         doc_num = result.get("DocNumber", "")
         total = result.get("TotalAmt")
         display_name = result.get("DisplayName", "")
+        item_name = result.get("Name", "")
 
         # LLM-facing content stays terse and data-only so the model has no
         # receipt-shaped phrasing to bullet-point back to the user. The
@@ -578,6 +582,8 @@ def create_quickbooks_tools(
             parts.append(f"Total: ${total:.2f}")
         if display_name:
             parts.append(f"Name: {display_name}")
+        if not display_name and item_name:
+            parts.append(f"Name: {item_name}")
 
         return ToolResult(
             content=" | ".join(parts),
@@ -616,6 +622,7 @@ def create_quickbooks_tools(
         doc_num = result.get("DocNumber", "")
         total = result.get("TotalAmt")
         display_name = result.get("DisplayName", "")
+        item_name = result.get("Name", "")
 
         parts = ["ok", f"Id: {entity_id}"]
         if doc_num:
@@ -624,6 +631,8 @@ def create_quickbooks_tools(
             parts.append(f"Total: ${total:.2f}")
         if display_name:
             parts.append(f"Name: {display_name}")
+        if not display_name and item_name:
+            parts.append(f"Name: {item_name}")
 
         return ToolResult(
             content=" | ".join(parts),
@@ -697,13 +706,13 @@ def create_quickbooks_tools(
             name=ToolName.QB_CREATE,
             description=(
                 "Create an entity in QuickBooks Online. Pass the entity type "
-                "(Customer, Estimate, or Invoice) and the QBO API payload. "
+                "(Customer, Estimate, Invoice, or Item) and the QBO API payload. "
                 "See the QuickBooks skill for payload formats and examples."
             ),
             function=qb_create,
             params_model=QBCreateParams,
             usage_hint=(
-                "Create a Customer, Estimate, or Invoice in QB. "
+                "Create a Customer, Estimate, Invoice, or Item in QB. "
                 "Construct the QBO API payload as described in the skill docs."
             ),
             approval_policy=ApprovalPolicy(
@@ -718,14 +727,14 @@ def create_quickbooks_tools(
             name=ToolName.QB_UPDATE,
             description=(
                 "Update an existing entity in QuickBooks Online. Pass the entity type "
-                "(Customer, Estimate, or Invoice) and the full QBO API payload "
+                "(Customer, Estimate, Invoice, or Item) and the full QBO API payload "
                 "including Id and SyncToken from a prior qb_query. "
                 "See the QuickBooks skill for payload formats."
             ),
             function=qb_update,
             params_model=QBUpdateParams,
             usage_hint=(
-                "Update a Customer, Estimate, or Invoice in QB. "
+                "Update a Customer, Estimate, Invoice, or Item in QB. "
                 "Payload must include Id and SyncToken from a prior query."
             ),
             approval_policy=ApprovalPolicy(

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -38,6 +38,8 @@ class FakeQBService(QuickBooksService):
         }
         if entity_type == "Customer":
             result["DisplayName"] = data.get("DisplayName", "")
+        elif entity_type == "Item":
+            result["Name"] = data.get("Name", "")
         else:
             result["DocNumber"] = f"10{self._next_id}"
             result["TotalAmt"] = sum(line.get("Amount", 0) for line in data.get("Line", []))
@@ -48,6 +50,8 @@ class FakeQBService(QuickBooksService):
         result: dict[str, Any] = {**data}
         if entity_type == "Customer":
             result["DisplayName"] = data.get("DisplayName", "")
+        elif entity_type == "Item":
+            result["Name"] = data.get("Name", "")
         else:
             result["DocNumber"] = data.get("DocNumber", "")
             result["TotalAmt"] = sum(line.get("Amount", 0) for line in data.get("Line", []))
@@ -227,6 +231,63 @@ async def test_qb_create_invoice_with_linked_estimate() -> None:
 
 
 # ---------------------------------------------------------------------------
+# qb_create - Item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_qb_create_item() -> None:
+    """Create a service Item in QuickBooks."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_create")
+
+    result = await fn(
+        entity_type="Item",
+        data={
+            "Name": "Materials",
+            "Type": "Service",
+            "IncomeAccountRef": {"value": "1", "name": "Services"},
+        },
+    )
+
+    assert result.is_error is False
+    assert result.content.startswith("ok")
+    assert "Name: Materials" in result.content
+    assert len(svc.created) == 1
+    entity_type, body = svc.created[0]
+    assert entity_type == "Item"
+    assert body["Name"] == "Materials"
+    assert body["Type"] == "Service"
+    assert body["IncomeAccountRef"]["value"] == "1"
+
+
+@pytest.mark.asyncio()
+async def test_qb_create_item_inventory() -> None:
+    """Create an inventory Item with QtyOnHand."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_create")
+
+    result = await fn(
+        entity_type="Item",
+        data={
+            "Name": "Drywall Sheet 4x8",
+            "Type": "Inventory",
+            "UnitPrice": 12.50,
+            "QtyOnHand": 100,
+            "IncomeAccountRef": {"value": "1", "name": "Services"},
+        },
+    )
+
+    assert result.is_error is False
+    assert result.content.startswith("ok")
+    assert "Name: Drywall Sheet 4x8" in result.content
+    _, body = svc.created[0]
+    assert body["QtyOnHand"] == 100
+
+
+# ---------------------------------------------------------------------------
 # qb_create - validation
 # ---------------------------------------------------------------------------
 
@@ -321,6 +382,40 @@ async def test_qb_update_customer() -> None:
     assert "Name: John Smith" in result.content
     _, body = svc.updated[0]
     assert body["PrimaryPhone"]["FreeFormNumber"] == "555-9999"
+
+
+# ---------------------------------------------------------------------------
+# qb_update - Item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_qb_update_item() -> None:
+    """Update an Item's name and price."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    fn = _get_tool(tools, "qb_update")
+
+    result = await fn(
+        entity_type="Item",
+        data={
+            "Id": "1",
+            "SyncToken": "0",
+            "Name": "Materials (updated)",
+            "Type": "Service",
+            "IncomeAccountRef": {"value": "1", "name": "Services"},
+        },
+    )
+
+    assert result.is_error is False
+    assert result.content.startswith("ok")
+    assert "Id: 1" in result.content
+    assert "Name: Materials (updated)" in result.content
+    assert len(svc.updated) == 1
+    entity_type, body = svc.updated[0]
+    assert entity_type == "Item"
+    assert body["Name"] == "Materials (updated)"
+    assert body["SyncToken"] == "0"
 
 
 @pytest.mark.asyncio()
@@ -653,6 +748,8 @@ class FakeQBOServiceWithURL(QuickBooksOnlineService):
         result: dict[str, Any] = {"Id": str(self._next_id), **data}
         if entity_type == "Customer":
             result["DisplayName"] = data.get("DisplayName", "")
+        elif entity_type == "Item":
+            result["Name"] = data.get("Name", "")
         else:
             result["DocNumber"] = f"10{self._next_id}"
             result["TotalAmt"] = sum(line.get("Amount", 0) for line in data.get("Line", []))
@@ -662,6 +759,8 @@ class FakeQBOServiceWithURL(QuickBooksOnlineService):
         result: dict[str, Any] = {**data}
         if entity_type == "Customer":
             result["DisplayName"] = data.get("DisplayName", "")
+        elif entity_type == "Item":
+            result["Name"] = data.get("Name", "")
         else:
             result["DocNumber"] = data.get("DocNumber", "10000")
             result["TotalAmt"] = sum(line.get("Amount", 0) for line in data.get("Line", []))
@@ -809,6 +908,26 @@ def test_qb_create_approval_description_customer_keeps_short_form() -> None:
     assert description == "Create Customer in QuickBooks"
 
 
+def test_qb_create_approval_description_item_keeps_short_form() -> None:
+    """Item payloads have no Line array; the prompt must stay the
+    legacy short form."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_create")
+
+    description = builder(
+        {
+            "entity_type": "Item",
+            "data": {
+                "Name": "Materials",
+                "Type": "Service",
+                "IncomeAccountRef": {"value": "1", "name": "Services"},
+            },
+        }
+    )
+    assert description == "Create Item in QuickBooks"
+
+
 def test_qb_create_approval_description_falls_back_without_sales_item_detail() -> None:
     """A line missing SalesItemLineDetail still renders, using Amount alone."""
     svc = FakeQBService()
@@ -937,6 +1056,27 @@ def test_qb_update_approval_description_customer_short_form_includes_id() -> Non
         }
     )
     assert description == "Update Customer #100 in QuickBooks"
+
+
+def test_qb_update_approval_description_item_short_form_includes_id() -> None:
+    """For non-itemized entity types (Item), the qb_update short
+    form should still reference the Id being updated."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    builder = _get_description_builder(tools, "qb_update")
+
+    description = builder(
+        {
+            "entity_type": "Item",
+            "data": {
+                "Id": "1",
+                "SyncToken": "0",
+                "Name": "Materials",
+                "Type": "Service",
+            },
+        }
+    )
+    assert description == "Update Item #1 in QuickBooks"
 
 
 def test_qb_create_approval_description_uses_thousands_separator() -> None:


### PR DESCRIPTION
## Description

Add support for creating and updating QuickBooks Online 'Item' entities (service items, inventory items, etc.) in the qb_create and qb_update tools. Previously only Customer, Estimate, and Invoice were allowed.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (implemented by DeepSeek V4 Flash)
- [ ] No AI used

Fixes #1412

🤖 Generated by DeepSeek V4 Flash running on [ds4](https://github.com/antirez/ds4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request adds support for QuickBooks "Item" entities to the qb_create and qb_update tools, extending their capabilities beyond the previously supported Customer, Estimate, and Invoice entities. The change resolves issue `#1412` and enables users to create and update service items, inventory items, and other item types through the QuickBooks integration.

## What Changed

**Documentation (SKILL.md)**
- Added Item to the list of supported entity types in qb_create and qb_update tool documentation
- Included a new "Item payload" section with required and optional fields, field descriptions, and example JSON payloads

**Core Functionality (factory.py)**
- Extended qb_create and qb_update to allow "Item" as a valid entity_type
- Updated tool descriptions and usage hints to reflect Item support
- Improved result display by using the Item's "Name" field when "DisplayName" is not available
- Updated parameter descriptions for QBCreateParams and QBUpdateParams to indicate Item support

**Test Coverage (test_quickbooks_write.py)**
- Added comprehensive tests for Item creation (service items and inventory items with quantity tracking)
- Added tests for Item updates (renaming and field updates)
- Verified approval prompt descriptions work correctly with Item entities
- Extended fake QuickBooks services to properly handle Item entity operations

## Benefits

- Users can now create and update QuickBooks Items through the tools, filling a functional gap
- Improved flexibility for inventory and service management workflows in QuickBooks
- Clear documentation and test coverage ensure reliable Item operation support
- Consistent behavior with existing entity types in error handling and result formatting

## Technical Details

The implementation extends the existing entity creation/update flow by:
- Adding "Item" to allowed entity sets in both qb_create and qb_update functions
- Modifying the _receipt_target logic to extract and display the "Name" field for Items (which use "Name" instead of "DisplayName")
- Updating Pydantic field descriptions to reflect the new entity_type option
- Ensuring the approval prompts and result formatting work appropriately for Item entities with their specific field structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->