### PR TITLE
fix(appfolio): serialize work-order writes emitted in one turn

### DIFF
--- a/backend/app/integrations/appfolio_vendor/concurrency.py
+++ b/backend/app/integrations/appfolio_vendor/concurrency.py
@@ -1,0 +1,39 @@
+"""Serialization keys for AppFolio write tools.
+
+The agent runs every approved tool call from one model turn concurrently.
+Each AppFolio write targets a single work order, and several of them can be
+emitted together in one turn against the *same* work order:
+
+* ``appfolio_update_work_order_status`` racing
+  ``appfolio_undo_work_order_status`` leaves the status at whichever request
+  AppFolio happened to serve last.
+* ``appfolio_update_note`` racing the ``appfolio_add_note`` whose id it is
+  editing reaches AppFolio before that note exists.
+* ``appfolio_create_invoice`` racing ``appfolio_upload_invoice_pdf`` bills
+  the same work order twice.
+
+Keying on ``work_order_id`` serializes writes to one work order while
+leaving writes to *different* work orders parallel, which is the common
+case when the agent works through a batch of jobs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_WORK_ORDER_GROUP_PREFIX = "appfolio_work_order"
+
+
+def work_order_concurrency_key(args: dict[str, Any]) -> str | None:
+    """Resolve the serialization key for a work-order-scoped AppFolio write.
+
+    Returns ``None`` when the call carries no ``work_order_id``, which
+    leaves that call unserialized rather than lumping every id-less write
+    into one bucket. Every write tool declares ``work_order_id`` as a
+    required parameter, so this is a defensive fallback rather than an
+    expected path.
+    """
+    work_order_id = args.get("work_order_id")
+    if work_order_id is None or str(work_order_id).strip() == "":
+        return None
+    return f"{_WORK_ORDER_GROUP_PREFIX}:{str(work_order_id).strip()}"

--- a/backend/app/integrations/appfolio_vendor/errors.py
+++ b/backend/app/integrations/appfolio_vendor/errors.py
@@ -137,10 +137,15 @@ def service_error_to_tool_result(method_label: str, exc: BaseException) -> ToolR
             hint=_AUTH_SCOPE_HINT,
         )
     if isinstance(exc, AppFolioError):
+        # A 404 is not an outage. SERVICE tells the model an external
+        # service is temporarily unavailable and to try a different
+        # approach; for a missing work order or note the useful recovery
+        # is to look the id up, which is what NOT_FOUND steers toward.
+        kind = ToolErrorKind.NOT_FOUND if exc.status_code == 404 else ToolErrorKind.SERVICE
         return ToolResult(
             content=f"AppFolio error while {method_label}: {exc}",
             is_error=True,
-            error_kind=ToolErrorKind.SERVICE,
+            error_kind=kind,
         )
     logger.exception("Unexpected AppFolio failure %s", method_label)
     return ToolResult(

--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.concurrency import work_order_concurrency_key
 from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
 from backend.app.integrations.appfolio_vendor.media_resolver import resolve_staged_files
 from backend.app.integrations.appfolio_vendor.params import (
@@ -399,6 +400,7 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
             ),
             function=appfolio_create_invoice,
             params_model=AppFolioCreateInvoiceParams,
+            concurrency_group=work_order_concurrency_key,
             usage_hint=(
                 "Confirm each line item's description, quantity, and amount"
                 " with the user before submitting; this is a billing action."
@@ -415,6 +417,7 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
             ),
             function=appfolio_upload_invoice_pdf,
             params_model=AppFolioUploadInvoicePdfParams,
+            concurrency_group=work_order_concurrency_key,
             usage_hint=(
                 "Use when the user has already prepared an invoice document."
                 " For line-item entry, use appfolio_create_invoice instead."

--- a/backend/app/integrations/appfolio_vendor/notes.py
+++ b/backend/app/integrations/appfolio_vendor/notes.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.concurrency import work_order_concurrency_key
 from backend.app.integrations.appfolio_vendor.errors import (
     log_unexpected_response_shape,
     service_error_to_tool_result,
@@ -49,6 +50,18 @@ def _normalize_notes(payload: Any) -> list[dict[str, Any]]:
 
 def build_note_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[Tool]:
     """Return the AppFolio work-order note tools."""
+
+    # Note ids created during this agent run, keyed by work order. The tool
+    # list is rebuilt per inbound message, so this is scoped to one user
+    # turn (spanning every LLM round of that turn) and never leaks between
+    # messages or users.
+    #
+    # appfolio_update_note consults it to refuse a note_id the model
+    # predicted rather than read back from an appfolio_add_note result.
+    # Serializing the two writes fixes the ordering, but a predicted id
+    # that lands on a different real note overwrites that note's body,
+    # which the PM sees and the vendor does not.
+    added_note_ids: dict[str, set[str]] = {}
 
     async def appfolio_list_notes(work_order_id: str) -> ToolResult:
         try:
@@ -100,6 +113,8 @@ def build_note_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[T
         note_id = ""
         if isinstance(result, dict):
             note_id = str(result.get("id") or result.get("note", {}).get("id") or "")
+        if note_id:
+            added_note_ids.setdefault(work_order_id, set()).add(note_id)
         photo_count = len(files)
         photo_phrase = f" with {photo_count} photo(s)" if photo_count else ""
         return ToolResult(
@@ -123,6 +138,30 @@ def build_note_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[T
         if not text:
             return ToolResult(
                 content="Note body cannot be empty.",
+                is_error=True,
+                error_kind=ToolErrorKind.VALIDATION,
+            )
+        # When this turn added notes to this work order, the only ids the
+        # model can legitimately edit are the ones add_note handed back.
+        # Anything else is a prediction. Only enforced when we actually
+        # captured an id: AppFolio does not always return one, and an
+        # empty set must not block a legitimate edit.
+        turn_added = added_note_ids.get(work_order_id)
+        if turn_added and note_id.strip() not in turn_added:
+            known = ", ".join(sorted(turn_added))
+            logger.warning(
+                "appfolio_update_note_unverified_id work_order=%s requested=%s added=%s",
+                work_order_id,
+                note_id,
+                known,
+            )
+            return ToolResult(
+                content=(
+                    f"Refusing to edit note {note_id} on work order {work_order_id}: "
+                    f"this turn added note {known}, and {note_id} is not among them. "
+                    "Edit one of the ids returned by appfolio_add_note, or list the "
+                    "notes with appfolio_list_notes to find the right one."
+                ),
                 is_error=True,
                 error_kind=ToolErrorKind.VALIDATION,
             )
@@ -159,6 +198,7 @@ def build_note_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[T
             description=("Add a note (text + optional photos) to an AppFolio work order."),
             function=appfolio_add_note,
             params_model=AppFolioAddNoteParams,
+            concurrency_group=work_order_concurrency_key,
             usage_hint=(
                 "Pass photos by their original_url from the conversation or by"
                 " media handle from analyze_photo. Notes are visible to the PM."
@@ -178,9 +218,13 @@ def build_note_tools(service: AppFolioVendorService, ctx: ToolContext) -> list[T
         ),
         Tool(
             name=ToolName.APPFOLIO_UPDATE_NOTE,
-            description="Edit an existing AppFolio work-order note.",
+            description=(
+                "Edit an existing AppFolio work-order note. Pass the note_id returned"
+                " by appfolio_add_note or appfolio_list_notes; never predict one."
+            ),
             function=appfolio_update_note,
             params_model=AppFolioUpdateNoteParams,
+            concurrency_group=work_order_concurrency_key,
             usage_hint="Only use when the user wants to fix the text or attach more photos.",
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -74,7 +74,18 @@ value itself is opaque to AppFolio."""
 
 
 class AppFolioError(RuntimeError):
