### PR TITLE
fix(calendar): make batched multi-event approvals stop re-prompting and not partially apply

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -118,6 +118,20 @@ class ApprovalDecision(StrEnum):
     INTERRUPTED = "interrupted"
 
 
+# Sentinel returned by ``classify_approval_response`` when a reply is short
+# filler ("lol", "haha", "ok wait") that is neither a clear yes/no nor a clear
+# new request. The caller re-prompts for a clear decision instead of resolving
+# the gate as INTERRUPTED, which would abort the rest of a batched approval and
+# leave a multi-event action (e.g. rescheduling a multi-day job) half-applied.
+AMBIGUOUS_APPROVAL_REPLY: Literal["ambiguous"] = "ambiguous"
+
+# How many times a single pending approval may be re-prompted after ambiguous
+# replies before we give up and treat the next ambiguous reply as a genuine
+# interruption. Keeps a user who keeps sending filler from looping forever; the
+# approval timeout is the outer bound.
+_MAX_APPROVAL_REPROMPTS = 2
+
+
 # ---------------------------------------------------------------------------
 # ApprovalPolicy (attached to Tool definitions)
 # ---------------------------------------------------------------------------
@@ -417,6 +431,11 @@ class PendingApproval:
     description: str
     event: asyncio.Event = field(default_factory=asyncio.Event)
     decision: ApprovalDecision | None = None
+    # The exact prompt text the user was shown, kept so an ambiguous reply can
+    # be answered by re-sending it (see ``note_ambiguous_reply``).
+    prompt: str = ""
+    # Number of times this approval has been re-prompted after ambiguous replies.
+    reprompt_count: int = 0
 
 
 class ApprovalGate:
@@ -433,6 +452,26 @@ class ApprovalGate:
     def has_pending(self, user_id: str) -> bool:
         """Return True if there is a pending approval for this user."""
         return user_id in self._pending
+
+    def note_ambiguous_reply(self, user_id: str) -> str | None:
+        """Record an ambiguous reply against a pending approval.
+
+        Returns the prompt text to re-send so the caller can ask the user
+        for a clear yes/no, leaving the approval pending. Returns ``None``
+        when there is no pending approval or the re-prompt cap has been
+        reached, in which case the caller should fall back to resolving the
+        gate as INTERRUPTED.
+
+        Re-prompting (instead of interrupting) keeps a batched multi-tool
+        approval intact when the user replies with filler like "lol" partway
+        through: the blocked agent loop stays waiting for a real decision
+        rather than aborting the batch and leaving it half-applied.
+        """
+        pending = self._pending.get(user_id)
+        if pending is None or pending.reprompt_count >= _MAX_APPROVAL_REPROMPTS:
+            return None
+        pending.reprompt_count += 1
+        return pending.prompt
 
     async def request_approval(
         self,
@@ -482,6 +521,7 @@ class ApprovalGate:
 
         if prompt is None:
             prompt = format_approval_message(tool_name, description)
+        pending.prompt = prompt
         try:
             await publish_outbound(
                 OutboundMessage(channel=channel, chat_id=chat_id, content=prompt)
@@ -857,27 +897,36 @@ def _parse_approval_response(text: str) -> ApprovalDecision | None:
     return _APPROVAL_RESPONSE_FAST_PATH.get(normalized)
 
 
-async def classify_approval_response(text: str) -> ApprovalDecision | None:
+async def classify_approval_response(
+    text: str,
+) -> ApprovalDecision | Literal["ambiguous"] | None:
     """Classify a natural-language approval response using an LLM.
 
     Called when ``_parse_approval_response()`` returns None but an approval
     gate is pending. Uses structured output to resolve ambiguous responses
     like "Yes to both", "go ahead", "sure thing", etc.
 
-    Returns None if the LLM call fails or the response is not approval-related.
+    Returns ``AMBIGUOUS_APPROVAL_REPLY`` for short filler ("lol", "huh", "ok
+    wait") that is neither a clear yes/no nor a clear new request: the caller
+    re-prompts instead of interrupting the pending batch. Returns ``None`` if
+    the LLM call fails or the message is a clear, unrelated new request.
     """
 
     class ApprovalClassification(BaseModel):
         """Structured classification of a user's approval response."""
 
-        decision: Literal["approved", "denied", "always_allow", "always_deny", "unrelated"] = Field(
+        decision: Literal[
+            "approved", "denied", "always_allow", "always_deny", "ambiguous", "unrelated"
+        ] = Field(
             description=(
                 "Classify the user's message: "
                 "'approved' if they are saying yes/agreeing, "
                 "'denied' if they are saying no/refusing, "
                 "'always_allow' if they want to always allow (e.g. 'always', 'always yes'), "
                 "'always_deny' if they want to always deny (e.g. 'never', 'never allow'), "
-                "'unrelated' if the message is not an approval response at all"
+                "'ambiguous' if the message is short filler or unclear (e.g. 'lol', 'haha', "
+                "'hmm', 'wait', 'huh') that is neither a clear yes/no nor a clear new request, "
+                "'unrelated' if the message is a clear new request or a clear change of subject"
             )
         )
 
@@ -900,7 +949,10 @@ async def classify_approval_response(text: str) -> ApprovalDecision | None:
                             "yes (allow this once), no (deny this once), "
                             "always (allow and remember), never (deny and remember). "
                             "Classify their response into one of: approved, denied, "
-                            "always_allow, always_deny, unrelated."
+                            "always_allow, always_deny, ambiguous, unrelated. "
+                            "Use 'ambiguous' for short filler or unclear replies that do "
+                            "not commit to yes or no and are not a new request; the user "
+                            "will be asked to clarify."
                         ),
                     },
                     {"role": "user", "content": text},
@@ -910,9 +962,9 @@ async def classify_approval_response(text: str) -> ApprovalDecision | None:
                 # No ``temperature``: claude-opus-4-7 (and newer Anthropic
                 # models) return 400 ``temperature is deprecated for this
                 # model``, which made every fuzzy approval response fall
-                # through to the INTERRUPTED fallback in prod. The 5-value
-                # enum via ``response_format`` already constrains the output;
-                # temperature has no meaningful effect on it.
+                # through to the INTERRUPTED fallback in prod. The
+                # six-value enum via ``response_format`` already constrains the
+                # output; temperature has no meaningful effect on it.
             ),
         )
     except Exception:
@@ -933,9 +985,12 @@ async def classify_approval_response(text: str) -> ApprovalDecision | None:
     result = decision_map.get(parsed.decision)
     if result is not None:
         logger.info("LLM classified approval response %r as %s", text[:100], result)
-    else:
-        logger.info("LLM classified response %r as unrelated to approval", text[:100])
-    return result
+        return result
+    if parsed.decision == "ambiguous":
+        logger.info("LLM classified approval response %r as ambiguous (will re-prompt)", text[:100])
+        return AMBIGUOUS_APPROVAL_REPLY
+    logger.info("LLM classified response %r as unrelated to approval", text[:100])
+    return None
 
 
 def format_approval_message(tool_name: str, description: str) -> str:

--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -22,6 +22,7 @@ from sqlalchemy import CursorResult, delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.agent.approval import (
+    AMBIGUOUS_APPROVAL_REPLY,
     ApprovalDecision,
     _parse_approval_response,
     classify_approval_response,
@@ -796,7 +797,48 @@ async def process_inbound_from_bus(
             )
             decision = await classify_approval_response(inbound.text)
 
-        if decision is not None:
+        if decision == AMBIGUOUS_APPROVAL_REPLY:
+            # Short filler ("lol", "huh", "ok wait") is neither a yes/no nor a
+            # new request. Re-prompt for a clear decision and leave the gate
+            # pending, so a batched multi-tool approval is not aborted partway
+            # through (which would leave e.g. a multi-day reschedule applied to
+            # only some of its events).
+            clarification = gate.note_ambiguous_reply(user.id)
+            if clarification is not None:
+                from backend.app.bus import OutboundMessage, message_bus
+
+                reprompt = "Sorry, I didn't catch that as a yes or no.\n\n" + clarification
+                logger.info(
+                    "Ambiguous approval reply from user %s (%r); re-prompting",
+                    user.id,
+                    inbound.text[:100],
+                )
+                # Webchat replies carry a request_id whose SSE stream must be
+                # closed; messaging channels (no request_id) get the re-prompt
+                # pushed as a normal outbound message.
+                if inbound.request_id:
+                    message_bus.resolve_response(
+                        inbound.request_id,
+                        OutboundMessage(
+                            channel=inbound.channel,
+                            chat_id=inbound.sender_id,
+                            content=reprompt,
+                        ),
+                    )
+                else:
+                    await message_bus.publish_outbound(
+                        OutboundMessage(
+                            channel=inbound.channel,
+                            chat_id=inbound.sender_id,
+                            content=reprompt,
+                        )
+                    )
+                return
+            # Re-prompt cap reached: stop nagging and treat the next ambiguous
+            # reply as a genuine interruption via the fall-through path below.
+            decision = None
+
+        if isinstance(decision, ApprovalDecision):
             # The body is intentionally not persisted as a Message row (see
             # the explanatory block below). That makes it invisible to any
             # later audit query unless we leave a single visible breadcrumb

--- a/backend/app/integrations/calendar/factory.py
+++ b/backend/app/integrations/calendar/factory.py
@@ -826,7 +826,12 @@ def create_calendar_tools(
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
-                resource_extractor=lambda args: f"update {args.get('event_id', '')}",
+                # Coarse resource (not per-event_id) so "always allow" and the
+                # within-turn approval cache apply to every update in a batch.
+                # Rescheduling a multi-day job is one update per day; a per-id
+                # resource re-prompted for every day even after "always allow"
+                # (issue #1449). Mirrors create_event's "create event".
+                resource_extractor=lambda args: "update event",
                 description_builder=lambda args: (
                     f"Update calendar event: {args['title']}"
                     if args.get("title")
@@ -849,7 +854,10 @@ def create_calendar_tools(
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,
-                resource_extractor=lambda args: f"delete {args.get('event_id', '')}",
+                # Coarse resource (not per-event_id) so "always allow" and the
+                # within-turn approval cache apply to every delete in a batch,
+                # matching create_event/update_event (issue #1449).
+                resource_extractor=lambda args: "delete event",
                 description_builder=lambda args: "Delete a calendar event",
             ),
         ),

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import BaseModel
 
 from backend.app.agent.approval import (
+    AMBIGUOUS_APPROVAL_REPLY,
     ApprovalDecision,
     ApprovalGate,
     ApprovalPolicy,
@@ -28,7 +29,7 @@ from backend.app.agent.ingestion import (
     process_inbound_from_bus,
 )
 from backend.app.agent.tools.base import Tool, ToolResult
-from backend.app.bus import OutboundMessage
+from backend.app.bus import OutboundMessage, message_bus
 from backend.app.database import db_session_async
 from backend.app.models import User
 from tests.mocks.llm import make_text_response, make_tool_call_response
@@ -758,6 +759,40 @@ class TestApprovalGate:
         )
         await task
 
+    @pytest.mark.asyncio()
+    async def test_note_ambiguous_reply_returns_prompt_then_caps(self) -> None:
+        """note_ambiguous_reply returns the prompt until the re-prompt cap."""
+        gate = ApprovalGate()
+        # No pending approval -> nothing to re-prompt.
+        assert gate.note_ambiguous_reply("1") is None
+
+        mock_publish = AsyncMock()
+
+        async def _drive() -> None:
+            await _await_pending(gate, "1")
+            # First two ambiguous replies return the stored prompt to re-send.
+            first = gate.note_ambiguous_reply("1")
+            assert first is not None
+            assert "yes" in first.lower()
+            assert gate.note_ambiguous_reply("1") is not None
+            # Third one is over the cap: caller should fall back to INTERRUPTED.
+            assert gate.note_ambiguous_reply("1") is None
+            # Gate is still pending the whole time -- re-prompting never resolves it.
+            assert gate.has_pending("1")
+            await gate.resolve("1", ApprovalDecision.APPROVED)
+
+        task = asyncio.create_task(_drive())
+        await gate.request_approval(
+            user_id="1",
+            tool_name="t",
+            description="d",
+            publish_outbound=mock_publish,
+            channel="telegram",
+            chat_id="c",
+            timeout=5.0,
+        )
+        await task
+
 
 # ---------------------------------------------------------------------------
 # Agent integration
@@ -1249,6 +1284,132 @@ class TestIngestionIntercept:
         assert not gate.has_pending(test_user.id)
 
     @pytest.mark.asyncio()
+    async def test_ambiguous_reply_reprompts_and_keeps_gate_pending(self, test_user: User) -> None:
+        """Filler like "lol" re-prompts without interrupting the batch.
+
+        Regression for the calendar partial-apply bug: an ambiguous reply
+        during a batched approval used to resolve the gate as INTERRUPTED,
+        aborting the rest of the batch. It should instead re-prompt for a
+        clear yes/no and leave the gate pending.
+        """
+        gate = get_approval_gate()
+        mock_publish = AsyncMock()
+
+        async def _start_approval() -> ApprovalDecision:
+            return await gate.request_approval(
+                user_id=test_user.id,
+                tool_name="calendar_update_event",
+                description="Update calendar event: Day 4",
+                publish_outbound=mock_publish,
+                channel="telegram",
+                chat_id="chat_1",
+                timeout=5.0,
+            )
+
+        approval_task = asyncio.create_task(_start_approval())
+        await _await_pending(gate, test_user.id)
+
+        inbound = InboundMessage(
+            channel="telegram",
+            sender_id=str(test_user.id),
+            text="lol",
+        )
+
+        mock_batcher = AsyncMock()
+        with (
+            patch(
+                "backend.app.agent.ingestion._get_or_create_user",
+                new_callable=AsyncMock,
+                return_value=test_user,
+            ),
+            patch(
+                "backend.app.agent.ingestion.classify_approval_response",
+                new_callable=AsyncMock,
+                return_value=AMBIGUOUS_APPROVAL_REPLY,
+            ),
+            patch(
+                "backend.app.agent.ingestion.message_batcher",
+                mock_batcher,
+            ),
+            patch.object(message_bus, "publish_outbound", new_callable=AsyncMock) as mock_out,
+        ):
+            await process_inbound_from_bus(inbound)
+
+            # The gate stays pending: the blocked agent loop is still waiting.
+            assert gate.has_pending(test_user.id)
+            # The user got a re-prompt asking for a clear yes/no.
+            mock_out.assert_called_once()
+            sent: OutboundMessage = mock_out.call_args.args[0]
+            assert sent.content.startswith("Sorry, I didn't catch that")
+            assert "yes" in sent.content.lower()
+            # The filler message was NOT dispatched to the pipeline.
+            mock_batcher.enqueue.assert_not_called()
+
+            # A clear "yes" now resolves the still-pending gate.
+            await gate.resolve(test_user.id, ApprovalDecision.APPROVED)
+
+        decision = await approval_task
+        assert decision == ApprovalDecision.APPROVED
+        assert not gate.has_pending(test_user.id)
+
+    @pytest.mark.asyncio()
+    async def test_repeated_ambiguous_replies_eventually_interrupt(self, test_user: User) -> None:
+        """After the re-prompt cap, an ambiguous reply falls back to INTERRUPTED."""
+        gate = get_approval_gate()
+        mock_publish = AsyncMock()
+
+        async def _start_approval() -> ApprovalDecision:
+            return await gate.request_approval(
+                user_id=test_user.id,
+                tool_name="calendar_update_event",
+                description="Update calendar event: Day 4",
+                publish_outbound=mock_publish,
+                channel="telegram",
+                chat_id="chat_1",
+                timeout=5.0,
+            )
+
+        approval_task = asyncio.create_task(_start_approval())
+        await _await_pending(gate, test_user.id)
+
+        inbound = InboundMessage(
+            channel="telegram",
+            sender_id=str(test_user.id),
+            text="haha",
+        )
+
+        mock_batcher = AsyncMock()
+        with (
+            patch(
+                "backend.app.agent.ingestion._get_or_create_user",
+                new_callable=AsyncMock,
+                return_value=test_user,
+            ),
+            patch(
+                "backend.app.agent.ingestion.classify_approval_response",
+                new_callable=AsyncMock,
+                return_value=AMBIGUOUS_APPROVAL_REPLY,
+            ),
+            patch(
+                "backend.app.agent.ingestion.message_batcher",
+                mock_batcher,
+            ),
+            patch.object(message_bus, "publish_outbound", new_callable=AsyncMock),
+        ):
+            # First two ambiguous replies re-prompt; the gate stays pending.
+            await process_inbound_from_bus(inbound)
+            await process_inbound_from_bus(inbound)
+            assert gate.has_pending(test_user.id)
+            # The third one exceeds the cap and interrupts the batch instead.
+            await process_inbound_from_bus(inbound)
+
+        decision = await approval_task
+        assert decision == ApprovalDecision.INTERRUPTED
+        assert not gate.has_pending(test_user.id)
+        # The interrupting message falls through to the pipeline.
+        mock_batcher.enqueue.assert_called_once()
+
+    @pytest.mark.asyncio()
     async def test_message_with_attachments_is_not_eaten_as_approval(self, test_user: User) -> None:
         """A message with media attachments bypasses approval-eating.
 
@@ -1570,6 +1731,42 @@ class TestClassifyApprovalResponseCallShape:
         assert "response_format" in kwargs, (
             "response_format is what actually constrains the output to the enum"
         )
+
+    @pytest.mark.asyncio()
+    @pytest.mark.parametrize(
+        ("decision", "expected"),
+        [
+            ("approved", ApprovalDecision.APPROVED),
+            ("denied", ApprovalDecision.DENIED),
+            ("always_allow", ApprovalDecision.ALWAYS_ALLOW),
+            ("always_deny", ApprovalDecision.ALWAYS_DENY),
+            ("ambiguous", AMBIGUOUS_APPROVAL_REPLY),
+            ("unrelated", None),
+        ],
+    )
+    async def test_classification_maps_to_expected_result(
+        self, decision: str, expected: object
+    ) -> None:
+        """Each classifier label maps to its decision; 'ambiguous' re-prompts."""
+        from pydantic import BaseModel as _BaseModel
+
+        class _Parsed(_BaseModel):
+            decision: str
+
+        mock_msg = AsyncMock()
+        mock_msg.parsed = _Parsed(decision=decision)
+        mock_choice = AsyncMock()
+        mock_choice.message = mock_msg
+        mock_response = AsyncMock()
+        mock_response.choices = [mock_choice]
+
+        with patch(
+            "backend.app.agent.approval.acompletion",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            result = await classify_approval_response("lol")
+
+        assert result == expected
 
 
 class TestApprovalEvents:

--- a/tests/test_calendar_tools.py
+++ b/tests/test_calendar_tools.py
@@ -201,6 +201,33 @@ def test_check_availability_is_ask(cal_tools: list[Tool]) -> None:
     assert tool.approval_policy.default_level == PermissionLevel.ASK
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "expected_resource"),
+    [
+        (ToolName.CALENDAR_CREATE_EVENT, "create event"),
+        (ToolName.CALENDAR_UPDATE_EVENT, "update event"),
+        (ToolName.CALENDAR_DELETE_EVENT, "delete event"),
+    ],
+)
+def test_mutation_resource_is_coarse_not_per_event(
+    cal_tools: list[Tool], tool_name: str, expected_resource: str
+) -> None:
+    """Create/update/delete scope approvals per action type, not per event_id.
+
+    Regression for issue #1449: a per-event_id resource made "always allow"
+    (and the within-turn approval cache) miss for every other event in a
+    batch, so rescheduling a multi-day job re-prompted on each day even
+    after the user chose "always allow". A coarse resource fixes that and
+    keeps all three mutation tools consistent.
+    """
+    tool = _get_tool(cal_tools, tool_name)
+    assert tool.approval_policy is not None
+    assert tool.approval_policy.resource_extractor is not None
+    # Two different events resolve to the same resource, so one approval covers both.
+    assert tool.approval_policy.resource_extractor({"event_id": "evt-A"}) == expected_resource
+    assert tool.approval_policy.resource_extractor({"event_id": "evt-B"}) == expected_resource
+
+
 # ---------------------------------------------------------------------------
 # Description builders
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #1449.

Rescheduling a multi-day calendar job (one event per day) produced a confusing approval experience: the user was re-prompted for every day even after choosing "always allow", and an ambiguous reply midway left the batch partially applied. A production audit log for one reschedule showed four `calendar_update_event` prompts decided `always_allow`, `always_allow`, `approved`, then `interrupted` ("lol").

Two root causes, fixed in two commits:

**1. Per-event approval resource (primary).** `calendar_update_event` and `calendar_delete_event` extracted an approval resource of `f"update {event_id}"` / `f"delete {event_id}"`, scoping the stored permission to a single event. Each day of a job has a distinct `event_id`, so "always allow" on the first day never matched the rest: the within-turn approval cache (keyed on `(tool_name, resource)`) missed, the persisted ALWAYS override missed, and the user got re-prompted per day. Fixed by using a coarse constant resource (`"update event"` / `"delete event"`), matching `calendar_create_event`'s existing `"create event"`. Now one approval (yes or always) covers every same-type mutation in the batch, and "always allow" persists tool-wide.

**2. Ambiguous reply aborted the batch (safety net).** Short filler like "lol", "haha", "ok wait" classified as neither yes/no nor a new request returned no decision, and ingestion resolved the approval gate as INTERRUPTED, aborting the rest of the batch and leaving it half-applied. `classify_approval_response` now returns a dedicated "ambiguous" result, and ingestion re-sends the approval prompt ("Sorry, I didn't catch that as a yes or no.") while leaving the gate pending, so the blocked agent loop keeps waiting for a real decision. Re-prompts are capped (the approval timeout is the outer bound) so persistent filler still falls back to INTERRUPTED. Genuine new requests still classify as unrelated and interrupt as before.

### Files
- `backend/app/integrations/calendar/factory.py`: coarse approval resource for update/delete.
- `backend/app/agent/approval.py`: `AMBIGUOUS_APPROVAL_REPLY` sentinel, `"ambiguous"` classifier category, `PendingApproval` prompt/reprompt-count, `ApprovalGate.note_ambiguous_reply()`.
- `backend/app/agent/ingestion.py`: re-prompt on ambiguous reply instead of interrupting.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 2949 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Regression tests: `tests/test_calendar_tools.py` asserts create/update/delete resolve different `event_id`s to the same coarse resource; `tests/test_approval.py` covers the classifier mapping, the re-prompt path keeping the gate pending, and the re-prompt cap falling back to INTERRUPTED.

## AI Usage
- [x] AI-assisted (authored by Claude via back-and-forth with @njbrake; diagnosis driven by a production approval audit log he provided)
- [ ] No AI used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes two related issues when rescheduling multi-day calendar jobs (stored as one event per day):

### What Changed

**Approval Resources (Calendar Module)**
- Calendar update and delete event tools now use action-level approval resources (`"update event"`, `"delete event"`) instead of event-specific ones (`f"update {event_id}"`), matching the pattern already used for create operations.

**Approval Reply Handling (Approval & Ingestion Modules)**
- Added support for recognizing and handling "ambiguous" user replies (e.g., "lol", "ok wait") that are neither clear approvals/denials nor intentional conversation changes.
- When ambiguous replies are detected, the system now re-sends the approval prompt to the user instead of aborting the entire batch operation.
- Re-prompting is capped by the existing approval timeout to prevent infinite loops.

### What Was Added

- New `AMBIGUOUS_APPROVAL_REPLY` constant in the approval module to identify ambiguous classification results
- `ApprovalGate.note_ambiguous_reply()` method to manage re-prompt logic and counts
- Storage of the original prompt text and reprompt counter in `PendingApproval` objects
- Enhanced LLM-based classification to distinguish between "ambiguous", "approved", "denied", and "unrelated/interrupt" responses
- Regression tests verifying coarse resource extraction across multi-event batches and ambiguous reply handling

### Benefits

- **Better user experience**: Users selecting "always allow" on the first day now have that permission apply to all subsequent days in a multi-day reschedule, eliminating repeated approval prompts for the same operation.
- **Reduced operational interruption**: Casual/filler responses no longer abort entire batch operations; instead, users are politely prompted to clarify their intent, with a timeout fallback to prevent hanging.
- **Consistency**: Calendar mutation tools now follow the same approval resource pattern, simplifying the mental model for how permissions work across create/update/delete operations.

---

## Technical Details

**Changes to `backend/app/agent/approval.py`** (+66/-11 lines)
- Added `AMBIGUOUS_APPROVAL_REPLY: Literal["ambiguous"]` constant
- Extended `PendingApproval` dataclass to store the sent `prompt` text and `reprompt_count`
- Updated `classify_approval_response()` return type to include `Literal["ambiguous"]` and modified the LLM schema/prompt to classify ambiguous replies
- Implemented `ApprovalGate.note_ambiguous_reply(user_id)` that returns the stored prompt for the first N ambiguous replies, then `None` after the reprompt cap

**Changes to `backend/app/agent/ingestion.py`** (+43/-1 lines)
- Approval response handler now recognizes `AMBIGUOUS_APPROVAL_REPLY` classification
- Calls `gate.note_ambiguous_reply()` to retrieve a reprompt; if available, publishes it and returns without resolving the gate
- Gate resolution logic tightened to only execute when a definitive `ApprovalDecision` is reached

**Changes to `backend/app/integrations/calendar/factory.py`** (+10/-2 lines)
- `ToolName.CALENDAR_UPDATE_EVENT` and `ToolName.CALENDAR_DELETE_EVENT` approval policies now use fixed resource extractors (`"update event"` / `"delete event"`) instead of event-ID-scoped ones

**Test Coverage**
- New `test_note_ambiguous_reply_returns_prompt_then_caps` verifies reprompt lifecycle
- New `test_ambiguous_reply_reprompts_and_keeps_gate_pending` and `test_repeated_ambiguous_replies_eventually_interrupt` verify end-to-end ingestion behavior
- New `test_classification_maps_to_expected_result` parameterized test confirms LLM classification mappings
- New `test_mutation_resource_is_coarse_not_per_event` regression test validates coarse resource extraction across different event IDs

All 2949 tests pass (2 skipped).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->