### PR TITLE
fix: emit dynamic system content after history to keep the message-history cache

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -60,7 +60,10 @@ from backend.app.agent.observer import (
     emit_llm_request,
     emit_llm_response,
 )
-from backend.app.agent.system_prompt import build_agent_system_prompt, build_time_user_context
+from backend.app.agent.system_prompt import (
+    build_agent_system_prompt_parts,
+    build_time_user_context,
+)
 from backend.app.agent.tool_errors import (
     _DEFAULT_ERROR_HINT,
     _ERROR_KIND_HINTS,
@@ -80,6 +83,7 @@ from backend.app.config import settings
 from backend.app.logging_utils import mask_pii
 from backend.app.models import User
 from backend.app.services.llm_service import (
+    apply_history_cache_breakpoint,
     apply_tool_caching,
     prepare_system_with_caching,
     reasoning_effort_to_thinking,
@@ -397,9 +401,14 @@ class ClawboltAgent:
             )
         self._prev_tool_names = current
 
-    async def _build_system_prompt(self, message_context: str) -> str:
-        """Build the full system prompt via the composable builder."""
-        return await build_agent_system_prompt(
+    async def _build_system_prompt(self, message_context: str) -> tuple[str, str]:
+        """Build the system prompt as ``(stable, dynamic)`` halves.
+
+        *stable* goes in the cacheable ``system`` param; *dynamic* (memory,
+        integrations, cross-session context) is appended to the current
+        user turn so it does not invalidate the history cache (#1420).
+        """
+        return await build_agent_system_prompt_parts(
             self.user,
             self.tools,
             message_context,
@@ -478,6 +487,7 @@ class ClawboltAgent:
         await self._send_typing_indicator()
         effective_max_tokens = max_tokens or settings.llm_max_tokens_agent
         system_str, msg_dicts = messages_to_messages_api(messages)
+        msg_dicts = apply_history_cache_breakpoint(msg_dicts)
         system: str | list[dict[str, Any]] | None = system_str
         if system is not None:
             system = prepare_system_with_caching(system)
@@ -560,6 +570,7 @@ class ClawboltAgent:
                     len(trim_result.messages),
                 )
                 retry_system_str, trimmed_dicts = messages_to_messages_api(trim_result.messages)
+                trimmed_dicts = apply_history_cache_breakpoint(trimmed_dicts)
                 system = (
                     prepare_system_with_caching(retry_system_str)
                     if retry_system_str is not None
@@ -1097,7 +1108,22 @@ class ClawboltAgent:
             len(message_context),
             len(conversation_history) if conversation_history else 0,
         )
-        system_prompt = system_prompt_override or await self._build_system_prompt(message_context)
+        # The system prompt splits into a stable half (cacheable, sent in
+        # the ``system`` param) and a dynamic half (memory, integrations,
+        # cross-session context). The dynamic half is appended to the
+        # current user turn rather than the system param so a memory write
+        # does not invalidate the message-history cache (#1420). An
+        # override (e.g. onboarding) is treated as fully stable.
+        if system_prompt_override is not None:
+            stable_system, dynamic_context = system_prompt_override, ""
+        else:
+            stable_system, dynamic_context = await self._build_system_prompt(message_context)
+        # The full assembled prompt for observers / debugging. The dynamic
+        # half physically ships on the user turn now, but this field still
+        # reflects everything the model was given as instruction context.
+        system_prompt = (
+            f"{stable_system}\n\n{dynamic_context}" if dynamic_context else stable_system
+        )
         await self._emit(
             AgentStartEvent(
                 user_id=self.user.id,
@@ -1105,13 +1131,20 @@ class ClawboltAgent:
             )
         )
 
-        messages: list[AgentMessage] = [SystemMessage(content=system_prompt)]
+        messages: list[AgentMessage] = [SystemMessage(content=stable_system)]
 
         if conversation_history:
             messages.extend(conversation_history)
 
         time_context = build_time_user_context(self.user)
-        messages.append(UserMessage(content=f"{time_context}\n\n{message_context}"))
+        # Order: time context, then dynamic context (memory, integrations,
+        # cross-session), then the user's actual message last so the model
+        # reads the ask after its context, mirroring how time is prepended.
+        current_turn_parts = [time_context]
+        if dynamic_context:
+            current_turn_parts.append(dynamic_context)
+        current_turn_parts.append(message_context)
+        messages.append(UserMessage(content="\n\n".join(current_turn_parts)))
 
         # Trim oldest conversation history if content exceeds the limit.
         # Uses the block-based trimmer which preserves tool-call/result pairing

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -31,9 +31,11 @@ class SystemPromptBuilder:
 
     Sections may be marked ``dynamic=True`` to indicate their content
     changes between calls (e.g. memory, cross-session context).
-    ``build()`` uses this flag to split the prompt into a cacheable
-    stable prefix and a non-cached dynamic suffix so that Anthropic
-    prompt caching can reuse the stable prefix across turns.
+    ``build_parts()`` uses this flag to separate the cacheable stable
+    sections from the dynamic ones. The agent loop sends the stable half
+    in the ``system`` param (cacheable) and emits the dynamic half after
+    the message history so a memory write no longer invalidates the
+    history cache (see #1420).
     """
 
     def __init__(self) -> None:
@@ -61,31 +63,46 @@ class SystemPromptBuilder:
         self._sections.append((heading, content, dynamic))
         return self
 
-    # Marker inserted between stable and dynamic sections so the caching
-    # layer can split the prompt into a cacheable prefix and a dynamic suffix.
-    CACHE_BOUNDARY = "\n<!-- CACHE_BOUNDARY -->\n"
+    def build_parts(self) -> tuple[str, str]:
+        """Return the ``(stable, dynamic)`` halves of the prompt.
 
-    def build(self) -> str:
-        """Assemble all sections into the final prompt string.
+        *stable* is the preamble plus every non-dynamic section, joined
+        with blank lines. It is byte-stable across turns and is sent in
+        the cacheable ``system`` param.
 
-        A ``CACHE_BOUNDARY`` marker is inserted before the first dynamic
-        section so ``prepare_system_with_caching()`` can split the prompt
-        into a cacheable stable prefix and a non-cached dynamic suffix.
+        *dynamic* is every section marked ``dynamic=True`` (memory,
+        integration status, cross-session context). It changes between
+        turns and is emitted outside the ``system`` param by the agent
+        loop so it does not gate the message-history cache.
+
+        Section order within each half is preserved.
         """
-        parts: list[str] = []
+        stable_parts: list[str] = []
+        dynamic_parts: list[str] = []
         if self._preamble:
-            parts.append(self._preamble)
+            stable_parts.append(self._preamble)
 
-        hit_dynamic = False
         for heading, content, dynamic in self._sections:
             if not content:
                 continue
-            if dynamic and not hit_dynamic:
-                hit_dynamic = True
-                parts.append(self.CACHE_BOUNDARY.strip())
-            parts.append(f"## {heading}\n{content}")
+            target = dynamic_parts if dynamic else stable_parts
+            target.append(f"## {heading}\n{content}")
 
-        return "\n\n".join(parts)
+        return "\n\n".join(stable_parts), "\n\n".join(dynamic_parts)
+
+    def build(self) -> str:
+        """Assemble all sections into a single prompt string.
+
+        Stable sections come first, then dynamic ones. Used by callers
+        that want the full prompt as one string (e.g. the system-prompt
+        preview endpoint and prompts with no dynamic sections). The agent
+        loop uses :meth:`build_parts` instead so it can place the dynamic
+        half after the history.
+        """
+        stable, dynamic = self.build_parts()
+        if stable and dynamic:
+            return f"{stable}\n\n{dynamic}"
+        return stable or dynamic
 
 
 # -----------------------------------------------------------------------
@@ -328,13 +345,18 @@ async def build_cross_session_context(
 # -----------------------------------------------------------------------
 
 
-async def build_agent_system_prompt(
+async def _build_agent_prompt_builder(
     user: User,
     tools: list[Tool],
     message_context: str,
     current_session_id: str = "",
-) -> str:
-    """Assemble the full system prompt for the main agent loop."""
+) -> SystemPromptBuilder:
+    """Assemble the composable builder for the main agent loop.
+
+    Shared by :func:`build_agent_system_prompt` (full string, used by the
+    preview endpoint) and :func:`build_agent_system_prompt_parts` (stable
+    and dynamic halves, used by the agent loop).
+    """
     builder = SystemPromptBuilder()
     builder.set_preamble("You are an AI assistant for solo tradespeople.")
 
@@ -373,7 +395,40 @@ async def build_agent_system_prompt(
         if cross:
             builder.add_section("Recent Activity (other channel)", cross, dynamic=True)
 
+    return builder
+
+
+async def build_agent_system_prompt(
+    user: User,
+    tools: list[Tool],
+    message_context: str,
+    current_session_id: str = "",
+) -> str:
+    """Assemble the full system prompt for the main agent loop.
+
+    Returns the stable and dynamic sections as one string. Used by the
+    system-prompt preview endpoint; the agent loop uses
+    :func:`build_agent_system_prompt_parts` instead.
+    """
+    builder = await _build_agent_prompt_builder(user, tools, message_context, current_session_id)
     return builder.build()
+
+
+async def build_agent_system_prompt_parts(
+    user: User,
+    tools: list[Tool],
+    message_context: str,
+    current_session_id: str = "",
+) -> tuple[str, str]:
+    """Assemble the agent system prompt as ``(stable, dynamic)`` halves.
+
+    The agent loop sends *stable* in the cacheable ``system`` param and
+    appends *dynamic* (memory, integration status, cross-session context)
+    to the current user turn, so a memory write does not invalidate the
+    message-history prompt cache (#1420).
+    """
+    builder = await _build_agent_prompt_builder(user, tools, message_context, current_session_id)
+    return builder.build_parts()
 
 
 async def build_heartbeat_system_prompt(

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -108,9 +108,6 @@ async def resolve_user_llm_override(user_id: str) -> tuple[str, str] | None:
 # ---------------------------------------------------------------------------
 
 
-_CACHE_BOUNDARY = "<!-- CACHE_BOUNDARY -->"
-
-
 def _cache_control() -> dict[str, Any]:
     """Build the ``cache_control`` block honoring the extended-TTL flag.
 
@@ -126,27 +123,68 @@ def _cache_control() -> dict[str, Any]:
 
 
 def prepare_system_with_caching(system: str) -> list[dict[str, Any]]:
-    """Wrap a system prompt string as content blocks with cache_control.
+    """Wrap a system prompt string as a single cache-marked content block.
 
-    If the prompt contains a ``<!-- CACHE_BOUNDARY -->`` marker (inserted
-    by ``SystemPromptBuilder``), the text before the marker is cached and
-    the text after it is sent without caching.  This allows the stable
-    prefix (identity, instructions) to be reused across turns even when
-    dynamic sections (memory, cross-session context) change.
+    The whole system string is stable across turns: the agent loop now
+    emits dynamic content (memory, cross-session context) after the
+    message history rather than in the ``system`` param, so there is no
+    dynamic suffix to exclude from the cache (#1420).
 
     Providers that do not support caching silently ignore the
     ``cache_control`` key.
     """
-    if _CACHE_BOUNDARY in system:
-        stable, dynamic = system.split(_CACHE_BOUNDARY, 1)
-        blocks: list[dict[str, Any]] = [
-            {"type": "text", "text": stable.strip(), "cache_control": _cache_control()},
-        ]
-        dynamic = dynamic.strip()
-        if dynamic:
-            blocks.append({"type": "text", "text": dynamic})
-        return blocks
     return [{"type": "text", "text": system, "cache_control": _cache_control()}]
+
+
+def apply_history_cache_breakpoint(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Stamp a ``cache_control`` breakpoint on the prior-history tail.
+
+    Anthropic caches the prefix up to and including a marked block, so
+    marking the last message of the prior conversation history makes that
+    history independently cacheable rather than depending on automatic
+    prefix caching (which the old dynamic ``system`` suffix broke on every
+    memory write, #1420).
+
+    The breakpoint lands on the message immediately before the current
+    inbound user turn. The current turn carries volatile content (the
+    injected current time and dynamic context) and changes every turn, so
+    a breakpoint there would never be read back. The prior history reloads
+    byte-identical next turn, so the breakpoint advances forward as the
+    conversation grows (the standard rotation).
+
+    The current inbound turn is the last ``user``-role message whose
+    content is a plain string; tool-result turns carry list content and
+    assistant turns carry block content, so this reliably distinguishes
+    it. Returns the list unchanged when there is no prior history to
+    cache.
+    """
+    current_turn_idx: int | None = None
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
+        if msg.get("role") == "user" and isinstance(msg.get("content"), str):
+            current_turn_idx = idx
+            break
+
+    if current_turn_idx is None or current_turn_idx == 0:
+        return messages
+
+    anchor = messages[current_turn_idx - 1]
+    content = anchor.get("content")
+    if isinstance(content, str):
+        blocks: list[dict[str, Any]] = [
+            {"type": "text", "text": content, "cache_control": _cache_control()}
+        ]
+    elif isinstance(content, list) and content:
+        blocks = [dict(block) for block in content]
+        blocks[-1] = {**blocks[-1], "cache_control": _cache_control()}
+    else:
+        # Empty or unexpected content shape: nothing safe to mark.
+        return messages
+
+    messages[current_turn_idx - 1] = {**anchor, "content": blocks}
+    return messages
 
 
 def apply_tool_caching(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -166,7 +166,8 @@ async def test_agent_system_prompt_includes_soul(mock_amessages: object, test_us
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
 async def test_system_prompt_includes_tool_hints(mock_amessages: object, test_user: User) -> None:
-    """System prompt should include usage hints from registered tools."""
+    """Tool usage hints are dynamic, so they ride on the current user turn,
+    not the cacheable system param (#1420)."""
     mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
 
     async def dummy(**kwargs: object) -> ToolResult:
@@ -194,10 +195,12 @@ async def test_system_prompt_includes_tool_hints(mock_amessages: object, test_us
     await agent.process_message("Hello")
 
     call_args = mock_amessages.call_args  # type: ignore[union-attr]
-    system_prompt = extract_system_text(call_args.kwargs["system"])
-    assert "Tool Guidelines" in system_prompt
-    assert "When you learn new info, save it." in system_prompt
-    assert "Search memory for relevant information." in system_prompt
+    current_turn = call_args.kwargs["messages"][-1]["content"]
+    assert "Tool Guidelines" in current_turn
+    assert "When you learn new info, save it." in current_turn
+    assert "Search memory for relevant information." in current_turn
+    # Dynamic hints must stay out of the cacheable system param.
+    assert "Tool Guidelines" not in extract_system_text(call_args.kwargs["system"])
 
 
 @pytest.mark.asyncio()
@@ -222,7 +225,7 @@ async def test_system_prompt_omits_tool_section_when_no_hints(
 async def test_system_prompt_skips_tools_without_hints(
     mock_amessages: object, test_user: User
 ) -> None:
-    """Tools with empty usage_hint should not appear in the system prompt."""
+    """Tools with empty usage_hint should not appear in the tool guidelines."""
     mock_amessages.return_value = make_text_response("Ok!")  # type: ignore[union-attr]
 
     async def dummy(**kwargs: object) -> ToolResult:
@@ -249,9 +252,10 @@ async def test_system_prompt_skips_tools_without_hints(
     await agent.process_message("Hello")
 
     call_args = mock_amessages.call_args  # type: ignore[union-attr]
-    system_prompt = extract_system_text(call_args.kwargs["system"])
-    assert "This tool does something useful." in system_prompt
-    assert "tool_without_hint" not in system_prompt
+    # Tool guidelines are dynamic and now ride on the current user turn.
+    current_turn = call_args.kwargs["messages"][-1]["content"]
+    assert "This tool does something useful." in current_turn
+    assert "tool_without_hint" not in current_turn
 
 
 @pytest.mark.asyncio()

--- a/tests/test_agent_events.py
+++ b/tests/test_agent_events.py
@@ -15,6 +15,7 @@ from backend.app.agent.events import (
     TurnEndEvent,
     TurnStartEvent,
 )
+from backend.app.agent.messages import AgentMessage, AssistantMessage, UserMessage
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.models import User
 from tests.mocks.llm import make_text_response, make_tool_call_response
@@ -39,14 +40,14 @@ def agent(test_user: User) -> ClawboltAgent:
 
 @pytest.mark.asyncio
 @patch("backend.app.agent.core.amessages")
-@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
 async def test_events_emitted_for_text_response(
     mock_prompt: AsyncMock,
     mock_llm: AsyncMock,
     agent: ClawboltAgent,
 ) -> None:
     """Text-only response should emit start, turn_start, turn_end, and end events."""
-    mock_prompt.return_value = "system prompt"
+    mock_prompt.return_value = ("system prompt", "")
     mock_llm.return_value = make_text_response("Hello!")
 
     events: list[object] = []
@@ -69,14 +70,14 @@ async def test_events_emitted_for_text_response(
 
 @pytest.mark.asyncio
 @patch("backend.app.agent.core.amessages")
-@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
 async def test_events_emitted_for_tool_call(
     mock_prompt: AsyncMock,
     mock_llm: AsyncMock,
     agent: ClawboltAgent,
 ) -> None:
     """Tool call should emit tool execution start/end events."""
-    mock_prompt.return_value = "system prompt"
+    mock_prompt.return_value = ("system prompt", "")
 
     async def mock_tool(**kwargs: object) -> ToolResult:
         return ToolResult(content="saved")
@@ -126,14 +127,14 @@ async def test_events_emitted_for_tool_call(
 
 @pytest.mark.asyncio
 @patch("backend.app.agent.core.amessages")
-@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
 async def test_no_events_without_subscribers(
     mock_prompt: AsyncMock,
     mock_llm: AsyncMock,
     agent: ClawboltAgent,
 ) -> None:
     """Without subscribers, no errors should occur."""
-    mock_prompt.return_value = "system prompt"
+    mock_prompt.return_value = ("system prompt", "")
     mock_llm.return_value = make_text_response("Hello!")
 
     # No subscriber registered -- should work fine
@@ -143,14 +144,14 @@ async def test_no_events_without_subscribers(
 
 @pytest.mark.asyncio
 @patch("backend.app.agent.core.amessages")
-@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
 async def test_subscriber_error_does_not_crash_agent(
     mock_prompt: AsyncMock,
     mock_llm: AsyncMock,
     agent: ClawboltAgent,
 ) -> None:
     """A failing subscriber should not crash the agent pipeline."""
-    mock_prompt.return_value = "system prompt"
+    mock_prompt.return_value = ("system prompt", "")
     mock_llm.return_value = make_text_response("Hello!")
 
     async def bad_subscriber(event: object) -> None:
@@ -165,14 +166,14 @@ async def test_subscriber_error_does_not_crash_agent(
 
 @pytest.mark.asyncio
 @patch("backend.app.agent.core.amessages")
-@patch("backend.app.agent.core.build_agent_system_prompt", new_callable=AsyncMock)
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
 async def test_multiple_subscribers(
     mock_prompt: AsyncMock,
     mock_llm: AsyncMock,
     agent: ClawboltAgent,
 ) -> None:
     """Multiple subscribers should all receive events."""
-    mock_prompt.return_value = "system prompt"
+    mock_prompt.return_value = ("system prompt", "")
     mock_llm.return_value = make_text_response("Hello!")
 
     events_a: list[object] = []
@@ -195,3 +196,73 @@ def test_event_dataclasses_are_frozen() -> None:
     except AttributeError:
         frozen = True
     assert frozen
+
+
+class TestDynamicContentCachePlacement:
+    """Regression tests for #1420: dynamic content must not sit in the
+    ``system`` param ahead of the history, and the prior history must carry
+    an explicit cache breakpoint."""
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.core.amessages")
+    @patch(
+        "backend.app.agent.core.build_agent_system_prompt_parts",
+        new_callable=AsyncMock,
+    )
+    async def test_dynamic_block_in_user_turn_not_system(
+        self,
+        mock_prompt: AsyncMock,
+        mock_llm: AsyncMock,
+        agent: ClawboltAgent,
+    ) -> None:
+        mock_prompt.return_value = ("STABLE-SYSTEM-PREFIX", "DYNAMIC-MEMORY-BLOCK")
+        mock_llm.return_value = make_text_response("ok")
+
+        history: list[AgentMessage] = [
+            UserMessage(content="earlier question", seq=1),
+            AssistantMessage(content="earlier answer", seq=2),
+        ]
+        await agent.process_message("what's next?", conversation_history=history)
+
+        kwargs = mock_llm.call_args.kwargs
+        system_text = " ".join(block["text"] for block in kwargs["system"])
+        assert "STABLE-SYSTEM-PREFIX" in system_text
+        # The dynamic block must NOT be in the system param (that is the bug).
+        assert "DYNAMIC-MEMORY-BLOCK" not in system_text
+
+        messages = kwargs["messages"]
+        current_turn = messages[-1]
+        assert current_turn["role"] == "user"
+        assert isinstance(current_turn["content"], str)
+        assert "DYNAMIC-MEMORY-BLOCK" in current_turn["content"]
+        assert "what's next?" in current_turn["content"]
+
+    @pytest.mark.asyncio
+    @patch("backend.app.agent.core.amessages")
+    @patch(
+        "backend.app.agent.core.build_agent_system_prompt_parts",
+        new_callable=AsyncMock,
+    )
+    async def test_history_breakpoint_on_prior_turn(
+        self,
+        mock_prompt: AsyncMock,
+        mock_llm: AsyncMock,
+        agent: ClawboltAgent,
+    ) -> None:
+        mock_prompt.return_value = ("STABLE", "DYNAMIC")
+        mock_llm.return_value = make_text_response("ok")
+
+        history: list[AgentMessage] = [
+            UserMessage(content="earlier question", seq=1),
+            AssistantMessage(content="earlier answer", seq=2),
+        ]
+        await agent.process_message("what's next?", conversation_history=history)
+
+        messages = mock_llm.call_args.kwargs["messages"]
+        # Current turn is the last message and carries no breakpoint.
+        assert isinstance(messages[-1]["content"], str)
+        assert "cache_control" not in messages[-1]
+        # The prior-history message right before it carries the breakpoint.
+        anchor = messages[-2]
+        assert isinstance(anchor["content"], list)
+        assert anchor["content"][-1].get("cache_control", {}).get("type") == "ephemeral"

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 import pytest
 
 from backend.app.services.llm_service import (
+    _cache_control,
+    apply_history_cache_breakpoint,
     apply_tool_caching,
     prepare_system_with_caching,
     resolve_user_llm_override,
@@ -135,13 +137,9 @@ class TestApplyHistoryCacheBreakpoint:
     """The history breakpoint lands on the message before the current turn."""
 
     def _control(self) -> dict[str, object]:
-        from backend.app.services.llm_service import _cache_control
-
         return _cache_control()
 
     def test_marks_message_before_current_turn(self) -> None:
-        from backend.app.services.llm_service import apply_history_cache_breakpoint
-
         messages = [
             {"role": "user", "content": "older question"},
             {"role": "assistant", "content": [{"type": "text", "text": "older answer"}]},
@@ -155,8 +153,6 @@ class TestApplyHistoryCacheBreakpoint:
         assert "cache_control" not in result[2]
 
     def test_converts_string_anchor_to_block(self) -> None:
-        from backend.app.services.llm_service import apply_history_cache_breakpoint
-
         messages = [
             {"role": "user", "content": "older question"},
             {"role": "user", "content": "current turn"},
@@ -168,8 +164,6 @@ class TestApplyHistoryCacheBreakpoint:
         assert anchor["content"][0]["cache_control"] == self._control()
 
     def test_marks_last_block_of_tool_result_anchor(self) -> None:
-        from backend.app.services.llm_service import apply_history_cache_breakpoint
-
         messages = [
             {"role": "assistant", "content": [{"type": "text", "text": "calling tool"}]},
             {
@@ -187,16 +181,12 @@ class TestApplyHistoryCacheBreakpoint:
         assert tool_results[1]["cache_control"] == self._control()
 
     def test_no_breakpoint_without_prior_history(self) -> None:
-        from backend.app.services.llm_service import apply_history_cache_breakpoint
-
         messages = [{"role": "user", "content": "only the current turn"}]
         result = apply_history_cache_breakpoint(messages)
         assert result == messages
         assert "cache_control" not in result[0]
 
     def test_no_breakpoint_when_no_string_user_turn(self) -> None:
-        from backend.app.services.llm_service import apply_history_cache_breakpoint
-
         # Only tool-result (list-content) user messages: no current inbound
         # string turn to anchor against.
         messages = [

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -119,19 +119,96 @@ def test_apply_tool_caching_falls_back_to_5min_when_disabled() -> None:
     assert result[0]["cache_control"] == {"type": "ephemeral"}
 
 
-def test_prepare_system_with_cache_boundary_marks_only_stable_prefix() -> None:
-    """When a CACHE_BOUNDARY marker is present, only the stable prefix
-    block carries cache_control; the dynamic suffix block has no marker
-    so per-turn variation does not bust the cache."""
-    text = "stable prefix\n<!-- CACHE_BOUNDARY -->\ndynamic suffix"
+def test_prepare_system_wraps_whole_string_in_one_cached_block() -> None:
+    """The whole system string is stable now (dynamic content moved to the
+    user turn, #1420), so it is a single cache-marked block."""
+    text = "stable prefix\n\ndynamic suffix"
     with patch("backend.app.services.llm_service.settings") as mock_settings:
         mock_settings.llm_cache_extended_ttl = True
         result = prepare_system_with_caching(text)
-    assert len(result) == 2
-    assert result[0]["text"] == "stable prefix"
+    assert len(result) == 1
+    assert result[0]["text"] == text
     assert result[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
-    assert result[1]["text"] == "dynamic suffix"
-    assert "cache_control" not in result[1]
+
+
+class TestApplyHistoryCacheBreakpoint:
+    """The history breakpoint lands on the message before the current turn."""
+
+    def _control(self) -> dict[str, object]:
+        from backend.app.services.llm_service import _cache_control
+
+        return _cache_control()
+
+    def test_marks_message_before_current_turn(self) -> None:
+        from backend.app.services.llm_service import apply_history_cache_breakpoint
+
+        messages = [
+            {"role": "user", "content": "older question"},
+            {"role": "assistant", "content": [{"type": "text", "text": "older answer"}]},
+            {"role": "user", "content": "current turn with time + dynamic"},
+        ]
+        result = apply_history_cache_breakpoint(messages)
+        # Breakpoint stamped on the assistant message (index 1), not the
+        # volatile current turn (index 2).
+        assert result[1]["content"][-1]["cache_control"] == self._control()
+        assert isinstance(result[2]["content"], str)
+        assert "cache_control" not in result[2]
+
+    def test_converts_string_anchor_to_block(self) -> None:
+        from backend.app.services.llm_service import apply_history_cache_breakpoint
+
+        messages = [
+            {"role": "user", "content": "older question"},
+            {"role": "user", "content": "current turn"},
+        ]
+        result = apply_history_cache_breakpoint(messages)
+        anchor = result[0]
+        assert isinstance(anchor["content"], list)
+        assert anchor["content"][0]["text"] == "older question"
+        assert anchor["content"][0]["cache_control"] == self._control()
+
+    def test_marks_last_block_of_tool_result_anchor(self) -> None:
+        from backend.app.services.llm_service import apply_history_cache_breakpoint
+
+        messages = [
+            {"role": "assistant", "content": [{"type": "text", "text": "calling tool"}]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "a", "content": "one"},
+                    {"type": "tool_result", "tool_use_id": "b", "content": "two"},
+                ],
+            },
+            {"role": "user", "content": "current turn"},
+        ]
+        result = apply_history_cache_breakpoint(messages)
+        tool_results = result[1]["content"]
+        assert "cache_control" not in tool_results[0]
+        assert tool_results[1]["cache_control"] == self._control()
+
+    def test_no_breakpoint_without_prior_history(self) -> None:
+        from backend.app.services.llm_service import apply_history_cache_breakpoint
+
+        messages = [{"role": "user", "content": "only the current turn"}]
+        result = apply_history_cache_breakpoint(messages)
+        assert result == messages
+        assert "cache_control" not in result[0]
+
+    def test_no_breakpoint_when_no_string_user_turn(self) -> None:
+        from backend.app.services.llm_service import apply_history_cache_breakpoint
+
+        # Only tool-result (list-content) user messages: no current inbound
+        # string turn to anchor against.
+        messages = [
+            {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "a", "content": "x"}],
+            },
+        ]
+        result = apply_history_cache_breakpoint(messages)
+        assert all("cache_control" not in block for block in result[0]["content"])
+        assert all("cache_control" not in block for block in result[1]["content"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -10,6 +10,7 @@ from backend.app.agent.system_prompt import (
     SystemPromptBuilder,
     _strip_integrations_block,
     build_agent_system_prompt,
+    build_agent_system_prompt_parts,
     build_cross_session_context,
     build_date_section,
     build_heartbeat_system_prompt,
@@ -24,6 +25,7 @@ from backend.app.agent.system_prompt import (
     to_local_time,
 )
 from backend.app.models import User
+from backend.app.services.llm_service import prepare_system_with_caching
 
 
 class TestSystemPromptBuilder:
@@ -128,8 +130,6 @@ class TestBuildParts:
 
     def test_prepare_system_single_cached_block(self) -> None:
         """prepare_system_with_caching wraps the whole string in one cached block."""
-        from backend.app.services.llm_service import prepare_system_with_caching
-
         blocks = prepare_system_with_caching("Just a plain prompt")
         assert len(blocks) == 1
         assert "cache_control" in blocks[0]
@@ -138,8 +138,6 @@ class TestBuildParts:
     @pytest.mark.asyncio
     async def test_agent_prompt_parts_split_dynamic_out(self) -> None:
         """build_agent_system_prompt_parts returns memory in the dynamic half only."""
-        from backend.app.agent.system_prompt import build_agent_system_prompt_parts
-
         user = MagicMock()
         user.id = "user-123"
         user.soul_text = "soul"
@@ -281,8 +279,6 @@ class TestBuildAgentSystemPrompt:
         """Tool guidelines must sit in the dynamic half so that specialist
         activation mid-conversation does not bust the stable system-prompt
         cache. They must never leak into the stable half."""
-        from backend.app.agent.system_prompt import build_agent_system_prompt_parts
-
         user = MagicMock()
         user.soul_text = "I'm Bolt."
         user.user_text = ""
@@ -736,8 +732,6 @@ class TestAgentPromptIncludesLiveIntegrationStatus:
         stable prefix. Placing it ``dynamic=True`` keeps it in the dynamic
         half that is appended to the user turn.
         """
-        from backend.app.agent.system_prompt import build_agent_system_prompt_parts
-
         user = MagicMock()
         user.soul_text = "soul"
         user.user_text = "user"

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -92,55 +92,54 @@ class TestSystemPromptBuilder:
         assert "## B" in result
 
 
-class TestCacheBoundary:
-    def test_boundary_inserted_before_dynamic(self) -> None:
-        """CACHE_BOUNDARY marker should appear before the first dynamic section."""
+class TestBuildParts:
+    def test_dynamic_sections_split_into_second_half(self) -> None:
+        """build_parts puts stable sections in the first half, dynamic in the second."""
         builder = SystemPromptBuilder()
         builder.set_preamble("Preamble")
         builder.add_section("Stable", "stable content")
         builder.add_section("Dynamic", "dynamic content", dynamic=True)
-        result = builder.build()
-        assert SystemPromptBuilder.CACHE_BOUNDARY.strip() in result
-        idx = result.index(SystemPromptBuilder.CACHE_BOUNDARY.strip())
-        assert result.index("stable content") < idx
-        assert result.index("dynamic content") > idx
+        stable, dynamic = builder.build_parts()
+        assert "Preamble" in stable
+        assert "stable content" in stable
+        assert "dynamic content" not in stable
+        assert "dynamic content" in dynamic
+        assert "stable content" not in dynamic
 
-    def test_no_boundary_when_all_stable(self) -> None:
-        """No marker should appear when no sections are dynamic."""
+    def test_dynamic_empty_when_all_stable(self) -> None:
+        """The dynamic half is empty when no sections are dynamic."""
         builder = SystemPromptBuilder()
         builder.set_preamble("Preamble")
         builder.add_section("A", "content a")
         builder.add_section("B", "content b")
-        result = builder.build()
-        assert SystemPromptBuilder.CACHE_BOUNDARY.strip() not in result
+        stable, dynamic = builder.build_parts()
+        assert dynamic == ""
+        assert "content a" in stable
+        assert "content b" in stable
 
-    def test_prepare_system_splits_on_boundary(self) -> None:
-        """prepare_system_with_caching should split into two blocks at the marker."""
-        from backend.app.services.llm_service import prepare_system_with_caching
-
+    def test_build_joins_stable_then_dynamic(self) -> None:
+        """build() returns stable sections first, then dynamic ones."""
         builder = SystemPromptBuilder()
         builder.set_preamble("Preamble")
         builder.add_section("Instructions", "be helpful")
         builder.add_section("Memory", "user likes coffee", dynamic=True)
-        prompt = builder.build()
-        blocks = prepare_system_with_caching(prompt)
-        assert len(blocks) == 2
-        assert "cache_control" in blocks[0]
-        assert "cache_control" not in blocks[1]
-        assert "be helpful" in blocks[0]["text"]
-        assert "user likes coffee" in blocks[1]["text"]
+        result = builder.build()
+        assert result.index("be helpful") < result.index("user likes coffee")
 
-    def test_prepare_system_single_block_without_boundary(self) -> None:
-        """Without a boundary marker the whole prompt is one cached block."""
+    def test_prepare_system_single_cached_block(self) -> None:
+        """prepare_system_with_caching wraps the whole string in one cached block."""
         from backend.app.services.llm_service import prepare_system_with_caching
 
         blocks = prepare_system_with_caching("Just a plain prompt")
         assert len(blocks) == 1
         assert "cache_control" in blocks[0]
+        assert blocks[0]["text"] == "Just a plain prompt"
 
     @pytest.mark.asyncio
-    async def test_agent_prompt_has_boundary(self) -> None:
-        """build_agent_system_prompt should include the cache boundary marker."""
+    async def test_agent_prompt_parts_split_dynamic_out(self) -> None:
+        """build_agent_system_prompt_parts returns memory in the dynamic half only."""
+        from backend.app.agent.system_prompt import build_agent_system_prompt_parts
+
         user = MagicMock()
         user.id = "user-123"
         user.soul_text = "soul"
@@ -151,8 +150,12 @@ class TestCacheBoundary:
             new_callable=AsyncMock,
             return_value="some memory",
         ):
-            prompt = await build_agent_system_prompt(user, tools=[], message_context="hello")
-        assert SystemPromptBuilder.CACHE_BOUNDARY.strip() in prompt
+            stable, dynamic = await build_agent_system_prompt_parts(
+                user, tools=[], message_context="hello"
+            )
+        assert "some memory" in dynamic
+        assert "some memory" not in stable
+        assert "AI assistant for solo tradespeople" in stable
 
 
 class TestSectionBuilders:
@@ -274,11 +277,12 @@ class TestBuildAgentSystemPrompt:
         assert "Proactive Messaging" in result
 
     @pytest.mark.asyncio
-    async def test_tool_guidelines_live_after_cache_boundary(self) -> None:
-        """Tool guidelines must sit in the dynamic suffix so that specialist
+    async def test_tool_guidelines_live_in_dynamic_half(self) -> None:
+        """Tool guidelines must sit in the dynamic half so that specialist
         activation mid-conversation does not bust the stable system-prompt
-        cache. They should appear after CACHE_BOUNDARY, never inside
-        Instructions."""
+        cache. They must never leak into the stable half."""
+        from backend.app.agent.system_prompt import build_agent_system_prompt_parts
+
         user = MagicMock()
         user.soul_text = "I'm Bolt."
         user.user_text = ""
@@ -293,23 +297,18 @@ class TestBuildAgentSystemPrompt:
             new_callable=AsyncMock,
             return_value="",
         ):
-            result = await build_agent_system_prompt(
+            stable, dynamic = await build_agent_system_prompt_parts(
                 user=user,
                 tools=[tool],
                 message_context="hello",
             )
 
-        marker = SystemPromptBuilder.CACHE_BOUNDARY.strip()
-        assert marker in result
-        boundary_idx = result.index(marker)
-        guidelines_idx = result.index("Tool Guidelines")
-        assert guidelines_idx > boundary_idx
-        # The stable Instructions block (everything before the boundary)
-        # must not leak the tool hints, or activating a new specialist
-        # would invalidate the cached prefix.
-        stable_prefix = result[:boundary_idx]
-        assert "Tool Guidelines" not in stable_prefix
-        assert "save_fact" not in stable_prefix
+        assert "Tool Guidelines" in dynamic
+        assert "save_fact" in dynamic
+        # The stable half must not leak the tool hints, or activating a new
+        # specialist would invalidate the cached prefix.
+        assert "Tool Guidelines" not in stable
+        assert "save_fact" not in stable
 
     @pytest.mark.asyncio
     async def test_preamble_is_generic(self) -> None:
@@ -729,13 +728,16 @@ class TestBuildIntegrationStatusSection:
 
 class TestAgentPromptIncludesLiveIntegrationStatus:
     @pytest.mark.asyncio
-    async def test_section_appears_after_cache_boundary(self) -> None:
-        """The live integration status sits in the dynamic suffix.
+    async def test_section_lands_in_dynamic_half(self) -> None:
+        """The live integration status sits in the dynamic half.
 
         Mid-conversation OAuth completions must take effect on the very
         next turn, which means the section cannot be inside the cached
-        prefix. Placing it ``dynamic=True`` puts it after the boundary.
+        stable prefix. Placing it ``dynamic=True`` keeps it in the dynamic
+        half that is appended to the user turn.
         """
+        from backend.app.agent.system_prompt import build_agent_system_prompt_parts
+
         user = MagicMock()
         user.soul_text = "soul"
         user.user_text = "user"
@@ -757,19 +759,16 @@ class TestAgentPromptIncludesLiveIntegrationStatus:
                 ),
             ),
         ):
-            prompt = await build_agent_system_prompt(
+            stable, dynamic = await build_agent_system_prompt_parts(
                 user=user,
                 tools=[],
                 message_context="hello",
             )
 
-        assert "## Connected Integrations" in prompt
-        assert "Connected: google_calendar" in prompt
-        assert "Not connected: google_drive" in prompt
-        # Must sit after CACHE_BOUNDARY.
-        boundary_idx = prompt.index(SystemPromptBuilder.CACHE_BOUNDARY.strip())
-        section_idx = prompt.index("## Connected Integrations")
-        assert section_idx > boundary_idx
+        assert "## Connected Integrations" in dynamic
+        assert "Connected: google_calendar" in dynamic
+        assert "Not connected: google_drive" in dynamic
+        assert "## Connected Integrations" not in stable
 
     @pytest.mark.asyncio
     async def test_heartbeat_prompt_includes_section(self) -> None:


### PR DESCRIPTION
## Description

The agent placed its dynamic system content (memory, tool guidelines, integration status, cross-session context) in the `system` param, ahead of the conversation history in the prompt-cache prefix. Anthropic builds its cache prefix in tools -> system -> messages order, so any change to that dynamic block invalidated the cache for everything after it, including the entire message history. Every memory write (a routine event for an active user) re-billed the full history at uncached input price on the next turn.

This PR makes two coordinated changes from #1420:

1. **Move dynamic content out of `system`.** `SystemPromptBuilder.build_parts()` splits sections into stable/dynamic halves using the existing `dynamic=True` flag (the `CACHE_BOUNDARY` machinery is removed). The agent loop sends only the stable half in the cacheable `system` param and injects the dynamic half into the current user turn (after the time context, before the user's message, so the model reads the ask last). The dynamic content is uncached today and stays uncached after the move; it just no longer gates the history.

2. **Add an explicit history cache breakpoint.** `apply_history_cache_breakpoint()` stamps `cache_control` on the message immediately before the current inbound turn (identified as the last `user`-role message with plain string content). That prior history reloads byte-identical next turn, so the breakpoint advances forward as the conversation grows, and the history is cached independently of the dynamic block rather than relying on automatic prefix caching the dynamic suffix used to break.

Net effect: a memory write between turns no longer re-bills the full history at input price. Anthropic's four-breakpoint budget is respected (stable system, last tool, history = 3).

### Sequencing note

#1421 (token-governed working window) depends on this change landing first; this PR is the prerequisite, not the window-size change.

### Files

- `backend/app/agent/system_prompt.py`: `build_parts()`, `build_agent_system_prompt_parts()`, shared `_build_agent_prompt_builder()`; `build_agent_system_prompt()` retained for the preview endpoint.
- `backend/app/services/llm_service.py`: simplified `prepare_system_with_caching()` (single cached block); new `apply_history_cache_breakpoint()`.
- `backend/app/agent/core.py`: split prompt into stable/dynamic, inject dynamic on the user turn, apply the breakpoint in both the main and trim-retry call paths.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2880 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Regression coverage: end-to-end tests assert the dynamic block lands on the user turn (not `system`) and the breakpoint sits on the prior-history message, not the volatile current turn; unit tests cover `apply_history_cache_breakpoint` placement across string / assistant-block / tool-result anchors and no-op cases.

## AI Usage
- [x] AI-assisted (implemented by Claude via back-and-forth with @njbrake; reasoning and decisions are his)
- [ ] No AI used

Fixes #1420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary

This PR changes how dynamic system content is placed in prompts so updates (e.g., memory writes, tool guidelines, integration status, cross-session context) no longer invalidate the cached message history. Dynamic sections are no longer sent in the cacheable system parameter; instead they are emitted after the message history by appending them into the current user turn. An explicit cache breakpoint is added at the end of the prior history so the history becomes independently cacheable.

## What moved / added / removed

- Moved dynamic content out of the cacheable system payload and into the current user message (inserted after time context and before the user's message).
- Split system prompt construction into two halves: a stable, cacheable prefix and a dynamic suffix.
- Replaced the old CACHE_BOUNDARY marker logic with a single cached system block and an explicit history cache breakpoint.
- Added utilities to apply cache-control breakpoints to the message immediately before the current inbound turn.
- Updated agent request flows (main and trim-retry paths) to inject dynamic content into user turns and to stamp the history breakpoint consistently.
- Tests updated/added to assert dynamic content placement and correct breakpoint behavior.

## Files changed (high level)

- backend/app/agent/system_prompt.py
  - Added SystemPromptBuilder.build_parts() and build_agent_system_prompt_parts() to emit (stable, dynamic) halves.
  - build_agent_system_prompt now composes from the shared builder helper.
- backend/app/agent/core.py
  - Uses the split prompt parts; sends only the stable half as the system param and injects dynamic half into the current user message.
  - Applies history breakpoint in both normal and retry/trim paths.
- backend/app/services/llm_service.py
  - prepare_system_with_caching simplified to a single cached block.
  - Added apply_history_cache_breakpoint(messages) to stamp cache_control on the prior-history message.
  - Removed CACHE_BOUNDARY handling.
- tests/*
  - Updated and added tests to verify: dynamic content lands in the current user turn (not system), the history breakpoint is applied to the prior turn, and prepare-system caching wraps the system block correctly.
  - New regression and unit tests exercising cache-breakpoint scenarios and dynamic-block placement.

## Benefits

- Reduced token/billing cost for memory writes and other dynamic updates — the history no longer gets re-billed at full input price when dynamic content changes.
- History becomes independently cacheable, improving cache-read hit rates.
- Respects Anthropic breakpoint budget (cycles breakpoint forward while staying within limits).
- Internal-only changes; external agent API/behavior remains compatible.

## Technical notes (concise)

- SystemPromptBuilder.build_parts() returns (stable_system, dynamic_context).
- Agent sends stable_system as SystemMessage; dynamic_context is appended to the current UserMessage content.
- apply_history_cache_breakpoint() finds the last prior user-role plain-string message (or last block of a tool-result anchor) and attaches cache_control (type="ephemeral") to it.
- Breakpoint is applied before the inbound turn in both initial and trim-retry LLM calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->