### PR TITLE
ci(sidecar): publish the sidecar image to GHCR so the platform needs no repo access

### DIFF
--- a/.github/workflows/hd-sidecar-image.yml
+++ b/.github/workflows/hd-sidecar-image.yml
@@ -1,0 +1,75 @@
+# Publish the Home Depot sidecar container image to GHCR.
+#
+# The sidecar runs as its own service, typically on a different host from
+# Clawbolt, and needs a browser. Publishing an image here rather than having the
+# hosting platform build from source means:
+#
+#   * The platform needs no access to this repository. That matters when the
+#     Railway project lives in a personal account while the repo belongs to an
+#     org: granting the platform's GitHub App access to an org repo needs org
+#     admin, and without it the platform silently rebuilds whatever stale
+#     snapshot it last managed to fetch.
+#   * The image is built once, here, from a known commit. No mystery about which
+#     revision is actually deployed.
+#
+# Deploy it by pointing the service at the image instead of a repo:
+#   ghcr.io/mozilla-ai/clawbolt-hd-sidecar:latest
+name: Home Depot sidecar image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sidecar/home_depot/**"
+      - ".github/workflows/hd-sidecar-image.yml"
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/clawbolt-hd-sidecar
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: sidecar/home_depot
+          # amd64 only: every PaaS worth deploying this to runs amd64, and an
+          # arm64 leg would double build time for nothing. Build locally with
+          # --platform linux/amd64 to match.
+          platforms: linux/amd64
+          push: true
+          # :latest for the deploy target, :sha so a bad deploy can be pinned
+          # back to a known-good revision.
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summarise
+        run: |
+          {
+            echo "### Home Depot sidecar image pushed"
+            echo
+            echo '```'
+            echo "${{ env.IMAGE }}:latest"
+            echo "${{ env.IMAGE }}:${{ github.sha }}"
+            echo '```'
+            echo
+            echo "The package defaults to private. Make it public once, under the"
+            echo "package settings, or give the deploy platform a registry credential."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/sidecar/home_depot/README.md
+++ b/sidecar/home_depot/README.md
@@ -169,7 +169,8 @@ again, reporting `geocoded: true` when it did.
 ## Connecting Clawbolt
 
 Point Clawbolt at the sidecar and it becomes the preferred product-search
-backend, ahead of the direct endpoints and SerpApi:
+backend, ahead of the optional SerpApi fallback, and the only source of store
+lookup:
 
 ```bash
 HOME_DEPOT_SIDECAR_URL=http://localhost:8899

--- a/sidecar/home_depot/README.md
+++ b/sidecar/home_depot/README.md
@@ -86,8 +86,23 @@ rather than quietly downgrading.
 
 ### Railway
 
-Deploy it as a service separate from the app, pointed at this repo with **root
-directory** `sidecar/home_depot`:
+Deploy from the **published image** rather than from source:
+
+```
+ghcr.io/mozilla-ai/clawbolt-hd-sidecar:latest
+```
+
+`.github/workflows/hd-sidecar-image.yml` builds and pushes that on every change
+under `sidecar/home_depot/`. Deploying the image is the path of least resistance
+for a reason worth knowing: if the Railway project lives in a personal account
+while this repo belongs to an org, connecting the repo needs org admin to grant
+the Railway GitHub App access. Without it Railway cannot fetch new commits and
+keeps rebuilding the last snapshot it managed to get, which presents as fixes
+that never take effect and build logs where every layer is `cached`. The image
+route sidesteps that entirely. The GHCR package defaults to private, so make it
+public once or give Railway a registry credential.
+
+Then, on the service:
 
 - Add a volume with mount path `/data`.
 - Set `HD_SIDECAR_TOKEN`, and set `PORT=8899` so the listening port is
@@ -97,8 +112,9 @@ directory** `sidecar/home_depot`:
 - Do not assign a public domain. Reach it over the private network instead:
   `http://<service>.railway.internal:8899`.
 
-Confirm `/search` returns products before wiring the app to it. `/health` only
-proves the browser started, not that Home Depot is answering.
+Confirm `/search` returns products before wiring the app to it: `/health` going
+green only means the port is up and the browser launched, not that Home Depot is
+answering.
 
 ## API
 


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Publishes the Home Depot sidecar as a container image so the hosting platform never needs access to this repository.

Having the platform build from source turned out to be the hard part, and the failure mode was expensive to diagnose. The Railway project lives in a personal account while this repo belongs to an org, so connecting the two requires an org admin to grant the Railway GitHub App access. Without that grant Railway cannot fetch new commits, and rather than failing it **silently rebuilds the last snapshot it managed to get.** The symptoms are fixes that never take effect and build logs where every layer reports `cached` even though the inputs demonstrably changed. `railway up` sidesteps the connection but has its own trouble archiving a working tree.

`.github/workflows/hd-sidecar-image.yml` builds `sidecar/home_depot` on changes under that directory and pushes to:

```
ghcr.io/<owner>/clawbolt-hd-sidecar:latest
ghcr.io/<owner>/clawbolt-hd-sidecar:<sha>
```

`:latest` is the deploy target; `:sha` makes the deployed revision unambiguous and lets a bad deploy pin back to a known-good one. amd64 only, since that is what the platforms run and an arm64 leg would double build time for nothing.

Also updates the README's Railway section to document the image route, and corrects a stale line that still described the sidecar as sitting "ahead of the direct endpoints and SerpApi" (the direct backend was deleted; it is now sidecar then SerpApi for product search, and sidecar only for stores).

## Note for whoever deploys this

The GHCR package defaults to **private**. Either make it public once in the package settings, or give the deploy platform a registry credential. Otherwise the platform will fail to pull with an auth error rather than anything descriptive.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass: unchanged, no application code touched
- [x] Lint passes: unchanged, no application code touched
- [ ] New tests added for new functionality (n/a, workflow and docs)
- [ ] Bug fixes include regression tests (n/a)

The workflow YAML was parse-checked locally. It has not run yet, so the first execution on `main` is the real test.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude wrote this after several failed attempts to get Railway to build from source, once the build logs showed it was deploying a two-commit-old snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
