### PR TITLE
feat(agent): auto-inject SKILL.md on first specialist tool use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ The agent's capabilities are extended by adding tools. Tools follow a factory/re
 ### Core vs. Specialist
 
 - **Core tools** (`core=True`): Always available to the agent on every message. Use for universal capabilities (math, messaging, files, workspace). No activation step needed.
-- **Specialist tools** (`core=False`): Activated on demand via the `list_capabilities` meta-tool. Use for integrations and domain-specific features (calendar, QuickBooks, CompanyCam). Keeps the initial tool schema small.
+- **Specialist tools** (`core=False`): Gated on the integration's `auth_check`; loaded onto the schema from turn 1 once the user connects the integration (the tool list is held stable per auth state for prompt-cache reasons, issue #1170). Use for integrations and domain-specific features (calendar, QuickBooks, CompanyCam). The `list_capabilities` meta-tool surfaces unconnected integrations and serves SKILL.md guidance; it does not activate tools.
 
 ### Checklist for adding a tool
 
@@ -202,7 +202,7 @@ The agent's capabilities are extended by adding tools. Tools follow a factory/re
 
 7. **Write tests** at `tests/test_<name>_tools.py`. Call the factory function directly (e.g., `_create_calculator_tools()`) and invoke the tool function. No database needed for stateless tools.
 
-8. **(Specialist only) Add a SKILL.md** at `backend/app/agent/skills/<name>/SKILL.md` if the tool has complex workflows the LLM needs guidance on. This markdown is injected into the conversation when the LLM activates the category via `list_capabilities`. Core tools do not need SKILL.md; their `description` and `usage_hint` fields in the Python code serve the same purpose. See "SKILL.md structure for specialist tools" below for the expected skeleton.
+8. **(Specialist only) Add a SKILL.md** at `backend/app/agent/skills/<name>/SKILL.md` if the tool has complex workflows the LLM needs guidance on. This markdown is delivered into the conversation as a tool result: either when the LLM calls `list_capabilities("<name>")`, or auto-appended to the first result of the category's tools when the model skips discovery (each delivery carries a `[skill-guidance: <name>]` marker so it happens at most once per context window). Core tools do not need SKILL.md; their `description` and `usage_hint` fields in the Python code serve the same purpose. See "SKILL.md structure for specialist tools" below for the expected skeleton.
 
 ### Key files
 
@@ -227,7 +227,7 @@ After editing, read the diff and ask: did I add a new fact, or restate an old on
 
 ### SKILL.md structure for specialist tools
 
-A specialist SKILL.md is injected only when the agent calls `list_capabilities("<name>")`, so it pays its cost in one place. Aim for 60-150 lines covering what tool descriptions and `usage_hint` strings cannot carry on their own.
+A specialist SKILL.md is delivered at most once per context window (on `list_capabilities("<name>")` or first use of the category's tools), so it pays its cost in one place. Aim for 60-150 lines covering what tool descriptions and `usage_hint` strings cannot carry on their own.
 
 Use this skeleton; drop sections that do not apply:
 

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -937,7 +937,11 @@ class ClawboltAgent:
                 )
                 result_str = validation_error + "\n\n" + hint
                 actions_taken.append(f"Failed: {tool_name} (validation)")
-                tool_call_records.append(
+                # A validation failure on a specialist tool is the clearest
+                # signal the model is flying without the category's SKILL.md
+                # (wrong arg shapes are what the guidance prevents), so run
+                # first-use injection here too and inform the retry.
+                v_record, v_msg = self._attach_first_use_skill_guidance(
                     StoredToolInteraction(
                         tool_call_id=tc_req.id,
                         name=tool_name,
@@ -945,15 +949,15 @@ class ClawboltAgent:
                         result=result_str,
                         is_error=True,
                         tags=set(tool_tags),
-                    )
-                )
-                tool_results.append(
+                    ),
                     ToolResultMessage(
                         tool_call_id=tc_req.id,
                         content=result_str,
                         is_error=True,
-                    )
+                    ),
                 )
+                tool_call_records.append(v_record)
+                tool_results.append(v_msg)
                 continue
 
             dup_key = (tool_name, _normalize_tool_args(validated_args))

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -62,6 +62,11 @@ from backend.app.agent.observer import (
     emit_llm_request,
     emit_llm_response,
 )
