### PR TITLE
fix: harden agent tool reliability across four production failure modes

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import json
 import logging
 import random
@@ -177,6 +178,40 @@ def _normalize_tool_args(args: dict[str, Any]) -> str:
         return json.dumps(args, sort_keys=True, default=str)
     except (TypeError, ValueError):
         return repr(sorted(args.items()))
+
+
+def _stringify_numbers_for_string_fields(
+    tool_args: dict[str, Any], exc: ValidationError
+) -> dict[str, Any] | None:
+    """Stringify numeric values that failed ``str`` field validation.
+
+    LLMs emit numeric-looking values (work order numbers, street numbers,
+    event titles like "20240") as JSON numbers. Pydantic v2 rejects
+    ``int``/``float`` input for ``str`` fields by default, which fails the
+    whole tool call even though the intent is unambiguous. Returns a copy
+    of ``tool_args`` with each offending value stringified, or ``None``
+    when no error is coercible (the original error should be reported).
+    Booleans are left alone: ``True`` for a string field is a real bug,
+    not a serialization quirk.
+    """
+    coerced: Any = copy.deepcopy(tool_args)
+    fixed_any = False
+    for error in exc.errors():
+        if error.get("type") != "string_type":
+            continue
+        value = error.get("input")
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            continue
+        container: Any = coerced
+        loc = error.get("loc", ())
+        try:
+            for key in loc[:-1]:
+                container = container[key]
+            cast("dict[Any, Any]", container)[loc[-1]] = str(value)
+        except (KeyError, IndexError, TypeError):
+            continue
+        fixed_any = True
+    return coerced if fixed_any else None
 
 
 def _resolve_concurrency_group(tool: Tool, validated_args: dict[str, Any]) -> str | None:
@@ -676,6 +711,13 @@ class ClawboltAgent:
             validated = tool.params_model.model_validate(tool_args)
             return validated.model_dump(), None
         except ValidationError as exc:
+            coerced_args = _stringify_numbers_for_string_fields(tool_args, exc)
+            if coerced_args is not None:
+                try:
+                    validated = tool.params_model.model_validate(coerced_args)
+                    return validated.model_dump(), None
+                except ValidationError as retry_exc:
+                    return tool_args, format_validation_error(tool.name, retry_exc, tool)
             return tool_args, format_validation_error(tool.name, exc, tool)
 
     def _get_tool_tags(self, tool_name: str) -> set[ToolTags]:

--- a/backend/app/integrations/appfolio_vendor/work_orders.py
+++ b/backend/app/integrations/appfolio_vendor/work_orders.py
@@ -20,6 +20,7 @@ from backend.app.integrations.appfolio_vendor.service import (
     AppFolioError,
     AppFolioVendorService,
     AuthExpiredError,
+    AuthScopeError,
 )
 
 logger = logging.getLogger(__name__)
@@ -165,7 +166,16 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
                         f"{list(_KNOWN_WO_LIST_ENVELOPES)} containing the list"
                     ),
                 )
-            return ToolResult(content=f"No work orders matched '{search_term}'.")
+            return ToolResult(
+                content=(
+                    f"No work orders matched '{search_term}'. The portal only"
+                    " surfaces work orders this vendor login can access: a"
+                    " specific number the user expects to exist may be closed,"
+                    " canceled, or archived, or belong to a property manager"
+                    " this login is not authorized for. Explain that to the"
+                    " user instead of just reporting the miss."
+                )
+            )
         lines = [f"{len(items)} match(es) for '{search_term}':"]
         lines.extend(_fmt_work_order_line(w) for w in items[:20])
         return ToolResult(content="\n".join(lines))
@@ -173,6 +183,19 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
     async def appfolio_get_work_order(customer_id: str, work_order_id: str) -> ToolResult:
         try:
             wo = await service.get_work_order(customer_id, work_order_id)
