### PR TITLE
fix(sidecar): drop the VOLUME instruction, which Railway rejects

### DIFF
--- a/sidecar/home_depot/Dockerfile
+++ b/sidecar/home_depot/Dockerfile
@@ -57,7 +57,12 @@ RUN useradd --create-home --shell /bin/bash sidecar \
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-VOLUME ["/data"]
+# No VOLUME instruction: Railway's builder rejects it outright ("docker VOLUME
+# is not supported, use Railway Volumes"), and persistence is the deployer's
+# call regardless. Mount something at /data or the profile is rebuilt on every
+# restart, which makes each boot look like a first-time visitor:
+#   Railway: add a volume with mount path /data
+#   docker:  -v hd-profile:/data
 EXPOSE 8899
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/sidecar/home_depot/README.md
+++ b/sidecar/home_depot/README.md
@@ -64,6 +64,42 @@ that a search costs roughly a second.
 | `HD_PROFILE_DIR` | `~/.hd-sidecar-profile` | Persistent browser profile. Keep it between runs. |
 | `HD_WARM_SECONDS` | `7` | Homepage settle time before serving. |
 
+## Running it in a container
+
+```bash
+docker build -t hd-sidecar sidecar/home_depot
+docker run --rm -p 8899:8899 -v hd-profile:/data -e HD_SIDECAR_TOKEN=secret hd-sidecar
+```
+
+Mount something at `/data`. The browser profile lives there, and without a mount
+it is rebuilt on every restart, which makes each boot look like a first-time
+visitor to Home Depot. There is no `VOLUME` instruction in the Dockerfile
+because Railway's builder rejects it, so persistence is always the deployer's
+call.
+
+The container starts as root purely to take ownership of that mount, then drops
+to an unprivileged user before starting Chromium. Chromium running as root
+disables its own sandbox, which is one of the signals this whole approach
+depends on avoiding, so this is not optional. It does mean the host has to allow
+unprivileged user namespaces; where it does not, Chromium refuses to start
+rather than quietly downgrading.
+
+### Railway
+
+Deploy it as a service separate from the app, pointed at this repo with **root
+directory** `sidecar/home_depot`:
+
+- Add a volume with mount path `/data`.
+- Set `HD_SIDECAR_TOKEN`, and set `PORT=8899` so the listening port is
+  predictable. Railway injects its own `PORT`, which the entrypoint honours, so
+  without pinning it the internal URL below will not match.
+- Give it ~1GB of memory and point the healthcheck at `/health`.
+- Do not assign a public domain. Reach it over the private network instead:
+  `http://<service>.railway.internal:8899`.
+
+Confirm `/search` returns products before wiring the app to it. `/health` only
+proves the browser started, not that Home Depot is answering.
+
 ## API
 
 `GET /health` returns `{"ok": true}` once the browser is warm. It round-trips an


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Railway's builder refuses to build the sidecar image:

```
dockerfile invalid: docker VOLUME at Line 60 is not supported, use Railway Volumes
```

Removes the `VOLUME ["/data"]` instruction. It was not earning its place: persistence is the deployer's call, and the entrypoint already takes ownership of whatever is mounted at `/data`, so behaviour is unchanged whether the mount comes from a Railway volume, `docker run -v`, or nothing at all.

Also documents the container and Railway paths in the README, which predated the Dockerfile. Two details in there are easy to get wrong and both fail quietly:

- **Mount something at `/data`.** Without it the browser profile is rebuilt on every restart, so every boot looks like a first-time visitor to Home Depot. That is one of the three signals this approach depends on.
- **Pin `PORT=8899`.** Railway injects its own `PORT` and the entrypoint honours it, so the `railway.internal` URL will not match unless it is pinned.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`): unchanged, no Python touched
- [x] Lint passes: unchanged, no Python touched
- [ ] New tests added for new functionality (n/a, Dockerfile and docs only)
- [ ] Bug fixes include regression tests (n/a, the build itself is the test and CI cannot reach Railway's builder)

Caveat carried over from the parent PR: this image still has not been built anywhere. This fixes the one error Railway reported, and there may be more behind it.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude wrote the fix from the build error @njbrake pasted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
