### PR TITLE
fix(agent): never deliver or persist a truncated turn with no tool calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,8 +81,8 @@ LLM_MODEL=
 # VISION_PROVIDER=           # empty = fall back to LLM_PROVIDER
 
 # LLM token limits
-# LLM_MAX_TOKENS_AGENT=500
-# LLM_MAX_TOKENS_HEARTBEAT=300
+# LLM_MAX_TOKENS_AGENT=8192
+# LLM_MAX_TOKENS_HEARTBEAT=12000
 # LLM_MAX_TOKENS_VISION=1000
 
 # LLM Provider API Keys — uncomment and set the key for your chosen provider.

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -30,7 +30,11 @@ from backend.app.agent.approval import (
     get_approval_gate,
     get_approval_store,
 )
-from backend.app.agent.context import StoredToolInteraction, StoredToolReceipt
+from backend.app.agent.context import (
+    StoredToolInteraction,
+    StoredToolReceipt,
+    trigger_compaction_for_dropped,
+)
 from backend.app.agent.events import (
     AgentEndEvent,
     AgentEvent,
@@ -1495,8 +1499,6 @@ class ClawboltAgent:
                 all_dropped.extend(self._reactive_trim_dropped)
                 self._reactive_trim_dropped = []
             if all_dropped:
-                from backend.app.agent.context import trigger_compaction_for_dropped
-
                 await trigger_compaction_for_dropped(self.user.id, all_dropped)
 
             await self._emit(
@@ -1691,10 +1693,13 @@ class ClawboltAgent:
             # say, and a truncated round whose tool calls happened to validate
             # is just as likely to truncate again on the next one. The
             # ``_MAX_TOKENS_CEILING`` cap bounds the ladder
-            # (8192 -> 16384) before we give up.
+            # (8192 -> 16384) before we give up. The outer ``max`` keeps the
+            # cap from *lowering* a budget an operator (or the heartbeat
+            # caller) deliberately set above the ceiling: this branch only
+            # ever raises.
             if response_truncated:
                 effective = max_tokens or settings.llm_max_tokens_agent
-                max_tokens = min(effective * 2, _MAX_TOKENS_CEILING)
+                max_tokens = max(effective, min(effective * 2, _MAX_TOKENS_CEILING))
                 logger.info(
                     "Response truncated, increasing max_tokens to %d",
                     max_tokens,
@@ -1726,8 +1731,6 @@ class ClawboltAgent:
 
         # Trigger background compaction for all dropped messages
         if all_dropped:
-            from backend.app.agent.context import trigger_compaction_for_dropped
-
             await trigger_compaction_for_dropped(self.user.id, all_dropped)
 
         total_duration = (time.monotonic() - agent_start_time) * 1000

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -114,6 +114,19 @@ MAX_INPUT_TOKENS = settings.max_input_tokens
 # context poisoning.
 _VALID_STOP_REASONS: set[str | None] = {"end_turn", "max_tokens", "tool_use", "stop_sequence", None}
 
+# Ceiling for the truncation auto-recovery ladder. A turn that keeps hitting
+# ``max_tokens`` doubles its budget each round (8192 -> 16384) and then gives
+# up rather than growing without bound.
+#
+# The bound is a *latency* budget, not a cost one: ``max_tokens`` is a ceiling
+# rather than a spend, so raising it is free on turns that finish early (the
+# common case runs 300-800 output tokens). It is only ever reached by a
+# degenerate turn that generates until something stops it, and there the cap
+# is the whole bill. Measured against a DeepSeek-family model: a runaway takes
+# ~30s to fill 8192 tokens and ~78s to fill 16384. Two rungs is therefore the
+# most a user should be asked to wait before we give up on the turn.
+_MAX_TOKENS_CEILING = 16384
+
 _LLM_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
 
 # Provider phrasings for "this prompt is longer than the model's context window"
@@ -1465,6 +1478,53 @@ class ClawboltAgent:
         _total_output_tokens = 0
         _total_cache_creation_tokens = 0
         _total_cache_read_tokens = 0
+        parsed_raw: list[ParsedToolCall] = []
+
+        async def _abort_without_persisting(response: MessageResponse) -> AgentResponse:
+            """Return the error fallback, discarding the model's output.
+
+            Used for responses that must never reach the user or the session
+            history: provider-level error stop reasons, and truncated turns
+            whose partial output is not a reply (see the ``max_tokens``
+            guard in the loop). ``persist_outbound`` short-circuits on
+            ``is_error_fallback``, so returning this keeps the bad text out
+            of ``messages`` and therefore out of the next prompt.
+            """
+            # Compact any messages already dropped before early return
+            if self._reactive_trim_dropped:
+                all_dropped.extend(self._reactive_trim_dropped)
+                self._reactive_trim_dropped = []
+            if all_dropped:
+                from backend.app.agent.context import trigger_compaction_for_dropped
+
+                await trigger_compaction_for_dropped(self.user.id, all_dropped)
+
+            await self._emit(
+                AgentEndEvent(
+                    reply_text=_LLM_ERROR_FALLBACK,
+                    actions_taken=actions_taken,
+                    total_duration_ms=(time.monotonic() - agent_start_time) * 1000,
+                )
+            )
+            return AgentResponse(
+                reply_text=_LLM_ERROR_FALLBACK,
+                actions_taken=actions_taken,
+                memories_saved=memories_saved,
+                tool_calls=tool_call_records,
+                is_error_fallback=True,
+                total_input_tokens=_total_input_tokens,
+                total_output_tokens=_total_output_tokens,
+                total_cache_creation_input_tokens=_total_cache_creation_tokens,
+                total_cache_read_input_tokens=_total_cache_read_tokens,
+                system_prompt=system_prompt,
+                # Surface any reasoning that preceded the abort so downstream
+                # observers (and a future persistence policy that records
+                # error fallbacks) can see what the model was working through
+                # before it bailed. Today ``persist_outbound`` short-circuits
+                # on ``is_error_fallback``, so this rides along the in-memory
+                # response only.
+                thinking_text=get_response_thinking(response),
+            )
 
         for _round in range(MAX_TOOL_ROUNDS):
             logger.debug(
@@ -1525,46 +1585,41 @@ class ClawboltAgent:
                     _round,
                     response.stop_reason,
                 )
-                # Compact any messages already dropped before early return
-                if self._reactive_trim_dropped:
-                    all_dropped.extend(self._reactive_trim_dropped)
-                    self._reactive_trim_dropped = []
-                if all_dropped:
-                    from backend.app.agent.context import trigger_compaction_for_dropped
-
-                    await trigger_compaction_for_dropped(self.user.id, all_dropped)
-
-                total_duration = (time.monotonic() - agent_start_time) * 1000
-                await self._emit(
-                    AgentEndEvent(
-                        reply_text=_LLM_ERROR_FALLBACK,
-                        actions_taken=actions_taken,
-                        total_duration_ms=total_duration,
-                    )
-                )
-                return AgentResponse(
-                    reply_text=_LLM_ERROR_FALLBACK,
-                    actions_taken=actions_taken,
-                    memories_saved=memories_saved,
-                    tool_calls=tool_call_records,
-                    is_error_fallback=True,
-                    total_input_tokens=_total_input_tokens,
-                    total_output_tokens=_total_output_tokens,
-                    total_cache_creation_input_tokens=_total_cache_creation_tokens,
-                    total_cache_read_input_tokens=_total_cache_read_tokens,
-                    system_prompt=system_prompt,
-                    # Surface any reasoning that preceded the error stop so
-                    # downstream observers (and a future persistence policy
-                    # that records error fallbacks) can see what the model
-                    # was working through before it bailed. Today
-                    # ``persist_outbound`` short-circuits on
-                    # ``is_error_fallback``, so this rides along the in-memory
-                    # response only.
-                    thinking_text=get_response_thinking(response),
-                )
+                return await _abort_without_persisting(response)
 
             # Parse tool calls via shared parser
             parsed_raw = parse_tool_calls(response)
+
+            # Guard: a turn truncated by ``max_tokens`` that yielded no tool
+            # call is a partial emission, not a reply. Providers that render
+            # tool calls as markup in the completion text (rather than as
+            # structured tool_call objects) rely on a server-side parser to
+            # extract them; when generation is cut before the block closes,
+            # that parser fails open and the raw markup arrives as ordinary
+            # content. Shipping it would both show the user provider
+            # internals and, once persisted, teach the model on the next turn
+            # that emitting markup-as-text is in-distribution here. Retry with
+            # a larger budget instead, and discard the partial output if the
+            # ceiling is already reached.
+            if not parsed_raw and response.stop_reason == "max_tokens":
+                effective = max_tokens or settings.llm_max_tokens_agent
+                if effective < _MAX_TOKENS_CEILING:
+                    max_tokens = min(effective * 2, _MAX_TOKENS_CEILING)
+                    logger.warning(
+                        "Round %d: truncated with no tool calls; retrying with max_tokens=%d",
+                        _round,
+                        max_tokens,
+                    )
+                    continue
+                logger.warning(
+                    "Round %d: truncated with no tool calls at the max_tokens "
+                    "ceiling (%d); discarding %d chars of partial output",
+                    _round,
+                    _MAX_TOKENS_CEILING,
+                    len(get_response_text(response)),
+                )
+                return await _abort_without_persisting(response)
+
             if not parsed_raw:
                 reply_text = get_response_text(response)
                 # Capture thinking from the final response only. Earlier
@@ -1629,24 +1684,37 @@ class ClawboltAgent:
                 response_truncated=response_truncated,
             )
 
-            # If the response was truncated and produced validation errors,
-            # auto-increase max_tokens for the next round so the LLM has
-            # enough room to generate the full tool call payload. The
-            # 8192 cap leaves one further recovery step beyond the
-            # current 2048 default (2048 -> 4096 -> 8192) before we
-            # give up and surface the truncation to the user.
-            if response_truncated and any(r.is_error for r in tool_results):
+            # If the response was truncated, auto-increase max_tokens for the
+            # next round so the LLM has enough room to finish the tool call
+            # payload. This is deliberately not gated on the round producing a
+            # validation error: truncation always means the model had more to
+            # say, and a truncated round whose tool calls happened to validate
+            # is just as likely to truncate again on the next one. The
+            # ``_MAX_TOKENS_CEILING`` cap bounds the ladder
+            # (8192 -> 16384) before we give up.
+            if response_truncated:
                 effective = max_tokens or settings.llm_max_tokens_agent
-                max_tokens = min(effective * 2, 8192)
+                max_tokens = min(effective * 2, _MAX_TOKENS_CEILING)
                 logger.info(
-                    "Response truncated with errors, increasing max_tokens to %d",
+                    "Response truncated, increasing max_tokens to %d",
                     max_tokens,
                 )
 
             messages.extend(tool_results)
             await self._emit(TurnEndEvent(round_number=_round, has_more_tool_calls=True))
         else:
-            # Max rounds reached -- use last response content
+            # Max rounds reached -- use last response content. If that last
+            # response was a truncated turn with no tool call, the same
+            # reasoning as the in-loop guard applies: it is a partial
+            # emission, not a reply, so discard it rather than let the
+            # round budget running out become a delivery path for it.
+            if not parsed_raw and response.stop_reason == "max_tokens":
+                logger.warning(
+                    "Max tool rounds (%d) reached on a truncated response with "
+                    "no tool calls; discarding partial output",
+                    MAX_TOOL_ROUNDS,
+                )
+                return await _abort_without_persisting(response)
             reply_text = get_response_text(response)
             thinking_text = get_response_thinking(response)
             logger.debug("Max tool rounds (%d) reached, using last response", MAX_TOOL_ROUNDS)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -99,14 +99,30 @@ class Settings(BaseSettings):
     vision_model: str = ""  # empty = fall back to llm_model
     vision_provider: str = ""  # empty = fall back to llm_provider
     reasoning_effort: str = "auto"  # none, minimal, low, medium, high, xhigh, auto
-    # 2048 is sized to fit a typical multi-tool turn (one ~200-token reply
-    # plus a tool call whose JSON args can run 500-1500 tokens for nested
-    # entity payloads in the QuickBooks / CompanyCam tools). The previous
-    # 1024 default truncated mid-tool-call on real workloads, leaving the
-    # validator to catch the malformed args; auto-recovery in
-    # ``core.py:_call_llm_with_retry`` doubles ``max_tokens`` on the next
-    # round, but a higher floor avoids the wasted round entirely.
-    llm_max_tokens_agent: int = Field(default=2048, ge=1)
+    # Sized to fit a typical multi-tool turn (one ~200-token reply plus a tool
+    # call whose JSON args can run 500-1500 tokens for nested entity payloads
+    # in the QuickBooks / CompanyCam tools) *plus* the reasoning tokens a
+    # thinking-by-default model spends before it emits anything at all.
+    #
+    # Raised 2048 -> 8192: reasoning models bill their chain-of-thought against
+    # this same budget, so 2048 left almost no headroom, and this path had the
+    # tightest budget in the file despite being the most tool-heavy one
+    # (heartbeat already gets 12000, compaction 16000).
+    #
+    # Truncation is not a benign "reply got cut short": a provider that renders
+    # tool calls as markup in the completion text needs the closing token to
+    # parse them, so a cut mid-block yields zero tool calls and leaks the raw
+    # markup as content (the ``core.py`` guard now discards that rather than
+    # delivering it). Measured against a DeepSeek-family model on a two-event
+    # calendar request: at 2048, 3 of 6 turns truncated and leaked; a
+    # *successful* turn consumed 1817 output tokens; and one turn needed more
+    # than 4096, recovering only on the ladder's second rung.
+    #
+    # Raising this is close to free. ``max_tokens`` is a ceiling, not a spend,
+    # and healthy turns here run 300-800 output tokens, so the higher default
+    # changes nothing about what they cost. It is only reached by a degenerate
+    # turn, which is what ``_MAX_TOKENS_CEILING`` bounds.
+    llm_max_tokens_agent: int = Field(default=8192, ge=1)
     llm_max_tokens_heartbeat: int = Field(default=12000, ge=1)
     llm_max_tokens_vision: int = Field(default=1000, ge=1)
 

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -132,8 +132,8 @@ Photos and files the user sends over a messaging channel are cached on disk whil
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LLM_MAX_TOKENS_AGENT` | `500` | Max tokens per agent loop LLM response |
-| `LLM_MAX_TOKENS_HEARTBEAT` | `300` | Max tokens per heartbeat LLM response |
+| `LLM_MAX_TOKENS_AGENT` | `8192` | Max tokens per agent loop LLM response. A turn truncated at this limit is retried once with a doubled budget and then discarded rather than delivered, so sizing this too low costs a wasted round. |
+| `LLM_MAX_TOKENS_HEARTBEAT` | `12000` | Max tokens per heartbeat LLM response |
 | `LLM_MAX_TOKENS_VISION` | `1000` | Max tokens per vision/image analysis response |
 
 ## Agent loop

--- a/tests/mocks/llm.py
+++ b/tests/mocks/llm.py
@@ -111,6 +111,26 @@ def make_truncated_tool_call_response(
     )
 
 
+def make_truncated_text_response(text: str) -> MessageResponse:
+    """Build a text-only MessageResponse with ``stop_reason='max_tokens'``.
+
+    Simulates a turn cut off before it produced any tool_use block. Providers
+    that render tool calls as markup in the completion text and parse them
+    server-side fail open in exactly this way: the closing token never
+    arrives, the parser extracts nothing, and the partial markup is returned
+    as ordinary content.
+    """
+    return MessageResponse(
+        id="msg_mock",
+        content=[TextBlock(type="text", text=text)],
+        model="mock-model",
+        role="assistant",
+        type="message",
+        stop_reason="max_tokens",
+        usage=MessageUsage(input_tokens=0, output_tokens=0),
+    )
+
+
 def make_error_response(
     stop_reason: str = "error",
     content: str = "",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2923,6 +2923,48 @@ async def test_truncated_response_increases_max_tokens_without_validation_errors
     assert second_max == first_max * 2
 
 
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_truncation_ladder_never_lowers_a_budget_above_the_ceiling(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """The ceiling caps growth; it must not claw back a caller's larger budget.
+
+    ``min(effective * 2, _MAX_TOKENS_CEILING)`` alone turns the "increase"
+    into a decrease whenever an operator configures ``llm_max_tokens_agent``
+    (or the heartbeat caller passes a ``max_tokens``) above the ceiling.
+    """
+
+    async def create_entity(**kwargs: object) -> ToolResult:
+        return ToolResult(content="created")
+
+    class CreateParams(BaseModel):
+        entity_type: str
+
+    tool = Tool(
+        name="qb_create",
+        description="Create an entity",
+        function=create_entity,
+        params_model=CreateParams,
+    )
+
+    mock_amessages.side_effect = [
+        make_truncated_tool_call_response(
+            [{"name": "qb_create", "arguments": {"entity_type": "Invoice"}}]
+        ),
+        make_text_response("Done."),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    with patch("backend.app.agent.core.settings.llm_max_tokens_agent", 32000):
+        await agent.process_message("Create an invoice", system_prompt_override="system")
+
+    budgets = [c.kwargs["max_tokens"] for c in mock_amessages.call_args_list]
+    assert budgets == [32000, 32000]
+
+
 def _tool_stub(name: str) -> Tool:
     async def _noop(**_: object) -> ToolResult:
         return ToolResult(content="")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -14,6 +14,7 @@ from any_llm import (
 from pydantic import BaseModel
 
 from backend.app.agent.core import (
+    MAX_TOOL_ROUNDS,
     ClawboltAgent,
     _is_context_overflow,
 )
@@ -34,6 +35,7 @@ from tests.mocks.llm import (
     make_error_response,
     make_text_response,
     make_tool_call_response,
+    make_truncated_text_response,
     make_truncated_tool_call_response,
 )
 
@@ -2645,8 +2647,13 @@ async def test_tool_errors_still_returned_to_llm_in_loop(
 async def test_valid_stop_reasons_not_treated_as_error(
     mock_amessages: object, test_user: User
 ) -> None:
-    """Responses with valid stop_reasons should be processed normally."""
-    for stop_reason in ("end_turn", "max_tokens", "stop_sequence"):
+    """Responses with valid stop_reasons should be processed normally.
+
+    ``max_tokens`` is deliberately excluded: a truncated turn that produced no
+    tool call is a partial emission rather than a reply, and is covered by the
+    truncation guard tests below.
+    """
+    for stop_reason in ("end_turn", "stop_sequence"):
         from any_llm.types.messages import MessageResponse, MessageUsage, TextBlock
 
         mock_amessages.return_value = MessageResponse(  # type: ignore[union-attr]
@@ -2817,6 +2824,103 @@ async def test_truncated_response_increases_max_tokens(
     first_max = first_call.kwargs["max_tokens"]
     second_max = second_call.kwargs["max_tokens"]
     assert second_max > first_max
+
+
+# Truncated-with-no-tool-calls guard. A provider that renders tool calls as
+# markup in the completion text needs the closing token to parse them; cut the
+# generation short and the raw markup arrives as ordinary content with
+# stop_reason=max_tokens and zero tool_use blocks. Shipping that both exposes
+# provider internals to the user and, once persisted, teaches the model on the
+# next turn that markup-as-text is in-distribution here.
+_LEAKED_MARKUP = '<|DSML|tool_calls>\n<|DSML|invoke name="calendar_create_event">\n<|DSML|para'
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_truncated_no_tool_calls_retries_with_larger_budget(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """A truncated, tool-call-less turn retries with more room instead of shipping."""
+    mock_amessages.side_effect = [
+        make_truncated_text_response(_LEAKED_MARKUP),
+        make_text_response("Added both events."),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    response = await agent.process_message("Add two events", system_prompt_override="system")
+
+    assert response.is_error_fallback is False
+    assert response.reply_text == "Added both events."
+    assert "DSML" not in response.reply_text
+    first_max = mock_amessages.call_args_list[0].kwargs["max_tokens"]
+    second_max = mock_amessages.call_args_list[1].kwargs["max_tokens"]
+    assert second_max == first_max * 2
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_truncated_no_tool_calls_never_delivered_at_ceiling(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """Partial markup is discarded, not delivered, once the budget ladder tops out."""
+    mock_amessages.return_value = make_truncated_text_response(_LEAKED_MARKUP)
+
+    agent = ClawboltAgent(user=test_user)
+    response = await agent.process_message("Add two events", system_prompt_override="system")
+
+    assert response.is_error_fallback is True
+    assert "DSML" not in response.reply_text
+    assert response.reply_text != _LEAKED_MARKUP
+    # The ladder climbs and then stops rather than retrying forever.
+    budgets = [c.kwargs["max_tokens"] for c in mock_amessages.call_args_list]
+    assert budgets[-1] == 16384
+    assert budgets == sorted(budgets)
+    assert len(budgets) < MAX_TOOL_ROUNDS
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core.amessages")
+async def test_truncated_response_increases_max_tokens_without_validation_errors(
+    mock_amessages: AsyncMock,
+    test_user: User,
+) -> None:
+    """Truncation alone raises the budget; it is not gated on a tool error.
+
+    A truncated round whose tool calls happened to validate is just as likely
+    to truncate again on the next round, so the recovery must not require
+    ``any(r.is_error for r in tool_results)``.
+    """
+
+    async def create_entity(**kwargs: object) -> ToolResult:
+        return ToolResult(content="created")
+
+    class CreateParams(BaseModel):
+        entity_type: str
+
+    tool = Tool(
+        name="qb_create",
+        description="Create an entity",
+        function=create_entity,
+        params_model=CreateParams,
+    )
+
+    mock_amessages.side_effect = [
+        # Valid args, so the tool round produces no error -- but still truncated.
+        make_truncated_tool_call_response(
+            [{"name": "qb_create", "arguments": {"entity_type": "Invoice"}}]
+        ),
+        make_text_response("Done."),
+    ]
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([tool])
+    await agent.process_message("Create an invoice", system_prompt_override="system")
+
+    first_max = mock_amessages.call_args_list[0].kwargs["max_tokens"]
+    second_max = mock_amessages.call_args_list[1].kwargs["max_tokens"]
+    assert second_max == first_max * 2
 
 
 def _tool_stub(name: str) -> Tool:


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

A turn ending with `stop_reason=max_tokens` and zero parsed tool calls was being delivered to the user and written to session history. Providers that render tool calls as markup in the completion text parse them server-side; cut generation before the block closes and that parser fails open, returning the raw markup as ordinary content. The persisted copy then sat above `last_trim_seq` as an assistant exemplar, so the next turn was primed to do it again. Reverting the model did not clear it; rows had to be deleted by hand.

Two guards failed:

1. The context-poisoning guard at `core.py:1519` only fired on stop reasons outside `_VALID_STOP_REASONS`, and `"max_tokens"` is in that set.
2. The truncation recovery required `any(r.is_error for r in tool_results)`, which cannot be true when zero tool calls parsed, so `max_tokens` was never raised and every retry hit the same wall.

Now a truncated turn with no tool calls retries on a doubling ladder and, at `_MAX_TOKENS_CEILING`, returns the error fallback so `persist_outbound` skips it. Recovery is no longer gated on a tool error. The max-rounds exit carries the same guard, so exhausting the round budget cannot become a second delivery path for a no-tool-call partial.

Scope note: a turn that truncates *with* a valid tool call still delivers its partial text if it also exhausts the round budget. That is deliberate. Discarding it would throw away turns whose tools already executed, which is worse than the gap. Only the no-tool-call case, where the text is provider markup rather than a reply, is discarded.

`llm_max_tokens_agent` goes 2048 to 8192. Reasoning models bill chain-of-thought against this budget, and this was the tightest limit in the file despite being the most tool-heavy path (heartbeat 12000, compaction 16000).

Measured against a DeepSeek-family model on a two-event calendar request, 6 trials each:

| | before | after |
|---|---|---|
| garbage delivered | 3/6 | 0/6 |
| clean tool call | 3/6 | 5/6 |
| recovered on ladder | 0 | 1/6 |

The leak reproduces deterministically at `max_tokens=128` with a perfectly healthy model, so this is provider-agnostic and not tied to any one backend.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) : 3125 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Four regression tests cover the retry path, the discard-at-ceiling path, the ungated recovery, and the ladder never lowering an above-ceiling budget. `test_valid_stop_reasons_not_treated_as_error` asserted that a `max_tokens` text response is delivered as a normal reply, which encoded the bug, so it is narrowed to `end_turn` and `stop_sequence` with a comment pointing at the new tests.

Second commit applies review follow-ups: the ladder's `min(effective * 2, ceiling)` could *lower* a budget configured above the ceiling (reproduced at `LLM_MAX_TOKENS_AGENT=32000` as `[32000, 16384]`, logged as an increase), `trigger_compaction_for_dropped` is hoisted to module scope per AGENTS.md, and the `LLM_MAX_TOKENS_AGENT` / `LLM_MAX_TOKENS_HEARTBEAT` defaults in `.env.example` and `docs/self-host/configuration.md` are corrected. Those docs were already stale before this PR.

## AI Usage
- [x] AI-assisted: investigated, diagnosed, and implemented by Claude Code, with direction and review from @njbrake. Before/after numbers come from live runs against the affected model.
