### PR TITLE
fix: retry compaction events stuck in pending on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,7 @@ LLM_MODEL=
 # AGENT_PROCESSING_TIMEOUT_SECONDS=300  # Max seconds for agent processing (includes lock wait)
 # MESSAGE_BATCH_WINDOW_MS=1500  # Batch rapid-fire messages per user (0 to disable)
 # INBOUND_RECOVERY_LOOKBACK_MINUTES=30  # Sweep for inbound messages persisted but never run on startup (0 disables)
+# COMPACTION_RETRY_LOOKBACK_MINUTES=10080  # Retry compaction events stuck in 'pending' on startup (0 disables)
 # MAX_TOOL_ROUNDS=10
 # MAX_INPUT_TOKENS=600000  # Hard ceiling on the input token budget; the trim trigger must stay at or below this
 # CONTEXT_TRIM_TARGET_TOKENS=120000  # Drop-to token budget after trimming (the primary trim governor)

--- a/alembic/versions/039_add_compaction_event_retry_count.py
+++ b/alembic/versions/039_add_compaction_event_retry_count.py
@@ -1,0 +1,34 @@
+"""Add ``retry_count`` to ``compaction_events``.
+
+The startup sweep in ``backend/app/agent/compaction_recovery.py`` retries
+events stuck in ``'pending'`` (the async compaction LLM call crashed or
+the process restarted mid-call). ``retry_count`` bounds those retries:
+each attempt increments it before the LLM call, and rows at the cap stop
+being selected so a poisoned range cannot retry forever.
+
+Revision ID: 039
+Revises: 038
+Create Date: 2026-06-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "039"
+down_revision: str | None = "038"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "compaction_events",
+        sa.Column("retry_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("compaction_events", "retry_count")

--- a/backend/app/agent/compaction_recovery.py
+++ b/backend/app/agent/compaction_recovery.py
@@ -1,0 +1,308 @@
+"""Startup retry for compaction events stuck in ``'pending'``.
+
+``trigger_compaction_for_dropped`` advances the trim watermark
+synchronously, then runs the compaction LLM call as a fire-and-forget
+background task. When the process dies mid-call (deploy restart, OOM) or
+the call fails (provider outage), the ``CompactionEvent`` row stays
+``'pending'`` forever: the watermark is already advanced, so the seq
+range never reaches the LLM again, and the facts in it were never
+extracted into MEMORY.md / USER.md / SOUL.md.
+
+Everything needed to recover is durable: the row records the seq range
+(``min_message_seq`` / ``max_message_seq``) and message rows are never
+deleted. This module sweeps for stale pending rows on app startup and
+re-runs ``compact_session`` against the original range, mirroring the
+``inbound_recovery`` sweep (per-process advisory lock, lookback window,
+best-effort semantics, one worker per rolling restart).
+
+Bounds, so the sweep cannot loop or race:
+
+- Only rows older than ``_GRACE_SECONDS`` are considered, so the sweep
+  never races a compaction task that is legitimately still in flight.
+- Only rows younger than ``compaction_retry_lookback_minutes`` are
+  considered; ``0`` disables the sweep entirely.
+- Each attempt increments ``retry_count`` *before* the LLM call, so a
+  crash mid-retry still counts the attempt. Rows at ``_MAX_ATTEMPTS``
+  stop being selected: a poisoned range cannot retry forever. They stay
+  ``'pending'`` so an admin can still find them (the conversation that
+  should have been compacted is recoverable via the seq range).
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Select, select, text
+
+from backend.app.agent.compaction import compact_session
+from backend.app.agent.context import _stored_messages_to_agent_messages
+from backend.app.agent.session_db import _msg_to_stored
+from backend.app.config import settings
+from backend.app.database import AsyncSessionLocal, db_session_async, get_async_engine
+from backend.app.models import ChatSession, CompactionEvent, Message, User
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncConnection
+
+logger = logging.getLogger(__name__)
+
+# Postgres advisory lock key; one worker runs the sweep per rolling
+# restart. Same shape as ``inbound_recovery._RECOVERY_LOCK_KEY``.
+_RECOVERY_LOCK_KEY = "compaction_recovery:cleanup"
+
+# Do not retry rows younger than this. A compaction LLM call that is
+# still legitimately in flight (slow provider, long input) must not be
+# raced by the sweep; 10 minutes comfortably exceeds any sane call.
+_GRACE_SECONDS = 600
+
+# Attempts per row across all boots. At the cap the row stays
+# ``'pending'`` but stops being selected.
+_MAX_ATTEMPTS = 3
+
+
+def _stale_pending_events_select(
+    cutoff_utc: datetime.datetime,
+    grace_floor_utc: datetime.datetime,
+) -> Select[tuple[CompactionEvent]]:
+    """Pure builder for the stale-pending-event query.
+
+    Rows must carry a seq range: legacy rows (pre-watermark feature) have
+    NULL ``min_message_seq`` and cannot be replayed deterministically.
+    """
+    return (
+        select(CompactionEvent)
+        .where(
+            CompactionEvent.status == "pending",
+            CompactionEvent.triggered_at >= cutoff_utc,
+            CompactionEvent.triggered_at <= grace_floor_utc,
+            CompactionEvent.retry_count < _MAX_ATTEMPTS,
+            CompactionEvent.min_message_seq.is_not(None),
+            CompactionEvent.max_message_seq.is_not(None),
+        )
+        .order_by(CompactionEvent.triggered_at.asc())
+    )
+
+
+def _messages_in_range_select(cs_id: int, min_seq: int, max_seq: int) -> Select[tuple[Message]]:
+    """Messages covered by a pending event's recorded seq range."""
+    return (
+        select(Message)
+        .where(
+            Message.session_id == cs_id,
+            Message.seq >= min_seq,
+            Message.seq <= max_seq,
+        )
+        .order_by(Message.seq)
+    )
+
+
+async def _try_acquire_lock_async(conn: AsyncConnection) -> bool:
+    """Acquire the per-process sweep lock on a dedicated connection.
+
+    Must be an ``AsyncConnection``, not an ``AsyncSession``: the
+    session-scoped advisory lock has to stay pinned to one physical
+    Postgres session from acquire through unlock. See the equivalent
+    helper in ``backend/app/agent/inbound_recovery.py`` for the full
+    rationale.
+    """
+    try:
+        result = await conn.execute(
+            text("SELECT pg_try_advisory_lock(hashtext(:k))"),
+            {"k": _RECOVERY_LOCK_KEY},
+        )
+        got_lock = result.scalar()
+        await conn.commit()
+    except Exception:
+        logger.exception("Failed to acquire compaction-recovery advisory lock")
+        return False
+    return bool(got_lock)
+
+
+async def _release_lock_async(conn: AsyncConnection) -> None:
+    """Best-effort release; must run on the connection that took the lock."""
+    try:
+        await conn.execute(
+            text("SELECT pg_advisory_unlock(hashtext(:k))"),
+            {"k": _RECOVERY_LOCK_KEY},
+        )
+        await conn.commit()
+    except Exception:
+        logger.exception("Failed to release compaction-recovery advisory lock")
+
+
+async def _claim_attempt(event_id: int) -> bool:
+    """Increment ``retry_count`` under a row lock; False when not claimable.
+
+    Runs in its own transaction *before* the LLM call so a crash
+    mid-retry still consumes the attempt. Re-checks status and the
+    attempt cap under the lock so two sweeps (or a sweep racing the
+    original background task's late completion) cannot double-claim.
+    """
+    async with db_session_async() as db:
+        ev = (
+            await db.execute(select(CompactionEvent).filter_by(id=event_id).with_for_update())
+        ).scalar_one_or_none()
+        if ev is None or ev.status != "pending" or ev.retry_count >= _MAX_ATTEMPTS:
+            return False
+        ev.retry_count += 1
+        await db.commit()
+        return True
+
+
+async def _exhaust_event(event_id: int) -> None:
+    """Stop retrying a row whose seq range has nothing left to compact."""
+    async with db_session_async() as db:
+        ev = (
+            await db.execute(select(CompactionEvent).filter_by(id=event_id).with_for_update())
+        ).scalar_one_or_none()
+        if ev is not None and ev.status == "pending":
+            ev.retry_count = _MAX_ATTEMPTS
+            await db.commit()
+
+
+async def _event_completed(event_id: int) -> bool:
+    """Read back whether ``compact_session`` flipped the row."""
+    db = AsyncSessionLocal()
+    try:
+        status = (
+            await db.execute(select(CompactionEvent.status).filter_by(id=event_id))
+        ).scalar_one_or_none()
+        return status == "completed"
+    finally:
+        await db.close()
+
+
+async def _retry_event(
+    event_id: int,
+    user_id: str,
+    min_seq: int,
+    max_seq: int,
+) -> bool:
+    """Re-run one pending event; True when the row flipped to completed."""
+    if not await _claim_attempt(event_id):
+        return False
+
+    db = AsyncSessionLocal()
+    try:
+        cs = (await db.execute(select(ChatSession).filter_by(user_id=user_id))).scalar_one_or_none()
+        user = (await db.execute(select(User).filter_by(id=user_id))).scalar_one_or_none()
+        rows = (
+            list(
+                (await db.execute(_messages_in_range_select(cs.id, min_seq, max_seq)))
+                .scalars()
+                .all()
+            )
+            if cs is not None
+            else []
+        )
+    finally:
+        await db.close()
+
+    tz_name = user.timezone if user is not None else ""
+    stored = [_msg_to_stored(m) for m in rows]
+    agent_messages = _stored_messages_to_agent_messages(stored, tz_name=tz_name)
+    if not agent_messages:
+        # The session or the rows were deleted since the event was
+        # written, or every row in the range is filtered (approval
+        # prompts, blank placeholders). Nothing to extract; stop
+        # selecting the row.
+        logger.info(
+            "Compaction recovery: event id=%d user=%s seq=[%d,%d] has no "
+            "recoverable messages; exhausting",
+            event_id,
+            user_id,
+            min_seq,
+            max_seq,
+        )
+        await _exhaust_event(event_id)
+        return False
+
+    logger.info(
+        "Retrying pending compaction event id=%d user=%s seq=[%d,%d] (%d message(s))",
+        event_id,
+        user_id,
+        min_seq,
+        max_seq,
+        len(agent_messages),
+    )
+    # ``compact_session`` flips the row to 'completed' on success
+    # (including the nothing-changed case). On LLM failure it logs and
+    # returns early, leaving the row 'pending' for the next boot,
+    # bounded by the retry_count cap.
+    await compact_session(
+        user_id,
+        agent_messages,
+        max_message_seq=max_seq,
+        event_id=event_id,
+    )
+    return await _event_completed(event_id)
+
+
+async def recover_pending_compactions() -> int:
+    """Retry compaction events stuck in ``'pending'``.
+
+    Called from ``lifespan`` after channels start. Returns the number of
+    events that flipped to ``'completed'``, for the startup log line.
+    Best-effort: the caller wraps the sweep in try/except so a recovery
+    bug never blocks app startup.
+    """
+    lookback_minutes = settings.compaction_retry_lookback_minutes
+    if lookback_minutes == 0 or not settings.compaction_enabled:
+        logger.debug("Compaction recovery disabled")
+        return 0
+
+    now = datetime.datetime.now(datetime.UTC)
+    cutoff = now - datetime.timedelta(minutes=lookback_minutes)
+    grace_floor = now - datetime.timedelta(seconds=_GRACE_SECONDS)
+
+    lock_conn = await get_async_engine().connect()
+    lock_acquired = False
+    try:
+        if not await _try_acquire_lock_async(lock_conn):
+            logger.info("Another worker is running compaction recovery; skipping on this boot")
+            return 0
+        lock_acquired = True
+
+        db = AsyncSessionLocal()
+        try:
+            events = [
+                (ev.id, ev.user_id, ev.min_message_seq, ev.max_message_seq)
+                for ev in (
+                    (await db.execute(_stale_pending_events_select(cutoff, grace_floor)))
+                    .scalars()
+                    .all()
+                )
+            ]
+        finally:
+            await db.close()
+
+        if not events:
+            return 0
+
+        logger.info(
+            "Compaction recovery: found %d stale pending event(s) between %s and %s",
+            len(events),
+            cutoff.isoformat(),
+            grace_floor.isoformat(),
+        )
+
+        completed = 0
+        for event_id, user_id, min_seq, max_seq in events:
+            if event_id is None or min_seq is None or max_seq is None:
+                continue
+            try:
+                if await _retry_event(event_id, user_id, min_seq, max_seq):
+                    completed += 1
+            except Exception:
+                logger.exception(
+                    "Compaction retry failed for event id=%d user=%s",
+                    event_id,
+                    user_id,
+                )
+        return completed
+    finally:
+        if lock_acquired:
+            await _release_lock_async(lock_conn)
+        await lock_conn.close()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -98,6 +98,16 @@ class Settings(BaseSettings):
     # unlikely to still be relevant; tune up if you have evidence
     # otherwise. 0 disables the sweep entirely.
     inbound_recovery_lookback_minutes: int = Field(default=30, ge=0)