+from backend.app.agent.skills.loader import (
+    extract_delivered_skills,
+    get_skill_instructions,
+    skill_delivery_marker,
+)
 from backend.app.agent.system_prompt import (
     build_agent_system_prompt_parts,
     build_time_user_context,
@@ -333,6 +338,12 @@ class ClawboltAgent:
         # chains calls. ALWAYS_ALLOW is persisted to PERMISSIONS.json and does
         # not need this cache.
         self._approval_cache: dict[tuple[str, str | None], ApprovalDecision] = {}
+        # Specialist categories whose SKILL.md is already in this
+        # conversation's context, via a list_capabilities lookup or
+        # first-use auto-injection. Seeded each turn by scanning the
+        # post-trim history for delivery markers, so guidance dropped by
+        # trimming re-injects on the category's next use.
+        self._delivered_skill_categories: set[str] = set()
 
     def subscribe(self, callback: Callable[[AgentEvent], Awaitable[None]]) -> None:
         """Register an event subscriber.
@@ -1209,11 +1220,53 @@ class ClawboltAgent:
             # and tool_results match the sequence the model emitted.
             for pos in range(len(approved_entries)):
                 record, msg, label = results_by_pos[pos]
+                record, msg = self._attach_first_use_skill_guidance(record, msg)
                 actions_taken.append(label)
                 tool_call_records.append(record)
                 tool_results.append(msg)
 
         return tool_results
+
+    def _attach_first_use_skill_guidance(
+        self,
+        record: StoredToolInteraction,
+        msg: ToolResultMessage,
+    ) -> tuple[StoredToolInteraction, ToolResultMessage]:
+        """Append a category's SKILL.md to its first tool result in context.
+
+        SKILL.md delivery via ``list_capabilities`` is opt-in, so the model
+        can call a specialist tool without ever seeing the category's
+        guidance (issue #1457). When that happens, attach the guidance to
+        the first result. The appended text persists in the stored record,
+        so reloaded history carries the marker and later turns skip
+        re-injection until trimming drops it.
+        """
+        # Results that already carry guidance (a list_capabilities lookup
+        # earlier in this round's batch, or this injection) mark their
+        # category delivered for the rest of the turn.
+        self._delivered_skill_categories |= extract_delivered_skills(msg.content)
+        if self._registry is None:
+            return record, msg
+        category = self._registry.get_specialist_factory_for_tool(record.name)
+        if category is None or category in self._delivered_skill_categories:
+            return record, msg
+        # Mark categories without a SKILL.md too, so the lookup runs once.
+        self._delivered_skill_categories.add(category)
+        instructions = get_skill_instructions(category)
+        if not instructions:
+            return record, msg
+        logger.info(
+            "skill_auto_injection tool=%s category=%s",
+            record.name,
+            category,
+        )
+        block = f"\n\n{skill_delivery_marker(category)}\n{instructions}"
+        record.result = record.result + block
+        return record, ToolResultMessage(
+            tool_call_id=msg.tool_call_id,
+            content=msg.content + block,
+            is_error=msg.is_error,
+        )
 
     async def process_message(
         self,
@@ -1288,6 +1341,12 @@ class ClawboltAgent:
         )
         messages = trim_result.messages
         all_dropped = list(trim_result.dropped)
+        # Seed skill-delivery state from what actually survived trimming:
+        # a marker present in a reloaded tool result means that category's
+        # SKILL.md is in context and first-use injection must not repeat it.
+        for m in messages:
+            if isinstance(m, ToolResultMessage):
+                self._delivered_skill_categories |= extract_delivered_skills(m.content)
         trimmed_count = original_count - len(messages)
         if trimmed_count > 0:
             logger.warning(

--- a/backend/app/agent/skills/loader.py
+++ b/backend/app/agent/skills/loader.py
@@ -12,8 +12,15 @@ import importlib
 import logging
 import os
 import pkgutil
+import re
 
 logger = logging.getLogger(__name__)
+
+# Marker line prepended to SKILL.md content whenever it is delivered into a
+# tool result (via list_capabilities or first-use auto-injection). Scanning
+# reloaded history for these markers tells the agent which categories'
+# guidance is already in context, so trimming a delivery re-arms injection.
+_SKILL_MARKER_RE = re.compile(r"\[skill-guidance: ([A-Za-z0-9_-]+)\]")
 
 # Mapping of factory name -> SKILL.md content, populated by load_all_skills().
 _skill_instructions: dict[str, str] = {}
@@ -72,3 +79,13 @@ def _scan_package(package_path: str) -> None:
 def get_skill_instructions(factory_name: str) -> str | None:
     """Return the SKILL.md content for a factory name, or None if not found."""
     return _skill_instructions.get(factory_name)
+
+
+def skill_delivery_marker(factory_name: str) -> str:
+    """Return the marker line that tags delivered skill guidance in a tool result."""
+    return f"[skill-guidance: {factory_name}]"
+
+
+def extract_delivered_skills(text: str) -> set[str]:
+    """Return factory names whose delivery marker appears in *text*."""
+    return set(_SKILL_MARKER_RE.findall(text))

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -343,9 +343,10 @@ async def _build_agent_prompt_builder(
 
     # Dynamic sections: content changes between turns, placed after the
     # stable prefix so prompt caching can reuse the stable portion. Tool
-    # guidelines are dynamic because newly activated specialists append
-    # their usage hints mid-conversation. Keeping them out of Instructions
-    # prevents that activation from busting the stable system-prompt cache.
+    # guidelines are dynamic because the tool list tracks integration
+    # state: an OAuth connect or dashboard toggle between turns changes
+    # which usage hints render. Keeping them out of Instructions prevents
+    # that change from busting the stable system-prompt cache.
     tool_guidelines = build_tool_guidelines_section(tools)
     if tool_guidelines:
         builder.add_section("Tool Guidelines", tool_guidelines, dynamic=True)

--- a/backend/app/agent/tools/registry.py
+++ b/backend/app/agent/tools/registry.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field
 
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
+from backend.app.agent.skills.loader import get_skill_instructions, skill_delivery_marker
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
 from backend.app.agent.tools.names import ToolName
 from backend.app.media.download import DownloadedMedia
@@ -157,8 +158,6 @@ def create_list_capabilities_tool(
     information is surfaced so the LLM can tell users about disabled
     capabilities.
     """
-    from backend.app.agent.skills.loader import get_skill_instructions
-
     _unauthenticated = unauthenticated or {}
     _disabled_subs = disabled_sub_tools or {}
 
@@ -225,7 +224,10 @@ def create_list_capabilities_tool(
             )
         skill_instructions = get_skill_instructions(category)
         if skill_instructions:
-            guidance_msg += f"\n\n{skill_instructions}"
+            # The marker lets the agent loop detect from reloaded history
+            # that this category's guidance is already in context, so
+            # first-use auto-injection does not deliver a second copy.
+            guidance_msg += f"\n\n{skill_delivery_marker(category)}\n{skill_instructions}"
         return ToolResult(content=guidance_msg)
 
     summary_lines = [

--- a/tests/test_skill_autoinjection.py
+++ b/tests/test_skill_autoinjection.py
@@ -38,10 +38,14 @@ _MARKER = skill_delivery_marker("estimation")
 
 
 class _QueryParams(BaseModel):
+    """Single required-string params model; missing ``query`` fails validation."""
+
     query: str
 
 
 def _noop_tool(name: str) -> Tool:
+    """Build a stub tool that echoes its own name."""
+
     async def _run(query: str) -> ToolResult:
         return ToolResult(content=f"{name} ok")
 
@@ -49,6 +53,7 @@ def _noop_tool(name: str) -> Tool:
 
 
 def _specialist_registry() -> ToolRegistry:
+    """Build a registry with one specialist factory owning generate_estimate."""
     reg = ToolRegistry()
     reg.register(
         "estimation",
@@ -61,6 +66,7 @@ def _specialist_registry() -> ToolRegistry:
 
 
 def _patched_skills() -> AbstractContextManager[dict[str, str]]:
+    """Patch the loader's skill map so the estimation category has a SKILL.md."""
     return patch.dict(loader._skill_instructions, {"estimation": _SKILL_BODY})
 
 
@@ -92,6 +98,30 @@ async def test_first_use_appends_skill_guidance(mock_amessages: object, test_use
         if block.get("type") == "tool_result"
     ]
     assert any(_SKILL_BODY in block["content"] for block in tool_result_blocks)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_validation_error_gets_skill_guidance(
+    mock_amessages: object, test_user: User
+) -> None:
+    """A first-use validation failure carries the guidance so the retry is informed."""
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response([{"name": "generate_estimate", "arguments": {}}]),
+        make_tool_call_response([{"name": "generate_estimate", "arguments": {"query": "deck"}}]),
+        make_text_response("done"),
+    ]
+    agent = ClawboltAgent(user=test_user, registry=_specialist_registry())
+    agent.register_tools([_noop_tool("generate_estimate")])
+
+    with _patched_skills():
+        response = await agent.process_message("estimate my deck")
+
+    assert len(response.tool_calls) == 2
+    invalid_record, valid_record = response.tool_calls
+    assert invalid_record.is_error
+    assert _SKILL_BODY in invalid_record.result
+    assert _SKILL_BODY not in valid_record.result
 
 
 @pytest.mark.asyncio()

--- a/tests/test_skill_autoinjection.py
+++ b/tests/test_skill_autoinjection.py
@@ -1,0 +1,211 @@
+"""Tests for first-use SKILL.md auto-injection into specialist tool results.
+
+SKILL.md delivery via ``list_capabilities`` is opt-in; when the model calls
+a specialist tool without ever fetching the category's guidance, the agent
+appends the SKILL.md to that first tool result (issue #1457). Delivery is
+tracked via ``[skill-guidance: <category>]`` markers scanned from history,
+so guidance lands at most once per context window.
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.messages import (
+    AssistantMessage,
+    ToolCallRequest,
+    ToolResultMessage,
+    UserMessage,
+)
+from backend.app.agent.skills import loader
+from backend.app.agent.skills.loader import skill_delivery_marker
+from backend.app.agent.tools.base import Tool, ToolResult
+from backend.app.agent.tools.registry import (
+    SubToolInfo,
+    ToolRegistry,
+    create_list_capabilities_tool,
+)
+from backend.app.models import User
+from tests.mocks.llm import make_text_response, make_tool_call_response
+
+_SKILL_BODY = "## Estimation guide\nAlways confirm square footage first."
+_MARKER = skill_delivery_marker("estimation")
+
+
+class _QueryParams(BaseModel):
+    query: str
+
+
+def _noop_tool(name: str) -> Tool:
+    async def _run(query: str) -> ToolResult:
+        return ToolResult(content=f"{name} ok")
+
+    return Tool(name=name, description=name, function=_run, params_model=_QueryParams)
+
+
+def _specialist_registry() -> ToolRegistry:
+    reg = ToolRegistry()
+    reg.register(
+        "estimation",
+        lambda ctx: [_noop_tool("generate_estimate")],
+        core=False,
+        summary="Generate estimates",
+        sub_tools=[SubToolInfo("generate_estimate", "Generate estimates")],
+    )
+    return reg
+
+
+def _patched_skills() -> AbstractContextManager[dict[str, str]]:
+    return patch.dict(loader._skill_instructions, {"estimation": _SKILL_BODY})
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_first_use_appends_skill_guidance(mock_amessages: object, test_user: User) -> None:
+    """The first specialist tool result carries the category's SKILL.md."""
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response([{"name": "generate_estimate", "arguments": {"query": "deck"}}]),
+        make_text_response("done"),
+    ]
+    agent = ClawboltAgent(user=test_user, registry=_specialist_registry())
+    agent.register_tools([_noop_tool("generate_estimate")])
+
+    with _patched_skills():
+        response = await agent.process_message("estimate my deck")
+
+    assert len(response.tool_calls) == 1
+    record = response.tool_calls[0]
+    assert _MARKER in record.result
+    assert _SKILL_BODY in record.result
+    # The follow-up LLM call must see the guidance in the tool_result block.
+    followup_messages = mock_amessages.call_args_list[1].kwargs["messages"]  # type: ignore[union-attr]
+    tool_result_blocks = [
+        block
+        for msg in followup_messages
+        if isinstance(msg.get("content"), list)
+        for block in msg["content"]
+        if block.get("type") == "tool_result"
+    ]
+    assert any(_SKILL_BODY in block["content"] for block in tool_result_blocks)
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_no_reinjection_within_turn(mock_amessages: object, test_user: User) -> None:
+    """A second call to the same category in a later round gets no second copy."""
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response([{"name": "generate_estimate", "arguments": {"query": "deck"}}]),
+        make_tool_call_response([{"name": "generate_estimate", "arguments": {"query": "fence"}}]),
+        make_text_response("done"),
+    ]
+    agent = ClawboltAgent(user=test_user, registry=_specialist_registry())
+    agent.register_tools([_noop_tool("generate_estimate")])
+
+    with _patched_skills():
+        response = await agent.process_message("estimate my deck and fence")
+
+    assert len(response.tool_calls) == 2
+    assert _SKILL_BODY in response.tool_calls[0].result
+    assert _SKILL_BODY not in response.tool_calls[1].result
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_no_reinjection_when_history_carries_marker(
+    mock_amessages: object, test_user: User
+) -> None:
+    """A delivery marker in reloaded history suppresses injection this turn."""
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response([{"name": "generate_estimate", "arguments": {"query": "deck"}}]),
+        make_text_response("done"),
+    ]
+    history = [
+        UserMessage(content="estimate my shed"),
+        AssistantMessage(
+            content=None,
+            tool_calls=[ToolCallRequest(id="c1", name="generate_estimate", arguments={})],
+        ),
+        ToolResultMessage(
+            tool_call_id="c1",
+            content=f"generate_estimate ok\n\n{_MARKER}\n{_SKILL_BODY}",
+        ),
+        AssistantMessage(content="Shed estimate sent."),
+    ]
+    agent = ClawboltAgent(user=test_user, registry=_specialist_registry())
+    agent.register_tools([_noop_tool("generate_estimate")])
+
+    with _patched_skills():
+        response = await agent.process_message("now the deck", conversation_history=history)
+
+    assert len(response.tool_calls) == 1
+    assert _SKILL_BODY not in response.tool_calls[0].result
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_list_capabilities_lookup_suppresses_first_use_injection(
+    mock_amessages: object, test_user: User
+) -> None:
+    """Guidance fetched via list_capabilities is not delivered a second time."""
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(
+            [{"name": "list_capabilities", "arguments": {"category": "estimation"}}]
+        ),
+        make_tool_call_response([{"name": "generate_estimate", "arguments": {"query": "deck"}}]),
+        make_text_response("done"),
+    ]
+    agent = ClawboltAgent(user=test_user, registry=_specialist_registry())
+    meta_tool = create_list_capabilities_tool({"estimation": "Generate estimates"})
+    agent.register_tools([_noop_tool("generate_estimate"), meta_tool])
+
+    with _patched_skills():
+        response = await agent.process_message("estimate my deck")
+
+    assert len(response.tool_calls) == 2
+    lookup_record, estimate_record = response.tool_calls
+    assert lookup_record.name == "list_capabilities"
+    assert _SKILL_BODY in lookup_record.result
+    assert _SKILL_BODY not in estimate_record.result
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_core_tool_result_gets_no_guidance(mock_amessages: object, test_user: User) -> None:
+    """Tools outside any specialist factory are left untouched."""
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response([{"name": "calculate", "arguments": {"query": "2+2"}}]),
+        make_text_response("done"),
+    ]
+    agent = ClawboltAgent(user=test_user, registry=_specialist_registry())
+    agent.register_tools([_noop_tool("calculate")])
+
+    with _patched_skills():
+        response = await agent.process_message("what is 2+2")
+
+    assert len(response.tool_calls) == 1
+    assert "[skill-guidance:" not in response.tool_calls[0].result
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_category_without_skill_md_is_untouched(
+    mock_amessages: object, test_user: User
+) -> None:
+    """Specialist categories with no SKILL.md get no marker appended."""
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response([{"name": "generate_estimate", "arguments": {"query": "deck"}}]),
+        make_text_response("done"),
+    ]
+    agent = ClawboltAgent(user=test_user, registry=_specialist_registry())
+    agent.register_tools([_noop_tool("generate_estimate")])
+
+    with patch.dict(loader._skill_instructions, {}, clear=True):
+        response = await agent.process_message("estimate my deck")
+
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].result == "generate_estimate ok"

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -8,9 +8,11 @@ import pytest
 
 from backend.app.agent.skills.loader import (
     _skill_instructions,
+    extract_delivered_skills,
     get_skill_instructions,
     load_all_skills,
     load_skill_instructions,
+    skill_delivery_marker,
 )
 from backend.app.agent.tools.base import ToolResult
 from backend.app.agent.tools.registry import create_list_capabilities_tool
