### PR TITLE
fix(pricing): stop one supplier outage becoming an eight-call retry loop

### DIFF
--- a/backend/app/integrations/supplier_pricing/factory.py
+++ b/backend/app/integrations/supplier_pricing/factory.py
@@ -35,9 +35,39 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Shared across all users; the sidecar client is stateless so only the cache
-# needs to be a singleton.
+# Shared across all users; the sidecar client is stateless so only the caches
+# need to be singletons.
 _cache = SupplierCache()
+
+# Consecutive failures per (supplier, zip), so a retailer that just went down
+# stops being asked. The positive cache cannot do this job: it is keyed on the
+# exact query string, so a model that rewords its search misses it every time
+# and each miss pays a full round trip through every backend.
+_OUTAGE_TTL_SECONDS = 90
+_outages = SupplierCache(maxsize=500, ttl_seconds=_OUTAGE_TTL_SECONDS)
+
+# Let one retry through before suppressing. The sidecar warms its browser lazily
+# and evicts it when idle, so a second attempt genuinely does often succeed, and
+# _BACKEND_RETRY_HINT tells the model to make it. Suppression starts at the point
+# where retrying has stopped being evidence-gathering and started being a storm.
+_OUTAGE_STREAK_BEFORE_SUPPRESSING = 2
+
+# Both failure modes are infrastructure, never the search term. Saying so is the
+# whole point of the hint: the timeout copy used to read "Try a simpler search
+# term", and a model that believed it spent eight calls rewording one query,
+# every attempt waiting out two stacked timeouts (issue #1496).
+_BACKEND_RETRY_HINT = (
+    "The failure is not caused by the search term, so rewording will not help. "
+    "One retry is worth it: the backend warms a browser session lazily and the "
+    "second attempt often succeeds. If it fails again, tell the user the lookup "
+    "is unavailable and offer the other retailer, which may still work."
+)
+
+_OUTAGE_HINT = (
+    "This retailer has failed repeatedly in the last minute, so no request was "
+    "sent. Retrying and rewording will both fail. Tell the user the lookup is "
+    "unavailable and offer the other retailer, which may still work."
+)
 
 
 class SupplierSearchParams(BaseModel):