+    # Startup sweep for ``compaction_events`` rows stuck in ``'pending'``:
+    # the async compaction LLM call crashed (deploy restart, provider
+    # outage) after the trim watermark advanced, so the seq range's facts
+    # were never extracted into MEMORY.md. Rows older than a 10-minute
+    # grace floor and younger than this lookback are retried on boot
+    # (max 3 attempts per row, tracked in ``retry_count``). Unlike
+    # orphaned inbounds, a stale compaction stays fully recoverable for
+    # as long as the message rows exist, so the default lookback is a
+    # week rather than minutes. 0 disables the sweep entirely.
+    compaction_retry_lookback_minutes: int = Field(default=10_080, ge=0)
     max_tool_rounds: int = Field(default=10, ge=1)
     max_input_tokens: int = Field(default=600_000, ge=1)
     # Primary trim governor: the raw conversation window is bounded by

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from fastapi.staticfiles import StaticFiles
 from sqlalchemy import select, text
 
 from backend.app.agent.approval import cleanup_orphaned_approvals
+from backend.app.agent.compaction_recovery import recover_pending_compactions
 from backend.app.agent.heartbeat import heartbeat_scheduler
 from backend.app.agent.inbound_recovery import recover_orphan_inbound_messages
 from backend.app.bus import message_bus
