### PR TITLE
fix(agent): include cached tokens in the trim governor's prompt size

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -109,7 +109,9 @@ _VALID_STOP_REASONS: set[str | None] = {"end_turn", "max_tokens", "tool_use", "s
 
 _LLM_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
 
-# Last API-reported input token count per user, surviving across agent
+# Last API-reported prompt size per user (input + cache-read +
+# cache-creation tokens, since ``usage.input_tokens`` alone excludes the
+# cached slice under prompt caching), surviving across agent
 # instances. A fresh ClawboltAgent is constructed per message, so without
 # this the proactive trim at the top of ``process_message`` always falls
 # back to the chars/4 + flat-overhead heuristic, which ignores tool
@@ -123,7 +125,7 @@ _LAST_INPUT_TOKENS_MAX = 1024
 
 
 def _remember_input_tokens(user_id: str, tokens: int) -> None:
-    """Record the latest API-reported input token count for *user_id*."""
+    """Record the latest full prompt token count for *user_id*."""
     _LAST_INPUT_TOKENS[user_id] = tokens
     _LAST_INPUT_TOKENS.move_to_end(user_id)
     while len(_LAST_INPUT_TOKENS) > _LAST_INPUT_TOKENS_MAX:
@@ -131,7 +133,7 @@ def _remember_input_tokens(user_id: str, tokens: int) -> None:
 
 
 def _recall_input_tokens(user_id: str) -> int | None:
-    """Return the last reported input token count for *user_id*, if any."""
+    """Return the last recorded prompt token count for *user_id*, if any."""
     return _LAST_INPUT_TOKENS.get(user_id)
 
 
@@ -1331,12 +1333,20 @@ class ClawboltAgent:
                 provider=self._llm_provider_override or settings.llm_provider,
             )
             if response.usage and response.usage.input_tokens:
-                self._last_input_tokens = response.usage.input_tokens
-                _remember_input_tokens(self.user.id, response.usage.input_tokens)
-                _total_input_tokens += response.usage.input_tokens
-                _total_output_tokens += response.usage.output_tokens or 0
                 cache_create = response.usage.cache_creation_input_tokens or 0
                 cache_read = response.usage.cache_read_input_tokens or 0
