### PR TITLE
fix: stop loading compacted rows on the hot inbound path

### DIFF
--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -137,6 +137,27 @@ def _select_messages_for_session(cs_id: int) -> Select[tuple[Message]]:
     return select(Message).filter_by(session_id=cs_id).order_by(Message.seq)
 
 
+def _select_messages_above_watermark(
+    cs_id: int, last_trim_seq: int | None
+) -> Select[tuple[Message]]:
+    """Messages still visible to the agent: ``seq > last_trim_seq``.
+
+    The hot inbound path (:meth:`SessionStore.get_or_create_session_async`)
+    uses this instead of :func:`_select_messages_for_session` so rows that
+    have been compacted out of LLM context are never loaded from the
+    database. ``load_conversation_history`` applies the same filter in
+    Python, so the visible result is identical; doing it SQL-side keeps
+    the per-message load bounded by the visible window instead of growing
+    with the user's lifetime message count (issue #1428). The
+    ``uq_message_seq`` unique constraint on ``(session_id, seq)`` indexes
+    the range scan. NULL watermark = no filter, matching the loader.
+    """
+    stmt = select(Message).filter_by(session_id=cs_id)
+    if last_trim_seq is not None:
+        stmt = stmt.where(Message.seq > last_trim_seq)
+    return stmt.order_by(Message.seq)
+
+
 def _select_message_by_seq(cs_id: int, seq: int) -> Select[tuple[Message]]:
     return select(Message).filter_by(session_id=cs_id, seq=seq)
 
@@ -310,6 +331,19 @@ class SessionStore:
         ``(session, is_new)`` where ``is_new`` is True only on the very
         first call for a user.
 
