### PR TITLE
fix: conversation pipeline hardening (watermark, dead query, trim heuristic, erosion signal)

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -14,6 +14,7 @@ import json
 import logging
 import re
 import time
+from collections import Counter
 from datetime import UTC
 from typing import Any, cast
 
@@ -82,6 +83,24 @@ def _serialize_snapshot(text: str | None, cap: int) -> str | None:
         },
         ensure_ascii=False,
     )
+
+
+def _line_diff_counts(before: str, after: str) -> tuple[int, int]:
+    """Multiset line diff: ``(added, removed)`` counts between two texts.
+
+    Cheap deterministic signal for memory erosion across compaction
+    rewrites (issue #1433): the rewrite model can silently drop a valid
+    line on any cycle, and the compliance audit explicitly encourages
+    deletion, so erosion looks like a large removed count not matched by
+    additions. Counter-based and order-insensitive: a pure reorder
+    reports ``(0, 0)``. Surfaced on the ``compaction.summary`` log line
+    so an aggregator can alert on unexplained large removals.
+    """
+    before_counts = Counter(before.splitlines())
+    after_counts = Counter(after.splitlines())
+    added = sum((after_counts - before_counts).values())
+    removed = sum((before_counts - after_counts).values())
+    return added, removed
 
 
 _URL_RE = re.compile(r"https?://\S+")
