### PR TITLE
fix(quickbooks): stop qb_send racing qb_create in the same turn

### DIFF
--- a/backend/app/integrations/quickbooks/factory.py
+++ b/backend/app/integrations/quickbooks/factory.py
@@ -76,6 +76,23 @@ _UPDATABLE_ENTITIES = {"Customer", "Estimate", "Invoice", "Item"}
 # Entity types that qb_send is allowed to send via email.
 _SENDABLE_ENTITIES = {"Invoice", "Estimate"}
 
+# Serialization key shared by every QuickBooks write tool.
+#
+# The agent runs all approved tool calls from one model turn concurrently.
+# The model routinely emits ``qb_create`` and ``qb_send`` in the same turn,
+# predicting the id the create will return. Without a shared group the send
+# races the create and QBO answers ``code=610 Object Not Found`` because the
+# transaction genuinely does not exist yet. These tools all mutate the same
+# QBO company and read each other's ids, so they share one static key rather
+# than a per-entity resolver: ordering across entity types matters too (an
+# Invoice line can reference an Item created in the same turn).
+_QB_WRITE_CONCURRENCY_GROUP = "quickbooks_write"
+
+# Intuit fault codes that mean "the entity is not there", as opposed to a
+# transient backend failure. Surfaced as NOT_FOUND so the model looks the id
+# up again instead of blindly retrying a "service unavailable".
+_INTUIT_NOT_FOUND_CODES = {"610"}
+
 
 class QBQueryParams(BaseModel):
     """Parameters for the qb_query tool."""
