### PR TITLE
fix(appfolio): stop routing writes through the endpoint that 401s

### DIFF
--- a/backend/app/integrations/appfolio_vendor/errors.py
+++ b/backend/app/integrations/appfolio_vendor/errors.py
@@ -97,9 +97,9 @@ _AUTH_EXPIRED_HINT = (
 # the user for a fresh magic link they do not need.
 _AUTH_SCOPE_HINT = (
     "Do not ask the user to reconnect. The AppFolio session is valid;"
-    " the request just used a customer_id the JWT is not authorized for."
-    " Resolve the right customer_id (e.g. via appfolio_list_work_orders)"
-    " and retry."
+    " AppFolio rejected this particular request, most often because the"
+    " customer_id is one the JWT is not authorized for. Resolve the right"
+    " customer_id (e.g. via appfolio_list_work_orders) and retry."
 )
 
 

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -71,10 +71,26 @@ async def _appfolio_vendor_factory(ctx: ToolContext) -> list[Tool]:
             refresh_token=refresh_token,
         )
 
+    async def _persist_customer_ids(customer_ids: list[str]) -> None:
+        # The OAuth2 exchange does not return customer IDs, so the service
+        # discovers them on the first write and hands them here. Persisting
+        # makes it a one-time cost instead of a discovery round-trip on
+        # every turn. ``cred`` is the object the service mutates, so the
+        # JWT and refresh token read here are current even when a token
+        # refresh happened earlier in this same turn.
+        await save_credential(
+            user_id=user_id,
+            jwt=cred.jwt,
+            fingerprint=cred.fingerprint,
+            customer_ids=customer_ids,
+            refresh_token=cred.refresh_token,
+        )
+
     service = build_service(
         cred,
         api_base=settings.appfolio_vendor_api_base,
         on_token_refresh=_persist_refreshed,
+        on_customer_ids_resolved=_persist_customer_ids,
     )
     tools: list[Tool] = []
     tools.extend(build_work_order_tools(service))

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -15,9 +15,10 @@ Key request conventions captured from the SPA bundle:
 
 There is no CSRF token, no request signing, and no per-request nonce.
 A 401 response carries ``{"login_url": "..."}`` in the body, which the
-SPA uses to redirect the user back through the magic-link flow; we
-surface that as :class:`AuthExpiredError` so tools can prompt the user
-for a fresh link.
+SPA uses to redirect the user back through the magic-link flow. Note
+that *every* unauthenticated 401 carries it, including on routes that
+reject a JWT the data APIs accept, so it is not a usable expiry signal;
+see the classification comment in ``AppFolioVendorService._request``.
 """
 
 from __future__ import annotations
@@ -98,13 +99,16 @@ class AppFolioUnavailableError(AppFolioError):
 
 
 class AuthExpiredError(AppFolioError):
-    """JWT was rejected because the credential genuinely expired.
+    """The credential is dead and the user must supply a new magic link.
 
-    The caller must prompt the user for a new magic link. AppFolio
-    signals this by returning HTTP 401 with a ``login_url`` field in
-    the body that the SPA would redirect the user to.
+    Raised when the OAuth endpoint rejects the refresh grant, and as the
+    default verdict on a 401 we have no evidence to classify. Note that
+    the ``login_url`` in a 401 body is *not* that evidence: AppFolio
+    returns it on every unauthenticated 401, whatever the cause. See
+    ``AppFolioVendorService._request``.
 
-    ``login_url`` is that URL; tools relay it to the user.
+    ``login_url`` is the URL the SPA would redirect to; tools relay it
+    to the user when AppFolio supplied one.
     """
 
     def __init__(self, login_url: str = "") -> None:
@@ -113,19 +117,17 @@ class AuthExpiredError(AppFolioError):
 
 
 class AuthScopeError(AppFolioError):
-    """JWT is valid but not authorized for the customer in the request.
+    """The credential is live but AppFolio rejected this request with a 401.
 
-    AppFolio reuses HTTP 401 for two distinct cases: the JWT itself
-    expired (``AuthExpiredError`` above, with a ``login_url`` payload),
-    and the JWT is fine but the path's customer scope (or the body's
-    ``customer_id``) does not match what the JWT was minted for. The
-    second case is signalled by a 401 with no ``login_url`` in the
-    body, and reconnecting will not help: the caller must retry with
-    the correct customer instead.
+    Raised when the session is provably good (a 2xx already seen on this
+    credential, or a refresh the OAuth endpoint honoured) and a 401 comes
+    back anyway. Usually the request carries a ``customer_id`` the JWT is
+    not authorized for, but some routes reject the bearer JWT outright no
+    matter which customer is named. Either way reconnecting does not help.
 
-    Tools that synthesize a customer_id (e.g. by guessing from a
-    search response) catch this to fall back to the canonical
-    ``/profiles/me`` value before surfacing the failure to the user.
+    Tools that synthesize a customer_id (e.g. by guessing from a search
+    response) catch this to retry with the canonical value before
+    surfacing the failure to the user.
     """
 
 
@@ -425,6 +427,59 @@ def _log_raw_response(method: str, path: str, status: int, byte_len: int, parsed
     )
 
 
+KNOWN_WO_LIST_ENVELOPES = ("work_orders", "workOrders", "results", "data")
+"""Envelope keys AppFolio has been observed wrapping work-order lists in."""
+
+
+def normalize_work_order_list(payload: Any) -> list[dict[str, Any]]:
+    """Return a list of work-order dicts from whichever envelope AppFolio used.
+
+    Returns ``[]`` when the response shape is not one we recognize; the
+    *caller* is responsible for logging that case via
+    ``log_unexpected_response_shape`` so the empty-list semantics stay
+    simple and the diagnostic carries the calling tool's label.
+
+    Lives here rather than in the tool module because customer-ID
+    discovery (:meth:`AppFolioVendorService._discover_customer_ids`)
+    parses the same payload, and the read tools and the service must not
+    keep two copies of the envelope list.
+    """
+    if isinstance(payload, list):
+        return [w for w in payload if isinstance(w, dict)]
+    if isinstance(payload, dict):
+        for key in KNOWN_WO_LIST_ENVELOPES:
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [w for w in value if isinstance(w, dict)]
+    return []
+
+
+def _collect_customer_ids(items: list[dict[str, Any]]) -> list[str]:
+    """Harvest unique customer IDs from work-order-shaped dicts.
+
+    Accepts both spellings AppFolio uses: the maintenance work-order
+    schema carries a scalar ``customer_id``, the universal search schema
+    a ``customer_ids`` list. Order is preserved so the first work order's
+    customer stays the primary one.
+    """
+    ids: list[str] = []
+    for item in items:
+        candidates: list[Any] = []
+        scalar = item.get("customer_id") or item.get("customerId")
+        if scalar is not None:
+            candidates.append(scalar)
+        plural = item.get("customer_ids") or item.get("customerIds")
+        if isinstance(plural, list):
+            candidates.extend(plural)
+        for candidate in candidates:
+            if candidate is None:
+                continue
+            text = str(candidate)
+            if text and text not in ids:
+                ids.append(text)
+    return ids
+
+
 class AppFolioVendorService:
     """Async REST client bound to one user's credential.
 
