### PR TITLE
fix: anchor compaction history breadcrumbs to event time, not compaction time

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -447,8 +447,12 @@ async def compact_session(
     # the read-and-write, so the snapshot we record matches what landed in
     # the DB even when two compactions race.
     if result.summary:
-        timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M")
-        entry = result.summary.replace("[TIMESTAMP]", f"[{timestamp}]")
+        # Real event times come from the model, anchored to the conversation's
+        # [Weekday, ...] markers (see compaction.md Step 4). Any leftover
+        # [TIMESTAMP] placeholder means the model saw no marker for that event;
+        # fill it with the compaction time as a fallback.
+        fallback_ts = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M")
+        entry = result.summary.replace("[TIMESTAMP]", f"[{fallback_ts}]")
         try:
             new_history = await memory_store.append_history(entry)
             logger.info("Compaction appended history entry for user %s", user_id)

--- a/backend/app/agent/prompts/compaction.md
+++ b/backend/app/agent/prompts/compaction.md
@@ -46,9 +46,9 @@ One terse 1 to 3 sentence breadcrumb entry per event, one per line.
 
 **Timestamp each entry in exactly one format: `[YYYY-MM-DD HH:MM]` (24-hour).** Never use weekdays, AM/PM, ranges, or arrows. If you know the day an event happened but not the time, write `[YYYY-MM-DD]` with no time rather than guessing one.
 
-Take the time from the nearest marker at or before the event in `<conversation>`, converted to 24-hour form. Markers only appear after a gap or a new day, so one marker can sit far above the event it precedes. If the only available marker is hours away from when the event actually happened, drop the time and stamp the date alone: do not propagate the batch's opening marker time onto every event in the batch. When no marker is visible at all, write the literal `[TIMESTAMP]` and the system fills in the current time.
+Take each event's time from the nearest marker at or before it, in 24-hour form. A marker can sit far above the event it precedes, so when the nearest one is hours off, drop the time and stamp the date alone; never copy one marker's time onto every event under it. With no marker visible, write the literal `[TIMESTAMP]` and the system fills in the current time.
 
-**Resolve every relative time reference to an absolute date in the prose.** "today", "tomorrow", "this Friday", "earlier" are wrong when this breadcrumb is read days later. Write "scheduled the Miller job for June 3-5", never "added Miller today". Keep the day an action was taken distinct from the day it targets.
+**Resolve every relative time reference to an absolute date in the prose.** "today", "tomorrow", "this Friday", "earlier" are wrong when this breadcrumb is read days later. Write "scheduled the Miller job for June 3-5", never "added Miller today".
 
 Pointers over numbers. Drop deep links, draft IDs, and dollar amounts (unless the dollar is genuinely the news). Skip trivial small talk. Return an empty string when nothing noteworthy happened.
 

--- a/backend/app/agent/prompts/compaction.md
+++ b/backend/app/agent/prompts/compaction.md
@@ -22,6 +22,8 @@ Memory exists for cross-system knowledge that lives nowhere else.
 
 You will receive `<current_memory>`, `<user_profile>`, `<soul>`, `<heartbeat>`, and optionally `<conversation>`.
 
+Messages in `<conversation>` may carry an inline time marker on their own line, formatted `[Weekday, YYYY-MM-DD HH:MM AM/PM]`. A marker appears at the first message and again only after a gap or a new day, so it timestamps every message at or after it until the next marker. Treat these markers as the clock for the conversation; they are not text the contractor wrote.
+
 ## Workflow
 
 Perform these steps in order.
@@ -40,7 +42,15 @@ Extract any profile or personality changes from `<conversation>`. Preserve every
 
 ### Step 4: Build HISTORY.md summary
 
-One terse 1 to 3 sentence breadcrumb entry per event, prefixed `[TIMESTAMP]`. Pointers over numbers. Drop deep links, draft IDs, and dollar amounts (unless the dollar is genuinely the news). Skip trivial small talk. Return an empty string when nothing noteworthy happened.
+One terse 1 to 3 sentence breadcrumb entry per event, one per line.
+
+**Timestamp each entry in exactly one format: `[YYYY-MM-DD HH:MM]` (24-hour).** Never use weekdays, AM/PM, ranges, or arrows. If you know the day an event happened but not the time, write `[YYYY-MM-DD]` with no time rather than guessing one.
+
+Take the time from the nearest marker at or before the event in `<conversation>`, converted to 24-hour form. Markers only appear after a gap or a new day, so one marker can sit far above the event it precedes. If the only available marker is hours away from when the event actually happened, drop the time and stamp the date alone: do not propagate the batch's opening marker time onto every event in the batch. When no marker is visible at all, write the literal `[TIMESTAMP]` and the system fills in the current time.
+
+**Resolve every relative time reference to an absolute date in the prose.** "today", "tomorrow", "this Friday", "earlier" are wrong when this breadcrumb is read days later. Write "scheduled the Miller job for June 3-5", never "added Miller today". Keep the day an action was taken distinct from the day it targets.
+
+Pointers over numbers. Drop deep links, draft IDs, and dollar amounts (unless the dollar is genuinely the news). Skip trivial small talk. Return an empty string when nothing noteworthy happened.
 
 ## MEMORY.md: cross-system business knowledge
 
@@ -81,7 +91,7 @@ The `<heartbeat>` section is read-only context. Do not promote already-fired hea
 Return only a JSON object:
 
 1. `memory_update`: full updated MEMORY.md with compliance audit applied (Step 1) and new facts merged (Step 2). Return existing verbatim only when the existing content already contains no exclusion-list violations AND no new facts were added.
-2. `summary`: 1 to 3 sentence breadcrumb starting `[TIMESTAMP]`. Empty string for trivial conversations.
+2. `summary`: newline-separated breadcrumbs, one per event, each starting with that event's time as `[YYYY-MM-DD HH:MM]` or `[YYYY-MM-DD]` (or the literal `[TIMESTAMP]` only when no marker was visible). Empty string for trivial conversations.
 3. `user_profile_update`: full updated USER.md, all fields preserved. Empty string if no change.
 4. `soul_update`: full updated SOUL.md. Empty string if no change.
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1025,6 +1025,51 @@ async def test_compact_session_appends_history(test_user: UserData) -> None:
 
 
 @pytest.mark.asyncio()
+async def test_compact_session_preserves_event_timestamps_in_summary(
+    test_user: UserData,
+) -> None:
+    """A real event timestamp emitted by the model survives into HISTORY.md
+    verbatim, and is not overwritten by the compaction wall-clock time.
+
+    Regression for issue #1423: compaction used to stamp every breadcrumb
+    with the moment the compaction ran (the ``[TIMESTAMP]`` placeholder was
+    always replaced with ``now``). When older messages were trimmed, the
+    agent lost when the events actually happened and would later claim a
+    past action happened "today". Now the model anchors each breadcrumb to
+    the event's own time (from the conversation markers); the placeholder
+    fill is only a fallback for events with no visible marker.
+
+    This response mixes both cases in one multi-line summary: a breadcrumb
+    with a concrete event time, and a second with the literal placeholder.
+    """
+    summary = (
+        "[2026-06-02 19:27] Scheduled the Carter job for June 3-5 on the work calendar.\n"
+        "[TIMESTAMP] Added a full-day labor entry for June 2."
+    )
+    llm_response_text = json.dumps({"memory_update": "", "summary": summary})
+    mock_response = make_text_response(llm_response_text)
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="Schedule the Carter job June 3-5, 8 to 4."),
+        AssistantMessage(content="Done, added Carter June 3-5."),
+    ]
+
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        await compact_session(test_user.id, messages, max_message_seq=2)
+
+    memory_store = get_memory_store(test_user.id)
+    history_content = await memory_store.read_history_async()
+
+    # The concrete event time is preserved exactly, not squashed to "now".
+    assert "[2026-06-02 19:27] Scheduled the Carter job for June 3-5" in history_content
+    # The placeholder line still gets a real timestamp filled in.
+    assert "Added a full-day labor entry for June 2." in history_content
+    assert "[TIMESTAMP]" not in history_content
+    # The summary must use absolute dates, never relative words that drift.
+    assert "today" not in history_content.lower()
+
+
+@pytest.mark.asyncio()
 async def test_compact_session_no_summary_skips_history(test_user: UserData) -> None:
     """compact_session should not write HISTORY.md when summary is empty."""
     llm_response_text = json.dumps({"memory_update": "", "summary": ""})


