### PR TITLE
fix(models): restrict the api_base override to local providers

### DIFF
--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -47,7 +47,11 @@ from backend.app.schemas import (
     UserProfileResponse,
     UserProfileUpdate,
 )
-from backend.app.services.llm_service import get_configured_providers, get_models
+from backend.app.services.llm_service import (
+    get_configured_providers,
+    get_models,
+    is_local_provider,
+)
 
 router = APIRouter()
 
@@ -477,10 +481,37 @@ async def list_providers(
 @router.get("/user/providers/{provider}/models")
 async def list_provider_models(
     provider: str,
-    api_base: str | None = Query(None),
+    api_base: str | None = Query(
+        None,
+        description=(
+            "Endpoint to enumerate. Local providers only; a hosted provider always"
+            " uses the configured LLM_API_BASE."
+        ),
+    ),
     _current_user: User = Depends(get_current_user),
 ) -> list[str]:
-    """List available models for a provider."""
+    """List available models for a provider.
+
+    ``api_base`` is honored only for a local provider. any-llm resolves a missing
+    ``api_key`` from the server's environment, so honoring a caller-supplied base
+    for a hosted provider would send that provider's key to whatever host the
+    caller named. Local providers are keyless, so there is nothing to send, and
+    they are the only case the settings UI uses the field for: the API-base input
+    and its "Fetch Models" button render only when the selected provider is
+    local, and a hosted provider is always listed with no base.
+
+    This endpoint is gated by ``get_current_user`` alone, which is every user in
+    a single-tenant deployment but every *tenant* under a multi-tenant auth
+    plugin, so the parameter must not be able to redirect a credentialed call.
+    """
+    if api_base and not is_local_provider(provider):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"api_base is only accepted for a local provider; '{provider}' is"
+                " hosted and is listed against the configured LLM_API_BASE."
+            ),
+        )
     try:
         return await get_models(provider, api_base=api_base)
     except Exception as exc:

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -46,6 +46,17 @@ _LOCAL_PROVIDERS = {"ollama", "llamafile", "llamacpp", "lmstudio", "vllm"}
 _HIDDEN_PROVIDERS = {"platform", "gateway"}
 
 