@@ -126,3 +128,32 @@ async def test_list_capabilities_unknown_category() -> None:
     result: ToolResult = await tool.function(category="nonexistent")
     assert result.is_error is True
     assert "Unknown category" in result.content
+
+
+@pytest.mark.asyncio()
+async def test_list_capabilities_result_carries_delivery_marker() -> None:
+    """SKILL.md delivery must be tagged so the agent loop can detect it in history."""
+    load_all_skills()
+    tool = create_list_capabilities_tool({"quickbooks": "QB tools"})
+    result: ToolResult = await tool.function(category="quickbooks")
+    assert skill_delivery_marker("quickbooks") in result.content
+    assert extract_delivered_skills(result.content) == {"quickbooks"}
+
+
+# ---------------------------------------------------------------------------
+# delivery markers
+# ---------------------------------------------------------------------------
+
+
+def test_extract_delivered_skills_round_trip() -> None:
+    """Markers embedded in tool-result text are recovered by extraction."""
+    text = (
+        f"did the thing\n\n{skill_delivery_marker('companycam')}\nguidance here\n"
+        f"more output\n{skill_delivery_marker('calendar')}\nother guidance"
+    )
+    assert extract_delivered_skills(text) == {"companycam", "calendar"}
+
+
+def test_extract_delivered_skills_ignores_plain_text() -> None:
+    """Text without markers yields an empty set."""
+    assert extract_delivered_skills("no markers here, just [brackets] and words") == set()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Closes the gap identified while evaluating #1457 (see the [evaluation comment](https://github.com/mozilla-ai/clawbolt/issues/1457#issuecomment-5021387376)): SKILL.md delivery via `list_capabilities` is opt-in, so the model can drive a specialist integration without ever reading its guidance. The #1401 telemetry exists because we suspected delivery rates are low.

