### PR TITLE
fix(sidecar): install xauth, which xvfb-run needs and xvfb does not pull in

### DIFF
--- a/sidecar/home_depot/Dockerfile
+++ b/sidecar/home_depot/Dockerfile
@@ -40,10 +40,15 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# xvfb supplies the display a non-headless Chromium needs; util-linux supplies
-# setpriv for the privilege drop; patchright pulls Chromium's own libraries.
+# xvfb supplies the display a non-headless Chromium needs. xauth is a separate
+# package that xvfb does NOT depend on, but xvfb-run shells out to it to build
+# the X authority file and dies with "xauth command not found" without it. It is
+# present on most desktop and CI images, which is exactly why it is easy to miss
+# on a slim base. util-linux supplies setpriv for the privilege drop, plus the
+# mcookie and getopt that xvfb-run also needs. patchright pulls Chromium's own
+# shared libraries.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends xvfb util-linux \
+    && apt-get install -y --no-install-recommends xvfb xauth util-linux \
     && patchright install-deps chromium \
     && patchright install chromium \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

The sidecar container crash-looped on Railway:

```
xvfb-run: error: xauth command not found
```

`xauth` ships in its own Debian package and `xvfb` does not depend on it, so a slim base gets `xvfb-run` without the `xauth` it shells out to. Desktop and CI images almost always have it already, which is why this passed local testing and only surfaced on a slim image.

Verified rather than assumed. `xvfb`'s dependencies are `xserver-common`, `libaudit1`, `libc6`, `libgl1`, `libnettle8`, `libpixman-1-0`, `libselinux1` and `libsystemd0`, with no `xauth` among them, and `xvfb-run` calls `xauth` directly to build the authority file.

Since every iteration here costs a deploy, I checked the rest of `xvfb-run`'s external commands in the same pass:

| Command | Provided by | Status |
|---|---|---|
| `Xvfb` | `xvfb` | already installed |
| `xauth` | `xauth` | **was missing, added** |
| `mcookie`, `getopt` | `util-linux` | already installed |
| `mktemp` | `coreutils` | in the base image |
| `awk` | `mawk` | only on a line guarded with `\|\| true`, so harmless |

`xauth` was the only gap.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass: unchanged, no Python touched
- [x] Lint passes: unchanged, no Python touched
- [ ] New tests added for new functionality (n/a, Dockerfile only)
- [ ] Bug fixes include regression tests (n/a, CI cannot build against Railway's builder; the deploy is the test)

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude diagnosed this from the crash-loop logs @njbrake pasted, and confirmed the package relationships on a live system before changing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