+def is_local_provider(provider: str) -> bool:
+    """True when *provider* runs on the operator's own machine and needs no key.
+
+    Used to decide whether a caller may choose the endpoint a model listing hits.
+    A local provider carries no server-held credential, so pointing one at
+    another URL leaks nothing; a hosted provider does, so it must not be
+    redirectable by a request parameter.
+    """
+    return provider.lower() in _LOCAL_PROVIDERS
+
+
 def get_configured_providers() -> list[ProviderInfo]:
     """Return all known providers. Actual validation happens when listing models."""
     return [

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -925,7 +925,7 @@
     "/api/user/providers/{provider}/models": {
       "get": {
         "summary": "List Provider Models",
-        "description": "List available models for a provider.",
+        "description": "List available models for a provider.\n\n``api_base`` is honored only for a local provider. any-llm resolves a missing\n``api_key`` from the server's environment, so honoring a caller-supplied base\nfor a hosted provider would send that provider's key to whatever host the\ncaller named. Local providers are keyless, so there is nothing to send, and\nthey are the only case the settings UI uses the field for: the API-base input\nand its \"Fetch Models\" button render only when the selected provider is\nlocal, and a hosted provider is always listed with no base.\n\nThis endpoint is gated by ``get_current_user`` alone, which is every user in\na single-tenant deployment but every *tenant* under a multi-tenant auth\nplugin, so the parameter must not be able to redirect a credentialed call.",
         "operationId": "list_provider_models_api_user_providers__provider__models_get",
         "parameters": [
           {
@@ -950,8 +950,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Endpoint to enumerate. Local providers only; a hosted provider always uses the configured LLM_API_BASE.",
               "title": "Api Base"
-            }
+            },
+            "description": "Endpoint to enumerate. Local providers only; a hosted provider always uses the configured LLM_API_BASE."
           }
         ],
         "responses": {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -649,6 +649,18 @@ export interface paths {
         /**
          * List Provider Models
          * @description List available models for a provider.
+         *
+         *     ``api_base`` is honored only for a local provider. any-llm resolves a missing
+         *     ``api_key`` from the server's environment, so honoring a caller-supplied base
+         *     for a hosted provider would send that provider's key to whatever host the
+         *     caller named. Local providers are keyless, so there is nothing to send, and
+         *     they are the only case the settings UI uses the field for: the API-base input
+         *     and its "Fetch Models" button render only when the selected provider is
+         *     local, and a hosted provider is always listed with no base.
+         *
+         *     This endpoint is gated by ``get_current_user`` alone, which is every user in
+         *     a single-tenant deployment but every *tenant* under a multi-tenant auth
+         *     plugin, so the parameter must not be able to redirect a credentialed call.
          */
         get: operations["list_provider_models_api_user_providers__provider__models_get"];
         put?: never;
@@ -2520,6 +2532,7 @@ export interface operations {
     list_provider_models_api_user_providers__provider__models_get: {
         parameters: {
             query?: {
+                /** @description Endpoint to enumerate. Local providers only; a hosted provider always uses the configured LLM_API_BASE. */
                 api_base?: string | null;
             };
             header?: never;

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -356,3 +356,87 @@ def test_list_provider_models_error_returns_502(
     resp = client.get("/api/user/providers/badprovider/models")
     assert resp.status_code == 502
     assert "Failed to list models" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# api_base is not a caller-controlled destination for a credentialed call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("provider", ["anthropic", "openai", "gemini", "groq"])
+@patch(
+    "backend.app.routers.user_profile.get_models",
+    new_callable=AsyncMock,
+)
+def test_api_base_rejected_for_hosted_provider(
+    mock_get_models: AsyncMock, client: TestClient, provider: str
+) -> None:
+    """A hosted provider must not be listable against a caller-chosen host.
+
+    any-llm resolves a missing ``api_key`` from the server's environment, so
+    honoring this parameter for a hosted provider makes the server deliver that
+    provider's key to whatever URL the caller names. This endpoint is gated by
+    ``get_current_user`` alone, which under a multi-tenant auth plugin is every
+    tenant, so the parameter must be refused rather than merely ignored.
+    """
+    resp = client.get(
+        f"/api/user/providers/{provider}/models",
+        params={"api_base": "http://attacker.example.com"},
+    )
+    assert resp.status_code == 400
+    assert "local provider" in resp.json()["detail"]
+    mock_get_models.assert_not_awaited()
+
+
+@pytest.mark.parametrize("provider", ["ollama", "lmstudio", "llamacpp", "llamafile", "vllm"])
+@patch(
+    "backend.app.routers.user_profile.get_models",
+    new_callable=AsyncMock,
+)
+def test_api_base_allowed_for_local_provider(
+    mock_get_models: AsyncMock, client: TestClient, provider: str
+) -> None:
+    """Local providers keep the parameter: they are keyless, so there is nothing
+    to leak, and pointing one at a loopback port is the whole point of the field.
+    The settings UI renders the API-base input only when the provider is local.
+    """
+    mock_get_models.return_value = ["local-model"]
+    resp = client.get(
+        f"/api/user/providers/{provider}/models",
+        params={"api_base": "http://localhost:1234/v1"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == ["local-model"]
+    assert mock_get_models.await_args is not None
+    assert mock_get_models.await_args.kwargs["api_base"] == "http://localhost:1234/v1"
+
+
+@patch(
+    "backend.app.routers.user_profile.get_models",
+    new_callable=AsyncMock,
+)
+def test_hosted_provider_without_api_base_still_lists(
+    mock_get_models: AsyncMock, client: TestClient
+) -> None:
+    """The guard only fires when a base is actually supplied, so the normal
+    cloud-provider path (which the UI always calls with no base) is unchanged."""
+    mock_get_models.return_value = ["claude-opus-4-5"]
+    resp = client.get("/api/user/providers/anthropic/models")
+    assert resp.status_code == 200
+    assert mock_get_models.await_args is not None
+    assert mock_get_models.await_args.kwargs["api_base"] is None
+
+
+@patch(
+    "backend.app.routers.user_profile.get_models",
+    new_callable=AsyncMock,
+)
+def test_empty_api_base_is_not_treated_as_supplied(
+    mock_get_models: AsyncMock, client: TestClient
+) -> None:
+    """The OSS settings page sends ``base || undefined``, but a hand-built request
+    can still send ``?api_base=``. An empty value names no host, so it must not
+    trip the guard for a hosted provider."""
+    mock_get_models.return_value = []
+    resp = client.get("/api/user/providers/anthropic/models", params={"api_base": ""})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Description

`GET /api/user/providers/{provider}/models` accepted a caller-supplied `api_base` and passed it straight to any-llm. `get_models` sends `api_key=None`, and any-llm resolves a missing key from the server's environment, so the outbound request carried the configured provider's API key to whatever host the caller named.

That parameter only ever needed to serve **local** providers. In `SettingsPage.tsx` the API-base input and its "Fetch Models" button render only when the selected provider is local (`providerValue && isLocal && showApiBase`), and a hosted provider is always listed with `fetchModels(provider, '')`, i.e. no base. Local providers are keyless, so honoring the parameter for them sends no credential anywhere.

So gate it. `api_base` is accepted for `ollama`, `llamafile`, `llamacpp`, `lmstudio`, and `vllm`, and rejected with a 400 for a hosted provider, which is listed against the configured `LLM_API_BASE` instead. **No working flow changes**: the request the UI actually makes is unaffected either way.

This matters because the endpoint is gated by `get_current_user` alone. In a single-tenant deployment that is the operator, who already owns the credential, so there is no boundary to cross. Under a multi-tenant auth plugin it is every *tenant*, and an operator-settings helper should not let a tenant redirect a credentialed call.

`is_local_provider` is added to `llm_service` next to the `_LOCAL_PROVIDERS` set that already backs the `local` flag on `GET /user/providers`, so the route and the listing cannot disagree about what counts as local.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 3017 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) — plus `ty check` and `npm run typecheck`, all clean
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Eight tests: four hosted providers rejected without ever reaching `get_models` (verified with `assert_not_awaited`), five local providers honored with the base forwarded intact, and the two no-base cases that must keep working (parameter absent, and an explicitly empty value). The four rejection tests were confirmed to fail with the guard stubbed out; the rest pass either way, as negative controls should.

OpenAPI spec and `frontend/src/generated/api.d.ts` regenerated, since the route signature and docstring changed.

### Follow-up, deliberately not in this PR

A local provider can still be pointed at an internal address, which leaves a low-value blind SSRF with no credential attached. Blocking private addresses there would defeat the field's entire purpose, since `http://localhost:1234/v1` is the documented example. Properly closing that means a multi-tenant deployment not exposing this operator-settings route to tenants at all, which is a downstream authorization decision rather than an OSS one.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Found by Claude Opus 5 via Claude Code during an independent review of an unrelated PR, while checking whether a newly added admin `api_base` parameter was a credential surface. It was, and this pre-existing route turned out to be the more exposed instance. The behavior was reproduced in isolation against a local HTTP sink before the fix was written.
