### PR TITLE
fix(appfolio): log raw responses on success so we can debug from user reports

### DIFF
--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -191,6 +191,82 @@ _LOG_BODY_PREVIEW_LIMIT = 1500
 error in full; short enough to keep individual log lines manageable."""
 
 
+_RAW_RESPONSE_LOG_LIMIT = 8000
+"""Cap on the summarized response body in the success raw-response log.
+Larger than :data:`_LOG_BODY_PREVIEW_LIMIT` on purpose: that limit is for an
+error *preview*, whereas the raw-response log exists to capture the *full*
+work-order shape (every id / number / customer_id in a list) so AppFolio's
+display-number-to-internal-id mapping is reconstructable from logs alone."""
+
+
+# Response keys whose values are credential-ish and must never reach the
+# logs. Read responses don't normally carry these, but ``_request`` is the
+# one funnel for every call (auth/refresh bodies included), so redact
+# defensively rather than trusting each caller.
+_RESPONSE_SECRET_KEYS = frozenset(
+    {
+        "jwt",
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "authorization",
+        "password",
+        "secret",
+    }
+)
+
+
+# Response keys whose values are personal information. AppFolio work-order
+# responses carry tenant names, addresses, and contact details; per the
+# repo's PII rules those must not land in logs. We deliberately keep the
+# fields that the number/id translation debugging actually needs (id,
+# numberForDisplay, customer_id, status) and redact the rest. Free-text
+# fields (description/title) can still carry incidental PII, but redacting
+# them would gut the debug value; treat that as soft PII handled by the
+# 200-char string collapse, not blanket redaction.
+_RESPONSE_PII_KEYS = frozenset(
+    {
+        "name",
+        "full_name",
+        "fullname",
+        "first_name",
+        "last_name",
+        "display_name",
+        "tenant",
+        "tenant_name",
+        "occupant",
+        "resident",
+        "contact",
+        "contact_name",
+        "email",
+        "email_address",
+        "phone",
+        "phone_number",
+        "mobile",
+        "cell",
+        "address",
+        "address_1",
+        "address_2",
+        "address1",
+        "address2",
+        "street",
+        "street_address",
+        "property_address",
+        "propertyaddress",
+        "city",
+        "state",
+        "zip",
+        "zip_code",
+        "zipcode",
+        "postal_code",
+    }
+)
+
+
+_RESPONSE_REDACT_KEYS = _RESPONSE_SECRET_KEYS | _RESPONSE_PII_KEYS
+
+
 def _summarize_body_for_log(body: Any) -> Any:
     """Replace base64-encoded file payloads with size markers for log output.
 
@@ -239,6 +315,73 @@ def _summarize_files_field(body: Any) -> Any:
         else:
             out[k] = _summarize_body_for_log(v)
     return out
+
+
+def _summarize_response_for_log(body: Any) -> Any:
+    """Collapse base64/long strings and redact secret + PII keys for logs.
+
+    Reuses the request summarizer's base64/long-string collapsing (so photo
+    URLs or any inlined blobs don't bury the structure) and additionally
+    redacts values under known credential and personal-information keys.
+    The fields the number/id translation debugging needs (id,
+    numberForDisplay, customer_id, status) pass through untouched; tenant
+    names, addresses, and contact details are redacted per the repo's PII
+    rules.
+    """
+    if isinstance(body, dict):
+        out: dict[str, Any] = {}
+        for k, v in body.items():
+            if isinstance(k, str) and k.lower() in _RESPONSE_REDACT_KEYS:
+                out[k] = "<redacted>"
+            else:
+                out[k] = _summarize_response_for_log(v)
+        return out
+    if isinstance(body, list):
+        return [_summarize_response_for_log(v) for v in body]
+    if isinstance(body, str) and len(body) > 200:
+        return f"<{len(body)} char string>"
+    return body
+
+
+def _response_shape(body: Any) -> str:
+    """One-line structural descriptor for a parsed response (no values).
+
+    Mirrors :func:`errors.log_unexpected_response_shape` so the success
+    log and the unexpected-shape warning describe shapes the same way.
+    """
+    if isinstance(body, dict):
+        return f"dict keys={sorted(body.keys())!r}"
+    if isinstance(body, list):
+        if body and isinstance(body[0], dict):
+            return f"list len={len(body)} sample_keys={sorted(body[0].keys())!r}"
+        return f"list len={len(body)}"
+    return f"type={type(body).__name__}"
+
+
+def _log_raw_response(method: str, path: str, status: int, byte_len: int, parsed: Any) -> None:
+    """INFO-log the full (summarized, secret- and PII-redacted) response.
+
+    Success responses were previously logged only as a byte count, so a
+    200 OK with a surprising shape (e.g. a work-order search that returns
+    an internal id but not the user-facing number) left nothing to debug
+    from after the fact. We can't reach AppFolio ourselves, so the only way
+    to debug a user's report later is to have captured what AppFolio
+    actually returned at the time. This logs the structure on every call:
+    short scalar fields intact, base64/long strings collapsed, credential
+    keys redacted, truncated at :data:`_RAW_RESPONSE_LOG_LIMIT`.
+    """
+    body_repr = repr(_summarize_response_for_log(parsed))
+    if len(body_repr) > _RAW_RESPONSE_LOG_LIMIT:
+        body_repr = body_repr[:_RAW_RESPONSE_LOG_LIMIT] + f"...<{len(body_repr)} chars>"
+    logger.info(
+        "AppFolio raw response: %s %s -> status=%d (%d bytes) | shape=%s | body=%s",
+        method,
+        path,
+        status,
+        byte_len,
+        _response_shape(parsed),
+        body_repr,
+    )
 
 
 class AppFolioVendorService:
@@ -398,18 +541,32 @@ class AppFolioVendorService:
             # messages flow into ToolResult.content (visible to the LLM and
             # the end user). The full body stays in the warning log above.
             raise AppFolioError(f"AppFolio {method} {path} failed: HTTP {resp.status_code}")
+        byte_len = len(resp.content or b"")
         logger.debug(
             "AppFolio %s %s ok (%d, %d bytes)",
             method,
             path,
             resp.status_code,
-            len(resp.content or b""),
+            byte_len,
         )
         if not resp.content:
             return None
         ctype = resp.headers.get("content-type", "")
         if "application/json" in ctype:
-            return resp.json()
+            parsed = resp.json()
+            _log_raw_response(method, path, resp.status_code, byte_len, parsed)
+            return parsed
+        # Non-JSON payload (e.g. a PDF or image download): never log the
+        # bytes; the size and content-type are enough to debug from.
+        logger.info(
+            "AppFolio raw response: %s %s -> status=%d non-JSON content-type=%r"
+            " (%d bytes, body not logged)",
+            method,
+            path,
+            resp.status_code,
+            ctype,
+            byte_len,
+        )
         return resp.content
 
     async def get(self, path: str, *, params: dict[str, Any] | None = None) -> Any:

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -27,6 +28,8 @@ from backend.app.integrations.appfolio_vendor.service import (
     AppFolioVendorService,
     AuthExpiredError,
     AuthScopeError,
+    _response_shape,
+    _summarize_response_for_log,
     build_service,
     connect_via_magic_link,
     exchange_magic_link,
@@ -2130,3 +2133,109 @@ async def test_connected_user_sees_appfolio_in_specialist_summaries() -> None:
     # ("AppFolio is read-only on my end..."). The summary must surface
     # write capabilities so the LLM knows the full surface area.
     assert "note" in summary or "invoice" in summary
+
+
+# ---------------------------------------------------------------------------
+# Raw-response logging (debug aid for the display-number/internal-id mapping)
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_response_for_log_preserves_mapping_fields() -> None:
+    """The fields the number/id debugging needs (id, numberForDisplay,
+    customer_id, status) must survive untouched."""
+    out = _summarize_response_for_log(
+        [{"id": 900113, "numberForDisplay": "WO-2026-0042", "customer_id": "c1", "status": "new"}]
+    )
+    assert out == [
+        {"id": 900113, "numberForDisplay": "WO-2026-0042", "customer_id": "c1", "status": "new"}
+    ]
+
+
+def test_summarize_response_for_log_redacts_pii_fields() -> None:
+    """Tenant names, addresses, and contact details are PII and must not
+    reach the logs, while the id stays so the record is still identifiable."""
+    out = _summarize_response_for_log(
+        {
+            "id": 900113,
+            "name": "a real person",
+            "email": "someone@example.com",
+            "phone": "+15555550123",
+            "address": "123 Example St",
+            "city": "Anytown",
+        }
+    )
+    assert out["id"] == 900113
+    assert out["name"] == "<redacted>"
+    assert out["email"] == "<redacted>"
+    assert out["phone"] == "<redacted>"
+    assert out["address"] == "<redacted>"
+    assert out["city"] == "<redacted>"
+
+
+def test_summarize_response_for_log_redacts_secret_keys() -> None:
+    """An auth/refresh body funnelled through ``_request`` must never log
+    its tokens, even though read responses don't normally carry them."""
+    out = _summarize_response_for_log(
+        {"access_token": "jwt-abc", "refresh_token": "rt-xyz", "expires_in": 7200}
+    )
+    assert out == {
+        "access_token": "<redacted>",
+        "refresh_token": "<redacted>",
+        "expires_in": 7200,
+    }
+
+
+def test_summarize_response_for_log_collapses_long_strings() -> None:
+    out = _summarize_response_for_log({"blob": "x" * 500, "short": "ok"})
+    assert out["blob"] == "<500 char string>"
+    assert out["short"] == "ok"
+
+
+def test_response_shape_describes_dict_and_list() -> None:
+    assert _response_shape({"results": []}) == "dict keys=['results']"
+    assert _response_shape([{"id": 1}, {"id": 2}]) == "list len=2 sample_keys=['id']"
+
+
+@pytest.mark.asyncio()
+async def test_successful_read_logs_raw_response_body(caplog: Any) -> None:
+    """A 200 OK is logged at INFO with the full (summarized) body, so a
+    surprising shape is reconstructable from logs alone. This is the exact
+    gap that made a number search undebuggable: when the raw response
+    carries only an internal id and no user-facing number, the byte-count
+    log we had before told us nothing."""
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    # The failing shape: search returns an internal id, no display number.
+    response = _mock_response(json_data=[{"id": 900113}])
+
+    with (
+        caplog.at_level(logging.INFO, logger="backend.app.integrations.appfolio_vendor.service"),
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+    ):
+        cm, _ = _patch_request(response)
+        cls.return_value = cm
+        result = await service.search_work_orders("WO-2026-0042")
+
+    assert result == [{"id": 900113}]
+    record_text = "\n".join(r.message for r in caplog.records)
+    assert "raw response" in record_text
+    assert "/api/v1/search/work_order_search" in record_text
+    assert "900113" in record_text
+    assert "list len=1 sample_keys=['id']" in record_text
+
+
+@pytest.mark.asyncio()
+async def test_raw_response_log_redacts_tokens(caplog: Any) -> None:
+    """Secret values in a JSON response body never reach the log line."""
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={"access_token": "super-secret-jwt", "ok": True})
+
+    with (
+        caplog.at_level(logging.INFO, logger="backend.app.integrations.appfolio_vendor.service"),
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+    ):
+        cm, _ = _patch_request(response)
+        cls.return_value = cm
+        await service.get("/api/v1/anything")
+
+    assert "super-secret-jwt" not in caplog.text
+    assert "<redacted>" in caplog.text


