### PR TITLE
fix(sidecar): set HOME across the privilege drop so Chromium can start

### DIFF
--- a/sidecar/home_depot/Dockerfile
+++ b/sidecar/home_depot/Dockerfile
@@ -1,25 +1,21 @@
 # Home Depot sidecar: FastAPI + patchright Chromium.
 #
-# UNTESTED: built by reading the platform docs, not by running it. The steps it
-# performs are each verified on a live host (patchright install, non-root
-# Chromium under Xvfb, the app itself), but this exact image has never been
-# built. Expect to iterate on the first deploy.
+# Two things here are load-bearing because Home Depot's bot manager reads them:
 #
-# Three things here are load-bearing rather than stylistic, because Home Depot's
-# bot manager reads all of them:
-#
-#   1. Chromium runs as a NON-ROOT user so its own sandbox stays enabled.
-#      Running it as root would force --no-sandbox, a strong bot signal. This
-#      needs unprivileged user namespaces on the host; if the platform forbids
-#      them Chromium refuses to start, which is a deliberate hard failure rather
-#      than a silent downgrade.
+#   1. patchright, not playwright, for the patched CDP Runtime.enable leak.
 #   2. The browser profile lives on a mounted volume so it survives redeploys.
 #      A brand-new profile every boot looks like a first-time visitor every time.
-#   3. patchright, not playwright, for the patched CDP Runtime.enable leak.
+#
+# Running Chromium as a NON-ROOT user is hygiene, not a bot-detection
+# requirement. patchright passes --no-sandbox by default, so the sandbox is off
+# regardless of the user, and every working measurement was taken that way. Do
+# not add chromium_sandbox=True expecting an improvement: it would add a
+# user-namespace requirement the host may not grant, for no observed benefit.
 #
 # The container starts as root purely to fix volume ownership (platform volumes
 # mount root-owned, so a plain USER directive leaves the app unable to write its
 # profile), then drops to the unprivileged user with setpriv before exec'ing.
+# The entrypoint has to set HOME across that handover; see the comment there.
 #
 # Build and run locally:
 #   docker build -t hd-sidecar sidecar/home_depot

--- a/sidecar/home_depot/README.md
+++ b/sidecar/home_depot/README.md
@@ -21,8 +21,6 @@ all measured rather than assumed:
 What works is a browser with no automation tells, which is what this runs:
 
 - **patchright** instead of playwright, which patches the `Runtime.enable` leak.
-- **A non-root user**, so Chromium's real sandbox is on and `--no-sandbox` (a
-  strong bot signal) is not needed.
 - **A persistent profile**, so the session looks like a returning visitor.
 
 None of this is IP-related. It was all measured from a residential connection.
@@ -37,7 +35,7 @@ python -m venv .venv && . .venv/bin/activate
 pip install -r requirements.txt
 patchright install chromium
 
