### PR TITLE
fix: route history-window overflow through compaction

### DIFF
--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -65,6 +65,16 @@ def _is_approval_prompt(content: str) -> bool:
 
 DEFAULT_HISTORY_LIMIT = settings.conversation_history_limit
 
+# Hysteresis for the window-overflow compaction path in
+# ``load_conversation_history``: when rows fall outside the loader window,
+# this many additional rows (oldest first) are compacted along with them.
+# Without the headroom, every message after the first overflow would push
+# one more row out of the window and re-fire compaction per message, the
+# exact churn the trim path's trigger/target gap exists to prevent. 32
+# rows is the row-equivalent of the trim path's default 16-turn trigger
+# buffer (a user turn is typically an inbound + outbound row pair).
+_WINDOW_OVERFLOW_BATCH_ROWS = 32
+
 # Strong references to fire-and-forget background tasks so they are not
 # garbage-collected before completion.
 _background_tasks: set[asyncio.Task[None]] = set()
@@ -117,8 +127,10 @@ async def trigger_compaction_for_dropped(
     """Fire compaction for messages that were trimmed from context.
 
     Called from the agent loop (``process_message``) when ``trim_messages``
-    drops messages. Two-phase to keep the watermark and the audit log
-    consistent under crash:
+    drops messages, and from ``load_conversation_history`` when rows fall
+    outside the history window before trim could ever see them (issue
+    #1427). Two-phase to keep the watermark and the audit log consistent
+    under crash:
 
     1. Synchronously, in one transaction: insert a ``'pending'``
        ``CompactionEvent`` row (with ``min_message_seq`` /
@@ -135,7 +147,8 @@ async def trigger_compaction_for_dropped(
        advanced regardless: this is the design tradeoff (no per-message
        compaction churn) for losing facts on a crashed compaction call.
 
-    This is the only compaction trigger in the system.
+    Together with :func:`admin_compact_visible_messages`, these are the
+    only compaction triggers in the system.
     """
     if not dropped_messages or not settings.compaction_enabled:
         return
@@ -457,7 +470,9 @@ async def load_conversation_history(
 
     The *limit* parameter is a soft safety net that bounds memory usage
     (default 500). Token-based trimming in the agent loop is the primary
-    guard against exceeding the LLM context window.
+    guard against exceeding the LLM context window. Rows that fall outside
+    the window are routed through compaction (see below) so they are never
+    silently lost.
     """
     all_messages = session.messages
 
@@ -469,6 +484,32 @@ async def load_conversation_history(
     if session.last_trim_seq is not None:
         all_messages = [m for m in all_messages if m.seq > session.last_trim_seq]
     total_count = len(all_messages)
+
+    # Window-overflow compaction (issue #1427). Rows older than the
+    # ``limit`` window never reach ``trim_messages``, so the trim-driven
+    # compaction path cannot see them, and a token-light conversation can
+    # grow past the row cap while staying under the token trigger forever.
+    # Route the overflowed rows, plus a headroom batch so this does not
+    # re-fire on every subsequent message, through the same watermark +
+    # compaction machinery the trim path uses. The batch is still returned
+    # in this turn's history; the advanced watermark filters it from the
+    # next turn, mirroring trim semantics (dropped messages are visible on
+    # the turn that drops them, gone afterwards). PR #843 removed the old
+    # loader-driven compaction because it re-fired per message; the
+    # watermark advance plus headroom batching is what makes this
+    # reintroduction safe.
+    if total_count > limit and settings.compaction_enabled:
+        compact_count = min(total_count - 1, (total_count - limit) + _WINDOW_OVERFLOW_BATCH_ROWS)
+        overflow = all_messages[:compact_count]
+        overflow_agent_messages = _stored_messages_to_agent_messages(overflow, tz_name=tz_name)
+        if overflow_agent_messages:
+            await trigger_compaction_for_dropped(session.user_id, overflow_agent_messages)
+        else:
+            # Every overflowed row was filtered (approval prompts, blank
+            # attachment placeholders). There is nothing to extract facts
+            # from, but the watermark must still advance or this branch
+            # re-detects the same rows on every message forever.
+            await _advance_trim_watermark_only(session.user_id, overflow[-1].seq)
 
     # Get the most recent `limit` messages, excluding the current (last) one
     if total_count > 1:

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -75,6 +75,18 @@ DEFAULT_HISTORY_LIMIT = settings.conversation_history_limit
 # buffer (a user turn is typically an inbound + outbound row pair).
 _WINDOW_OVERFLOW_BATCH_ROWS = 32
 
+# Upper bound on rows compacted per turn by the window-overflow path. A
+# legacy session can arrive with a multi-thousand-row backlog above the
+# watermark (compaction disabled for a while, or rows accumulated before
+# the overflow path shipped). Compacting the whole backlog in one go
+# would feed the entire thing into a single compaction LLM call and blow
+# its context. The batch is always a contiguous prefix starting at the
+# oldest row above the watermark, so capping it is safe: the watermark
+# advances to the end of the capped batch and the next message picks up
+# the next chunk, converging over a handful of turns. At a token-light
+# ~300 tokens/row, 200 rows is roughly 60K tokens of compaction input.
+_WINDOW_OVERFLOW_MAX_ROWS_PER_TURN = 200
+
 # Strong references to fire-and-forget background tasks so they are not
 # garbage-collected before completion.
 _background_tasks: set[asyncio.Task[None]] = set()
@@ -527,7 +539,11 @@ async def load_conversation_history(
     # watermark advance plus headroom batching is what makes this
     # reintroduction safe.
     if total_count > limit and settings.compaction_enabled:
-        compact_count = min(total_count - 1, (total_count - limit) + _WINDOW_OVERFLOW_BATCH_ROWS)
+        compact_count = min(
+            total_count - 1,
+            (total_count - limit) + _WINDOW_OVERFLOW_BATCH_ROWS,
+            _WINDOW_OVERFLOW_MAX_ROWS_PER_TURN,
+        )
         overflow = all_messages[:compact_count]
         overflow_agent_messages = _stored_messages_to_agent_messages(overflow, tz_name=tz_name)
         if overflow_agent_messages:

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -159,14 +159,47 @@ async def trigger_compaction_for_dropped(
         # summary) with no DB rows to watermark against. Nothing to compact.
         return
 
-    min_seq = min(dropped_seqs)
-    max_seq = max(dropped_seqs)
     triggered_at = datetime.datetime.now(datetime.UTC)
 
     # Phase 1: insert + watermark advance, in one transaction.
     event_id: int
     try:
         async with db_session_async() as db:
+            cs = (
+                await db.execute(select(ChatSession).filter_by(user_id=user_id))
+            ).scalar_one_or_none()
+
+            # Re-check the live watermark before compacting. The caller
+            # computed ``dropped_messages`` from a session snapshot that may
+            # predate another trigger's watermark advance: the window-overflow
+            # path in ``load_conversation_history`` runs earlier in the same
+            # turn than the trim path in ``process_message``, and both can
+            # fire when a conversation crosses the row cap and the token
+            # budget together. Rows at or below the live watermark are
+            # already covered by a prior CompactionEvent; re-compacting them
+            # would double the LLM cost and write a confusing duplicate
+            # audit row for the same seq range.
+            current_watermark = (cs.last_trim_seq or 0) if cs is not None else 0
+            if current_watermark:
+                dropped_seqs = [s for s in dropped_seqs if s > current_watermark]
+                if not dropped_seqs:
+                    logger.info(
+                        "Skipping compaction for user %s: all dropped rows are"
+                        " at or below the live watermark %d",
+                        user_id,
+                        current_watermark,
+                    )
+                    return
+                kept: list[AgentMessage] = []
+                for m in dropped_messages:
+                    seq = getattr(m, "seq", None)
+                    if not isinstance(seq, int) or seq > current_watermark:
+                        kept.append(m)
+                dropped_messages = kept
+
+            min_seq = min(dropped_seqs)
+            max_seq = max(dropped_seqs)
+
             event = CompactionEvent(
                 user_id=user_id,
                 triggered_at=triggered_at,
@@ -180,13 +213,8 @@ async def trigger_compaction_for_dropped(
             assert event.id is not None, "flush() must populate the autoincrement id"
             event_id = event.id
 
-            cs = (
-                await db.execute(select(ChatSession).filter_by(user_id=user_id))
-            ).scalar_one_or_none()
-            if cs is not None:
-                current = cs.last_trim_seq or 0
-                if max_seq > current:
-                    cs.last_trim_seq = max_seq
+            if cs is not None and max_seq > current_watermark:
+                cs.last_trim_seq = max_seq
             await db.commit()
     except Exception:
         logger.exception(

--- a/backend/app/agent/trimming.py
+++ b/backend/app/agent/trimming.py
@@ -15,7 +15,7 @@ from backend.app.agent.messages import (
     ToolResultMessage,
     UserMessage,
 )
-from backend.app.config import settings
+from backend.app.config import CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS, settings
 
 _SUMMARY_MAX_CHARS = 500
 
@@ -29,7 +29,9 @@ _CHARS_PER_TOKEN = 4
 # When ``trigger_turns`` is unset and ``target_turns`` is set, the trigger
 # defaults to ``target_turns + _DEFAULT_TRIGGER_BUFFER_TURNS``. Hysteresis
 # prevents per-message re-triggering once the conversation crosses the cap.
-_DEFAULT_TRIGGER_BUFFER_TURNS = 16
+# The value lives in config.py so ``log_config_warnings`` can compute the
+# effective trigger without importing agent code.
+_DEFAULT_TRIGGER_BUFFER_TURNS = CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS
 
 
 def _count_user_turns(msgs: list[AgentMessage]) -> int:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,14 @@ from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 
+# Default hysteresis buffer for the turn-count trim backstop: when
+# ``context_trim_trigger_turns`` is unset, the trigger resolves to
+# ``context_trim_target_turns + CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS``
+# (see ``trim_messages`` in backend/app/agent/trimming.py). Lives here, not
+# in trimming.py, so ``log_config_warnings`` can compute the effective
+# trigger without importing agent code.
+CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS: int = 16
+
 
 def _derive_webhook_secret(bot_token: str) -> str:
     """Derive a deterministic webhook secret from the bot token via HMAC-SHA256."""
@@ -111,20 +119,25 @@ class Settings(BaseSettings):
     # per-turn cost; the full window is sent every turn.
     context_trim_target_tokens: int = Field(default=120_000, ge=1)
     context_trim_trigger_tokens: int = Field(default=150_000, ge=1)
-    # Turn-count backstop, not the primary governor. Tokens bind first in
-    # normal use (150K is ~330 turns for a token-light user); this cap only
-    # catches pathological message-count bloat (many tiny messages), a
-    # latency and attention concern independent of tokens. Keep it well
-    # above the turn-equivalent of the token budget. Trimming oldest turns
-    # past this cap rolls them through compaction into MEMORY.md / USER.md
-    # / SOUL.md. ge=2 so at least one prior turn is always retained; not
-    # ``None``, which would disable the guard entirely.
-    context_trim_target_turns: int = Field(default=600, ge=2)
+    # Turn-count backstop. Tokens bind first for token-heavy users (150K
+    # is reached well before this cap when messages carry tool traffic);
+    # this cap is what protects token-light users, whose conversations
+    # can grow past ``conversation_history_limit`` rows while staying
+    # under the token trigger forever. The backstop must therefore be
+    # reachable inside the loader window: a user turn is typically an
+    # inbound + outbound row pair, so the effective trigger needs about
+    # 2x its value in rows, and ``log_config_warnings`` warns when
+    # ``2 * (trigger + 1) > conversation_history_limit`` (issue #1427).
+    # Trimming oldest turns past this cap rolls them through compaction
+    # into MEMORY.md / USER.md / SOUL.md. ge=2 so at least one prior turn
+    # is always retained; not ``None``, which would disable the guard
+    # entirely.
+    context_trim_target_turns: int = Field(default=200, ge=2)
     # Turn-backstop trigger threshold: the turn cap fires only when the
     # user-turn count exceeds this, then drops to
     # ``context_trim_target_turns`` (same hysteresis rationale as the token
-    # path). When ``None``, defaults to ``context_trim_target_turns + 16``
-    # inside ``trim_messages``.
+    # path). When ``None``, defaults to ``context_trim_target_turns +
+    # CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS`` inside ``trim_messages``.
     context_trim_trigger_turns: int | None = Field(default=None)
     # Per-file truncation cap for memory-text snapshots persisted on
     # ``compaction_events`` rows. A user with a 500KB MEMORY.md would
@@ -489,6 +502,25 @@ def log_config_warnings(s: Settings | None = None) -> list[str]:
             f"context_trim_trigger_tokens ({s.context_trim_trigger_tokens})"
             f" > max_input_tokens ({s.max_input_tokens});"
             " trimming will never trigger"
+        )
+    # Invariant: the turn backstop must be reachable inside the history
+    # loader window. A user turn is typically an inbound + outbound row
+    # pair, so reaching the trigger takes about 2x its value in rows.
+    # When the row cap binds first, facts are still protected by the
+    # window-overflow compaction path in load_conversation_history
+    # (issue #1427), but that path has less hysteresis than the turn
+    # backstop and compacts rows that are still visible to the agent.
+    effective_trigger_turns = (
+        s.context_trim_trigger_turns
+        if s.context_trim_trigger_turns is not None
+        else s.context_trim_target_turns + CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS
+    )
+    if 2 * (effective_trigger_turns + 1) > s.conversation_history_limit:
+        warnings.append(
+            f"conversation_history_limit ({s.conversation_history_limit}) is below"
+            f" 2x the effective turn-trim trigger ({effective_trigger_turns});"
+            " the row cap will bind before the turn backstop and old messages"
+            " will roll through window-overflow compaction instead"
         )
 
     # Warn when an iMessage backend is configured but the address users are

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -868,10 +868,13 @@ async def test_compact_session_does_not_log_when_no_messages(test_user: UserData
     mock_log.assert_not_called()
 
 
-# --- Integration: load_conversation_history no longer triggers compaction ---
-# Compaction is now triggered from process_message() when trim_messages() drops
-# messages, not from load_conversation_history(). The tests below verify the new
-# behavior. See test_agent.py for trim-triggered compaction tests.
+# --- Integration: load_conversation_history compaction behavior ---
+# Compaction is triggered from process_message() when trim_messages() drops
+# messages, and (issue #1427) from load_conversation_history() when rows
+# fall outside the loader window before trim could ever see them. The
+# loader path reuses trigger_compaction_for_dropped, so the watermark
+# advance plus headroom batching prevents the per-message churn that led
+# PR #843 to remove the original loader-driven compaction.
 
 
 @pytest.mark.asyncio()
@@ -882,7 +885,7 @@ async def test_load_history_returns_all_messages_under_limit(
     """load_conversation_history should return all messages when under the soft limit."""
     _add_messages(session, 8)
 
-    # No compaction should be triggered from load_history anymore
+    # Under the limit there is no overflow, so no compaction fires.
     with patch("backend.app.agent.compaction.amessages") as mock_llm:
         history = await load_conversation_history(session, limit=500)
 
@@ -899,25 +902,134 @@ async def test_load_history_soft_limit_caps_messages(
     """The soft limit should still cap how many messages are loaded into memory."""
     _add_messages(session, 10)
 
-    history = await load_conversation_history(session, limit=5)
+    with patch("backend.app.agent.context.trigger_compaction_for_dropped", new=AsyncMock()):
+        history = await load_conversation_history(session, limit=5)
     # 5 loaded, minus 1 for current = 4
     assert len(history) == 4
 
 
 @pytest.mark.asyncio()
-async def test_load_history_no_compaction_regardless_of_count(
+async def test_load_history_overflow_routes_to_compaction(
     test_user: UserData,
     session: SessionState,
 ) -> None:
-    """load_conversation_history should never trigger compaction, even over limit."""
+    """Rows that fall outside the loader window must be passed to
+    trigger_compaction_for_dropped, with a headroom batch so the path
+    does not re-fire on every subsequent message (issue #1427).
+    """
     _add_messages(session, 100)
 
-    with patch("backend.app.agent.compaction.amessages") as mock_llm:
+    with patch(
+        "backend.app.agent.context.trigger_compaction_for_dropped", new=AsyncMock()
+    ) as mock_trigger:
         history = await load_conversation_history(session, limit=5)
 
-    # No compaction LLM call should happen from load_history
-    mock_llm.assert_not_called()
+    mock_trigger.assert_awaited_once()
+    assert mock_trigger.await_args is not None
+    user_id_arg, overflow_arg = mock_trigger.await_args.args
+    assert user_id_arg == test_user.id
+    # overflow (100 - 5 = 95) + 32 headroom rows, capped at total - 1 = 99:
+    # the current message is never compacted.
+    seqs = [m.seq for m in overflow_arg if getattr(m, "seq", None) is not None]
+    assert max(seqs) == 99
+    # The returned window is unchanged on the turn that detects overflow.
     assert len(history) == 4
+
+
+@pytest.mark.asyncio()
+async def test_load_history_overflow_skips_when_compaction_disabled(
+    test_user: UserData,
+    session: SessionState,
+) -> None:
+    """With compaction disabled, overflow keeps the pre-#1427 silent
+    fall-off behavior: no trigger, no watermark write.
+    """
+    _add_messages(session, 100)
+
+    with (
+        patch.object(settings, "compaction_enabled", False),
+        patch(
+            "backend.app.agent.context.trigger_compaction_for_dropped", new=AsyncMock()
+        ) as mock_trigger,
+    ):
+        history = await load_conversation_history(session, limit=5)
+
+    mock_trigger.assert_not_called()
+    assert len(history) == 4
+
+
+@pytest.mark.asyncio()
+async def test_load_history_overflow_advances_watermark_and_compacts(
+    test_user: User,
+) -> None:
+    """End-to-end overflow path against a DB-backed session: the watermark
+    advances past the compacted batch, a CompactionEvent row is written,
+    and the extracted facts land in MEMORY.md (issue #1427).
+    """
+    from backend.app.agent import context as _context_module
+
+    cs = await _seed_session_with_messages(test_user, message_count=20)
+    store = get_session_store(test_user.id)
+    session = await store.load_session_async(cs.session_id)
+    assert session is not None
+
+    mock_response = make_text_response(
+        json.dumps({"memory_update": "## Facts\n- fact: from_overflow", "summary": ""})
+    )
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        history = await load_conversation_history(session, limit=10)
+        if _context_module._background_tasks:
+            await asyncio.gather(*list(_context_module._background_tasks), return_exceptions=True)
+
+    # The window itself is unchanged this turn: last 10 rows minus current.
+    assert len(history) == 9
+
+    async with db_session_async() as db:
+        cs_ref = (await db.execute(select(ChatSession).filter_by(id=cs.id))).scalar_one_or_none()
+        assert cs_ref is not None
+        # overflow (20 - 10 = 10) + 32 headroom rows, capped at total - 1 = 19.
+        assert cs_ref.last_trim_seq == 19
+        events = (
+            (await db.execute(select(CompactionEvent).filter_by(user_id=test_user.id)))
+            .scalars()
+            .all()
+        )
+        assert len(events) == 1
+
+    content = await get_memory_store(test_user.id).read_memory_async()
+    assert "fact: from_overflow" in content
+
+
+@pytest.mark.asyncio()
+async def test_load_history_overflow_does_not_refire_after_watermark(
+    test_user: User,
+) -> None:
+    """Once the overflow batch is watermarked, the next load sees no
+    overflow and must not trigger compaction again (hysteresis).
+    """
+    cs = await _seed_session_with_messages(test_user, message_count=20)
+    store = get_session_store(test_user.id)
+
+    session = await store.load_session_async(cs.session_id)
+    assert session is not None
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("", None)),
+    ):
+        await load_conversation_history(session, limit=10)
+        await asyncio.sleep(0)
+
+    # Reload: the advanced watermark filters the compacted rows, so the
+    # visible set is back under the limit.
+    session2 = await store.load_session_async(cs.session_id)
+    assert session2 is not None
+    assert session2.last_trim_seq == 19
+    with patch(
+        "backend.app.agent.context.trigger_compaction_for_dropped", new=AsyncMock()
+    ) as mock_trigger:
+        await load_conversation_history(session2, limit=10)
+
+    mock_trigger.assert_not_called()
 
 
 # --- trigger_compaction_for_dropped tests ---

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1723,6 +1723,75 @@ async def test_watermark_event_seq_invariant_after_compaction(test_user: User) -
         assert cs_ref.last_trim_seq == event.max_message_seq == 8
 
 
+@pytest.mark.asyncio()
+async def test_trigger_compaction_skips_rows_below_live_watermark(test_user: User) -> None:
+    """Rows at or below the live watermark must not be re-compacted.
+
+    The loader's window-overflow path and the trim path can both fire in
+    one turn over an overlapping seq range (issue #1427): the loader
+    advances the watermark during load_history_step, then the trim path
+    in process_message drops rows from a history snapshot taken before
+    that advance. The trigger must re-check the live watermark so the
+    overlap is not compacted twice.
+    """
+    cs = await _seed_session_with_messages(test_user, message_count=20)
+    async with db_session_async() as db:
+        cs_ref = (await db.execute(select(ChatSession).filter_by(id=cs.id))).scalar_one_or_none()
+        assert cs_ref is not None
+        cs_ref.last_trim_seq = 10
+        await db.commit()
+
+    # Fully covered range: no event row, no compaction call.
+    fully_covered: list[AgentMessage] = [
+        UserMessage(content="old", seq=9),
+        AssistantMessage(content="old reply", seq=10),
+    ]
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("", None)),
+    ) as mock_compact:
+        await trigger_compaction_for_dropped(test_user.id, fully_covered)
+        await asyncio.sleep(0)
+    mock_compact.assert_not_called()
+    async with db_session_async() as db:
+        events = (
+            (await db.execute(select(CompactionEvent).filter_by(user_id=test_user.id)))
+            .scalars()
+            .all()
+        )
+        assert len(events) == 0
+
+    # Partial overlap: only the rows above the watermark are compacted,
+    # and the event row records the filtered range.
+    partial: list[AgentMessage] = [
+        AssistantMessage(content="old reply", seq=10),
+        UserMessage(content="new message", seq=11),
+        AssistantMessage(content="new reply", seq=12),
+    ]
+    with patch(
+        "backend.app.agent.context.compact_session",
+        new=AsyncMock(return_value=("", None)),
+    ) as mock_compact:
+        await trigger_compaction_for_dropped(test_user.id, partial)
+        await asyncio.sleep(0)
+    mock_compact.assert_called_once()
+    compacted_msgs = mock_compact.call_args.args[1]
+    compacted_seqs = sorted(
+        m.seq for m in compacted_msgs if isinstance(getattr(m, "seq", None), int)
+    )
+    assert compacted_seqs == [11, 12]
+    async with db_session_async() as db:
+        event = (
+            await db.execute(select(CompactionEvent).filter_by(user_id=test_user.id))
+        ).scalar_one_or_none()
+        cs_ref = (await db.execute(select(ChatSession).filter_by(id=cs.id))).scalar_one_or_none()
+        assert event is not None
+        assert event.min_message_seq == 11
+        assert event.max_message_seq == 12
+        assert cs_ref is not None
+        assert cs_ref.last_trim_seq == 12
+
+
 # ---------------------------------------------------------------------------
 # compact_session with event_id: UPDATE the pre-inserted row
 # ---------------------------------------------------------------------------

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -937,6 +937,32 @@ async def test_load_history_overflow_routes_to_compaction(
 
 
 @pytest.mark.asyncio()
+async def test_load_history_overflow_batch_capped_per_turn(
+    test_user: UserData,
+    session: SessionState,
+) -> None:
+    """A huge legacy backlog must not be compacted in one LLM call: the
+    overflow batch is a contiguous prefix capped at 200 rows per turn, so
+    the backlog converges over several turns instead of blowing the
+    compaction model's context (issue #1427).
+    """
+    _add_messages(session, 400)
+
+    with patch(
+        "backend.app.agent.context.trigger_compaction_for_dropped", new=AsyncMock()
+    ) as mock_trigger:
+        await load_conversation_history(session, limit=5)
+
+    mock_trigger.assert_awaited_once()
+    assert mock_trigger.await_args is not None
+    _user_id_arg, overflow_arg = mock_trigger.await_args.args
+    seqs = [m.seq for m in overflow_arg if getattr(m, "seq", None) is not None]
+    # Contiguous prefix from the oldest row, capped at 200.
+    assert min(seqs) == 1
+    assert max(seqs) == 200
+
+
+@pytest.mark.asyncio()
 async def test_load_history_overflow_skips_when_compaction_disabled(
     test_user: UserData,
     session: SessionState,

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import SecretStr, ValidationError
 
 from backend.app.config import (
+    CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS,
     Settings,
     log_config_warnings,
     resolve_imessage_backend,
@@ -137,6 +138,29 @@ class TestLogConfigWarnings:
         assert s.context_trim_target_tokens < s.context_trim_trigger_tokens <= s.max_input_tokens
         trim_warnings = [w for w in log_config_warnings(s) if "context_trim" in w]
         assert trim_warnings == []
+
+    def test_warns_history_limit_below_turn_trigger(self) -> None:
+        """A loader window too small for the turn backstop must warn.
+
+        Regression for issue #1427: when the row cap binds before the
+        turn trigger, old messages roll through window-overflow compaction
+        instead of the turn backstop. The operator should know.
+        """
+        s = Settings(conversation_history_limit=100)  # default trigger is 216 turns
+        warnings = log_config_warnings(s)
+        assert any("conversation_history_limit" in w for w in warnings)
+
+    def test_default_turn_trigger_reachable_in_history_window(self) -> None:
+        """Defaults must keep the turn backstop reachable inside the loader
+        window: 2 * (effective_trigger + 1) <= conversation_history_limit.
+        Regression for issue #1427, where target_turns=600 made the turn
+        backstop unreachable behind the 500-row loader cap.
+        """
+        s = Settings()
+        effective_trigger = s.context_trim_target_turns + CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS
+        assert 2 * (effective_trigger + 1) <= s.conversation_history_limit
+        limit_warnings = [w for w in log_config_warnings(s) if "conversation_history_limit" in w]
+        assert limit_warnings == []
 
     def test_logs_warnings(self, caplog: pytest.LogCaptureFixture) -> None:
         s = Settings(max_tool_rounds=100)


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #1427.

Token-light conversations could grow past the `conversation_history_limit` row cap (500) while staying under the 150k token trim trigger forever. Rows beyond the window were silently excluded from LLM context without ever passing through `trim_messages`, so the trim-driven compaction path never saw them: no MEMORY.md update, no HISTORY.md breadcrumb, no watermark advance. The turn backstop could not catch it either: its default (600 turns, effective trigger 616) was unreachable behind a window that holds at most ~250 user turns.

Three changes:

1. **Window-overflow compaction.** `load_conversation_history` now routes rows that fall outside the window through `trigger_compaction_for_dropped`, plus a 32-row headroom batch so the path does not re-fire on every subsequent message. PR #843 removed the old loader-driven compaction because it re-fired per message with no watermark; the watermark advance plus headroom batching is what makes this reintroduction safe. When every overflowed row is filtered (approval prompts, blank attachment placeholders), the watermark still advances so the branch cannot re-detect the same rows forever. The compacted batch is still returned in this turn's history; the advanced watermark filters it from the next turn, mirroring trim semantics.

2. **Reachable turn backstop.** `context_trim_target_turns` default drops from 600 to 200 so the backstop is reachable inside the loader window (2 x 217 = 434 <= 500 rows). A user turn is typically an inbound + outbound row pair. The trigger-buffer constant (16) moves to `config.py` (`CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS`) so the config validator can compute the effective trigger without importing agent code; `trimming.py` imports it from there. Note for reviewers: this trades some raw recall for mid-weight users (turn trim now binds around 216 turns for conversations that stay under 150k tokens) in exchange for facts actually surviving into MEMORY.md. The alternative was raising `conversation_history_limit` above ~1250 rows, which works against the hot-path memory bound (#1428).

3. **Config warning.** `log_config_warnings` warns when `2 * (effective_trigger + 1) > conversation_history_limit`, the configuration shape that reproduces the original bug.

Behavioral change to an existing test: `test_load_history_no_compaction_regardless_of_count` asserted the loader never compacts (the #843 contract). That contract is deliberately amended by this fix; the test is replaced by overflow tests that assert the new watermark-guarded behavior, including a no-re-fire hysteresis test.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (2890 passed, 2 skipped)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): Claude analyzed the conversation/compaction design, filed the issue, implemented the fix, and wrote the tests, with direction and review by @njbrake.
- [ ] No AI used
