### PR TITLE
fix(tools): stop _strip_titles deleting a parameter named "title"

### DIFF
--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -115,10 +115,39 @@ def _inline_refs(schema: dict[str, Any]) -> dict[str, Any]:
     return resolve(schema)
 
 
-def _strip_titles(obj: Any) -> Any:
-    """Recursively remove all 'title' keys from a schema dict."""
+# JSON Schema containers whose *keys* are caller-chosen names rather than
+# schema keywords. A parameter literally named ``title`` lives in one of these
+# and must survive ``_strip_titles``; only annotation-level ``title`` keys are
+# noise worth dropping. ``$defs`` / ``definitions`` are normally gone by the
+# time we run (``_inline_refs`` pops them), and are listed for safety.
+_NAME_KEYED_SCHEMA_CONTAINERS = frozenset(
+    {"properties", "patternProperties", "$defs", "definitions"}
+)
+
+
+def _strip_titles(obj: Any, *, _in_name_map: bool = False) -> Any:
+    """Recursively remove Pydantic's ``title`` annotations from a schema.
+
+    Pydantic stamps a ``title`` onto every schema node, which is pure noise in
+    the tool definitions we send on each request, so dropping it saves tokens.
+
+    The subtlety is that ``title`` is only noise when it is a schema *keyword*.
+    Inside ``properties`` the keys are parameter names, and a tool with a
+    parameter named ``title`` (``calendar_create_event``) had that parameter
+    deleted from the schema while ``required`` kept listing it. The model was
+    then told ``title`` was mandatory and given no definition for it, so it had
+    nowhere to put the value and the call could never validate. ``_in_name_map``
+    tracks that context so parameter names are never filtered.
+    """
     if isinstance(obj, dict):
-        return {k: _strip_titles(v) for k, v in obj.items() if k != "title"}
+        if _in_name_map:
+            # Keys here are caller-chosen names, not schema keywords.
+            return {k: _strip_titles(v) for k, v in obj.items()}
+        return {
+            k: _strip_titles(v, _in_name_map=k in _NAME_KEYED_SCHEMA_CONTAINERS)
+            for k, v in obj.items()
+            if k != "title"
+        }
     if isinstance(obj, list):
         return [_strip_titles(item) for item in obj]
     return obj

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib
+import pkgutil
+import sys
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import BaseModel, Field
 
 import backend.app.agent.tools.registry as _reg
-from backend.app.agent.tools.base import Tool, ToolTags
+from backend.app.agent.tools.base import Tool, ToolResult, ToolTags, tool_to_function_schema
 from backend.app.agent.tools.registry import (
     ToolContext,
     default_registry,
@@ -253,6 +257,108 @@ async def test_ask_sub_tools_have_approval_policy() -> None:
         "Tools with default_permission='ask' must have an ApprovalPolicy "
         "on the Tool object so the runtime enforces permissions:\n" + "\n".join(missing)
     )
