### PR TITLE
fix(llm): only stamp cache_control for providers that honor it

### DIFF
--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -367,7 +367,7 @@ async def compact_session(
     messages: list[dict[str, Any]] = [
         {"role": "user", "content": "\n".join(user_prompt_parts)},
     ]
-    compaction_system = prepare_system_with_caching(COMPACTION_SYSTEM_PROMPT)
+    compaction_system = prepare_system_with_caching(COMPACTION_SYSTEM_PROMPT, provider)
     compaction_thinking = reasoning_effort_to_thinking(settings.reasoning_effort)
 
     started_at = datetime.datetime.now(UTC)

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -614,20 +614,20 @@ class ClawboltAgent:
         await self._send_typing_indicator()
         effective_max_tokens = max_tokens or settings.llm_max_tokens_agent
         system_str, msg_dicts = messages_to_messages_api(messages)
-        msg_dicts = apply_history_cache_breakpoint(msg_dicts)
+        effective_model = self._llm_model_override or settings.llm_model
+        effective_provider = self._llm_provider_override or settings.llm_provider
+        msg_dicts = apply_history_cache_breakpoint(msg_dicts, effective_provider)
         # Rounds N > 0 end in tool results: mark the trailing block so the
         # current turn plus prior rounds read from cache instead of being
         # re-sent as fresh input every round (issue #1430). No-op on round 0.
-        msg_dicts = apply_in_turn_cache_breakpoint(msg_dicts)
+        msg_dicts = apply_in_turn_cache_breakpoint(msg_dicts, effective_provider)
         system: str | list[dict[str, Any]] | None = system_str
         if system is not None:
-            system = prepare_system_with_caching(system)
+            system = prepare_system_with_caching(system, effective_provider)
         if tool_schemas:
-            tool_schemas = apply_tool_caching(tool_schemas)
+            tool_schemas = apply_tool_caching(tool_schemas, effective_provider)
         tool_count = len(tool_schemas) if tool_schemas else 0
         thinking = reasoning_effort_to_thinking(settings.reasoning_effort)
-        effective_model = self._llm_model_override or settings.llm_model
-        effective_provider = self._llm_provider_override or settings.llm_provider
         logger.debug(
             "Calling LLM: model=%s provider=%s messages=%d tools=%d max_tokens=%d",
             effective_model,
@@ -758,10 +758,12 @@ class ClawboltAgent:
             len(trim_result.messages),
         )
         retry_system_str, trimmed_dicts = messages_to_messages_api(trim_result.messages)
-        trimmed_dicts = apply_history_cache_breakpoint(trimmed_dicts)
-        trimmed_dicts = apply_in_turn_cache_breakpoint(trimmed_dicts)
+        trimmed_dicts = apply_history_cache_breakpoint(trimmed_dicts, effective_provider)
+        trimmed_dicts = apply_in_turn_cache_breakpoint(trimmed_dicts, effective_provider)
         system = (
-            prepare_system_with_caching(retry_system_str) if retry_system_str is not None else None
+            prepare_system_with_caching(retry_system_str, effective_provider)
+            if retry_system_str is not None
+            else None
         )
         followup_started_at = datetime.now(UTC)
         await emit_llm_request(

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -456,7 +456,7 @@ async def evaluate_heartbeat_need(
     time_context = build_time_user_context(user)
     max_retries = settings.llm_max_retries
     response: MessageResponse | None = None
-    heartbeat_system = prepare_system_with_caching(prompt)
+    heartbeat_system = prepare_system_with_caching(prompt, provider)
     heartbeat_messages: list[dict[str, Any]] = [
         {
             "role": "user",

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -128,7 +128,7 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
             model=model,
             provider=provider,
             api_base=settings.llm_api_base,
-            system=prepare_system_with_caching(VISION_SYSTEM_PROMPT),
+            system=prepare_system_with_caching(VISION_SYSTEM_PROMPT, provider),
             messages=[
                 {"role": "user", "content": user_content},
             ],

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -45,6 +45,33 @@ _LOCAL_PROVIDERS = {"ollama", "llamafile", "llamacpp", "lmstudio", "vllm"}
 # Meta-providers that proxy to other providers and should not be directly selectable.
 _HIDDEN_PROVIDERS = {"platform", "gateway"}
 
+# Providers that serve the Anthropic Messages API natively, so a ``cache_control``
+# marker survives to the wire. Every other provider goes through any-llm's
+# Messages-to-Completions bridge, which rebuilds user, assistant and tool blocks
+# (silently dropping their markers) and forwards a block-list ``system`` verbatim
+# into ``messages[0].content``, where a strict OpenAI-compatible backend rejects
+# the whole request (Fireworks answers 400 "Input should be a valid string,
+# field: 'messages[0].content.str'"). See any-llm#1228.
+#
+# Gateway providers are deliberately absent even though any-llm's ``otari``
+# provider forwards Messages natively: whether the markers are honored then
+# depends on the gateway's downstream provider, which is encoded in the model
+# string rather than the provider name. Sending markers we cannot verify fails
+# closed as a 400, while omitting them only forgoes caching, so the fail-safe
+# choice is to omit.
+_CACHE_CONTROL_PROVIDERS = {"anthropic", "azureanthropic", "vertexaianthropic"}
+
+
+def provider_honors_cache_control(provider: str) -> bool:
+    """True when *provider* delivers Anthropic ``cache_control`` markers to the wire.
+
+    Gates every cache breakpoint the agent stamps. Marking a prompt for a provider
+    that cannot honor it is never merely wasteful: the ``system`` breakpoint makes
+    the request unserializable for strict OpenAI-compatible backends, so the marker
+    has to be withheld rather than stamped and ignored.
+    """
+    return provider.lower() in _CACHE_CONTROL_PROVIDERS
+
 
 def is_local_provider(provider: str) -> bool:
     """True when *provider* runs on the operator's own machine and needs no key.
@@ -146,7 +173,7 @@ def _cache_control() -> dict[str, Any]:
     return {"type": "ephemeral"}
 
 
-def prepare_system_with_caching(system: str) -> list[dict[str, Any]]:
+def prepare_system_with_caching(system: str, provider: str) -> str | list[dict[str, Any]]:
     """Wrap a system prompt string as a single cache-marked content block.
 
     The whole system string is stable across turns: the agent loop now
@@ -154,14 +181,20 @@ def prepare_system_with_caching(system: str) -> list[dict[str, Any]]:
     message history rather than in the ``system`` param, so there is no
     dynamic suffix to exclude from the cache (#1420).
 
-    Providers that do not support caching silently ignore the
-    ``cache_control`` key.
+    Returns *system* unchanged when *provider* cannot honor the marker. A
+    provider that does not serve the Messages API natively does not merely
+    ignore the ``cache_control`` key: the block-list shape itself reaches the
+    provider as ``messages[0].content`` and a strict OpenAI-compatible backend
+    rejects the request outright. See :func:`provider_honors_cache_control`.
     """
+    if not provider_honors_cache_control(provider):
+        return system
     return [{"type": "text", "text": system, "cache_control": _cache_control()}]
 
 
 def apply_history_cache_breakpoint(
     messages: list[dict[str, Any]],
+    provider: str,
 ) -> list[dict[str, Any]]:
     """Stamp a ``cache_control`` breakpoint on the prior-history tail.
 
@@ -182,8 +215,14 @@ def apply_history_cache_breakpoint(
     content is a plain string; tool-result turns carry list content and
     assistant turns carry block content, so this reliably distinguishes
     it. Returns the list unchanged when there is no prior history to
-    cache.
+    cache, or when *provider* cannot honor the marker.
+
+    Withholding the marker also avoids rewriting a plain-string user message
+    into a block list for a provider that would only flatten it back again.
     """
+    if not provider_honors_cache_control(provider):
+        return messages
+
     current_turn_idx: int | None = None
     for idx in range(len(messages) - 1, -1, -1):
         msg = messages[idx]
@@ -213,6 +252,7 @@ def apply_history_cache_breakpoint(
 
 def apply_in_turn_cache_breakpoint(
     messages: list[dict[str, Any]],
+    provider: str,
 ) -> list[dict[str, Any]]:
     """Stamp a ``cache_control`` breakpoint on a trailing tool-result block.
 
@@ -237,8 +277,10 @@ def apply_in_turn_cache_breakpoint(
     Round 0 ends in the current user turn (plain string content), not
     tool results, so this is a no-op there and the request keeps three
     breakpoints. Returns the list unchanged when there is nothing safe
-    to mark.
+    to mark, or when *provider* cannot honor the marker.
     """
+    if not provider_honors_cache_control(provider):
+        return messages
     if not messages:
         return messages
     last = messages[-1]
@@ -256,13 +298,15 @@ def apply_in_turn_cache_breakpoint(
     return messages
 
 
-def apply_tool_caching(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def apply_tool_caching(tools: list[dict[str, Any]], provider: str) -> list[dict[str, Any]]:
     """Add a cache_control marker to the last tool definition.
 
     Anthropic caches everything up to and including the marked block, so
     marking the last tool covers the entire tool list. Returns the list
-    unchanged when empty.
+    unchanged when empty, or when *provider* cannot honor the marker.
     """
+    if not provider_honors_cache_control(provider):
+        return tools
     if not tools:
         return tools
     tools[-1] = {**tools[-1], "cache_control": _cache_control()}

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -112,7 +112,7 @@ async def test_prompt_caching_system_format_accepted() -> None:
     # Pad the system prompt to exceed the caching minimum token threshold.
     padding = " ".join(f"word{i}" for i in range(1200))
     system_text = f"You are a helpful assistant. Reply briefly. Context: {padding}"
-    system = prepare_system_with_caching(system_text)
+    system = prepare_system_with_caching(system_text, "anthropic")
 
     # Call should succeed with the cache-marked system format
     resp = await amessages(

--- a/tests/test_agent_events.py
+++ b/tests/test_agent_events.py
@@ -203,6 +203,16 @@ class TestDynamicContentCachePlacement:
     ``system`` param ahead of the history, and the prior history must carry
     an explicit cache breakpoint."""
 
+    @pytest.fixture
+    def agent(self, test_user: User) -> ClawboltAgent:
+        """An agent pinned to a provider that honors ``cache_control``.
+
+        The breakpoints these tests assert on are only stamped for a provider
+        that serves the Messages API natively (any-llm#1228), and the default
+        test settings leave ``llm_provider`` empty.
+        """
+        return ClawboltAgent(user=test_user, llm_provider_override="anthropic")
+
     @pytest.mark.asyncio
     @patch("backend.app.agent.core.amessages")
     @patch(

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -15,14 +15,19 @@ from backend.app.services.llm_service import (
     apply_tool_caching,
     get_models,
     prepare_system_with_caching,
+    provider_honors_cache_control,
     resolve_user_llm_override,
     set_user_llm_resolver,
 )
 
+# Any provider that serves the Messages API natively, so the markers are stamped.
+_CACHING_PROVIDER = "anthropic"
+
 
 def test_prepare_system_with_caching_returns_content_block() -> None:
     """prepare_system_with_caching wraps a string in a cache-marked content block."""
-    result = prepare_system_with_caching("You are a helpful assistant.")
+    result = prepare_system_with_caching("You are a helpful assistant.", _CACHING_PROVIDER)
+    assert isinstance(result, list)
     assert len(result) == 1
     assert result[0]["type"] == "text"
     assert result[0]["text"] == "You are a helpful assistant."
@@ -33,7 +38,8 @@ def test_prepare_system_with_caching_returns_content_block() -> None:
 def test_prepare_system_with_caching_preserves_content() -> None:
     """The original system prompt text is preserved exactly."""
     long_prompt = "A" * 5000
-    result = prepare_system_with_caching(long_prompt)
+    result = prepare_system_with_caching(long_prompt, _CACHING_PROVIDER)
+    assert isinstance(result, list)
     assert result[0]["text"] == long_prompt
 
 
@@ -44,7 +50,7 @@ def test_apply_tool_caching_marks_last_tool() -> None:
         {"name": "tool_b", "description": "Second tool", "input_schema": {}},
         {"name": "tool_c", "description": "Third tool", "input_schema": {}},
     ]
-    result = apply_tool_caching(tools)
+    result = apply_tool_caching(tools, _CACHING_PROVIDER)
     assert len(result) == 3
     assert "cache_control" not in result[0]
     assert "cache_control" not in result[1]
@@ -54,14 +60,14 @@ def test_apply_tool_caching_marks_last_tool() -> None:
 def test_apply_tool_caching_single_tool() -> None:
     """apply_tool_caching works with a single tool."""
     tools = [{"name": "only_tool", "description": "Solo", "input_schema": {}}]
-    result = apply_tool_caching(tools)
+    result = apply_tool_caching(tools, _CACHING_PROVIDER)
     assert result[0]["cache_control"]["type"] == "ephemeral"
     assert result[0]["name"] == "only_tool"
 
 
 def test_apply_tool_caching_empty_list() -> None:
     """apply_tool_caching returns empty list unchanged."""
-    result = apply_tool_caching([])
+    result = apply_tool_caching([], _CACHING_PROVIDER)
     assert result == []
 
 
@@ -69,7 +75,7 @@ def test_apply_tool_caching_does_not_mutate_original() -> None:
     """apply_tool_caching should not modify the original tool dicts."""
     original = {"name": "tool_a", "description": "A tool", "input_schema": {}}
     tools = [original]
-    result = apply_tool_caching(tools)
+    result = apply_tool_caching(tools, _CACHING_PROVIDER)
     # The result's last element should have cache_control
     assert "cache_control" in result[0]
     # But the original dict should be unmodified
@@ -91,7 +97,8 @@ def test_prepare_system_uses_1h_ttl_by_default() -> None:
     """
     with patch("backend.app.services.llm_service.settings") as mock_settings:
         mock_settings.llm_cache_extended_ttl = True
-        result = prepare_system_with_caching("hello")
+        result = prepare_system_with_caching("hello", _CACHING_PROVIDER)
+    assert isinstance(result, list)
     assert result[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
 
 
@@ -101,7 +108,8 @@ def test_prepare_system_falls_back_to_5min_when_disabled() -> None:
     a non-Anthropic provider rejects the ttl field."""
     with patch("backend.app.services.llm_service.settings") as mock_settings:
         mock_settings.llm_cache_extended_ttl = False
-        result = prepare_system_with_caching("hello")
+        result = prepare_system_with_caching("hello", _CACHING_PROVIDER)
+    assert isinstance(result, list)
     assert result[0]["cache_control"] == {"type": "ephemeral"}
 
 
@@ -111,6 +119,7 @@ def test_apply_tool_caching_uses_1h_ttl_by_default() -> None:
         mock_settings.llm_cache_extended_ttl = True
         result = apply_tool_caching(
             [{"name": "t", "description": "", "input_schema": {}}],
+            _CACHING_PROVIDER,
         )
     assert result[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
 
@@ -120,6 +129,7 @@ def test_apply_tool_caching_falls_back_to_5min_when_disabled() -> None:
         mock_settings.llm_cache_extended_ttl = False
         result = apply_tool_caching(
             [{"name": "t", "description": "", "input_schema": {}}],
+            _CACHING_PROVIDER,
         )
     assert result[0]["cache_control"] == {"type": "ephemeral"}
 
@@ -130,7 +140,8 @@ def test_prepare_system_wraps_whole_string_in_one_cached_block() -> None:
     text = "stable prefix\n\ndynamic suffix"
     with patch("backend.app.services.llm_service.settings") as mock_settings:
         mock_settings.llm_cache_extended_ttl = True
-        result = prepare_system_with_caching(text)
+        result = prepare_system_with_caching(text, _CACHING_PROVIDER)
+    assert isinstance(result, list)
     assert len(result) == 1
     assert result[0]["text"] == text
     assert result[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
@@ -148,7 +159,7 @@ class TestApplyHistoryCacheBreakpoint:
             {"role": "assistant", "content": [{"type": "text", "text": "older answer"}]},
             {"role": "user", "content": "current turn with time + dynamic"},
         ]
-        result = apply_history_cache_breakpoint(messages)
+        result = apply_history_cache_breakpoint(messages, _CACHING_PROVIDER)
         # Breakpoint stamped on the assistant message (index 1), not the
         # volatile current turn (index 2).
         assert result[1]["content"][-1]["cache_control"] == self._control()
@@ -160,7 +171,7 @@ class TestApplyHistoryCacheBreakpoint:
             {"role": "user", "content": "older question"},
             {"role": "user", "content": "current turn"},
         ]
-        result = apply_history_cache_breakpoint(messages)
+        result = apply_history_cache_breakpoint(messages, _CACHING_PROVIDER)
         anchor = result[0]
         assert isinstance(anchor["content"], list)
         assert anchor["content"][0]["text"] == "older question"
@@ -178,14 +189,14 @@ class TestApplyHistoryCacheBreakpoint:
             },
             {"role": "user", "content": "current turn"},
         ]
-        result = apply_history_cache_breakpoint(messages)
+        result = apply_history_cache_breakpoint(messages, _CACHING_PROVIDER)
         tool_results = result[1]["content"]
         assert "cache_control" not in tool_results[0]
         assert tool_results[1]["cache_control"] == self._control()
 
     def test_no_breakpoint_without_prior_history(self) -> None:
         messages = [{"role": "user", "content": "only the current turn"}]
-        result = apply_history_cache_breakpoint(messages)
+        result = apply_history_cache_breakpoint(messages, _CACHING_PROVIDER)
         assert result == messages
         assert "cache_control" not in result[0]
 
@@ -199,7 +210,7 @@ class TestApplyHistoryCacheBreakpoint:
                 "content": [{"type": "tool_result", "tool_use_id": "a", "content": "x"}],
             },
         ]
-        result = apply_history_cache_breakpoint(messages)
+        result = apply_history_cache_breakpoint(messages, _CACHING_PROVIDER)
         assert all("cache_control" not in block for block in result[0]["content"])
         assert all("cache_control" not in block for block in result[1]["content"])
 
@@ -222,7 +233,7 @@ class TestApplyInTurnCacheBreakpoint:
                 ],
             },
         ]
-        result = apply_in_turn_cache_breakpoint(messages)
+        result = apply_in_turn_cache_breakpoint(messages, _CACHING_PROVIDER)
         tool_results = result[-1]["content"]
         assert "cache_control" not in tool_results[0]
         assert tool_results[1]["cache_control"] == self._control()
@@ -234,7 +245,7 @@ class TestApplyInTurnCacheBreakpoint:
             {"role": "assistant", "content": [{"type": "text", "text": "older answer"}]},
             {"role": "user", "content": "current turn"},
         ]
