### PR TITLE
fix(agent): keep the typing indicator alive during long waits

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -135,13 +135,20 @@ _MAX_TOKENS_CEILING = 16384
 _LLM_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
 
 # How often to re-send the typing indicator while the agent is blocked on a
-# slow operation. Messaging clients expire a typing bubble on their own after a
-# short idle period, so the single indicator fired before an LLM call or tool
-# round goes stale partway through and the user is left with no signal for the
-# rest of the wait. Well under the shortest client expiry observed on iMessage
-# so a dropped refresh is not user-visible; also short enough that a self-hosted
-# bridge dropping one request self-heals on the next tick.
-_TYPING_KEEPALIVE_SECONDS = 8.0
+# slow operation. Clients that render an indicator expire it on their own once
+# refreshes stop, so the single indicator fired before an LLM call or tool round
+# goes stale partway through and the user is left with no signal for the rest of
+# the wait.
+#
+# The keepalive is channel-agnostic, so the interval has to stay under the
+# shortest expiry of any channel that renders one. Telegram is both the tightest
+# and the only one that documents a number: ``sendChatAction`` holds the status
+# for "5 seconds or less". iMessage sits at the other end and clears slowly
+# rather than promptly, which is why ``stop_typing_indicator`` exists to cancel
+# it explicitly; its expiry has not been measured, so Telegram is the binding
+# constraint here. Also short enough that a self-hosted bridge dropping one
+# request self-heals on the next tick.
+_TYPING_KEEPALIVE_SECONDS = 4.0
 
 # Provider phrasings for "this prompt is longer than the model's context window"
 # that any-llm does NOT classify as ``ContextLengthExceededError``. Its
@@ -481,13 +488,19 @@ class ClawboltAgent:
             yield
             return
 
-        task = asyncio.create_task(self._typing_keepalive_loop())
+        task = asyncio.create_task(self._typing_keepalive_loop(), name="typing-keepalive")
         try:
             yield
         finally:
             task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+            # ``gather(return_exceptions=True)`` rather than