+
+
+def _all_tool_params_models() -> dict[str, type[BaseModel]]:
+    """Every ``*Params`` model that backs a tool, keyed by qualified name.
+
+    Deliberately discovered by walking imported modules rather than by building
+    tools through their factories. Most integration factories are auth-gated and
+    return nothing without OAuth credentials, so a factory-driven sweep silently
+    skips them: at the time of writing it reaches 18 of the ~62 tools an agent
+    actually sees, and ``calendar_create_event`` is not among them. A schema
+    invariant that cannot see the tool it was written for is worse than no test.
+    """
+    ensure_tool_modules_imported()
+
+    import backend.app.integrations as integrations_pkg
+
+    for mod_info in pkgutil.walk_packages(
+        integrations_pkg.__path__, integrations_pkg.__name__ + "."
+    ):
+        with contextlib.suppress(Exception):
+            importlib.import_module(mod_info.name)
+
+    found: dict[str, type[BaseModel]] = {}
+    for mod_name, module in list(sys.modules.items()):
+        if not mod_name.startswith("backend.app") or module is None:
+            continue
+        for attr in vars(module).values():
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, BaseModel)
+                and attr is not BaseModel
+                and attr.__name__.endswith("Params")
+            ):
+                found[f"{attr.__module__}.{attr.__name__}"] = attr
+    return found
+
+
+def test_every_required_param_is_defined_in_properties() -> None:
+    """No tool may require a parameter its schema never defines.
+
+    ``required`` naming a key absent from ``properties`` is an unsatisfiable
+    contract: the model is told the parameter is mandatory and given nowhere to
+    put it, so the call can never validate no matter how the model responds.
+
+    This shipped for real. ``_strip_titles`` dropped every key named ``title``,
+    including the ``title`` *parameter* of ``calendar_create_event``, while
+    ``required`` kept listing it. Measured against a non-Claude model, 10 of 12
+    calls came back with the title stuffed into ``location`` and no ``title``
+    field, and every one failed validation. Lenient models papered over it; a
+    strict one rejected the schema outright with a 400.
+    """
+    models = _all_tool_params_models()
+    assert len(models) > 40, f"discovery looks broken, only found {len(models)} params models"
+    assert any(name.endswith("CalendarCreateEventParams") for name in models), (
+        "CalendarCreateEventParams must be covered; it is the model this test exists for"
+    )
+
+    async def _noop(**_: object) -> ToolResult:
+        return ToolResult(content="")
+
+    broken: list[str] = []
+    for qualname, model in sorted(models.items()):
+        tool = Tool(name="probe", description="", function=_noop, params_model=model)
+        schema = tool_to_function_schema(tool)["input_schema"]
+        declared = set(schema.get("properties") or {})
+        required = set(schema.get("required") or [])
+        undefined = required - declared
+        if undefined:
+            broken.append(f"{qualname}: required but undefined in properties: {sorted(undefined)}")
+
+    assert not broken, (
+        "Every name in a tool's `required` list must also appear in `properties`, "
+        "or the model is asked for a parameter it has no way to supply:\n" + "\n".join(broken)
+    )
+
+
+def test_strip_titles_keeps_a_parameter_named_title() -> None:
+    """A parameter named ``title`` survives; annotation titles still go."""
+
+    class ParamsWithTitle(BaseModel):
+        title: str = Field(description="Event title.")
+        start: str = Field(description="ISO 8601 start.")
+
+    async def _noop(**_: object) -> ToolResult:
+        return ToolResult(content="")
+
+    tool = Tool(
+        name="thing_create",
+        description="Create a thing.",
+        function=_noop,
+        params_model=ParamsWithTitle,
+    )
+    schema = tool_to_function_schema(tool)["input_schema"]
+
+    assert "title" in schema["properties"], "the `title` parameter was stripped from properties"
+    assert set(schema["required"]) <= set(schema["properties"])
+    assert schema["properties"]["title"]["type"] == "string"
+    # The token-saving behaviour is preserved: Pydantic's annotation-level
+    # ``title`` on the model and on each property is still removed.
+    assert "title" not in schema
+    assert "title" not in schema["properties"]["start"]
+    assert "title" not in schema["properties"]["title"]
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

`_strip_titles` removes Pydantic's `title` annotations from tool schemas to save tokens on every request. It recursed blindly, so it could not distinguish a schema keyword from a *parameter name*. Inside `properties`, a parameter literally named `title` was deleted while `required` kept listing it.

`calendar_create_event` reached the model as:

```
properties: [calendar_id, description, end, location, reminder_minutes_before, start]
required:   [end, start, title]
```

An unsatisfiable contract. The model was told `title` was mandatory and given nowhere to put it, so it put the title into `location` and omitted `title`, and the call failed validation every time.

Measured against a non-Claude model through the gateway, 12 trials per arm:

| arm | succeeded | call missing `title` | runaway |
|---|---|---|---|
| broken schema, retry after the error | **0/12** | 10 | 1 |
| fixed schema, same retry context | **11/12** | 0 | 0 |
| fixed schema, fresh request | **12/12** | 0 | 0 |

`p < 0.0001`. The fixed schema recovers even with the stale validation error still in context, so conversations already carrying a failed turn do not need cleaning.

Claude tolerated the broken schema by inferring the parameter from `required` plus the tool description, which is why this stayed latent until the deployed model changed. A strict model rejected the schema outright with a 400.

`calendar_update_event` has a `title` field too and had the same defect.

## Fix

Recursion now tracks whether it is inside a name-keyed container (`properties`, `patternProperties`, `$defs`, `definitions`) and never filters keys there. Annotation-level `title` is still stripped, so the token saving is unchanged.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) : 3128 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Two regression tests, both confirmed to fail with the fix reverted:

- `test_strip_titles_keeps_a_parameter_named_title` covers the mechanism and asserts annotation titles are still removed, so the token saving cannot be lost silently.
- `test_every_required_param_is_defined_in_properties` enforces `required` as a subset of `properties` across all 68 `*Params` models.

The invariant test discovers models by walking imported modules rather than by building tools through their factories. A factory-driven sweep reaches only 18 of the ~62 tools an agent sees, because most integration factories are auth-gated and return nothing without credentials, and `calendar_create_event` is not among the 18. The first draft did just that and passed on the broken code. It now asserts that discovery found more than 40 models and that `CalendarCreateEventParams` is covered, so it cannot go vacuous again.

## AI Usage
- [x] AI-assisted: root-caused and implemented by Claude Code, with direction and review from @njbrake. The before/after table comes from live runs against the affected model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `_strip_titles` so it preserves parameters named `title`.
- Continued removing annotation-level `title` fields to retain token savings.
- Added schema tests that verify required parameters are defined.
- Added coverage for model discovery, including `CalendarCreateEventParams`.

## Benefits

- Prevents invalid tool schemas for calendar tools.
- Detects similar schema regressions across discovered parameter models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->