### PR TITLE
fix(sidecar): clear the stale X display lock so a restart can boot

### DIFF
--- a/sidecar/home_depot/docker-entrypoint.sh
+++ b/sidecar/home_depot/docker-entrypoint.sh
@@ -45,11 +45,23 @@ fi
 
 log "python: $(python --version 2>&1)"
 
+# A restart is not a redeploy: it reuses the container filesystem, so the lock
+# and socket from the previous run are still on disk and Xvfb refuses to start
+# on a display it believes is already live. Nothing else in this container owns
+# the display, so a leftover is always stale. Without this, a platform-initiated
+# restart exits FATAL, exhausts restartPolicyMaxRetries in about ten seconds,
+# and leaves the deployment CRASHED until a human redeploys. `-f` matters: the
+# files are absent on a fresh container and `set -e` would abort on the failure.
+rm -f "/tmp/.X${DISPLAY_NUM}-lock" "/tmp/.X11-unix/X${DISPLAY_NUM}"
+
 Xvfb ":$DISPLAY_NUM" -screen 0 1440x900x24 -nolisten tcp &
 XVFB_PID=$!
 sleep 2
 if ! kill -0 "$XVFB_PID" 2>/dev/null; then
-    log "FATAL: Xvfb died immediately on :$DISPLAY_NUM"
+    # Xvfb writes its own reason to stderr, which reaches the platform log
+    # ahead of this line. Name the lock anyway: it is the cause that took a
+    # production outage to find, and the wording is what an operator greps for.
+    log "FATAL: Xvfb died immediately on :$DISPLAY_NUM (stale /tmp/.X${DISPLAY_NUM}-lock?)"
     exit 1
 fi
 export DISPLAY=":$DISPLAY_NUM"

--- a/tests/test_sidecar_entrypoint.py
+++ b/tests/test_sidecar_entrypoint.py
@@ -1,0 +1,61 @@
+"""Tests for the sidecar container entrypoint.
+
+The entrypoint is shell, so there is no unit to call. It is read as text and
+asserted against instead, in the same spirit as the source-parsing lock test in
+``test_sidecar_locks.py``: the failure modes here are silent until a container
+event that may be months apart, so an assertion is worth more than a comment.
+
+What is guarded is the Xvfb startup ordering. A Railway restart reuses the
+container filesystem, unlike a redeploy, so ``/tmp/.X99-lock`` survives from the
+previous run and Xvfb refuses to start on a display it believes is live. That
+took the production sidecar down on 2026-08-12: the entrypoint exited FATAL,
+Railway exhausted its three retries in about ten seconds, and the deployment sat
+CRASHED until someone redeployed it (issue #1499).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ENTRYPOINT = (
+    Path(__file__).resolve().parents[1] / "sidecar" / "home_depot" / "docker-entrypoint.sh"
+)
+
+
+def _lines() -> list[str]:
+    return _ENTRYPOINT.read_text().splitlines()
+
+
+def _index_of(pattern: str) -> int:
+    """Return the line number matching ``pattern``, failing loudly if absent."""
+    matcher = re.compile(pattern)
+    for number, line in enumerate(_lines()):
+        if matcher.search(line):
+            return number
+    pytest.fail(f"no line in docker-entrypoint.sh matches {pattern!r}")
+
+
+class TestStaleDisplayLock:
+    def test_the_lock_is_cleared_before_xvfb_starts(self) -> None:
+        """Clearing it afterwards would be useless; Xvfb has already refused."""
+        assert _index_of(r"^rm -f .*-lock") < _index_of(r"^Xvfb ")
+
+    def test_the_socket_is_cleared_too(self) -> None:
+        """A lock with no socket still counts as an active display to Xvfb."""
+        lines = _lines()
+        removal = lines[_index_of(r"^rm -f .*-lock")]
+        assert ".X11-unix/X" in removal
+
+    def test_the_removal_is_forced(self) -> None:
+        """`set -e` is on and a fresh container has neither file.
+
+        Without `-f` this fix would trade a broken restart for a broken cold
+        start, which is the more common path by far.
+        """
+        assert _index_of(r"^rm -f .*-lock") == _index_of(r"^rm -f ")
+
+    def test_the_display_number_is_not_hardcoded(self) -> None:
+        """HD_DISPLAY is configurable, so removing :99 by hand would miss it."""
+        removal = _lines()[_index_of(r"^rm -f .*-lock")]
+        assert "$DISPLAY_NUM" in removal or "${DISPLAY_NUM}" in removal


### PR DESCRIPTION
## Description

A Railway restart left the sidecar permanently dead. It reuses the container filesystem, unlike a redeploy, so `/tmp/.X99-lock` survives from the previous run, Xvfb refuses to start on a display it believes is live, and the entrypoint exits FATAL. Three retries later the deployment sits CRASHED until a human redeploys. This took production down on 2026-08-12, and a platform-initiated restart would do the same with nobody watching.

Remove the lock and the matching socket before starting Xvfb. Nothing else in the container owns that display, so a leftover is always stale. The `-f` is load-bearing rather than habit: both files are absent on a cold start and `set -e` would otherwise trade a broken restart for a broken first boot, which is the far more common path.

The FATAL log line now names the lock, since that is what an operator greps for.

Tests read the entrypoint as text and assert the ordering, the socket removal, the `-f`, and that the display number comes from `DISPLAY_NUM` rather than a hardcoded 99. Shell offers no unit to call, and this failure mode stays silent until a container event that may be months apart, so the assertion is worth more than a comment. Same approach as the existing source-parsing lock test in `tests/test_sidecar_locks.py`.

Verified beyond the tests: `sh -n` on the script, and the removal run under `set -eu` both with the stale files present and with them absent, exiting 0 either way. All four tests were confirmed to fail against the unpatched entrypoint.

Unrelated to #1498, which is Home Depot blocking the browser. This is purely about surviving a restart.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) — 3170 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) — plus `sidecar/`, and `ty` clean
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how)

Found by Claude Opus 5 while investigating #1496, by restarting the production sidecar and reading the crash logs. Patch and tests written by Claude via back-and-forth with @njbrake; the reasoning and decisions are his.
- [ ] No AI used

Fixes #1499