+        except AuthScopeError:
+            # The agent often arrives with a wrong or guessed customer_id
+            # (search results carry a different customer_id field than the
+            # path expects). Resolve the canonical primary customer from
+            # /profiles/me and retry once before surfacing the failure.
+            try:
+                canonical_customer_id = await service._resolve_primary_customer_id()
+            except Exception as exc:
+                return _service_error("resolving the AppFolio customer", exc)
+            try:
+                wo = await service.get_work_order(canonical_customer_id, work_order_id)
+            except Exception as exc:
+                return _service_error("fetching work order", exc)
         except Exception as exc:
             return _service_error("fetching work order", exc)
 

--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -42,6 +42,11 @@ the user a customer, invoice, or estimate does not exist, and never create a
 new one, until `qb_query` has returned no match for the identifier they gave.
 An ID you already resolved this session can be reused without re-querying.
 
+Amounts, balances, and statuses are the opposite of IDs: they go stale
+(payments land, invoices get edited). Quote them only from rows a query
+returned this turn. If the entity the user asked about is not in those rows,
+query for it directly; do not recite numbers remembered from an earlier turn.
+
 ## Creating Entities (qb_create)
 
 Pass `entity_type` (Customer, Estimate, Invoice, or Item) and `data` (the QBO API payload).

--- a/backend/app/media/pipeline.py
+++ b/backend/app/media/pipeline.py
@@ -111,18 +111,25 @@ async def process_message_media(
         ", ".join(f"{r.category} ({len(r.extracted_text)} chars)" for r in media_results),
     )
 
-    parts: list[str] = []
-    if text_body:
-        parts.append(f"[Text message]: {text_body!r}")
+    media_parts: list[str] = []
     for i, result in enumerate(media_results):
         label = _format_label(result.category, i + 1, result.handle)
         if result.extracted_text:
-            parts.append(f"[{label}]: {result.extracted_text}")
+            media_parts.append(f"[{label}]: {result.extracted_text}")
         elif result.category == "image" and result.handle:
-            parts.append(
+            media_parts.append(
                 f"[{label}]: (staged, call analyze_photo(handle={result.handle!r})"
                 " if you need a description)"
             )
+
+    # The "[Text message]:" wrapper delimits the user's text from the media
+    # descriptions that follow it. With no media parts it is pure noise the
+    # model can parrot back as its own reply, so text-only messages pass
+    # through verbatim.
+    parts: list[str] = []
+    if text_body:
+        parts.append(f"[Text message]: {text_body!r}" if media_parts else text_body)
+    parts.extend(media_parts)
 
     combined_context = "\n\n".join(parts)
 

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1636,6 +1636,71 @@ async def test_create_invoice_tool_falls_back_when_customer_id_scope_rejected() 
     assert create_invoice.call_args.kwargs["customer_id"] == "canonical-cust"
 
 
+@pytest.mark.asyncio()
+async def test_get_work_order_tool_falls_back_when_customer_id_scope_rejected() -> None:
+    """appfolio_get_work_order retries with the canonical customer on a scope 401.
+
+    Same production failure mode as the invoice tool: the agent guesses a
+    ``customer_id`` (a name, or a stale id from an earlier turn), the GET
+    answers 401 with no ``login_url``, and without the retry the agent
+    dead-ends and falls back to scanning the full work-order list.
+    """
+    from backend.app.integrations.appfolio_vendor.work_orders import build_work_order_tools
+
+    cred = AppFolioCredential(
+        user_id="u1",
+        jwt="jwt-1",
+        fingerprint="fp-1",
+        customer_ids=[],
+        extra={"fingerprint": "fp-1"},
+    )
+    service = AppFolioVendorService(cred, api_base="https://api.test")
+    get_wo = AsyncMock(
+        side_effect=[
+            AuthScopeError("wrong customer in path"),
+            {
+                "work_order_number": "42",
+                "status": "open",
+                "property_address": "123 Example Street",
+            },
+        ]
+    )
+    get_profile = AsyncMock(return_value={"customers": [{"customer_id": "canonical-cust"}]})
+    get_details = AsyncMock(return_value={})
+    service.get_work_order = get_wo  # type: ignore[method-assign]
+    service.get_profile = get_profile  # type: ignore[method-assign]
+    service.get_work_order_details = get_details  # type: ignore[method-assign]
+
+    tools = build_work_order_tools(service)
+    get_tool = next(t for t in tools if t.name == "appfolio_get_work_order")
+    result = await get_tool.function(customer_id="agent-guess", work_order_id="42")
+
+    assert result.is_error is False
+    assert get_wo.await_count == 2
+    assert get_wo.await_args_list[0].args == ("agent-guess", "42")
+    assert get_wo.await_args_list[1].args == ("canonical-cust", "42")
+    assert "Work order #42" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_search_work_orders_no_match_explains_visibility_limits() -> None:
+    """A no-match search result tells the agent why the number may be missing,
+    so it can explain (closed/archived or different property manager) instead
+    of dead-ending with a bare "can't find it"."""
+    from backend.app.integrations.appfolio_vendor.work_orders import build_work_order_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    service.search_work_orders = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    tools = build_work_order_tools(service)
+    search = next(t for t in tools if t.name == "appfolio_search_work_orders")
+    result = await search.function(search_term="99999")
+
+    assert result.is_error is False
+    assert "No work orders matched '99999'" in result.content
+    assert "closed, canceled, or archived" in result.content
+
+
 # ---------------------------------------------------------------------------
 # Wire-shape: amount * quantity collapsed before POST
 # ---------------------------------------------------------------------------

--- a/tests/test_media_pipeline.py
+++ b/tests/test_media_pipeline.py
@@ -57,6 +57,31 @@ async def test_process_text_only() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_text_only_message_has_no_wrapper() -> None:
+    """Text-only messages pass through verbatim, without the "[Text message]:"
+    delimiter. The wrapper only earns its keep next to media parts; alone it
+    is formatting noise the model can parrot back as its own reply."""
+    result = await process_message_media("Yes", [])
+    assert result.combined_context == "Yes"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.media.pipeline.analyze_image", new_callable=AsyncMock)
+async def test_text_with_media_keeps_wrapper(mock_vision: AsyncMock, test_user: User) -> None:
+    """When media parts are present, the text keeps its delimiting wrapper."""
+    await media_staging.clear_user(test_user.id)
+    await media_staging.stage(
+        test_user.id, "https://example.com/media", b"fake-bytes", "image/jpeg"
+    )
+    result = await process_message_media(
+        "Check this deck", [_make_media("image/jpeg")], user_id=test_user.id
+    )
+    assert result.combined_context.startswith("[Text message]: 'Check this deck'")
+    assert "Photo 1" in result.combined_context
+    await media_staging.clear_user(test_user.id)
+
+
+@pytest.mark.asyncio()
 async def test_process_unknown_media_type() -> None:
     """Unknown media type should be skipped gracefully with a placeholder."""
     result = await process_message_media("", [_make_media("application/octet-stream")])

--- a/tests/test_quickbooks_skill_md.py
+++ b/tests/test_quickbooks_skill_md.py
@@ -192,6 +192,22 @@ def test_skill_md_requires_query_before_claiming_absence() -> None:
     )
 
 