+                # With prompt caching, ``usage.input_tokens`` counts only the
+                # uncached slice of the prompt; the cached slice is reported
+                # in the two cache fields. The trim governor needs the full
+                # prompt size: recording the uncached slice alone reads a
+                # mostly-cached 165k-token context as ~7k, so the token
+                # trigger never fires and the ContextLengthExceededError
+                # retry trim no-ops.
+                prompt_tokens = response.usage.input_tokens + cache_create + cache_read
+                self._last_input_tokens = prompt_tokens
+                _remember_input_tokens(self.user.id, prompt_tokens)
+                _total_input_tokens += response.usage.input_tokens
+                _total_output_tokens += response.usage.output_tokens or 0
                 _total_cache_creation_tokens += cache_create
                 _total_cache_read_tokens += cache_read
                 logger.debug(

--- a/backend/app/agent/trimming.py
+++ b/backend/app/agent/trimming.py
@@ -120,8 +120,9 @@ def trim_messages(
 ) -> TrimResult:
     """Trim conversation messages to fit within a token and turn budget.
 
-    Uses *input_tokens* (from ``response.usage.input_tokens``) to make
-    accurate trimming decisions using the API-reported token count. When
+    Uses *input_tokens* (the API-reported full prompt size: uncached input
+    plus cache-read plus cache-creation tokens) to make accurate trimming
+    decisions. When
     *input_tokens* is ``None`` (e.g. first call in a session), a
     character-based heuristic (~4 chars/token + overhead) is used to
     estimate whether trimming is needed.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -886,6 +886,149 @@ async def test_agent_trims_history_when_exceeding_token_limit(
 
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core.amessages")
+async def test_agent_records_full_prompt_size_including_cached_tokens(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """The recorded prompt size must include cache-read and cache-creation
+    tokens, not just ``usage.input_tokens``.
+
+    With prompt caching, ``usage.input_tokens`` counts only the uncached
+    slice of the prompt. Recording it alone makes the trim governor read
+    a mostly-cached 180k-token context as 7k, so the token trigger never
+    fires and compaction goes quiet for token-heavy, turn-light users.
+    """
+    from backend.app.agent.core import _recall_input_tokens, reset_last_input_tokens
+
+    reset_last_input_tokens()
+    mock_amessages.return_value = make_text_response(
+        "Ok!",
+        input_tokens=7_000,
+        output_tokens=10,
+        cache_creation_input_tokens=3_000,
+        cache_read_input_tokens=170_000,
+    )
+
+    agent = ClawboltAgent(user=test_user)
+    await agent.process_message("Current message")
+
+    assert agent._last_input_tokens == 180_000
+    assert _recall_input_tokens(test_user.id) == 180_000
+    reset_last_input_tokens()
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_token_trim_fires_on_cached_heavy_context(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """The proactive token trim must fire when the prompt is over the
+    trigger but mostly served from the prompt cache.
+
+    First turn: the API reports 7k uncached + 173k cached tokens (a 180k
+    prompt, over the 150k trigger). Second turn: the proactive trim at the
+    top of ``process_message`` must drop history and inject a summary.
+    Recording only the uncached 7k would leave the history untrimmed.
+    """
+    from backend.app.agent.core import reset_last_input_tokens
+
+    reset_last_input_tokens()
+    mock_amessages.return_value = make_text_response(
+        "Ok!",
+        input_tokens=7_000,
+        output_tokens=10,
+        cache_creation_input_tokens=3_000,
+        cache_read_input_tokens=170_000,
+    )
+    # Turn-light history: far below the turn backstop, so only the token
+    # trigger can cause a trim.
+    history = _build_turn_history(turn_pairs=30)
+
+    agent = ClawboltAgent(user=test_user)
+    with (
+        patch("backend.app.agent.core.settings.context_trim_target_tokens", 120_000),
+        patch("backend.app.agent.core.settings.context_trim_trigger_tokens", 150_000),
+    ):
+        await agent.process_message(
+            "First message",
+            conversation_history=history,
+            system_prompt_override="Short system prompt",
+        )
+        first_sent = mock_amessages.call_args.kwargs["messages"]
+        # First turn has no recorded count; the chars/4 heuristic keeps
+        # this small history untrimmed.
+        assert "[Summary of earlier conversation:" not in first_sent[0]["content"]
+
+        await agent.process_message(
+            "Second message",
+            conversation_history=history,
+            system_prompt_override="Short system prompt",
+        )
+
+    second_sent = mock_amessages.call_args.kwargs["messages"]
+    assert "[Summary of earlier conversation:" in second_sent[0]["content"]
+    assert len(second_sent) < len(first_sent)
+    reset_last_input_tokens()
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_reactive_trim_drops_messages_on_cached_heavy_context(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """The ``ContextLengthExceededError`` retry trim must actually drop
+    messages when the last prompt was mostly cached.
+
+    The retry path trims with ``input_tokens=self._last_input_tokens``.
+    If that recorded only the uncached 7k slice of a 180k prompt, the
+    trimmer sees 7k < target, drops nothing, and the retry re-sends the
+    same oversized prompt until retries exhaust and the turn fails.
+    """
+    from backend.app.agent.core import reset_last_input_tokens
+
+    reset_last_input_tokens()
+    mock_amessages.side_effect = [
+        make_text_response(
+            "Ok!",
+            input_tokens=7_000,
+            output_tokens=10,
+            cache_creation_input_tokens=3_000,
+            cache_read_input_tokens=170_000,
+        ),
+        ContextLengthExceededError("Input too long"),
+        make_text_response("Recovered!"),
+    ]
+    history = _build_turn_history(turn_pairs=30)
+
+    agent = ClawboltAgent(user=test_user)
+    # Disable the proactive trim so this test isolates the reactive path.
+    with (
+        patch("backend.app.agent.core.settings.context_trim_target_tokens", 900_000),
+        patch("backend.app.agent.core.settings.context_trim_trigger_tokens", 1_000_000),
+    ):
+        await agent.process_message(
+            "First message",
+            conversation_history=history,
+            system_prompt_override="Short system prompt",
+        )
+        response = await agent.process_message(
+            "Second message",
+            conversation_history=history,
+            system_prompt_override="Short system prompt",
+        )
+
+    assert response.reply_text == "Recovered!"
+    assert mock_amessages.call_count == 3
+    failed_attempt = mock_amessages.call_args_list[1].kwargs["messages"]
+    retry_attempt = mock_amessages.call_args_list[2].kwargs["messages"]
+    assert len(retry_attempt) < len(failed_attempt)
+    reset_last_input_tokens()
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
 async def test_agent_raises_content_filter_error(
     mock_amessages: AsyncMock,
     test_user: User,


### PR DESCRIPTION
## Description

The token-side context-trim trigger has been blind since prompt caching was enabled. With caching, `usage.input_tokens` counts only the uncached slice of the prompt; the cached slice is reported separately in `cache_read_input_tokens` / `cache_creation_input_tokens`. The agent loop recorded only `usage.input_tokens` as `_last_input_tokens`, so the trim governor read a mostly-cached prompt as tiny and the 150k token trigger never fired.

Observed in production while investigating why a daily-active user had not compacted in a month: his real prompt was ~168k tokens (7k uncached + 158k cache read + 3k cache creation), already past the 150k trigger, while the trim governor saw 7k. Every trim-driven compaction that user ever got came from the 216-user-turn backstop, visible as uniform ~34-seq `compaction_events` ranges. After an admin "compact now" reset the turn counter, nothing fired at all while the context climbed.

The sharper edge: the `ContextLengthExceededError` retry path trims with the same undercounted figure. Once a conversation reaches the model's hard context limit, `trim_messages` sees "7k, nothing to drop", the retry re-sends the same oversized prompt, and the turn fails; the agent stays broken on every message until the turn backstop happens to fire.

Fix: record the full prompt size (`input_tokens + cache_creation_input_tokens + cache_read_input_tokens`) in `_last_input_tokens` and the per-user token cache. Billing and usage accounting fields are unchanged; the cache totals were already tracked separately.

Regression tests (all three fail on `main`):
- `test_agent_records_full_prompt_size_including_cached_tokens`: recorded size includes cached tokens.
- `test_agent_token_trim_fires_on_cached_heavy_context`: proactive trim fires on a cached-heavy prompt over the trigger.
- `test_reactive_trim_drops_messages_on_cached_heavy_context`: the `ContextLengthExceededError` retry actually drops messages instead of no-opping.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) (2969 passed, 2 skipped)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): Claude Code investigated the production symptom, diagnosed the root cause, and wrote the fix and tests, reviewed by @njbrake.
- [ ] No AI used

🤖 Generated with [Claude Code](https://claude.com/claude-code)