+            # ``suppress(CancelledError)`` around ``await task``: the latter also
+            # swallows a cancellation aimed at *this* task when one lands while
+            # we are suspended here, which silently defeats the surrounding
+            # ``asyncio.timeout`` in the ingestion pipeline (no truncation and no
+            # ``TimeoutError``, since ``Timeout.__aexit__`` only converts a
+            # ``CancelledError`` that actually reaches it).
+            await asyncio.gather(task, return_exceptions=True)
 
     async def _get_tool_permission(
         self,

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import copy
 import json
 import logging
@@ -6,7 +7,7 @@ import random
 import re
 import time
 from collections import OrderedDict
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -132,6 +133,15 @@ _VALID_STOP_REASONS: set[str | None] = {"end_turn", "max_tokens", "tool_use", "s
 _MAX_TOKENS_CEILING = 16384
 
 _LLM_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
+
+# How often to re-send the typing indicator while the agent is blocked on a
+# slow operation. Messaging clients expire a typing bubble on their own after a
+# short idle period, so the single indicator fired before an LLM call or tool
+# round goes stale partway through and the user is left with no signal for the
+# rest of the wait. Well under the shortest client expiry observed on iMessage
+# so a dropped refresh is not user-visible; also short enough that a self-hosted
+# bridge dropping one request self-heals on the next tick.
+_TYPING_KEEPALIVE_SECONDS = 8.0
 
 # Provider phrasings for "this prompt is longer than the model's context window"
 # that any-llm does NOT classify as ``ContextLengthExceededError``. Its
@@ -425,6 +435,11 @@ class ClawboltAgent:
             except Exception:
                 logger.exception("Event subscriber error for %s", type(event).__name__)
 
+    @property
+    def _can_send_typing(self) -> bool:
+        """Whether this agent has a channel target to send typing indicators to."""
+        return bool(self._publish_outbound and self._chat_id and self._channel)
+
     async def _send_typing_indicator(self) -> None:
         """Send a typing indicator via the bus if a publish callback and chat_id are available."""
         if self._publish_outbound and self._chat_id and self._channel:
@@ -441,6 +456,38 @@ class ClawboltAgent:
                 )
             except Exception:
                 logger.debug("Failed to send typing indicator to %s", mask_pii(self._chat_id))
+
+    async def _typing_keepalive_loop(self) -> None:
+        """Re-send the typing indicator on a fixed interval until cancelled."""
+        while True:
+            await asyncio.sleep(_TYPING_KEEPALIVE_SECONDS)
+            await self._send_typing_indicator()
+
+    @contextlib.asynccontextmanager
+    async def _typing_keepalive(self) -> AsyncIterator[None]:
+        """Hold the typing indicator active for the duration of a slow await.
+
+        Callers fire a single indicator before entering, and this refreshes it
+        every ``_TYPING_KEEPALIVE_SECONDS`` until the block exits so a long LLM
+        call or tool round does not leave the user watching an expired bubble.
+
+        The first refresh is deliberately delayed by a full interval, so an
+        operation that finishes quickly publishes nothing beyond the indicator
+        its caller already sent. The task is always cancelled on exit, including
+        on exception, so a keepalive can never outlive the wait it covers and
+        strand a phantom bubble after the reply lands.
+        """
+        if not self._can_send_typing:
+            yield
+            return
+
+        task = asyncio.create_task(self._typing_keepalive_loop())
+        try:
+            yield
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
     async def _get_tool_permission(
         self,
@@ -674,19 +721,20 @@ class ClawboltAgent:
         )
         for attempt in range(LLM_MAX_RETRIES):
             try:
-                response = cast(
-                    MessageResponse,
-                    await amessages(
-                        model=effective_model,
-                        provider=effective_provider,
-                        api_base=settings.llm_api_base,
-                        system=system,
-                        messages=msg_dicts,
-                        tools=tool_schemas,
-                        max_tokens=effective_max_tokens,
-                        thinking=thinking,
-                    ),
-                )
+                async with self._typing_keepalive():
+                    response = cast(
+                        MessageResponse,
+                        await amessages(
+                            model=effective_model,
+                            provider=effective_provider,
+                            api_base=settings.llm_api_base,
+                            system=system,
+                            messages=msg_dicts,
+                            tools=tool_schemas,
+                            max_tokens=effective_max_tokens,
+                            thinking=thinking,
+                        ),
+                    )
                 await self._emit_response(
                     response,
                     purpose=PURPOSE_AGENT_MAIN,
@@ -801,19 +849,20 @@ class ClawboltAgent:
                 started_at=followup_started_at,
             )
         )
