### PR TITLE
feat(approval): blanket "always all" approval for resource-scoped tools

### DIFF
--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -114,6 +114,7 @@ class ApprovalDecision(StrEnum):
     APPROVED = "approved"
     DENIED = "denied"
     ALWAYS_ALLOW = "always_allow"
+    ALWAYS_ALLOW_ALL = "always_allow_all"
     ALWAYS_DENY = "always_deny"
     INTERRUPTED = "interrupted"
 
@@ -148,11 +149,19 @@ class ApprovalPolicy:
         description_builder: Optional callable that produces a human-readable
             description of what the tool call will do, shown in the approval
             prompt.
+        resource_noun: Optional plural noun for the resources this tool scopes
+            by (e.g. "recipients" for an email-send tool, "domains" for a web
+            fetch). When set alongside ``resource_extractor``, the approval
+            prompt offers an extra "always all" option that grants a blanket
+            tool-level approval covering every resource, not just the one in
+            front of the user. Leave ``None`` to keep approvals strictly
+            per-resource.
     """
 
     default_level: PermissionLevel = PermissionLevel.ASK
     resource_extractor: Callable[[dict[str, Any]], str | None] | None = None
     description_builder: Callable[[dict[str, Any]], str] | None = None
+    resource_noun: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -860,6 +869,15 @@ _APPROVAL_RESPONSE_FAST_PATH: dict[str, ApprovalDecision] = {
     "always y": ApprovalDecision.ALWAYS_ALLOW,
     "always allow": ApprovalDecision.ALWAYS_ALLOW,
     "allow always": ApprovalDecision.ALWAYS_ALLOW,
+    # Blanket tool-level allow ("always all") -- only offered for tools that
+    # scope by a resource (e.g. invoice recipients). Stored as a tool-level
+    # ALWAYS so every resource is covered, not just the one in front of the
+    # user. Conservative phrasings only; anything else falls to the LLM.
+    "always all": ApprovalDecision.ALWAYS_ALLOW_ALL,
+    "all always": ApprovalDecision.ALWAYS_ALLOW_ALL,
+    "allow all": ApprovalDecision.ALWAYS_ALLOW_ALL,
+    "always everyone": ApprovalDecision.ALWAYS_ALLOW_ALL,
+    "always anyone": ApprovalDecision.ALWAYS_ALLOW_ALL,
     "no never": ApprovalDecision.ALWAYS_DENY,
     "never no": ApprovalDecision.ALWAYS_DENY,
     "n never": ApprovalDecision.ALWAYS_DENY,
@@ -916,13 +934,22 @@ async def classify_approval_response(
         """Structured classification of a user's approval response."""
 
         decision: Literal[
-            "approved", "denied", "always_allow", "always_deny", "ambiguous", "unrelated"
+            "approved",
+            "denied",
+            "always_allow",
+            "always_allow_all",
+            "always_deny",
+            "ambiguous",
+            "unrelated",
         ] = Field(
             description=(
                 "Classify the user's message: "
                 "'approved' if they are saying yes/agreeing, "
                 "'denied' if they are saying no/refusing, "
-                "'always_allow' if they want to always allow (e.g. 'always', 'always yes'), "
+                "'always_allow' if they want to always allow this specific target "
+                "(e.g. 'always', 'always yes'), "
+                "'always_allow_all' if they want to always allow this action for every "
+                "target, not just this one (e.g. 'always all', 'allow all', 'always everyone'), "
                 "'always_deny' if they want to always deny (e.g. 'never', 'never allow'), "
                 "'ambiguous' if the message is short filler or unclear (e.g. 'lol', 'haha', "
                 "'hmm', 'wait', 'huh') that is neither a clear yes/no nor a clear new request, "
@@ -945,11 +972,16 @@ async def classify_approval_response(
                         "role": "system",
                         "content": (
                             "The user was asked to approve or deny a tool action. "
-                            "They were shown a four-option menu: "
+                            "They were shown a menu: "
                             "yes (allow this once), no (deny this once), "
-                            "always (allow and remember), never (deny and remember). "
+                            "always (allow and remember this target), "
+                            "never (deny and remember). For actions that target a "
+                            "specific resource (such as an email recipient) they may "
+                            "also have seen 'always all' (allow and remember for every "
+                            "target, not just this one). "
                             "Classify their response into one of: approved, denied, "
-                            "always_allow, always_deny, ambiguous, unrelated. "
+                            "always_allow, always_allow_all, always_deny, ambiguous, "
+                            "unrelated. "
                             "Use 'ambiguous' for short filler or unclear replies that do "
                             "not commit to yes or no and are not a new request; the user "
                             "will be asked to clarify."
@@ -980,6 +1012,7 @@ async def classify_approval_response(
         "approved": ApprovalDecision.APPROVED,
         "denied": ApprovalDecision.DENIED,
         "always_allow": ApprovalDecision.ALWAYS_ALLOW,
+        "always_allow_all": ApprovalDecision.ALWAYS_ALLOW_ALL,
         "always_deny": ApprovalDecision.ALWAYS_DENY,
     }
     result = decision_map.get(parsed.decision)
@@ -993,23 +1026,46 @@ async def classify_approval_response(
     return None
 
 
-def format_approval_message(tool_name: str, description: str) -> str:
+def format_approval_message(
+    tool_name: str,
+    description: str,
+    *,
+    offer_blanket: bool = False,
+    resource_noun: str | None = None,
+) -> str:
     """Build a plain-text approval prompt for the user.
 
-    The four reply options are listed as a vertical menu so each choice
-    is unambiguous. A previous wording, ``"Reply yes or no
-    (always/never to remember your choice)"``, was misread by users as
-    a two-axis answer ("yes always" or "no never"); the menu form makes
-    it clear that exactly one of {yes, no, always, never} is the
-    expected response. The parser still accepts the compound forms in
-    case a user types one anyway.
+    The reply options are listed as a vertical menu so each choice is
+    unambiguous. A previous wording, ``"Reply yes or no (always/never to
+    remember your choice)"``, was misread by users as a two-axis answer
+    ("yes always" or "no never"); the menu form makes it clear that
+    exactly one option is the expected response. The parser still accepts
+    the compound forms in case a user types one anyway.
+
+    When *offer_blanket* is True (a resource-scoped tool whose policy
+    declares a ``resource_noun``), an extra "always all" option is shown
+    between "always" and "never". Picking it grants a tool-level approval
+    covering every resource, so the user is not re-prompted for each new
+    recipient/target. The "always" line stays scoped to the one in front
+    of them. ``resource_noun`` (e.g. "recipients") fills the wording; it
+    falls back to "of them" when not supplied.
+
+    The "never: deny and remember" line stays last on purpose:
+    ``context.py`` identifies stored approval prompts in history by that
+    trailing line, so the blanket option must be inserted before it.
     """
+    blanket_line = ""
+    if offer_blanket:
+        noun = resource_noun or "of them"
+        blanket_line = f"  always all: allow for all {noun} and remember\n"
+
     return (
         f"I'd like to: {description}\n\n"
         "Reply with one of:\n"
         "  yes: allow this once\n"
         "  no: deny this once\n"
         "  always: allow and remember\n"
+        f"{blanket_line}"
         "  never: deny and remember"
     )
 

--- a/backend/app/agent/approval.py
+++ b/backend/app/agent/approval.py
@@ -869,7 +869,7 @@ _APPROVAL_RESPONSE_FAST_PATH: dict[str, ApprovalDecision] = {
     "always y": ApprovalDecision.ALWAYS_ALLOW,
     "always allow": ApprovalDecision.ALWAYS_ALLOW,
     "allow always": ApprovalDecision.ALWAYS_ALLOW,
-    # Blanket tool-level allow ("always all") -- only offered for tools that
+    # Blanket tool-level allow ("always all"). Only offered for tools that
     # scope by a resource (e.g. invoice recipients). Stored as a tool-level
     # ALWAYS so every resource is covered, not just the one in front of the
     # user. Conservative phrasings only; anything else falls to the LLM.

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1029,7 +1029,20 @@ class ClawboltAgent:
                     )
                     decision = cached_decision
                 elif self._publish_outbound is not None and self._chat_id is not None:
-                    prompt = format_approval_message(tool_obj.name, description)
+                    # Offer the blanket "always all" option only when the tool
+                    # scopes by a resource (resource is not None) and its policy
+                    # opts in with a resource_noun. Picking it stores a
+                    # tool-level ALWAYS so the user is not re-prompted per
+                    # recipient/target.
+                    policy = tool_obj.approval_policy
+                    resource_noun = policy.resource_noun if policy is not None else None
+                    offer_blanket = resource is not None and resource_noun is not None
+                    prompt = format_approval_message(
+                        tool_obj.name,
+                        description,
+                        offer_blanket=offer_blanket,
+                        resource_noun=resource_noun,
+                    )
 
                     # We deliberately do not persist the approval prompt to the
                     # session here. Past attempts persisted it as an OUTBOUND
@@ -1066,8 +1079,16 @@ class ClawboltAgent:
                 else:
                     decision = ApprovalDecision.DENIED
 
-                if decision in (ApprovalDecision.APPROVED, ApprovalDecision.ALWAYS_ALLOW):
+                if decision in (
+                    ApprovalDecision.APPROVED,
+                    ApprovalDecision.ALWAYS_ALLOW,
+                    ApprovalDecision.ALWAYS_ALLOW_ALL,
+                ):
                     approved_entries.append(entry)
+                    # ALWAYS_ALLOW remembers just this resource; ALWAYS_ALLOW_ALL
+                    # remembers at the tool level (resource=None) so every
+                    # resource is covered. Resolution still lets a more specific
+                    # resource-level NEVER override the blanket ALWAYS later.
                     if decision == ApprovalDecision.ALWAYS_ALLOW:
                         try:
                             await store.set_permission(
@@ -1075,6 +1096,15 @@ class ClawboltAgent:
                             )
                         except Exception:
                             logger.warning("Failed to persist ALWAYS for tool %s", tool_obj.name)
+                    elif decision == ApprovalDecision.ALWAYS_ALLOW_ALL:
+                        try:
+                            await store.set_permission(
+                                self.user.id, tool_obj.name, PermissionLevel.ALWAYS, resource=None
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Failed to persist ALWAYS (all) for tool %s", tool_obj.name
+                            )
 
                 elif decision == ApprovalDecision.INTERRUPTED:
                     # User changed subject. Error this entry + all remaining.

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1089,22 +1089,33 @@ class ClawboltAgent:
                     # remembers at the tool level (resource=None) so every
                     # resource is covered. Resolution still lets a more specific
                     # resource-level NEVER override the blanket ALWAYS later.
-                    if decision == ApprovalDecision.ALWAYS_ALLOW:
+                    if decision in (
+                        ApprovalDecision.ALWAYS_ALLOW,
+                        ApprovalDecision.ALWAYS_ALLOW_ALL,
+                    ):
+                        # The blanket grant is only honored for tools that
+                        # offered it (policy declares a resource_noun). The
+                        # "always all" keywords resolve globally, so without
+                        # this gate a typed "allow all" on a resource-scoped
+                        # tool that never showed the option (e.g. web_fetch)
+                        # would grant a broader permission than was advertised.
+                        # In that case, fall back to scoping the shown resource.
+                        policy = tool_obj.approval_policy
+                        supports_blanket = policy is not None and policy.resource_noun is not None
+                        persist_resource = (
+                            None
+                            if (decision == ApprovalDecision.ALWAYS_ALLOW_ALL and supports_blanket)
+                            else resource
+                        )
                         try:
                             await store.set_permission(
-                                self.user.id, tool_obj.name, PermissionLevel.ALWAYS, resource
+                                self.user.id,
+                                tool_obj.name,
+                                PermissionLevel.ALWAYS,
+                                persist_resource,
                             )
                         except Exception:
                             logger.warning("Failed to persist ALWAYS for tool %s", tool_obj.name)
-                    elif decision == ApprovalDecision.ALWAYS_ALLOW_ALL:
-                        try:
-                            await store.set_permission(
-                                self.user.id, tool_obj.name, PermissionLevel.ALWAYS, resource=None
-                            )
-                        except Exception:
-                            logger.warning(
-                                "Failed to persist ALWAYS (all) for tool %s", tool_obj.name
-                            )
 
                 elif decision == ApprovalDecision.INTERRUPTED:
                     # User changed subject. Error this entry + all remaining.

--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -764,6 +764,9 @@ def create_quickbooks_tools(
                     f"Send {args.get('entity_type', 'entity')} "
                     f"to {args.get('email', 'recipient')} via QuickBooks"
                 ),
+                # Lets the user grant a blanket "always all" approval covering
+                # every recipient instead of approving each email separately.
+                resource_noun="recipients",
             ),
         ),
     ]

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -298,6 +298,27 @@ class TestParseApprovalResponse:
     @pytest.mark.parametrize(
         ("text", "expected"),
         [
+            # Blanket "always all" replies grant a tool-level approval that
+            # covers every resource (e.g. all invoice recipients), not just
+            # the one in front of the user. These resolve at the fast path.
+            ("always all", ApprovalDecision.ALWAYS_ALLOW_ALL),
+            ("Always all", ApprovalDecision.ALWAYS_ALLOW_ALL),
+            ("all always", ApprovalDecision.ALWAYS_ALLOW_ALL),
+            ("allow all", ApprovalDecision.ALWAYS_ALLOW_ALL),
+            ("always everyone", ApprovalDecision.ALWAYS_ALLOW_ALL),
+            ("always anyone", ApprovalDecision.ALWAYS_ALLOW_ALL),
+            ("always all.", ApprovalDecision.ALWAYS_ALLOW_ALL),  # punctuation stripped
+            ("always  all", ApprovalDecision.ALWAYS_ALLOW_ALL),  # whitespace collapsed
+        ],
+    )
+    def test_blanket_allow_all_responses(self, text: str, expected: ApprovalDecision) -> None:
+        """ "always all" and its natural variants resolve to a blanket
+        tool-level approval at the fast path, not the LLM classifier."""
+        assert _parse_approval_response(text) == expected
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
             # Trailing punctuation users type out of habit. All these
             # should route through the fast path, not the LLM classifier.
             ("Yes.", ApprovalDecision.APPROVED),
@@ -385,6 +406,43 @@ class TestFormatApprovalMessage:
         msg = format_approval_message("any_tool", "do the thing")
         assert "—" not in msg  # em dash
         assert " -- " not in msg  # double-hyphen approximation
+
+    def test_blanket_option_absent_by_default(self) -> None:
+        """The "always all" line only appears when explicitly offered."""
+        msg = format_approval_message("any_tool", "do the thing")
+        assert "always all" not in msg
+
+    def test_blanket_option_shown_with_noun(self) -> None:
+        """offer_blanket adds an "always all" line using the resource noun."""
+        msg = format_approval_message(
+            "qb_send",
+            "Send Invoice to alice@example.com via QuickBooks",
+            offer_blanket=True,
+            resource_noun="recipients",
+        )
+        assert "  always all: allow for all recipients and remember" in msg
+        # The per-target "always" line is still there and distinct.
+        assert "  always: allow and remember" in msg
+
+    def test_blanket_option_falls_back_when_noun_missing(self) -> None:
+        """Without a resource noun the line uses a generic phrasing."""
+        msg = format_approval_message("some_tool", "do it", offer_blanket=True)
+        assert "  always all: allow for all of them and remember" in msg
+
+    def test_blanket_prompt_keeps_never_as_trailer(self) -> None:
+        """The blanket option must be inserted before the "never" line so
+        context.py can still identify stored approval prompts in history by
+        their trailing menu line (issue #1049 filter)."""
+        from backend.app.agent.context import _is_approval_prompt
+
+        msg = format_approval_message(
+            "qb_send",
+            "Send Invoice to alice@example.com via QuickBooks",
+            offer_blanket=True,
+            resource_noun="recipients",
+        )
+        assert msg.rstrip().endswith("never: deny and remember")
+        assert _is_approval_prompt(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -998,6 +1056,124 @@ class TestAgentApproval:
         store = get_approval_store()
         level = await store.check_permission(test_user.id, "fetcher")
         assert level == PermissionLevel.ALWAYS
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_always_allow_all_persists_tool_level_for_every_resource(
+        self, mock_amessages: object, test_user: User
+    ) -> None:
+        """'always all' on a resource-scoped tool persists a tool-level ALWAYS.
+
+        Regression for the QuickBooks invoice-send complaint (issue #1451):
+        approving one recipient with the blanket option must auto-approve a
+        DIFFERENT recipient too, instead of re-prompting per email.
+        """
+        mock_publish = AsyncMock()
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch URL",
+            function=_fetch_tool,
+            params_model=_UrlParams,
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                resource_extractor=_extract_domain,
+                description_builder=_describe_fetch,
+                resource_noun="domains",
+            ),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [{"name": "fetcher", "arguments": {"url": "https://example.com"}}]
+            ),
+            make_text_response("Done!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _always_all_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            await gate.resolve(test_user.id, ApprovalDecision.ALWAYS_ALLOW_ALL)
+
+        agent = ClawboltAgent(
+            user=test_user,
+            channel="telegram",
+            publish_outbound=mock_publish,
+            chat_id="chat_1",
+        )
+        agent.register_tools([tool])
+
+        task = asyncio.create_task(_always_all_soon())
+        await agent.process_message("fetch example.com")
+        await task
+
+        store = get_approval_store()
+        # Stored at the tool level (resource=None), so a brand-new resource
+        # the user never saw is already approved.
+        assert await store.check_permission(test_user.id, "fetcher") == PermissionLevel.ALWAYS
+        assert (
+            await store.check_permission(test_user.id, "fetcher", resource="other.com")
+            == PermissionLevel.ALWAYS
+        )
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
+    async def test_always_allow_scopes_to_single_resource(
+        self, mock_amessages: object, test_user: User
+    ) -> None:
+        """Contrast with the blanket option: plain 'always' on a resource-scoped
+        tool only remembers the one resource, so a different one still asks."""
+        mock_publish = AsyncMock()
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch URL",
+            function=_fetch_tool,
+            params_model=_UrlParams,
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                resource_extractor=_extract_domain,
+                description_builder=_describe_fetch,
+                resource_noun="domains",
+            ),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [{"name": "fetcher", "arguments": {"url": "https://example.com"}}]
+            ),
+            make_text_response("Done!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _always_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            await gate.resolve(test_user.id, ApprovalDecision.ALWAYS_ALLOW)
+
+        agent = ClawboltAgent(
+            user=test_user,
+            channel="telegram",
+            publish_outbound=mock_publish,
+            chat_id="chat_1",
+        )
+        agent.register_tools([tool])
+
+        task = asyncio.create_task(_always_soon())
+        await agent.process_message("fetch example.com")
+        await task
+
+        store = get_approval_store()
+        assert (
+            await store.check_permission(test_user.id, "fetcher", resource="example.com")
+            == PermissionLevel.ALWAYS
+        )
+        # A different recipient/domain was never approved, so it still asks.
+        assert (
+            await store.check_permission(test_user.id, "fetcher", resource="other.com")
+            == PermissionLevel.ASK
+        )
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
@@ -1739,6 +1915,7 @@ class TestClassifyApprovalResponseCallShape:
             ("approved", ApprovalDecision.APPROVED),
             ("denied", ApprovalDecision.DENIED),
             ("always_allow", ApprovalDecision.ALWAYS_ALLOW),
+            ("always_allow_all", ApprovalDecision.ALWAYS_ALLOW_ALL),
             ("always_deny", ApprovalDecision.ALWAYS_DENY),
             ("ambiguous", AMBIGUOUS_APPROVAL_REPLY),
             ("unrelated", None),

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1119,6 +1119,69 @@ class TestAgentApproval:
 
     @pytest.mark.asyncio()
     @patch("backend.app.agent.core.amessages")
+    async def test_always_allow_all_does_not_escalate_when_tool_opted_out(
+        self, mock_amessages: object, test_user: User
+    ) -> None:
+        """A blanket decision must not grant more than the tool offered.
+
+        The "always all" keywords resolve globally, but only tools that
+        declare a resource_noun show the option. A resource-scoped tool that
+        opted out (no resource_noun) must scope the grant to the shown
+        resource, so a typed "allow all" cannot silently allow every target.
+        """
+        mock_publish = AsyncMock()
+
+        tool = Tool(
+            name="fetcher",
+            description="Fetch URL",
+            function=_fetch_tool,
+            params_model=_UrlParams,
+            approval_policy=ApprovalPolicy(
+                default_level=PermissionLevel.ASK,
+                resource_extractor=_extract_domain,
+                description_builder=_describe_fetch,
+                # No resource_noun: this tool never offers the blanket option.
+            ),
+        )
+        mock_amessages.side_effect = [  # type: ignore[union-attr]
+            make_tool_call_response(
+                [{"name": "fetcher", "arguments": {"url": "https://example.com"}}]
+            ),
+            make_text_response("Done!"),
+        ]
+
+        gate = get_approval_gate()
+
+        async def _always_all_soon() -> None:
+            while not gate.has_pending(test_user.id):
+                await asyncio.sleep(0.005)
+            await gate.resolve(test_user.id, ApprovalDecision.ALWAYS_ALLOW_ALL)
+
+        agent = ClawboltAgent(
+            user=test_user,
+            channel="telegram",
+            publish_outbound=mock_publish,
+            chat_id="chat_1",
+        )
+        agent.register_tools([tool])
+
+        task = asyncio.create_task(_always_all_soon())
+        await agent.process_message("fetch example.com")
+        await task
+
+        store = get_approval_store()
+        # Scoped to the shown resource only; a different one still asks.
+        assert (
+            await store.check_permission(test_user.id, "fetcher", resource="example.com")
+            == PermissionLevel.ALWAYS
+        )
+        assert (
+            await store.check_permission(test_user.id, "fetcher", resource="other.com")
+            == PermissionLevel.ASK
+        )
+
+    @pytest.mark.asyncio()
+    @patch("backend.app.agent.core.amessages")
     async def test_always_allow_scopes_to_single_resource(
         self, mock_amessages: object, test_user: User
     ) -> None:

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -22,6 +22,7 @@ from backend.app.agent.approval import (
     reset_approval_gate,
 )
 from backend.app.agent.concurrency import user_locks
+from backend.app.agent.context import _is_approval_prompt
 from backend.app.agent.core import ClawboltAgent
 from backend.app.agent.ingestion import (
     InboundMessage,
@@ -433,8 +434,6 @@ class TestFormatApprovalMessage:
         """The blanket option must be inserted before the "never" line so
         context.py can still identify stored approval prompts in history by
         their trailing menu line (issue #1049 filter)."""
-        from backend.app.agent.context import _is_approval_prompt
-
         msg = format_approval_message(
             "qb_send",
             "Send Invoice to alice@example.com via QuickBooks",

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -511,6 +511,18 @@ async def test_qb_update_api_error() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_qb_send_policy_offers_blanket_recipient_approval() -> None:
+    """qb_send declares a resource_noun so the approval prompt can offer a
+    blanket "always all" option covering every recipient (issue #1451),
+    instead of asking the user to approve each email individually."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    tool = next(t for t in tools if t.name == "qb_send")
+    assert tool.approval_policy is not None
+    assert tool.approval_policy.resource_extractor is not None
+    assert tool.approval_policy.resource_noun == "recipients"
+
+
 @pytest.mark.asyncio()
 async def test_qb_send_invoice_success() -> None:
     svc = FakeQBService()


### PR DESCRIPTION
## Description

Resource-scoped tools (like `qb_send`) remember an "always allow" decision per resource, so a user sending invoices had to approve every new recipient email individually. This adds a way to grant a blanket, tool-level approval covering every recipient at once.

The store and resolution layers already supported tool-level entries and the resolution order (resource match, then tool match, then policy default), so this only adds a way to *record* the blanket decision:

- New `ApprovalDecision.ALWAYS_ALLOW_ALL`, fast-path keywords (`always all`, `allow all`, `always everyone`, ...), and an LLM-classifier label.
- `format_approval_message` gains an opt-in "always all" menu line, inserted before the "never" trailer so `context.py` can still identify stored approval prompts in history.
- `ApprovalPolicy.resource_noun` drives the wording. Only tools that set it offer the blanket option (`qb_send`: "recipients"); web fetch and others are untouched.
- On `ALWAYS_ALLOW_ALL`, `core.py` persists `set_permission(..., resource=None)` (tool level). The per-resource "always" still works, and a more specific resource-level `NEVER` still overrides the blanket `ALWAYS`.

Approval is text-reply based across all channels (no button UI), so this is backend only. No API schemas or routes change, so no frontend OpenAPI regeneration is needed.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Code implemented the change end to end via back-and-forth with @njbrake: enum + policy field + prompt wording + core wiring + tests. Reasoning and decisions are his.)
- [ ] No AI used

Fixes #1451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR adds a blanket “always allow all” approval option for resource-scoped tools, solving a key usability problem in the QuickBooks invoice-sending workflow. Instead of approving every newly encountered recipient email address one-by-one, users can opt to approve **all recipients** at once for that tool—while still keeping the option to approve specific recipients individually when they want tighter control.

### What Changed

**Core approval system (backend-only):**
- Introduced a new approval choice: **“always all”** (with multiple user-friendly phrasing fast-paths like “always all” / “allow all” / “always everyone”).
- Updated the approval prompt generation to optionally include an **“always all”** menu item, placed **before “never”** to preserve compatibility with existing prompt detection/history.
- Extended the LLM-based classifier mapping so “always all” is recognized and converted into the new decision.
- Updated permission persistence so selecting **“always all”** stores an **unscoped tool-level allow** (rather than a resource-specific one), enabling future calls to the tool to be auto-approved.
- Kept safety/compatibility behavior: tools must opt in (via configuration) to offer the blanket option, and existing per-resource approvals still work as before.

**QuickBooks integration:**
- Updated the `qb_send` tool configuration to opt into the feature by setting `resource_noun="recipients"`, ensuring the prompt correctly communicates what the blanket option covers.

**Tests:**
- Added unit tests for parsing/classification of the new “always all” fast-paths.
- Added prompt-format tests to verify the conditional menu line and wording.
- Added integration-style coverage confirming blanket approval results in tool-level permission persistence and affects approval outcomes for new (previously unseen) recipients.
- Added a QuickBooks-specific test asserting `qb_send` is configured to offer the blanket recipient option.

### Benefits

- **Less friction:** users can approve all invoice recipients at once.
- **Preserves control:** users can still approve specific recipients individually when preferred.
- **Backward compatible:** existing per-recipient “always” approvals continue to behave the same.
- **Clear auditing semantics:** blanket approval is recorded as a distinct decision type (not silently repurposed).

### Potential Areas for Further Enhancement
- Extend the same opt-in configuration (`resource_noun`) approach to other eligible resource-scoped tools if/when they require similar blanket approvals, and ensure prompt phrasing stays intuitive per tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->