### PR TITLE
feat: advance prompt-cache breakpoint within the tool loop

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -84,6 +84,7 @@ from backend.app.logging_utils import mask_pii
 from backend.app.models import User
 from backend.app.services.llm_service import (
     apply_history_cache_breakpoint,
+    apply_in_turn_cache_breakpoint,
     apply_tool_caching,
     prepare_system_with_caching,
     reasoning_effort_to_thinking,
@@ -488,6 +489,10 @@ class ClawboltAgent:
         effective_max_tokens = max_tokens or settings.llm_max_tokens_agent
         system_str, msg_dicts = messages_to_messages_api(messages)
         msg_dicts = apply_history_cache_breakpoint(msg_dicts)
+        # Rounds N > 0 end in tool results: mark the trailing block so the
+        # current turn plus prior rounds read from cache instead of being
+        # re-sent as fresh input every round (issue #1430). No-op on round 0.
+        msg_dicts = apply_in_turn_cache_breakpoint(msg_dicts)
         system: str | list[dict[str, Any]] | None = system_str
         if system is not None:
             system = prepare_system_with_caching(system)
@@ -571,6 +576,7 @@ class ClawboltAgent:
                 )
                 retry_system_str, trimmed_dicts = messages_to_messages_api(trim_result.messages)
                 trimmed_dicts = apply_history_cache_breakpoint(trimmed_dicts)
+                trimmed_dicts = apply_in_turn_cache_breakpoint(trimmed_dicts)
                 system = (
                     prepare_system_with_caching(retry_system_str)
                     if retry_system_str is not None

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -187,6 +187,51 @@ def apply_history_cache_breakpoint(
     return messages
 
 
+def apply_in_turn_cache_breakpoint(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Stamp a ``cache_control`` breakpoint on a trailing tool-result block.
+
+    During the tool loop, every round re-sends the current user turn
+    (which carries the dynamic context: memory, integrations,
+    cross-session) plus all prior rounds' tool calls and results as
+    uncached input, because the only message-side breakpoint
+    (:func:`apply_history_cache_breakpoint`) sits before the current
+    turn and never advances within it. With ``max_tool_rounds=10`` and
+    large tool results, that cost grows quadratically with round count
+    (issue #1430).
+
+    When the request ends in tool results (rounds N > 0), marking the
+    last ``tool_result`` block makes the current turn plus rounds
+    0..N-1 cacheable for round N; only the newest round's content pays
+    cache-write. The message dicts are re-serialized from typed
+    messages on every round, so the marker naturally advances with the
+    loop instead of accumulating: each request carries at most four
+    breakpoints (system, tools, prior-history tail, this one), which is
+    Anthropic's limit.
+
+    Round 0 ends in the current user turn (plain string content), not
+    tool results, so this is a no-op there and the request keeps three
+    breakpoints. Returns the list unchanged when there is nothing safe
+    to mark.
+    """
+    if not messages:
+        return messages
+    last = messages[-1]
+    content = last.get("content")
+    if (
+        last.get("role") != "user"
+        or not isinstance(content, list)
+        or not content
+        or content[-1].get("type") != "tool_result"
+    ):
+        return messages
+    blocks = [dict(block) for block in content]
+    blocks[-1] = {**blocks[-1], "cache_control": _cache_control()}
+    messages[-1] = {**last, "content": blocks}
+    return messages
+
+
 def apply_tool_caching(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Add a cache_control marker to the last tool definition.
 

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -10,6 +10,7 @@ import pytest
 from backend.app.services.llm_service import (
     _cache_control,
     apply_history_cache_breakpoint,
+    apply_in_turn_cache_breakpoint,
     apply_tool_caching,
     prepare_system_with_caching,
     resolve_user_llm_override,
@@ -199,6 +200,77 @@ class TestApplyHistoryCacheBreakpoint:
         result = apply_history_cache_breakpoint(messages)
         assert all("cache_control" not in block for block in result[0]["content"])
         assert all("cache_control" not in block for block in result[1]["content"])
+
+
+class TestApplyInTurnCacheBreakpoint:
+    """The in-turn breakpoint advances with the tool loop (issue #1430)."""
+
+    def _control(self) -> dict[str, object]:
+        return _cache_control()
+
+    def test_marks_trailing_tool_result_block(self) -> None:
+        messages = [
+            {"role": "user", "content": "current turn"},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "a", "name": "t"}]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "a", "content": "one"},
+                    {"type": "tool_result", "tool_use_id": "b", "content": "two"},
+                ],
+            },
+        ]
+        result = apply_in_turn_cache_breakpoint(messages)
+        tool_results = result[-1]["content"]
+        assert "cache_control" not in tool_results[0]
+        assert tool_results[1]["cache_control"] == self._control()
+
+    def test_noop_on_round_zero(self) -> None:
+        # Round 0 ends in the current user turn (string content).
+        messages = [
+            {"role": "user", "content": "older question"},
+            {"role": "assistant", "content": [{"type": "text", "text": "older answer"}]},
+            {"role": "user", "content": "current turn"},
+        ]
+        result = apply_in_turn_cache_breakpoint(messages)
+        assert isinstance(result[-1]["content"], str)
+        assert "cache_control" not in result[-1]
+
+    def test_noop_on_trailing_assistant_message(self) -> None:
+        messages = [
+            {"role": "user", "content": "current turn"},
+            {"role": "assistant", "content": [{"type": "text", "text": "reply"}]},
+        ]
+        result = apply_in_turn_cache_breakpoint(messages)
+        assert all("cache_control" not in block for block in result[-1]["content"])
+
+    def test_noop_on_empty_list(self) -> None:
+        assert apply_in_turn_cache_breakpoint([]) == []
+
+    def test_at_most_four_breakpoints_with_history_anchor(self) -> None:
+        """Combined with the history anchor, the message side carries at
+        most two breakpoints; system and tools carry the other two, which
+        is Anthropic's four-breakpoint limit.
+        """
+        messages = [
+            {"role": "user", "content": "older question"},
+            {"role": "assistant", "content": [{"type": "text", "text": "older answer"}]},
+            {"role": "user", "content": "current turn"},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "a", "name": "t"}]},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "a", "content": "x"}],
+            },
+        ]
+        result = apply_history_cache_breakpoint(messages)
+        result = apply_in_turn_cache_breakpoint(result)
+
+        marker_count = 0
+        for msg in result:
+            content = msg.get("content")
+            if isinstance(content, list):
+                marker_count += sum(1 for block in content if "cache_control" in block)
+        assert marker_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #1430.