@@ -326,6 +327,20 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             logger.info("Re-dispatched %d orphan inbound message(s) on startup", recovered_inbounds)
     except Exception:
         logger.exception("Orphan inbound recovery failed on startup")
+
+    # Retry compaction events stuck in 'pending' (the async LLM call
+    # crashed or the process restarted mid-call). The trim watermark is
+    # already advanced for these ranges, so without the retry their facts
+    # never reach MEMORY.md. Same shape as the recoveries above.
+    try:
+        retried_compactions = await recover_pending_compactions()
+        if retried_compactions:
+            logger.info(
+                "Completed %d stale pending compaction event(s) on startup",
+                retried_compactions,
+            )
+    except Exception:
+        logger.exception("Pending compaction recovery failed on startup")
 
     # Replay any BlueBubbles iMessages that arrived while Clawbolt was down.
     # The orphan recovery above only handles messages that reached our DB;

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -741,6 +741,12 @@ class CompactionEvent(Base):
     # re-run that compaction manually. Existing pre-feature rows are
     # ``'completed'`` via the server-side default in migration 029.
     status: Mapped[str] = mapped_column(String, default="completed")
+    # Startup-sweep retry attempts (see
+    # ``backend/app/agent/compaction_recovery.py``). Incremented before
+    # each retry's LLM call so a crash mid-retry still counts; rows at
+    # the sweep's cap stay ``'pending'`` but stop being selected, so a
+    # poisoned range cannot retry forever. Migration 039.
+    retry_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     # Before/after snapshots of the four memory files this event touched.
     # Stored as envelope-encrypted text so an admin can inspect what the
     # compaction LLM call actually changed. ``None`` means either the field

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -144,6 +144,7 @@ Photos and files the user sends over a messaging channel are cached on disk whil
 | `AGENT_PROCESSING_TIMEOUT_SECONDS` | `300` | Maximum seconds for a single message's agent processing (includes waiting for the per-user lock). Prevents one hung LLM call from blocking all subsequent messages for the same user |
 | `MESSAGE_BATCH_WINDOW_MS` | `1500` | Milliseconds to wait for more messages before processing. Groups rapid-fire messages into one agent call. Set to `0` to disable |
 | `INBOUND_RECOVERY_LOOKBACK_MINUTES` | `30` | On startup, sweep for inbound messages persisted but never dispatched to the agent (worker died during the batcher window). Re-dispatch each one. Older orphans are skipped. Set to `0` to disable |
