### PR TITLE
feat(bluebubbles): auth-aware health probe and webhook registration check

### DIFF
--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -4,9 +4,12 @@ import asyncio
 import datetime
 import hashlib
 import hmac
+import json
 import logging
 import uuid
-from urllib.parse import quote
+from dataclasses import dataclass
+from typing import cast
+from urllib.parse import parse_qs, quote, urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, Request
@@ -69,6 +72,17 @@ _TRANSIENT_HTTP_EXCEPTIONS = (
     httpx.PoolTimeout,
     httpx.RemoteProtocolError,
 )
+
+
+# Path the BlueBubbles server POSTs inbound messages to, and the single event
+# we subscribe to. Both the registration path and the health check that
+# verifies registration read these, so the two can never drift apart.
+INBOUND_WEBHOOK_PATH = "/api/webhooks/bluebubbles"
+INBOUND_WEBHOOK_EVENT = "new-message"
+
+# Timeout for the server-info probe. Deliberately short: this runs on a timer
+# against a residential Mac, and a slow answer is itself a bad sign.
+_SERVER_INFO_TIMEOUT_SECONDS = 5.0
 
 
 def _derive_webhook_token(password: str) -> str:
@@ -136,6 +150,110 @@ class BBWebhookPayload(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class RegisteredWebhook:
+    """One webhook subscription as the BlueBubbles server reports it."""
+
+    id: str
+    url: str
+    # Empty when the server's event list could not be parsed. Callers must
+    # treat that as "unknown", never as "not subscribed": guessing wrong
+    # would report a working bridge as broken.
+    events: tuple[str, ...] = ()
+
+
+def _parse_webhook_events(raw: object) -> tuple[str, ...]:
+    """Normalize the ``events`` field, which BlueBubbles has shipped three ways.
+
+    Depending on server version it arrives as a JSON-encoded string, a list of
+    plain strings, or a list of ``{"label": ..., "value": ...}`` objects.
+    Anything unrecognized yields an empty tuple, meaning "unknown".
+    """
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except ValueError:
+            return (raw,) if raw else ()
+    if not isinstance(raw, list):
+        return ()
+    events: list[str] = []
+    for item in raw:
+        if isinstance(item, str):
+            events.append(item)
+        elif isinstance(item, dict):
+            entry = cast("dict[str, object]", item)
+            value = entry.get("value") or entry.get("label")
+            if isinstance(value, str):
+                events.append(value)
+    return tuple(events)
+
+
+async def list_bluebubbles_webhooks(
+    server_url: str, password: str = ""
+) -> list[RegisteredWebhook] | None:
+    """List webhook subscriptions registered on the BlueBubbles server.
+
+    Returns ``None`` when the list could not be retrieved at all, which is
+    distinct from an empty list: "the server told us there are no webhooks"
+    is an actionable finding, "we could not ask" is not.
+
+    Catches broadly on purpose. This feeds a health check and a cleanup pass,
+    and both want "unknown" rather than an exception when a third-party server
+    answers with something unexpected.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{server_url}/api/v1/webhook",
+                params={"password": password or settings.bluebubbles_password},
+                timeout=settings.http_timeout_seconds,
+            )
+            if resp.status_code >= 400:
+                return None
+            data = resp.json()
+    except Exception:
+        logger.debug("Could not list BlueBubbles webhooks", exc_info=True)
+        return None
+
+    raw_hooks = data if isinstance(data, list) else data.get("data", [])
+    if not isinstance(raw_hooks, list):
+        return None
+
+    hooks: list[RegisteredWebhook] = []
+    for wh in raw_hooks:
+        if not isinstance(wh, dict):
+            continue
+        wh_id = wh.get("id")
+        wh_url = wh.get("url")
+        if wh_id is None or not isinstance(wh_url, str):
+            continue
+        hooks.append(
+            RegisteredWebhook(
+                id=str(wh_id), url=wh_url, events=_parse_webhook_events(wh.get("events"))
+            )
+        )
+    return hooks
+
+
+def _webhook_matches(candidate_url: str, expected_url: str) -> bool:
+    """True when a registered webhook URL is the one we would register now.
+
+    Compares scheme, host, path, and the ``token`` query parameter rather than
+    the raw strings, so a server that re-encodes the query on read-back still
+    matches. The token is part of the comparison on purpose: a registration
+    carrying a token derived from an old password is delivered to us and then
+    rejected at the door, which looks identical to no registration at all.
+    """
+    candidate, expected = urlparse(candidate_url), urlparse(expected_url)
+    if (candidate.scheme, candidate.netloc, candidate.path.rstrip("/")) != (
+        expected.scheme,
+        expected.netloc,
+        expected.path.rstrip("/"),
+    ):
+        return False
+    return parse_qs(candidate.query).get("token") == parse_qs(expected.query).get("token")
+
+
 async def _cleanup_stale_webhooks(server_url: str, our_endpoint: str) -> None:
     """Remove existing BlueBubbles webhooks that point to our endpoint.
 
@@ -143,28 +261,20 @@ async def _cleanup_stale_webhooks(server_url: str, our_endpoint: str) -> None:
     lists all registered webhooks and deletes any whose URL contains our
     endpoint path, preventing duplicate deliveries.
     """
+    webhooks = await list_bluebubbles_webhooks(server_url)
+    if not webhooks:
+        return
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{server_url}/api/v1/webhook",
-                params={"password": settings.bluebubbles_password},
-                timeout=settings.http_timeout_seconds,
-            )
-            if resp.status_code >= 400:
-                return
-            data = resp.json()
-            webhooks = data if isinstance(data, list) else data.get("data", [])
             for wh in webhooks:
-                wh_url = wh.get("url", "")
-                wh_id = wh.get("id")
-                if not wh_id or our_endpoint not in wh_url:
+                if our_endpoint not in wh.url:
                     continue
                 await client.delete(
-                    f"{server_url}/api/v1/webhook/{wh_id}",
+                    f"{server_url}/api/v1/webhook/{wh.id}",
                     params={"password": settings.bluebubbles_password},
                     timeout=settings.http_timeout_seconds,
                 )
-                logger.info("Removed stale BlueBubbles webhook %s", wh_id)
+                logger.info("Removed stale BlueBubbles webhook %s", wh.id)
     except Exception:
         logger.debug("Could not clean up stale BlueBubbles webhooks", exc_info=True)
 
@@ -212,6 +322,221 @@ async def register_bluebubbles_webhook(server_url: str, webhook_url: str) -> boo
         return False
 
 
+def build_webhook_url(base_url: str, password: str = "") -> str:
+    """Build the inbound webhook URL to register for *base_url*.
+
+    Single definition shared by the code that registers the webhook and the
+    health check that verifies it is still registered. If these were built
+    separately, a change to either would make the check quietly compare
+    against a URL nobody registers.
+    """
+    token = _derive_webhook_token(password or settings.bluebubbles_password)
+    return f"{base_url.rstrip('/')}{INBOUND_WEBHOOK_PATH}?token={quote(token, safe='')}"
+
+
+@dataclass(frozen=True)
+class WebhookCheck:
+    """Whether the BlueBubbles server will actually deliver inbound messages."""
+
+    ok: bool
+    detail: str = ""
+    # False when the webhook list could not be retrieved, so ``ok=False`` means
+    # "unknown" rather than "missing" and callers should not try to repair it.
+    listed: bool = False
+    registered_endpoints: tuple[str, ...] = ()
+
+
+async def verify_webhook_registration(
+    server_url: str, expected_webhook_url: str, password: str = ""
+) -> WebhookCheck:
+    """Check that *expected_webhook_url* is registered for new-message events.
+
+    This closes the gap that nothing else covers. Registration happens once at
+    startup; if the Mac was asleep or slow at that moment the attempt fails,
+    logs a warning, and is never retried. The bridge then comes back online,
+    every reachability check goes green, and inbound iMessage stays dead until
+    somebody redeploys. The same silence follows a base-URL change, which
+    leaves the old registration pointing at a URL that no longer answers.
+    """
+    webhooks = await list_bluebubbles_webhooks(server_url, password)
+    if webhooks is None:
+        return WebhookCheck(
+            ok=False,
+            detail="could not list webhooks on the BlueBubbles server",
+            listed=False,
+        )
+
+    endpoints = tuple(sorted({wh.url.split("?")[0] for wh in webhooks}))
+    expected_endpoint = expected_webhook_url.split("?")[0]
+
+    for wh in webhooks:
+        if not _webhook_matches(wh.url, expected_webhook_url):
+            continue
+        # An empty event tuple means the server's format was unrecognized.
+        # Unknown is not a failure.
+        if wh.events and INBOUND_WEBHOOK_EVENT not in wh.events:
+            return WebhookCheck(
+                ok=False,
+                detail=(
+                    f"webhook is registered but subscribed to {', '.join(wh.events)} "
+                    f"rather than {INBOUND_WEBHOOK_EVENT}"
+                ),
+                listed=True,
+                registered_endpoints=endpoints,
+            )
+        return WebhookCheck(ok=True, listed=True, registered_endpoints=endpoints)
+
+    if any(endpoint == expected_endpoint for endpoint in endpoints):
+        detail = (
+            f"a webhook for {expected_endpoint} is registered but its token does not "
+            "match the current server password, so deliveries are rejected on arrival"
+        )
+    elif endpoints:
+        detail = (
+            f"no webhook registered for {expected_endpoint}; the server has "
+            f"{len(webhooks)} registered instead: {', '.join(endpoints)}"
+        )
+    else:
+        detail = (
+            f"no webhooks are registered on the BlueBubbles server (expected {expected_endpoint})"
+        )
+    return WebhookCheck(ok=False, detail=detail, listed=True, registered_endpoints=endpoints)
+
+
+# ---------------------------------------------------------------------------
+# Server health probing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BlueBubblesHealth:
+    """Outcome of one ``/api/v1/server/info`` probe.
+
+    ``reachable`` and ``authenticated`` are separate fields because they fail
+    for different reasons and need different fixes: an unreachable host is a
+    sleeping Mac or a dead tunnel and may resolve itself, while a rejected
+    password is a configuration error that waiting will never fix. A single
+    ``status_code < 500`` boolean could not tell them apart and reported an
+    HTTP 401 as a healthy bridge.
+
+    The readiness flags are tri-state. ``None`` means the server did not report
+    that field, which older BlueBubbles builds do; a missing field must never
+    manufacture an outage.
+    """
+
+    reachable: bool
+    authenticated: bool
+    detail: str = ""
+    server_version: str = ""
+    private_api: bool | None = None
+    helper_connected: bool | None = None
+    # Whether the Mac is signed in to iMessage. Stored as a bool rather than
+    # the account address the server reports, so the operator's iCloud email
+    # never reaches a log line, an alert email, or the admin UI.
+    imessage_signed_in: bool | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.reachable and self.authenticated
+
+
+def _optional_bool(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+async def probe_bluebubbles_server(
+    server_url: str,
+    password: str,
+    timeout: float = _SERVER_INFO_TIMEOUT_SECONDS,
+) -> BlueBubblesHealth:
+    """Probe ``/api/v1/server/info`` and report what the answer proves.
+
+    Never raises: an exception here is itself the health signal.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{server_url}/api/v1/server/info",
+                params={"password": password},
+                timeout=timeout,
+            )
+    except httpx.HTTPError as exc:
+        # The exception text can carry the request URL, and the URL carries
+        # the password. Report the type only.
+        return BlueBubblesHealth(
+            reachable=False,
+            authenticated=False,
+            detail=f"{type(exc).__name__} contacting the BlueBubbles server",
+        )
+
+    if resp.status_code in (401, 403):
+        return BlueBubblesHealth(
+            reachable=True,
+            authenticated=False,
+            detail=(
+                f"BlueBubbles rejected the server password (HTTP {resp.status_code}); "
+                "check BLUEBUBBLES_PASSWORD"
+            ),
+        )
+    if resp.status_code >= 500:
+        return BlueBubblesHealth(
+            reachable=False,
+            authenticated=False,
+            detail=f"BlueBubbles server returned HTTP {resp.status_code}",
+        )
+    if resp.status_code != 200:
+        return BlueBubblesHealth(
+            reachable=True,
+            authenticated=False,
+            detail=(
+                f"unexpected HTTP {resp.status_code} from /api/v1/server/info; "
+                "check BLUEBUBBLES_SERVER_URL points at a BlueBubbles server"
+            ),
+        )
+
+    try:
+        body = resp.json()
+    except ValueError:
+        return BlueBubblesHealth(
+            reachable=True,
+            authenticated=False,
+            detail="/api/v1/server/info returned a non-JSON body",
+        )
+    payload = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(payload, dict):
+        payload = {}
+
+    account = payload.get("detected_icloud")
+    return BlueBubblesHealth(
+        reachable=True,
+        authenticated=True,
+        server_version=str(payload.get("server_version") or ""),
+        private_api=_optional_bool(payload.get("private_api")),
+        helper_connected=_optional_bool(payload.get("helper_connected")),
+        imessage_signed_in=bool(account) if "detected_icloud" in payload else None,
+    )
+
+
+def describe_send_readiness(health: BlueBubblesHealth, send_method: str = "") -> str:
+    """Return why outbound iMessage would fail, or ``""`` when nothing is wrong.
+
+    ``/api/v1/server/info`` answering proves the bridge process is alive. It
+    does not prove the Mac can still send: Messages.app signed out of iMessage,
+    or a private-api send method whose helper is not connected, both leave the
+    server perfectly reachable and every send failing.
+    """
+    if health.imessage_signed_in is False:
+        return "the Mac is not signed in to iMessage (BlueBubbles reports no iCloud account)"
+    if (send_method or settings.bluebubbles_send_method) == "private-api":
+        if health.private_api is False:
+            return "send method is private-api but the BlueBubbles Private API is disabled"
+        if health.helper_connected is False:
+            return (
+                "send method is private-api but the BlueBubbles Private API helper is not connected"
+            )
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # BlueBubbles channel implementation
 # ---------------------------------------------------------------------------