The only message-side cache breakpoint (`apply_history_cache_breakpoint`) sits before the current inbound user turn and never moves during the tool loop. Every round N > 0 therefore re-sent the current turn (which carries the full dynamic context: MEMORY.md up to 25KB, integration status, cross-session context) plus all prior rounds' tool calls and results as fresh, uncached input. With `max_tool_rounds=10` and large tool results, the per-turn cost grows quadratically with round count.

New `apply_in_turn_cache_breakpoint` stamps a `cache_control` marker on the trailing `tool_result` block when the request ends in tool results (rounds N > 0). Round N then reads the current turn plus rounds 0..N-1 from cache and pays cache-write only on the newest round's content.

Safety properties:

- **No marker accumulation.** Message dicts are re-serialized from typed `AgentMessage` objects on every round (`messages_to_messages_api`), so the marker naturally advances with the loop; it cannot pile up across rounds.
- **At most four breakpoints per request** (system, tools, prior-history tail, in-turn), which is Anthropic's limit. A test asserts the message side carries at most two.
- **Round 0 unchanged.** The request ends in the current user turn (plain string content), so the function is a no-op there and the request shape is byte-identical to today.
- Applied on both the main call path and the `ContextLengthExceededError` retry path.

The existing `Agent turn cache summary` log line (`cache_read_input_tokens`) is the production signal to confirm the improvement on multi-round turns.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (2890 passed, 2 skipped)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests (not a bug fix; performance feature)

## AI Usage
- [x] AI-assisted (describe how): Claude analyzed the per-round cache behavior, implemented the breakpoint rotation, and wrote the tests, with direction and review by @njbrake.
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR implements an **in-turn cache breakpoint** feature to improve efficiency in multi-round tool-using agent calls. Previously, when an agent ran multiple rounds of tool calls and tool results, each subsequent round would re-send the entire current user turn (which can include large dynamic context like memory files) and all prior tool calls and results as uncached input, wasting cache capacity and tokens. This PR adds a smart cache marker that allows subsequent rounds to reuse cached content from earlier rounds.

## What Changed

**Added:**
- A new cache control function (`apply_in_turn_cache_breakpoint`) that marks the last tool-result message block in the current turn as cacheable
- Logic in the agent core to apply this marker before sending requests with tool results
- Comprehensive test coverage validating the marker is placed correctly and doesn't accumulate

**Modified:**
- Agent call pipeline to invoke the new cache breakpoint function on both the main request path and on error retry paths (when context length is exceeded)

**No Changes to:**
- Single-round behavior (marked as "Round 0") — requests ending in user messages behave identically
- Overall request structure or message sequencing

## Benefits

- **Reduced token waste**: Multi-round tool calls now reuse cached context from earlier rounds, paying cache tokens only once for the current turn's content
- **Better scalability**: Agents with large context (up to 25KB dynamic content per turn) benefit from avoiding repeated uncached sends
- **Maintained safety**: The implementation ensures at most four cache breakpoints per request (Anthropic limit) and prevents marker accumulation
- **Backward compatible**: Single-round requests and existing behavior remain unchanged

## Technical Details

The implementation:
- Stamps a `cache_control` marker on the trailing `tool_result` block in the message list when a request ends in tool results
- Performs safety checks to ensure the marker only applies to valid tool-result messages
- Leverages message re-serialization each round to prevent marker accumulation
- Works with both the main LLM call path and the `ContextLengthExceededError` retry handler
- Maintains the existing prior-history cache breakpoint placement for cross-turn consistency

Tests validate that the marker is correctly placed on tool-result blocks, not applied on round zero, and that when combined with the existing history breakpoint, the total marker count stays within limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->