### PR DESCRIPTION
_Drafted by Claude in discussion with the repo maintainer; the reasoning and decisions are the maintainer's, the prose is Claude's._

## Description

On a successful AppFolio call we only logged a byte count, never the body. When AppFolio answers 200 OK with a surprising shape, there is nothing to debug from after the fact.

The concrete case: a work-order number search whose raw response carries only an internal id and no user-facing number. The formatter falls back to the internal id, the agent reads a false mismatch against the number the user asked for, and it can refuse to act. Because we never logged the body, we could not tell whether search returned the right record (a thin payload) or the wrong one (a genuine number/id translation bug). We can't reach AppFolio ourselves, so the only way to debug a user report later is to have captured the raw response at the time.

The change adds an INFO-level raw-response log in the single request funnel (`_request`), covering list, search, get, and writes:

- short scalar fields (`id`, `numberForDisplay`, `customer_id`, `status`) pass through intact, which is what we need to reconstruct the display-number to internal-id mapping;
- base64 and long strings are collapsed (reuses the existing request summarizer) so photo blobs don't bury the structure;
- credential keys (`jwt`, `access_token`, `refresh_token`, and similar) and PII keys (names, addresses, email, phone) are redacted, so neither secrets nor tenant data reach the logs;
- a one-line shape descriptor matching `log_unexpected_response_shape`;
- truncated at 8000 chars; non-JSON bodies log size and content-type only, never the bytes.

To use it: after a user reports a bad AppFolio lookup, grep the logs for `AppFolio raw response` to see the structure of what AppFolio actually returned, including whether a search hit carried the user-facing number or only an internal id.

Note on retention: this writes to application logs, so it helps only while logs are retained. Durable per-user capture would be a larger follow-up.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (drafted by Claude in discussion with the maintainer; the reasoning and decisions are the maintainer's)
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

### What Changed
- **Enhanced AppFolio API observability** by adding **INFO-level logging of successful JSON responses** in `backend/app/integrations/appfolio_vendor/service.py`.
- Introduced response-log helpers:
  - **`_summarize_response_for_log()`**: redacts sensitive/PII fields, collapses very long strings (including large/base64-like payloads) into short size markers, while keeping key debugging identifiers intact.
  - **`_response_shape()`**: emits a compact “shape” description of the response (dict keys / list length + sample keys).
  - **`_log_raw_response()`**: writes the final single-line log entry, with **truncation at 8000 characters**.
- Updated the core **`_request()`** flow:
  - For **JSON + success**, it now parses the JSON, logs the summarized/redacted body at INFO, and returns the parsed object.
  - For **non-JSON payloads**, it **does not log the body bytes**—it logs only status, content-type, and size.

### Tests
- In `tests/test_appfolio_vendor.py`, added coverage for:
  - **Preserving mapping/debug fields** needed for id/display-number troubleshooting.
  - **Redacting** token/secret values (e.g., `access_token`) and **PII fields**.
  - **Collapsing long strings** into size markers.
  - **Response shape descriptor** formatting.
  - **INFO logging behavior** on successful reads, including that **raw token values never appear** in logs.

### Key Benefits
- **Faster debugging from user reports**: when AppFolio returns an unexpected “shape,” you can reconstruct what was received by inspecting logs.
- **Safer logs**: secrets/tokens and sensitive personal fields are defensively redacted, and large payloads are summarized to keep logs readable.
- **Performance/log hygiene**: avoids dumping large/non-JSON bodies into logs while still capturing the structure needed for diagnosis.

### Test Suite
- Full test suite passes (**94 tests**).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->