@@ -163,6 +193,7 @@ def _create_pricing_tools(
     sidecars: dict[str, SidecarSupplier],
     fallback: HomeDepotSupplier | None,
     cache: SupplierCache,
+    outages: SupplierCache,
 ) -> list[Tool]:
     """Build the pricing tool list.
 
@@ -170,6 +201,11 @@ def _create_pricing_tools(
     tries the requested retailer's sidecar and falls through to ``fallback``
     (SerpApi) when it cannot answer, which only helps Home Depot: SerpApi has no
     Lowe's engine. Store lookup is Home Depot sidecar only.
+
+    ``outages`` counts consecutive search failures per (supplier, zip) so a
+    retailer that is already down is not asked again on every reworded query.
+    It is passed in rather than built here because the factory runs per tool
+    context, and a per-context counter would never see a streak.
     """
 
     async def _search_with_fallback(
@@ -189,11 +225,17 @@ def _create_pricing_tools(
         for index, (name, backend) in enumerate(chain):
             try:
                 return await backend.search_products(query, location, max_results=max_results)
-            except SupplierUnavailableError:
+            except SupplierUnavailableError as exc:
                 if index == len(chain) - 1:
                     raise
-                logger.info(
-                    "%s %s backend unavailable, trying %s", supplier, name, chain[index + 1][0]
+                # Warning, not info: this is the only line that says which
+                # backend failed and why, and the root logger sits at warning.
+                logger.warning(
+                    "%s %s backend unavailable (%s), trying %s",
+                    supplier,
+                    name,
+                    exc,
+                    chain[index + 1][0],
                 )
         raise SupplierUnavailableError(f"No backend answered for {supplier}")
 
@@ -231,29 +273,47 @@ def _create_pricing_tools(
                 content=_format_results(cached, query, resolved_zip, label, localized=localized)
             )
 
+        outage_key = f"{supplier}:{cache_scope}"
+        failures: int = await outages.get(outage_key) or 0
+        if failures >= _OUTAGE_STREAK_BEFORE_SUPPRESSING:
+            logger.warning(
+                "%s search suppressed after %d consecutive failures: query=%r zip=%s",
+                label,
+                failures,
+                query,
+                resolved_zip,
+            )
+            return ToolResult(
+                content=f"{label} pricing is still down, so this lookup was not sent.",
+                is_error=True,
+                error_kind=ToolErrorKind.SERVICE,
+                hint=_OUTAGE_HINT,
+            )
+
         try:
             location = Location(zip_code=resolved_zip, store_id=resolved_store)
             results = await _search_with_fallback(supplier, query, location, 5)
-        except SupplierUnavailableError:
-            logger.warning("%s refused the search: query=%r", label, query)
+        except SupplierUnavailableError as exc:
+            await outages.set(outage_key, failures + 1)
+            logger.warning("%s refused the search: query=%r reason=%s", label, query, exc)
             return ToolResult(
                 content=f"Couldn't reach {label} to look up pricing.",
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
-                hint=(
-                    "The failure is not caused by the search term, so rewording will "
-                    "not help. One retry is worth it: the backend warms a browser "
-                    "session lazily and the second attempt often succeeds. If it fails "
-                    "again, tell the user the lookup is unavailable and offer the other "
-                    "retailer, which may still work."
-                ),
+                hint=_BACKEND_RETRY_HINT,
             )
         except httpx.TimeoutException:
+            # Only the SerpApi fallback reaches this: the sidecar client maps its
+            # own timeouts to SupplierUnavailableError so the chain keeps falling
+            # through. Either way the term is not what timed out, so the hint has
+            # to match the branch above rather than send the model off rewording.
+            await outages.set(outage_key, failures + 1)
             logger.warning("%s search timed out: query=%r zip=%s", label, query, resolved_zip)
             return ToolResult(
-                content="The price lookup timed out. Try a simpler search term.",
+                content=f"{label} pricing timed out.",
                 is_error=True,
                 error_kind=ToolErrorKind.SERVICE,
+                hint=_BACKEND_RETRY_HINT,
             )
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
@@ -285,6 +345,9 @@ def _create_pricing_tools(
             )
 
         await cache.set(cache_key, results)
+        # The streak counts consecutive failures, so an answer ends it.
+        if failures:
+            await outages.set(outage_key, 0)
         return ToolResult(
             content=_format_results(results, query, resolved_zip, label, localized=localized)
         )
@@ -407,7 +470,7 @@ def _pricing_factory(ctx: ToolContext) -> list[Tool]:
         sorted(sidecars) or "none",
         fallback is not None,
     )
-    return _create_pricing_tools(sidecars, fallback, _cache)
+    return _create_pricing_tools(sidecars, fallback, _cache, _outages)
 
 
 async def _pricing_auth_check(ctx: ToolContext) -> str | None:

--- a/backend/app/integrations/supplier_pricing/sidecar_client.py
+++ b/backend/app/integrations/supplier_pricing/sidecar_client.py
@@ -89,6 +89,20 @@ class SidecarSupplier:
             raise SupplierUnavailableError(
                 f"{self.display_name} sidecar returned {exc.response.status_code} for {path}"
             ) from exc
+        except httpx.TimeoutException as exc:
+            # A timeout is still an unavailable backend, so the caller keeps
+            # falling through, but it has to name itself on the way out.
+            # `httpx.TimeoutException` subclasses `HTTPError`, so without this
+            # clause the generic handler below swallowed it and every sidecar
+            # timeout read as "unreachable" in the logs. A sidecar that runs out
+            # the clock is warming a browser or wedged; one that refuses the
+            # connection is down. Those are different pages to go look at.
+            logger.warning(
+                "%s sidecar timed out after %.0fs for %s", self.display_name, self._timeout, path
+            )
+            raise SupplierUnavailableError(
+                f"{self.display_name} sidecar timed out after {self._timeout:.0f}s for {path}"
+            ) from exc
         except (httpx.HTTPError, ValueError) as exc:
             raise SupplierUnavailableError(
                 f"{self.display_name} sidecar is unreachable: {exc}"

--- a/sidecar/home_depot/README.md
+++ b/sidecar/home_depot/README.md
@@ -67,6 +67,7 @@ that a search costs roughly a second.
 | `HD_PROFILE_DIR` | `~/.hd-sidecar-profile` | Persistent browser profile. Keep it between runs. |
 | `HD_WARM_SECONDS` | `7` | Homepage settle time before serving. |
 | `HD_IDLE_SECONDS` | `3600` | Close Chromium after this many idle seconds. The next request warms a fresh browser. Set to `0` to keep it open. |
+| `HD_REQUEST_BUDGET_SECONDS` | `25` | How long one request may drive a retailer's page once it holds that retailer's lock. Must stay below the client's 35s timeout: a request that outlives its caller holds the lock with nobody waiting for the answer. |
 
 ## Running it in a container
 

--- a/sidecar/home_depot/sidecar.py
+++ b/sidecar/home_depot/sidecar.py
@@ -590,10 +590,20 @@ class BrowserBackedSearch:
             deadline=deadline,
         )
         if res["status"] != 200:
+            # The status and the head of the body are the only evidence of why
+            # Home Depot refused, and neither was recorded. A run of 502s in the
+            # logs was just a run of 502s, when the useful question is whether
+            # the session is being bot-checked or the payload is malformed.
+            logger.warning(
+                "home_depot refused the search: status=%s body=%.300s",
+                res["status"],
+                res["body"],
+            )
             raise HTTPException(502, f"Home Depot returned {res['status']}")
         try:
             payload = json.loads(res["body"])
         except ValueError as exc:
+            logger.warning("home_depot returned a non-JSON body: %.300s", res["body"])
             raise HTTPException(502, "Home Depot returned a non-JSON body") from exc
         return (payload.get("data") or {}).get("searchModel") or {}
 
@@ -607,10 +617,16 @@ class BrowserBackedSearch:
             deadline=deadline,
         )
         if res["status"] != 200:
+            logger.warning(
+                "home_depot store locator refused the lookup: status=%s body=%.300s",
+                res["status"],
+                res["body"],
+            )
             raise HTTPException(502, f"Home Depot store locator returned {res['status']}")
         try:
             payload = json.loads(res["body"])
         except ValueError as exc:
+            logger.warning("home_depot store locator returned a non-JSON body: %.300s", res["body"])
             raise HTTPException(502, "Store locator returned a non-JSON body") from exc
         if "GenericError" in res["body"] and "stores" not in payload:
             raise HTTPException(502, "Home Depot refused the store lookup")

--- a/sidecar/home_depot/sidecar.py
+++ b/sidecar/home_depot/sidecar.py
@@ -56,6 +56,22 @@ WARM_SECONDS = float(os.environ.get("HD_WARM_SECONDS", "7"))
 # only when the next request arrives. Set to 0 to keep the browser open.
 IDLE_SECONDS = float(os.environ.get("HD_IDLE_SECONDS", "3600"))
 
+# How long one request may spend driving a retailer's page once it holds that
+# retailer's lock. This has to stay under the client's own timeout (35s, see
+# backend/app/integrations/supplier_pricing/sidecar_client.py). A request that
+# outlives its caller is worse than useless: it holds the lock with nobody left
+# to receive the answer, and everything queued behind it spends its own budget
+# waiting for a reply that will be thrown away. Eight failed lookups in one
+# conversation traced back to exactly that (issue #1496).
+REQUEST_BUDGET_SECONDS = float(os.environ.get("HD_REQUEST_BUDGET_SECONDS", "25"))
+
+# The in-page fetch aborts itself at the remaining budget, which is the clean
+# path: it returns a structured error and leaves the page healthy. This grace is
+# for the case where the page never runs the script at all, a wedged renderer
+# being the obvious one, so `evaluate` itself has to be cut loose. Kept small
+# enough that budget plus grace still lands under the client's 35s.
+_EVALUATE_GRACE_SECONDS = 5.0
+
 # Lowe's results are server-rendered into the page, so the wait is a poll for the
 # payload rather than a fixed settle. Roughly 6s of headroom in total.
 LOWES_STATE_POLL_MS = 400
@@ -68,19 +84,34 @@ _NAV_RE = re.compile(r"/(N-[A-Za-z0-9]+)")
 
 # Executed inside the page so the request carries the browser's own TLS
 # fingerprint, cookies, and bot-manager state.
+#
+# Both scripts take a timeout in milliseconds as their last argument and hand it
+# to AbortSignal.timeout. Without it a retailer that accepts the connection and
+# then goes quiet, which is what a throttle or a bot-detection blackhole looks
+# like from here, leaves the fetch pending forever. `page.evaluate` has no
+# timeout of its own, so that pending promise used to park the whole request
+# while it held the retailer's lock. Errors come back in the return value rather
+# than as a thrown exception so the caller can tell an abort from a bad status
+# without matching on message text.
 _STORE_JS = """
-async ([query]) => {
-  const r = await fetch("/StoreSearchServices/v2/storesearch?" + query,
-                        {credentials: "include"});
-  return {status: r.status, body: await r.text()};
+async ([query, timeoutMs]) => {
+  try {
+    const r = await fetch("/StoreSearchServices/v2/storesearch?" + query,
+                          {credentials: "include", signal: AbortSignal.timeout(timeoutMs)});
+    return {status: r.status, body: await r.text()};
+  } catch (e) {
+    return {status: 0, body: "", error: String((e && e.name) || e)};
+  }
 }
 """
 
 _FETCH_JS = """
-async ([query, keyword, navParam, currentUrl, storeId, zipCode, pageSize]) => {
+async ([query, keyword, navParam, currentUrl, storeId, zipCode, pageSize, timeoutMs]) => {
+ try {
   const r = await fetch("/federation-gateway/graphql?opname=searchModel", {
     method: "POST",
     credentials: "include",
+    signal: AbortSignal.timeout(timeoutMs),
     headers: {
       "content-type": "application/json",
       "accept": "*/*",
@@ -119,6 +150,9 @@ async ([query, keyword, navParam, currentUrl, storeId, zipCode, pageSize]) => {
     }),
   });
   return {status: r.status, body: await r.text()};
+ } catch (e) {
+  return {status: 0, body: "", error: String((e && e.name) || e)};
+ }
 }
 """
 
@@ -216,6 +250,60 @@ class BrowserBackedSearch:
             lock = asyncio.Lock()
             self._locks[site] = lock
         return lock
+
+    @contextlib.asynccontextmanager
+    async def _timed_lock(self, site: str, what: str) -> AsyncIterator[float]:
+        """Hold a retailer's lock for one request, yielding its work deadline.
+
+        The two durations logged here answer different questions. Time queued
+        says this retailer's single page is the bottleneck and requests are
+        stacking up behind each other; time working says the retailer itself is
+        slow. Neither was recorded before, so a search that took thirty seconds
+        and one that took two looked identical in the logs and there was no way
+        to tell a hang from a queue (issue #1496).
+        """
+        queued = time.monotonic()
+        async with self._lock_for(site):
+            started = time.monotonic()
+            try:
+                yield started + REQUEST_BUDGET_SECONDS
+            finally:
+                logger.info(
+                    "%s: %.1fs queued, %.1fs working",
+                    what,
+                    started - queued,
+                    time.monotonic() - started,
+                )
+
+    async def _evaluate(
+        self, page: Any, script: str, args: list[Any], *, what: str, deadline: float
+    ) -> dict[str, Any]:
+        """Run one in-page fetch, bounded by the request's remaining budget.
+
+        Two layers, because they fail differently. The script aborts its own
+        fetch at the remaining budget and returns a structured error, which
+        leaves the page healthy and reusable. `asyncio.wait_for` is the backstop
+        for a page that never runs the script at all; cancelling unwinds the
+        `async with` blocks above, so the retailer's lock is released either way
+        and the next request is not punished for this one.
+        """
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            # Refuse rather than granting a fresh slice. A second call inside one
+            # request (the category-redirect retry) must not be able to push the
+            # total past the budget, or budget plus grace stops being the bound
+            # this whole design rests on.
+            raise HTTPException(504, f"{what} ran out of budget before it could start")
+        try:
+            res = await asyncio.wait_for(
+                page.evaluate(script, [*args, int(remaining * 1000)]),
+                timeout=remaining + _EVALUATE_GRACE_SECONDS,
+            )
+        except TimeoutError as exc:
+            raise HTTPException(504, f"{what} did not respond within {remaining:.0f}s") from exc
+        if res.get("error"):
+            raise HTTPException(504, f"{what} failed in the page: {res['error']}")
+        return res
 
     def start_background(self) -> None:
         """Launch the browser without blocking the caller.
@@ -447,10 +535,16 @@ class BrowserBackedSearch:
         benefit, against Home Depot's sub-second GraphQL call.
         """
         async with self._use_browser():
-            async with self._lock_for("lowes"):
+            async with self._timed_lock("lowes", f"lowes search {keyword!r}"):
                 page = await self._lowes_page()
+                # The warm above keeps its own generous timeout: it runs once per
+                # session and a re-warm is expensive. This navigation runs on
+                # every search, so it gets the per-request budget instead of the
+                # old 90s, which was nearly three times the client's patience.
                 await page.goto(
-                    lowes.search_url(keyword), wait_until="domcontentloaded", timeout=90_000
+                    lowes.search_url(keyword),
+                    wait_until="domcontentloaded",
+                    timeout=int(REQUEST_BUDGET_SECONDS * 1000),
                 )
                 html = await page.content()
                 state = lowes.extract_preloaded_state(html)
@@ -478,13 +572,22 @@ class BrowserBackedSearch:
             )
 
     async def _call(
-        self, keyword: str, nav_param: str | None, store_id: str, zip_code: str, page_size: int
+        self,
+        keyword: str,
+        nav_param: str | None,
+        store_id: str,
+        zip_code: str,
+        page_size: int,
+        deadline: float,
     ) -> dict[str, Any]:
         encoded = urllib.parse.quote(keyword)
         current_url = f"/b/{nav_param}" if nav_param else f"/s/{encoded}"