-        result = apply_in_turn_cache_breakpoint(messages)
+        result = apply_in_turn_cache_breakpoint(messages, _CACHING_PROVIDER)
         assert isinstance(result[-1]["content"], str)
         assert "cache_control" not in result[-1]
 
@@ -243,11 +254,11 @@ class TestApplyInTurnCacheBreakpoint:
             {"role": "user", "content": "current turn"},
             {"role": "assistant", "content": [{"type": "text", "text": "reply"}]},
         ]
-        result = apply_in_turn_cache_breakpoint(messages)
+        result = apply_in_turn_cache_breakpoint(messages, _CACHING_PROVIDER)
         assert all("cache_control" not in block for block in result[-1]["content"])
 
     def test_noop_on_empty_list(self) -> None:
-        assert apply_in_turn_cache_breakpoint([]) == []
+        assert apply_in_turn_cache_breakpoint([], _CACHING_PROVIDER) == []
 
     def test_at_most_four_breakpoints_with_history_anchor(self) -> None:
         """Combined with the history anchor, the message side carries at
@@ -264,8 +275,8 @@ class TestApplyInTurnCacheBreakpoint:
                 "content": [{"type": "tool_result", "tool_use_id": "a", "content": "x"}],
             },
         ]
-        result = apply_history_cache_breakpoint(messages)
-        result = apply_in_turn_cache_breakpoint(result)
+        result = apply_history_cache_breakpoint(messages, _CACHING_PROVIDER)
+        result = apply_in_turn_cache_breakpoint(result, _CACHING_PROVIDER)
 
         marker_count = 0
         for msg in result:
@@ -359,3 +370,113 @@ async def test_get_models_reraises_other_unified_errors() -> None:
         pytest.raises(ProviderError),
     ):
         await get_models("openai")
+
+
+# ---------------------------------------------------------------------------
+# Cache markers are gated on the provider honoring them (any-llm#1228)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheControlProviderGate:
+    """Only providers that serve the Messages API natively get cache markers.
+
+    Every other provider reaches the wire through any-llm's
+    Messages-to-Completions bridge. That bridge rebuilds user, assistant and
+    tool blocks (dropping their markers) but forwards a block-list ``system``
+    verbatim into ``messages[0].content``, which a strict OpenAI-compatible
+    backend rejects with a 400. Stamping a marker such a provider cannot honor
+    is therefore not a harmless no-op, it breaks the request.
+    """
+
+    @pytest.mark.parametrize("provider", ["anthropic", "azureanthropic", "vertexaianthropic"])
+    def test_native_messages_providers_are_honored(self, provider: str) -> None:
+        assert provider_honors_cache_control(provider) is True
+
+    @pytest.mark.parametrize(
+        "provider",
+        [
+            "fireworks",
+            "openai",
+            "bedrock",
+            "ollama",
+            # Gateways are excluded on purpose: the downstream provider rides in
+            # the model string, so the marker cannot be verified from the name.
+            "gateway",
+            "mzai",
+            "otari",
+        ],
+    )
+    def test_bridge_providers_are_not_honored(self, provider: str) -> None:
+        assert provider_honors_cache_control(provider) is False
+
+    def test_provider_match_is_case_insensitive(self) -> None:
+        assert provider_honors_cache_control("Anthropic") is True
+        assert provider_honors_cache_control("FIREWORKS") is False
+
+    def test_system_stays_a_plain_string_for_bridge_provider(self) -> None:
+        """The regression: a block-list system is what Fireworks rejected.
+
+        Fireworks answered 400 "Input should be a valid string, field:
+        'messages[0].content.str'" because the block list arrived as the
+        converted system message.
+        """
+        result = prepare_system_with_caching("You are a helpful assistant.", "fireworks")
+        assert result == "You are a helpful assistant."
+        assert isinstance(result, str)
+
+    def test_history_breakpoint_is_skipped_for_bridge_provider(self) -> None:
+        """No marker, and the string anchor is not rewritten into a block list.
+
+        The bridge would only flatten such a rewrite back to content parts, so
+        the rewrite buys nothing and widens the shape sent to the provider.
+        """
+        messages = [
+            {"role": "user", "content": "older question"},
+            {"role": "user", "content": "current turn"},
+        ]
+        result = apply_history_cache_breakpoint(messages, "fireworks")
+        assert result[0]["content"] == "older question"
+        assert isinstance(result[0]["content"], str)
+
+    def test_in_turn_breakpoint_is_skipped_for_bridge_provider(self) -> None:
+        messages = [
+            {"role": "user", "content": "current turn"},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "a", "name": "t"}]},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "a", "content": "one"}],
+            },
+        ]
+        result = apply_in_turn_cache_breakpoint(messages, "fireworks")
+        assert all("cache_control" not in block for block in result[-1]["content"])
+
+    def test_tool_caching_is_skipped_for_bridge_provider(self) -> None:
+        tools = [{"name": "tool_a", "description": "A tool", "input_schema": {}}]
+        result = apply_tool_caching(tools, "fireworks")
+        assert "cache_control" not in result[0]
+
+    def test_no_marker_survives_anywhere_for_a_bridge_provider(self) -> None:
+        """End to end over all four breakpoints: the request carries none of them."""
+        messages = [
+            {"role": "user", "content": "older question"},
+            {"role": "assistant", "content": [{"type": "text", "text": "older answer"}]},
+            {"role": "user", "content": "current turn"},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "a", "name": "t"}]},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "a", "content": "x"}],
+            },
+        ]
+        result = apply_history_cache_breakpoint(messages, "fireworks")
+        result = apply_in_turn_cache_breakpoint(result, "fireworks")
+        tools = apply_tool_caching(
+            [{"name": "t", "description": "", "input_schema": {}}], "fireworks"
+        )
+        system = prepare_system_with_caching("system prompt", "fireworks")
+
+        assert isinstance(system, str)
+        assert all("cache_control" not in tool for tool in tools)
+        for msg in result:
+            content = msg.get("content")
+            if isinstance(content, list):
+                assert all("cache_control" not in block for block in content)

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -129,7 +129,8 @@ class TestBuildParts:
 
     def test_prepare_system_single_cached_block(self) -> None:
         """prepare_system_with_caching wraps the whole string in one cached block."""
-        blocks = prepare_system_with_caching("Just a plain prompt")
+        blocks = prepare_system_with_caching("Just a plain prompt", "anthropic")
+        assert isinstance(blocks, list)
         assert len(blocks) == 1
         assert "cache_control" in blocks[0]
         assert blocks[0]["text"] == "Just a plain prompt"


### PR DESCRIPTION
## Description

Only stamp Anthropic `cache_control` breakpoints when the target provider will actually deliver them to the wire. Fixes a hard failure against Fireworks behind a gateway:

```
Error code: 400 - {'error': {'type': 'invalid_request_error', 'message':
'2 request validation errors: Input should be a valid string,
field: \'messages[0].content.str\', value: [{\'type\': \'text\',
\'text\': \'You are an AI assistant for solo tradespeople...
```

### Why the marker breaks the request rather than being ignored

`prepare_system_with_caching` wrapped the system prompt in a content-block list unconditionally, on the documented assumption that "providers that do not support caching silently ignore the `cache_control` key". That assumption holds for the other three breakpoints but not for the system one.

Only `BaseAnthropicProvider` overrides any-llm's `_amessages`, so every other provider reaches the wire through `messages_params_to_completion_params`. That bridge normalizes user, assistant and tool blocks by rebuilding them, which incidentally drops their markers, but it forwards `system` verbatim:

```python
if params.system:
    messages.append({"role": "system", "content": params.system})
```

So the block list lands in `messages[0].content` and a strict OpenAI-compatible backend rejects the whole request. Filed upstream as any-llm#1228.

Two consequences worth stating, because together they make this a free fix:

- On any non-Anthropic provider the markers bought us **nothing** already. Three of the four were being stripped in conversion, and the fourth was breaking the call. Verified against the bridge directly: a marked history block comes back as bare `{"type": "text", "text": "prior turn"}`, assistant blocks join to a plain string, a marked `tool_result` becomes `{"role": "tool", "content": "res"}`, and `_convert_tools_to_openai` rebuilds tool defs from scratch.
- It is not gateway specific. Pointing `amessages` straight at `fireworks` with no gateway in the path reproduces it identically.

### What changed

`provider_honors_cache_control` in `llm_service.py`, next to the `is_local_provider` helper added in #1478, gates all four breakpoint helpers. Each helper takes the effective provider and returns its input untouched when the provider cannot honor a marker, so none of them can be called wrongly by construction. All five call sites already had the provider in scope; in `_call_llm_with_retry` the `effective_provider` assignment moved a few lines earlier.

`prepare_system_with_caching` now returns `str | list[dict]`. `LLMRequestPayload.system` and the `amessages` `system` kwarg were already typed for both, so nothing downstream needed widening.

### Why gateways are excluded

`anthropic`, `azureanthropic` and `vertexaianthropic` are in; gateway providers are deliberately out, even though any-llm's `otari` provider does forward Messages natively. Behind a gateway, whether the marker is honored depends on the downstream provider, which rides in the model string (`fireworks:accounts/fireworks/models/...`) rather than the provider name. Sending a marker we cannot verify fails closed with a 400; omitting one only forgoes caching. So the fail-safe direction is to omit.

Consequence to be explicit about: a deployment routing Anthropic models through a gateway loses the system-prompt breakpoint it may have been getting. That was already the minority of the benefit there, since the bridge was stripping the other three. An operator who wants full caching through a gateway should configure `LLM_PROVIDER=anthropic` with `LLM_API_BASE` pointed at it, which takes the native pass-through and preserves all four.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

`ruff check`, `ruff format` and `ty check` all clean over `backend/ tests/ alembic/`. No frontend diff, so the OpenAPI export and the `frontend` typecheck/deadcode gates are untouched (no route signature, schema or response model changed).

Ten regression tests in `TestCacheControlProviderGate`, 16 cases with parametrization: the honored set and the bridge set (including `gateway`, `mzai` and `otari` asserted as not honored, so the deliberate exclusion cannot be quietly reverted), case-insensitive matching, the reported failure (a block-list system stays a plain string for `fireworks`), each of the three other helpers as a no-op, and an end-to-end pass asserting no marker survives anywhere across all four breakpoints.

The coverage was mutation checked rather than assumed: adding `fireworks` to `_CACHE_CONTROL_PROVIDERS` fails 7 of the 16, one per helper plus the end-to-end case. Full suite is 3105 passed, 2 skipped, 13 deselected.

One existing test needed a real provider rather than a changed assertion: `TestDynamicContentCachePlacement` asserts on breakpoint placement, and the default test settings leave `llm_provider` empty, so its agent is now built with `llm_provider_override="anthropic"`. The assertions themselves are unchanged. Everything else passed untouched, because the `extract_system_text` mock helper already normalized both system shapes.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Investigated and implemented by Claude Opus 5 via Claude Code, at @njbrake's direction. Claude traced the 400 to the any-llm bridge, confirmed the asymmetry between the system field and its siblings by running the conversion directly, verified the defect is still on any-llm `main` after #1198 and #1201, filed any-llm#1228, and wrote this change and its tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added provider-aware handling for Anthropic `cache_control` markers.
- Applied cache markers only for providers that support them.
- Preserved unchanged string content for unsupported providers, including gateway providers.
- Updated agent, heartbeat, vision, compaction, and follow-up request flows to pass the active provider.
- Added regression tests for provider matching, bridge providers, Fireworks compatibility, and end-to-end behavior.

## Benefits

This prevents strict OpenAI-compatible providers from rejecting Anthropic-specific content blocks. It also keeps caching behavior consistent across request paths.

## Further enhancement

Provider capability detection may need review if gateway routing becomes more reliable in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->