### PR TITLE
fix: compare-and-swap memory file writes against compaction races

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -430,10 +430,23 @@ async def compact_session(
     # silently corrupt durable state. The conversation that triggered
     # this compaction will still trim, and the next compaction will get
     # another chance to produce an in-budget rewrite.
+    #
+    # All three writes are compare-and-swap against the value read at the
+    # top of this function (issue #1429). The LLM call between the read
+    # and the write takes tens of seconds, and the conversation keeps
+    # running: the agent's workspace tools can write a new fact in that
+    # window, and a second compaction for the same user can land first.
+    # A full rewrite computed from the stale read would silently clobber
+    # the newer value. On a CAS miss we keep the newer value and skip
+    # this rewrite: losing one batch's extraction is recoverable (the
+    # conversation that was sent to the LLM is preserved in the event
+    # row's ``prompt_text`` audit column), while clobbering a durable
+    # file, possibly holding an explicit user save, is not.
     if memory_changed:
         try:
-            await memory_store.write_memory_async(result.memory_update)
-            logger.info("Compaction rewrote MEMORY.md for user %s", user_id)
+            wrote = await memory_store.write_memory_async(
+                result.memory_update, expected_current=current_memory
+            )
         except BudgetExceededError as exc:
             logger.warning(
                 "Compaction skipping MEMORY.md update for user %s: %s",
@@ -441,6 +454,17 @@ async def compact_session(
                 exc,
             )
             memory_changed = False
+        else:
+            if wrote:
+                logger.info("Compaction rewrote MEMORY.md for user %s", user_id)
+            else:
+                logger.warning(
+                    "Compaction skipping MEMORY.md update for user %s: the file"
+                    " changed since this compaction read it (concurrent agent"
+                    " write or another compaction); keeping the newer value",
+                    user_id,
+                )
+                memory_changed = False
 
     # Append summary to HISTORY.md if the LLM produced one. ``append_history``
     # returns the new full text under the same row-level lock that protected
@@ -460,11 +484,13 @@ async def compact_session(
             logger.exception("Failed to append history for user %s", user_id)
 
     # Write updated USER.md only when the rewrite actually differs.
-    # See MEMORY.md branch above for the BudgetExceededError handling.
+    # See MEMORY.md branch above for the BudgetExceededError and
+    # compare-and-swap handling.
     if user_changed:
         try:
-            await memory_store.write_user_async(result.user_profile_update)
-            logger.info("Compaction updated USER.md for user %s", user_id)
+            wrote = await memory_store.write_user_async(
+                result.user_profile_update, expected_current=current_user_profile
+            )
         except BudgetExceededError as exc:
             logger.warning(
                 "Compaction skipping USER.md update for user %s: %s",
@@ -472,12 +498,25 @@ async def compact_session(
                 exc,
             )
             user_changed = False
+        else:
+            if wrote:
+                logger.info("Compaction updated USER.md for user %s", user_id)
+            else:
+                logger.warning(
+                    "Compaction skipping USER.md update for user %s: the file"
+                    " changed since this compaction read it; keeping the"
+                    " newer value",
+                    user_id,
+                )
+                user_changed = False
 
     # Write updated SOUL.md only when the rewrite actually differs.
+    # See MEMORY.md branch above for the compare-and-swap handling.
     if soul_changed:
         try:
-            await memory_store.write_soul_async(result.soul_update)
-            logger.info("Compaction updated SOUL.md for user %s", user_id)
+            wrote = await memory_store.write_soul_async(
+                result.soul_update, expected_current=current_soul
+            )
         except BudgetExceededError as exc:
             logger.warning(
                 "Compaction skipping SOUL.md update for user %s: %s",
@@ -485,6 +524,17 @@ async def compact_session(
                 exc,
             )
             soul_changed = False
+        else:
+            if wrote:
+                logger.info("Compaction updated SOUL.md for user %s", user_id)
+            else:
+                logger.warning(
+                    "Compaction skipping SOUL.md update for user %s: the file"
+                    " changed since this compaction read it; keeping the"
+                    " newer value",
+                    user_id,
+                )
+                soul_changed = False
 
     # Single structured summary line. Fields are space-separated key=value
     # so log aggregators (Railway, Loki) can group / filter without

--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -51,6 +51,17 @@ def _user_select(user_id: str) -> Select[tuple[User]]:
     return select(User).filter_by(id=user_id)
 
 
+def _user_select_for_update(user_id: str) -> Select[tuple[User]]:
+    """Builder for the locked read used by compare-and-swap writes.
+
+    ``write_user_async`` / ``write_soul_async`` re-read the row under
+    ``FOR UPDATE`` when the caller supplies *expected_current*, so the
+    compare and the write are atomic against concurrent writers (the
+    agent's workspace tools, another compaction). See issue #1429.
+    """
+    return select(User).filter_by(id=user_id).with_for_update()
+
+
 def _doc_select_for_update(user_id: str) -> Select[tuple[MemoryDocument]]:
     """Builder for the locked read used by ``append_history``.
 
@@ -148,8 +159,20 @@ class MemoryStore:
         finally:
             await db.close()
 
-    async def write_memory_async(self, content: str) -> None:
+    async def write_memory_async(
+        self, content: str, *, expected_current: str | None = None
+    ) -> bool:
         """Write memory text (full rewrite, equivalent of MEMORY.md).
+
+        Returns True when the write landed. When *expected_current* is
+        provided, the write is compare-and-swap: the row is re-read under
+        the per-user advisory lock plus ``FOR UPDATE``, and when the
+        stored text no longer matches (another writer landed since the
+        caller's read: the agent's workspace tools mid-conversation, or a
+        concurrent compaction), nothing is written and False is returned.
+        Full rewrites computed from a stale read must not clobber a newer
+        value (issue #1429). *expected_current* is compared in the same
+        normalized form :meth:`read_memory_async` returns (stripped).
 
         Raises :class:`BudgetExceededError` when the value exceeds the
         ``MEMORY.md`` byte budget declared in
@@ -160,9 +183,30 @@ class MemoryStore:
         stored = content.rstrip() + "\n"
         assert_within_budget("MEMORY.md", stored)
         async with db_session_async() as db:
-            doc = await self._get_or_create_doc_async(db)
+            if expected_current is None:
+                doc = await self._get_or_create_doc_async(db)
+            else:
+                # Advisory lock so the no-row-yet branch cannot race a
+                # concurrent first writer (FOR UPDATE on a missing row
+                # acquires no predicate lock; same rationale as
+                # ``append_history``).
+                await db.execute(
+                    _advisory_lock_sql(),
+                    {"k": _advisory_lock_key(self.user_id)},
+                )
+                doc = (await db.execute(_doc_select_for_update(self.user_id))).scalar_one_or_none()
+                if doc is None:
+                    doc = MemoryDocument(user_id=self.user_id, memory_text="", history_text="")
+                    db.add(doc)
+                    await db.flush()
+                if (doc.memory_text or "").strip() != expected_current.strip():
+                    # Early return without commit: db_session_async closes
+                    # the session, rolling back the open transaction and
+                    # releasing the row lock.
+                    return False
             doc.memory_text = stored
             await db.commit()
+            return True
 
     # -- history text ------------------------------------------------------
 
@@ -258,8 +302,13 @@ class MemoryStore:
         finally:
             await db.close()
 
-    async def write_soul_async(self, content: str) -> None:
+    async def write_soul_async(self, content: str, *, expected_current: str | None = None) -> bool:
         """Write soul text to User model.
+
+        Returns True when the write landed. When *expected_current* is
+        provided, the write is compare-and-swap against the current value
+        in the same normalized form :meth:`read_soul_async` returns; see
+        :meth:`write_memory_async` for the rationale (issue #1429).
 
         Raises :class:`BudgetExceededError` when the wrapped value
         exceeds the ``SOUL.md`` byte budget. Compaction wraps the call
@@ -268,10 +317,21 @@ class MemoryStore:
         stored = f"# Soul\n\n{content}\n"
         assert_within_budget("SOUL.md", stored)
         async with db_session_async() as db:
-            user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
-            if user is not None:
-                user.soul_text = stored
-                await db.commit()
+            stmt = (
+                _user_select(self.user_id)
+                if expected_current is None
+                else _user_select_for_update(self.user_id)
+            )
+            user = (await db.execute(stmt)).scalar_one_or_none()
+            if user is None:
+                return False
+            if expected_current is not None:
+                current = _strip_section_prefix(user.soul_text or "", "# Soul")
+                if current != expected_current.strip():
+                    return False
+            user.soul_text = stored
+            await db.commit()
+            return True
 
     # -- user text ---------------------------------------------------------
 
@@ -286,8 +346,13 @@ class MemoryStore:
         finally:
             await db.close()
 
-    async def write_user_async(self, content: str) -> None:
+    async def write_user_async(self, content: str, *, expected_current: str | None = None) -> bool:
         """Write user text to User model.
+
+        Returns True when the write landed. When *expected_current* is
+        provided, the write is compare-and-swap against the current value
+        in the same normalized form :meth:`read_user_async` returns; see
+        :meth:`write_memory_async` for the rationale (issue #1429).
 
         Raises :class:`BudgetExceededError` when the wrapped value
         exceeds the ``USER.md`` byte budget. Compaction wraps the call
@@ -296,10 +361,21 @@ class MemoryStore:
         stored = f"# User\n\n{content}\n"
         assert_within_budget("USER.md", stored)
         async with db_session_async() as db:
-            user = (await db.execute(_user_select(self.user_id))).scalar_one_or_none()
-            if user is not None:
-                user.user_text = stored
-                await db.commit()
+            stmt = (
+                _user_select(self.user_id)
+                if expected_current is None
+                else _user_select_for_update(self.user_id)
+            )
+            user = (await db.execute(stmt)).scalar_one_or_none()
+            if user is None:
+                return False
+            if expected_current is not None:
+                current = _strip_section_prefix(user.user_text or "", "# User")
+                if current != expected_current.strip():
+                    return False
+            user.user_text = stored
+            await db.commit()
+            return True
 
     # -- composite helpers -------------------------------------------------
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -241,6 +241,59 @@ async def test_compact_session_rewrites_memory(test_user: UserData) -> None:
 
 
 @pytest.mark.asyncio()
+async def test_compact_session_skips_memory_write_on_concurrent_change(
+    test_user: UserData,
+) -> None:
+    """A write landing during the compaction LLM call must win (issue #1429).
+
+    compact_session reads MEMORY.md, runs an LLM call that takes tens of
+    seconds, then writes a full rewrite. If the agent's workspace tools
+    (or a second compaction) write a new fact in that window, the rewrite
+    is based on a stale read and must not clobber the newer value: the
+    compare-and-swap in write_memory_async detects the drift and skips.
+    """
+    store = get_memory_store(test_user.id)
+    await store.write_memory_async("## Facts\n- original")
+
+    mock_response = make_text_response(
+        json.dumps(
+            {
+                "memory_update": "## Facts\n- original\n- from compaction",
+                "summary": "",
+            }
+        )
+    )
+
+    async def _llm_with_concurrent_write(*args: Any, **kwargs: Any) -> Any:
+        # Simulates the agent writing a new fact while the compaction
+        # LLM call is in flight.
+        await store.write_memory_async("## Facts\n- original\n- agent fact")
+        return mock_response
+
+    messages: list[AgentMessage] = [
+        UserMessage(content="some old conversation", seq=1),
+        AssistantMessage(content="noted", seq=2),
+    ]
+    with patch("backend.app.agent.compaction.amessages", side_effect=_llm_with_concurrent_write):
+        memory_update, _ = await compact_session(test_user.id, messages, max_message_seq=2)
+
+    # CAS miss: compaction reports no memory change and the concurrent
+    # write is preserved.
+    assert memory_update == ""
+    content = await store.read_memory_async()
+    assert "agent fact" in content
+    assert "from compaction" not in content
+
+    # The audit row records that no memory update landed.
+    async with db_session_async() as db:
+        event = (
+            await db.execute(select(CompactionEvent).filter_by(user_id=test_user.id))
+        ).scalar_one_or_none()
+        assert event is not None
+        assert event.memory_updated is False
+
+
+@pytest.mark.asyncio()
 async def test_compact_session_includes_current_memory_and_user(
     test_user: UserData,
 ) -> None:

--- a/tests/test_memory_db_async.py
+++ b/tests/test_memory_db_async.py
@@ -26,6 +26,83 @@ from backend.app.agent.memory_db import MemoryStore, get_memory_store
 from backend.app.models import MemoryDocument, User
 
 # ---------------------------------------------------------------------------
+# compare-and-swap writes (issue #1429)
+# ---------------------------------------------------------------------------
+
+
+async def test_async_write_memory_cas_match_writes(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """CAS write lands when the row still matches the caller's read."""
+    store = MemoryStore(async_test_user.id)
+    await store.write_memory_async("v1")
+    current = await store.read_memory_async()
+    assert await store.write_memory_async("v2", expected_current=current) is True
+    assert "v2" in await store.read_memory_async()
+
+
+async def test_async_write_memory_cas_mismatch_skips(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """A rewrite computed from a stale read must not clobber a newer write."""
+    store = MemoryStore(async_test_user.id)
+    await store.write_memory_async("v1")
+    stale = await store.read_memory_async()
+    # A concurrent writer (agent workspace tool, another compaction)
+    # lands after the caller's read.
+    await store.write_memory_async("agent fact")
+    assert await store.write_memory_async("stale rewrite", expected_current=stale) is False
+    assert await store.read_memory_async() == "agent fact"
+
+
+async def test_async_write_memory_cas_empty_expected_matches_missing_row(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    """``expected_current=""`` matches a missing row (first compaction)."""
+    store = MemoryStore(async_test_user.id)
+    assert await store.write_memory_async("first", expected_current="") is True
+    assert "first" in await store.read_memory_async()
+
+
+async def test_async_write_user_cas_mismatch_skips(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    store = MemoryStore(async_test_user.id)
+    await store.write_user_async("trade: deck builder")
+    stale = await store.read_user_async()
+    await store.write_user_async("trade: general contractor")
+    assert await store.write_user_async("stale rewrite", expected_current=stale) is False
+    assert await store.read_user_async() == "trade: general contractor"
+
+
+async def test_async_write_soul_cas_mismatch_skips(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    store = MemoryStore(async_test_user.id)
+    await store.write_soul_async("tone: friendly")
+    stale = await store.read_soul_async()
+    await store.write_soul_async("tone: blunt, no emojis")
+    assert await store.write_soul_async("stale rewrite", expected_current=stale) is False
+    assert await store.read_soul_async() == "tone: blunt, no emojis"
+
+
+async def test_async_write_user_cas_match_writes(
+    async_db: async_sessionmaker,
+    async_test_user: User,
+) -> None:
+    store = MemoryStore(async_test_user.id)
+    await store.write_user_async("trade: deck builder")
+    current = await store.read_user_async()
+    assert await store.write_user_async("trade: remodeler", expected_current=current) is True
+    assert await store.read_user_async() == "trade: remodeler"
+
+
+# ---------------------------------------------------------------------------
 # memory_text: read / write
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #1429.

`compact_session` reads MEMORY.md / USER.md / SOUL.md, runs an LLM call that takes tens of seconds, then writes full rewrites. Compaction runs as a fire-and-forget background task, so the conversation keeps going during the call: the agent's workspace tools can write a new fact in that window, and a second compaction for the same user can land first (the snapshot logic already acknowledges concurrent `compact_session` tasks). The blind overwrite then clobbers the newer value silently, including explicit user saves. HISTORY.md was already protected (advisory lock + `FOR UPDATE` in `append_history`); MEMORY/USER/SOUL were last-writer-wins.

Changes:

- `write_memory_async` / `write_user_async` / `write_soul_async` accept an optional keyword-only `expected_current` and return `bool`. When provided, the compare runs inside the write transaction under `FOR UPDATE` (plus the per-user advisory lock for the no-row-yet MEMORY.md branch, mirroring `append_history`). On drift the write is skipped and `False` is returned. Comparison uses the same normalized form the corresponding `read_*_async` returns, so callers pass exactly what they read.
- `compact_session` passes its top-of-function reads as `expected_current`, logs a warning on a CAS miss, and records `memory_updated=False` (etc.) on the audit row so the before/after snapshots stay truthful.

**Tradeoff, made deliberately:** on a CAS miss the batch's extraction is dropped rather than re-merged with a second LLM call. Losing one batch's extraction is recoverable (the conversation sent to the LLM is preserved in the event row's `prompt_text` audit column, migration 031); clobbering a durable file is not. A bounded re-merge retry would be a reasonable follow-up if CAS misses turn out to be common; the new warning log line makes that measurable.

Plain calls without `expected_current` (e.g. the user-facing memory editor in `user_memory.py`) keep last-writer-wins semantics, which is correct for direct user edits.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (2892 passed, 2 skipped)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests (CAS unit tests for all three files plus an end-to-end mid-compaction-write race test)

## AI Usage
- [x] AI-assisted (describe how): Claude analyzed the race, implemented the CAS writes, and wrote the tests, with direction and review by @njbrake.
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a critical race condition where compaction operations could silently overwrite concurrent writes to memory files (MEMORY.md, USER.md, SOUL.md) during long-running LLM operations. The solution implements compare-and-swap (CAS) semantics to detect and skip writes when the underlying file has changed since the initial read.

## What Changed

**Compaction Process (compaction.py)**
- Modified `compact_session` to use compare-and-swap when persisting LLM-generated updates
- Instead of unconditionally overwriting memory files, the method now validates that the file hasn't changed since the initial read
- If a concurrent write is detected, the compaction update is skipped (rather than clobbering the new content) and logged appropriately
- Compaction audit records now accurately reflect whether an update succeeded or was skipped

**Memory Storage Layer (memory_db.py)**
- Enhanced three write methods (`write_memory_async`, `write_user_async`, `write_soul_async`) to support optional compare-and-swap validation
- When CAS is enabled, writes acquire database locks and perform atomic check-then-write operations
- Methods now return a boolean indicating success/failure instead of `None`
- If the stored content has changed since the initial read, the write is safely skipped without overwriting

## What Was Added

**Test Coverage**
- New end-to-end test simulating a mid-compaction concurrent write to validate correct race condition handling
- Six dedicated CAS unit tests covering match/mismatch scenarios for memory, user, and soul files
- Tests verify that concurrent writes are preserved rather than lost

## Benefits

- **Eliminates silent data loss**: Concurrent writes during compaction are no longer lost
- **Maintains accuracy**: Compaction audit records now truthfully reflect what changed
- **Graceful degradation**: On race detection, the compaction batch is dropped but remains recoverable from the event log
- **Backward compatible**: Regular user-facing writes (without CAS) maintain simple last-writer-wins semantics
- **Production-safe**: Database-level locking ensures correctness even with multiple concurrent compactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->