### PR TITLE
feat(supplier): add Lowe's product search alongside Home Depot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
       - run: uv sync --all-extras
-      - run: uv run ruff check backend/ tests/ alembic/
-      - run: uv run ruff format --check backend/ tests/ alembic/
+      # sidecar/ is included deliberately: it is not part of the installed
+      # package, so nothing else keeps it clean, and it now holds several modules.
+      - run: uv run ruff check backend/ tests/ alembic/ sidecar/
+      - run: uv run ruff format --check backend/ tests/ alembic/ sidecar/
 
   typecheck:
     runs-on: ubuntu-latest

--- a/backend/app/integrations/supplier_pricing/factory.py
+++ b/backend/app/integrations/supplier_pricing/factory.py
@@ -1,15 +1,17 @@
 """Supplier pricing specialist tools.
 
-Home Depot product search and store lookup, both served by the browser sidecar
-(``sidecar/home_depot/``). Home Depot's bot manager refuses plain HTTP clients,
-so a real browser is the only client it serves; SerpApi stays available as an
-optional fallback for product search only.
+Product search at Home Depot and Lowe's, plus Home Depot store lookup, all served
+by the browser sidecar (``sidecar/home_depot/``). Both retailers refuse plain HTTP
+clients, so a real browser is the only client either serves.
+
+SerpApi stays available as a fallback for Home Depot product search only: it has
+no Lowe's engine, and no store locator.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 from pydantic import BaseModel, Field
@@ -21,12 +23,12 @@ from backend.app.config import settings
 from backend.app.integrations.supplier_pricing.cache import SupplierCache
 from backend.app.integrations.supplier_pricing.errors import SupplierUnavailableError
 from backend.app.integrations.supplier_pricing.homedepot import HomeDepotSupplier
-from backend.app.integrations.supplier_pricing.homedepot_sidecar import HomeDepotSidecarSupplier
 from backend.app.integrations.supplier_pricing.protocol import (
     Location,
     ProductResult,
     StoreResult,
 )
+from backend.app.integrations.supplier_pricing.sidecar_client import SidecarSupplier
 
 if TYPE_CHECKING:
     from backend.app.agent.tools.registry import ToolContext
@@ -41,11 +43,18 @@ _cache = SupplierCache()
 class SupplierSearchParams(BaseModel):
     query: str = Field(description="Product search term, e.g. '3/4 plywood' or 'Kilz primer'")
     zip_code: str = Field(default="", description="5-digit US zip code for local pricing")
+    supplier: Literal["home_depot", "lowes"] = Field(
+        default="home_depot",
+        description=(
+            "Which retailer to search. Call once per retailer to compare prices. "
+            "Home Depot supports store_id for store-specific pricing; Lowe's does not."
+        ),
+    )
     store_id: str = Field(
         default="",
         description=(
             "Home Depot store number for store-specific pricing and shelf stock. "
-            "Get one from supplier_find_stores. Optional."
+            "Get one from supplier_find_stores. Ignored for Lowe's. Optional."
         ),
     )
 
@@ -128,30 +137,36 @@ def _format_stores(stores: list[StoreResult], near: str) -> str:
     return "\n".join(lines).rstrip()
 
 
+# Human-facing retailer names, keyed by the tool's `supplier` argument.
+_SUPPLIER_LABELS = {"home_depot": "Home Depot", "lowes": "Lowe's"}
+
+
 def _create_pricing_tools(
-    sidecar: HomeDepotSidecarSupplier | None,
+    sidecars: dict[str, SidecarSupplier],
     fallback: HomeDepotSupplier | None,
     cache: SupplierCache,
 ) -> list[Tool]:
     """Build the pricing tool list.
 
-    Product search tries ``sidecar`` (a real browser, the only client Home Depot
-    serves) and falls through to ``fallback`` (SerpApi, needs a key) when the
-    sidecar cannot answer. Store lookup is sidecar-only: SerpApi has no
-    equivalent endpoint.
+    ``sidecars`` is keyed by the tool's ``supplier`` argument. Product search
+    tries the requested retailer's sidecar and falls through to ``fallback``
+    (SerpApi) when it cannot answer, which only helps Home Depot: SerpApi has no
+    Lowe's engine. Store lookup is Home Depot sidecar only.
     """
 
     async def _search_with_fallback(
-        query: str, location: Location, max_results: int
+        supplier: str, query: str, location: Location, max_results: int
     ) -> list[ProductResult]:
-        """Try each configured backend in order, on to the next when unavailable."""
-        chain: list[tuple[str, Any]] = [
-            (name, backend)
-            for name, backend in (("sidecar", sidecar), ("serpapi", fallback))
-            if backend is not None
-        ]
+        """Try the retailer's sidecar, then SerpApi where it applies."""
+        chain: list[tuple[str, Any]] = []
+        sidecar = sidecars.get(supplier)
+        if sidecar is not None:
+            chain.append(("sidecar", sidecar))
+        # SerpApi only has a Home Depot engine, so it is not a fallback for Lowe's.
+        if fallback is not None and supplier == "home_depot":
+            chain.append(("serpapi", fallback))
         if not chain:
-            raise SupplierUnavailableError("No Home Depot backend is configured")
+            raise SupplierUnavailableError(f"No backend is configured for {supplier}")
 
         for index, (name, backend) in enumerate(chain):
             try:
@@ -160,12 +175,12 @@ def _create_pricing_tools(
                 if index == len(chain) - 1:
                     raise
                 logger.info(
-                    "Home Depot %s backend unavailable, trying %s", name, chain[index + 1][0]
+                    "%s %s backend unavailable, trying %s", supplier, name, chain[index + 1][0]
                 )
-        raise SupplierUnavailableError("No Home Depot backend answered")
+        raise SupplierUnavailableError(f"No backend answered for {supplier}")
 
     async def supplier_search_products(
-        query: str, zip_code: str = "", store_id: str = ""
+        query: str, zip_code: str = "", supplier: str = "home_depot", store_id: str = ""
     ) -> ToolResult:
         resolved_zip = zip_code.strip()
         if not resolved_zip:
@@ -181,31 +196,33 @@ def _create_pricing_tools(
             )
 
         resolved_store = store_id.strip()
+        label = _SUPPLIER_LABELS.get(supplier, supplier)
         cache_key = SupplierCache.make_key(
-            "homedepot",
+            supplier,
             query,
             f"{resolved_zip}:{resolved_store}" if resolved_store else resolved_zip,
         )
         cached = await cache.get(cache_key)
         if cached is not None:
-            return ToolResult(content=_format_results(cached, query, resolved_zip))
+            return ToolResult(content=_format_results(cached, query, resolved_zip, label))
 
         try:
             location = Location(zip_code=resolved_zip, store_id=resolved_store)
-            results = await _search_with_fallback(query, location, 5)
+            results = await _search_with_fallback(supplier, query, location, 5)
         except SupplierUnavailableError:
-            logger.warning("Home Depot refused the search: query=%r", query)
+            logger.warning("%s refused the search: query=%r", label, query)
             return ToolResult(
-                content="Couldn't reach Home Depot to look up pricing.",
+                content=f"Couldn't reach {label} to look up pricing.",
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
                 hint=(
                     "Do not retry this query; the failure is not caused by the search "
-                    "term. Tell the user the lookup is unavailable right now."
+                    "term. Tell the user the lookup is unavailable right now. Another "
+                    "retailer may still work, so trying the other supplier is reasonable."
                 ),
             )
         except httpx.TimeoutException:
-            logger.warning("Home Depot search timed out: query=%r zip=%s", query, resolved_zip)
+            logger.warning("%s search timed out: query=%r zip=%s", label, query, resolved_zip)
             return ToolResult(
                 content="The price lookup timed out. Try a simpler search term.",
                 is_error=True,
@@ -222,18 +239,18 @@ def _create_pricing_tools(
                 )
             if status == 429:
                 return ToolResult(
-                    content="Home Depot pricing is temporarily busy. Try again in a moment.",
+                    content=f"{label} pricing is temporarily busy. Try again in a moment.",
                     is_error=True,
                     error_kind=ToolErrorKind.SERVICE,
                 )
             logger.error("SerpApi error %d for query=%r", status, query)
             return ToolResult(
-                content="Couldn't reach Home Depot pricing. Try again shortly.",
+                content=f"Couldn't reach {label} pricing. Try again shortly.",
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
             )
         except Exception:
-            logger.exception("Unexpected error in Home Depot search: query=%r", query)
+            logger.exception("Unexpected error in %s search: query=%r", label, query)
             return ToolResult(
                 content="Got an unexpected error looking up pricing. Try again.",
                 is_error=True,
@@ -241,7 +258,7 @@ def _create_pricing_tools(
             )
 
         await cache.set(cache_key, results)
-        return ToolResult(content=_format_results(results, query, resolved_zip))
+        return ToolResult(content=_format_results(results, query, resolved_zip, label))
 
     async def supplier_find_stores(near: str, radius_miles: int = 25) -> ToolResult:
         resolved_near = near.strip()
@@ -252,7 +269,8 @@ def _create_pricing_tools(
                 error_kind=ToolErrorKind.VALIDATION,
                 hint="Ask the user where they want to look, then call this tool again.",
             )
-        if sidecar is None:
+        hd = sidecars.get("home_depot")
+        if hd is None:
             return ToolResult(
                 content="Store lookup is not available.",
                 is_error=True,
@@ -269,7 +287,7 @@ def _create_pricing_tools(
             return ToolResult(content=_format_stores(cached, resolved_near))
 
         try:
-            stores = await sidecar.find_stores(resolved_near, radius_miles=radius_miles)
+            stores = await hd.find_stores(resolved_near, radius_miles=radius_miles)
         except SupplierUnavailableError:
             logger.warning("Home Depot refused the store lookup: near=%r", resolved_near)
             return ToolResult(
@@ -292,17 +310,22 @@ def _create_pricing_tools(
         Tool(
             name=ToolName.SUPPLIER_SEARCH_PRODUCTS,
             description=(
-                "Search for products at Home Depot by keyword. "
+                "Search for products at Home Depot or Lowe's by keyword. "
                 "Returns product names, prices, stock, and links. "
                 "A zip_code is required for local pricing. Check the user's profile "
-                "(USER.md) for a stored zip code before asking. Pass store_id as well "
-                "when you know it to get that store's price and shelf count."
+                "(USER.md) for a stored zip code before asking. Set supplier to pick "
+                "the retailer, and call once per retailer when the user wants prices "
+                "compared. Pass store_id as well when you know it to get that store's "
+                "price and shelf count; Home Depot only."
             ),
             function=supplier_search_products,
             params_model=SupplierSearchParams,
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ALWAYS,
-                description_builder=lambda args: f'Search Home Depot for "{args.get("query", "")}"',
+                description_builder=lambda args: (
+                    f"Search {_SUPPLIER_LABELS.get(args.get('supplier', 'home_depot'), 'Home Depot')}"
+                    f' for "{args.get("query", "")}"'
+                ),
             ),
         ),
         Tool(
@@ -327,27 +350,35 @@ def _create_pricing_tools(
 
 def _pricing_factory(ctx: ToolContext) -> list[Tool]:
     """Factory called by the tool registry."""
-    sidecar = (
-        HomeDepotSidecarSupplier(
-            settings.home_depot_sidecar_url, token=settings.home_depot_sidecar_token
-        )
-        if settings.home_depot_sidecar_url
-        else None
-    )
+    sidecars: dict[str, SidecarSupplier] = {}
+    if settings.home_depot_sidecar_url:
+        # One sidecar process serves both retailers; only the site differs.
+        for site, name, label in (
+            ("home_depot", "homedepot", "Home Depot"),
+            ("lowes", "lowes", "Lowe's"),
+        ):
+            sidecars[site] = SidecarSupplier(
+                settings.home_depot_sidecar_url,
+                site=site,
+                name=name,
+                display_name=label,
+                token=settings.home_depot_sidecar_token,
+            )
+
     fallback = (
         HomeDepotSupplier(api_key=settings.serpapi_api_key) if settings.serpapi_api_key else None
     )
 
-    if sidecar is None and fallback is None:
-        logger.info("supplier_pricing factory: no Home Depot backend configured, skipping")
+    if not sidecars and fallback is None:
+        logger.info("supplier_pricing factory: no supplier backend configured, skipping")
         return []
 
     logger.info(
-        "supplier_pricing factory: creating Home Depot tools (sidecar=%s, serpapi=%s)",
-        sidecar is not None,
+        "supplier_pricing factory: creating supplier tools (sidecar_sites=%s, serpapi=%s)",
+        sorted(sidecars) or "none",
         fallback is not None,
     )
-    return _create_pricing_tools(sidecar, fallback, _cache)
+    return _create_pricing_tools(sidecars, fallback, _cache)
 
 
 async def _pricing_auth_check(ctx: ToolContext) -> str | None:

--- a/backend/app/integrations/supplier_pricing/factory.py
+++ b/backend/app/integrations/supplier_pricing/factory.py
@@ -65,14 +65,26 @@ class SupplierFindStoresParams(BaseModel):
 
 
 def _format_results(
-    results: list[ProductResult], query: str, zip_code: str, supplier_name: str = "Home Depot"
+    results: list[ProductResult],
+    query: str,
+    zip_code: str,
+    supplier_name: str = "Home Depot",
+    *,
+    localized: bool = True,
 ) -> str:
-    """Format product results as plain text suitable for SMS/iMessage."""
+    """Format product results as plain text suitable for SMS/iMessage.
+
+    ``localized`` says whether the zip actually shaped these results. Only claim
+    it when it did: Lowe's results come from whichever store the sidecar's own
+    session is pinned to, so labelling them with the user's zip would invite a
+    tradesperson to drive to a store on the strength of someone else's shelf
+    count.
+    """
     if not results:
         return f'No products found for "{query}" at {supplier_name}.'
 
     header = f'Found {len(results)} result(s) for "{query}" at {supplier_name}'
-    if zip_code:
+    if zip_code and localized:
         header += f" (zip {zip_code})"
     has_any_price = any(p.price_dollars is not None for p in results)
     if not has_any_price:
@@ -110,6 +122,12 @@ def _format_results(
         url = p.product_url or "(no link available)"
         lines.append(f"   Link: {url}")
         lines.append("")
+
+    if not localized and any(p.stock_quantity is not None for p in results):
+        lines.append(
+            "Note: these are not localized to your zip. Stock counts are for "
+            f"{supplier_name}'s default store, so confirm before making a trip."
+        )
 
     return "\n".join(lines).rstrip()
 
@@ -197,14 +215,21 @@ def _create_pricing_tools(
 
         resolved_store = store_id.strip()
         label = _SUPPLIER_LABELS.get(supplier, supplier)
-        cache_key = SupplierCache.make_key(
-            supplier,
-            query,
-            f"{resolved_zip}:{resolved_store}" if resolved_store else resolved_zip,
+        # Only Home Depot's search takes the zip and store into account; Lowe's
+        # ignores both, so keying its cache on them would only cause redundant
+        # fetches for answers that cannot differ.
+        localized = supplier == "home_depot"
+        cache_scope = (
+            (f"{resolved_zip}:{resolved_store}" if resolved_store else resolved_zip)
+            if localized
+            else "national"
         )
+        cache_key = SupplierCache.make_key(supplier, query, cache_scope)
         cached = await cache.get(cache_key)
         if cached is not None:
-            return ToolResult(content=_format_results(cached, query, resolved_zip, label))
+            return ToolResult(
+                content=_format_results(cached, query, resolved_zip, label, localized=localized)
+            )
 
         try:
             location = Location(zip_code=resolved_zip, store_id=resolved_store)
@@ -216,9 +241,11 @@ def _create_pricing_tools(
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
                 hint=(
-                    "Do not retry this query; the failure is not caused by the search "
-                    "term. Tell the user the lookup is unavailable right now. Another "
-                    "retailer may still work, so trying the other supplier is reasonable."
+                    "The failure is not caused by the search term, so rewording will "
+                    "not help. One retry is worth it: the backend warms a browser "
+                    "session lazily and the second attempt often succeeds. If it fails "
+                    "again, tell the user the lookup is unavailable and offer the other "
+                    "retailer, which may still work."
                 ),
             )
         except httpx.TimeoutException:
@@ -258,7 +285,9 @@ def _create_pricing_tools(
             )
 
         await cache.set(cache_key, results)
-        return ToolResult(content=_format_results(results, query, resolved_zip, label))
+        return ToolResult(
+            content=_format_results(results, query, resolved_zip, label, localized=localized)
+        )
 
     async def supplier_find_stores(near: str, radius_miles: int = 25) -> ToolResult:
         resolved_near = near.strip()
@@ -394,15 +423,17 @@ def _register() -> None:
         "supplier_pricing",
         _pricing_factory,
         core=False,
-        summary="Search product prices and find stores at Home Depot",
-        display_name="Home Depot pricing",
-        dashboard_description="Search product prices and find stores at Home Depot",
+        summary="Search product prices at Home Depot and Lowe's, and find Home Depot stores",
+        display_name="Supplier pricing",
+        dashboard_description=(
+            "Search product prices at Home Depot and Lowe's, and find Home Depot stores"
+        ),
         dashboard_group="Integrations",
         dashboard_group_order=3,
         sub_tools=[
             SubToolInfo(
                 ToolName.SUPPLIER_SEARCH_PRODUCTS,
-                "Search products by keyword at Home Depot",
+                "Search products by keyword at Home Depot or Lowe's",
                 default_permission="always",
             ),
             SubToolInfo(

--- a/backend/app/integrations/supplier_pricing/factory.py
+++ b/backend/app/integrations/supplier_pricing/factory.py
@@ -125,8 +125,8 @@ def _format_results(
 
     if not localized and any(p.stock_quantity is not None for p in results):
         lines.append(
-            "Note: these are not localized to your zip. Stock counts are for "
-            f"{supplier_name}'s default store, so confirm before making a trip."
+            "Note: these are not localized to your zip. Stock counts are for the "
+            f"default {supplier_name} store, so confirm before making a trip."
         )
 
     return "\n".join(lines).rstrip()

--- a/backend/app/integrations/supplier_pricing/sidecar_client.py
+++ b/backend/app/integrations/supplier_pricing/sidecar_client.py
@@ -1,8 +1,13 @@
-"""Home Depot product search and store lookup via the browser sidecar.
+"""Client for the retail browser sidecar.
 
-Home Depot's bot manager refuses plain HTTP clients, so the only way to reach it
-is to have a real browser issue the request. ``sidecar/home_depot/`` is that
-browser, wrapped in a small HTTP API, and this module is the client for it.
+Home Depot and Lowe's both refuse plain HTTP clients, so the only way to reach
+either is to have a real browser issue the request. ``sidecar/home_depot/`` is
+that browser, wrapped in a small HTTP API, and this module is the client for it.
+
+One class serves both retailers because the sidecar hides the differences. Behind
+its ``site`` parameter, Home Depot answers a GraphQL call made from inside the
+page while Lowe's results are read out of its search page's embedded state, but
+both come back in the same shape.
 
 The sidecar is ordinary infrastructure from this side: our own service, plain
 JSON, no bot protection, so ``httpx`` is the right tool. Run it wherever a
@@ -31,18 +36,26 @@ logger = logging.getLogger(__name__)
 _DEFAULT_TIMEOUT_SECONDS = 20.0
 
 
-class HomeDepotSidecarSupplier:
-    """Home Depot search and store lookup delegated to the browser sidecar."""
+class SidecarSupplier:
+    """A retailer served by the browser sidecar.
+
+    ``site`` selects the retailer inside the sidecar. Store lookup is Home Depot
+    only, since that is the only locator implemented there.
+    """
 
     def __init__(
         self,
         base_url: str,
         *,
+        site: str = "home_depot",
+        name: str = "homedepot",
+        display_name: str = "Home Depot",
         token: str = "",
         timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
-        self.name = "homedepot"
-        self.display_name = "Home Depot"
+        self.name = name
+        self.display_name = display_name
+        self.site = site
         self._base_url = base_url.rstrip("/")
         self._token = token
         self._timeout = timeout_seconds
@@ -83,7 +96,7 @@ class HomeDepotSidecarSupplier:
     async def search_products(
         self, query: str, location: Location, *, max_results: int = 5
     ) -> list[ProductResult]:
-        """Search Home Depot through the sidecar.
+        """Search this supplier's retailer through the sidecar.
 
         Raises:
             SupplierUnavailableError: the sidecar is unreachable or errored, so
@@ -93,17 +106,18 @@ class HomeDepotSidecarSupplier:
             "/search",
             {
                 "q": query,
+                "site": self.site,
                 "zip": location.zip_code,
                 "store_id": location.store_id,
                 "limit": str(max_results),
             },
         )
-        return [_to_product(p) for p in (payload.get("products") or [])[:max_results]]
+        return [_to_product(p, self.name) for p in (payload.get("products") or [])[:max_results]]
 
     async def find_stores(
         self, near: str, *, radius_miles: int = 25, max_results: int = 5
     ) -> list[StoreResult]:
-        """Find Home Depot stores near a zip code, city, or address.
+        """Find stores near a zip code, city, or address (Home Depot only).
 
         Raises:
             SupplierUnavailableError: the sidecar is unreachable or errored.
@@ -115,10 +129,10 @@ class HomeDepotSidecarSupplier:
         return [_to_store(s) for s in (payload.get("stores") or [])[:max_results]]
 
 
-def _to_product(raw: dict[str, Any]) -> ProductResult:
+def _to_product(raw: dict[str, Any], supplier: str) -> ProductResult:
     """Map a sidecar product onto the shared :class:`ProductResult`."""
     return ProductResult(
-        supplier="homedepot",
+        supplier=supplier,
         product_id=str(raw.get("item_id") or ""),
         name=raw.get("name") or "Unknown product",
         brand=raw.get("brand") or "",

--- a/backend/app/integrations/supplier_pricing/sidecar_client.py
+++ b/backend/app/integrations/supplier_pricing/sidecar_client.py
@@ -30,10 +30,13 @@ from backend.app.integrations.supplier_pricing.protocol import (
 
 logger = logging.getLogger(__name__)
 
-# Measured p100 for a live search is ~1.3s, so anything beyond a few seconds
-# means the sidecar is wedged rather than slow. Fail fast to the next backend
-# instead of stalling the user's turn.
-_DEFAULT_TIMEOUT_SECONDS = 20.0
+# A warm search measures ~1-2s, so a few seconds would normally be plenty. The
+# ceiling is set by the uncommon case instead: if the sidecar has not yet warmed a
+# retailer's page, that request pays the warm (a homepage load, a click, and two
+# settle waits, ~19s for Lowe's). The sidecar pre-warms both retailers at startup,
+# so this should be rare, but at 20s a cold request timed out just short of
+# succeeding and the user saw a failure for work that was about to land.
+_DEFAULT_TIMEOUT_SECONDS = 35.0
 
 
 class SidecarSupplier:
@@ -84,13 +87,17 @@ class SidecarSupplier:
                 payload = resp.json()
         except httpx.HTTPStatusError as exc:
             raise SupplierUnavailableError(
-                f"Home Depot sidecar returned {exc.response.status_code} for {path}"
+                f"{self.display_name} sidecar returned {exc.response.status_code} for {path}"
             ) from exc
         except (httpx.HTTPError, ValueError) as exc:
-            raise SupplierUnavailableError(f"Home Depot sidecar is unreachable: {exc}") from exc
+            raise SupplierUnavailableError(
+                f"{self.display_name} sidecar is unreachable: {exc}"
+            ) from exc
 
         if not isinstance(payload, dict):
-            raise SupplierUnavailableError(f"Home Depot sidecar sent an unexpected body for {path}")
+            raise SupplierUnavailableError(
+                f"{self.display_name} sidecar sent an unexpected body for {path}"
+            )
         return payload
 
     async def search_products(

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -276,7 +276,9 @@ ServiceTitan uses OAuth 2.0 client credentials (machine-to-machine), one set per
 | `HOME_DEPOT_SIDECAR_TOKEN` | | Bearer token for the sidecar. Must match its `HD_SIDECAR_TOKEN`. |
 | `SERPAPI_API_KEY` | | Optional fallback for product search only. Free tier: 250 searches/month at [serpapi.com](https://serpapi.com) |
 
-The agent gets two specialist tools here: `supplier_search_products` (prices, ratings, stock, and links by keyword and zip code) and `supplier_find_stores` (store number, address, phone, and distance near a zip code, city, or address). Feed a store number from the second into the first to get that store's price and shelf count instead of regional pricing.
+The agent gets two specialist tools here: `supplier_search_products` (prices, ratings, stock, and links by keyword and zip code, at **Home Depot or Lowe's** via its `supplier` argument) and `supplier_find_stores` (store number, address, phone, and distance near a zip code, city, or address). Feed a store number from the second into the first to get that store's price and shelf count instead of regional pricing; Home Depot only.
+
+Both retailers are served by the same sidecar process, so one `HOME_DEPOT_SIDECAR_URL` covers both. SerpApi is a fallback for Home Depot only, because it has no Lowe's engine; a Lowe's lookup that the sidecar cannot serve reports the failure rather than silently returning Home Depot prices.
 
 Home Depot has no public API and its bot manager refuses plain HTTP clients on both product and store routes, so everything here goes through the sidecar (`sidecar/home_depot/`), which drives a real browser. See its README for how to run it and how to point Clawbolt at one on a different host.
 

--- a/sidecar/home_depot/Dockerfile
+++ b/sidecar/home_depot/Dockerfile
@@ -47,9 +47,11 @@ RUN apt-get update \
     && patchright install chromium \
     && rm -rf /var/lib/apt/lists/*
 
-# lowes.py is imported by sidecar.py at module level, so leaving it out makes the
-# image die on `import lowes` before uvicorn binds a port: no /health to ask.
-COPY sidecar.py lowes.py search_model.graphql ./
+# Globbed rather than listed. An earlier explicit list omitted lowes.py, which
+# sidecar.py imports at module level, so the image died on `import lowes` before
+# uvicorn bound a port, leaving no /health to ask what went wrong. A glob cannot
+# forget the next module.
+COPY *.py search_model.graphql ./
 
 RUN useradd --create-home --shell /bin/bash sidecar \
     && chown -R sidecar:sidecar /app \

--- a/sidecar/home_depot/Dockerfile
+++ b/sidecar/home_depot/Dockerfile
@@ -47,7 +47,9 @@ RUN apt-get update \
     && patchright install chromium \
     && rm -rf /var/lib/apt/lists/*
 
-COPY sidecar.py search_model.graphql ./
+# lowes.py is imported by sidecar.py at module level, so leaving it out makes the
+# image die on `import lowes` before uvicorn binds a port: no /health to ask.
+COPY sidecar.py lowes.py search_model.graphql ./
 
 RUN useradd --create-home --shell /bin/bash sidecar \
     && chown -R sidecar:sidecar /app \

--- a/sidecar/home_depot/README.md
+++ b/sidecar/home_depot/README.md
@@ -208,7 +208,8 @@ navigation versus in-page XHR, and the egress IP.
 What actually matters is **warming with a real click**. A homepage visit alone
 still gets the deny; one organic click into a category first, and `/search`
 returns results. That is why `_lowes_page` clicks a `/pl/` link before serving
-anything, and why it logs loudly when it cannot find one.
+anything, and why a page that never got one is closed rather than cached: keeping
+it would pin every later search to a session the edge refuses.
 
 Results come from `window['__PRELOADED_STATE__']`, not the DOM. The payload is
 ~400KB and carries `itemList` with price, per-store on-hand quantity, brand,

--- a/sidecar/home_depot/README.md
+++ b/sidecar/home_depot/README.md
@@ -1,6 +1,11 @@
-# Home Depot sidecar
+# Retail sidecar
 
-Clawbolt's Home Depot product search and store lookup, backed by a real browser.
+Clawbolt's product search at Home Depot and Lowe's, plus Home Depot store lookup,
+backed by a real browser.
+
+The directory is still named `home_depot` because a rename would change the
+published image name and every deployment pointing at it. Not worth the churn for
+a name.
 
 ## Why this exists
 
@@ -137,7 +142,14 @@ platform healthcheck reads as a dead container and which gives a remote operator
 no HTTP response to diagnose. `/search` and `/stores` return `503` with the same
 reason until the browser is ready.
 
-`GET /search?q=<keyword>&zip=<zip>&store_id=<id>&limit=<n>`
+`GET /search?q=<keyword>&site=<home_depot|lowes>&zip=<zip>&store_id=<id>&limit=<n>`
+
+`site` defaults to `home_depot`. The two retailers are reached differently, which
+is invisible to callers but explains the parameter differences: Home Depot answers
+a GraphQL call issued from inside the page, so `zip` and `store_id` localize the
+result, while Lowe's has no reachable product API and its results are read out of
+the search page's embedded state, with localization riding on the session's own
+store rather than on parameters.
 
 ```console
 $ curl -s 'localhost:8899/search?q=cordless+drill&zip=30301&limit=2' | jq
@@ -183,6 +195,31 @@ $ curl -s 'localhost:8899/stores?near=30301&limit=2' | jq
 A non-zip `near` makes Home Depot answer with geocoding candidates instead of
 stores; the sidecar resolves the first candidate to coordinates and looks up
 again, reporting `geocoded: true` when it did.
+
+## Lowe's
+
+Same wall, one extra step. Lowe's runs the same Akamai Bot Manager, and its
+`/search`, `/Search=` and `/store/api/search` routes are all refused with a 403
+edge deny (`errors.edgesuite.net`, `Reference #18.…`) rather than a solvable
+challenge. Ruled out as causes, each measured: profile freshness, cookies, the
+`X11; Linux` User-Agent, client hints overridden via CDP to claim macOS,
+navigation versus in-page XHR, and the egress IP.
+
+What actually matters is **warming with a real click**. A homepage visit alone
+still gets the deny; one organic click into a category first, and `/search`
+returns results. That is why `_lowes_page` clicks a `/pl/` link before serving
+anything, and why it logs loudly when it cannot find one.
+
+Results come from `window['__PRELOADED_STATE__']`, not the DOM. The payload is
+~400KB and carries `itemList` with price, per-store on-hand quantity, brand,
+model, rating and review count. Two reasons to prefer it over selectors: it is
+stable against markup changes, and a DOM scrape picks up the "Previously Viewed"
+carousel, which silently returns items from earlier queries.
+
+Store lookup is Home Depot only. Lowe's has no equivalent implemented, and
+SerpApi has no Lowe's engine at all, so there is no fallback for Lowe's search
+either: if the sidecar cannot answer, the tool reports that rather than quietly
+returning Home Depot prices.
 
 ## Connecting Clawbolt
 

--- a/sidecar/home_depot/lowes.py
+++ b/sidecar/home_depot/lowes.py
@@ -22,6 +22,7 @@ otherwise contaminates a DOM scrape with items from earlier queries.
 from __future__ import annotations
 
 import json
+import math
 import re
 from typing import Any
 from urllib.parse import quote_plus
@@ -91,17 +92,26 @@ def _as_float(value: Any) -> float | None:
     dropped every rating and review count, so accept both representations and
     reject only what cannot be read as a number. bool is excluded deliberately,
     since True would otherwise coerce to 1.0.
+
+    NaN and the infinities are rejected as unusable too. ``json.loads`` accepts
+    both as bare literals, and a page-state serialiser can emit them, so they do
+    reach here: unguarded, NaN makes ``_as_int`` raise ValueError and infinity
+    makes it raise OverflowError, and a NaN that survives as a float fails
+    Starlette's ``allow_nan=False`` encoder. Either way the whole search 500s,
+    which is the outcome these helpers exist to prevent.
     """
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
+        number = float(value)
+    elif isinstance(value, str):
         try:
-            return float(value.strip())
+            number = float(value.strip())
         except ValueError:
             return None
-    return None
+    else:
+        return None
+    return number if math.isfinite(number) else None
 
 
 def _as_int(value: Any) -> int | None:

--- a/sidecar/home_depot/lowes.py
+++ b/sidecar/home_depot/lowes.py
@@ -24,12 +24,17 @@ from __future__ import annotations
 import json
 import re
 from typing import Any
+from urllib.parse import quote_plus
 
 ORIGIN = "https://www.lowes.com"
 
-# The state assignment as the page emits it. Anchored on the bracket form
-# because that is what Lowe's ships; a dotted form would not match.
-_STATE_RE = re.compile(r"window\['__PRELOADED_STATE__'\]\s*=\s*")
+# The state assignment. Lowe's currently emits the single-quoted bracket form,
+# but accept the double-quoted and dotted forms too: a minifier change would
+# otherwise turn every search into a silent 502, and matching all three costs
+# nothing.
+_STATE_RE = re.compile(
+    r"""window(?:\[['"]__PRELOADED_STATE__['"]\]|\.__PRELOADED_STATE__)\s*=\s*"""
+)
 
 
 def extract_preloaded_state(html: str) -> dict[str, Any] | None:
@@ -77,6 +82,39 @@ def extract_preloaded_state(html: str) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
+def _as_float(value: Any) -> float | None:
+    """Coerce a payload number, returning None for anything unusable.
+
+    Numeric strings count as usable, and that is the whole point: Lowe's ships
+    ``rating`` and ``reviewCount`` as strings ('4.7', '4076') while ``sellingPrice``
+    is a JSON number. A stricter check that accepted only int and float silently
+    dropped every rating and review count, so accept both representations and
+    reject only what cannot be read as a number. bool is excluded deliberately,
+    since True would otherwise coerce to 1.0.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _as_int(value: Any) -> int | None:
+    """Coerce a payload count, returning None for anything unusable."""
+    number = _as_float(value)
+    return int(number) if number is not None else None
+
+
+def total_products(state: dict[str, Any]) -> int | None:
+    """Read the result count, tolerating a payload that reports it oddly."""
+    return _as_int(state.get("itemCount"))
+
+
 def _stock_from_inventory(location: dict[str, Any]) -> tuple[bool | None, int | None]:
     """Reduce Lowe's per-fulfilment availability to (in_stock, quantity).
 
@@ -94,8 +132,8 @@ def _stock_from_inventory(location: dict[str, Any]) -> tuple[bool | None, int | 
     for entry in entries:
         if entry.get("isAvlSts"):
             in_stock = True
-        on_hand = entry.get("onhandQty")
-        if isinstance(on_hand, int) and (quantity is None or on_hand > quantity):
+        on_hand = _as_int(entry.get("onhandQty"))
+        if on_hand is not None and (quantity is None or on_hand > quantity):
             quantity = on_hand
     return in_stock, quantity
 
@@ -120,12 +158,15 @@ def parse_products(state: dict[str, Any], limit: int) -> list[dict[str, Any]]:
                 "name": product.get("description") or "Unknown product",
                 "brand": product.get("brand") or "",
                 "model_number": str(product.get("modelId") or ""),
-                "price_dollars": float(price) if isinstance(price, (int, float)) else None,
+                "price_dollars": _as_float(price),
                 "was_price_dollars": None,
                 "in_stock": in_stock,
                 "stock_quantity": quantity,
-                "rating": product.get("rating"),
-                "review_count": product.get("reviewCount"),
+                # Coerced like the price: these reach a pydantic model, so a
+                # string or bool from a payload change would 500 the sidecar
+                # rather than degrade to an unrated product.
+                "rating": _as_float(product.get("rating")),
+                "review_count": _as_int(product.get("reviewCount")),
                 "product_url": url,
                 "image_url": product.get("imageUrl") or "",
             }
@@ -134,10 +175,8 @@ def parse_products(state: dict[str, Any], limit: int) -> list[dict[str, Any]]:
     return products
 
 
-def search_url(keyword: str, store_id: str = "") -> str:
+def search_url(keyword: str) -> str:
     """Build the search URL. Store selection rides on the session, not the URL."""
-    from urllib.parse import quote_plus
-
     return f"{ORIGIN}/search?searchTerm={quote_plus(keyword)}"
 
 

--- a/sidecar/home_depot/lowes.py
+++ b/sidecar/home_depot/lowes.py
@@ -1,0 +1,146 @@
+"""Lowe's site adapter for the retail sidecar.
+
+Lowe's differs from Home Depot in two ways that matter, both measured rather than
+assumed.
+
+**Warming needs a real click.** A homepage visit alone is not enough: navigating
+to /search from a session warmed only by the homepage is refused with a 403
+Akamai edge deny ("You don't have permission to access ... on this server"). One
+organic click into a category first, and the same navigation returns results.
+Freshly created profiles are denied; profiles warmed this way are served.
+
+**There is no product JSON API to call.** Home Depot exposes a GraphQL gateway
+that can be fetched from inside the page. Lowe's equivalent, /store/api/search,
+is denied by the same edge rule, so results have to come from the search page
+itself. They do not have to come from the DOM though: the page embeds the whole
+result set in ``window['__PRELOADED_STATE__']``, which carries price, per-store
+on-hand quantity, brand, model, rating and review count. Parsing that is far
+sturdier than selectors, and it also avoids the "Previously Viewed" carousel that
+otherwise contaminates a DOM scrape with items from earlier queries.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+ORIGIN = "https://www.lowes.com"
+
+# The state assignment as the page emits it. Anchored on the bracket form
+# because that is what Lowe's ships; a dotted form would not match.
+_STATE_RE = re.compile(r"window\['__PRELOADED_STATE__'\]\s*=\s*")
+
+
+def extract_preloaded_state(html: str) -> dict[str, Any] | None:
+    """Pull ``window['__PRELOADED_STATE__']`` out of a page.
+
+    Brace-matched rather than regex-terminated: the payload is ~400KB of nested
+    JSON containing braces inside strings, so a greedy or lazy pattern gets the
+    boundary wrong. Returns None when the marker is absent or the slice does not
+    parse, which is the caller's signal that the page was not a result page.
+    """
+    match = _STATE_RE.search(html)
+    if match is None:
+        return None
+
+    start = match.end()
+    depth = 0
+    in_string = False
+    escaped = False
+    index = start
+
+    while index < len(html):
+        char = html[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                index += 1
+                break
+        index += 1
+
+    try:
+        parsed = json.loads(html[start:index])
+    except ValueError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _stock_from_inventory(location: dict[str, Any]) -> tuple[bool | None, int | None]:
+    """Reduce Lowe's per-fulfilment availability to (in_stock, quantity).
+
+    ``itemAvailList`` carries one entry per fulfilment method (Parcel, Pickup,
+    ...), each with its own availability flag and on-hand count. Treat the item
+    as in stock if any method is available, and report the largest on-hand seen,
+    which is the local store's shelf count.
+    """
+    entries = (location.get("itemInventory") or {}).get("itemAvailList") or []
+    if not entries:
+        return None, None
+
+    in_stock = False
+    quantity: int | None = None
+    for entry in entries:
+        if entry.get("isAvlSts"):
+            in_stock = True
+        on_hand = entry.get("onhandQty")
+        if isinstance(on_hand, int) and (quantity is None or on_hand > quantity):
+            quantity = on_hand
+    return in_stock, quantity
+
+
+def parse_products(state: dict[str, Any], limit: int) -> list[dict[str, Any]]:
+    """Map ``itemList`` entries onto the sidecar's product shape."""
+    products: list[dict[str, Any]] = []
+
+    for entry in (state.get("itemList") or [])[:limit]:
+        product = entry.get("product") or {}
+        location = entry.get("location") or {}
+
+        price = (location.get("price") or {}).get("sellingPrice")
+        in_stock, quantity = _stock_from_inventory(location)
+
+        detail_path = product.get("pdURL") or ""
+        url = f"{ORIGIN}{detail_path}" if detail_path.startswith("/") else detail_path
+
+        products.append(
+            {
+                "item_id": str(product.get("omniItemId") or ""),
+                "name": product.get("description") or "Unknown product",
+                "brand": product.get("brand") or "",
+                "model_number": str(product.get("modelId") or ""),
+                "price_dollars": float(price) if isinstance(price, (int, float)) else None,
+                "was_price_dollars": None,
+                "in_stock": in_stock,
+                "stock_quantity": quantity,
+                "rating": product.get("rating"),
+                "review_count": product.get("reviewCount"),
+                "product_url": url,
+                "image_url": product.get("imageUrl") or "",
+            }
+        )
+
+    return products
+
+
+def search_url(keyword: str, store_id: str = "") -> str:
+    """Build the search URL. Store selection rides on the session, not the URL."""
+    from urllib.parse import quote_plus
+
+    return f"{ORIGIN}/search?searchTerm={quote_plus(keyword)}"
+
+
+def is_denied(html: str) -> bool:
+    """True when the edge refused the request rather than serving a page."""
+    return "Access Denied" in html

--- a/sidecar/home_depot/sidecar.py
+++ b/sidecar/home_depot/sidecar.py
@@ -35,6 +35,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
+import lowes
 from fastapi import Depends, FastAPI, Header, HTTPException, Query
 from patchright.async_api import async_playwright
 from pydantic import BaseModel
@@ -49,6 +50,11 @@ SEARCH_MODEL_QUERY = QUERY_PATH.read_text()
 PROFILE_DIR = os.environ.get("HD_PROFILE_DIR", str(Path.home() / ".hd-sidecar-profile"))
 AUTH_TOKEN = os.environ.get("HD_SIDECAR_TOKEN", "")
 WARM_SECONDS = float(os.environ.get("HD_WARM_SECONDS", "7"))
+
+# Lowe's results are server-rendered into the page, so the wait is a poll for the
+# payload rather than a fixed settle. Roughly 6s of headroom in total.
+LOWES_STATE_POLL_MS = 400
+LOWES_STATE_POLL_ATTEMPTS = 15
 
 # Home Depot maps some keywords to a category browse page instead of a keyword
 # result set. The redirect path carries an "N-<token>" that has to be replayed
@@ -160,6 +166,10 @@ class BrowserBackedSearch:
         self._pw: Any = None
         self._ctx: Any = None
         self._page: Any = None
+        # One page per site, each parked on its own origin. Home Depot's search
+        # is an in-page fetch, so the page has to already be on homedepot.com;
+        # sharing a single page would mean re-warming on every site switch.
+        self._site_pages: dict[str, Any] = {}
         self._lock = asyncio.Lock()
         self.state = "starting"
         """One of starting, ready, failed. Reported by /health."""
@@ -168,6 +178,7 @@ class BrowserBackedSearch:
         """Why startup failed, surfaced over HTTP so a broken deploy is diagnosable."""
 
         self._task: asyncio.Task[None] | None = None
+        self._prewarm: asyncio.Task[None] | None = None
 
     def start_background(self) -> None:
         """Launch the browser without blocking the caller.
@@ -192,9 +203,16 @@ class BrowserBackedSearch:
                 timezone_id="America/New_York",
             )
             self._page = self._ctx.pages[0] if self._ctx.pages else await self._ctx.new_page()
+            self._site_pages["home_depot"] = self._page
             await self._warm()
             self.state = "ready"
             self.error = None
+            # Pre-warm Lowe's too. Its warm costs a homepage load plus a click, so
+            # the first Lowe's query would otherwise pay ~19s while Home Depot
+            # answers in one. Doing it after state=ready keeps Home Depot
+            # available immediately, and a failure here is not fatal: the lazy
+            # path in _lowes_page still runs on demand.
+            self._prewarm = asyncio.create_task(self._prewarm_lowes())
         except Exception as exc:
             # Chromium failing to launch lands here. Keep the message verbatim:
             # it is the only signal a remote operator gets, and the causes are
@@ -223,10 +241,11 @@ class BrowserBackedSearch:
             return False
 
     async def stop(self) -> None:
-        if self._task is not None and not self._task.done():
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await self._task
+        for task in (self._prewarm, self._task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
         for closer in (self._ctx, self._pw):
             if closer is not None:
                 with contextlib.suppress(Exception):
@@ -237,6 +256,80 @@ class BrowserBackedSearch:
         await self._page.goto(f"{ORIGIN}/", wait_until="domcontentloaded", timeout=90_000)
         await self._page.wait_for_timeout(int(WARM_SECONDS * 1000))
         logger.info("browser warmed: %s", await self._page.title())
+
+    async def _prewarm_lowes(self) -> None:
+        """Warm the Lowe's page in the background, tolerating failure."""
+        try:
+            async with self._lock:
+                await self._lowes_page()
+        except Exception:
+            logger.warning("lowes pre-warm failed; will warm on first use", exc_info=True)
+
+    async def _lowes_page(self) -> Any:
+        """Return a page warmed for Lowe's, creating and warming it on first use.
+
+        Lowe's needs more than a homepage visit. Navigating to /search from a
+        session warmed only by the homepage is refused with a 403 edge deny; one
+        organic click into a category first, and the same navigation is served.
+        The click is the load-bearing step, so a failure to find a category link
+        is worth logging rather than swallowing.
+        """
+        page = self._site_pages.get("lowes")
+        if page is not None:
+            return page
+
+        page = await self._ctx.new_page()
+        await page.goto(f"{lowes.ORIGIN}/", wait_until="domcontentloaded", timeout=90_000)
+        await page.wait_for_timeout(int(WARM_SECONDS * 1000))
+
+        clicked = False
+        try:
+            link = page.locator("a[href*='/pl/']").first
+            if await link.count():
+                await link.click()
+                await page.wait_for_timeout(int(WARM_SECONDS * 1000))
+                clicked = True
+        except Exception:
+            logger.warning("lowes: organic warm click failed", exc_info=True)
+        if not clicked:
+            logger.warning("lowes: no category link to click; search will likely be denied")
+
+        logger.info("lowes page warmed (clicked=%s): %s", clicked, await page.title())
+        self._site_pages["lowes"] = page
+        return page
+
+    async def search_lowes(self, keyword: str, *, page_size: int) -> SearchResponse:
+        """Search Lowe's by reading the search page's embedded state.
+
+        The payload is server-rendered into the HTML, so there is nothing to wait
+        for once the document arrives. Poll for it rather than sleeping a fixed
+        interval: a blanket wait cost about seven seconds per query for no
+        benefit, against Home Depot's sub-second GraphQL call.
+        """
+        async with self._lock:
+            page = await self._lowes_page()
+            await page.goto(
+                lowes.search_url(keyword), wait_until="domcontentloaded", timeout=90_000
+            )
+            html = await page.content()
+            for _ in range(int(LOWES_STATE_POLL_ATTEMPTS)):
+                if lowes.is_denied(html) or lowes.extract_preloaded_state(html) is not None:
+                    break
+                await page.wait_for_timeout(LOWES_STATE_POLL_MS)
+                html = await page.content()
+
+        if lowes.is_denied(html):
+            raise HTTPException(502, "Lowe's refused the search")
+        state = lowes.extract_preloaded_state(html)
+        if state is None:
+            raise HTTPException(502, "Lowe's search page carried no result payload")
+
+        return SearchResponse(
+            keyword=keyword,
+            total_products=state.get("itemCount"),
+            used_nav_param=None,
+            products=[Product(**p) for p in lowes.parse_products(state, page_size)],
+        )
 
     async def _call(
         self, keyword: str, nav_param: str | None, store_id: str, zip_code: str, page_size: int
@@ -461,11 +554,22 @@ async def health() -> dict[str, Any]:
 @app.get("/search", response_model=SearchResponse, dependencies=[Depends(require_token)])
 async def search(
     q: str = Query(min_length=1, description="Product search keyword"),
+    site: str = Query(default="home_depot", pattern="^(home_depot|lowes)$"),
     zip_code: str = Query(default="", alias="zip"),
     store_id: str = Query(default=""),
     limit: int = Query(default=5, ge=1, le=24),
 ) -> SearchResponse:
+    """Search a retailer for `q`.
+
+    The two sites are reached differently. Home Depot answers a GraphQL call made
+    from inside the page, so `zip` and `store_id` localize the result. Lowe's has
+    no reachable product API, so its results are read out of the search page's
+    embedded state and localization rides on the session's own store rather than
+    on parameters.
+    """
     _engine.require_ready()
+    if site == "lowes":
+        return await _engine.search_lowes(q, page_size=limit)
     return await _engine.search(q, store_id=store_id, zip_code=zip_code, page_size=limit)
 
 
@@ -475,5 +579,6 @@ async def stores(
     radius_miles: int = Query(default=25, ge=1, le=100),
     limit: int = Query(default=5, ge=1, le=25),
 ) -> StoresResponse:
+    """Find Home Depot stores. Lowe's store lookup is not implemented."""
     _engine.require_ready()
     return await _engine.find_stores(near, radius_miles=radius_miles, limit=limit)

--- a/sidecar/home_depot/sidecar.py
+++ b/sidecar/home_depot/sidecar.py
@@ -170,7 +170,13 @@ class BrowserBackedSearch:
         # is an in-page fetch, so the page has to already be on homedepot.com;
         # sharing a single page would mean re-warming on every site switch.
         self._site_pages: dict[str, Any] = {}
-        self._lock = asyncio.Lock()
+        # A lock per site, not one shared lock. Requests to one retailer must
+        # serialize against each other because they drive that retailer's single
+        # page, but they have no reason to block the other retailer. Sharing one
+        # lock made the Lowe's pre-warm (a homepage load, a click, and two settle
+        # waits, ~17s) hold off every Home Depot request right after startup,
+        # close to the client's 20s timeout.
+        self._locks: dict[str, asyncio.Lock] = {}
         self.state = "starting"
         """One of starting, ready, failed. Reported by /health."""
 
@@ -179,6 +185,18 @@ class BrowserBackedSearch:
 
         self._task: asyncio.Task[None] | None = None
         self._prewarm: asyncio.Task[None] | None = None
+
+    def _lock_for(self, site: str) -> asyncio.Lock:
+        """Return the per-site lock, creating it on first use.
+
+        Safe to create lazily: the event loop is single-threaded, so no two
+        coroutines can interleave between the lookup and the insert.
+        """
+        lock = self._locks.get(site)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[site] = lock
+        return lock
 
     def start_background(self) -> None:
         """Launch the browser without blocking the caller.
@@ -260,7 +278,7 @@ class BrowserBackedSearch:
     async def _prewarm_lowes(self) -> None:
         """Warm the Lowe's page in the background, tolerating failure."""
         try:
-            async with self._lock:
+            async with self._lock_for("lowes"):
                 await self._lowes_page()
         except Exception:
             logger.warning("lowes pre-warm failed; will warm on first use", exc_info=True)
@@ -271,30 +289,38 @@ class BrowserBackedSearch:
         Lowe's needs more than a homepage visit. Navigating to /search from a
         session warmed only by the homepage is refused with a 403 edge deny; one
         organic click into a category first, and the same navigation is served.
-        The click is the load-bearing step, so a failure to find a category link
-        is worth logging rather than swallowing.
+        The click is the load-bearing step, so a page that never got one is not
+        cached: keeping it would pin every later search to a session the edge
+        refuses, with no way back short of a restart. Discard it instead and let
+        the next request try the whole warm again.
         """
         page = self._site_pages.get("lowes")
         if page is not None:
             return page
 
         page = await self._ctx.new_page()
-        await page.goto(f"{lowes.ORIGIN}/", wait_until="domcontentloaded", timeout=90_000)
-        await page.wait_for_timeout(int(WARM_SECONDS * 1000))
-
-        clicked = False
         try:
-            link = page.locator("a[href*='/pl/']").first
-            if await link.count():
-                await link.click()
-                await page.wait_for_timeout(int(WARM_SECONDS * 1000))
-                clicked = True
-        except Exception:
-            logger.warning("lowes: organic warm click failed", exc_info=True)
-        if not clicked:
-            logger.warning("lowes: no category link to click; search will likely be denied")
+            await page.goto(f"{lowes.ORIGIN}/", wait_until="domcontentloaded", timeout=90_000)
+            await page.wait_for_timeout(int(WARM_SECONDS * 1000))
 
-        logger.info("lowes page warmed (clicked=%s): %s", clicked, await page.title())
+            clicked = False
+            try:
+                link = page.locator("a[href*='/pl/']").first
+                if await link.count():
+                    await link.click()
+                    await page.wait_for_timeout(int(WARM_SECONDS * 1000))
+                    clicked = True
+            except Exception:
+                logger.warning("lowes: organic warm click failed", exc_info=True)
+            if not clicked:
+                raise HTTPException(503, "Lowe's warm-up found no category link to click")
+
+            logger.info("lowes page warmed: %s", await page.title())
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await page.close()
+            raise
+
         self._site_pages["lowes"] = page
         return page
 
@@ -306,27 +332,30 @@ class BrowserBackedSearch:
         interval: a blanket wait cost about seven seconds per query for no
         benefit, against Home Depot's sub-second GraphQL call.
         """
-        async with self._lock:
+        async with self._lock_for("home_depot"):
             page = await self._lowes_page()
             await page.goto(
                 lowes.search_url(keyword), wait_until="domcontentloaded", timeout=90_000
             )
             html = await page.content()
+            state = lowes.extract_preloaded_state(html)
             for _ in range(int(LOWES_STATE_POLL_ATTEMPTS)):
-                if lowes.is_denied(html) or lowes.extract_preloaded_state(html) is not None:
+                if state is not None or lowes.is_denied(html):
                     break
                 await page.wait_for_timeout(LOWES_STATE_POLL_MS)
                 html = await page.content()
+                state = lowes.extract_preloaded_state(html)
 
-        if lowes.is_denied(html):
-            raise HTTPException(502, "Lowe's refused the search")
-        state = lowes.extract_preloaded_state(html)
+        # Prefer a payload we actually parsed over the "Access Denied" substring,
+        # which is a heuristic and could appear in legitimate page content.
         if state is None:
+            if lowes.is_denied(html):
+                raise HTTPException(502, "Lowe's refused the search")
             raise HTTPException(502, "Lowe's search page carried no result payload")
 
         return SearchResponse(
             keyword=keyword,
-            total_products=state.get("itemCount"),
+            total_products=lowes.total_products(state),
             used_nav_param=None,
             products=[Product(**p) for p in lowes.parse_products(state, page_size)],
         )
@@ -368,7 +397,7 @@ class BrowserBackedSearch:
         geocoding candidates instead of stores, so the first candidate's
         coordinates drive a second lookup.
         """
-        async with self._lock:
+        async with self._lock_for("home_depot"):
             data = await self._store_call(
                 {"address": near, "radius": str(radius_miles), "pagesize": str(limit)}
             )
@@ -393,7 +422,7 @@ class BrowserBackedSearch:
     async def search(
         self, keyword: str, *, store_id: str, zip_code: str, page_size: int
     ) -> SearchResponse:
-        async with self._lock:
+        async with self._lock_for("lowes"):
             model = await self._call(keyword, None, store_id, zip_code, page_size)
             used_nav: str | None = None
 

--- a/sidecar/home_depot/sidecar.py
+++ b/sidecar/home_depot/sidecar.py
@@ -170,6 +170,12 @@ class BrowserBackedSearch:
         # is an in-page fetch, so the page has to already be on homedepot.com;
         # sharing a single page would mean re-warming on every site switch.
         self._site_pages: dict[str, Any] = {}
+        # Consecutive Lowe's failures. A warmed page can go stale later (the edge
+        # starts denying, or stops embedding the payload), and keeping it would
+        # 502 every subsequent search until the process restarts. Discard after
+        # two in a row rather than one, so a single transient hiccup does not cost
+        # a ~20s re-warm.
+        self._lowes_failures = 0
         # A lock per site, not one shared lock. Requests to one retailer must
         # serialize against each other because they drive that retailer's single
         # page, but they have no reason to block the other retailer. Sharing one
@@ -275,6 +281,24 @@ class BrowserBackedSearch:
         await self._page.wait_for_timeout(int(WARM_SECONDS * 1000))
         logger.info("browser warmed: %s", await self._page.title())
 
+    async def _note_lowes_failure(self) -> None:
+        """Drop a Lowe's session that has failed repeatedly so the next call re-warms.
+
+        Without this, a page that warmed successfully but later went stale pins
+        every subsequent search to a 502 until the process restarts. The threshold
+        is two rather than one because a re-warm costs roughly twenty seconds, and
+        a lone transient failure is not worth paying that for.
+        """
+        self._lowes_failures += 1
+        if self._lowes_failures < 2:
+            return
+        page = self._site_pages.pop("lowes", None)
+        self._lowes_failures = 0
+        if page is not None:
+            logger.warning("lowes: discarding a stale session after repeated failures")
+            with contextlib.suppress(Exception):
+                await page.close()
+
     async def _prewarm_lowes(self) -> None:
         """Warm the Lowe's page in the background, tolerating failure."""
         try:
@@ -332,14 +356,14 @@ class BrowserBackedSearch:
         interval: a blanket wait cost about seven seconds per query for no
         benefit, against Home Depot's sub-second GraphQL call.
         """
-        async with self._lock_for("home_depot"):
+        async with self._lock_for("lowes"):
             page = await self._lowes_page()
             await page.goto(
                 lowes.search_url(keyword), wait_until="domcontentloaded", timeout=90_000
             )
             html = await page.content()
             state = lowes.extract_preloaded_state(html)
-            for _ in range(int(LOWES_STATE_POLL_ATTEMPTS)):
+            for _ in range(LOWES_STATE_POLL_ATTEMPTS):
                 if state is not None or lowes.is_denied(html):
                     break
                 await page.wait_for_timeout(LOWES_STATE_POLL_MS)
@@ -349,10 +373,12 @@ class BrowserBackedSearch:
         # Prefer a payload we actually parsed over the "Access Denied" substring,
         # which is a heuristic and could appear in legitimate page content.
         if state is None:
+            await self._note_lowes_failure()
             if lowes.is_denied(html):
                 raise HTTPException(502, "Lowe's refused the search")
             raise HTTPException(502, "Lowe's search page carried no result payload")
 
+        self._lowes_failures = 0
         return SearchResponse(
             keyword=keyword,
             total_products=lowes.total_products(state),
@@ -422,7 +448,7 @@ class BrowserBackedSearch:
     async def search(
         self, keyword: str, *, store_id: str, zip_code: str, page_size: int
     ) -> SearchResponse:
-        async with self._lock_for("lowes"):
+        async with self._lock_for("home_depot"):
             model = await self._call(keyword, None, store_id, zip_code, page_size)
             used_nav: str | None = None
 

--- a/tests/test_lowes_parsing.py
+++ b/tests/test_lowes_parsing.py
@@ -1,0 +1,155 @@
+"""Tests for the Lowe's preloaded-state parser.
+
+The parser lives in the sidecar (``sidecar/home_depot/lowes.py``), which is
+outside the installed package because it carries the browser stack. It is
+imported here by path so its pure functions still get covered: they are the part
+most likely to break when Lowe's changes its payload, and they need no browser.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "sidecar" / "home_depot" / "lowes.py"
+
+
+def _load_lowes() -> Any:
+    spec = importlib.util.spec_from_file_location("sidecar_lowes", _MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+lowes = _load_lowes()
+
+
+def _state(items: list[dict] | None = None, count: int = 39) -> dict:
+    if items is None:
+        items = [
+            {
+                "product": {
+                    "omniItemId": "3009537",
+                    "description": "3.5 Quarts Premixed All-purpose Drywall Joint Compound",
+                    "brand": "SHEETROCK Brand",
+                    "modelId": "385140",
+                    "pdURL": "/pd/SHEETROCK-Brand-3-5-Quart/3009537",
+                    "rating": 4.7,
+                    "reviewCount": 1284,
+                    "imageUrl": "https://mobileimages.lowes.com/a.jpg",
+                },
+                "location": {
+                    "price": {"sellingPrice": 13.26},
+                    "itemInventory": {
+                        "itemAvailList": [
+                            {"fullMtdMsg": "Parcel", "isAvlSts": False, "onhandQty": 0},
+                            {"fullMtdMsg": "Pickup", "isAvlSts": True, "onhandQty": 106},
+                        ]
+                    },
+                },
+            }
+        ]
+    return {"itemCount": count, "itemList": items}
+
+
+def _page(state: dict) -> str:
+    return (
+        "<html><body><script>window.Lowes = {}</script>"
+        f"<script>window['__PRELOADED_STATE__'] = {json.dumps(state)};</script>"
+        "</body></html>"
+    )
+
+
+class TestExtractPreloadedState:
+    def test_extracts_the_payload(self) -> None:
+        got = lowes.extract_preloaded_state(_page(_state()))
+        assert got is not None
+        assert got["itemCount"] == 39
+
+    def test_returns_none_without_the_marker(self) -> None:
+        assert lowes.extract_preloaded_state("<html><body>nothing here</body></html>") is None
+
+    def test_braces_inside_strings_do_not_end_the_object(self) -> None:
+        """Brace matching has to ignore braces that live inside JSON strings."""
+        state = _state()
+        state["itemList"][0]["product"]["description"] = 'Weird }{ name with "quotes" and {braces}'
+        got = lowes.extract_preloaded_state(_page(state))
+        assert got is not None
+        assert got["itemList"][0]["product"]["description"].startswith("Weird }{")
+
+    def test_trailing_markup_after_the_object_is_ignored(self) -> None:
+        html = _page(_state()) + "<script>window.other = {a: 1}</script>"
+        got = lowes.extract_preloaded_state(html)
+        assert got is not None and got["itemCount"] == 39
+
+    def test_returns_none_on_unparseable_payload(self) -> None:
+        html = "<script>window['__PRELOADED_STATE__'] = {not valid json,,};</script>"
+        assert lowes.extract_preloaded_state(html) is None
+
+
+class TestParseProducts:
+    def test_maps_every_field(self) -> None:
+        product = lowes.parse_products(_state(), 5)[0]
+        assert product["item_id"] == "3009537"
+        assert product["brand"] == "SHEETROCK Brand"
+        assert product["model_number"] == "385140"
+        assert product["price_dollars"] == 13.26
+        assert product["rating"] == 4.7
+        assert product["review_count"] == 1284
+        assert product["product_url"] == (
+            "https://www.lowes.com/pd/SHEETROCK-Brand-3-5-Quart/3009537"
+        )
+
+    def test_stock_takes_the_best_fulfilment_method(self) -> None:
+        """Availability is per method; any available method means in stock."""
+        product = lowes.parse_products(_state(), 5)[0]
+        assert product["in_stock"] is True
+        assert product["stock_quantity"] == 106
+
+    def test_out_of_stock_when_no_method_is_available(self) -> None:
+        state = _state()
+        state["itemList"][0]["location"]["itemInventory"]["itemAvailList"] = [
+            {"fullMtdMsg": "Pickup", "isAvlSts": False, "onhandQty": 0}
+        ]
+        product = lowes.parse_products(state, 5)[0]
+        assert product["in_stock"] is False
+
+    def test_unknown_stock_when_inventory_is_absent(self) -> None:
+        state = _state()
+        state["itemList"][0]["location"].pop("itemInventory")
+        product = lowes.parse_products(state, 5)[0]
+        assert product["in_stock"] is None
+        assert product["stock_quantity"] is None
+
+    def test_missing_price_is_none_rather_than_zero(self) -> None:
+        state = _state()
+        state["itemList"][0]["location"]["price"] = {}
+        assert lowes.parse_products(state, 5)[0]["price_dollars"] is None
+
+    def test_minimal_entry_does_not_raise(self) -> None:
+        product = lowes.parse_products({"itemList": [{}]}, 5)[0]
+        assert product["name"] == "Unknown product"
+        assert product["price_dollars"] is None
+
+    def test_respects_the_limit(self) -> None:
+        items = _state()["itemList"] * 10
+        assert len(lowes.parse_products({"itemList": items}, 3)) == 3
+
+    def test_empty_item_list(self) -> None:
+        assert lowes.parse_products({"itemList": []}, 5) == []
+
+
+class TestHelpers:
+    @pytest.mark.parametrize(
+        "keyword,expected",
+        [("putty knife", "searchTerm=putty+knife"), ("1/2 copper", "searchTerm=1%2F2+copper")],
+    )
+    def test_search_url_encodes_the_keyword(self, keyword: str, expected: str) -> None:
+        assert expected in lowes.search_url(keyword)
+
+    def test_is_denied_detects_the_edge_refusal(self) -> None:
+        assert lowes.is_denied("<H1>Access Denied</H1>") is True
+        assert lowes.is_denied(_page(_state())) is False

--- a/tests/test_lowes_parsing.py
+++ b/tests/test_lowes_parsing.py
@@ -196,6 +196,23 @@ class TestPayloadShapeChanges:
         ]
         assert lowes.parse_products(state, 5)[0]["stock_quantity"] == 106
 
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), "NaN", "Infinity", "-Infinity"])
+    def test_non_finite_numbers_are_rejected(self, bad: object) -> None:
+        """json.loads accepts bare NaN/Infinity, and both used to 500 the search."""
+        assert lowes.total_products({"itemCount": bad}) is None
+        state = _state()
+        state["itemList"][0]["product"]["rating"] = bad
+        state["itemList"][0]["product"]["reviewCount"] = bad
+        state["itemList"][0]["location"]["price"]["sellingPrice"] = bad
+        state["itemList"][0]["location"]["itemInventory"]["itemAvailList"] = [
+            {"fullMtdMsg": "Pickup", "isAvlSts": True, "onhandQty": bad}
+        ]
+        product = lowes.parse_products(state, 5)[0]
+        assert product["rating"] is None
+        assert product["review_count"] is None
+        assert product["price_dollars"] is None
+        assert product["stock_quantity"] is None
+
     def test_review_count_from_a_float_becomes_an_int(self) -> None:
         state = _state()
         state["itemList"][0]["product"]["reviewCount"] = 1284.0

--- a/tests/test_lowes_parsing.py
+++ b/tests/test_lowes_parsing.py
@@ -142,6 +142,66 @@ class TestParseProducts:
         assert lowes.parse_products({"itemList": []}, 5) == []
 
 
+class TestPayloadShapeChanges:
+    """Guards for the ways a payload change could break this quietly."""
+
+    @pytest.mark.parametrize(
+        "assignment",
+        [
+            "window['__PRELOADED_STATE__'] = ",
+            'window["__PRELOADED_STATE__"] = ',
+            "window.__PRELOADED_STATE__ = ",
+        ],
+    )
+    def test_all_assignment_forms_are_accepted(self, assignment: str) -> None:
+        """A minifier switching quote style must not silently break search."""
+        html = f"<script>{assignment}{json.dumps(_state())};</script>"
+        got = lowes.extract_preloaded_state(html)
+        assert got is not None and got["itemCount"] == 39
+
+    @pytest.mark.parametrize("bad", ["not-a-number", None, True, [], {}])
+    def test_total_products_coerces_unusable_values_to_none(self, bad: object) -> None:
+        """Reaches a pydantic model, so junk must not 500 the sidecar."""
+        assert lowes.total_products({"itemCount": bad}) is None
+
+    def test_total_products_accepts_a_numeric_string(self) -> None:
+        """Lowe's ships some numbers as strings, so those must survive."""
+        assert lowes.total_products({"itemCount": "39"}) == 39
+
+    def test_total_products_reads_a_real_count(self) -> None:
+        assert lowes.total_products({"itemCount": 39}) == 39
+
+    @pytest.mark.parametrize("bad", ["n/a", None, True, {}])
+    def test_rating_and_reviews_coerce_unusable_values(self, bad: object) -> None:
+        state = _state()
+        state["itemList"][0]["product"]["rating"] = bad
+        state["itemList"][0]["product"]["reviewCount"] = bad
+        product = lowes.parse_products(state, 5)[0]
+        assert product["rating"] is None
+        assert product["review_count"] is None
+
+    def test_rating_and_reviews_arrive_as_strings_in_the_real_payload(self) -> None:
+        """Lowe's really does send these as strings; rejecting them lost real data."""
+        state = _state()
+        state["itemList"][0]["product"]["rating"] = "4.7"
+        state["itemList"][0]["product"]["reviewCount"] = "4076"
+        product = lowes.parse_products(state, 5)[0]
+        assert product["rating"] == 4.7
+        assert product["review_count"] == 4076
+
+    def test_stock_quantity_survives_a_string_count(self) -> None:
+        state = _state()
+        state["itemList"][0]["location"]["itemInventory"]["itemAvailList"] = [
+            {"fullMtdMsg": "Pickup", "isAvlSts": True, "onhandQty": "106"}
+        ]
+        assert lowes.parse_products(state, 5)[0]["stock_quantity"] == 106
+
+    def test_review_count_from_a_float_becomes_an_int(self) -> None:
+        state = _state()
+        state["itemList"][0]["product"]["reviewCount"] = 1284.0
+        assert lowes.parse_products(state, 5)[0]["review_count"] == 1284
+
+
 class TestHelpers:
     @pytest.mark.parametrize(
         "keyword,expected",

--- a/tests/test_pricing_tools.py
+++ b/tests/test_pricing_tools.py
@@ -430,8 +430,8 @@ class TestSupplierSearchTool:
 
         from backend.app.integrations.supplier_pricing.factory import _create_pricing_tools
 
-        # Drive the SerpApi backend directly by leaving the sidecar out.
-        tools = _create_pricing_tools(None, mock_supplier, cache)
+        # Drive the SerpApi backend directly by configuring no sidecars.
+        tools = _create_pricing_tools({}, mock_supplier, cache)
         tool_fn = tools[0].function
         return tool_fn, mock_supplier, cache
 

--- a/tests/test_sidecar_locks.py
+++ b/tests/test_sidecar_locks.py
@@ -1,0 +1,186 @@
+"""Tests for the sidecar's per-site locking and stale-session recovery.
+
+The sidecar lives outside the installed package because it carries the browser
+stack, and it was previously assumed untestable for that reason. It is not:
+stubbing ``patchright.async_api`` in ``sys.modules`` is enough to import it with
+no browser and no extra dependency. That assumption is what let a transposed
+lock mapping ship, so the mapping is asserted here directly.
+
+Two properties matter, and one of them is not obvious:
+
+* Requests for one retailer must serialize against each other, because they
+  drive that retailer's single page.
+* Requests for different retailers must not, or the Lowe's pre-warm (a homepage
+  load, a click, and two settle waits) blocks every Home Depot request for
+  roughly 20 seconds right after startup.
+"""
+
+import ast
+import asyncio
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SIDECAR_DIR = Path(__file__).resolve().parents[1] / "sidecar" / "home_depot"
+
+
+def _load_sidecar() -> Any:
+    """Import the sidecar module with the browser stack stubbed out."""
+    stub_root = types.ModuleType("patchright")
+    stub_api = types.ModuleType("patchright.async_api")
+    stub_api.async_playwright = lambda: None  # type: ignore[attr-defined]
+    stub_root.async_api = stub_api  # type: ignore[attr-defined]
+
+    saved = {k: sys.modules.get(k) for k in ("patchright", "patchright.async_api")}
+    sys.modules["patchright"] = stub_root
+    sys.modules["patchright.async_api"] = stub_api
+    sys.path.insert(0, str(_SIDECAR_DIR))
+    try:
+        import importlib
+
+        module = importlib.import_module("sidecar")
+        return importlib.reload(module)
+    finally:
+        sys.path.remove(str(_SIDECAR_DIR))
+        for key, value in saved.items():
+            if value is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+
+sidecar = _load_sidecar()
+
+
+def _lock_site_by_function() -> dict[str, str]:
+    """Read which site each method locks, straight from the source.
+
+    Parsed rather than executed so the assertion cannot be satisfied by a mock:
+    the previous defect was a literal string in the wrong function body.
+    """
+    tree = ast.parse((_SIDECAR_DIR / "sidecar.py").read_text())
+    found: dict[str, str] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            continue
+        for inner in ast.walk(node):
+            call = None
+            if isinstance(inner, ast.Call):
+                call = inner
+            if call is None or not isinstance(call.func, ast.Attribute):
+                continue
+            if call.func.attr != "_lock_for" or not call.args:
+                continue
+            arg = call.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                found[node.name] = arg.value
+    return found
+
+
+class TestLockMapping:
+    def test_each_method_locks_its_own_retailer(self) -> None:
+        """A transposed mapping shipped once; assert it explicitly."""
+        assert _lock_site_by_function() == {
+            "_prewarm_lowes": "lowes",
+            "search_lowes": "lowes",
+            "search": "home_depot",
+            "find_stores": "home_depot",
+        }
+
+    def test_lock_for_returns_a_stable_lock_per_site(self) -> None:
+        engine = sidecar.BrowserBackedSearch()
+        assert engine._lock_for("lowes") is engine._lock_for("lowes")
+        assert engine._lock_for("lowes") is not engine._lock_for("home_depot")
+
+
+class TestLockIsolation:
+    @pytest.mark.asyncio
+    async def test_one_retailer_does_not_block_the_other(self) -> None:
+        """The Lowe's warm must not hold up Home Depot; that regression shipped."""
+        engine = sidecar.BrowserBackedSearch()
+        released = asyncio.Event()
+
+        async def hold_lowes() -> None:
+            async with engine._lock_for("lowes"):
+                await released.wait()
+
+        holder = asyncio.create_task(hold_lowes())
+        await asyncio.sleep(0)  # let it take the lock
+
+        # Home Depot's lock must be free while Lowe's is held.
+        await asyncio.wait_for(engine._lock_for("home_depot").acquire(), timeout=0.5)
+        engine._lock_for("home_depot").release()
+
+        released.set()
+        await holder
+
+    @pytest.mark.asyncio
+    async def test_same_retailer_still_serializes(self) -> None:
+        """Both Home Depot entry points drive one page, so they must exclude."""
+        engine = sidecar.BrowserBackedSearch()
+        async with engine._lock_for("home_depot"):
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(engine._lock_for("home_depot").acquire(), timeout=0.1)
+
+
+class TestStaleSessionRecovery:
+    """A warmed Lowe's page can go stale; it must not pin every later search."""
+
+    @staticmethod
+    def _engine_with_page() -> tuple[Any, Any]:
+        engine = sidecar.BrowserBackedSearch()
+        closed: list[bool] = []
+
+        class FakePage:
+            async def close(self) -> None:
+                closed.append(True)
+
+        page = FakePage()
+        engine._site_pages["lowes"] = page
+        return engine, closed
+
+    @pytest.mark.asyncio
+    async def test_one_failure_keeps_the_session(self) -> None:
+        """A re-warm costs ~20s, so a lone transient failure should not trigger it."""
+        engine, closed = self._engine_with_page()
+
+        await engine._note_lowes_failure()
+
+        assert "lowes" in engine._site_pages
+        assert closed == []
+
+    @pytest.mark.asyncio
+    async def test_two_consecutive_failures_discard_the_session(self) -> None:
+        engine, closed = self._engine_with_page()
+
+        await engine._note_lowes_failure()
+        await engine._note_lowes_failure()
+
+        assert "lowes" not in engine._site_pages, "a stale page must not be reused"
+        assert closed == [True], "the discarded page must be closed, not leaked"
+
+    @pytest.mark.asyncio
+    async def test_the_counter_resets_after_discarding(self) -> None:
+        """Otherwise the next single failure would discard a freshly warmed page."""
+        engine, _ = self._engine_with_page()
+        await engine._note_lowes_failure()
+        await engine._note_lowes_failure()
+        assert engine._lowes_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_discarding_survives_a_page_that_fails_to_close(self) -> None:
+        engine = sidecar.BrowserBackedSearch()
+
+        class ExplodingPage:
+            async def close(self) -> None:
+                raise RuntimeError("browser already gone")
+
+        engine._site_pages["lowes"] = ExplodingPage()
+        await engine._note_lowes_failure()
+        await engine._note_lowes_failure()
+
+        assert "lowes" not in engine._site_pages

--- a/tests/test_sidecar_supplier.py
+++ b/tests/test_sidecar_supplier.py
@@ -429,6 +429,73 @@ class TestLowesRouting:
         lowes.search_products.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_lowes_results_are_not_labelled_with_the_users_zip(self) -> None:
+        """Lowe's ignores the zip, so claiming it would mislead about local stock."""
+        lowes = self._backend("lowes")
+        lowes.search_products = AsyncMock(
+            return_value=[
+                ProductResult(
+                    supplier="lowes",
+                    product_id="1",
+                    name="Joint Compound",
+                    price_dollars=13.26,
+                    in_stock=True,
+                    stock_quantity=106,
+                )
+            ]
+        )
+        search = self._tools({"lowes": lowes}, None)["supplier_search_products"]
+
+        result = await search(query="joint compound", zip_code="30301", supplier="lowes")
+
+        assert "zip 30301" not in result.content
+        assert "not localized to your zip" in result.content
+
+    @pytest.mark.asyncio
+    async def test_home_depot_results_keep_the_zip_label(self) -> None:
+        hd = self._backend("homedepot")
+        hd.search_products = AsyncMock(
+            return_value=[
+                ProductResult(
+                    supplier="homedepot",
+                    product_id="1",
+                    name="Joint Compound",
+                    price_dollars=6.98,
+                    in_stock=True,
+                    stock_quantity=24,
+                )
+            ]
+        )
+        search = self._tools({"home_depot": hd}, None)["supplier_search_products"]
+
+        result = await search(query="joint compound", zip_code="30301", supplier="home_depot")
+
+        assert "zip 30301" in result.content
+        assert "not localized" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_lowes_cache_ignores_the_zip(self) -> None:
+        """The zip cannot change a Lowe's answer, so it must not fragment the cache."""
+        lowes = self._backend("lowes")
+        search = self._tools({"lowes": lowes}, None)["supplier_search_products"]
+
+        await search(query="drill", zip_code="30301", supplier="lowes")
+        await search(query="drill", zip_code="99999", supplier="lowes")
+
+        lowes.search_products.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_serpapi_alone_cannot_serve_a_lowes_request(self) -> None:
+        """Falling back would return Home Depot prices labelled as Lowe's."""
+        serpapi = self._backend("homedepot")
+        search = self._tools({}, serpapi)["supplier_search_products"]
+
+        result = await search(query="drill", zip_code="30301", supplier="lowes")
+
+        assert result.is_error
+        serpapi.search_products.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_store_lookup_uses_home_depot_even_when_lowes_present(self) -> None:
         hd, lowes = self._backend("homedepot"), self._backend("lowes")
         hd.find_stores = AsyncMock(return_value=[])

--- a/tests/test_sidecar_supplier.py
+++ b/tests/test_sidecar_supplier.py
@@ -1,9 +1,10 @@
-"""Tests for the browser-sidecar Home Depot backend and the backend chain.
+"""Tests for the browser-sidecar supplier client and the backend chain.
 
 The sidecar itself drives a real browser and is exercised by hand (see
 sidecar/home_depot/README.md). What is covered here is the client that calls it,
-for both product search and store lookup, plus the fall-through order the
-factory builds: sidecar -> SerpApi for product search, sidecar-only for stores.
+for product search and store lookup at both retailers, plus the fall-through the
+factory builds: sidecar then SerpApi for Home Depot, sidecar only for Lowe's
+(SerpApi has no Lowe's engine) and for store lookup.
 """
 
 from collections.abc import Awaitable, Callable
@@ -19,12 +20,12 @@ from backend.app.integrations.supplier_pricing.factory import (
     _create_pricing_tools,
     _pricing_factory,
 )
-from backend.app.integrations.supplier_pricing.homedepot_sidecar import HomeDepotSidecarSupplier
 from backend.app.integrations.supplier_pricing.protocol import (
     Location,
     ProductResult,
     StoreResult,
 )
+from backend.app.integrations.supplier_pricing.sidecar_client import SidecarSupplier
 
 SIDECAR_URL = "http://sidecar.test:8899"
 
@@ -75,10 +76,10 @@ class TestSidecarClient:
     @pytest.mark.asyncio
     async def test_search_maps_products(self) -> None:
         client = _client_returning(_response(200, _payload()))
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL)
+        supplier = SidecarSupplier(SIDECAR_URL)
 
         with patch(
-            "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+            "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
             return_value=client,
         ):
             results = await supplier.search_products("cordless drill", Location(zip_code="30301"))
@@ -97,10 +98,10 @@ class TestSidecarClient:
     @pytest.mark.asyncio
     async def test_search_forwards_query_params(self) -> None:
         client = _client_returning(_response(200, _payload()))
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL)
+        supplier = SidecarSupplier(SIDECAR_URL)
 
         with patch(
-            "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+            "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
             return_value=client,
         ):
             await supplier.search_products(
@@ -108,15 +109,21 @@ class TestSidecarClient:
             )
 
         params = client.get.call_args.kwargs["params"]
-        assert params == {"q": "drill", "zip": "30301", "store_id": "4136", "limit": "3"}
+        assert params == {
+            "q": "drill",
+            "site": "home_depot",
+            "zip": "30301",
+            "store_id": "4136",
+            "limit": "3",
+        }
 
     @pytest.mark.asyncio
     async def test_bearer_token_is_sent_when_configured(self) -> None:
         client = _client_returning(_response(200, _payload()))
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL, token="s3cret")
+        supplier = SidecarSupplier(SIDECAR_URL, token="s3cret")
 
         with patch(
-            "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+            "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
             return_value=client,
         ):
             await supplier.search_products("drill", Location(zip_code="30301"))
@@ -126,10 +133,10 @@ class TestSidecarClient:
     @pytest.mark.asyncio
     async def test_no_auth_header_without_token(self) -> None:
         client = _client_returning(_response(200, _payload()))
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL)
+        supplier = SidecarSupplier(SIDECAR_URL)
 
         with patch(
-            "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+            "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
             return_value=client,
         ):
             await supplier.search_products("drill", Location(zip_code="30301"))
@@ -139,10 +146,10 @@ class TestSidecarClient:
     @pytest.mark.asyncio
     async def test_trailing_slash_in_base_url_is_normalised(self) -> None:
         client = _client_returning(_response(200, _payload()))
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL + "/")
+        supplier = SidecarSupplier(SIDECAR_URL + "/")
 
         with patch(
-            "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+            "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
             return_value=client,
         ):
             await supplier.search_products("drill", Location(zip_code="30301"))
@@ -153,10 +160,10 @@ class TestSidecarClient:
     async def test_truncates_to_max_results(self) -> None:
         many = [dict(_payload()["products"][0], item_id=str(i)) for i in range(10)]
         client = _client_returning(_response(200, _payload(many)))
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL)
+        supplier = SidecarSupplier(SIDECAR_URL)
 
         with patch(
-            "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+            "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
             return_value=client,
         ):
             results = await supplier.search_products(
@@ -172,11 +179,11 @@ class TestSidecarClient:
         client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
         client.__aenter__ = AsyncMock(return_value=client)
         client.__aexit__ = AsyncMock(return_value=False)
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL)
+        supplier = SidecarSupplier(SIDECAR_URL)
 
         with (
             patch(
-                "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+                "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
                 return_value=client,
             ),
             pytest.raises(SupplierUnavailableError),
@@ -186,11 +193,11 @@ class TestSidecarClient:
     @pytest.mark.asyncio
     async def test_error_status_raises_blocked(self) -> None:
         client = _client_returning(_response(502, {"detail": "browser died"}))
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL)
+        supplier = SidecarSupplier(SIDECAR_URL)
 
         with (
             patch(
-                "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+                "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
                 return_value=client,
             ),
             pytest.raises(SupplierUnavailableError),
@@ -199,11 +206,11 @@ class TestSidecarClient:
 
     @pytest.mark.asyncio
     async def test_healthy_reflects_sidecar_state(self) -> None:
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL)
+        supplier = SidecarSupplier(SIDECAR_URL)
         for body, expected in (({"ok": True}, True), ({"ok": False}, False)):
             client = _client_returning(_response(200, body))
             with patch(
-                "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+                "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
                 return_value=client,
             ):
                 assert await supplier.healthy() is expected
@@ -214,10 +221,10 @@ class TestSidecarClient:
         client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
         client.__aenter__ = AsyncMock(return_value=client)
         client.__aexit__ = AsyncMock(return_value=False)
-        supplier = HomeDepotSidecarSupplier(SIDECAR_URL)
+        supplier = SidecarSupplier(SIDECAR_URL)
 
         with patch(
-            "backend.app.integrations.supplier_pricing.homedepot_sidecar.httpx.AsyncClient",
+            "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
             return_value=client,
         ):
             assert await supplier.healthy() is False
@@ -228,7 +235,8 @@ class TestBackendChain:
 
     @staticmethod
     def _tools(sidecar: object, serpapi: object) -> dict[str, Callable[..., Awaitable[ToolResult]]]:
-        tools = _create_pricing_tools(sidecar, serpapi, SupplierCache())  # type: ignore[arg-type]
+        sidecars = {"home_depot": sidecar} if sidecar is not None else {}
+        tools = _create_pricing_tools(sidecars, serpapi, SupplierCache())  # type: ignore[arg-type]
         return {t.name: t.function for t in tools}
 
     @classmethod
@@ -330,6 +338,107 @@ class TestBackendChain:
 
         assert result.is_error
         assert result.error_kind is ToolErrorKind.SERVICE
+
+
+class TestLowesRouting:
+    """Lowe's shares the client and sidecar; only the `site` parameter differs."""
+
+    @staticmethod
+    def _tools(sidecars: dict, serpapi: object) -> dict[str, Callable[..., Awaitable[ToolResult]]]:
+        tools = _create_pricing_tools(sidecars, serpapi, SupplierCache())  # type: ignore[arg-type]
+        return {t.name: t.function for t in tools}
+
+    @staticmethod
+    def _backend(name: str, blocked: bool = False) -> AsyncMock:
+        backend = AsyncMock()
+        if blocked:
+            backend.search_products = AsyncMock(side_effect=SupplierUnavailableError(name))
+        else:
+            backend.search_products = AsyncMock(
+                return_value=[ProductResult(supplier=name, product_id="1", name=f"{name}-item")]
+            )
+        return backend
+
+    @pytest.mark.asyncio
+    async def test_site_is_forwarded_to_the_sidecar(self) -> None:
+        client = _client_returning(_response(200, _payload()))
+        supplier = SidecarSupplier(SIDECAR_URL, site="lowes", name="lowes", display_name="Lowe's")
+
+        with patch(
+            "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
+            return_value=client,
+        ):
+            results = await supplier.search_products("drill", Location(zip_code="30301"))
+
+        assert client.get.call_args.kwargs["params"]["site"] == "lowes"
+        # Results are attributed to the retailer that produced them.
+        assert results[0].supplier == "lowes"
+
+    @pytest.mark.asyncio
+    async def test_supplier_argument_selects_the_backend(self) -> None:
+        hd, lowes = self._backend("homedepot"), self._backend("lowes")
+        search = self._tools({"home_depot": hd, "lowes": lowes}, None)["supplier_search_products"]
+
+        await search(query="drill", zip_code="30301", supplier="lowes")
+
+        lowes.search_products.assert_awaited_once()
+        hd.search_products.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lowes_does_not_fall_back_to_serpapi(self) -> None:
+        """SerpApi has no Lowe's engine, so falling back would return the wrong retailer."""
+        lowes = self._backend("lowes", blocked=True)
+        serpapi = self._backend("homedepot")
+        search = self._tools({"lowes": lowes}, serpapi)["supplier_search_products"]
+
+        result = await search(query="drill", zip_code="30301", supplier="lowes")
+
+        assert result.is_error
+        assert result.error_kind is ToolErrorKind.SERVICE
+        serpapi.search_products.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_home_depot_still_falls_back_to_serpapi(self) -> None:
+        hd = self._backend("homedepot", blocked=True)
+        serpapi = self._backend("from-serpapi")
+        search = self._tools({"home_depot": hd}, serpapi)["supplier_search_products"]
+
+        result = await search(query="drill", zip_code="30301", supplier="home_depot")
+
+        assert not result.is_error
+        serpapi.search_products.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_retailer_name_appears_in_output(self) -> None:
+        search = self._tools({"lowes": self._backend("lowes")}, None)["supplier_search_products"]
+
+        result = await search(query="drill", zip_code="30301", supplier="lowes")
+
+        assert "Lowe's" in result.content
+
+    @pytest.mark.asyncio
+    async def test_cache_is_keyed_per_retailer(self) -> None:
+        """The same query at two retailers must not share a cached answer."""
+        hd, lowes = self._backend("homedepot"), self._backend("lowes")
+        search = self._tools({"home_depot": hd, "lowes": lowes}, None)["supplier_search_products"]
+
+        await search(query="drill", zip_code="30301", supplier="home_depot")
+        await search(query="drill", zip_code="30301", supplier="lowes")
+
+        hd.search_products.assert_awaited_once()
+        lowes.search_products.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_store_lookup_uses_home_depot_even_when_lowes_present(self) -> None:
+        hd, lowes = self._backend("homedepot"), self._backend("lowes")
+        hd.find_stores = AsyncMock(return_value=[])
+        lowes.find_stores = AsyncMock(return_value=[])
+        tools = self._tools({"home_depot": hd, "lowes": lowes}, None)
+
+        await tools["supplier_find_stores"](near="30301")
+
+        hd.find_stores.assert_awaited_once()
+        lowes.find_stores.assert_not_called()
 
 
 class TestFactoryBuildsChain:


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds Lowe's product search alongside Home Depot. One sidecar process serves both retailers behind a `site` parameter, and the agent chooses with a new `supplier` argument on `supplier_search_products`.

Fixes #1475.

The issue predicted this would be "the same shape" as Home Depot because both sites serve the same Akamai marker. That was too shallow a read, and the two differences are the interesting part.

### Warming needs a real click

Navigating to `/search` from a session warmed only by the homepage is refused with a 403 Akamai edge deny (`errors.edgesuite.net`, `Reference #18.…`). One organic click into a category first, and the same navigation is served.

Ruled out before finding it, each measured rather than reasoned about:

| Hypothesis | Result |
|---|---|
| Burned profile / fresh profile | denied either way |
| Cookies cleared mid-session | denied |
| `X11; Linux` User-Agent | denied with macOS UA too |
| Client hints, overridden via CDP to a coherent macOS identity | denied |
| Navigation vs in-page XHR | denied |
| `/search?`, `/Search=`, `/store/api/search` | all denied |
| Egress IP | identical to the client being offered a solvable challenge |

### There is no product API to call

Home Depot answers a GraphQL fetch issued from inside the page. Lowe's equivalent, `/store/api/search`, sits behind the same deny. Results therefore come from `window['__PRELOADED_STATE__']`, which the page server-renders: ~400KB carrying `itemList` with price, per-store on-hand quantity, brand, model, rating and review count.

That is sturdier than DOM selectors, which was the fragility worry raised before starting. It also avoids a trap: a DOM scrape picks up the "Previously Viewed" carousel and silently returns items from *earlier queries*. Every early attempt returned the same Trex decking item regardless of what was searched.

Parsing is brace-matched rather than regex-terminated, since the payload contains braces inside strings. There is a test for exactly that case.

## Two performance bugs found while verifying

**A fixed 7-second settle after navigation**, pointless because the payload is server-rendered. Replaced with a poll: **8s down to 1.4s** per query.

**A 19-second cold start** on the first Lowe's query, from the homepage-plus-click warm. Now pre-warmed in the background once Home Depot reports ready, so no user pays it. Confirmed by `lowes page warmed (clicked=True)` at startup.

Measured after both fixes: **Home Depot 0.8s, Lowe's 1.2 to 1.9s.**

## Deliberate choices

**No SerpApi fallback for Lowe's.** SerpApi has no Lowe's engine, so falling through would return Home Depot prices labelled as Lowe's. A Lowe's failure reports itself instead. Covered by a test.

**The sidecar directory keeps its `home_depot` name** despite now serving both retailers. Renaming would change the published GHCR image name and break deployments pointing at it, which is not worth paying for a name. Noted in the README.

**Store lookup stays Home Depot only.** Lowe's has no locator implemented here.

## Verification

Live, through the real agent tool, against both retailers:

```
Lowe's       $13.26  SHEETROCK Brand  3.5 Quarts Premixed Joint Compound  stock=True(106)
Home Depot   $6.98   DAP              DryDex 32 oz Joint Compound         stock=True(24)
```

Also checked: `putty knife`, `copper pipe`, `deck screws`, `romex 12-2` all return relevant products with prices and stock. Home Depot search and store lookup were re-tested for regressions, and an invalid `site` value is rejected with a 422.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`): 3029 passed, 2 skipped
- [x] Lint passes (`ruff check` and `ruff format --check` over `backend/ tests/ alembic/ sidecar/`), plus `ty`, and frontend `typecheck` / `deadcode`
- [x] New tests added for new functionality: 16 for the state parser, 7 for retailer routing
- [ ] Bug fixes include regression tests (n/a, this is a feature; the two performance bugs were introduced and fixed within it)

No OpenAPI drift. The sidecar's browser paths are exercised by hand rather than in CI, since they need a real browser; the parser and the client are unit tested.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Written with Claude Code: protocol reverse engineering, implementation, and tests. Worth recording that Claude twice concluded Lowe's was infeasible and was wrong both times, first calling it the same shape as Home Depot and then calling it closed entirely. @njbrake's instruction to keep going is what produced the working result, and his question about whether a category map would rot is what led to the autocomplete taxonomy finding, which turned out to be unnecessary once search itself worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added Lowe’s product search through the existing shared sidecar.
- Added the `supplier` argument to `supplier_search_products`.
- Added Lowe’s product, price, rating, review, and stock parsing.
- Added retailer-specific routing, caching, errors, and status reporting.
- Kept SerpApi fallback and store lookup limited to Home Depot.
- Added isolated browser warming and locks for each retailer.
- Included Lowe’s in the Docker image and registry metadata.
- Added parser, routing, fallback, caching, and validation tests.
- Updated sidecar and configuration documentation.

## Benefits

- Users can search products from Home Depot or Lowe’s.
- Lowe’s failures cannot return incorrect Home Depot results.
- Shared infrastructure avoids duplicated retailer integrations.
- Retailer-specific behavior remains clear and testable.
- Deployment includes all required Lowe’s components.

## Potential follow-up

- Add Lowe’s store lookup if a stable supported interface becomes available.
- Monitor Lowe’s embedded page-state format for future changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->