@@ -439,12 +494,21 @@ class AppFolioVendorService:
         api_base: str,
         timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
         on_token_refresh: Callable[[str, str], Awaitable[None]] | None = None,
+        on_customer_ids_resolved: Callable[[list[str]], Awaitable[None]] | None = None,
     ) -> None:
         self._credential = credential
         self._api_base = api_base.rstrip("/")
         self._timeout = timeout_seconds
         self._on_token_refresh = on_token_refresh
+        self._on_customer_ids_resolved = on_customer_ids_resolved
         self._refreshed_once = False
+        # Evidence that the credential is live, used to tell an expired
+        # session apart from a request AppFolio rejects for another
+        # reason. Both start False and only ever flip to True: a 2xx on
+        # any path, or a token refresh the OAuth endpoint honoured,
+        # proves the credential itself is good.
+        self._saw_success = False
+        self._refresh_succeeded = False
 
     @property
     def credential(self) -> AppFolioCredential:
@@ -518,9 +582,25 @@ class AppFolioVendorService:
                         refresh_token=self._credential.refresh_token,
                         timeout_seconds=self._timeout,
                     )
-                except AppFolioError:
-                    pass
+                except AuthExpiredError:
+                    # The OAuth endpoint rejected the refresh grant itself.
+                    # That is the one unambiguous expiry signal we get: the
+                    # whole credential is dead and only a new magic link
+                    # recovers it. refresh_access_token already logged the
+                    # status and body.
+                    raise
+                except AppFolioError as exc:
+                    # Could not reach the token endpoint. Says nothing about
+                    # whether the credential is still valid, so fall through
+                    # to the evidence-based classification below.
+                    logger.warning(
+                        "AppFolio %s %s: token refresh failed transiently: %s",
+                        method,
+                        path,
+                        exc,
+                    )
                 else:
+                    self._refresh_succeeded = True
                     self._credential.jwt = refreshed.jwt
                     self._credential.refresh_token = (
                         refreshed.refresh_token or self._credential.refresh_token
@@ -551,22 +631,28 @@ class AppFolioVendorService:
                     body_for_log,
                     resp.text[:_LOG_BODY_PREVIEW_LIMIT],
                 )
-                # AppFolio returns 401 for two distinct cases. When the
-                # JWT itself expired the body carries a ``login_url`` for
-                # the SPA to redirect the user to. When the JWT is valid
-                # but the path's customer scope or body ``customer_id``
-                # does not match the JWT's bound customer, the body has
-                # no ``login_url`` and reconnecting will not help. Tell
-                # the caller which one happened so they can react
-                # accordingly: write tools that guess customer_id (e.g.
-                # from a search response) catch the scope variant and
-                # retry with the canonical ``/profiles/me`` value.
-                if login_url:
-                    raise AuthExpiredError(login_url=login_url)
-                raise AuthScopeError(
-                    f"AppFolio {method} {path} rejected the request scope (401);"
-                    " the JWT is valid but not authorized for this customer."
-                )
+                # AppFolio returns 401 both when the credential is dead and
+                # when a live credential is not accepted on this particular
+                # route. ``login_url`` does NOT separate them: every
+                # unauthenticated 401 from vendor.appf.io carries the same
+                # ``login_url`` body, including on routes that reject a JWT
+                # the data APIs accept. Classifying on it told users their
+                # session had expired while other calls in the same turn were
+                # returning 200 (#1503).
+                #
+                # Decide on evidence instead. A 2xx already seen on this
+                # credential, or a refresh the OAuth endpoint honoured, proves
+                # the credential is live, so this 401 is about the request.
+                # With no such evidence we cannot tell, and reconnecting is
+                # the user's only available recovery, so keep the expiry
+                # verdict as the default.
+                if self._saw_success or self._refresh_succeeded:
+                    raise AuthScopeError(
+                        f"AppFolio {method} {path} rejected the request (401)"
+                        " although the session is valid; the route or the"
+                        " customer_id is not authorized for this credential."
+                    )
+                raise AuthExpiredError(login_url=login_url)
         if resp.status_code >= 400:
             response_text = resp.text[:_LOG_BODY_PREVIEW_LIMIT]
             logger.warning(
@@ -585,6 +671,10 @@ class AppFolioVendorService:
                 f"AppFolio {method} {path} failed: HTTP {resp.status_code}",
                 status_code=resp.status_code,
             )