### PR DESCRIPTION
## Description

Compaction replaced the `[TIMESTAMP]` placeholder in every HISTORY.md breadcrumb with the moment the compaction ran. Once older messages were trimmed, the agent lost when events actually happened and would read a timeless or wrongly-stamped breadcrumb and place a past action "today". Observed in production: the agent claimed a calendar event added the previous evening was scheduled "today", and fused two separate jobs into one.

The conversation handed to the compactor already carries the per-message time markers added for history display (`[Weekday, YYYY-MM-DD HH:MM]`), so the model can anchor each breadcrumb to the event's own time. This PR:

- Tells the compaction prompt those markers exist and to use them as the conversation clock.
- Mandates one timestamp format (`[YYYY-MM-DD HH:MM]`, or date-only when the time is unknown) instead of the mix of weekday / AM-PM / range shapes seen in production history.
- Forbids propagating the batch's opening-marker time onto every event (which stamped 7 PM work as 07:20 AM), and forbids relative-time words ("today", "tomorrow") that drift once the breadcrumb is read days later.
- Keeps the now-time substitution as a fallback only for events with no visible marker.

The code change is a rename plus a comment: `.replace("[TIMESTAMP]", now)` already leaves real timestamps untouched, so it degrades cleanly into the no-marker fallback.

### Caveat
This makes the recorded time honest (date-only instead of a confidently-wrong time of day), but true per-event time precision is still capped by marker density in `context.py` (markers only appear at a >30 min gap or a day boundary). Denser markers would be a separate change with a token-cost tradeoff.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude drafted the prompt change, code rename, and regression test through back-and-forth with @njbrake; the diagnosis and decisions are his)
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)