### PR TITLE
build: add html-to-image dependency for snippet image export

### DIFF
--- a/frontend/knip.config.ts
+++ b/frontend/knip.config.ts
@@ -14,6 +14,7 @@ const config: KnipConfig = {
     'tailwind-merge', // Peer dep of tailwind-variants (HeroUI)
     'remark-gfm', // Imported by premium's DocsPage overlay, not OSS
     'rehype-highlight', // Imported by premium's DocsPage overlay, not OSS
+    'html-to-image', // Imported by premium's share-snippet overlay, not OSS
     'esbuild', // Used by scripts/gen-tokens.mjs; provided transitively by vite
   ],
   vite: { config: ['vite.config.ts'] },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@tailwindcss/vite": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
         "framer-motion": "^12.35.2",
+        "html-to-image": "^1.11.13",
         "openapi-fetch": "^0.17.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
@@ -7271,6 +7272,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/vite": "^4.2.0",
     "@tanstack/react-query": "^5.90.21",
     "framer-motion": "^12.35.2",
+    "html-to-image": "^1.11.13",
     "openapi-fetch": "^0.17.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds the `html-to-image` dependency to the frontend so the premium admin layer can export a PNG of a conversation snippet.

Premium's admin activity feed is gaining a Share snippet dialog (mozilla-ai/clawbolt-premium#607) that lets an admin highlight conversation rows and either copy them as text or download a PNG of the panel (useful when a long transcript is hard to screenshot). The DOM-to-image rasterization uses `html-to-image`. Because the premium frontend overlays this repo and builds from its `node_modules`, the runtime dependency has to live here; the premium overlay imports it.

This is a build-only change: no OSS code imports `html-to-image`, so OSS behavior is unchanged. The companion premium PR pins `OSS_REF` to the commit that includes this dependency.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (no backend change; `npm ci` resolves the locked tree)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) (no backend change)
- [ ] New tests added for new functionality (n/a, dependency add)
- [ ] Bug fixes include regression tests (n/a)

## AI Usage
- [x] AI-assisted (Claude added the dependency and authored this PR)
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Added a new frontend build dependency, html-to-image, and told Knip to ignore it. These are the only modifications in this PR.

## Benefits

Enables the premium admin UI to export conversation snippets as PNGs (used by the Share snippet dialog), so admins can download highlighted conversation panels as images in addition to copying text. No runtime change for OSS consumers—this is to support the premium overlay build.

## Technical details

- frontend/package.json: added dependency html-to-image@^1.11.13
- frontend/knip.config.ts: added html-to-image to Knip's ignoreDependencies with a note that it's imported by the premium overlay
- Tests and lint pass; no backend changes and no OSS code imports html-to-image
- Companion premium PR pins OSS_REF to this commit so the premium build includes the new dependency

## Potential follow-ups

- Consider documenting the dependency in the premium overlay README to make the cross-repo dependency explicit.
- Periodically review knip ignores to ensure they remain accurate and minimal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->