+        # AppFolio answered on this credential, so it is live. Recorded for
+        # the 401 classification above, which must not call a session expired
+        # while other calls on the same credential are succeeding.
+        self._saw_success = True
         byte_len = len(resp.content or b"")
         logger.debug(
             "AppFolio %s %s ok (%d, %d bytes)",
@@ -667,6 +757,39 @@ class AppFolioVendorService:
     async def get_profile(self) -> Any:
         return await self.get("/profiles/me", params={"viewed": "true"})
 
+    async def _discover_customer_ids(self) -> list[str]:
+        """Find the vendor's customer IDs from whatever AppFolio will answer.
+
+        The work-order list is tried first because it is a route the
+        credential demonstrably works on: every read tool calls it, and
+        each work order carries the ``customer_id`` of the property
+        manager that raised it.
+
+        ``/profiles/me`` is the documented source but it rejects the
+        OAuth2 bearer JWT that the data APIs accept, so it is the
+        fallback rather than the primary, and its failure is swallowed:
+        by the time we ask, the work-order list has already answered on
+        this same credential, so a 401 here says nothing about the
+        session and must not be re-raised as one (#1503).
+        """
+        # Widest net: a vendor whose only visible work is already closed
+        # still has to be able to invoice it.
+        payload = await self.list_work_orders(include_completed=True)
+        ids = _collect_customer_ids(normalize_work_order_list(payload))
+        if ids:
+            return ids
+        try:
+            profile = await self.get_profile()
+        except AppFolioError as exc:
+            logger.warning("AppFolio /profiles/me unusable for customer_id discovery: %s", exc)
+            return []
+        if not isinstance(profile, dict):
+            return []
+        customers = profile.get("customers")
+        if not isinstance(customers, list):
+            return []
+        return _collect_customer_ids([c for c in customers if isinstance(c, dict)])
+
     async def _resolve_primary_customer_id(self) -> str:
         """Return the vendor's primary customer ID.
 
@@ -674,10 +797,11 @@ class AppFolioVendorService:
         ``customer_id`` (the property manager's ID) at the request level.
         The legacy ``/access`` exchange returned this in the body and we
         cached it on the credential; the new OAuth2 endpoint does not, so
-        existing connected users have ``customer_ids=[]`` on their
-        persisted credential. Fall back to ``/profiles/me`` for those
-        cases and stash the result on the credential so we don't refetch
-        every call within the same service-instance lifetime.
+        every OAuth2-connected user starts with ``customer_ids=[]`` and
+        reaches :meth:`_discover_customer_ids`. What we find is cached on
+        the in-memory credential and handed to
+        ``on_customer_ids_resolved`` so it is persisted once rather than
+        rediscovered every turn.
 
         Single-customer vendors (the common case) get the lone customer
         back. Multi-customer vendors get the first one; tools that need
@@ -686,25 +810,16 @@ class AppFolioVendorService:
         """
         if self._credential.customer_ids:
             return str(self._credential.customer_ids[0])
-        profile = await self.get_profile()
-        ids: list[str] = []
-        if isinstance(profile, dict):
-            customers = profile.get("customers") or []
-            if isinstance(customers, list):
-                for c in customers:
-                    if isinstance(c, dict):
-                        cid = c.get("customer_id") or c.get("customerId")
-                        if cid is not None:
-                            s = str(cid)
-                            if s not in ids:
-                                ids.append(s)
+        ids = await self._discover_customer_ids()
         if not ids:
             raise AppFolioError(
-                "AppFolio /profiles/me returned no customer IDs; cannot make this request"
+                "Could not determine the AppFolio customer (property manager) ID"
+                " for this vendor: no work orders were visible and the profile"
+                " endpoint did not supply one."
             )
-        # Cache on the in-memory credential for the rest of this turn.
-        # Persistence to oauth_tokens.extra_json happens at next refresh.
         self._credential.customer_ids = ids
+        if self._on_customer_ids_resolved is not None:
+            await self._on_customer_ids_resolved(ids)
         return ids[0]
 
     async def update_work_order_status(
@@ -893,6 +1008,7 @@ def build_service(
     api_base: str,
     timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
     on_token_refresh: Callable[[str, str], Awaitable[None]] | None = None,
+    on_customer_ids_resolved: Callable[[list[str]], Awaitable[None]] | None = None,
 ) -> AppFolioVendorService:
     """Construct an :class:`AppFolioVendorService` for a credential."""
     if not credential.jwt:
@@ -904,6 +1020,7 @@ def build_service(
         api_base=api_base,
         timeout_seconds=timeout_seconds,
         on_token_refresh=on_token_refresh,
+        on_customer_ids_resolved=on_customer_ids_resolved,
     )
 
 

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -119,11 +119,13 @@ class AuthExpiredError(AppFolioError):
 class AuthScopeError(AppFolioError):
     """The credential is live but AppFolio rejected this request with a 401.
 
-    Raised when the session is provably good (a 2xx already seen on this
-    credential, or a refresh the OAuth endpoint honoured) and a 401 comes
-    back anyway. Usually the request carries a ``customer_id`` the JWT is
-    not authorized for, but some routes reject the bearer JWT outright no
-    matter which customer is named. Either way reconnecting does not help.
+    Two triggers, both meaning reconnecting will not help:
+
+    * A 401 whose body has no ``login_url``. AppFolio accepted the
+      credential and refused the request's customer scope (#1288).
+    * A 401 that does carry a ``login_url`` on a credential already
+      proven live by a 2xx or an honoured refresh. The route will not
+      take this credential no matter which customer is named (#1503).
 
     Tools that synthesize a customer_id (e.g. by guessing from a search
     response) catch this to retry with the canonical value before
@@ -455,29 +457,45 @@ def normalize_work_order_list(payload: Any) -> list[dict[str, Any]]:
 
 
 def _collect_customer_ids(items: list[dict[str, Any]]) -> list[str]:
-    """Harvest unique customer IDs from work-order-shaped dicts.
+    """Harvest unique customer IDs from the scalar ``customer_id`` field.
 
-    Accepts both spellings AppFolio uses: the maintenance work-order
-    schema carries a scalar ``customer_id``, the universal search schema
-    a ``customer_ids`` list. Order is preserved so the first work order's
-    customer stays the primary one.
+    Order is preserved so the first work order's customer stays the
+    primary one.
+
+    Deliberately reads only the scalar spelling, which is what both
+    discovery sources use: the maintenance work-order list and the
+    ``customers`` array on ``/profiles/me``. Universal-search hits are
+    NOT a valid input here. Their ids have burned us twice: the scalar
+    ``customer_id`` on a search hit carried a value the write endpoints
+    reject (prod saw ``1`` from search against ``1963538`` from the list
+    endpoint, #1288), and the usable id lives in a separate
+    ``customer_ids`` list (#1445). Accepting either spelling here would
+    quietly re-open #1288 the first time a payload carried both.
     """
     ids: list[str] = []
     for item in items:
-        candidates: list[Any] = []
-        scalar = item.get("customer_id") or item.get("customerId")
-        if scalar is not None:
-            candidates.append(scalar)
-        plural = item.get("customer_ids") or item.get("customerIds")
-        if isinstance(plural, list):
-            candidates.extend(plural)
-        for candidate in candidates:
-            if candidate is None:
-                continue
-            text = str(candidate)
-            if text and text not in ids:
-                ids.append(text)
+        value = item.get("customer_id") or item.get("customerId")
+        if value is None:
+            continue
+        text = str(value)
+        if text and text not in ids:
+            ids.append(text)
     return ids
+
+
+def _extract_login_url(resp: httpx.Response) -> str:
+    """Return the ``login_url`` from a 401 body, or ``""`` when absent.
+
+    Its presence separates "AppFolio would not accept this credential
+    here" from "AppFolio accepted the credential and refused the
+    customer scope" (#1288). It does not, on its own, mean the session
+    expired; see the classification in :meth:`_request`.
+    """
+    with contextlib.suppress(Exception):
+        payload = resp.json()
+        if isinstance(payload, dict):
+            return str(payload.get("login_url") or "")
+    return ""
 
 
 class AppFolioVendorService:
@@ -574,6 +592,26 @@ class AppFolioVendorService:
             ) from exc
 
         if resp.status_code == 401:
+            # A 401 with no ``login_url`` means AppFolio accepted the
+            # credential and refused the request's customer scope (#1288,
+            # observed in prod when the agent guesses a customer_id). The
+            # credential is fine, so do not burn the one-shot refresh on it
+            # and never report it as an expired session: the invoice and
+            # work-order tools catch AuthScopeError here and retry with the
+            # canonical customer.
+            if not _extract_login_url(resp):
+                logger.warning(
+                    "AppFolio %s %s rejected the request scope (401, no login_url)"
+                    " | params=%r body=%r",
+                    method,
+                    path,
+                    params,
+                    body_for_log,
+                )
+                raise AuthScopeError(
+                    f"AppFolio {method} {path} rejected the request scope (401);"
+                    " the JWT is valid but not authorized for this customer."
+                )
             # One-shot refresh-and-retry when we have a refresh_token on file.
             if self._credential.refresh_token and not self._refreshed_once:
                 self._refreshed_once = True
@@ -618,9 +656,13 @@ class AppFolioVendorService:
                             json=json_body,
                         )
             if resp.status_code == 401:
-                login_url = ""
-                with contextlib.suppress(Exception):
-                    login_url = resp.json().get("login_url") or ""
+                login_url = _extract_login_url(resp)
+                if not login_url:
+                    # The refresh swapped an expired-JWT 401 for a scope 401.
+                    raise AuthScopeError(
+                        f"AppFolio {method} {path} rejected the request scope (401);"
+                        " the JWT is valid but not authorized for this customer."
+                    )
                 logger.warning(
                     "AppFolio %s %s rejected the JWT (401) | login_url=%r"
                     " | params=%r body=%r response=%s",
@@ -631,26 +673,24 @@ class AppFolioVendorService:
                     body_for_log,
                     resp.text[:_LOG_BODY_PREVIEW_LIMIT],
                 )
-                # AppFolio returns 401 both when the credential is dead and
-                # when a live credential is not accepted on this particular
-                # route. ``login_url`` does NOT separate them: every
-                # unauthenticated 401 from vendor.appf.io carries the same
-                # ``login_url`` body, including on routes that reject a JWT
-                # the data APIs accept. Classifying on it told users their
-                # session had expired while other calls in the same turn were
-                # returning 200 (#1503).
+                # A ``login_url`` means AppFolio did not accept the credential
+                # on this route, which is NOT the same as the credential being
+                # dead: every unauthenticated 401 from vendor.appf.io carries
+                # one, including from routes that reject a JWT the data APIs
+                # accept. Treating it as proof of expiry told users their
+                # session had expired while other calls on the same credential
+                # were returning 200 (#1503).
                 #
-                # Decide on evidence instead. A 2xx already seen on this
-                # credential, or a refresh the OAuth endpoint honoured, proves
-                # the credential is live, so this 401 is about the request.
-                # With no such evidence we cannot tell, and reconnecting is
-                # the user's only available recovery, so keep the expiry
-                # verdict as the default.
+                # A 2xx already seen on this credential, or a refresh the OAuth
+                # endpoint honoured, proves the credential is live, so this 401
+                # is about the route. With no such evidence we cannot tell, and
+                # reconnecting is the user's only available recovery, so keep
+                # the expiry verdict as the default.
                 if self._saw_success or self._refresh_succeeded:
                     raise AuthScopeError(
                         f"AppFolio {method} {path} rejected the request (401)"
-                        " although the session is valid; the route or the"
-                        " customer_id is not authorized for this credential."
+                        " although the session is valid; this route does not"
+                        " accept the credential."
                     )
                 raise AuthExpiredError(login_url=login_url)
         if resp.status_code >= 400:

--- a/backend/app/integrations/appfolio_vendor/work_orders.py
+++ b/backend/app/integrations/appfolio_vendor/work_orders.py
@@ -17,10 +17,12 @@ from backend.app.integrations.appfolio_vendor.params import (
     AppFolioSearchWorkOrdersParams,
 )
 from backend.app.integrations.appfolio_vendor.service import (
+    KNOWN_WO_LIST_ENVELOPES,
     AppFolioError,
     AppFolioVendorService,
     AuthExpiredError,
     AuthScopeError,
+    normalize_work_order_list,
 )
 
 logger = logging.getLogger(__name__)
@@ -85,27 +87,6 @@ def _fmt_work_order_line(wo: dict[str, Any]) -> str:
     if summary:
         pieces.append(str(summary)[:100])
     return f"- ID: {wo_id} | " + " | ".join(pieces)
-
-
-_KNOWN_WO_LIST_ENVELOPES = ("work_orders", "workOrders", "results", "data")
-
-
-def _normalize_list(payload: Any) -> list[dict[str, Any]]:
-    """Return a list of work-order dicts from whichever envelope AppFolio used.
-
-    Returns ``[]`` when the response shape is not one we recognize; the
-    *caller* is responsible for logging that case via
-    :func:`log_unexpected_response_shape` so the empty-list semantics
-    stay simple and the diagnostic carries the calling tool's label.
-    """
-    if isinstance(payload, list):
-        return [w for w in payload if isinstance(w, dict)]
-    if isinstance(payload, dict):
-        for key in _KNOWN_WO_LIST_ENVELOPES:
-            value = payload.get(key)
-            if isinstance(value, list):
-                return [w for w in value if isinstance(w, dict)]
-    return []
 
 
 def _normalize_search_hit(hit: dict[str, Any]) -> dict[str, Any]:
@@ -176,7 +157,7 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
         except Exception as exc:
             return _service_error("listing work orders", exc)
 
-        items = _normalize_list(payload)
+        items = normalize_work_order_list(payload)
         if not items:
             # An empty list is a legitimate result, but if the response
             # was a non-empty dict the shape is probably the issue (we
@@ -188,7 +169,7 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
                     payload,
                     expected=(
                         "list of work-order dicts, or a dict with one of "
-                        f"{list(_KNOWN_WO_LIST_ENVELOPES)} containing the list"
+                        f"{list(KNOWN_WO_LIST_ENVELOPES)} containing the list"
                     ),
                 )
             return ToolResult(content="No matching work orders.")
@@ -207,7 +188,7 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
         # The search endpoint returns its own hit schema (result_text,
         # customer_ids); remap each hit to the work-order shape so the
         # display number and customer_id surface instead of the bare id.
-        items = [_normalize_search_hit(hit) for hit in _normalize_list(payload)]
+        items = [_normalize_search_hit(hit) for hit in normalize_work_order_list(payload)]
         if not items:
             if isinstance(payload, dict) and payload:
                 log_unexpected_response_shape(
@@ -215,7 +196,7 @@ def build_work_order_tools(service: AppFolioVendorService) -> list[Tool]:
                     payload,
                     expected=(
                         "list of work-order dicts, or a dict with one of "
-                        f"{list(_KNOWN_WO_LIST_ENVELOPES)} containing the list"
+                        f"{list(KNOWN_WO_LIST_ENVELOPES)} containing the list"
                     ),
                 )
             return ToolResult(

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -24,6 +24,7 @@ from backend.app.integrations.appfolio_vendor.params import (
     AppFolioListWorkOrdersParams,
 )
 from backend.app.integrations.appfolio_vendor.service import (
+    AccessExchangeResult,
     AppFolioError,
     AppFolioVendorService,
     AuthExpiredError,
@@ -38,6 +39,12 @@ from backend.app.integrations.appfolio_vendor.work_orders import (
     _normalize_search_hit,
     build_work_order_tools,
 )
+
+
+async def _record(sink: list[list[str]], ids: list[str]) -> None:
+    """Stand-in for the factory's persistence hook, capturing what it was handed."""
+    sink.append(list(ids))
+
 
 # ---------------------------------------------------------------------------
 # Magic-link parsing
@@ -372,12 +379,12 @@ async def test_service_get_returns_json() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_service_401_with_login_url_raises_auth_expired() -> None:
-    """401 + ``login_url`` body means the JWT actually expired.
+async def test_service_401_with_no_evidence_raises_auth_expired() -> None:
+    """A 401 we cannot classify defaults to expired, and relays login_url.
 
-    AppFolio's contract: the SPA sees this and redirects the user to
-    re-auth. We mirror that signal as :class:`AuthExpiredError` so
-    tools can prompt the user for a fresh magic link.
+    Nothing has succeeded on this credential yet, so the session really
+    may be dead. Reconnecting is the user's only available recovery, so
+    the expiry verdict stays the default in the no-evidence case.
     """
     service = AppFolioVendorService(_credential(), api_base="https://api.test")
     response = _mock_response(json_data={"login_url": "https://login/here"}, status_code=401)
@@ -389,24 +396,71 @@ async def test_service_401_with_login_url_raises_auth_expired() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_service_401_without_login_url_raises_auth_scope() -> None:
-    """401 without a ``login_url`` body means the request scope is wrong.
+async def test_service_401_after_a_success_raises_auth_scope_despite_login_url() -> None:
+    """A 401 on a credential that just returned 200 is not an expired session.
 
-    The JWT itself is fine; the request's ``customer_id`` (in the path
-    or the body) is not in this credential's authorized set.
-    Reconnecting will not help, so we must NOT raise
-    :class:`AuthExpiredError` and tell the user to log in again.
+    Regression test for #1503. Every unauthenticated 401 from
+    vendor.appf.io carries a ``login_url`` body, including on routes that
+    reject a JWT the data APIs accept, so classifying on ``login_url``
+    told users to reconnect while other calls in the same turn were
+    returning 200. The 200 is proof the credential is live; the 401 must
+    come back as a scope error even though ``login_url`` is present.
     """
     service = AppFolioVendorService(_credential(), api_base="https://api.test")
-    response = _mock_response(json_data={}, status_code=401)
+    ok = _mock_response(json_data={"hello": "world"})
+    denied = _mock_response(json_data={"login_url": "https://login/here"}, status_code=401)
     with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
-        cls.return_value = _patch_async_client("request", response)
+        client = AsyncMock()
+        client.request = AsyncMock(side_effect=[ok, denied])
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        assert await service.get("/works") == {"hello": "world"}
         with pytest.raises(AuthScopeError) as exc_info:
-            await service.get("/anything")
+            await service.get("/denied")
     # AuthScopeError must NOT be a misclassified AuthExpiredError; the
     # tool layer checks isinstance() and would tell the user to
     # reconnect (the trust-eroding bug we're fixing).
     assert not isinstance(exc_info.value, AuthExpiredError)
+
+
+@pytest.mark.asyncio()
+async def test_service_401_after_successful_refresh_raises_auth_scope() -> None:
+    """A refresh the OAuth endpoint honoured also proves the credential is live."""
+    cred = _credential()
+    cred.refresh_token = "refresh-1"
+    service = AppFolioVendorService(cred, api_base="https://api.test")
+    denied = _mock_response(json_data={"login_url": "https://login/here"}, status_code=401)
+    with (
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+        patch(
+            "backend.app.integrations.appfolio_vendor.service.refresh_access_token",
+            AsyncMock(return_value=AccessExchangeResult(jwt="jwt-2", customer_ids=[], raw={})),
+        ),
+    ):
+        cls.return_value = _patch_async_client("request", denied)
+        with pytest.raises(AuthScopeError):
+            await service.get("/denied")
+
+
+@pytest.mark.asyncio()
+async def test_service_401_with_rejected_refresh_grant_raises_auth_expired() -> None:
+    """The OAuth endpoint refusing the refresh grant is the one true expiry signal."""
+    cred = _credential()
+    cred.refresh_token = "refresh-dead"
+    service = AppFolioVendorService(cred, api_base="https://api.test")
+    denied = _mock_response(json_data={"login_url": "https://login/here"}, status_code=401)
+    with (
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+        patch(
+            "backend.app.integrations.appfolio_vendor.service.refresh_access_token",
+            AsyncMock(side_effect=AuthExpiredError()),
+        ),
+    ):
+        cls.return_value = _patch_async_client("request", denied)
+        with pytest.raises(AuthExpiredError):
+            await service.get("/anything")
 
 
 @pytest.mark.asyncio()
@@ -632,10 +686,13 @@ async def test_add_work_order_note_includes_customer_id_in_body() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_add_work_order_note_resolves_customer_id_when_missing() -> None:
-    """A credential persisted before the customer_id backfill landed has
-    ``customer_ids=[]``. The service must lazy-fetch ``/profiles/me`` so
-    existing connected users don't have to disconnect/reconnect.
+async def test_add_work_order_note_resolves_customer_id_from_work_order_list() -> None:
+    """Every OAuth2-connected credential starts with ``customer_ids=[]``.
+
+    Regression test for #1503. The write must source the customer_id from
+    the work-order list, a route the credential demonstrably works on,
+    rather than ``/profiles/me``, which rejects the bearer JWT and turned
+    every AppFolio write into a bogus "session expired".
     """
     cred = AppFolioCredential(
         user_id="u1",
@@ -644,41 +701,96 @@ async def test_add_work_order_note_resolves_customer_id_when_missing() -> None:
         customer_ids=[],
         extra={},
     )
-    service = AppFolioVendorService(cred, api_base="https://api.test")
-
-    profile_response = _mock_response(
-        json_data={"customers": [{"customer_id": "cust-9001", "customer_name": "Acme Properties"}]}
+    persisted: list[list[str]] = []
+    service = AppFolioVendorService(
+        cred,
+        api_base="https://api.test",
+        on_customer_ids_resolved=lambda ids: _record(persisted, ids),
     )
+
+    list_response = _mock_response(json_data=[{"id": 1, "customer_id": "cust-9001"}])
     note_response = _mock_response(json_data={"id": 42})
 
     with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
         client = AsyncMock()
-        client.request = AsyncMock(side_effect=[profile_response, note_response])
+        client.request = AsyncMock(side_effect=[list_response, note_response])
         cm = MagicMock()
         cm.__aenter__ = AsyncMock(return_value=client)
         cm.__aexit__ = AsyncMock(return_value=False)
         cls.return_value = cm
         await service.add_work_order_note("999001", body_text="status update")
 
-    # First call: GET /profiles/me to discover customer_id
+    # First call: the work-order list, never /profiles/me.
     first_args, _ = client.request.call_args_list[0]
     assert first_args[0] == "GET"
-    assert "/profiles/me" in first_args[1]
+    assert "/maintenance/api/work_orders.json" in first_args[1]
+    assert not any("/profiles/me" in c.args[1] for c in client.request.call_args_list)
     # Second call: POST /notes with the resolved customer_id
     second_args, second_kwargs = client.request.call_args_list[1]
     assert second_args[0] == "POST"
     assert "/notes" in second_args[1]
     assert second_kwargs["json"]["customer_id"] == "cust-9001"
-    # The credential should be backfilled in-memory so subsequent calls
-    # don't refetch.
+    # Backfilled in-memory so the rest of the turn doesn't refetch, and
+    # handed to the persistence hook so later turns don't either.
+    assert cred.customer_ids == ["cust-9001"]
+    assert persisted == [["cust-9001"]]
+
+
+@pytest.mark.asyncio()
+async def test_resolve_customer_id_falls_back_to_profile_when_list_is_empty() -> None:
+    """A vendor with no open work orders still resolves via ``/profiles/me``."""
+    cred = AppFolioCredential(
+        user_id="u1", jwt="jwt-1", fingerprint="fp-1", customer_ids=[], extra={}
+    )
+    service = AppFolioVendorService(cred, api_base="https://api.test")
+    responses = [
+        _mock_response(json_data=[]),
+        _mock_response(json_data={"customers": [{"customer_id": "cust-9001"}]}),
+        _mock_response(json_data={"id": 42}),
+    ]
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(side_effect=responses)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        await service.add_work_order_note("999001", body_text="x")
     assert cred.customer_ids == ["cust-9001"]
 
 
 @pytest.mark.asyncio()
-async def test_resolve_customer_id_raises_when_profile_has_none() -> None:
-    """A credential with no customers and a profile that returns no
-    customers should raise rather than silently succeed with bad data.
+async def test_resolve_customer_id_does_not_report_profile_401_as_expired() -> None:
+    """A 401 from the ``/profiles/me`` fallback is not an expired session.
+
+    Regression test for #1503. The work-order list answered 200 on this
+    same credential moments earlier, so the fallback's 401 says nothing
+    about the session and must surface as a customer_id problem instead
+    of sending the user off to reconnect.
     """
+    cred = AppFolioCredential(
+        user_id="u1", jwt="jwt-1", fingerprint="fp-1", customer_ids=[], extra={}
+    )
+    service = AppFolioVendorService(cred, api_base="https://api.test")
+    responses = [
+        _mock_response(json_data=[]),
+        _mock_response(json_data={"login_url": "https://login/here"}, status_code=401),
+    ]
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        client = AsyncMock()
+        client.request = AsyncMock(side_effect=responses)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = cm
+        with pytest.raises(AppFolioError, match="Could not determine") as exc_info:
+            await service.add_work_order_note("999001", body_text="x")
+    assert not isinstance(exc_info.value, AuthExpiredError)
+
+
+@pytest.mark.asyncio()
+async def test_resolve_customer_id_raises_when_nothing_yields_one() -> None:
+    """No customer IDs anywhere should raise rather than succeed with bad data."""
     cred = AppFolioCredential(
         user_id="u1",
         jwt="jwt-1",
@@ -690,7 +802,7 @@ async def test_resolve_customer_id_raises_when_profile_has_none() -> None:
     response = _mock_response(json_data={"customers": []})
     with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
         cls.return_value = _patch_async_client("request", response)
-        with pytest.raises(AppFolioError, match="no customer IDs"):
+        with pytest.raises(AppFolioError, match="Could not determine"):
             await service.add_work_order_note("999001", body_text="x")
 
 
@@ -1587,10 +1699,10 @@ async def test_create_invoice_tool_falls_back_when_customer_id_scope_rejected() 
     Reproduces the production failure mode: the agent extracted a
     ``customer_id`` from a search response (which carries a different
     field than the write endpoints expect), passed it in, and the
-    work-order GET answered HTTP 401 with no ``login_url``. The fix
-    catches :class:`AuthScopeError`, resolves the canonical customer
-    via ``/profiles/me``, retries the GET, and uses the canonical
-    value for the subsequent ``create_invoice`` POST.
+    work-order GET answered HTTP 401. The fix catches
+    :class:`AuthScopeError`, resolves the canonical customer, retries
+    the GET, and uses the canonical value for the subsequent
+    ``create_invoice`` POST.
     """
     from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
 
@@ -1598,8 +1710,7 @@ async def test_create_invoice_tool_falls_back_when_customer_id_scope_rejected() 
         user_id="u1",
         jwt="jwt-1",
         fingerprint="fp-1",
-        # No cached customer_ids: forces the resolver down the
-        # ``/profiles/me`` path so we exercise it end-to-end.
+        # No cached customer_ids: forces the resolver to discover one.
         customer_ids=[],
         extra={"fingerprint": "fp-1"},
     )
@@ -1614,9 +1725,12 @@ async def test_create_invoice_tool_falls_back_when_customer_id_scope_rejected() 
         ]
     )
     create_invoice = AsyncMock(return_value={"id": "inv-1"})
+    # Empty work-order list so discovery exercises the /profiles/me fallback.
+    list_wos = AsyncMock(return_value=[])
     get_profile = AsyncMock(return_value={"customers": [{"customer_id": "canonical-cust"}]})
     service.get_work_order = get_wo  # type: ignore[method-assign]
     service.create_invoice = create_invoice  # type: ignore[method-assign]
+    service.list_work_orders = list_wos  # type: ignore[method-assign]
     service.get_profile = get_profile  # type: ignore[method-assign]
 
     ctx = MagicMock()
@@ -1649,8 +1763,8 @@ async def test_get_work_order_tool_falls_back_when_customer_id_scope_rejected() 
 
     Same production failure mode as the invoice tool: the agent guesses a
     ``customer_id`` (a name, or a stale id from an earlier turn), the GET
-    answers 401 with no ``login_url``, and without the retry the agent
-    dead-ends and falls back to scanning the full work-order list.
+    answers 401, and without the retry the agent dead-ends and falls back
+    to scanning the full work-order list.
     """
     from backend.app.integrations.appfolio_vendor.work_orders import build_work_order_tools
 
@@ -1675,6 +1789,8 @@ async def test_get_work_order_tool_falls_back_when_customer_id_scope_rejected() 
     get_profile = AsyncMock(return_value={"customers": [{"customer_id": "canonical-cust"}]})
     get_details = AsyncMock(return_value={})
     service.get_work_order = get_wo  # type: ignore[method-assign]
+    # Empty work-order list so discovery exercises the /profiles/me fallback.
+    service.list_work_orders = AsyncMock(return_value=[])  # type: ignore[method-assign]
     service.get_profile = get_profile  # type: ignore[method-assign]
     service.get_work_order_details = get_details  # type: ignore[method-assign]
 
@@ -2058,6 +2174,60 @@ async def test_disconnected_data_factory_reports_not_connected_and_returns_no_to
         data_tools = await _appfolio_vendor_factory(ctx)
     data_names = {t.name for t in data_tools}
     assert ToolName.APPFOLIO_LIST_WORK_ORDERS not in data_names
+
+
+@pytest.mark.asyncio()
+async def test_factory_persists_discovered_customer_ids() -> None:
+    """Customer IDs discovered mid-turn are written back to the credential.
+
+    Regression test for #1503. Without persistence every turn repeats
+    discovery, so the write path keeps paying a round-trip and keeps
+    depending on discovery succeeding again next time.
+    """
+    from backend.app.agent.tools.registry import ToolContext
+    from backend.app.integrations.appfolio_vendor.factory import _appfolio_vendor_factory
+    from backend.app.models import User
+
+    cred = AppFolioCredential(
+        user_id="u1",
+        jwt="jwt-1",
+        fingerprint="fp-1",
+        customer_ids=[],
+        extra={},
+        refresh_token="refresh-1",
+    )
+    saved = AsyncMock()
+    captured: dict[str, Any] = {}
+
+    def _capture(_cred: AppFolioCredential, **kwargs: Any) -> MagicMock:
+        captured.update(kwargs)
+        return MagicMock()
+
+    ctx = ToolContext(user=User(id="u1", user_id="test"))
+    with (
+        patch(
+            "backend.app.integrations.appfolio_vendor.factory.load_credential",
+            new=AsyncMock(return_value=cred),
+        ),
+        patch("backend.app.integrations.appfolio_vendor.factory.save_credential", new=saved),
+        patch(
+            "backend.app.integrations.appfolio_vendor.factory.build_service",
+            side_effect=_capture,
+        ),
+    ):
+        await _appfolio_vendor_factory(ctx)
+        await captured["on_customer_ids_resolved"](["cust-9001"])
+
+    saved.assert_awaited_once()
+    assert saved.await_args is not None
+    kwargs = saved.await_args.kwargs
+    assert kwargs["customer_ids"] == ["cust-9001"]
+    assert kwargs["user_id"] == "u1"
+    # The JWT and refresh token come off the live credential, so a token
+    # refresh earlier in the same turn is not overwritten with stale values.
+    assert kwargs["jwt"] == "jwt-1"
+    assert kwargs["refresh_token"] == "refresh-1"
+    assert kwargs["fingerprint"] == "fp-1"
 
 
 @pytest.mark.asyncio()

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -379,6 +379,71 @@ async def test_service_get_returns_json() -> None:
 
 
 @pytest.mark.asyncio()
+async def test_service_401_without_login_url_raises_auth_scope() -> None:
+    """401 without a ``login_url`` body means the request scope is wrong.
+
+    Regression test for #1288. The JWT itself is fine; the request's
+    ``customer_id`` (in the path or the body) is not in this credential's
+    authorized set. Reconnecting will not help, so we must NOT raise
+    :class:`AuthExpiredError` and tell the user to log in again, and the
+    invoice and work-order tools depend on catching the scope variant to
+    retry with the canonical customer.
+    """
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    response = _mock_response(json_data={}, status_code=401)
+    with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
+        cls.return_value = _patch_async_client("request", response)
+        with pytest.raises(AuthScopeError) as exc_info:
+            await service.get("/anything")
+    # AuthScopeError must NOT be a misclassified AuthExpiredError; the
+    # tool layer checks isinstance() and would tell the user to
+    # reconnect (the trust-eroding bug #1288 fixed).
+    assert not isinstance(exc_info.value, AuthExpiredError)
+
+
+@pytest.mark.asyncio()
+async def test_service_scope_401_does_not_spend_the_one_shot_refresh() -> None:
+    """A scope 401 must not burn the refresh: the credential is already good.
+
+    Guards the #1288 path against the evidence-based classification added
+    in #1503. Refreshing here would be wasted, and a refresh that failed
+    for its own reasons could turn a scope error back into a bogus
+    "session expired".
+    """
+    cred = _credential()
+    cred.refresh_token = "refresh-1"
+    service = AppFolioVendorService(cred, api_base="https://api.test")
+    response = _mock_response(json_data={}, status_code=401)
+    refresh = AsyncMock(side_effect=AuthExpiredError())
+    with (
+        patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls,
+        patch("backend.app.integrations.appfolio_vendor.service.refresh_access_token", refresh),
+    ):
+        cls.return_value = _patch_async_client("request", response)
+        with pytest.raises(AuthScopeError):
+            await service.get("/anything")
+    refresh.assert_not_awaited()
+
+
+def test_collect_customer_ids_ignores_the_search_hit_plural_field() -> None:
+    """Discovery reads the scalar ``customer_id`` only.
+
+    Guards #1288: universal-search hits carry a scalar ``customer_id``
+    the write endpoints reject alongside a separate ``customer_ids``
+    list (#1445). Accepting either spelling in one helper would let a
+    payload carrying both hand back the wrong id.
+    """
+    from backend.app.integrations.appfolio_vendor.service import _collect_customer_ids
+
+    assert _collect_customer_ids([{"customer_ids": ["1963538"]}]) == []
+    assert _collect_customer_ids([{"customer_id": "1963538"}]) == ["1963538"]
+    # Order preserved, duplicates collapsed.
+    assert _collect_customer_ids(
+        [{"customer_id": 42}, {"customer_id": 42}, {"customer_id": 7}]
+    ) == ["42", "7"]
+
+
+@pytest.mark.asyncio()
 async def test_service_401_with_no_evidence_raises_auth_expired() -> None:
     """A 401 we cannot classify defaults to expired, and relays login_url.
 
@@ -1077,7 +1142,12 @@ async def test_service_request_refreshes_on_401_and_retries() -> None:
     refreshed_resp = _mock_response(
         json_data={"access_token": "new-jwt", "refresh_token": "rt-2", "expires_in": 7200}
     )
-    api_resp_401 = _mock_response(json_data={"login_url": ""}, status_code=401)
+    # A rejected-credential 401 always carries a real login_url in prod; a
+    # 401 with none means the credential was accepted and the customer
+    # scope was refused (#1288), which deliberately skips the refresh.
+    api_resp_401 = _mock_response(
+        json_data={"login_url": "https://passport.appf.io/authorize"}, status_code=401
+    )
     api_resp_ok = _mock_response(json_data={"ok": True})
 
     persisted: list[tuple[str, str]] = []


### PR DESCRIPTION
*Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's.*

## Description

Every AppFolio write failed with "AppFolio session expired" while reads on the same credential returned 200 in the same turn. Prod logs show one turn where `appfolio_search_work_orders` got a 200 and both `appfolio_add_note` calls 401'd 250ms earlier, never reaching the note endpoint.

The OAuth2 exchange never returns customer IDs, so every connected credential starts with `customer_ids=[]` and each write resolved one via `GET /profiles/me`. That route rejects the vendor bearer JWT the data APIs accept. Reads need no customer_id, which is why only writes broke. Reconnecting produced another `customer_ids=[]` credential and failed identically.

1. **Customer IDs are discovered from the work-order list**, a route the credential demonstrably works on and the one that backfilled the id in #1445, with `/profiles/me` demoted to a fallback whose failure no longer propagates. It now has no other caller: the `appfolio_get_profile` tool went away in #1331. A new `on_customer_ids_resolved` hook persists the result, so discovery costs one round-trip per credential rather than one per turn.

2. **A 401 that carries a `login_url` is no longer proof of expiry.** Every unauthenticated 401 from vendor.appf.io carries one, including from routes that reject a JWT the data APIs accept, so reading it that way told users to reconnect while the session was live. A 2xx already seen on the credential, or a refresh the OAuth endpoint honoured, now downgrades that 401 to `AuthScopeError`. A rejected refresh grant is promoted to the expiry signal it actually is. No-evidence 401s keep the expiry default, since reconnecting is the only recovery left.

The #1288 rule is untouched: a 401 with **no** `login_url` still means AppFolio accepted the credential and refused the customer scope, and it now short-circuits before the refresh is spent, since a credential AppFolio just accepted has nothing to refresh. `_collect_customer_ids` deliberately reads only the scalar `customer_id`, so the search-hit ids that caused #1288 and #1445 cannot leak into discovery.

`normalize_work_order_list` moves from `work_orders` into `service` so discovery and the read tools share one copy of the envelope handling.

Rebased on #1502, which serializes AppFolio writes; the two compose (writes to one work order now share the discovered id rather than racing to fetch it).

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: root cause traced from Railway logs and the fix implemented by Claude Opus 5 via Claude Code, reviewed by @njbrake.