@@ -224,8 +549,14 @@ class BlueBubblesChannel(BaseChannel):
         self._client: httpx.AsyncClient | None = None
         # In-memory cache: sender_address -> chat_guid
         self._chat_cache: dict[str, str] = {}
-        # Set to True once the BlueBubbles server is confirmed reachable.
+        # Set to True once the BlueBubbles server is confirmed reachable and
+        # answering authenticated requests.
         self.server_reachable: bool = False
+        # Full result of the most recent probe, kept so monitoring can report
+        # *why* the bridge is unhealthy and check send readiness without
+        # running a second poller against the operator's Mac. ``None`` until
+        # the first probe completes.
+        self.last_health: BlueBubblesHealth | None = None
         # Background tasks owned by this channel: periodic health check
         # and recurring backfill. Started in ``start()`` and cancelled in
         # ``stop()`` so the lifespan shutdown is clean.
@@ -250,20 +581,23 @@ class BlueBubblesChannel(BaseChannel):
 
     # -- Lifecycle -------------------------------------------------------------
 
+    async def check_health(self) -> BlueBubblesHealth:
+        """Probe the server, remember the result, and return it."""
+        health = await probe_bluebubbles_server(
+            settings.bluebubbles_server_url, settings.bluebubbles_password
+        )
+        self.last_health = health
+        return health
+
     async def _check_server_reachable(self) -> bool:
-        """Ping the BlueBubbles server to verify connectivity."""
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(
-                    f"{settings.bluebubbles_server_url}/api/v1/server/info",
-                    params={"password": settings.bluebubbles_password},
-                    timeout=5,
-                )
-                return resp.status_code < 500
-        except httpx.ConnectError:
-            return False
-        except httpx.HTTPError:
-            return False
+        """Ping the BlueBubbles server to verify connectivity.
+
+        "Reachable" requires an authenticated 200, not merely a non-5xx.
+        A wrong password answers 401 while delivering nothing, and treating
+        that as reachable put a green light on a bridge that could not pass a
+        single message.
+        """
+        return (await self.check_health()).ok
 
     async def start(self) -> None:
         """Discover tunnel URL and auto-register BlueBubbles webhook."""
@@ -303,8 +637,7 @@ class BlueBubblesChannel(BaseChannel):
             )
             return
 
-        token = _derive_webhook_token(settings.bluebubbles_password)
-        webhook_url = f"{tunnel_url}/api/webhooks/bluebubbles?token={token}"
+        webhook_url = build_webhook_url(tunnel_url)
 
         if not await wait_for_dns(tunnel_url):
             logger.warning(
@@ -351,22 +684,23 @@ class BlueBubblesChannel(BaseChannel):
             while True:
                 await asyncio.sleep(interval)
                 try:
-                    reachable = await self._check_server_reachable()
+                    health = await self.check_health()
                 except Exception:
                     logger.exception("BlueBubbles periodic health check failed")
                     continue
-                if reachable != self.server_reachable:
-                    if reachable:
+                if health.ok != self.server_reachable:
+                    if health.ok:
                         logger.info(
-                            "BlueBubbles server reachable again at %s",
+                            "BlueBubbles server healthy again at %s",
                             settings.bluebubbles_server_url,
                         )
                     else:
                         logger.warning(
-                            "BlueBubbles server went unreachable at %s",
+                            "BlueBubbles server went unhealthy at %s: %s",
                             settings.bluebubbles_server_url,
+                            health.detail,
                         )
-                    self.server_reachable = reachable
+                    self.server_reachable = health.ok
         except asyncio.CancelledError:
             return
 
@@ -395,8 +729,7 @@ class BlueBubblesChannel(BaseChannel):
         """Register BlueBubbles webhook using a stable PaaS base URL."""
         if not settings.bluebubbles_server_url or not settings.bluebubbles_password:
             return None
-        token = _derive_webhook_token(settings.bluebubbles_password)
-        webhook_url = f"{base_url}/api/webhooks/bluebubbles?token={quote(token, safe='')}"
+        webhook_url = build_webhook_url(base_url)
         return await register_bluebubbles_webhook(settings.bluebubbles_server_url, webhook_url)
 
     async def stop(self) -> None:

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -80,6 +80,12 @@ _TRANSIENT_HTTP_EXCEPTIONS = (
 INBOUND_WEBHOOK_PATH = "/api/webhooks/bluebubbles"
 INBOUND_WEBHOOK_EVENT = "new-message"
 
+# BlueBubbles ships "All Events" as a first-class event value and its dispatcher
+# short-circuits on it (``if (!eventTypes.includes("*") && ...) continue``), so a
+# webhook subscribed to "*" does receive new-message. Treating it as a mismatch
+# would report a delivering bridge as broken.
+_WILDCARD_WEBHOOK_EVENT = "*"
+
 # Timeout for the server-info probe. Deliberately short: this runs on a timer
 # against a residential Mac, and a slow answer is itself a bad sign.
 _SERVER_INFO_TIMEOUT_SECONDS = 5.0
@@ -215,7 +221,15 @@ async def list_bluebubbles_webhooks(
         logger.debug("Could not list BlueBubbles webhooks", exc_info=True)
         return None
 
-    raw_hooks = data if isinstance(data, list) else data.get("data", [])
+    if isinstance(data, list):
+        raw_hooks: object = data
+    elif isinstance(data, dict):
+        raw_hooks = data.get("data", [])
+    else:
+        # A 200 carrying a JSON scalar or null is not something we can read.
+        # Returning None keeps the documented "unknown" contract instead of
+        # raising out of a function two health paths call without a handler.
+        return None
     if not isinstance(raw_hooks, list):
         return None
 
@@ -374,7 +388,7 @@ async def verify_webhook_registration(
             continue
         # An empty event tuple means the server's format was unrecognized.
         # Unknown is not a failure.
-        if wh.events and INBOUND_WEBHOOK_EVENT not in wh.events:
+        if wh.events and not {INBOUND_WEBHOOK_EVENT, _WILDCARD_WEBHOOK_EVENT} & set(wh.events):
             return WebhookCheck(
                 ok=False,
                 detail=(
@@ -392,9 +406,11 @@ async def verify_webhook_registration(
             "match the current server password, so deliveries are rejected on arrival"
         )
     elif endpoints:
+        # Count the endpoints being listed, not the raw registrations: quoting
+        # "3 registered" beside two deduplicated URLs reads as a missing entry.
         detail = (
             f"no webhook registered for {expected_endpoint}; the server has "
-            f"{len(webhooks)} registered instead: {', '.join(endpoints)}"
+            f"{len(endpoints)} other endpoint(s) registered: {', '.join(endpoints)}"
         )
     else:
         detail = (
@@ -460,7 +476,12 @@ async def probe_bluebubbles_server(
                 params={"password": password},
                 timeout=timeout,
             )
-    except httpx.HTTPError as exc:
+    except Exception as exc:
+        # Catch broadly, not just ``httpx.HTTPError``: ``httpx.InvalidURL``
+        # derives straight from ``Exception``, so a malformed
+        # BLUEBUBBLES_SERVER_URL (an unbracketed IPv6 literal, say) would
+        # otherwise escape a function documented never to raise, and
+        # ``start()`` would abort before the health and backfill loops spawn.
         # The exception text can carry the request URL, and the URL carries
         # the password. Report the type only.
         return BlueBubblesHealth(
@@ -506,14 +527,23 @@ async def probe_bluebubbles_server(
     if not isinstance(payload, dict):
         payload = {}
 
-    account = payload.get("detected_icloud")
+    # ``detected_icloud`` is read off MobileMeAccounts.plist, so it reports the
+    # Mac's *iCloud* login, not the Messages.app sign-in, and it comes back null
+    # whenever that plist read fails. ``detected_imessage`` is derived from the
+    # iMessage chat database and is null on a Mac with no iMessage chats yet.
+    # Either one being populated proves a signed-in account, so require both to
+    # be empty before claiming the Mac cannot send. Neither field present means
+    # an older server and stays ``None``.
+    account_fields = [f for f in ("detected_icloud", "detected_imessage") if f in payload]
     return BlueBubblesHealth(
         reachable=True,
         authenticated=True,
         server_version=str(payload.get("server_version") or ""),
         private_api=_optional_bool(payload.get("private_api")),
         helper_connected=_optional_bool(payload.get("helper_connected")),
-        imessage_signed_in=bool(account) if "detected_icloud" in payload else None,
+        imessage_signed_in=(
+            any(bool(payload.get(f)) for f in account_fields) if account_fields else None
+        ),
     )
 
 
@@ -526,7 +556,7 @@ def describe_send_readiness(health: BlueBubblesHealth, send_method: str = "") ->
     server perfectly reachable and every send failing.
     """
     if health.imessage_signed_in is False:
-        return "the Mac is not signed in to iMessage (BlueBubbles reports no iCloud account)"
+        return "the Mac is not signed in to iMessage (BlueBubbles reports no signed-in account)"
     if (send_method or settings.bluebubbles_send_method) == "private-api":
         if health.private_api is False:
             return "send method is private-api but the BlueBubbles Private API is disabled"

--- a/tests/test_bluebubbles_channel.py
+++ b/tests/test_bluebubbles_channel.py
@@ -1057,29 +1057,37 @@ async def test_start_checks_reachability_even_with_paas_webhook_registered() -> 
 
 
 async def test_check_server_reachable_success() -> None:
-    """_check_server_reachable returns True when server responds."""
+    """_check_server_reachable returns True when the server answers an authenticated 200.
+
+    Uses a real response rather than an ``AsyncMock``: the check now parses the
+    ``/api/v1/server/info`` body, so a mock that only carries ``status_code``
+    would pass without exercising the parse. Deeper coverage of the probe
+    itself lives in test_bluebubbles_health.py.
+    """
     channel = BlueBubblesChannel()
 
-    mock_resp = AsyncMock()
-    mock_resp.status_code = 200
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"status": 200, "data": {"server_version": "1.9.8", "private_api": True}}
+        )
 
+    real_client = httpx.AsyncClient
     with (
         patch(
             "backend.app.channels.bluebubbles.settings.bluebubbles_server_url",
             "https://my-mac.example.com",
         ),
         patch("backend.app.channels.bluebubbles.settings.bluebubbles_password", "test-pw"),
-        patch("backend.app.channels.bluebubbles.httpx.AsyncClient") as mock_cls,
+        patch(
+            "backend.app.channels.bluebubbles.httpx.AsyncClient",
+            lambda **_kw: real_client(transport=httpx.MockTransport(handler)),
+        ),
     ):
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.get.return_value = mock_resp
-        mock_cls.return_value = mock_client
-
         result = await channel._check_server_reachable()
 
     assert result is True
+    assert channel.last_health is not None
+    assert channel.last_health.server_version == "1.9.8"
 
 
 async def test_check_server_reachable_connect_error() -> None:

--- a/tests/test_bluebubbles_health.py
+++ b/tests/test_bluebubbles_health.py
@@ -156,6 +156,19 @@ async def test_probe_omitted_flags_are_unknown_not_false() -> None:
     assert describe_send_readiness(health, "private-api") == ""
 
 
+async def test_probe_survives_a_malformed_server_url() -> None:
+    """``httpx.InvalidURL`` is not an ``httpx.HTTPError``; the probe must not raise.
+
+    ``start()`` awaits this before spawning the health and backfill loops, so an
+    escape here would silently leave both loops unstarted for the process life.
+    """
+    health = await probe_bluebubbles_server("http://[::1", _PASSWORD, timeout=0.1)
+
+    assert not health.ok
+    assert health.reachable is False
+    assert "InvalidURL" in health.detail
+
+
 # ---------------------------------------------------------------------------
 # Send readiness
 # ---------------------------------------------------------------------------
@@ -163,12 +176,28 @@ async def test_probe_omitted_flags_are_unknown_not_false() -> None:
 
 async def test_send_readiness_flags_signed_out_mac() -> None:
     """Reachable and authenticated, but Messages.app is signed out: every send fails."""
-    with _mock_bb_http(_info_response(detected_icloud="")):
+    with _mock_bb_http(_info_response(detected_icloud="", detected_imessage="")):
         health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
 
     assert health.ok
     assert health.imessage_signed_in is False
     assert "not signed in to iMessage" in describe_send_readiness(health, "apple-script")
+
+
+async def test_send_readiness_trusts_the_imessage_account_when_icloud_is_absent() -> None:
+    """``detected_icloud`` reads the iCloud login, which a signed-in Mac can lack.
+
+    It comes from MobileMeAccounts.plist, so a Mac using iMessage without iCloud
+    (or one where the plist read fails) reports null there while
+    ``detected_imessage``, derived from the chat database, is populated. Alerting
+    on the iCloud field alone would email the operator about a working bridge.
+    """
+    with _mock_bb_http(_info_response(detected_icloud=None, detected_imessage="a@example.com")):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert health.imessage_signed_in is True
+    assert describe_send_readiness(health, "apple-script") == ""
+    assert "a@example.com" not in repr(health)
 
 
 def test_send_readiness_private_api_disabled_only_matters_for_private_api() -> None:
@@ -285,6 +314,37 @@ async def test_verify_parses_every_event_encoding(events: Any) -> None:
         check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
 
     assert check.ok
+
+
+async def test_verify_accepts_the_all_events_wildcard() -> None:
+    """BlueBubbles ships "All Events" as ``*`` and its dispatcher honours it.
+
+    An operator who repairs a broken registration by hand picks that option, and
+    the webhook does deliver new-message. Calling it a mismatch would report a
+    working bridge as broken and trigger a repair the premium monitor emails about.
+    """
+    expected = build_webhook_url("https://clawbolt.example", _PASSWORD)
+    with _mock_bb_http(_webhook_list_handler([{"id": 8, "url": expected, "events": ["*"]}])):
+        check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
+
+    assert check.ok
+
+
+async def test_list_webhooks_returns_none_for_a_scalar_json_body() -> None:
+    """A 200 carrying ``null`` used to raise ``AttributeError`` out of the helper.
+
+    ``verify_webhook_registration`` has no handler of its own, so the escape
+    reached the health path rather than reporting "unknown".
+    """
+    with _mock_bb_http(
+        lambda _req: httpx.Response(
+            200, content=b"null", headers={"content-type": "application/json"}
+        )
+    ):
+        assert await list_bluebubbles_webhooks("http://bb.example", "pw") is None
+        check = await verify_webhook_registration("http://bb.example", "https://x.example", "pw")
+
+    assert not check.listed
 
 
 async def test_verify_passes_when_the_event_format_is_unrecognized() -> None:

--- a/tests/test_bluebubbles_health.py
+++ b/tests/test_bluebubbles_health.py
@@ -1,0 +1,359 @@
+"""Tests for BlueBubbles health probing and webhook-registration verification.
+
+Two failure modes drive this module, and neither raises an exception:
+
+- A wrong server password answers HTTP 401. The old reachability check
+  accepted any status below 500, so a bridge that could not pass a single
+  message reported as healthy.
+- Webhook registration runs once at startup. If it fails (Mac asleep), the
+  bridge later comes back, every reachability check goes green, and inbound
+  iMessage stays dead until somebody redeploys.
+"""
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from backend.app.channels.bluebubbles import (
+    BlueBubblesChannel,
+    BlueBubblesHealth,
+    _derive_webhook_token,
+    build_webhook_url,
+    describe_send_readiness,
+    list_bluebubbles_webhooks,
+    probe_bluebubbles_server,
+    verify_webhook_registration,
+)
+from backend.app.config import settings
+
+_SERVER = "http://bluebubbles.example"
+_PASSWORD = "bb-test-password"
+
+
+@contextmanager
+def _mock_bb_http(handler: Any) -> Any:
+    """Route the module's ad-hoc ``httpx.AsyncClient()`` calls to *handler*.
+
+    The probe and webhook helpers create their own short-lived clients rather
+    than reusing the channel's, so there is no client attribute to swap.
+    """
+    real_client = httpx.AsyncClient
+
+    def factory(*_args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.pop("base_url", None)
+        kwargs.pop("transport", None)
+        return real_client(transport=httpx.MockTransport(handler), **kwargs)
+
+    with patch("backend.app.channels.bluebubbles.httpx.AsyncClient", factory):
+        yield
+
+
+def _info_response(**data: Any) -> Any:
+    """Build a ``/api/v1/server/info`` handler returning *data* in the envelope."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"status": 200, "message": "Success", "data": data})
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Server probe
+# ---------------------------------------------------------------------------
+
+
+async def test_probe_reports_healthy_server_with_flags() -> None:
+    """A 200 with readiness flags yields an authenticated, fully-populated result."""
+    with _mock_bb_http(
+        _info_response(
+            server_version="1.9.8",
+            private_api=True,
+            helper_connected=True,
+            detected_icloud="operator@example.com",
+        )
+    ):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert health.ok
+    assert health.reachable and health.authenticated
+    assert health.server_version == "1.9.8"
+    assert health.private_api is True
+    assert health.helper_connected is True
+    assert health.imessage_signed_in is True
+
+
+async def test_probe_does_not_carry_the_icloud_address() -> None:
+    """The account address is reduced to a bool so PII never reaches a log or email."""
+    with _mock_bb_http(_info_response(detected_icloud="operator@example.com")):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert health.imessage_signed_in is True
+    assert "operator@example.com" not in repr(health)
+
+
+async def test_probe_treats_401_as_authentication_failure() -> None:
+    """Regression: HTTP 401 used to pass ``status_code < 500`` and read as healthy."""
+    with _mock_bb_http(lambda _req: httpx.Response(401, text="Unauthorized")):
+        health = await probe_bluebubbles_server(_SERVER, "wrong-password")
+
+    assert not health.ok
+    assert health.reachable is True
+    assert health.authenticated is False
+    assert "password" in health.detail.lower()
+
+
+async def test_probe_treats_404_as_unauthenticated_with_url_hint() -> None:
+    """A URL that is not a BlueBubbles server answers 404 rather than failing to connect."""
+    with _mock_bb_http(lambda _req: httpx.Response(404, text="Not Found")):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert not health.ok
+    assert "BLUEBUBBLES_SERVER_URL" in health.detail
+
+
+async def test_probe_reports_5xx_as_unreachable() -> None:
+    with _mock_bb_http(lambda _req: httpx.Response(503, text="down")):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert health.reachable is False
+    assert "503" in health.detail
+
+
+async def test_probe_connect_error_does_not_leak_the_password() -> None:
+    """httpx exception text can include the request URL, and the URL carries the password."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(f"failed to connect to {request.url}", request=request)
+
+    with _mock_bb_http(handler):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert health.reachable is False
+    assert _PASSWORD not in health.detail
+    assert "ConnectError" in health.detail
+
+
+async def test_probe_non_json_body_is_not_authenticated() -> None:
+    with _mock_bb_http(lambda _req: httpx.Response(200, text="<html>login</html>")):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert not health.ok
+    assert "non-JSON" in health.detail
+
+
+async def test_probe_omitted_flags_are_unknown_not_false() -> None:
+    """Older servers omit these fields; a missing field must not invent an outage."""
+    with _mock_bb_http(_info_response(server_version="1.0.0")):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert health.ok
+    assert health.private_api is None
+    assert health.helper_connected is None
+    assert health.imessage_signed_in is None
+    assert describe_send_readiness(health, "private-api") == ""
+
+
+# ---------------------------------------------------------------------------
+# Send readiness
+# ---------------------------------------------------------------------------
+
+
+async def test_send_readiness_flags_signed_out_mac() -> None:
+    """Reachable and authenticated, but Messages.app is signed out: every send fails."""
+    with _mock_bb_http(_info_response(detected_icloud="")):
+        health = await probe_bluebubbles_server(_SERVER, _PASSWORD)
+
+    assert health.ok
+    assert health.imessage_signed_in is False
+    assert "not signed in to iMessage" in describe_send_readiness(health, "apple-script")
+
+
+def test_send_readiness_private_api_disabled_only_matters_for_private_api() -> None:
+    health = BlueBubblesHealth(
+        reachable=True, authenticated=True, private_api=False, helper_connected=False
+    )
+
+    assert "Private API is disabled" in describe_send_readiness(health, "private-api")
+    assert describe_send_readiness(health, "apple-script") == ""
+
+
+def test_send_readiness_flags_disconnected_helper() -> None:
+    health = BlueBubblesHealth(
+        reachable=True, authenticated=True, private_api=True, helper_connected=False
+    )
+
+    assert "helper is not connected" in describe_send_readiness(health, "private-api")
+
+
+def test_send_readiness_healthy_server_reports_nothing() -> None:
+    health = BlueBubblesHealth(
+        reachable=True,
+        authenticated=True,
+        private_api=True,
+        helper_connected=True,
+        imessage_signed_in=True,
+    )
+
+    assert describe_send_readiness(health, "private-api") == ""
+
+
+# ---------------------------------------------------------------------------
+# Webhook registration verification
+# ---------------------------------------------------------------------------
+
+
+def _webhook_list_handler(webhooks: list[dict[str, Any]]) -> Any:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"status": 200, "message": "Success", "data": webhooks})
+
+    return handler
+
+
+async def test_verify_accepts_the_url_we_would_register() -> None:
+    """Round-trip: the URL built for registration is the URL the check looks for."""
+    expected = build_webhook_url("https://clawbolt.example", _PASSWORD)
+    with _mock_bb_http(
+        _webhook_list_handler([{"id": 1, "url": expected, "events": ["new-message"]}])
+    ):
+        check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
+
+    assert check.ok
+    assert check.listed
+
+
+async def test_verify_reports_missing_registration() -> None:
+    """The failure that silently kills inbound: registration never landed."""
+    expected = build_webhook_url("https://clawbolt.example", _PASSWORD)
+    with _mock_bb_http(_webhook_list_handler([])):
+        check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
+
+    assert not check.ok
+    assert check.listed  # we asked and got an answer: safe to repair
+    assert "no webhooks are registered" in check.detail
+
+
+async def test_verify_reports_a_registration_for_a_different_base_url() -> None:
+    """A base-URL change leaves the old registration pointing at a dead URL."""
+    expected = build_webhook_url("https://new.example", _PASSWORD)
+    stale = build_webhook_url("https://old.example", _PASSWORD)
+    with _mock_bb_http(_webhook_list_handler([{"id": 7, "url": stale, "events": ["new-message"]}])):
+        check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
+
+    assert not check.ok
+    assert "no webhook registered for https://new.example" in check.detail
+    assert check.registered_endpoints == ("https://old.example/api/webhooks/bluebubbles",)
+
+
+async def test_verify_detects_a_stale_token_on_the_right_endpoint() -> None:
+    """Same URL, token from the previous password: delivered, then rejected at the door."""
+    expected = build_webhook_url("https://clawbolt.example", _PASSWORD)
+    stale = build_webhook_url("https://clawbolt.example", "the-old-password")
+    with _mock_bb_http(_webhook_list_handler([{"id": 3, "url": stale, "events": ["new-message"]}])):
+        check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
+
+    assert not check.ok
+    assert "token does not match" in check.detail
+
+
+async def test_verify_rejects_a_registration_without_the_new_message_event() -> None:
+    expected = build_webhook_url("https://clawbolt.example", _PASSWORD)
+    with _mock_bb_http(
+        _webhook_list_handler([{"id": 4, "url": expected, "events": ["typing-indicator"]}])
+    ):
+        check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
+
+    assert not check.ok
+    assert "typing-indicator" in check.detail
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        '["new-message"]',
+        [{"label": "New Message", "value": "new-message"}],
+        ["new-message", "updated-message"],
+    ],
+    ids=["json-string", "label-value-objects", "plain-list"],
+)
+async def test_verify_parses_every_event_encoding(events: Any) -> None:
+    """BlueBubbles has shipped the events field in all three shapes."""
+    expected = build_webhook_url("https://clawbolt.example", _PASSWORD)
+    with _mock_bb_http(_webhook_list_handler([{"id": 5, "url": expected, "events": events}])):
+        check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
+
+    assert check.ok
+
+
+async def test_verify_passes_when_the_event_format_is_unrecognized() -> None:
+    """Unknown is not failure: a shape we cannot parse must not read as an outage."""
+    expected = build_webhook_url("https://clawbolt.example", _PASSWORD)
+    with _mock_bb_http(_webhook_list_handler([{"id": 6, "url": expected, "events": {"weird": 1}}])):
+        check = await verify_webhook_registration("http://bb.example", expected, _PASSWORD)
+
+    assert check.ok
+
+
+async def test_verify_marks_an_unanswered_list_as_not_listed() -> None:
+    """``listed=False`` tells the caller "unknown", so it does not try to repair."""
+    with _mock_bb_http(lambda _req: httpx.Response(500, text="boom")):
+        check = await verify_webhook_registration("http://bb.example", "https://x.example", "pw")
+
+    assert not check.ok
+    assert not check.listed
+    assert "could not list" in check.detail
+
+
+async def test_list_webhooks_returns_none_when_unreachable() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused", request=request)
+
+    with _mock_bb_http(handler):
+        assert await list_bluebubbles_webhooks("http://bb.example", "pw") is None
+
+
+async def test_list_webhooks_distinguishes_empty_from_unreachable() -> None:
+    with _mock_bb_http(_webhook_list_handler([])):
+        assert await list_bluebubbles_webhooks("http://bb.example", "pw") == []
+
+
+def test_build_webhook_url_uses_the_derived_token_not_the_password() -> None:
+    url = build_webhook_url("https://clawbolt.example/", _PASSWORD)
+
+    assert url.startswith("https://clawbolt.example/api/webhooks/bluebubbles?token=")
+    assert _derive_webhook_token(_PASSWORD) in url
+    assert _PASSWORD not in url
+
+
+# ---------------------------------------------------------------------------
+# Channel integration
+# ---------------------------------------------------------------------------
+
+
+async def test_channel_check_health_stores_the_last_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "bluebubbles_server_url", _SERVER)
+    monkeypatch.setattr(settings, "bluebubbles_password", _PASSWORD)
+    channel = BlueBubblesChannel()
+    assert channel.last_health is None
+
+    with _mock_bb_http(_info_response(server_version="1.9.8", detected_icloud="a@example.com")):
+        health = await channel.check_health()
+
+    assert health.ok
+    assert channel.last_health is health
+
+
+async def test_channel_reachability_is_false_when_the_password_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the green-light-on-401 bug, at the channel level."""
+    monkeypatch.setattr(settings, "bluebubbles_server_url", _SERVER)
+    monkeypatch.setattr(settings, "bluebubbles_password", "wrong")
+    channel = BlueBubblesChannel()
+
+    with _mock_bb_http(lambda _req: httpx.Response(401, text="Unauthorized")):
+        assert await channel._check_server_reachable() is False


### PR DESCRIPTION
_Note: this description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Two BlueBubbles failures currently pass every check we have, and neither raises anything.

**A rejected server password reads as healthy.** `_check_server_reachable` accepted any status below 500, and a wrong `BLUEBUBBLES_PASSWORD` answers 401. `probe_bluebubbles_server` now tracks `reachable` and `authenticated` separately, so the bridge is only healthy when it answers an authenticated 200, and the detail names the misconfiguration.

**Webhook registration is never verified.** It is attempted once at startup; if the Mac is asleep at that moment the attempt fails, is never retried, and the bridge later comes back with every reachability signal green while inbound iMessage stays dead. `verify_webhook_registration` confirms our URL is registered for `new-message` events with a token derived from the current password. `build_webhook_url` gives the registration path and the check one shared definition so they cannot drift.

The channel stores its last probe result, so a monitoring caller can report why the bridge is unhealthy without running a second poller against the operator's Mac.

Two deliberate choices: readiness flags are tri-state, since older servers omit them and a missing field must not manufacture an outage; and the iCloud account is reduced to a bool so the operator's address never reaches a log line or an email.

Prompted by premium monitoring work, which consumes these helpers.

## Type
- [x] Feature
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`) — full suite, 3158 passed
- [x] Lint passes
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (Claude Opus 5 via Claude Code: investigation, implementation, and tests, reviewed and directed by @njbrake)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added authenticated BlueBubbles health checks with clear failure details.
- Added webhook registration verification for URL, token, and event matching.
- Reused webhook URL construction across registration and verification.
- Stored the latest health result for monitoring and periodic checks.
- Supported missing readiness flags from older servers.
- Reduced iCloud account reporting to a boolean to protect user data.
- Added broad test coverage for health checks, webhook verification, failures, and channel integration.

## Benefits

- Health status now reflects authentication and server readiness, not only network reachability.
- Webhook configuration errors are easier to detect and diagnose.
- Monitoring receives more useful and privacy-safe status data.
- Regression coverage reduces the risk of breaking older BlueBubbles servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->