-    """Generic AppFolio API failure (5xx, network, validation)."""
+    """Generic AppFolio API failure (5xx, network, validation).
+
+    ``status_code`` carries the HTTP status when the failure came from an
+    AppFolio response, so callers can tell "that thing is not there" (404)
+    apart from a transient backend failure without parsing the message
+    string. ``None`` for network and validation failures that never
+    reached an HTTP response.
+    """
+
+    def __init__(self, *args: object, status_code: int | None = None) -> None:
+        super().__init__(*args)
+        self.status_code = status_code
 
 
 class AppFolioUnavailableError(AppFolioError):
@@ -570,7 +581,10 @@ class AppFolioVendorService:
             # Don't echo response_text into the raised error: AppFolioError
             # messages flow into ToolResult.content (visible to the LLM and
             # the end user). The full body stays in the warning log above.
-            raise AppFolioError(f"AppFolio {method} {path} failed: HTTP {resp.status_code}")
+            raise AppFolioError(
+                f"AppFolio {method} {path} failed: HTTP {resp.status_code}",
+                status_code=resp.status_code,
+            )
         byte_len = len(resp.content or b"")
         logger.debug(
             "AppFolio %s %s ok (%d, %d bytes)",

--- a/backend/app/integrations/appfolio_vendor/work_order_writes.py
+++ b/backend/app/integrations/appfolio_vendor/work_order_writes.py
@@ -19,6 +19,7 @@ import logging
 from backend.app.agent.approval import ApprovalPolicy, PermissionLevel
 from backend.app.agent.tools.base import Tool, ToolReceipt, ToolResult
 from backend.app.agent.tools.names import ToolName
+from backend.app.integrations.appfolio_vendor.concurrency import work_order_concurrency_key
 from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
 from backend.app.integrations.appfolio_vendor.params import (
     AppFolioUndoWorkOrderStatusParams,
@@ -69,6 +70,7 @@ def build_work_order_write_tools(service: AppFolioVendorService) -> list[Tool]:
             description="Update the status code on an AppFolio work order.",
             function=appfolio_update_work_order_status,
             params_model=AppFolioUpdateWorkOrderStatusParams,
+            concurrency_group=work_order_concurrency_key,
             usage_hint=(
                 "Use to mark a job in-progress, completed, or back to needs-action."
                 " Confirm the target status with the user when uncertain."
@@ -86,6 +88,7 @@ def build_work_order_write_tools(service: AppFolioVendorService) -> list[Tool]:
             description="Revert a recent status change on an AppFolio work order.",
             function=appfolio_undo_work_order_status,
             params_model=AppFolioUndoWorkOrderStatusParams,
+            concurrency_group=work_order_concurrency_key,
             usage_hint=(
                 "Use only when the user explicitly asks to undo a status change they just made."
             ),

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -2341,3 +2341,251 @@ def test_summarize_response_for_log_redacts_business_and_freetext_pii() -> None:
         "description",
     ):
         assert out[key] == "<redacted>", key
+
+
+# ---------------------------------------------------------------------------
+# Write-tool serialization and predicted-id guards.
+#
+# The agent runs every approved call from one model turn concurrently. Every
+# AppFolio write targets a work order, so two writes emitted together against
+# the same work order raced: status vs undo-status left a nondeterministic
+# final status, and update_note reached AppFolio before the add_note whose id
+# it was editing had landed.
+# ---------------------------------------------------------------------------
+
+
+def _write_tool_ctx() -> Any:
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+    return ctx
+
+
+def _all_appfolio_tools() -> list[Any]:
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+    from backend.app.integrations.appfolio_vendor.notes import build_note_tools
+    from backend.app.integrations.appfolio_vendor.work_order_writes import (
+        build_work_order_write_tools,
+    )
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    ctx = _write_tool_ctx()
+    return [
+        *build_work_order_write_tools(service),
+        *build_note_tools(service, ctx),
+        *build_invoice_tools(service, ctx),
+    ]
+
+
+_WRITE_TOOL_NAMES = {
+    "appfolio_update_work_order_status",
+    "appfolio_undo_work_order_status",
+    "appfolio_add_note",
+    "appfolio_update_note",
+    "appfolio_create_invoice",
+    "appfolio_upload_invoice_pdf",
+}
+
+
+def test_appfolio_write_tools_declare_a_concurrency_group() -> None:
+    """Every work-order write must serialize against the others."""
+    tools = {t.name: t for t in _all_appfolio_tools()}
+    missing = [name for name in _WRITE_TOOL_NAMES if tools[name].concurrency_group is None]
+    assert not missing, f"AppFolio write tools missing concurrency_group: {missing}"
+
+
+def test_appfolio_read_tools_have_no_concurrency_group() -> None:
+    """Reads must stay parallelizable."""
+    tools = {t.name: t for t in _all_appfolio_tools()}
+    assert tools["appfolio_list_notes"].concurrency_group is None
+
+
+def test_appfolio_write_tools_serialize_per_work_order() -> None:
+    """Same work order shares a key; different work orders do not."""
+    tools = {t.name: t for t in _all_appfolio_tools()}
+    status = tools["appfolio_update_work_order_status"].concurrency_group
+    undo = tools["appfolio_undo_work_order_status"].concurrency_group
+    note = tools["appfolio_add_note"].concurrency_group
+
+    same_a = status({"work_order_id": "wo-1", "status_code": 3})
+    same_b = undo({"work_order_id": "wo-1", "previous_status": "2"})
+    same_c = note({"work_order_id": "wo-1", "body": "hi", "media_refs": []})
+    other = status({"work_order_id": "wo-2", "status_code": 3})
+
+    assert same_a == same_b == same_c, "writes to one work order must share a key"
+    assert same_a != other, "writes to different work orders must stay parallel"
+
+
+def test_appfolio_concurrency_key_is_none_without_work_order_id() -> None:
+    """An id-less call stays unserialized rather than joining a catch-all bucket."""
+    from backend.app.integrations.appfolio_vendor.concurrency import (
+        work_order_concurrency_key,
+    )
+
+    assert work_order_concurrency_key({}) is None
+    assert work_order_concurrency_key({"work_order_id": ""}) is None
+    assert work_order_concurrency_key({"work_order_id": "  "}) is None
+    assert work_order_concurrency_key({"work_order_id": "wo-1"}) == "appfolio_work_order:wo-1"
+
+
+@pytest.mark.asyncio()
+async def test_update_note_accepts_id_returned_by_add_note() -> None:
+    """The normal add-then-edit flow must still work."""
+    from backend.app.integrations.appfolio_vendor.notes import build_note_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    update_mock = AsyncMock(return_value={})
+    service.add_work_order_note = AsyncMock(return_value={"id": "note-77"})  # type: ignore[method-assign]
+    service.update_work_order_note = update_mock  # type: ignore[method-assign]
+
+    tools = {t.name: t for t in build_note_tools(service, _write_tool_ctx())}
+    await tools["appfolio_add_note"].function(work_order_id="wo-1", body="on site", media_refs=[])
+    result = await tools["appfolio_update_note"].function(
+        work_order_id="wo-1", note_id="note-77", body="on site, fixed", media_refs=[]
+    )
+
+    assert result.is_error is False
+    update_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
+async def test_update_note_refuses_predicted_id_after_add_in_same_turn() -> None:
+    """A predicted note id would overwrite a different real note's body."""
+    from backend.app.agent.tools.base import ToolErrorKind
+    from backend.app.integrations.appfolio_vendor.notes import build_note_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    update_mock = AsyncMock(return_value={})
+    service.add_work_order_note = AsyncMock(return_value={"id": "note-77"})  # type: ignore[method-assign]
+    service.update_work_order_note = update_mock  # type: ignore[method-assign]
+
+    tools = {t.name: t for t in build_note_tools(service, _write_tool_ctx())}
+    await tools["appfolio_add_note"].function(work_order_id="wo-1", body="on site", media_refs=[])
+    result = await tools["appfolio_update_note"].function(
+        work_order_id="wo-1", note_id="note-78", body="oops", media_refs=[]
+    )
+
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.VALIDATION
+    assert "note-77" in result.content
+    update_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_update_note_guard_is_scoped_per_work_order() -> None:
+    """Adding a note on one work order must not restrict edits on another."""
+    from backend.app.integrations.appfolio_vendor.notes import build_note_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    service.add_work_order_note = AsyncMock(return_value={"id": "note-77"})  # type: ignore[method-assign]
+    service.update_work_order_note = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+    tools = {t.name: t for t in build_note_tools(service, _write_tool_ctx())}
+    await tools["appfolio_add_note"].function(work_order_id="wo-1", body="on site", media_refs=[])
+    result = await tools["appfolio_update_note"].function(
+        work_order_id="wo-2", note_id="note-5", body="edit", media_refs=[]
+    )
+
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_update_note_allows_any_id_when_no_note_added_this_turn() -> None:
+    """Editing a pre-existing note stays unrestricted."""
+    from backend.app.integrations.appfolio_vendor.notes import build_note_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    service.update_work_order_note = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+    tools = {t.name: t for t in build_note_tools(service, _write_tool_ctx())}
+    result = await tools["appfolio_update_note"].function(
+        work_order_id="wo-1", note_id="note-900", body="edit", media_refs=[]
+    )
+
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_update_note_guard_inert_when_appfolio_returns_no_note_id() -> None:
+    """AppFolio does not always echo an id; an empty set must not block edits."""
+    from backend.app.integrations.appfolio_vendor.notes import build_note_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    service.add_work_order_note = AsyncMock(return_value={"ok": True})  # type: ignore[method-assign]
+    service.update_work_order_note = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+    tools = {t.name: t for t in build_note_tools(service, _write_tool_ctx())}
+    await tools["appfolio_add_note"].function(work_order_id="wo-1", body="on site", media_refs=[])
+    result = await tools["appfolio_update_note"].function(
+        work_order_id="wo-1", note_id="note-3", body="edit", media_refs=[]
+    )
+
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio()
+async def test_update_note_guard_does_not_leak_between_tool_builds() -> None:
+    """The tool list is rebuilt per inbound message, so the guard must reset."""
+    from backend.app.integrations.appfolio_vendor.notes import build_note_tools
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    service.add_work_order_note = AsyncMock(return_value={"id": "note-77"})  # type: ignore[method-assign]
+    service.update_work_order_note = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+    first = {t.name: t for t in build_note_tools(service, _write_tool_ctx())}
+    await first["appfolio_add_note"].function(work_order_id="wo-1", body="on site", media_refs=[])
+
+    second = {t.name: t for t in build_note_tools(service, _write_tool_ctx())}
+    result = await second["appfolio_update_note"].function(
+        work_order_id="wo-1", note_id="note-78", body="edit", media_refs=[]
+    )
+
+    assert result.is_error is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP status classification
+# ---------------------------------------------------------------------------
+
+
+def test_appfolio_404_maps_to_not_found() -> None:
+    """404 is a missing object, not an outage."""
+    from backend.app.agent.tools.base import ToolErrorKind
+    from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+
+    result = service_error_to_tool_result("updating note", AppFolioError("nope", status_code=404))
+
+    assert result.is_error is True
+    assert result.error_kind == ToolErrorKind.NOT_FOUND
+
+
+def test_appfolio_500_stays_service() -> None:
+    from backend.app.agent.tools.base import ToolErrorKind
+    from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+
+    result = service_error_to_tool_result("updating note", AppFolioError("boom", status_code=500))
+
+    assert result.error_kind == ToolErrorKind.SERVICE
+
+
+def test_appfolio_error_without_status_stays_service() -> None:
+    """Network and validation failures never reached an HTTP response."""
+    from backend.app.agent.tools.base import ToolErrorKind
+    from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+
+    result = service_error_to_tool_result("updating note", AppFolioError("timeout"))
+
+    assert result.error_kind == ToolErrorKind.SERVICE
+    assert AppFolioError("timeout").status_code is None
+
+
+def test_auth_errors_keep_their_own_kinds() -> None:
+    """The 404 mapping must not disturb the auth branches."""
+    from backend.app.agent.tools.base import ToolErrorKind
+    from backend.app.integrations.appfolio_vendor.errors import service_error_to_tool_result
+
+    expired = service_error_to_tool_result("adding note", AuthExpiredError(login_url="x"))
+    scope = service_error_to_tool_result("adding note", AuthScopeError("wrong customer"))
+
+    assert expired.error_kind == ToolErrorKind.AUTH
+    assert scope.error_kind == ToolErrorKind.SERVICE


### PR DESCRIPTION
*Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's.*

## Description

Same class of bug as #1501, found by looking for it: the agent runs every approved tool call from one model turn concurrently, and no AppFolio write tool declared a `concurrency_group`. Every AppFolio write targets a work order, so two writes emitted together against the same work order raced.

1. **All six write tools key on `work_order_id`** via a shared resolver in a new `concurrency.py`. Writes to one work order serialize; writes to different work orders stay parallel, which is the common case when the agent works through a batch of jobs. This fixes `appfolio_update_work_order_status` vs `appfolio_undo_work_order_status` leaving a nondeterministic final status, `appfolio_update_note` reaching AppFolio before the `appfolio_add_note` whose id it edits, and `appfolio_create_invoice` racing `appfolio_upload_invoice_pdf` on the same work order.

2. **`appfolio_update_note` refuses a `note_id` that no `appfolio_add_note` returned this turn**, when that turn added notes to the same work order. Ordering alone still lets a predicted id overwrite a different real note, which the PM sees and the vendor does not. Inert when AppFolio returns no id in the add response, so a legitimate edit is never blocked by a missing echo.

3. **`AppFolioError` now carries the HTTP status, and 404 maps to `NOT_FOUND` instead of `SERVICE`.** The status was previously only reachable by parsing the message string. `SERVICE` tells the model an external service is temporarily unavailable; for a missing work order or note the useful recovery is to look the id up.

Unlike the QuickBooks fix, which used one static key because QBO entity references cross types, AppFolio partitions cleanly by work order, so this uses the callable resolver form.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: written by Claude Opus 5 via Claude Code, reviewed by @njbrake.