+| `COMPACTION_RETRY_LOOKBACK_MINUTES` | `10080` | On startup, retry compaction events stuck in `pending` (the background compaction LLM call crashed or the process restarted mid-call). Rows older than a week or already retried 3 times are skipped. Set to `0` to disable |
 | `MAX_TOOL_ROUNDS` | `10` | Maximum tool-calling rounds per agent invocation |
 | `MAX_INPUT_TOKENS` | `600000` | Hard ceiling on the input token budget; the trim trigger must stay at or below this |
 | `CONTEXT_TRIM_TARGET_TOKENS` | `120000` | Drop-to token budget after trimming. The token budget is the primary trim governor: the raw conversation window is bounded by tokens, not turns. Lower this to trade raw recall for per-turn cost, since the full window is sent every turn |

--- a/tests/test_compaction_recovery.py
+++ b/tests/test_compaction_recovery.py
@@ -1,0 +1,215 @@
+"""Tests for the startup retry of stale pending compaction events.
+
+``trigger_compaction_for_dropped`` advances the trim watermark before the
+async compaction LLM call runs; a crash mid-call leaves the
+``CompactionEvent`` row ``'pending'`` forever and the seq range's facts
+were never extracted (issue #1431). ``recover_pending_compactions``
+sweeps those rows on startup and re-runs ``compact_session`` against the
+recorded seq range, bounded by ``retry_count``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+from backend.app.agent.compaction_recovery import (
+    _MAX_ATTEMPTS,
+    recover_pending_compactions,
+)
+from backend.app.agent.file_store import UserData
+from backend.app.agent.memory_db import get_memory_store
+from backend.app.config import settings
+from backend.app.database import db_session_async
+from backend.app.enums import MessageDirection
+from backend.app.models import ChatSession, CompactionEvent, Message, User
+from tests.mocks.llm import make_text_response
+
+
+async def _seed_session_with_messages(user: User | UserData, message_count: int) -> ChatSession:
+    """Insert a ChatSession with alternating inbound/outbound messages."""
+    async with db_session_async() as db:
+        cs = ChatSession(
+            session_id=f"session-{user.id}",
+            user_id=user.id,
+            channel="webchat",
+            initial_system_prompt="",
+        )
+        db.add(cs)
+        await db.flush()
+        for i in range(1, message_count + 1):
+            db.add(
+                Message(
+                    session_id=cs.id,
+                    seq=i,
+                    direction=(
+                        MessageDirection.INBOUND if i % 2 == 1 else MessageDirection.OUTBOUND
+                    ),
+                    body=f"msg {i}",
+                    processed_context="",
+                    tool_interactions_json="",
+                    external_message_id="",
+                    media_urls_json="[]",
+                )
+            )
+        await db.commit()
+        await db.refresh(cs)
+        db.expunge(cs)
+        return cs
+
+
+async def _insert_pending_event(
+    user_id: str,
+    min_seq: int,
+    max_seq: int,
+    age_minutes: int = 60,
+    retry_count: int = 0,
+) -> int:
+    """Insert a 'pending' CompactionEvent aged *age_minutes* into the past."""
+    triggered_at = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=age_minutes)
+    async with db_session_async() as db:
+        event = CompactionEvent(
+            user_id=user_id,
+            triggered_at=triggered_at,
+            status="pending",
+            min_message_seq=min_seq,
+            max_message_seq=max_seq,
+            trimmed_count=max_seq - min_seq + 1,
+            retry_count=retry_count,
+        )
+        db.add(event)
+        await db.commit()
+        assert event.id is not None
+        return event.id
+
+
+async def _read_event(event_id: int) -> CompactionEvent:
+    async with db_session_async() as db:
+        event = (await db.execute(select(CompactionEvent).filter_by(id=event_id))).scalar_one()
+        db.expunge(event)
+        return event
+
+
+@pytest.mark.asyncio()
+async def test_recovers_stale_pending_event(test_user: UserData) -> None:
+    """A stale pending event is retried, completed, and its facts land."""
+    await _seed_session_with_messages(test_user, message_count=6)
+    event_id = await _insert_pending_event(test_user.id, min_seq=1, max_seq=4)
+
+    mock_response = make_text_response(
+        json.dumps({"memory_update": "## Facts\n- fact: recovered", "summary": ""})
+    )
+    with patch("backend.app.agent.compaction.amessages", return_value=mock_response):
+        completed = await recover_pending_compactions()
+
+    assert completed == 1
+    event = await _read_event(event_id)
+    assert event.status == "completed"
+    assert event.retry_count == 1
+
+    content = await get_memory_store(test_user.id).read_memory_async()
+    assert "fact: recovered" in content
+
+
+@pytest.mark.asyncio()
+async def test_skips_fresh_pending_event(test_user: UserData) -> None:
+    """Events younger than the grace floor are in-flight, not stale."""
+    await _seed_session_with_messages(test_user, message_count=6)
+    event_id = await _insert_pending_event(test_user.id, min_seq=1, max_seq=4, age_minutes=0)
+
+    with patch("backend.app.agent.compaction.amessages") as mock_llm:
+        completed = await recover_pending_compactions()
+
+    assert completed == 0
+    mock_llm.assert_not_called()
+    event = await _read_event(event_id)
+    assert event.status == "pending"
+    assert event.retry_count == 0
+
+
+@pytest.mark.asyncio()
+async def test_skips_event_beyond_lookback(test_user: UserData) -> None:
+    """Events older than the lookback window are not retried."""
+    await _seed_session_with_messages(test_user, message_count=6)
+    lookback = settings.compaction_retry_lookback_minutes
+    event_id = await _insert_pending_event(
+        test_user.id, min_seq=1, max_seq=4, age_minutes=lookback + 60
+    )
+
+    with patch("backend.app.agent.compaction.amessages") as mock_llm:
+        completed = await recover_pending_compactions()
+
+    assert completed == 0
+    mock_llm.assert_not_called()
+    assert (await _read_event(event_id)).retry_count == 0
+
+
+@pytest.mark.asyncio()
+async def test_skips_exhausted_event(test_user: UserData) -> None:
+    """Rows at the attempt cap stop being selected (no infinite retry)."""
+    await _seed_session_with_messages(test_user, message_count=6)
+    event_id = await _insert_pending_event(
+        test_user.id, min_seq=1, max_seq=4, retry_count=_MAX_ATTEMPTS
+    )
+
+    with patch("backend.app.agent.compaction.amessages") as mock_llm:
+        completed = await recover_pending_compactions()
+
+    assert completed == 0
+    mock_llm.assert_not_called()
+    event = await _read_event(event_id)
+    assert event.status == "pending"
+    assert event.retry_count == _MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio()
+async def test_failed_retry_keeps_pending_and_counts_attempt(
+    test_user: UserData,
+) -> None:
+    """An LLM failure leaves the row pending; the attempt is consumed."""
+    await _seed_session_with_messages(test_user, message_count=6)
+    event_id = await _insert_pending_event(test_user.id, min_seq=1, max_seq=4)
+
+    with patch("backend.app.agent.compaction.amessages", side_effect=RuntimeError("provider down")):
+        completed = await recover_pending_compactions()
+
+    assert completed == 0
+    event = await _read_event(event_id)
+    assert event.status == "pending"
+    assert event.retry_count == 1
+
+
+@pytest.mark.asyncio()
+async def test_empty_range_exhausts_event(test_user: UserData) -> None:
+    """A range with no recoverable messages stops being selected."""
+    await _seed_session_with_messages(test_user, message_count=6)
+    event_id = await _insert_pending_event(test_user.id, min_seq=50, max_seq=60)
+
+    with patch("backend.app.agent.compaction.amessages") as mock_llm:
+        completed = await recover_pending_compactions()
+
+    assert completed == 0
+    mock_llm.assert_not_called()
+    event = await _read_event(event_id)
+    assert event.status == "pending"
+    assert event.retry_count == _MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio()
+async def test_sweep_disabled_by_zero_lookback(test_user: UserData) -> None:
+    await _seed_session_with_messages(test_user, message_count=6)
+    event_id = await _insert_pending_event(test_user.id, min_seq=1, max_seq=4)
+
+    with (
+        patch.object(settings, "compaction_retry_lookback_minutes", 0),
+        patch("backend.app.agent.compaction.amessages") as mock_llm,
+    ):
+        completed = await recover_pending_compactions()
+
+    assert completed == 0
+    mock_llm.assert_not_called()
+    assert (await _read_event(event_id)).retry_count == 0


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #1431.

`trigger_compaction_for_dropped` advances the trim watermark synchronously, then runs the compaction LLM call as a fire-and-forget background task. When the process dies mid-call (deploy restart, OOM) or the call fails (provider outage), the `CompactionEvent` row stays `'pending'` forever: the watermark is already advanced, so the seq range never reaches the LLM again, and its facts are never extracted into MEMORY.md. The row records everything needed to recover (the seq range) and message rows are never deleted, but nothing acted on it.

New `recover_pending_compactions` startup sweep, mirroring the `inbound_recovery` pattern:

- **One worker per rolling restart**: `pg_try_advisory_lock` on a dedicated `AsyncConnection` (same connection-pinning rationale documented in `inbound_recovery.py`).
- **Bounded selection**: rows older than a 10-minute grace floor (never races a call legitimately still in flight), younger than the new `COMPACTION_RETRY_LOOKBACK_MINUTES` (default 7 days; unlike orphan inbounds, a stale compaction stays fully recoverable for as long as the rows exist, so the window is generous; `0` disables).
- **Bounded retries**: each attempt increments the new `retry_count` column (migration 039, verified up/down/up) *before* the LLM call, so a crash mid-retry still consumes the attempt. Rows at the 3-attempt cap stay `'pending'` for admin visibility but stop being selected; a poisoned range cannot retry forever. Ranges whose messages were deleted are exhausted immediately.
- **Replay fidelity**: messages are reloaded by the recorded `[min_message_seq, max_message_seq]` range and rebuilt through the same `_stored_messages_to_agent_messages` conversion the live path uses, then `compact_session` runs with the original `event_id` so the same row is completed with full audit snapshots.
- Hooked into `lifespan` after the other startup recoveries, same best-effort try/except shape.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (2892 passed, 2 skipped)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (7 tests: recover, grace floor, lookback, attempt cap, failure accounting, deleted-range exhaustion, disable switch)
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): Claude designed the sweep after the inbound_recovery pattern, implemented it with the migration, and wrote the tests, with direction and review by @njbrake.
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a startup recovery sweep that retries compaction events left in "pending" when the asynchronous compaction LLM call fails or the process restarts mid-call, preventing trimmed message ranges from being lost.

What was added / changed
- New recovery module: backend/app/agent/compaction_recovery.py — scans for stale pending CompactionEvent rows and re-runs compaction for their recorded [min_message_seq,max_message_seq] ranges.
- Database migration: alembic/versions/039_add_compaction_event_retry_count.py — adds a non-null integer retry_count column (server default 0) to compaction_events.
- Model: backend/app/models.py — CompactionEvent gains retry_count.
- Config: backend/app/config.py and .env.example — new compaction_retry_lookback_minutes setting (default 10_080 = 7 days; 0 disables).
- Startup wiring: backend/app/main.py — calls recover_pending_compactions() during app lifespan startup (after other recoveries) with guarded try/except and logging.
- Docs: docs/self-host/configuration.md updated to document the new setting.
- Tests: tests/test_compaction_recovery.py — seven tests covering success, grace floor, lookback window, attempt cap, failure handling, deleted-range exhaustion, and disabling the sweep.

High-level behavior and safeguards
- Sweep selection: only considers events older than a 10-minute grace floor and younger than compaction_retry_lookback_minutes (0 disables).
- Concurrency: serializes work with a per-process Postgres advisory lock (pg_try_advisory_lock) so one worker runs the sweep per rolling restart.
- Retry bounding: retry_count is incremented under row lock before invoking the LLM so crashes still consume attempts; a 3-attempt cap (_MAX_ATTEMPTS) prevents infinite retries and leaves rows pending for admin visibility.
- Empty-range handling: events whose message ranges are gone or filter to no recoverable messages are immediately exhausted (retry_count set to max) to stop future retries.
- Replay fidelity: reloads stored messages for the recorded seq range, reconstructs agent messages, and calls compact_session with the original event_id so the same row is completed and original snapshots/audit remain intact.
- Best-effort startup call: hooked into lifespan with try/except; returns the count of events completed and logs failures without preventing startup.

Benefits
- Prevents permanent loss of facts from trimmed ranges when compaction background tasks fail or are interrupted.
- Improves operational resilience by automatically recovering transient failures on startup.
- Configurable and safe: operators can tune or disable the sweep; advisory locks and retry caps avoid duplicate work and endless loops.
- Visibility: exhausted or persistently failing rows remain visible for admin inspection.

Technical notes (brief)
- Migration: revision 039 adds compaction_events.retry_count (int, default 0).
- Key constants: grace floor = 600 seconds (10 minutes); _MAX_ATTEMPTS = 3; default lookback = 10_080 minutes (7 days).
- Implementation details: uses a dedicated AsyncConnection for pg_try_advisory_lock, selects pending events with non-null min/max seq and retry_count < _MAX_ATTEMPTS, claims attempts via SELECT ... FOR UPDATE and increments retry_count, rehydrates messages (Message rows → stored format → _stored_messages_to_agent_messages) and calls compact_session(user_id, agent_messages, max_message_seq=max_seq, event_id=event_id).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->