-        followup_response = cast(
-            MessageResponse,
-            await amessages(
-                model=effective_model,
-                provider=effective_provider,
-                api_base=settings.llm_api_base,
-                system=system,
-                messages=trimmed_dicts,
-                tools=tool_schemas,
-                max_tokens=effective_max_tokens,
-                thinking=thinking,
-            ),
-        )
+        async with self._typing_keepalive():
+            followup_response = cast(
+                MessageResponse,
+                await amessages(
+                    model=effective_model,
+                    provider=effective_provider,
+                    api_base=settings.llm_api_base,
+                    system=system,
+                    messages=trimmed_dicts,
+                    tools=tool_schemas,
+                    max_tokens=effective_max_tokens,
+                    thinking=thinking,
+                ),
+            )
         await self._emit_response(
             followup_response,
             purpose=PURPOSE_AGENT_FOLLOWUP,
@@ -1326,7 +1375,11 @@ class ClawboltAgent:
                     results.append((pos, record, msg, label))
                 return results
 
-            unit_outputs = await asyncio.gather(*(_run_unit(u) for u in schedule_units))
+            # A single slow tool (a supplier price lookup, a large sync) can run
+            # for minutes. Refresh the indicator for the whole fan-out so the
+            # bubble does not expire midway through the wait.
+            async with self._typing_keepalive():
+                unit_outputs = await asyncio.gather(*(_run_unit(u) for u in schedule_units))
 
             results_by_pos: dict[int, tuple[StoredToolInteraction, ToolResultMessage, str]] = {}
             for unit_output in unit_outputs:

--- a/backend/app/channels/bluebubbles.py
+++ b/backend/app/channels/bluebubbles.py
@@ -1056,6 +1056,11 @@ class BlueBubblesChannel(BaseChannel):
 
         Requires the BlueBubbles Private API to be enabled on the server.
         Silently skipped when using apple-script send method.
+
+        Logs every attempt, including successes. The endpoint answers 200 even
+        for a chat GUID that does not exist, so a 2xx is proof the request was
+        accepted and nothing more; without an explicit log line a typing
+        indicator that never reaches the device leaves no trace at all.
         """
         if settings.bluebubbles_send_method != "private-api":
             return
@@ -1072,6 +1077,12 @@ class BlueBubblesChannel(BaseChannel):
                     resp.status_code,
                     mask_pii(chat_guid),
                     resp.text[:500],
+                )
+            else:
+                logger.debug(
+                    "BlueBubbles typing indicator accepted: status=%s chatGuid=%s",
+                    resp.status_code,
+                    mask_pii(chat_guid),
                 )
         except Exception:
             logger.exception("Failed to send BlueBubbles typing indicator to %s", mask_pii(to))

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -354,6 +354,46 @@ async def test_typing_keepalive_stops_when_tool_raises(
 @pytest.mark.asyncio()
 @patch("backend.app.agent.core._TYPING_KEEPALIVE_SECONDS", 0.01)
 @patch("backend.app.agent.core.amessages")
+async def test_typing_keepalive_stops_when_the_wrapped_await_raises(
+    mock_amessages: object,
+    test_user: User,
+) -> None:
+    """An exception out of the covered await must still cancel the keepalive.
+
+    ``_execute_single_tool`` converts every tool exception into an error result,
+    so a raising tool exits the keepalive by the normal path. An exception from
+    the LLM call is the one that unwinds through the context manager, which is
+    the path that would strand a phantom bubble if the ``finally`` were missing.
+    """
+
+    async def slow_then_raise(**kwargs: object) -> object:
+        await asyncio.sleep(0.05)
+        msg = "provider exploded"
+        raise RuntimeError(msg)
+
+    mock_amessages.side_effect = slow_then_raise  # type: ignore[union-attr]
+
+    mock_publish = AsyncMock()
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="bluebubbles",
+        publish_outbound=mock_publish,
+        chat_id="+15551234567",
+    )
+    with pytest.raises(RuntimeError, match="provider exploded"):
+        await agent.process_message("Do the thing")
+
+    # Refreshes happened while the call was in flight, and then stopped.
+    assert len(_typing_calls(mock_publish)) >= 2
+    settled = len(_typing_calls(mock_publish))
+    await asyncio.sleep(0.05)
+    assert len(_typing_calls(mock_publish)) == settled, "keepalive survived a raising LLM call"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core._TYPING_KEEPALIVE_SECONDS", 0.01)
+@patch("backend.app.agent.core.amessages")
 async def test_typing_keepalive_noop_without_chat_id(
     mock_amessages: object,
     test_user: User,

--- a/tests/test_typing_indicator.py
+++ b/tests/test_typing_indicator.py
@@ -1,5 +1,6 @@
 """Tests for typing indicator integration with the agent loop, heartbeat, and ingestion."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -231,6 +232,165 @@ async def test_agent_sends_one_typing_indicator_per_tool_round(
     ]
     # 1 before initial LLM + 1 before the tool round + 1 before second LLM = 3
     assert len(typing_calls) == 3