@@ -496,10 +515,16 @@ async def compact_session(
     _input_tokens = response.usage.input_tokens or 0 if response.usage else 0
     _output_tokens = response.usage.output_tokens or 0 if response.usage else 0
     _duration_ms = int((time.monotonic() - _start_monotonic) * 1000)
+    # Erosion signal: how many MEMORY.md lines this rewrite added and
+    # removed. (0, 0) when the file did not change this event.
+    _memory_lines_added, _memory_lines_removed = (
+        _line_diff_counts(current_memory or "", result.memory_update) if memory_changed else (0, 0)
+    )
     logger.info(
         "compaction.summary user=%s trimmed_count=%d trimmed_chars=%d "
         "input_tokens=%d output_tokens=%d duration_ms=%d "
-        "memory_updated=%s user_updated=%s soul_updated=%s summary_len=%d",
+        "memory_updated=%s user_updated=%s soul_updated=%s summary_len=%d "
+        "memory_lines_added=%d memory_lines_removed=%d",
         user_id,
         _trimmed_count,
         _input_chars,
@@ -510,6 +535,8 @@ async def compact_session(
         user_changed,
         soul_changed,
         len(result.summary or ""),
+        _memory_lines_added,
+        _memory_lines_removed,
     )
 
     # Compute "after" snapshots deterministically from what was written

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -4,6 +4,7 @@ import logging
 import random
 import re
 import time
+from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -105,6 +106,37 @@ MAX_INPUT_TOKENS = settings.max_input_tokens
 _VALID_STOP_REASONS: set[str | None] = {"end_turn", "max_tokens", "tool_use", "stop_sequence", None}
 
 _LLM_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
+
+# Last API-reported input token count per user, surviving across agent
+# instances. A fresh ClawboltAgent is constructed per message, so without
+# this the proactive trim at the top of ``process_message`` always falls
+# back to the chars/4 + flat-overhead heuristic, which ignores tool
+# schemas and the real system prompt size and therefore fires later than
+# configured (issue #1433). Process-local by design: after a restart the
+# first message per user falls back to the heuristic once, then the real
+# count takes over. Bounded LRU so a multi-tenant deployment cannot grow
+# it without limit.
+_LAST_INPUT_TOKENS: OrderedDict[str, int] = OrderedDict()
+_LAST_INPUT_TOKENS_MAX = 1024
+
+
+def _remember_input_tokens(user_id: str, tokens: int) -> None:
+    """Record the latest API-reported input token count for *user_id*."""
+    _LAST_INPUT_TOKENS[user_id] = tokens
+    _LAST_INPUT_TOKENS.move_to_end(user_id)
+    while len(_LAST_INPUT_TOKENS) > _LAST_INPUT_TOKENS_MAX:
+        _LAST_INPUT_TOKENS.popitem(last=False)
+
+
+def _recall_input_tokens(user_id: str) -> int | None:
+    """Return the last reported input token count for *user_id*, if any."""
+    return _LAST_INPUT_TOKENS.get(user_id)
+
+
+def reset_last_input_tokens() -> None:
+    """Clear the per-user input-token cache (for tests)."""
+    _LAST_INPUT_TOKENS.clear()
+
 
 # Patterns that commonly appear in tool exception messages and would leak
 # secrets into the LLM context (and thence into provider logs and the
@@ -405,14 +437,13 @@ class ClawboltAgent:
         """Build the system prompt as ``(stable, dynamic)`` halves.
 
         *stable* goes in the cacheable ``system`` param; *dynamic* (memory,
-        integrations, cross-session context) is appended to the current
-        user turn so it does not invalidate the history cache (#1420).
+        integrations) is appended to the current user turn so it does not
+        invalidate the history cache (#1420).
         """
         return await build_agent_system_prompt_parts(
             self.user,
             self.tools,
             message_context,
-            current_session_id=self._session_id,
         )
 
     async def _emit_response(
@@ -1153,12 +1184,16 @@ class ClawboltAgent:
         # a backstop that catches message-count bloat even under the token
         # limit. Both use hysteresis to avoid re-firing compaction every turn.
         original_count = len(messages)
+        # ``self._last_input_tokens`` is 0 on a fresh agent (one is built
+        # per message), so fall back to the process-local per-user cache
+        # of the last API-reported count. Only without either does the
+        # trimmer use its chars/4 heuristic.
         trim_result = trim_messages(
             messages,
             target_tokens=settings.context_trim_target_tokens,
             target_turns=settings.context_trim_target_turns,
             trigger_tokens=settings.context_trim_trigger_tokens,
-            input_tokens=self._last_input_tokens or None,
+            input_tokens=self._last_input_tokens or _recall_input_tokens(self.user.id),
         )
         messages = trim_result.messages
         all_dropped = list(trim_result.dropped)
@@ -1208,6 +1243,7 @@ class ClawboltAgent:
             )
             if response.usage and response.usage.input_tokens:
                 self._last_input_tokens = response.usage.input_tokens
+                _remember_input_tokens(self.user.id, response.usage.input_tokens)
                 _total_input_tokens += response.usage.input_tokens
                 _total_output_tokens += response.usage.output_tokens or 0
                 cache_create = response.usage.cache_creation_input_tokens or 0

--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -156,22 +156,20 @@ def _select_last_timestamp(user_id: str, direction: str) -> Select[tuple[datetim
 def _select_recent_messages(
     user_id: str,
     count: int,
-    exclude_session_id: str | None = None,
 ) -> Select[tuple[Message]]:
-    """Most recent ``count`` messages across the user's sessions.
+    """Most recent ``count`` messages across the user's session.
 
     Returned in DESC order so the caller can ``reversed(...)`` to render
     chronologically; the ORDER BY is on the SQL side so LIMIT applies to
     the newest tail rather than to an arbitrary slice.
     """
-    stmt = (
+    return (
         select(Message)
         .join(ChatSession, Message.session_id == ChatSession.id)
         .where(ChatSession.user_id == user_id)
+        .order_by(Message.timestamp.desc())
+        .limit(count)
     )
-    if exclude_session_id:
-        stmt = stmt.where(ChatSession.session_id != exclude_session_id)
-    return stmt.order_by(Message.timestamp.desc()).limit(count)
 
 
 def _delete_message_by_seq(cs_id: int, seq: int) -> Delete[tuple[Message]]:
@@ -740,40 +738,24 @@ class SessionStore:
     # recent-message collectors
     # ------------------------------------------------------------------
 
-    async def _collect_messages_async(
-        self,
-        count: int | None = None,
-        exclude_session_id: str | None = None,
-    ) -> list[StoredMessage]:
-        """Collect the most recent messages, optionally excluding a session."""
+    async def get_recent_messages_async(self, count: int | None = None) -> list[StoredMessage]:
+        """Get the most recent messages in the user's session.
+
+        NOTE: the old ``get_other_session_messages_async`` peer (and the
+        ``exclude_session_id`` plumbing) was removed in issue #1433:
+        migration 026 collapsed sessions to one per user, so excluding
+        the current session always returned the empty list.
+        """
         resolved = count if count is not None else settings.heartbeat_recent_messages_count
         db = AsyncSessionLocal()
         try:
             messages = list(
-                (
-                    await db.execute(
-                        _select_recent_messages(self.user_id, resolved, exclude_session_id)
-                    )
-                )
-                .scalars()
-                .all()
+                (await db.execute(_select_recent_messages(self.user_id, resolved))).scalars().all()
             )
             # Return in chronological order
             return [_msg_to_stored(m) for m in reversed(messages)]
         finally:
             await db.close()
-
-    async def get_recent_messages_async(self, count: int | None = None) -> list[StoredMessage]:
-        """Get the most recent messages across all sessions."""
-        return await self._collect_messages_async(count)
-
-    async def get_other_session_messages_async(
-        self,
-        exclude_session_id: str,
-        count: int | None = None,
-    ) -> list[StoredMessage]:
-        """Get recent messages from sessions other than *exclude_session_id*."""
-        return await self._collect_messages_async(count, exclude_session_id)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -670,6 +670,8 @@ def reset_stores() -> None:
     global _idempotency_store
     _idempotency_store = None
 
+    from backend.app.agent.core import reset_last_input_tokens
     from backend.app.agent.user_db import reset_user_store
 
+    reset_last_input_tokens()
     reset_user_store()

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -14,7 +14,6 @@ import zoneinfo
 from backend.app.agent.markdown_registry import truncate_for_injection
 from backend.app.agent.memory_db import build_memory_context
 from backend.app.agent.prompts import load_prompt
-from backend.app.agent.session_db import get_session_store
 from backend.app.agent.tools.base import Tool
 from backend.app.models import User
 
@@ -311,35 +310,6 @@ def build_time_user_context(user: User) -> str:
     )
 
 
-async def build_cross_session_context(
-    user_id: str,
-    current_session_id: str,
-    count: int | None = None,
-) -> str:
-    """Build a summary of recent messages from other sessions.
-
-    Gives the agent awareness of recent conversations that happened on
-    a different channel (e.g. Telegram vs webchat) so it can maintain
-    continuity when the user switches channels.
-    """
-    store = get_session_store(user_id)
-    messages = await store.get_other_session_messages_async(current_session_id, count=count)
-    if not messages:
-        return ""
-    lines: list[str] = []
-    for msg in messages:
-        label = "You" if msg.direction == "outbound" else "User"
-        body = msg.body[:200].rstrip()
-        if len(msg.body) > 200:
-            body += "..."
-        lines.append(f"- [{label}] {body}")
-    return (
-        "These are your most recent messages from a different conversation session.\n"
-        "Use this context for continuity but do not explicitly mention "
-        '"another session" unless the user asks.\n\n' + "\n".join(lines)
-    )
-
-
 # -----------------------------------------------------------------------
 # Pre-built prompt assemblers
 # -----------------------------------------------------------------------
@@ -349,7 +319,6 @@ async def _build_agent_prompt_builder(
     user: User,
     tools: list[Tool],
     message_context: str,
-    current_session_id: str = "",
 ) -> SystemPromptBuilder:
     """Assemble the composable builder for the main agent loop.
 
@@ -390,10 +359,11 @@ async def _build_agent_prompt_builder(
     memory = await build_memory_section(user.id, query=message_context)
     builder.add_section("Your Memory", memory, dynamic=True)
 
-    if current_session_id:
-        cross = await build_cross_session_context(user.id, current_session_id)
-        if cross:
-            builder.add_section("Recent Activity (other channel)", cross, dynamic=True)
+    # NOTE: the old "Recent Activity (other channel)" cross-session section
+    # was removed (issue #1433): migration 026 collapsed sessions to one per
+    # user, so the query excluding the current session always returned
+    # empty. All channels share the single session, so channel switches are
+    # already covered by ordinary history.
 
     return builder
 
@@ -402,7 +372,6 @@ async def build_agent_system_prompt(
     user: User,
     tools: list[Tool],
     message_context: str,
-    current_session_id: str = "",
 ) -> str:
     """Assemble the full system prompt for the main agent loop.
 
@@ -410,7 +379,7 @@ async def build_agent_system_prompt(
     system-prompt preview endpoint; the agent loop uses
     :func:`build_agent_system_prompt_parts` instead.
     """
-    builder = await _build_agent_prompt_builder(user, tools, message_context, current_session_id)
+    builder = await _build_agent_prompt_builder(user, tools, message_context)
     return builder.build()
 
 
@@ -418,16 +387,15 @@ async def build_agent_system_prompt_parts(
     user: User,
     tools: list[Tool],
     message_context: str,
-    current_session_id: str = "",
 ) -> tuple[str, str]:
     """Assemble the agent system prompt as ``(stable, dynamic)`` halves.
 
     The agent loop sends *stable* in the cacheable ``system`` param and
-    appends *dynamic* (memory, integration status, cross-session context)
-    to the current user turn, so a memory write does not invalidate the
-    message-history prompt cache (#1420).
+    appends *dynamic* (memory, integration status) to the current user
+    turn, so a memory write does not invalidate the message-history
+    prompt cache (#1420).
     """
-    builder = await _build_agent_prompt_builder(user, tools, message_context, current_session_id)
+    builder = await _build_agent_prompt_builder(user, tools, message_context)
     return builder.build_parts()
 
 

--- a/backend/app/agent/trimming.py
+++ b/backend/app/agent/trimming.py
@@ -210,6 +210,25 @@ def trim_messages(
                     j += 1
                 else:
                     break
+            # History rebuild expands one outbound DB row into the
+            # tool-call AssistantMessage, its ToolResultMessages, AND a
+            # final-reply AssistantMessage, all sharing the row's seq
+            # (see context._expand_outbound_with_tools). Treat that
+            # reply as part of this block: dropping the tool-call half
+            # while keeping the reply would advance the trim watermark
+            # over the shared seq and silently filter the kept reply
+            # from the next turn's history (issue #1433). Live-loop
+            # messages carry seq=None and are unaffected.
+            if j < len(body):
+                nxt = body[j]
+                if (
+                    isinstance(nxt, AssistantMessage)
+                    and not nxt.tool_calls
+                    and msg.seq is not None
+                    and nxt.seq == msg.seq
+                ):
+                    block.append(nxt)
+                    j += 1
             blocks.append(block)
             i = j
         else:

--- a/backend/app/routers/user_sessions.py
+++ b/backend/app/routers/user_sessions.py
@@ -161,7 +161,6 @@ async def get_conversation_system_prompt(
             current_user,
             tools,
             message_context="",
-            current_session_id=session.session_id,
         )
 
     return SessionSystemPromptResponse(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1362,6 +1362,73 @@ def test_trim_messages_turn_cap_preserves_tool_call_pairs() -> None:
     assert has_tool_msg == has_tc_msg
 
 
+def test_input_token_cache_remember_recall_and_reset() -> None:
+    """The per-user input-token cache survives across agent instances so the
+    proactive trim uses the real API-reported count instead of the chars/4
+    heuristic (issue #1433), and is bounded plus resettable for tests.
+    """
+    from backend.app.agent.core import (
+        _LAST_INPUT_TOKENS_MAX,
+        _recall_input_tokens,
+        _remember_input_tokens,
+        reset_last_input_tokens,
+    )
+
+    reset_last_input_tokens()
+    assert _recall_input_tokens("user-a") is None
+
+    _remember_input_tokens("user-a", 42_000)
+    assert _recall_input_tokens("user-a") == 42_000
+
+    # Bounded: the LRU evicts the oldest entry past the cap.
+    for i in range(_LAST_INPUT_TOKENS_MAX):
+        _remember_input_tokens(f"user-{i}", i)
+    assert _recall_input_tokens("user-a") is None
+
+    reset_last_input_tokens()
+    assert _recall_input_tokens(f"user-{_LAST_INPUT_TOKENS_MAX - 1}") is None
+
+
+def test_trim_messages_keeps_same_row_reply_with_its_tool_block() -> None:
+    """The final-reply AssistantMessage expanded from the same DB row as a
+    tool-call block must trim atomically with that block (issue #1433).
+
+    History rebuild expands one outbound row into the tool-call
+    AssistantMessage, its ToolResultMessages, and a final-reply
+    AssistantMessage, all stamped with the row's seq. Dropping the
+    tool-call half while keeping the reply would advance the trim
+    watermark over the shared seq and silently filter the kept reply
+    from the next turn's history.
+    """
+    messages: list[AgentMessage] = [
+        SystemMessage(content="System prompt"),
+        UserMessage(content="Old user with tool", seq=1),
+        # One DB row (seq=2) expanded into three messages.
+        AssistantMessage(
+            content=None,
+            tool_calls=[ToolCallRequest(id="call_old", name="save_fact", arguments={})],
+            seq=2,
+        ),
+        ToolResultMessage(tool_call_id="call_old", content="Saved"),
+        AssistantMessage(content="Done, saved it!", seq=2),
+    ]
+    messages.extend(_build_turn_history(turn_pairs=50))
+    messages.append(UserMessage(content="Current message"))
+
+    result = trim_messages(messages, target_tokens=10_000_000, target_turns=10, input_tokens=500)
+
+    dropped_seq2 = [m for m in result.dropped if getattr(m, "seq", None) == 2]
+    kept_seq2 = [m for m in result.messages if getattr(m, "seq", None) == 2]
+    # Either the whole seq=2 expansion dropped or the whole thing stayed,
+    # never a split. With a 10-turn cap and 50 padding turns, it dropped.
+    assert len(dropped_seq2) == 2
+    assert kept_seq2 == []
+    # And the reply prose travels with the block into the compaction input.
+    assert any(
+        isinstance(m, AssistantMessage) and m.content == "Done, saved it!" for m in result.dropped
+    )
+
+
 def test_trim_messages_combined_token_and_turn_budgets() -> None:
     """Whichever budget binds first should drive trimming; both stay respected."""
     # Long, fat content: both budgets are violated.

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -200,6 +200,39 @@ def test_parse_missing_new_fields_defaults_empty() -> None:
     assert result.soul_update == ""
 
 
+# --- _line_diff_counts tests (memory erosion signal, issue #1433) ---
+
+
+def test_line_diff_counts_additions_and_removals() -> None:
+    from backend.app.agent.compaction import _line_diff_counts
+
+    before = "## Facts\n- keeps\n- gets dropped"
+    after = "## Facts\n- keeps\n- newly added\n- also added"
+    added, removed = _line_diff_counts(before, after)
+    assert added == 2
+    assert removed == 1
+
+
+def test_line_diff_counts_reorder_is_zero() -> None:
+    """A pure reorder is not erosion; the multiset diff reports (0, 0)."""
+    from backend.app.agent.compaction import _line_diff_counts
+
+    before = "- a\n- b\n- c"
+    after = "- c\n- a\n- b"
+    assert _line_diff_counts(before, after) == (0, 0)
+
+
+def test_line_diff_counts_large_removal_visible() -> None:
+    """Silently dropping many lines (the erosion failure mode) is loud."""
+    from backend.app.agent.compaction import _line_diff_counts
+
+    before = "\n".join(f"- fact {i}" for i in range(20))
+    after = "- fact 0"
+    added, removed = _line_diff_counts(before, after)
+    assert added == 0
+    assert removed == 19
+
+
 # --- compact_session tests ---
 
 
@@ -697,6 +730,9 @@ async def test_compact_session_emits_structured_summary_log(
     # value, not the substituted one).
     assert "summary_len=" in msg
     assert "duration_ms=" in msg
+    # Erosion signal (issue #1433): line-level diff counts for MEMORY.md.
+    assert "memory_lines_added=" in msg
+    assert "memory_lines_removed=" in msg
 
 
 @pytest.mark.asyncio()

--- a/tests/test_session_db_async.py
+++ b/tests/test_session_db_async.py
@@ -526,8 +526,11 @@ async def test_last_timestamp_async_returns_max_per_direction(
 
 
 # ---------------------------------------------------------------------------
-# recent / other-session collectors
+# recent-message collector
 # ---------------------------------------------------------------------------
+# NOTE: ``get_other_session_messages_async`` and its test were removed in
+# issue #1433: migration 026 collapsed sessions to one per user, so
+# excluding the current session always returned the empty list.
 
 
 async def test_get_recent_messages_async_returns_chronological(
@@ -541,20 +544,6 @@ async def test_get_recent_messages_async_returns_chronological(
 
     recent = await store.get_recent_messages_async(count=10)
     assert [m.body for m in recent] == ["first", "second", "third"]
-
-
-async def test_get_other_session_messages_async_excludes_named(
-    async_db: async_sessionmaker,
-) -> None:
-    user_id = await _create_user(async_db)
-    store = SessionStore(user_id)
-    session, _ = await store.get_or_create_session_async()
-    await store.add_message_async(session, direction="inbound", body="hidden")
-
-    excluded = await store.get_other_session_messages_async(
-        exclude_session_id=session.session_id, count=10
-    )
-    assert excluded == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -11,7 +11,6 @@ from backend.app.agent.system_prompt import (
     _strip_integrations_block,
     build_agent_system_prompt,
     build_agent_system_prompt_parts,
-    build_cross_session_context,
     build_date_section,
     build_heartbeat_system_prompt,
     build_identity_section,
@@ -486,116 +485,6 @@ class TestBuildTimeUserContext:
         assert "[Current time:" in result
         assert "(UTC)" in result
         assert "No timezone has been configured yet" in result
-
-
-class TestCrossSessionContext:
-    @pytest.mark.asyncio()
-    async def test_returns_empty_when_no_other_sessions(
-        self,
-        test_user: "User",
-    ) -> None:
-        """Should return empty string when no other sessions exist."""
-        result = await build_cross_session_context(
-            test_user.id, current_session_id="nonexistent_999"
-        )
-        assert result == ""
-
-    @pytest.mark.asyncio()
-    async def test_includes_messages_from_other_session(
-        self,
-        test_user: "User",
-    ) -> None:
-        """Should include messages from sessions other than the current one."""
-        from backend.app.agent.session_db import get_session_store
-
-        store = get_session_store(test_user.id)
-
-        # Create session A with messages
-        session_a, _ = await store.get_or_create_session()
-        await store.add_message(session_a, "inbound", "Hello from Telegram")
-        await store.add_message(session_a, "outbound", "Hi! How can I help?")
-
-        result = await build_cross_session_context(
-            test_user.id, current_session_id="different_session_999"
-        )
-        assert "Hello from Telegram" in result
-        assert "Hi! How can I help?" in result
-        assert "[User]" in result
-        assert "[You]" in result
-
-    @pytest.mark.asyncio()
-    async def test_excludes_current_session(
-        self,
-        test_user: "User",
-    ) -> None:
-        """Should not include messages from the current session."""
-        from backend.app.agent.session_db import get_session_store
-
-        store = get_session_store(test_user.id)
-
-        session_a, _ = await store.get_or_create_session()
-        await store.add_message(session_a, "inbound", "Message in session A")
-
-        # When querying with session A's own ID, nothing should appear
-        result = await build_cross_session_context(
-            test_user.id, current_session_id=session_a.session_id
-        )
-        assert result == ""
-
-    @pytest.mark.asyncio()
-    async def test_truncates_long_messages(
-        self,
-        test_user: "User",
-    ) -> None:
-        """Long message bodies should be truncated."""
-        from backend.app.agent.session_db import get_session_store
-
-        store = get_session_store(test_user.id)
-        session_a, _ = await store.get_or_create_session()
-        long_body = "x" * 300
-        await store.add_message(session_a, "inbound", long_body)
-
-        result = await build_cross_session_context(test_user.id, current_session_id="other_999")
-        assert "..." in result
-        # Should be truncated to ~200 chars + "..."
-        assert "x" * 201 not in result
-
-    @pytest.mark.asyncio()
-    async def test_agent_prompt_includes_cross_session_context(
-        self,
-        test_user: "User",
-    ) -> None:
-        """Agent system prompt should include cross-session context when available."""
-        from backend.app.agent.session_db import get_session_store
-
-        store = get_session_store(test_user.id)
-
-        # Create a session with messages (simulates a Telegram conversation)
-        session_a, _ = await store.get_or_create_session()
-        await store.add_message(session_a, "inbound", "Draft estimate for deck")
-        await store.add_message(session_a, "outbound", "Sure, what size deck?")
-
-        user = MagicMock()
-        user.soul_text = ""
-        user.user_text = ""
-        user.id = test_user.id
-        user.timezone = ""
-
-        with patch(
-            "backend.app.agent.system_prompt.build_memory_context",
-            new_callable=AsyncMock,
-            return_value="",
-        ):
-            result = await build_agent_system_prompt(
-                user=user,
-                tools=[],
-                message_context="hello",
-                current_session_id="webchat_session_999",
-            )
-
-        assert "## Recent Activity (other channel)" in result
-        assert "Draft estimate for deck" in result
-        assert "Sure, what size deck?" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #1433. Four small fixes from the conversation-design review, bundled as agreed on the issue.

**1. Same-row trim atomicity (correctness).** History rebuild expands one outbound DB row into a tool-call `AssistantMessage`, its `ToolResultMessage`s, and a final-reply `AssistantMessage`, all sharing the row's `seq` (`context._expand_outbound_with_tools`). `trim_messages` treated the reply as a separate block, so it could drop the tool-call half while keeping the reply; the watermark then advanced over the shared seq and silently filtered the kept reply from the next turn's history, and the reply prose never reached the compactor. The reply now trims atomically with its block. Live-loop messages carry `seq=None` and are unaffected.

**2. Remove the dead cross-session context section (perf/cleanup).** Migration 026 collapsed sessions to one per user, so `build_cross_session_context` excluding the current session always returned empty; every message paid a wasted query. Removed the function, the `get_other_session_messages_async` store method, and the `current_session_id` plumbing through the prompt assemblers. All channels share the single session, so channel switches are already covered by ordinary history.

**3. Accurate proactive trim (correctness of trigger).** A fresh `ClawboltAgent` is built per message, so `self._last_input_tokens` was always 0 at the proactive trim and the decision fell back to the chars/4 + flat 10k-overhead heuristic, which ignores tool schemas and the real system prompt size, firing later than configured. A bounded process-local LRU now carries the last API-reported `input_tokens` per user across agent instances (cleared by `reset_stores()` for test isolation); the heuristic remains the cold-start fallback after a restart.

**4. Memory erosion signal (observability).** Compaction full-rewrites MEMORY.md and the compliance audit explicitly encourages deletion, so a valid line can vanish on any cycle with no signal. The `compaction.summary` log line now carries `memory_lines_added` / `memory_lines_removed` (multiset line diff, reorder-insensitive) so a log aggregator can alert on large unexplained removals.

**Deliberate deviation from the issue:** item 4's acceptance criterion asked for the counts on `compaction_events` rows. This PR puts them on the structured log line only, because adding a migration here would collide with migration 039 in PR #1438 (independent PRs, same Alembic head). Persisting the counts is a 10-line follow-up once 039 lands.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (2884 passed, 2 skipped; 6 dead cross-session tests removed, 5 added)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): Claude implemented all four fixes and their tests, with direction and review by @njbrake.
- [ ] No AI used