+        Loads only the messages still visible to the agent
+        (``seq > last_trim_seq``); rows below the trim watermark have been
+        compacted into MEMORY.md / USER.md / SOUL.md and every downstream
+        consumer of this method either filters them out anyway
+        (``load_conversation_history``, ``admin_compact_visible_messages``)
+        or never reads ``messages`` at all (heartbeat persistence). This
+        keeps the hot inbound path bounded by the visible window instead
+        of re-materializing the user's full lifetime history on every
+        message (issue #1428). Callers that need the complete transcript
+        (webchat history endpoint, admin views) use
+        :meth:`load_session_async` / :meth:`list_sessions_async`, which
+        keep loading everything.
+
         Concurrent first-message arrivals on different channels would
         otherwise race the INSERT and one would lose to the unique
         constraint. We serialize with a transaction-scoped advisory lock
@@ -334,7 +368,9 @@ class SessionStore:
                 cs.last_message_at = now
                 await db.commit()
                 messages = list(
-                    (await db.execute(_select_messages_for_session(cs.id))).scalars().all()
+                    (await db.execute(_select_messages_above_watermark(cs.id, cs.last_trim_seq)))
+                    .scalars()
+                    .all()
                 )
                 return _session_to_state(cs, messages), False
 
@@ -358,7 +394,13 @@ class SessionStore:
                 cs = (await db.execute(_select_session_by_user(self.user_id))).scalar_one_or_none()
                 if cs is not None:
                     messages = list(
-                        (await db.execute(_select_messages_for_session(cs.id))).scalars().all()
+                        (
+                            await db.execute(
+                                _select_messages_above_watermark(cs.id, cs.last_trim_seq)
+                            )
+                        )
+                        .scalars()
+                        .all()
                     )
                     return _session_to_state(cs, messages), False
                 short_uid = uuid.uuid4().hex[:8]

--- a/tests/test_session_db_async.py
+++ b/tests/test_session_db_async.py
@@ -142,6 +142,57 @@ async def test_get_or_create_session_async_advances_last_message_at(
     assert second.last_message_at >= first.last_message_at
 
 
+async def test_get_or_create_session_async_excludes_compacted_rows(
+    async_db: async_sessionmaker,
+) -> None:
+    """The hot inbound path must not load rows at or below the trim
+    watermark: they were compacted out of LLM context and every consumer
+    of this method filters them out anyway (issue #1428). Loading them
+    made the per-message DB load grow with the user's lifetime message
+    count.
+    """
+    user_id = await _create_user(async_db)
+    store = SessionStore(user_id)
+    session, _ = await store.get_or_create_session_async()
+    for i in range(1, 7):
+        await store.add_message_async(
+            session, direction="inbound" if i % 2 else "outbound", body=f"msg {i}"
+        )
+
+    # Advance the watermark the same way trigger_compaction_for_dropped does.
+    async with async_db() as db:
+        cs = (
+            await db.execute(select(ChatSession).filter_by(session_id=session.session_id))
+        ).scalar_one()
+        cs.last_trim_seq = 4
+        await db.commit()
+
+    reloaded, is_new = await store.get_or_create_session_async()
+    assert is_new is False
+    assert [m.seq for m in reloaded.messages] == [5, 6]
+    assert reloaded.last_trim_seq == 4
+
+    # The full-transcript path is unchanged: load_session_async still
+    # returns every row (webchat history endpoint, admin views).
+    full = await store.load_session_async(session.session_id)
+    assert full is not None
+    assert [m.seq for m in full.messages] == [1, 2, 3, 4, 5, 6]
+
+
+async def test_get_or_create_session_async_null_watermark_loads_all(
+    async_db: async_sessionmaker,
+) -> None:
+    """NULL watermark (no compaction yet) keeps loading every row."""
+    user_id = await _create_user(async_db)
+    store = SessionStore(user_id)
+    session, _ = await store.get_or_create_session_async()
+    for i in range(1, 4):
+        await store.add_message_async(session, direction="inbound", body=f"m{i}")
+
+    reloaded, _ = await store.get_or_create_session_async()
+    assert [m.seq for m in reloaded.messages] == [1, 2, 3]
+
+
 # ---------------------------------------------------------------------------
 # add_message_async / add_message_by_session_id_async
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #1428.

`get_or_create_session_async` loaded every message the user had ever produced on every inbound message, including rows at or below the trim watermark that `load_conversation_history` filters out in Python a moment later. Messages are never deleted (they are the audit record), so the per-message DB load grew with the user's lifetime message count: O(lifetime) rows materialized into ORM objects and DTOs, including multi-KB `tool_interactions_json` blobs, per inbound message, forever.

The watermark filter now runs SQL-side via a dedicated builder (`seq > last_trim_seq`, range scan served by the existing `uq_message_seq` constraint on `(session_id, seq)`), so the hot path loads only the rows still visible to the agent. Consumer audit:

| Consumer of `get_or_create_session_async` | Effect |
| --- | --- |
| `load_conversation_history` (router `load_history_step`) | Applied the same filter in Python already; identical output |
| `admin_compact_visible_messages` | Filters `seq > watermark` itself; identical output |
| Heartbeat outbound persistence | Only appends; never reads `messages` |
| Inbound recovery state refresh | Needs recent state; visible window suffices |
| Onboarding `user_message_count` heuristic | Counts visible inbound rows; onboarding-age users have no watermark, so unaffected in practice |

Full-transcript surfaces (webchat history endpoint, admin views) go through `load_session_async` / `list_sessions_async`, which are unchanged and still load everything.

**Deliberate deviation from the issue:** the issue also proposed a tail `LIMIT`. Not included: a naive LIMIT would hide the oldest visible rows from the window-overflow compaction path (#1427 / PR #1434), which must see a contiguous prefix starting at the oldest row above the watermark to advance it safely. With that path in place, the row count above the watermark is bounded at steady state anyway, so the watermark filter alone bounds this load. The two PRs are independent and can merge in either order.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (2887 passed, 2 skipped)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): Claude analyzed the hot-path load, audited the consumers, implemented the fix, and wrote the tests, with direction and review by @njbrake.
- [ ] No AI used