+
+
+def _typing_calls(mock_publish: AsyncMock) -> list[OutboundMessage]:
+    """Extract the typing-indicator messages published to the bus."""
+    return [
+        c.args[0]
+        for c in mock_publish.call_args_list
+        if c.args and isinstance(c.args[0], OutboundMessage) and c.args[0].is_typing_indicator
+    ]
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core._TYPING_KEEPALIVE_SECONDS", 0.01)
+@patch("backend.app.agent.core.amessages")
+async def test_agent_refreshes_typing_indicator_during_slow_tool_call(
+    mock_amessages: object,
+    test_user: User,
+) -> None:
+    """A slow tool round should keep refreshing the typing indicator.
+
+    Regression test: indicators used to fire only *before* the tool round, so a
+    tool that ran for minutes (a supplier price lookup) left the user's typing
+    bubble to expire with no further signal for the rest of the wait. The user
+    reported the agent looked broken during exactly the turns that were slowest.
+    """
+
+    async def slow_tool_fn(**kwargs: object) -> ToolResult:
+        # ~10 keepalive intervals, so the refresh count has wide headroom and
+        # the assertion below does not race the event loop.
+        await asyncio.sleep(0.1)
+        return ToolResult(content="tool result")
+
+    tool = Tool(
+        name="slow_tool",
+        description="A slow tool",
+        function=slow_tool_fn,
+        params_model=_InputParams,
+    )
+
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(
+            [{"name": "slow_tool", "arguments": json.dumps({"input": "test"})}],
+            content=None,
+        ),
+        make_text_response("Done!"),
+    ]
+
+    mock_publish = AsyncMock()
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="bluebubbles",
+        publish_outbound=mock_publish,
+        chat_id="+15551234567",
+    )
+    agent.register_tools([tool])
+    response = await agent.process_message("Look up a price")
+
+    assert response.reply_text == "Done!"
+
+    # Without the keepalive this is exactly 3 (initial LLM, tool round, second
+    # LLM). The refreshes during the slow tool push it well past that.
+    calls = _typing_calls(mock_publish)
+    assert len(calls) >= 5, f"expected keepalive refreshes during the slow tool, got {len(calls)}"
+    assert all(c.chat_id == "+15551234567" for c in calls)
+    assert all(c.channel == "bluebubbles" for c in calls)
+
+    # The keepalive must not outlive the turn, or the user is left with a
+    # phantom bubble after the reply has already landed.
+    settled = len(_typing_calls(mock_publish))
+    await asyncio.sleep(0.05)
+    assert len(_typing_calls(mock_publish)) == settled, "keepalive outlived the agent turn"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core._TYPING_KEEPALIVE_SECONDS", 0.01)
+@patch("backend.app.agent.core.amessages")
+async def test_typing_keepalive_stops_when_tool_raises(
+    mock_amessages: object,
+    test_user: User,
+) -> None:
+    """A tool that raises must still cancel the keepalive on the way out."""
+
+    async def exploding_tool_fn(**kwargs: object) -> ToolResult:
+        await asyncio.sleep(0.03)
+        msg = "tool exploded"
+        raise RuntimeError(msg)
+
+    tool = Tool(
+        name="exploding_tool",
+        description="A tool that raises",
+        function=exploding_tool_fn,
+        params_model=_InputParams,
+    )
+
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(
+            [{"name": "exploding_tool", "arguments": json.dumps({"input": "test"})}],
+            content=None,
+        ),
+        make_text_response("Recovered."),
+    ]
+
+    mock_publish = AsyncMock()
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="bluebubbles",
+        publish_outbound=mock_publish,
+        chat_id="+15551234567",
+    )
+    agent.register_tools([tool])
+    await agent.process_message("Do the thing")
+
+    settled = len(_typing_calls(mock_publish))
+    await asyncio.sleep(0.05)
+    assert len(_typing_calls(mock_publish)) == settled, "keepalive survived a raising tool"
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.agent.core._TYPING_KEEPALIVE_SECONDS", 0.01)
+@patch("backend.app.agent.core.amessages")
+async def test_typing_keepalive_noop_without_chat_id(
+    mock_amessages: object,
+    test_user: User,
+) -> None:
+    """With no chat_id there is nowhere to send, so the keepalive stays idle."""
+
+    async def slow_tool_fn(**kwargs: object) -> ToolResult:
+        await asyncio.sleep(0.05)
+        return ToolResult(content="ok")
+
+    tool = Tool(
+        name="slow_tool",
+        description="A slow tool",
+        function=slow_tool_fn,
+        params_model=_InputParams,
+    )
+
+    mock_amessages.side_effect = [  # type: ignore[union-attr]
+        make_tool_call_response(
+            [{"name": "slow_tool", "arguments": json.dumps({"input": "test"})}],
+            content=None,
+        ),
+        make_text_response("Done!"),
+    ]
+
+    mock_publish = AsyncMock()
+
+    agent = ClawboltAgent(
+        user=test_user,
+        channel="telegram",
+        publish_outbound=mock_publish,
+        chat_id=None,
+    )
+    agent.register_tools([tool])
+    await agent.process_message("Do something")
+
+    assert _typing_calls(mock_publish) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Typing indicators were edge-triggered only: one on inbound receipt, one before each LLM call, one before each tool round. Messaging clients expire a typing bubble on their own after a short idle period, so any single wait longer than that expiry left the user with no signal for the rest of the turn. A supplier price lookup that ran for minutes showed a bubble for a few seconds and then looked broken. That is how it was reported: no indication the agent was working, during precisely the turns that were slowest.

