### PR TITLE
fix(appfolio): map search-hit schema so number/customer_id surface; harden log PII

### DIFF
--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -217,14 +217,15 @@ _RESPONSE_SECRET_KEYS = frozenset(
 )
 
 
-# Response keys whose values are personal information. AppFolio work-order
-# responses carry tenant names, addresses, and contact details; per the
-# repo's PII rules those must not land in logs. We deliberately keep the
-# fields that the number/id translation debugging actually needs (id,
-# numberForDisplay, customer_id, status) and redact the rest. Free-text
-# fields (description/title) can still carry incidental PII, but redacting
-# them would gut the debug value; treat that as soft PII handled by the
-# 200-char string collapse, not blanket redaction.
+# Response keys whose values are personal information. AppFolio responses
+# carry tenant names, addresses, contact details, business names, and
+# free-text instructions; per the repo's PII rules none of those may land
+# in logs. We deliberately keep only the fields the number/id translation
+# debugging needs (id, numberForDisplay/result_text, customer_id/
+# customer_ids, status) and redact the rest. This exact set is paired with
+# :data:`_RESPONSE_PII_SUBSTRINGS` below, which catches schema variants
+# (company_email, two_fa_phone_number_last_four, company_primary_address_1,
+# portfolio_name, ...) without us having to enumerate every one.
 _RESPONSE_PII_KEYS = frozenset(
     {
         "name",
@@ -233,6 +234,9 @@ _RESPONSE_PII_KEYS = frozenset(
         "first_name",
         "last_name",
         "display_name",
+        "company_name",
+        "customer_name",
+        "portfolio_name",
         "tenant",
         "tenant_name",
         "occupant",
@@ -260,11 +264,37 @@ _RESPONSE_PII_KEYS = frozenset(
         "zip_code",
         "zipcode",
         "postal_code",
+        # Free-text fields that routinely carry tenant names + phone numbers
+        # ("call or text <name> <number>"). Not needed for id/number
+        # debugging, so redact rather than risk leaking names into logs.
+        "description",
+        "vendor_instructions",
+        "vendorinstructions",
+        "instructions",
     }
 )
 
 
+# Substrings that mark a key as PII regardless of its exact name, to catch
+# schema variants the exact set above doesn't enumerate. Kept narrow and
+# unambiguous so the identifier keys the debugging needs -- id, customer_id,
+# customer_ids, numberForDisplay, result_text, result_type, status -- are
+# never caught. ("state" stays exact-only on purpose: it would otherwise
+# redact ``two_fa_enrollment_state`` and similar non-PII status fields.)
+_RESPONSE_PII_SUBSTRINGS = ("email", "phone", "address", "name", "last_four", "ssn", "tax_id")
+
+
 _RESPONSE_REDACT_KEYS = _RESPONSE_SECRET_KEYS | _RESPONSE_PII_KEYS
+
+
+def _is_pii_response_key(key: Any) -> bool:
+    """True if a response key should be redacted (exact match or PII substring)."""
+    if not isinstance(key, str):
+        return False
+    lowered = key.lower()
+    if lowered in _RESPONSE_REDACT_KEYS:
+        return True
+    return any(token in lowered for token in _RESPONSE_PII_SUBSTRINGS)
 
 
 def _summarize_body_for_log(body: Any) -> Any:
@@ -331,7 +361,7 @@ def _summarize_response_for_log(body: Any) -> Any:
     if isinstance(body, dict):
         out: dict[str, Any] = {}
         for k, v in body.items():
-            if isinstance(k, str) and k.lower() in _RESPONSE_REDACT_KEYS:
+            if _is_pii_response_key(k):
                 out[k] = "<redacted>"
             else:
                 out[k] = _summarize_response_for_log(v)

--- a/backend/app/integrations/appfolio_vendor/work_orders.py
+++ b/backend/app/integrations/appfolio_vendor/work_orders.py
@@ -108,6 +108,55 @@ def _normalize_list(payload: Any) -> list[dict[str, Any]]:
     return []
 
 
+def _normalize_search_hit(hit: dict[str, Any]) -> dict[str, Any]:
+    """Map an ``/api/v1/search/work_order_search`` hit into the work-order
+    dict shape :func:`_fmt_work_order_line` expects.
+
+    The search endpoint is a separate universal-search API with its own
+    field names, not the maintenance work-order schema. A hit looks like::
+
+        {"id": 900113, "result_text": "WO-2026-0042 - UnitLabel",
+         "result_type": "maintenance/work_order", "customer_ids": [4242]}
+
+    The user-facing number lives in ``result_text`` (``"<number> - <unit>"``)
+    and the customer id is a *list* under ``customer_ids`` -- neither of
+    which the formatter reads. Without this remap it falls back to the bare
+    internal ``id``, so a number search renders as a different number (the
+    agent then reports a false "that doesn't match") and write tools have
+    no customer_id and 404. Translate so the number and customer_id surface
+    from data the search already returned, with no extra API call.
+
+    Hits already in the work-order shape (or non-dicts) pass through.
+    """
+    if not isinstance(hit, dict):
+        return hit
+    if "result_text" not in hit and "customer_ids" not in hit:
+        return hit
+    out = dict(hit)
+    result_text = hit.get("result_text")
+    has_number = any(
+        hit.get(k)
+        for k in ("numberForDisplay", "number_for_display", "work_order_number", "number")
+    )
+    if result_text and not has_number:
+        # ``result_text`` is "<display number> - <unit label>"; the number
+        # is the segment before the first " - ". Keep the unit label as a
+        # summary so the agent has something to disambiguate on.
+        number, _, unit = str(result_text).partition(" - ")
+        out["numberForDisplay"] = number.strip() or str(result_text)
+        if unit.strip() and not any(hit.get(k) for k in ("description", "title", "summary")):
+            out["title"] = unit.strip()
+    customer_ids = hit.get("customer_ids")
+    if (
+        isinstance(customer_ids, list)
+        and customer_ids
+        and not hit.get("customer_id")
+        and not hit.get("customerId")
+    ):
+        out["customer_id"] = customer_ids[0]
+    return out
+
+
 def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
     """Return the AppFolio work-order read tools."""
 
@@ -155,7 +204,10 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
         except Exception as exc:
             return _service_error("searching work orders", exc)
 
-        items = _normalize_list(payload)
+        # The search endpoint returns its own hit schema (result_text,
+        # customer_ids); remap each hit to the work-order shape so the
+        # display number and customer_id surface instead of the bare id.
+        items = [_normalize_search_hit(hit) for hit in _normalize_list(payload)]
         if not items:
             if isinstance(payload, dict) and payload:
                 log_unexpected_response_shape(

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -34,6 +34,10 @@ from backend.app.integrations.appfolio_vendor.service import (
     connect_via_magic_link,
     exchange_magic_link,
 )
+from backend.app.integrations.appfolio_vendor.work_orders import (
+    _normalize_search_hit,
+    build_work_order_tools,
+)
 
 # ---------------------------------------------------------------------------
 # Magic-link parsing
@@ -2239,3 +2243,101 @@ async def test_raw_response_log_redacts_tokens(caplog: Any) -> None:
 
     assert "super-secret-jwt" not in caplog.text
     assert "<redacted>" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Search-hit schema remap (result_text / customer_ids -> work-order shape)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_search_hit_maps_result_text_and_customer_ids() -> None:
+    """The search endpoint puts the WO number in ``result_text`` and the
+    customer id in a ``customer_ids`` list; both must surface so the agent
+    sees the number and can route writes without a 404."""
+    out = _normalize_search_hit(
+        {
+            "id": 900113,
+            "result_text": "WO-2026-0042 - UnitLabel",
+            "result_type": "maintenance/work_order",
+            "customer_ids": [4242],
+        }
+    )
+    assert out["id"] == 900113
+    assert out["numberForDisplay"] == "WO-2026-0042"
+    assert out["customer_id"] == 4242
+
+
+def test_normalize_search_hit_passes_through_work_order_shape() -> None:
+    """A dict already in the work-order shape is returned untouched."""
+    wo = {"id": 900113, "numberForDisplay": "WO-9", "customer_id": 4242}
+    assert _normalize_search_hit(wo) == wo
+
+
+@pytest.mark.asyncio()
+async def test_search_work_orders_surfaces_number_and_customer_id() -> None:
+    """Regression: a number search used to render the bare internal id and a
+    false "doesn't match". The hit's result_text/customer_ids must drive the
+    output so the user-facing number and customer_id show instead."""
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    service.search_work_orders = AsyncMock(  # type: ignore[method-assign]
+        return_value=[
+            {
+                "id": 900113,
+                "result_text": "WO-2026-0042 - UnitLabel",
+                "result_type": "maintenance/work_order",
+                "customer_ids": [4242],
+            }
+        ]
+    )
+
+    tools = build_work_order_tools(service)
+    search = next(t for t in tools if t.name == "appfolio_search_work_orders")
+    result = await search.function(search_term="WO-2026-0042")
+
+    assert result.is_error is False
+    assert "ID: 900113" in result.content
+    assert "#WO-2026-0042" in result.content
+    assert "customer_id=4242" in result.content
+    # The bare-internal-id fallback must NOT be what gets shown as the number.
+    assert "#900113" not in result.content
+
+
+def test_summarize_response_for_log_redacts_business_and_freetext_pii() -> None:
+    """Business names, company_email, *_last_four, and free-text instructions
+    are PII and must be redacted; the id/number/customer fields stay so the
+    raw-response log is still useful for debugging."""
+    out = _summarize_response_for_log(
+        {
+            "id": 900113,
+            "numberForDisplay": "WO-9",
+            "result_text": "WO-9 - UnitLabel",
+            "customer_id": 4242,
+            "customer_ids": [4242],
+            "status_code": 3,
+            "two_fa_enrollment_state": "required",
+            "portfolio_name": "Some Property Co",
+            "company_email": "ops@example.com",
+            "company_primary_address_1": "1 Example Ave",
+            "current_payment_last_four": "0000",
+            "two_fa_phone_number_last_four": "0000",
+            "description": "free text that can carry a name and number",
+        }
+    )
+    # Identifiers needed for debugging survive.
+    assert out["id"] == 900113
+    assert out["numberForDisplay"] == "WO-9"
+    assert out["result_text"] == "WO-9 - UnitLabel"
+    assert out["customer_id"] == 4242
+    assert out["customer_ids"] == [4242]
+    assert out["status_code"] == 3
+    assert out["two_fa_enrollment_state"] == "required"
+    # PII is redacted.
+    for key in (
+        "portfolio_name",
+        "company_email",
+        "company_primary_address_1",
+        "current_payment_last_four",
+        "two_fa_phone_number_last_four",
+        "description",
+    ):
+        assert out[key] == "<redacted>", key


### PR DESCRIPTION
## Description

The raw-response logging shipped earlier let us capture what `/api/v1/search/work_order_search` actually returns in production. It is a **universal-search hit schema**, not the maintenance work-order schema:

```
search hit:  { id, result_text: "<number> - <unit>", result_type, customer_ids: [<id>], ... }
work order:  { id, numberForDisplay: "<number>", customer_id: <id>, ... }
```

`_fmt_work_order_line` reads `numberForDisplay` and `customer_id`, so a search hit matched **neither**: it fell back to the bare internal `id`, the agent reported a false "that number doesn't match what you gave me", and write tools had no customer_id (invoices 404'd until a 105-row `list_work_orders` call backfilled it). The number and customer_id were in the response the whole time, under different keys.

### Fix 1: map the search-hit schema
`_normalize_search_hit` remaps a search hit into the work-order shape before formatting:
- `result_text` ("`<number> - <unit>`") → `numberForDisplay` (number = segment before the first " - "), unit kept as a summary
- `customer_ids[0]` → `customer_id`

No extra API call. Eliminates the false mismatch and the invoice 404. Work-order-shaped dicts pass through untouched.

### Fix 2: harden raw-response log PII redaction
The same captures showed the exact-key redaction missed PII-bearing keys: `company_email`, business names (`portfolio_name`/`company_name`/`customer_name`, which the repo PII rules count as PII), `*_last_four`, `company_primary_address_1`, and free-text `description`/`instructions` that carry tenant name + phone. Added those to the redaction set plus a narrow PII **substring** check (`email`/`phone`/`address`/`name`/`last_four`/`ssn`/`tax_id`) to catch schema variants, while keeping the identifier fields the debugging needs (`id`, `numberForDisplay`, `result_text`, `customer_id`, `customer_ids`, `status`). `result_text` is kept on purpose since it carries the WO number we debug with.

### Tests
- `_normalize_search_hit` remap + work-order-shape passthrough
- search tool surfaces number + customer_id (regression: bare id no longer shown as the number)
- expanded redaction redacts business/free-text/last-four PII while keeping identifiers

All fixtures use synthetic values. Full `test_appfolio_vendor.py` passes (99).

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (diagnosed from production logs and implemented by Claude at the maintainer's direction)
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes two bugs in the AppFolio integration and hardens data privacy protections:

### Changes Made

**1. Fixed Search Results Display (work_orders.py)**
- Added a normalization function to reformat search results so they match the structure expected by the work-order display formatter
- Extracts the user-facing work-order number from search results and properly maps customer identifiers
- Search results now display the correct work-order numbers and include customer IDs needed by downstream operations
- Result: Agents no longer see false "number doesn't match" messages, and tools have the customer ID needed for operations like invoice lookups without triggering additional API calls

**2. Expanded PII Redaction (service.py)**
- Enhanced the logging system to redact more personally identifiable information from API responses
- Added redaction for business names (`company_name`, `portfolio_name`, `customer_name`), email addresses (`company_email`), bank card details (`*_last_four`), addresses, and free-text fields containing sensitive information like tenant names and phone numbers
- Introduced a helper function to detect both exact PII field names and fields containing PII-related keywords
- Preserved non-sensitive identifier fields (`id`, `numberForDisplay`, `status`) to maintain debugging capability

**3. Added Comprehensive Tests (tests/test_appfolio_vendor.py)**
- New tests verify that search results are correctly normalized into the expected format
- Regression test confirms the search tool outputs correct work-order numbers and customer IDs
- Tests validate that PII redaction works properly while preserving debugging identifiers

### Benefits
- **Improved Agent Experience**: Agents see accurate work-order numbers that match their AppFolio dashboard
- **Reduced API Calls**: Eliminated unnecessary `list_work_orders` fallback requests (previously needed 105-row calls to backfill missing customer IDs)
- **Enhanced Security**: Stricter PII redaction in logs while maintaining sufficient debugging information
- **Better Data Consistency**: Search results now use the same field names as list results, improving code maintainability

### Technical Details

**Schema Normalization**: The `/api/v1/search/work_order_search` endpoint returns a universal-search hit schema with `result_text` (formatted as "number - unit") and `customer_ids` array, but the work-order formatter expects `numberForDisplay` and single `customer_id`. The `_normalize_search_hit()` function bridges this gap by extracting the number from `result_text` and mapping `customer_ids[0]` to `customer_id`, leaving already-normalized dicts unchanged.

**PII Redaction**: Expanded `_RESPONSE_PII_KEYS` with additional exact matches (`company_name`, `customer_name`, `portfolio_name`, `company_email`, `company_primary_address_1`, `description`, `instructions`, vendor instruction variants) and added `_is_pii_response_key()` helper that performs both exact-key matching and substring pattern matching (for `email`, `phone`, `address`, `name`, `last_four`, `ssn`, `tax_id`) while explicitly preserving whitelisted fields like `id`, `numberForDisplay`, `result_text`, `customer_id`, `customer_ids`, `status`, and `status_code`.

All 99 tests in `test_appfolio_vendor.py` pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->