-        res = await self._page.evaluate(
+        res = await self._evaluate(
+            self._page,
             _FETCH_JS,
             [SEARCH_MODEL_QUERY, encoded, nav_param, current_url, store_id, zip_code, page_size],
+            what="Home Depot search",
+            deadline=deadline,
         )
         if res["status"] != 200:
             raise HTTPException(502, f"Home Depot returned {res['status']}")
@@ -494,9 +597,15 @@ class BrowserBackedSearch:
             raise HTTPException(502, "Home Depot returned a non-JSON body") from exc
         return (payload.get("data") or {}).get("searchModel") or {}
 
-    async def _store_call(self, params: dict[str, str]) -> dict[str, Any]:
+    async def _store_call(self, params: dict[str, str], deadline: float) -> dict[str, Any]:
         query = urllib.parse.urlencode(params)
-        res = await self._page.evaluate(_STORE_JS, [query])
+        res = await self._evaluate(
+            self._page,
+            _STORE_JS,
+            [query],
+            what="Home Depot store locator",
+            deadline=deadline,
+        )
         if res["status"] != 200:
             raise HTTPException(502, f"Home Depot store locator returned {res['status']}")
         try:
@@ -515,9 +624,10 @@ class BrowserBackedSearch:
         coordinates drive a second lookup.
         """
         async with self._use_browser():
-            async with self._lock_for("home_depot"):
+            async with self._timed_lock("home_depot", f"home_depot stores {near!r}") as deadline:
                 data = await self._store_call(
-                    {"address": near, "radius": str(radius_miles), "pagesize": str(limit)}
+                    {"address": near, "radius": str(radius_miles), "pagesize": str(limit)},
+                    deadline,
                 )
                 geocoded = False
                 if "stores" not in data and "ambiguousAddresses" in data:
@@ -531,7 +641,8 @@ class BrowserBackedSearch:
                             "longitude": str(point[1]),
                             "radius": str(radius_miles),
                             "pagesize": str(limit),
-                        }
+                        },
+                        deadline,
                     )
 
             stores = [_parse_store(s) for s in (data.get("stores") or [])[:limit]]
@@ -541,18 +652,22 @@ class BrowserBackedSearch:
         self, keyword: str, *, store_id: str, zip_code: str, page_size: int
     ) -> SearchResponse:
         async with self._use_browser():
-            async with self._lock_for("home_depot"):
-                model = await self._call(keyword, None, store_id, zip_code, page_size)
+            async with self._timed_lock("home_depot", f"home_depot search {keyword!r}") as deadline:
+                model = await self._call(keyword, None, store_id, zip_code, page_size, deadline)
                 used_nav: str | None = None
 
-                # Category redirect: retry once with the bare N- token.
+                # Category redirect: retry once with the bare N- token. The
+                # deadline is shared with the first call rather than restarted,
+                # so a slow first attempt cannot buy the retry a fresh budget.
                 if not model.get("products"):
                     redirect = (model.get("metadata") or {}).get("searchRedirect") or ""
                     match = _NAV_RE.search(redirect.split("?")[0])
                     if match:
                         used_nav = match.group(1)
                         logger.info("keyword %r redirected to navParam %s", keyword, used_nav)
-                        model = await self._call(keyword, used_nav, store_id, zip_code, page_size)
+                        model = await self._call(
+                            keyword, used_nav, store_id, zip_code, page_size, deadline
+                        )
 
             report = model.get("searchReport") or {}
             products = [_parse_product(p) for p in (model.get("products") or [])[:page_size]]

--- a/tests/test_pricing_tools.py
+++ b/tests/test_pricing_tools.py
@@ -430,8 +430,9 @@ class TestSupplierSearchTool:
 
         from backend.app.integrations.supplier_pricing.factory import _create_pricing_tools
 
-        # Drive the SerpApi backend directly by configuring no sidecars.
-        tools = _create_pricing_tools({}, mock_supplier, cache)
+        # Drive the SerpApi backend directly by configuring no sidecars. Fresh
+        # caches per tool set so one test's failures cannot suppress the next.
+        tools = _create_pricing_tools({}, mock_supplier, cache, SupplierCache())
         tool_fn = tools[0].function
         return tool_fn, mock_supplier, cache
 
@@ -497,6 +498,22 @@ class TestSupplierSearchTool:
         assert "timed out" in result.content.lower()
 
     @pytest.mark.asyncio
+    async def test_timeout_never_tells_the_model_to_reword(self) -> None:
+        """Regression for #1496.
+
+        The timeout branch used to answer "Try a simpler search term" with no
+        hint at all. A model that took the advice spent eight calls rewording
+        one query while every attempt sat through the full backend timeout. The
+        search term is never why a lookup times out, so the copy has to say so.
+        """
+        tool_fn, _, _ = self._make_tool(side_effect=httpx.TimeoutException("timeout"))
+        result = await tool_fn(query="test", zip_code="15213")
+
+        advice = f"{result.content} {result.hint}".lower()
+        assert "simpler search term" not in advice
+        assert "rewording will not help" in result.hint
+
+    @pytest.mark.asyncio
     async def test_401_error(self) -> None:
         exc = httpx.HTTPStatusError(
             "401",
@@ -529,6 +546,59 @@ class TestSupplierSearchTool:
 
         assert not result.is_error
         assert "No products found" in result.content
+
+    @pytest.mark.asyncio
+    async def test_repeated_failures_stop_reaching_the_backend(self) -> None:
+        """Regression for #1496.
+
+        Each query differs, exactly as it did in production: the model reworded
+        after every failure, so the positive cache (keyed on the query string)
+        never absorbed a single retry. One retry gets through, then the streak
+        suppresses the rest.
+        """
+        tool_fn, mock_supplier, _ = self._make_tool(side_effect=httpx.TimeoutException("timeout"))
+
+        for query in ("BR30 LED bulb", "BR30 LED flood bulb", "LED BR30 flood light bulb"):
+            result = await tool_fn(query=query, zip_code="15213")
+
+        assert mock_supplier.search_products.call_count == 2
+        assert result.is_error
+        assert "was not sent" in result.content
+        assert "Retrying and rewording will both fail" in result.hint
+
+    @pytest.mark.asyncio
+    async def test_an_answer_ends_the_failure_streak(self) -> None:
+        """A recovered supplier must be reachable again on the next query."""
+        product = ProductResult(
+            supplier="homedepot",
+            product_id="1",
+            name="Recovered Item",
+            price_dollars=1.0,
+            product_url="https://homedepot.com/p/1",
+        )
+        tool_fn, mock_supplier, _ = self._make_tool()
+        mock_supplier.search_products = AsyncMock(
+            side_effect=[httpx.TimeoutException("timeout"), [product], [product]]
+        )
+
+        await tool_fn(query="first", zip_code="15213")
+        await tool_fn(query="second", zip_code="15213")
+        result = await tool_fn(query="third", zip_code="15213")
+
+        assert mock_supplier.search_products.call_count == 3
+        assert not result.is_error
+        assert "Recovered Item" in result.content
+
+    @pytest.mark.asyncio
+    async def test_failure_streak_is_scoped_to_one_zip(self) -> None:
+        """A dead store lookup in one zip must not blind the tool everywhere."""
+        tool_fn, mock_supplier, _ = self._make_tool(side_effect=httpx.TimeoutException("timeout"))
+
+        await tool_fn(query="a", zip_code="15213")
+        await tool_fn(query="b", zip_code="15213")
+        await tool_fn(query="c", zip_code="30301")
+
+        assert mock_supplier.search_products.call_count == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sidecar_locks.py
+++ b/tests/test_sidecar_locks.py
@@ -56,6 +56,12 @@ def _load_sidecar() -> Any:
 sidecar = _load_sidecar()
 
 
+# Request paths take their lock through `_timed_lock`, which adds the deadline
+# and the timing log; the background pre-warm still takes it directly. Both name
+# their retailer as a literal first argument, which is the property under test.
+_LOCK_TAKING_CALLS = ("_lock_for", "_timed_lock")
+
+
 def _lock_site_by_function() -> dict[str, str]:
     """Read which site each method locks, straight from the source.
 
@@ -74,7 +80,7 @@ def _lock_site_by_function() -> dict[str, str]:
                 call = inner
             if call is None or not isinstance(call.func, ast.Attribute):
                 continue
-            if call.func.attr != "_lock_for" or not call.args:
+            if call.func.attr not in _LOCK_TAKING_CALLS or not call.args:
                 continue
             arg = call.args[0]
             if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
@@ -185,6 +191,174 @@ class TestStaleSessionRecovery:
         await engine._note_lowes_failure()
 
         assert "lowes" not in engine._site_pages
+
+
+class TestRequestBudget:
+    """A retailer that goes quiet must not park the lock (issue #1496).
+
+    The in-page fetch had no abort signal and `page.evaluate` takes no timeout,
+    so a connection that was accepted and never answered left the coroutine
+    pending forever while holding the retailer's lock. Everything queued behind
+    it then timed out client-side waiting for a page nobody was driving.
+    """
+
+    @staticmethod
+    def _hanging_page() -> Any:
+        class HangingPage:
+            async def evaluate(self, _script: str, _args: list) -> dict:
+                await asyncio.Event().wait()  # never resolves, like the real hang
+                raise AssertionError("unreachable")
+
+        return HangingPage()
+
+    @pytest.mark.asyncio
+    async def test_a_hung_page_gives_up_instead_of_pending_forever(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sidecar, "_EVALUATE_GRACE_SECONDS", 0.05)
+        engine = sidecar.BrowserBackedSearch()
+
+        with pytest.raises(sidecar.HTTPException) as caught:
+            await engine._evaluate(
+                self._hanging_page(),
+                "script",
+                ["arg"],
+                what="Home Depot search",
+                deadline=time.monotonic() + 0.1,
+            )
+
+        assert caught.value.status_code == 504
+
+    @pytest.mark.asyncio
+    async def test_a_hung_request_releases_the_lock_for_the_next_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The property that actually mattered: one bad request, not a cascade."""
+        monkeypatch.setattr(sidecar, "_EVALUATE_GRACE_SECONDS", 0.05)
+        monkeypatch.setattr(sidecar, "REQUEST_BUDGET_SECONDS", 0.1)
+        engine = sidecar.BrowserBackedSearch()
+        page = self._hanging_page()
+
+        async def one_request() -> None:
+            async with engine._timed_lock("home_depot", "hd") as deadline:
+                await engine._evaluate(page, "s", [], what="hd", deadline=deadline)
+
+        with pytest.raises(sidecar.HTTPException):
+            await one_request()
+
+        # The lock has to be free the instant the first request gives up.
+        await asyncio.wait_for(engine._lock_for("home_depot").acquire(), timeout=0.5)
+
+    @pytest.mark.asyncio
+    async def test_an_expired_budget_is_refused_rather_than_extended(self) -> None:
+        """The redirect retry shares one budget; it cannot mint a fresh slice."""
+        engine = sidecar.BrowserBackedSearch()
+
+        with pytest.raises(sidecar.HTTPException) as caught:
+            await engine._evaluate(
+                self._hanging_page(),
+                "script",
+                [],
+                what="Home Depot search",
+                deadline=time.monotonic() - 1,
+            )
+
+        assert caught.value.status_code == 504
+        assert "ran out of budget" in caught.value.detail
+
+    @pytest.mark.asyncio
+    async def test_an_aborted_fetch_becomes_a_gateway_timeout(self) -> None:
+        """The script reports its own abort in the payload rather than throwing."""
+        engine = sidecar.BrowserBackedSearch()
+
+        class AbortingPage:
+            async def evaluate(self, _script: str, _args: list) -> dict:
+                return {"status": 0, "body": "", "error": "TimeoutError"}
+
+        with pytest.raises(sidecar.HTTPException) as caught:
+            await engine._evaluate(
+                AbortingPage(),
+                "script",
+                [],
+                what="Home Depot search",
+                deadline=time.monotonic() + 5,
+            )
+
+        assert caught.value.status_code == 504
+        assert "TimeoutError" in caught.value.detail
+
+    @pytest.mark.asyncio
+    async def test_the_remaining_budget_is_handed_to_the_script(self) -> None:
+        """The script cannot abort itself without being told how long it has."""
+        engine = sidecar.BrowserBackedSearch()
+        seen: list[list] = []
+
+        class RecordingPage:
+            async def evaluate(self, _script: str, args: list) -> dict:
+                seen.append(args)
+                return {"status": 200, "body": "{}"}
+
+        await engine._evaluate(
+            RecordingPage(),
+            "script",
+            ["first", "second"],
+            what="Home Depot search",
+            deadline=time.monotonic() + 4,
+        )
+
+        assert seen[0][:2] == ["first", "second"]
+        timeout_ms = seen[0][-1]
+        assert isinstance(timeout_ms, int)
+        assert 3_000 < timeout_ms <= 4_000, "the script gets what is left, in milliseconds"
+
+    @pytest.mark.asyncio
+    async def test_the_budget_stays_under_the_clients_own_timeout(self) -> None:
+        """The sidecar has to fail first, or its caller is gone before it answers.
+
+        The client waits 35s (`_DEFAULT_TIMEOUT_SECONDS` in sidecar_client.py).
+        Budget plus grace is the worst case one request can take, and it has to
+        land below that with room to spare.
+        """
+        from backend.app.integrations.supplier_pricing.sidecar_client import (
+            _DEFAULT_TIMEOUT_SECONDS,
+        )
+
+        worst_case = sidecar.REQUEST_BUDGET_SECONDS + sidecar._EVALUATE_GRACE_SECONDS
+        assert worst_case < _DEFAULT_TIMEOUT_SECONDS
+
+
+class TestRequestTiming:
+    @pytest.mark.asyncio
+    async def test_queue_and_work_time_are_logged_separately(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A slow search and a queued one are different problems, and the logs
+        could not tell them apart before (issue #1496)."""
+        engine = sidecar.BrowserBackedSearch()
+
+        with caplog.at_level("INFO", logger="hd-sidecar"):
+            async with engine._timed_lock("home_depot", "home_depot search 'drill'"):
+                pass
+
+        assert any(
+            "home_depot search 'drill'" in r.message
+            and "queued" in r.message
+            and "working" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_timing_is_logged_even_when_the_request_fails(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failed request is the one whose duration you most want to see."""
+        engine = sidecar.BrowserBackedSearch()
+
+        with caplog.at_level("INFO", logger="hd-sidecar"), pytest.raises(RuntimeError):
+            async with engine._timed_lock("home_depot", "home_depot search 'drill'"):
+                raise RuntimeError("boom")
+
+        assert any("queued" in r.message for r in caplog.records)
 
 
 class TestIdleBrowserRecycling:

--- a/tests/test_sidecar_supplier.py
+++ b/tests/test_sidecar_supplier.py
@@ -191,6 +191,31 @@ class TestSidecarClient:
             await supplier.search_products("drill", Location(zip_code="30301"))
 
     @pytest.mark.asyncio
+    async def test_timeout_names_itself_in_the_error(self) -> None:
+        """Regression for #1496.
+
+        `httpx.TimeoutException` subclasses `HTTPError`, so the catch-all clause
+        used to swallow it and report a timed-out sidecar as "unreachable". The
+        two mean different things operationally and the message has to keep them
+        apart. It stays a SupplierUnavailableError either way, so the caller
+        still falls through to the next backend.
+        """
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=httpx.ReadTimeout("too slow"))
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        supplier = SidecarSupplier(SIDECAR_URL, timeout_seconds=35.0)
+
+        with (
+            patch(
+                "backend.app.integrations.supplier_pricing.sidecar_client.httpx.AsyncClient",
+                return_value=client,
+            ),
+            pytest.raises(SupplierUnavailableError, match="timed out after 35s"),
+        ):
+            await supplier.search_products("drill", Location(zip_code="30301"))
+
+    @pytest.mark.asyncio
     async def test_error_status_raises_blocked(self) -> None:
         client = _client_returning(_response(502, {"detail": "browser died"}))
         supplier = SidecarSupplier(SIDECAR_URL)
@@ -236,7 +261,14 @@ class TestBackendChain:
     @staticmethod
     def _tools(sidecar: object, serpapi: object) -> dict[str, Callable[..., Awaitable[ToolResult]]]:
         sidecars = {"home_depot": sidecar} if sidecar is not None else {}
-        tools = _create_pricing_tools(sidecars, serpapi, SupplierCache())  # type: ignore[arg-type]
+        # Fresh caches per tool set: a shared outage counter would let one test's
+        # failures suppress the next test's search.
+        tools = _create_pricing_tools(
+            sidecars,  # type: ignore[arg-type]
+            serpapi,  # type: ignore[arg-type]
+            SupplierCache(),
+            SupplierCache(),
+        )
         return {t.name: t.function for t in tools}
 
     @classmethod
@@ -345,7 +377,12 @@ class TestLowesRouting:
 
     @staticmethod
     def _tools(sidecars: dict, serpapi: object) -> dict[str, Callable[..., Awaitable[ToolResult]]]:
-        tools = _create_pricing_tools(sidecars, serpapi, SupplierCache())  # type: ignore[arg-type]
+        tools = _create_pricing_tools(
+            sidecars,
+            serpapi,  # type: ignore[arg-type]
+            SupplierCache(),
+            SupplierCache(),
+        )
         return {t.name: t.function for t in tools}
 
     @staticmethod


### PR DESCRIPTION
## Description

Eight consecutive failed `supplier_search_products` calls in one conversation, roughly seven minutes of user wait, all rewording the same query. This PR fixes the tool layer that turned one outage into eight calls, and hardens the sidecar path around it. The outage itself is #1498 and is not fixed here.

**The tool told the model to reword.** The timeout branch answered "The price lookup timed out. Try a simpler search term." with no hint, while the sibling unavailable branch already said rewording will not help. It now carries the same hint, from one shared constant. Consecutive failures per (supplier, zip) are counted in a short-TTL cache so a retailer that is already down stops being asked; the positive cache could not do this, being keyed on the exact query string the model was changing every time. One retry still gets through, since the sidecar warms lazily and a second attempt can succeed.

**Timeouts could not be told apart from refusals.** `httpx.TimeoutException` subclasses `HTTPError`, so the sidecar client's catch-all reported a timed-out sidecar as "unreachable", and the `TimeoutException` branch in the factory was unreachable from the sidecar entirely. Timeouts now name themselves, and the fall-through log is warning rather than info since it is the only line identifying which backend failed.

**Sidecar hardening, not a root-cause fix.** The Home Depot search path runs an in-page fetch through `page.evaluate`. The fetch carried no abort signal and `evaluate` takes no timeout, so a retailer that accepts a connection and then goes quiet would leave the coroutine pending with no way to end, holding that retailer's lock while everything behind it burned its own budget. That is not what happened in production, it is a hole found while reading the path. Both scripts now abort via `AbortSignal.timeout` and report it in the return value; `asyncio.wait_for` wraps `evaluate` as the backstop for a page that never runs the script, with cancellation guaranteeing the lock is released. One deadline per request, shared with the category-redirect retry and refused rather than extended once spent, so budget plus grace stays under the client's 35s, asserted in a test.

**Sidecar observability.** `_call` and `_store_call` raised on a non-200 status or an unparseable body without recording either, so five days of production 502s carried no indication of cause. They now log the status and the head of the body. Lock wait and work time are logged per request; a two-second search and a thirty-second one were previously indistinguishable.

Reading the production logs is what identified #1498 and corrected the original diagnosis in this PR: the sidecar was returning 502 in under a second, and the timeouts the user actually waited on came from the SerpApi fallback.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 3175 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) — plus `sidecar/`, and `ty` clean
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

The five tool-layer regression tests were verified to fail against the pre-fix source and pass after. The sidecar tests assert the new behaviour rather than reproducing the old hang, which by definition had no way to terminate.

## AI Usage
- [x] AI-assisted (describe how)

Investigation, patch, and tests written by Claude Opus 5 via back-and-forth with @njbrake, working from a production transcript and Railway logs he supplied. The reasoning and decisions are his.
- [ ] No AI used

Fixes #1496
Refs #1498


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents repeated supplier retries by caching failures by supplier and ZIP code for 90 seconds.
- Allows one retry before suppressing further requests to an unavailable supplier.
- Updates timeout messages so rewording does not trigger more futile retries.
- Separates sidecar timeout errors from other HTTP failures and improves error logging.
- Adds request deadlines, cancellation, timeout handling, and shared budgets across sidecar operations.
- Records lock queue and work durations.
- Adds regression tests for retry suppression, cache isolation, timeout handling, request cancellation, and lock behavior.

## Benefits

These changes reduce repeated backend requests, improve failure reporting, and prevent sidecar operations from exceeding their request budget. The expanded tests also protect the retry and timeout behavior against regressions.

## Potential enhancements

Future work could add metrics or dashboards for suppressed requests, timeout frequency, and cache effectiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->