Adds a keepalive that refreshes the indicator every 8s for the duration of the three long awaits: the main LLM call, the `_trim_and_retry` followup, and the tool fan-out. The first refresh is delayed a full interval so fast operations publish nothing extra, which keeps the existing per-round indicator counts intact. The task is cancelled in a `finally` block so it can never outlive its wait and strand a phantom bubble after the reply lands.

Deliberately **not** routing the typing POST through `_post_with_retry`. Those backoffs can stretch a call to roughly 47s (4 attempts x 10s timeout, plus 1/2/4 backoffs), so a retry would raise a bubble long after the reply had already landed. The keepalive makes retries pointless anyway, since a dropped request self-heals on the next tick. Note this is no longer a dispatch-stall risk: #1083 was fixed by making typing sends fire-and-forget via `_spawn_typing_task`, so a slow typing POST can no longer block replies.

Also logs accepted typing sends in the BlueBubbles channel. That endpoint returns 200 even for a chat GUID that does not exist, so the existing `status >= 400` branch can never fire, and an indicator that never reached the device left no trace in the logs at all. This is what made the original report expensive to diagnose.

Related: #1341 is an open decision on the same UX problem via interim text messages. This does not preempt it.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) | 3134 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) | plus `ty check` clean
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Four tests in `tests/test_typing_indicator.py`: refreshes during a slow tool round, teardown across a raising tool, teardown when the wrapped await itself raises, and no-op when there is no `chat_id`. The regression test fails without the fix with `got 3`, the exact pre-fix indicator count.

The refresh interval is 4s, not 8s: the keepalive is channel-agnostic and Telegram's `sendChatAction` holds its status for "5 seconds or less", which is the binding constraint. Teardown uses `gather(task, return_exceptions=True)` rather than `suppress(CancelledError)`, so a cancellation from the `asyncio.timeout()` wrapping every turn in `ingestion.py` is not swallowed.

Backend-only, no schema or route surface touched. Verified by regenerating `frontend/openapi.json`, which comes out identical.

## AI Usage
- [x] AI-assisted (describe how)

Investigated and implemented by Claude (Opus 5) via back-and-forth with @njbrake, working from production logs and live BlueBubbles API probing. The reasoning and decisions are his; the prose and code are the model's.