@@ -145,6 +162,38 @@ def _format_intuit_fault(exc: httpx.HTTPStatusError, *, entity: str | None = Non
     if hint:
         body = f"{body}\nHint: {hint}"
     return body
+
+
+def _intuit_fault_codes(exc: httpx.HTTPStatusError) -> set[str]:
+    """Collect the ``Fault.Error[].code`` values from a QBO error response.
+
+    Returns an empty set when the body is not a recognizable Intuit fault.
+    """
+    try:
+        raw_body = exc.response.json()
+    except Exception:
+        return set()
+    fault = (raw_body or {}).get("Fault") if isinstance(raw_body, dict) else None
+    errors = (fault or {}).get("Error") if isinstance(fault, dict) else None
+    if not isinstance(errors, list):
+        return set()
+    return {str(err["code"]) for err in errors if isinstance(err, dict) and err.get("code")}
+
+
+def _fault_error_kind(exc: Exception) -> ToolErrorKind:
+    """Classify a QBO failure for the LLM error hint.
+
+    A 610 is a 4xx about a missing object, not an outage. Reporting it as
+    SERVICE tells the model "temporarily unavailable, try a different
+    approach", which is the wrong instruction: the id is wrong (or not
+    visible yet) and the model should look it up rather than retry blind.
+    """
+    if (
+        isinstance(exc, httpx.HTTPStatusError)
+        and _intuit_fault_codes(exc) & _INTUIT_NOT_FOUND_CODES
+    ):
+        return ToolErrorKind.NOT_FOUND
+    return ToolErrorKind.SERVICE
 
 
 def _enum_hint(error_body: str, entity: str | None) -> str:
@@ -493,6 +542,17 @@ def create_quickbooks_tools(
 ) -> list[Tool]:
     """Create QuickBooks-related tools for the agent."""
 
+    # Entity ids created during this agent run, keyed by entity type. The
+    # tool list is rebuilt per inbound message, so this is scoped to one
+    # user turn (spanning every LLM round of that turn) and never leaks
+    # between messages or users.
+    #
+    # qb_send consults it to refuse an id the model predicted rather than
+    # read back from a qb_create result. A predicted id that happens to
+    # match a different live transaction would email one customer another
+    # customer's invoice, so the guess is rejected, not retried.
+    created_ids: dict[str, set[str]] = {}
+
     async def qb_query(query: str) -> ToolResult:
         """Run a read-only query against QuickBooks Online."""
         import re as _re
@@ -562,7 +622,7 @@ def create_quickbooks_tools(
             return ToolResult(
                 content=f"Failed to create {entity_type}: {error_str}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=_fault_error_kind(exc),
             )
 
         entity_id = result.get("Id", "?")
@@ -570,6 +630,9 @@ def create_quickbooks_tools(
         total = result.get("TotalAmt")
         display_name = result.get("DisplayName", "")
         item_name = result.get("Name", "")
+
+        if entity_id != "?":
+            created_ids.setdefault(entity_type, set()).add(str(entity_id))
 
         # LLM-facing content stays terse and data-only so the model has no
         # receipt-shaped phrasing to bullet-point back to the user. The
@@ -615,7 +678,7 @@ def create_quickbooks_tools(
             return ToolResult(
                 content=f"Failed to update {entity_type}: {error_str}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=_fault_error_kind(exc),
             )
 
         entity_id = result.get("Id", "?")
@@ -653,6 +716,30 @@ def create_quickbooks_tools(
                 error_kind=ToolErrorKind.VALIDATION,
             )
 
+        # When this turn created entities of the same type, the only ids the
+        # model can legitimately send are the ones qb_create handed back.
+        # Anything else is a prediction, and sending a predicted id delivers
+        # some other customer's transaction to this recipient.
+        turn_created = created_ids.get(entity_type)
+        if turn_created and entity_id.strip() not in turn_created:
+            known = ", ".join(sorted(turn_created))
+            logger.warning(
+                "qb_send_unverified_entity_id tool=qb_send entity_type=%s requested=%s created=%s",
+                entity_type,
+                entity_id,
+                known,
+            )
+            return ToolResult(
+                content=(
+                    f"Refusing to send {entity_type} {entity_id}: this turn created "
+                    f"{entity_type} {known}, and {entity_id} is not among them. "
+                    f"Send one of the ids returned by qb_create, or look the "
+                    f"intended {entity_type.lower()} up with qb_query first."
+                ),
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+
         try:
             await qb_service.send_entity_email(entity_type, entity_id, email)
         except Exception as exc:
@@ -664,7 +751,7 @@ def create_quickbooks_tools(
             return ToolResult(
                 content=f"Failed to send {entity_type.lower()}: {error_str}",
                 is_error=True,
-                error_kind=ToolErrorKind.SERVICE,
+                error_kind=_fault_error_kind(exc),
             )
 
         # Drop the verb + recipient from the LLM-facing content: that
@@ -711,6 +798,7 @@ def create_quickbooks_tools(
             ),
             function=qb_create,
             params_model=QBCreateParams,
+            concurrency_group=_QB_WRITE_CONCURRENCY_GROUP,
             usage_hint=(
                 "Create a Customer, Estimate, Invoice, or Item in QB. "
                 "Construct the QBO API payload as described in the skill docs."
@@ -733,6 +821,7 @@ def create_quickbooks_tools(
             ),
             function=qb_update,
             params_model=QBUpdateParams,
+            concurrency_group=_QB_WRITE_CONCURRENCY_GROUP,
             usage_hint=(
                 "Update a Customer, Estimate, Invoice, or Item in QB. "
                 "Payload must include Id and SyncToken from a prior query."
@@ -749,10 +838,11 @@ def create_quickbooks_tools(
             name=ToolName.QB_SEND,
             description=(
                 "Send an invoice or estimate to a customer via QuickBooks email. "
-                "The entity must already exist in QuickBooks."
+                "Pass the Id returned by qb_create or qb_query; never predict one."
             ),
             function=qb_send,
             params_model=QBSendParams,
+            concurrency_group=_QB_WRITE_CONCURRENCY_GROUP,
             usage_hint=(
                 "Send a QB invoice or estimate by email. "
                 "Confirm the email address with the user first."

--- a/tests/test_quickbooks_write.py
+++ b/tests/test_quickbooks_write.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 from pydantic import ValidationError
 
+from backend.app.agent.tools.base import ToolErrorKind
 from backend.app.integrations.quickbooks.factory import (
     QBCreateParams,
     QBUpdateParams,
@@ -1170,3 +1171,215 @@ def test_qb_create_approval_description_survives_format_approval_message() -> No
     # multi-line description has not stomped the reply instructions.
     assert "yes: allow this once" in prompt
     assert "never: deny and remember" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Same-turn create/send ordering. A qb_send emitted in the same model turn
+# as its qb_create ran concurrently with it, reached QBO first, and drew
+# "code=610 Object Not Found" for a transaction that did not exist yet.
+# ---------------------------------------------------------------------------
+
+
+def _get_tool_obj(tools: list, name: str) -> Any:
+    for t in tools:
+        if t.name == name:
+            return t
+    raise KeyError(f"Tool {name} not found")
+
+
+def test_qb_write_tools_share_a_concurrency_group() -> None:
+    """qb_create, qb_update and qb_send must serialize against each other.
+
+    The agent runs every approved call from one model turn concurrently, so
+    without a shared group a send emitted alongside its create reaches QBO
+    before the entity exists.
+    """
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+
+    groups = {
+        name: _get_tool_obj(tools, name).concurrency_group
+        for name in ("qb_create", "qb_update", "qb_send")
+    }
+    assert None not in groups.values(), f"QB write tools missing concurrency_group: {groups}"
+    assert len(set(groups.values())) == 1, f"QB write tools must share one group: {groups}"
+
+
+def test_qb_query_has_no_concurrency_group() -> None:
+    """The read-only tool must stay parallelizable."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    assert _get_tool_obj(tools, "qb_query").concurrency_group is None
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_accepts_id_returned_by_create_in_same_turn() -> None:
+    """The normal create-then-send flow must still work."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    create = _get_tool(tools, "qb_create")
+    send = _get_tool(tools, "qb_send")
+
+    created = await create(
+        entity_type="Estimate",
+        data={"CustomerRef": {"value": "3"}, "Line": [{"Amount": 100.0}]},
+    )
+    assert created.is_error is False
+    new_id = created.content.split("Id: ")[1].split(" ")[0]
+
+    result = await send(entity_type="Estimate", entity_id=new_id, email="dev@example.com")
+
+    assert result.is_error is False
+    assert svc.sent == [("Estimate", new_id, "dev@example.com")]
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_refuses_predicted_id_after_create_in_same_turn() -> None:
+    """A send must not target an id the model guessed rather than read back.
+
+    Serializing create before send fixes the race, but a wrong guess would
+    then email a live, unrelated transaction to this recipient.
+    """
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    create = _get_tool(tools, "qb_create")
+    send = _get_tool(tools, "qb_send")
+
+    created = await create(
+        entity_type="Estimate",
+        data={"CustomerRef": {"value": "3"}, "Line": [{"Amount": 100.0}]},
+    )
+    new_id = created.content.split("Id: ")[1].split(" ")[0]
+    predicted = str(int(new_id) + 3)
+
+    result = await send(entity_type="Estimate", entity_id=predicted, email="dev@example.com")
+
+    assert result.is_error is True
+    assert result.error_kind is ToolErrorKind.VALIDATION
+    assert new_id in result.content
+    assert svc.sent == [], "no email may go out for an unverified id"
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_allows_any_id_when_no_create_ran_this_turn() -> None:
+    """Sending a previously existing entity stays unrestricted."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    send = _get_tool(tools, "qb_send")
+
+    result = await send(entity_type="Invoice", entity_id="9001", email="dev@example.com")
+
+    assert result.is_error is False
+    assert svc.sent == [("Invoice", "9001", "dev@example.com")]
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_guard_is_scoped_per_entity_type() -> None:
+    """Creating an Item must not restrict which Invoice may be sent."""
+    svc = FakeQBService()
+    tools = create_quickbooks_tools(svc)
+    create = _get_tool(tools, "qb_create")
+    send = _get_tool(tools, "qb_send")
+
+    await create(entity_type="Item", data={"Name": "Labor"})
+    result = await send(entity_type="Invoice", entity_id="9001", email="dev@example.com")
+
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_guard_does_not_leak_between_tool_builds() -> None:
+    """The tool list is rebuilt per inbound message, so the guard must reset."""
+    svc = FakeQBService()
+    first = create_quickbooks_tools(svc)
+    created = await _get_tool(first, "qb_create")(
+        entity_type="Estimate",
+        data={"CustomerRef": {"value": "3"}, "Line": [{"Amount": 100.0}]},
+    )
+    other_id = str(int(created.content.split("Id: ")[1].split(" ")[0]) + 5)
+
+    second = create_quickbooks_tools(svc)
+    result = await _get_tool(second, "qb_send")(
+        entity_type="Estimate", entity_id=other_id, email="dev@example.com"
+    )
+
+    assert result.is_error is False
+
+
+# ---------------------------------------------------------------------------
+# Intuit fault classification
+# ---------------------------------------------------------------------------
+
+
+def _fault_error(code: str, status: int = 400) -> httpx.HTTPStatusError:
+    body = {
+        "Fault": {
+            "Error": [{"Message": "Object Not Found", "Detail": "Object Not Found", "code": code}],
+            "type": "ValidationFault",
+        }
+    }
+    request = httpx.Request("POST", "https://example.invalid/estimate/1/send")
+    response = httpx.Response(status, json=body, request=request)
+    return httpx.HTTPStatusError(f"{status}", request=request, response=response)
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_610_is_not_found_not_service() -> None:
+    """610 is a 4xx about a missing object, not an outage.
+
+    SERVICE tells the model "temporarily unavailable, try a different
+    approach"; NOT_FOUND tells it to verify the id, which is the correct
+    recovery.
+    """
+    svc = FakeQBService()
+    svc.send_entity_email = AsyncMock(side_effect=_fault_error("610"))  # type: ignore[method-assign]
+    tools = create_quickbooks_tools(svc)
+
+    result = await _get_tool(tools, "qb_send")(
+        entity_type="Estimate", entity_id="5001", email="dev@example.com"
+    )
+
+    assert result.is_error is True
+    assert result.error_kind is ToolErrorKind.NOT_FOUND
+
+
+@pytest.mark.asyncio()
+async def test_qb_send_other_faults_stay_service() -> None:
+    svc = FakeQBService()
+    svc.send_entity_email = AsyncMock(side_effect=_fault_error("2030"))  # type: ignore[method-assign]
+    tools = create_quickbooks_tools(svc)
+
+    result = await _get_tool(tools, "qb_send")(
+        entity_type="Estimate", entity_id="5001", email="dev@example.com"
+    )
+
+    assert result.is_error is True
+    assert result.error_kind is ToolErrorKind.SERVICE
+
+
+@pytest.mark.asyncio()
+async def test_qb_create_610_is_not_found() -> None:
+    svc = FakeQBService()
+    svc.create_entity = AsyncMock(side_effect=_fault_error("610"))  # type: ignore[method-assign]
+    tools = create_quickbooks_tools(svc)
+
+    result = await _get_tool(tools, "qb_create")(
+        entity_type="Invoice", data={"CustomerRef": {"value": "999"}}
+    )
+
+    assert result.is_error is True
+    assert result.error_kind is ToolErrorKind.NOT_FOUND
+
+
+@pytest.mark.asyncio()
+async def test_qb_create_non_http_error_stays_service() -> None:
+    svc = FakeQBService()
+    svc.create_entity = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+    tools = create_quickbooks_tools(svc)
+
+    result = await _get_tool(tools, "qb_create")(
+        entity_type="Invoice", data={"CustomerRef": {"value": "1"}}
+    )
+
+    assert result.is_error is True
+    assert result.error_kind is ToolErrorKind.SERVICE


### PR DESCRIPTION
*Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's.*

## Description

`qb_send` could reach QuickBooks before the entity it was sending existed, returning `code=610 Object Not Found`.

The agent runs every approved tool call from a single model turn concurrently, bucketed by `concurrency_group`. No QuickBooks tool declared one. The model routinely emits `qb_create` and `qb_send` in the same turn, predicting the id the create will return, so the send raced the create and lost. Its own retry on the next round then succeeded, which is why this showed up as a stray error inside an otherwise working flow.

1. **`qb_create`, `qb_update` and `qb_send` share a `concurrency_group`**, so QB writes serialize in submission order. One static key rather than a per-entity resolver: ordering across entity types matters too, since an Invoice line can reference an Item created in the same turn. `qb_query` stays parallel.

2. **`qb_send` refuses an `entity_id` that no `qb_create` returned this turn**, when that turn created entities of the same type. Serializing fixes the race, but the id is still a prediction, and a guess that lands on a different live transaction emails one customer another customer's invoice. Ids from `qb_query` or earlier turns are unaffected.

3. **Intuit fault 610 is now `NOT_FOUND`, not `SERVICE`.** `SERVICE` tells the model to treat it as a transient outage; the correct recovery for a 4xx about a missing object is to verify the id.

This was the missing step 6 of the `AGENTS.md` tool checklist. The global `test_state_mutating_tools_have_concurrency_group` guard only covers `MODIFIES_PROFILE` / `SENDS_REPLY` tools, so integration write tools slip past it. Widening it is worth a follow-up; other integrations with same-turn create/send pairs likely share the gap.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: root cause traced from logs and the fix implemented by Claude Opus 5 via Claude Code, reviewed by @njbrake.