-# Chromium's sandbox refuses to run as root; use an unprivileged user.
+# Run as a normal user, not root.
 export HD_SIDECAR_TOKEN="$(python -c 'import secrets;print(secrets.token_urlsafe(32))')"
 xvfb-run -a python -m uvicorn sidecar:app --host 0.0.0.0 --port 8899
 ```
@@ -78,11 +76,15 @@ because Railway's builder rejects it, so persistence is always the deployer's
 call.
 
 The container starts as root purely to take ownership of that mount, then drops
-to an unprivileged user before starting Chromium. Chromium running as root
-disables its own sandbox, which is one of the signals this whole approach
-depends on avoiding, so this is not optional. It does mean the host has to allow
-unprivileged user namespaces; where it does not, Chromium refuses to start
-rather than quietly downgrading.
+to an unprivileged user before starting Chromium. That handover also has to set
+`HOME`: `setpriv` changes uid but leaves the environment alone, and a `HOME` the
+new user cannot write makes Chromium's crashpad handler fail with `--database is
+required` and kill the browser with SIGTRAP before it opens a page. It cost a
+deploy to find, because `su` sets `HOME` and local testing used `su`.
+
+Running as a normal user is hygiene rather than a bot-detection requirement.
+patchright passes `--no-sandbox` by default, so Chromium's sandbox is off either
+way, and every working measurement here was taken that way.
 
 ### Railway
 

--- a/sidecar/home_depot/docker-entrypoint.sh
+++ b/sidecar/home_depot/docker-entrypoint.sh
@@ -5,8 +5,9 @@
 # Platform volumes (Railway, Fly, plain `docker run -v`) mount root-owned and
 # empty, so a bare USER directive in the Dockerfile leaves the app unable to
 # write its browser profile. Start as root, hand the volume to the runtime user,
-# and drop privileges before exec'ing: Chromium must not run as root or its
-# sandbox is disabled, which is exactly the signal we are avoiding.
+# and drop privileges before exec'ing. Running the browser as a normal user is
+# ordinary hygiene here rather than a requirement: patchright passes
+# --no-sandbox by default, so Chromium's sandbox is off either way.
 #
 # Every step announces itself. A container that dies silently between "Starting
 # Container" and the first uvicorn line is otherwise undiagnosable from a
@@ -60,5 +61,19 @@ if [ "$(id -u)" -ne 0 ]; then
     exec python -m uvicorn sidecar:app --host 0.0.0.0 --port "$PORT"
 fi
 
+# setpriv switches uid/gid but leaves the environment alone, so HOME would stay
+# /root: a directory the unprivileged user cannot write. Chromium's crashpad
+# handler then fails with "--database is required" and the browser dies with
+# SIGTRAP before it ever opens a page. `su` sets HOME, which is why this only
+# broke under setpriv. XDG_* follow HOME for the same reason.
+RUN_HOME="$(getent passwd "$RUN_AS" | cut -d: -f6)"
+RUN_HOME="${RUN_HOME:-/home/$RUN_AS}"
+mkdir -p "$RUN_HOME"
+chown "$RUN_AS:$RUN_AS" "$RUN_HOME"
+log "handing over with HOME=$RUN_HOME"
+
 exec setpriv --reuid "$RUN_AS" --regid "$RUN_AS" --init-groups \
-    python -m uvicorn sidecar:app --host 0.0.0.0 --port "$PORT"
+    env HOME="$RUN_HOME" \
+        XDG_CACHE_HOME="$RUN_HOME/.cache" \
+        XDG_CONFIG_HOME="$RUN_HOME/.config" \
+        python -m uvicorn sidecar:app --host 0.0.0.0 --port "$PORT"

--- a/sidecar/home_depot/sidecar.py
+++ b/sidecar/home_depot/sidecar.py
@@ -6,9 +6,8 @@ it.
 
 Home Depot's bot manager rejects plain HTTP clients, and also rejects a stock
 Playwright Chromium. What it accepts is a browser with no automation tells:
-patchright (which patches the CDP ``Runtime.enable`` leak), the real Chromium
-sandbox (so: not running as root, no ``--no-sandbox``), and a persistent profile
-that accumulates normal cookies. Requests must be issued *by that browser*.
+patchright (which patches the CDP ``Runtime.enable`` leak) and a persistent
+profile that accumulates normal cookies. Requests must be issued *by that browser*.
 Exporting its cookies to a plain HTTP client does not work, which is why this is
 a long-lived process rather than a cookie vendor.
 
@@ -197,9 +196,10 @@ class BrowserBackedSearch:
             self.state = "ready"
             self.error = None
         except Exception as exc:
-            # Chromium's sandbox needs unprivileged user namespaces, and a host
-            # that forbids them fails here. Keep the message: it is the only
-            # signal a remote operator gets.
+            # Chromium failing to launch lands here. Keep the message verbatim:
+            # it is the only signal a remote operator gets, and the causes are
+            # unobvious (an unwritable HOME breaks the crashpad handler, for
+            # instance).
             self.state = "failed"
             self.error = f"{type(exc).__name__}: {exc}"
             logger.exception("browser startup failed")


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Chromium died on Railway before it ever opened a page:

```
[pid=29][err] chrome_crashpad_handler: --database is required
<process did exit: exitCode=null, signal=SIGTRAP>
```

`setpriv` changes uid and gid but leaves the environment alone, so `HOME` stayed `/root` while the process ran as the unprivileged user, and that user cannot write `/root`. Chromium's crashpad handler cannot place its database and takes the browser down with it.

The entrypoint now looks up the run user's home with `getent`, ensures it exists and is owned by them, and passes `HOME` plus the `XDG_*` dirs across the `exec`.

**This is precisely why it worked locally and not in the container.** Local testing dropped privileges with `su`, which sets `HOME`. The container uses `setpriv`, which does not. Same user, same browser, same flags, different `HOME`.

## A claim I had wrong

The failure log's launch args include `--no-sandbox`, which nothing here passes deliberately. patchright defaults `chromium_sandbox` to `False`, so **the sandbox was never enabled**, including in every local run that successfully returned live Home Depot results.

So the "non-root user so Chromium's sandbox stays on" rationale, which I had written into the Dockerfile, the entrypoint, the README, and the module docstring, was wrong. Running as a normal user is hygiene, not a bot-detection requirement. The related caveat that the host must allow unprivileged user namespaces was never true of this configuration either, which also retires the concern I raised repeatedly about whether Railway would permit it.

All four places are corrected, with a note not to add `chromium_sandbox=True` expecting an improvement: it would introduce that user-namespace requirement for no observed benefit.

## Honesty about verification

The causal chain is inferred from four verified facts, not reproduced end to end:

1. `setpriv --reuid` leaves `HOME=/root` (measured).
2. The unprivileged user cannot write `/root` (measured).
3. The container fails inside crashpad, whose database path derives from the environment (from the log above).
4. The only difference from working local runs is the privilege-drop mechanism.

A local reproduction was blocked by an unrelated sandbox restriction on executing the test interpreter. The fix is correct regardless of whether crashpad is the whole story, since a writable `HOME` for the run user is right in every case. If the next deploy still shows a crashpad error, the follow-up is `--disable-crashpad`, kept separate deliberately so the next deploy discriminates between the two.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass: unchanged, no application code touched
- [x] Lint passes (`ruff check` and `ruff format --check` over `sidecar/`), entrypoint passes `sh -n`
- [ ] New tests added for new functionality (n/a, container entrypoint)
- [ ] Bug fixes include regression tests (n/a, reproducing needs a container privilege drop)

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Claude diagnosed this from the deploy logs @njbrake pasted. Those logs were only legible because of the preceding stderr-logging fix, which is the thing that turned four blind guesses into one measured cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed Chromium startup after the container switches from root to an unprivileged user.
- The entrypoint now prepares the user’s home directory and passes the required `HOME` and `XDG_*` variables.
- Updated documentation and comments to clarify Chromium sandbox behavior and the purpose of non-root execution.
- Expanded startup failure guidance to include unwritable home directories.

## Benefits

- Prevents Chromium crashpad failures caused by an invalid or unwritable home directory.
- Makes the privilege handoff more reliable.
- Keeps documentation aligned with the actual Patchright configuration.

## Follow-up

- An end-to-end container test would provide additional confidence when the local sandbox restriction is resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->