+def test_skill_md_requires_fresh_rows_for_amounts() -> None:
+    """The guard must tell the agent to quote amounts from current query rows.
+
+    Without this, the agent answers balance/status questions from its
+    in-context memory of an earlier pull: it runs a fresh query, then recites
+    a remembered breakdown (and an unverified payment status) instead of
+    reading the rows the query just returned.
+    """
+    content = SKILL_MD_PATH.read_text()
+    lowered = content.lower()
+    assert "returned this turn" in lowered, (
+        "The guard should require amounts, balances, and statuses to come "
+        "from rows a query returned this turn, not from conversation memory."
+    )
+
+
 def test_skill_md_new_customer_job_queries_first() -> None:
     """The 'New customer job' workflow must query Customer before creating.
 

--- a/tests/test_tool_param_validation.py
+++ b/tests/test_tool_param_validation.py
@@ -284,6 +284,134 @@ def test_delete_file_params_accepts_valid_path() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Numeric-to-string coercion: LLMs emit numeric-looking strings as JSON
+# numbers (e.g. a calendar event titled after a work order number), which
+# must not fail the whole tool call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_validation_coerces_int_for_string_field(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """A JSON integer sent for a str field should be stringified, not rejected."""
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "typed_tool",
+                # The LLM emits a numeric-only title as a JSON number.
+                "arguments": json.dumps({"title": 20240, "value": 1}),
+            }
+        ]
+    )
+    followup_response = make_text_response("Done!")
+    mock_amessages.side_effect = [tool_response, followup_response]
+
+    class TypedParams(BaseModel):
+        title: str = Field(description="A title")
+        value: int = Field(description="A value")
+
+    mock_func = AsyncMock(return_value=ToolResult(content="ok"))
+    tool = Tool(
+        name="typed_tool",
+        description="A typed tool",
+        function=mock_func,
+        params_model=TypedParams,
+    )
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    response = await agent.process_message("test", system_prompt_override="system")
+
+    mock_func.assert_called_once_with(title="20240", value=1)
+    assert response.tool_calls[0].is_error is False
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_validation_coerces_number_in_nested_string_field(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """Numeric values nested inside lists of models should also be stringified."""
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "typed_tool",
+                "arguments": json.dumps({"items": [{"label": 42, "amount": 7.5}]}),
+            }
+        ]
+    )
+    followup_response = make_text_response("Done!")
+    mock_amessages.side_effect = [tool_response, followup_response]
+
+    class LineItem(BaseModel):
+        label: str = Field(description="A label")
+        amount: float = Field(description="An amount")
+
+    class TypedParams(BaseModel):
+        items: list[LineItem] = Field(description="Line items")
+
+    mock_func = AsyncMock(return_value=ToolResult(content="ok"))
+    tool = Tool(
+        name="typed_tool",
+        description="A typed tool",
+        function=mock_func,
+        params_model=TypedParams,
+    )
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    response = await agent.process_message("test", system_prompt_override="system")
+
+    mock_func.assert_called_once_with(items=[{"label": "42", "amount": 7.5}])
+    assert response.tool_calls[0].is_error is False
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_validation_does_not_coerce_bool_for_string_field(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """A boolean for a str field is a real bug and should still be rejected."""
+    tool_response = make_tool_call_response(
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "typed_tool",
+                "arguments": json.dumps({"title": True}),
+            }
+        ]
+    )
+    followup_response = make_text_response("Let me fix that.")
+    mock_amessages.side_effect = [tool_response, followup_response]
+
+    class TypedParams(BaseModel):
+        title: str = Field(description="A title")
+
+    mock_func = AsyncMock(return_value=ToolResult(content="ok"))
+    tool = Tool(
+        name="typed_tool",
+        description="A typed tool",
+        function=mock_func,
+        params_model=TypedParams,
+    )
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    response = await agent.process_message("test", system_prompt_override="system")
+
+    mock_func.assert_not_called()
+    assert response.tool_calls[0].is_error is True
+    assert "Validation error" in response.tool_calls[0].result
+
+
+# ---------------------------------------------------------------------------
 # Eager (batch) validation tests: all errors reported in one round (#350)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Four fixes for agent failure modes observed while reviewing recent production sessions. Each one caused a user-visible dead end or confusing behavior.

**1. Numeric tool args for string fields fail the whole tool call** (`backend/app/agent/core.py`)

When a string field's value is numeric-looking (a work order number used as a calendar event title, a street number), LLMs emit it as a JSON number. Pydantic v2 rejects `int`/`float` input for `str` fields, so the call fails with a validation error the model often cannot recover from; in production the agent asked the user to retry and failed again the same way, and the user only escaped by renaming the event to something alphabetic. The agent now stringifies values that failed `string_type` validation and revalidates once. Booleans are deliberately not coerced, and there is no behavior change for any call that previously validated.

**2. Text-only messages no longer wrapped in `[Text message]: '...'`** (`backend/app/media/pipeline.py`)

The wrapper exists to delimit the user's text from media descriptions in the combined context. For text-only messages it wrapped the bare body anyway, and in production the model parroted the wrapper back verbatim as its reply (the user literally received `[Text message]: 'Yes'`), derailing a confirmation flow; the confirmed action then executed bundled into an unrelated later request. Text-only messages now pass through verbatim; messages with media keep the wrapper.

**3. AppFolio work-order lookups: scope-401 retry and an explanatory no-match message** (`backend/app/integrations/appfolio_vendor/work_orders.py`)

`appfolio_get_work_order` now catches `AuthScopeError` (agent guessed or stale `customer_id`), resolves the canonical customer from `/profiles/me`, and retries once, mirroring the existing pattern in the invoice tool. And when a search matches nothing, the tool result now explains why a number the user expects to exist may be missing (closed, canceled, archived, or under a property manager this login is not authorized for) so the agent can tell the user something useful instead of dead-ending with a bare miss across multiple sessions.

**4. QuickBooks skill: quote amounts from current query rows** (`backend/app/integrations/quickbooks/SKILL.md`)

In production the agent answered an invoice-amount question by running a fresh query and then reciting a remembered breakdown from an earlier turn, including a payment status the returned rows did not show. Added a terse rule next to the existing unknown-vs-absent guard: amounts, balances, and statuses go stale; quote them only from rows a query returned this turn.

All repro details in code and tests use synthetic values.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`): 2926 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (investigated via admin diagnostics, implemented and tested by Claude Code, reviewed by @njbrake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Agent Tool Reliability Improvements

## Overview
This PR addresses four production failure modes that caused agent tool calls to fail in real customer sessions. The fixes improve robustness in data validation, message formatting, API authentication, and LLM guidance.

## What Changed

**Core Changes:**
1. **Numeric-to-String Coercion** (`backend/app/agent/core.py`) - Added automatic conversion of numeric values to strings when they're provided for string-type fields. This handles a common LLM mistake where work order numbers or street addresses are emitted as numbers instead of text strings. The fix retries validation after coercion; booleans are not converted (preserved as errors).

2. **Message Wrapper Simplification** (`backend/app/media/pipeline.py`) - Removed unnecessary `[Text message]: '...'` wrapper from text-only messages. The wrapper is now applied only when media is present, preventing the agent from echoing back the wrapper text in responses.

3. **AppFolio Work Order Handling** (`backend/app/integrations/appfolio_vendor/work_orders.py`) - Enhanced error handling for authentication scope failures (401 errors). When a lookup fails due to customer scope, the tool now resolves the canonical customer ID and retries automatically. Added better error messages when no work orders match, explaining possible reasons (closed, canceled, archived, or scope limitations).

4. **QuickBooks Data Freshness Guidance** (`backend/app/integrations/quickbooks/SKILL.md`) - Added instruction requiring the agent to quote amounts, balances, and statuses only from the most recent query results, not from earlier conversation turns, preventing stale data from being used.

## What Was Added
- Helper function for numeric-to-string conversion with retry logic
- Authentication scope error handling with automatic retry using canonical customer IDs
- Descriptive error messages for failed work order searches
- New test coverage: 65+ lines for AppFolio tests, 25+ lines for media pipeline tests, 16+ lines for QuickBooks guidance validation, 128+ lines for parameter validation integration tests
- Total: ~242 lines of new test code across 4 test files

## Benefits
- **Improved Reliability**: Eliminates tool call failures caused by LLM type mismatches and authentication scope issues
- **Better User Experience**: Cleaner message formatting and more informative error messages guide users when lookups fail
- **Reduced Debugging**: Automatic retry for scope issues reduces support burden
- **Data Accuracy**: Freshness guidance prevents stale data from being incorrectly attributed to current queries
- **Comprehensive Coverage**: New tests validate all four fixes with realistic scenarios

## Technical Details

The implementation includes:
- Pydantic v2-compatible validation error handling with targeted type coercion
- Retry logic for AppFolio API calls with canonical customer ID resolution
- Conditional message wrapper application based on media presence
- Guard test coverage for SKILL.md guidance enforcement
- Integration-level tests mocking LLM message patterns to verify tool execution outcomes

All changes maintain backward compatibility with previously valid calls. Tests confirm 2,926 passed with no regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->