### PR TITLE
fix(agent): make the LLM error handlers actually reachable

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -12,9 +12,11 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 from any_llm import (
+    AnyLLMError,
     AuthenticationError,
     ContentFilterError,
     ContextLengthExceededError,
+    InvalidRequestError,
     RateLimitError,
     amessages,
 )
@@ -113,6 +115,51 @@ MAX_INPUT_TOKENS = settings.max_input_tokens
 _VALID_STOP_REASONS: set[str | None] = {"end_turn", "max_tokens", "tool_use", "stop_sequence", None}
 
 _LLM_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
+
+# Provider phrasings for "this prompt is longer than the model's context window"
+# that any-llm does NOT classify as ``ContextLengthExceededError``. Its
+# ``convert_exception`` matches ``context.*length``, ``length.*context``,
+# ``token limit``, and ``maximum.*length``; Anthropic's actual message,
+# "prompt is too long: 214231 tokens > 200000 maximum", matches none of them, so
+# a real overflow arrives as the more generic ``InvalidRequestError`` and would
+# skip the trim-and-retry recovery entirely.
+#
+# Kept narrow on purpose. A false positive here turns a genuinely malformed
+# request (an orphaned tool_use block, a bad tool schema) into a silent retry
+# with a shorter prompt, which hides the real error and burns a second call.
+#
+# Not every probe is strictly required: any-llm's regex already catches the two
+# entries containing "context_length" / "length of the messages", so those can
+# only arrive here if a provider rewords around it. They stay as defense in
+# depth. The first two are the ones any-llm genuinely misses today.
+_CONTEXT_OVERFLOW_PROBES = (
+    "prompt is too long",  # anthropic
+    "input is too long",  # anthropic, older wording
+    "context_length_exceeded",  # openai error code
+    "reduce the length of the messages",  # openai
+    "please reduce your prompt",  # openai
+)
+
+
+def _is_context_overflow(exc: AnyLLMError) -> bool:
+    """True when *exc* is a context overflow any-llm failed to classify as one.
+
+    Reads both the unified exception and its ``original_exception``, since
+    any-llm keeps the raw provider error on that attribute and the useful text
+    may live on either.
+
+    A gateway that strips upstream error messages (otari replaces every provider
+    400 body with a fixed string) defeats this by design: there is no signal left
+    to match, so an overflow behind such a gateway still surfaces as an error.
+    The proactive trim in ``process_message`` is the defense there; this is the
+    reactive backstop for when the provider message survives.
+    """
+    parts = [exc.message, str(exc)]
+    if exc.original_exception is not None:
+        parts.append(str(exc.original_exception))
+    haystack = " ".join(parts).lower()
+    return any(probe in haystack for probe in _CONTEXT_OVERFLOW_PROBES)
+
 
 # Last API-reported prompt size per user (input + cache-read +
 # cache-creation tokens, since ``usage.input_tokens`` alone excludes the
@@ -643,64 +690,35 @@ class ClawboltAgent:
                 )
                 await asyncio.sleep(delay)
             except ContextLengthExceededError:
-                trim_result = trim_messages(
+                return await self._trim_and_retry(
                     messages,
-                    input_tokens=self._last_input_tokens or MAX_INPUT_TOKENS,
+                    tool_schemas=tool_schemas,
+                    effective_model=effective_model,
+                    effective_provider=effective_provider,
+                    effective_max_tokens=effective_max_tokens,
+                    thinking=thinking,
                 )
-                self._reactive_trim_dropped.extend(trim_result.dropped)
+            except InvalidRequestError as exc:
+                # any-llm only reaches ``ContextLengthExceededError`` when the
+                # provider message matches its own regex, which several real
+                # overflow messages do not (see ``_is_context_overflow``). Treat a
+                # recognized overflow the same way; re-raise anything else so a
+                # genuinely malformed request still surfaces as an error instead of
+                # being silently retried with a shorter prompt.
+                if not _is_context_overflow(exc):
+                    raise
                 logger.warning(
-                    "Context length exceeded, trimmed from %d to %d messages and retrying",
-                    len(messages),
-                    len(trim_result.messages),
+                    "Provider reported a context overflow as a generic invalid request;"
+                    " trimming and retrying"
                 )
-                retry_system_str, trimmed_dicts = messages_to_messages_api(trim_result.messages)
-                trimmed_dicts = apply_history_cache_breakpoint(trimmed_dicts)
-                trimmed_dicts = apply_in_turn_cache_breakpoint(trimmed_dicts)
-                system = (
-                    prepare_system_with_caching(retry_system_str)
-                    if retry_system_str is not None
-                    else None
+                return await self._trim_and_retry(
+                    messages,
+                    tool_schemas=tool_schemas,
+                    effective_model=effective_model,
+                    effective_provider=effective_provider,
+                    effective_max_tokens=effective_max_tokens,
+                    thinking=thinking,
                 )
-                followup_started_at = datetime.now(UTC)
-                await emit_llm_request(
-                    LLMRequestPayload(
-                        schema_version=1,
-                        purpose=PURPOSE_AGENT_FOLLOWUP,
-                        user_id=self.user.id,
-                        session_id=self._session_id or None,
-                        request_id=self._request_id or None,
-                        model=effective_model,
-                        provider=effective_provider,
-                        max_tokens=effective_max_tokens,
-                        thinking=thinking,
-                        system=system,
-                        messages=trimmed_dicts,
-                        tools=tool_schemas,
-                        min_message_seq_in_prompt=compute_min_message_seq(trim_result.messages),
-                        started_at=followup_started_at,
-                    )
-                )
-                followup_response = cast(
-                    MessageResponse,
-                    await amessages(
-                        model=effective_model,
-                        provider=effective_provider,
-                        api_base=settings.llm_api_base,
-                        system=system,
-                        messages=trimmed_dicts,
-                        tools=tool_schemas,
-                        max_tokens=effective_max_tokens,
-                        thinking=thinking,
-                    ),
-                )
-                await self._emit_response(
-                    followup_response,
-                    purpose=PURPOSE_AGENT_FOLLOWUP,
-                    model=effective_model,
-                    provider=effective_provider,
-                    started_at=followup_started_at,
-                )
-                return followup_response
             except ContentFilterError:
                 logger.warning("Content blocked by provider safety filter")
                 raise
@@ -709,6 +727,82 @@ class ClawboltAgent:
                 raise
         # This should be unreachable, but satisfies the type checker.
         raise RuntimeError("LLM retry loop exited without returning")
+
+    async def _trim_and_retry(
+        self,
+        messages: list[AgentMessage],
+        *,
+        tool_schemas: list[Any] | None,
+        effective_model: str,
+        effective_provider: str,
+        effective_max_tokens: int,
+        thinking: dict[str, Any] | None,
+    ) -> MessageResponse:
+        """Drop the oldest history, then re-issue the call once as a followup.
+
+        The recovery path for a prompt the provider refused as too long, shared by
+        the ``ContextLengthExceededError`` handler and the ``InvalidRequestError``
+        handler that catches the overflow messages any-llm fails to classify.
+        Deliberately single-shot: if the trimmed prompt is still refused the error
+        propagates, because a loop here would re-trim toward an empty prompt while
+        the user waits.
+        """
+        trim_result = trim_messages(
+            messages,
+            input_tokens=self._last_input_tokens or MAX_INPUT_TOKENS,
+        )
+        self._reactive_trim_dropped.extend(trim_result.dropped)
+        logger.warning(
+            "Context length exceeded, trimmed from %d to %d messages and retrying",
+            len(messages),
+            len(trim_result.messages),
+        )
+        retry_system_str, trimmed_dicts = messages_to_messages_api(trim_result.messages)
+        trimmed_dicts = apply_history_cache_breakpoint(trimmed_dicts)
+        trimmed_dicts = apply_in_turn_cache_breakpoint(trimmed_dicts)
+        system = (
+            prepare_system_with_caching(retry_system_str) if retry_system_str is not None else None
+        )
+        followup_started_at = datetime.now(UTC)
+        await emit_llm_request(
+            LLMRequestPayload(
+                schema_version=1,
+                purpose=PURPOSE_AGENT_FOLLOWUP,
+                user_id=self.user.id,
+                session_id=self._session_id or None,
+                request_id=self._request_id or None,
+                model=effective_model,
+                provider=effective_provider,
+                max_tokens=effective_max_tokens,
+                thinking=thinking,
+                system=system,
+                messages=trimmed_dicts,
+                tools=tool_schemas,
+                min_message_seq_in_prompt=compute_min_message_seq(trim_result.messages),
+                started_at=followup_started_at,
+            )
+        )
+        followup_response = cast(
+            MessageResponse,
+            await amessages(
+                model=effective_model,
+                provider=effective_provider,
+                api_base=settings.llm_api_base,
+                system=system,
+                messages=trimmed_dicts,
+                tools=tool_schemas,
+                max_tokens=effective_max_tokens,
+                thinking=thinking,
+            ),
+        )
+        await self._emit_response(
+            followup_response,
+            purpose=PURPOSE_AGENT_FOLLOWUP,
+            model=effective_model,
+            provider=effective_provider,
+            started_at=followup_started_at,
+        )
+        return followup_response
 
     def _validate_tool_args(
         self, tool: Tool, tool_args: dict[str, Any]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,43 @@ from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 
+# Opt in to any-llm's unified exception family.
+#
+# any-llm still defaults to re-raising the raw provider SDK exception and only
+# converts to ``any_llm.exceptions`` types when this variable is truthy (see
+# ``any_llm.utils.exception_handler._handle_exception``). Without it, every
+# unified-exception handler in this codebase is dead code, because an
+# ``anthropic.RateLimitError`` is not an ``any_llm.RateLimitError``:
+#
+#   * ``core.py::_call_llm_with_retry`` never backs off on a rate limit, never
+#     trims and retries on a context overflow, and never logs the specific
+#     content-filter or auth diagnostics.
+#   * ``router.py::run_agent`` never returns ``CONTENT_FILTER_FALLBACK`` or
+#     ``AUTH_ERROR_FALLBACK``.
+#
+# Every failure instead lands in the generic ``except Exception`` and the user
+# gets "I'm having trouble thinking right now" with no retry. Observed in
+# production: an upstream 400 arrived as a raw ``anthropic.BadRequestError`` and
+# reached ``run_agent``'s generic handler.
+#
+# ``setdefault`` so an operator can opt out with
+# ``ANY_LLM_UNIFIED_EXCEPTIONS=0``, but note that has to be a real environment
+# variable: pydantic-settings reads ``.env`` into the ``Settings`` model without
+# writing it back to ``os.environ``, so a ``.env`` entry is invisible here. It
+# does work via ``docker compose`` ``env_file`` and on a platform's env config,
+# both of which inject real variables.
+#
+# any-llm reads the variable inside ``_handle_exception``, i.e. per raise rather
+# than at import time, so this does not depend on import ordering; config is
+# nonetheless imported by every module that calls ``amessages``.
+#
+# One conversion is load-bearing elsewhere: with this on, a provider that cannot
+# enumerate models raises ``NotImplementedError`` from inside any-llm's decorator
+# and arrives wrapped, which would silently kill the ``except
+# NotImplementedError`` branch callers use to render a free-text model field.
+# ``llm_service.get_models`` unwraps it so that signal survives.
+os.environ.setdefault("ANY_LLM_UNIFIED_EXCEPTIONS", "1")
+
 # Default hysteresis buffer for the turn-count trim backstop: when
 # ``context_trim_trigger_turns`` is unset, the trigger resolves to
 # ``context_trim_target_turns + CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS``

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from any_llm import LLMProvider, alist_models
+from any_llm import AnyLLMError, LLMProvider, alist_models
 
 from backend.app.config import settings
 from backend.app.schemas import ProviderInfo
@@ -60,8 +60,21 @@ async def get_models(
     api_key: str | None = None,
     api_base: str | None = None,
 ) -> list[str]:
-    """Fetch available models for a provider."""
-    raw = await alist_models(provider=provider, api_key=api_key, api_base=api_base)
+    """Fetch available models for a provider.
+
+    "This provider cannot enumerate models" surfaces as ``NotImplementedError``,
+    which callers branch on to render a free-text model field instead of an
+    error. any-llm raises that from inside its ``handle_exceptions`` decorator,
+    so with ``ANY_LLM_UNIFIED_EXCEPTIONS`` enabled (see ``config.py``) it arrives
+    wrapped in a ``ProviderError`` and the distinction is lost. Unwrap it so the
+    "unsupported" signal survives the conversion.
+    """
+    try:
+        raw = await alist_models(provider=provider, api_key=api_key, api_base=api_base)
+    except AnyLLMError as exc:
+        if isinstance(exc.original_exception, NotImplementedError):
+            raise exc.original_exception from exc
+        raise
     return [m.id if hasattr(m, "id") else str(m) for m in raw]
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -7,12 +8,14 @@ from any_llm import (
     AuthenticationError,
     ContentFilterError,
     ContextLengthExceededError,
+    InvalidRequestError,
     RateLimitError,
 )
 from pydantic import BaseModel
 
 from backend.app.agent.core import (
     ClawboltAgent,
+    _is_context_overflow,
 )
 from backend.app.agent.messages import (
     AgentMessage,
@@ -3066,3 +3069,122 @@ async def test_duplicate_tool_call_within_round_emits_telemetry(
     ]
     assert duplicate_logs, "expected a duplicate_tool_call_within_turn warning"
     assert any("search_thing" in rec.getMessage() for rec in duplicate_logs)
+
+
+# ---------------------------------------------------------------------------
+# Unified any-llm exceptions + context overflows any-llm fails to classify
+# ---------------------------------------------------------------------------
+
+
+def test_unified_any_llm_exceptions_are_enabled() -> None:
+    """any-llm only converts raw provider SDK errors into its unified exception
+    family when this variable is truthy. Without it every ``except RateLimitError``
+    / ``ContextLengthExceededError`` / ``ContentFilterError`` / ``AuthenticationError``
+    in the agent loop and in ``run_agent`` is dead code, because an
+    ``anthropic.RateLimitError`` is not an ``any_llm.RateLimitError``. Observed in
+    production: an upstream 400 reached ``run_agent``'s generic handler as a raw
+    ``anthropic.BadRequestError``, so the user got the "having trouble thinking"
+    fallback with no retry.
+    """
+    assert os.environ.get("ANY_LLM_UNIFIED_EXCEPTIONS") == "1"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "prompt is too long: 214231 tokens > 200000 maximum",
+        "Input is too long for requested model.",
+        "This model's maximum context length is 128000 tokens. Please reduce your prompt.",
+        "context_length_exceeded",
+        "Please reduce the length of the messages.",
+    ],
+)
+def test_is_context_overflow_matches_overflow_messages(message: str) -> None:
+    """Every real overflow wording is recognized.
+
+    The first two are the ones that matter: any-llm's own classifier matches
+    ``context.*length`` / ``token limit`` / ``maximum.*length``, and Anthropic's
+    real wording hits none of those, so an overflow arrives as a generic
+    ``InvalidRequestError``. The remaining three any-llm would already have
+    classified as ``ContextLengthExceededError``, so they cannot reach this
+    branch today; they are covered as defense in depth against a provider
+    rewording around that regex.
+    """
+    assert _is_context_overflow(InvalidRequestError(message)) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "messages.3: tool_use ids were found without tool_result blocks",
+        "max_tokens must be greater than thinking.budget_tokens",
+        "The provider rejected the request as invalid (check the model name and parameters)",
+        "A maximum of 4 blocks with cache_control may be provided",
+    ],
+)
+def test_is_context_overflow_ignores_other_invalid_requests(message: str) -> None:
+    """A genuinely malformed request must not be mistaken for an overflow: retrying
+    it with a shorter prompt would hide the real error and burn a second call. The
+    third case is a gateway that strips the upstream message (otari); there is no
+    signal left to match, so it correctly does not claim an overflow."""
+    assert _is_context_overflow(InvalidRequestError(message)) is False
+
+
+def test_is_context_overflow_reads_the_original_exception() -> None:
+    """any-llm's unified wrapper keeps the raw provider error on
+    ``original_exception``, so the useful text may live only there."""
+    raw = Exception("prompt is too long: 214231 tokens > 200000 maximum")
+    wrapped = InvalidRequestError("Invalid request", original_exception=raw)
+    assert _is_context_overflow(wrapped) is True
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_trims_on_overflow_reported_as_invalid_request(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """An overflow that any-llm classifies as ``InvalidRequestError`` (because
+    Anthropic's wording misses its regex) takes the same trim-and-retry recovery
+    as ``ContextLengthExceededError``, instead of failing the turn."""
+    mock_amessages.side_effect = [
+        InvalidRequestError("prompt is too long: 214231 tokens > 200000 maximum"),
+        make_text_response("Trimmed and retried!"),
+    ]
+
+    big_content = "x" * 4000
+    long_history: list[AgentMessage] = [
+        UserMessage(content=f"Message {i}: {big_content}")
+        if i % 2 == 0
+        else AssistantMessage(content=f"Message {i}: {big_content}")
+        for i in range(150)
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    response = await agent.process_message("Current message", conversation_history=long_history)
+
+    assert response.reply_text == "Trimmed and retried!"
+    assert mock_amessages.call_count == 2
+    retry_call = mock_amessages.call_args_list[1]
+    assert retry_call.kwargs["system"] is not None
+    assert len(retry_call.kwargs["messages"]) < 150
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_agent_does_not_retry_a_non_overflow_invalid_request(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """A malformed request is not silently retried with a shorter prompt. It
+    propagates so the caller can surface an error rather than masking the real
+    problem behind a second call."""
+    mock_amessages.side_effect = InvalidRequestError(
+        "messages.3: tool_use ids were found without tool_result blocks"
+    )
+
+    agent = ClawboltAgent(user=test_user)
+    with pytest.raises(InvalidRequestError):
+        await agent.process_message("Current message")
+
+    assert mock_amessages.call_count == 1

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -6,12 +6,14 @@ from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from any_llm.exceptions import ProviderError
 
 from backend.app.services.llm_service import (
     _cache_control,
     apply_history_cache_breakpoint,
     apply_in_turn_cache_breakpoint,
     apply_tool_caching,
+    get_models,
     prepare_system_with_caching,
     resolve_user_llm_override,
     set_user_llm_resolver,
@@ -316,3 +318,44 @@ async def test_resolve_user_llm_override_passes_through_none() -> None:
 
     set_user_llm_resolver(fake_resolver)
     assert await resolve_user_llm_override("user-xyz") is None
+
+
+# ---------------------------------------------------------------------------
+# get_models: preserve the "provider cannot list models" signal
+# ---------------------------------------------------------------------------
+
+
+async def test_get_models_unwraps_not_implemented_from_unified_error() -> None:
+    """A provider that cannot enumerate models must still raise NotImplementedError.
+
+    any-llm raises ``NotImplementedError`` from inside its ``handle_exceptions``
+    decorator, so with ``ANY_LLM_UNIFIED_EXCEPTIONS`` enabled it arrives wrapped
+    in a ``ProviderError``. Callers (the OSS profile endpoint and the premium
+    admin LLM picker) branch on ``NotImplementedError`` to render a free-text
+    model field instead of a listing failure, so the signal has to survive.
+    """
+    raw = NotImplementedError("Provider doesn't support listing models.")
+    wrapped = ProviderError(
+        message="Provider doesn't support listing models.",
+        original_exception=raw,
+        provider_name="voyage",
+    )
+    with (
+        patch("backend.app.services.llm_service.alist_models", side_effect=wrapped),
+        pytest.raises(NotImplementedError),
+    ):
+        await get_models("voyage")
+
+
+async def test_get_models_reraises_other_unified_errors() -> None:
+    """A real listing failure is not mistaken for "unsupported"."""
+    wrapped = ProviderError(
+        message="upstream 503",
+        original_exception=RuntimeError("upstream 503"),
+        provider_name="openai",
+    )
+    with (
+        patch("backend.app.services.llm_service.alist_models", side_effect=wrapped),
+        pytest.raises(ProviderError),
+    ):
+        await get_models("openai")


### PR DESCRIPTION
## Description

The agent loop and `run_agent` both branch on any-llm's unified exception family. That family is opt-in: `any_llm.utils.exception_handler._handle_exception` re-raises the **raw provider SDK exception** unless `ANY_LLM_UNIFIED_EXCEPTIONS` is truthy, and nothing in this repo ever set it. An `anthropic.RateLimitError` is not an `any_llm.RateLimitError`, so every one of these handlers has been dead code in production:

| Handler | What silently never happened |
|---|---|
| `core.py` `except RateLimitError` | no exponential-backoff retry on a 429 |
| `core.py` `except ContextLengthExceededError` | no trim-and-retry on an overflow |
| `core.py` `except ContentFilterError` / `AuthenticationError` | no specific diagnostics |
| `router.py` `except ContentFilterError` | `CONTENT_FILTER_FALLBACK` never returned |
| `router.py` `except AuthenticationError` | `AUTH_ERROR_FALLBACK` never returned |

Everything landed in `run_agent`'s generic `except Exception` instead, so a rate limit, an expired API key, and a malformed request all reached the user as the same "I'm having trouble thinking right now" with no retry.

Found while debugging a production incident: an upstream 400 arrived as a raw `anthropic.BadRequestError` and was logged from `router.py`'s generic handler, which is only possible with the flag off.

### 1. Enable the unified family

Set in `config.py`, which every module that calls `amessages` imports (`main.py`, `core.py`, `heartbeat.py`, `compaction.py`, `vision.py`, `approval.py`). `setdefault`, so an operator can opt out with `ANY_LLM_UNIFIED_EXCEPTIONS=0`. any-llm reads the variable per call rather than at import, so this does not depend on import ordering.

Low risk: nothing in `backend/` or `tests/` catches a raw provider SDK exception, so nothing regresses. Handlers that never fired start firing.

### 2. Detect the overflows any-llm's regex misses

Enabling the flag is necessary but not sufficient. any-llm reaches `ContextLengthExceededError` by regex on the provider message (`context.*length`, `length.*context`, `token limit`, `maximum.*length`). Anthropic's actual wording is:

```
prompt is too long: 214231 tokens > 200000 maximum
```

which matches none of them. So a genuine overflow classifies as the more generic `InvalidRequestError` and skips the trim-and-retry entirely. `_is_context_overflow` adds the phrasings any-llm misses (Anthropic's two wordings, OpenAI's `context_length_exceeded` and its two prose variants) and routes a recognized overflow into the same recovery.

Deliberately narrow. Anything unrecognized re-raises: silently retrying a malformed request with a shorter prompt would hide the real error and burn a second call. There are explicit negative tests for an orphaned `tool_use`, a `max_tokens` / `thinking.budget_tokens` conflict, and a `cache_control` limit.

One honest limitation, documented on the helper: a gateway that strips upstream error bodies (otari replaces every provider 400 with a fixed string) leaves no signal to match, so an overflow behind such a gateway still surfaces as an error. The proactive trim in `process_message` is the defense there; this is the reactive backstop for when the provider message survives.


### Added after review: the NotImplementedError conversion

Review caught a regression my own risk analysis missed, because that analysis stopped at `backend/`.

`any_llm.AnyLLM.alist_models` is decorated with `@handle_exceptions()`, and `_alist_models` raises a plain `NotImplementedError` when a provider has `SUPPORTS_LIST_MODELS = False`. With the flag on, that gets converted to an `AnyLLMError` too. Premium's admin LLM picker has `except NotImplementedError` returning `supports_listing=False`, which renders "this provider does not enumerate models, type the model id directly". That branch would have gone dead, and the endpoint would have fallen through to `except Exception` and rendered a red error with a Retry button instead. Premium's test for that branch mocks `get_models`, so it would have stayed green through the regression.

Verified directly against the real library:

```
ANY_LLM_UNIFIED_EXCEPTIONS=0   alist_models -> NotImplementedError   get_models -> NotImplementedError
ANY_LLM_UNIFIED_EXCEPTIONS=1   alist_models -> ProviderError         get_models -> NotImplementedError
```

`llm_service.get_models` now unwraps an `AnyLLMError` whose `original_exception` is a `NotImplementedError` and re-raises the original, so the "cannot enumerate" signal survives the conversion. That puts the fix on the OSS seam both layers already share rather than duplicating a workaround in premium, per the premium repo's no-duplication rule. Two regression tests in `tests/test_llm_service.py`, including one asserting an unrelated `ProviderError` still propagates.

Two accuracy corrections also from review:

- The `.env` opt-out claim was wrong. pydantic-settings reads `.env` into the `Settings` model without writing back to `os.environ`, so `ANY_LLM_UNIFIED_EXCEPTIONS=0` in a `.env` file is invisible to `setdefault`. It works via `docker compose` `env_file` and platform env config. Comment narrowed.
- Two of the five overflow probes describe messages any-llm's regex *already* classifies as `ContextLengthExceededError`, so they cannot reach the new branch today. The docstring claimed all five arrive as `InvalidRequestError`. They stay as defense against a provider rewording around that regex, and the comment now says so.

`_is_context_overflow` is also retyped from `BaseException` to `AnyLLMError` with direct `.message` / `.original_exception` access, per the AGENTS.md rule preferring typed attribute access over `getattr`.

### 3. Extract `_trim_and_retry`

The recovery body moves into a method so both handlers share it instead of duplicating ~50 lines. Behaviour is unchanged: still single-shot (a loop would re-trim toward an empty prompt while the user waits), still emits the followup observer event with the same purpose.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 3021 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) — plus `ty check`, all clean
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

15 new test items: the flag is asserted set, `_is_context_overflow` is pinned on 5 real overflow messages and 4 non-overflow ones, and two end-to-end tests confirm an `InvalidRequestError`-shaped overflow trims and retries while a malformed request propagates after exactly one call.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Written by Claude Opus 5 via Claude Code while investigating the production incident above, then reviewed by a second Claude instance with no knowledge of the first's reasoning. That review found the `NotImplementedError` regression, both accuracy errors, and independently reproduced the flag's behavior against live provider calls and the extraction's behavior-preservation via a whitespace-normalized token diff. The dead-handler claim was verified against a real prod traceback rather than inferred from reading any-llm alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Enabled any-llm unified exception handling by default. Operators can disable it with `ANY_LLM_UNIFIED_EXCEPTIONS=0`.
- Added context-overflow detection for Anthropic, OpenAI, and other provider error messages.
- Reused a shared trim-and-retry flow for recognized overflow errors.
- Preserved normal propagation for unrelated invalid requests and malformed requests.
- Preserved `NotImplementedError` behavior in `get_models`.
- Added tests for configuration, overflow handling, retry behavior, and model enumeration errors.

## Benefits

- Existing rate-limit, context-overflow, content-filter, and authentication handlers now work by default.
- Provider-specific overflow errors recover more consistently.
- Unrecognized errors remain visible instead of being incorrectly retried.

## Potential follow-up

- Add overflow patterns for more providers as their error formats change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->