**Fix: first-use auto-injection.** When the model calls a specialist category's tool and that category's guidance is not in context, the agent appends the SKILL.md to that first tool result:

- Every guidance delivery (via `list_capabilities` or auto-injection) now carries a `[skill-guidance: <category>]` marker line.
- Each turn the agent scans the post-trim history's tool results for markers to seed its delivered set, so guidance lands at most once per context window and self-heals: if trimming drops the delivery, it re-injects on the category's next use.
- Injection happens at the conversation tail and persists into the stored tool record, so it reloads with history on later turns. Append-only, so it stays prompt-cache friendly, consistent with the #1170 / #1281 design.
- A `skill_auto_injection` log line pairs with the existing `list_capabilities_lookup` telemetry (#1401) so we can measure how often the model skips discovery.

**Docs cleanup.** Refreshes prose that still described the activation model removed in #1281: the tool-guidelines comment in `system_prompt.py`, and the Core vs. Specialist and SKILL.md sections of `AGENTS.md`.

No schema or route changes, so no OpenAPI regeneration needed; frontend untouched.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`), 2984 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`), plus `ty check`
- [x] New tests added for new functionality: `tests/test_skill_autoinjection.py` (first-use injection, no re-injection within a turn, marker-in-history suppression, `list_capabilities`-first suppression, core tools untouched, categories without SKILL.md untouched) and marker round-trip tests in `tests/test_skill_loader.py`
- [ ] Bug fixes include regression tests (n/a, feature)

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Evaluation of #1457, gap analysis, implementation, and tests authored by Claude (Fable 5) via interactive discussion with @njbrake. Direction, scope decisions, and approvals are his.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added automatic first-use delivery of specialist `SKILL.md` guidance when specialist tools are used without prior guidance.
- Prevented duplicate guidance through delivery markers and history-aware tracking, including after history trimming.
- Updated capability lookup behavior, documentation, and telemetry to reflect the current activation model.
- Added coverage for injection, suppression, core tools, missing guidance, and history persistence.

## Benefits

- Provides relevant specialist instructions at the moment they are needed.
- Avoids repeated guidance and unnecessary prompt growth.
- Preserves guidance across conversation history reloads.

## Technical details

- Added skill marker creation and extraction helpers.
- Added `skill_auto_injection` telemetry alongside existing capability lookup telemetry.
- No schema, route, or frontend changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->