### PR TITLE
fix(sidecar): switch to Camoufox to clear Home Depot's advanced bot tier

### DIFF
--- a/sidecar/home_depot/Dockerfile
+++ b/sidecar/home_depot/Dockerfile
@@ -1,50 +1,42 @@
-# Home Depot sidecar: FastAPI + patchright Chromium.
+# Retail sidecar: FastAPI + Camoufox (a hardened Firefox).
 #
-# Two things here are load-bearing because Home Depot's bot manager reads them:
+# Camoufox, not patchright/Chromium, is load-bearing: Home Depot's advanced
+# Akamai tier fingerprints the CDP automation protocol every Chromium driver
+# speaks over, and answers a 206 no matter how clean the fingerprint otherwise
+# is (issue #1498). Camoufox is a patched Firefox with a consistent
+# non-automated fingerprint and no CDP surface, which clears both retailers.
 #
-#   1. patchright, not playwright, for the patched CDP Runtime.enable leak.
-#   2. The browser profile lives on a mounted volume so it survives redeploys.
-#      A brand-new profile every boot looks like a first-time visitor every time.
-#
-# Running Chromium as a NON-ROOT user is hygiene, not a bot-detection
-# requirement. patchright passes --no-sandbox by default, so the sandbox is off
-# regardless of the user, and every working measurement was taken that way. Do
-# not add chromium_sandbox=True expecting an improvement: it would add a
-# user-namespace requirement the host may not grant, for no observed benefit.
-#
-# The container starts as root purely to fix volume ownership (platform volumes
-# mount root-owned, so a plain USER directive leaves the app unable to write its
-# profile), then drops to the unprivileged user with setpriv before exec'ing.
-# The entrypoint has to set HOME across that handover; see the comment there.
+# No persistent profile and no volume. The browser is fetched fresh each launch
+# and the session is validated by a humanized warm, so there is nothing to
+# mount. The container still starts as root to drop to an unprivileged user with
+# setpriv (running the browser as non-root is hygiene), and the entrypoint sets
+# HOME across that handover; see the comment there.
 #
 # Build and run locally:
 #   docker build -t hd-sidecar sidecar/home_depot
 #   docker run --rm -p 8899:8899 -e HD_SIDECAR_TOKEN=secret hd-sidecar
 
-# Pinned to bookworm: patchright's install-deps only knows how to provision
-# Chromium's system libraries on the Debian releases Playwright supports, and
-# it fails outright on newer ones.
+# Pinned to bookworm: Playwright (Camoufox's driver dependency) only knows how
+# to provision Firefox's system libraries on the Debian releases it supports,
+# and install-deps fails outright on newer ones.
 FROM python:3.12-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PLAYWRIGHT_BROWSERS_PATH=/opt/browsers \
-    HD_PROFILE_DIR=/data/profile
+    PIP_NO_CACHE_DIR=1
 
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# xvfb supplies the display a non-headless Chromium needs; the entrypoint starts
-# Xvfb directly rather than via xvfb-run, so xauth is no longer required and is
-# kept only so the wrapper still works if anyone reaches for it. util-linux
-# supplies setpriv for the privilege drop. patchright pulls Chromium's own
-# shared libraries.
+# xvfb supplies the display Camoufox needs when run headful (HD_HEADLESS unset);
+# the entrypoint starts Xvfb directly rather than via xvfb-run, so xauth is kept
+# only so the wrapper still works if anyone reaches for it. util-linux supplies
+# setpriv/runuser for the privilege drop. `playwright install-deps firefox`
+# pulls Firefox's shared libraries; playwright ships as a Camoufox dependency.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends xvfb xauth util-linux \
-    && patchright install-deps chromium \
-    && patchright install chromium \
+    && playwright install-deps firefox \
     && rm -rf /var/lib/apt/lists/*
 
 # Globbed rather than listed. An earlier explicit list omitted lowes.py, which
@@ -53,19 +45,20 @@ RUN apt-get update \
 # forget the next module.
 COPY *.py search_model.graphql ./
 
+# Fetch the Camoufox browser AS the runtime user, so it lands in that user's
+# cache (~/.cache/camoufox) where the app finds it after the privilege drop.
+# The entrypoint sets XDG_CACHE_HOME=$HOME/.cache, so the paths line up. Fetching
+# as root would put it under /root, unreadable by sidecar.
 RUN useradd --create-home --shell /bin/bash sidecar \
     && chown -R sidecar:sidecar /app \
-    && chmod -R a+rX /opt/browsers
+    && runuser -u sidecar -- python -m camoufox fetch
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# No VOLUME instruction: Railway's builder rejects it outright ("docker VOLUME
-# is not supported, use Railway Volumes"), and persistence is the deployer's
-# call regardless. Mount something at /data or the profile is rebuilt on every
-# restart, which makes each boot look like a first-time visitor:
-#   Railway: add a volume with mount path /data
-#   docker:  -v hd-profile:/data
+# No VOLUME instruction and nothing to mount: the sidecar keeps no state between
+# runs. A fresh browser plus the humanized warm looks like a first-time visitor
+# every boot, which is fine, so there is no profile to persist.
 EXPOSE 8899
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/sidecar/home_depot/README.md
+++ b/sidecar/home_depot/README.md
@@ -9,26 +9,35 @@ a name.
 
 ## Why this exists
 
-Home Depot has no public API, and every product route (`/s/`, `/b/`, `/p/`, and
-the GraphQL gateway) sits behind their bot manager. Things that do **not** work,
-all measured rather than assumed:
+Neither retailer has a public API, and every product route sits behind Akamai
+Bot Manager. Home Depot additionally runs Akamai's **advanced** tier. Things
+that do **not** work, all measured rather than assumed:
 
 - `httpx` or `requests`: rejected on the TLS handshake.
 - `curl_cffi` with Chrome TLS impersonation: product routes return `403` or a
-  `206` wrapping `{"GenericError": null}`. The store locator served this client
-  for a while and then stopped, answering `206` while the browser kept getting
-  `200` from the same address. Do not assume a working endpoint stays working.
-- Stock Playwright Chromium, headless or headful: same `403`. The CDP
+  `206` wrapping `{"GenericError": null}`.
+- Stock Playwright Chromium, headless or headful: `403`. The CDP
   `Runtime.enable` leak gives it away.
-- Exporting a trusted browser's cookies into `curl_cffi`: still `206`. The
-  request has to come from the browser itself, so cookies alone are not enough.
+- **patchright** (Chromium with the CDP leaks patched): cleared Lowe's, but Home
+  Depot's advanced tier still answered `206` on every product and store call. It
+  fingerprints the CDP automation protocol itself, which every Chromium driver
+  speaks over, so patching the individual leaks is not enough (issue #1498). The
+  behavioral sensor validated and the block held regardless.
 
-What works is a browser with no automation tells, which is what this runs:
+What works is **Camoufox**, a hardened Firefox that is not driven over CDP, so
+that tell is absent. Two things carry the session past the behavioral sensor:
 
-- **patchright** instead of playwright, which patches the `Runtime.enable` leak.
-- **A persistent profile**, so the session looks like a returning visitor.
+- **A humanized warm.** Both retailers keep the session unvalidated until the
+  Akamai sensor sees human-like input, so the warm-up moves the pointer and
+  scrolls. Camoufox renders those moves as realistic curves; a teleported cursor
+  is not enough.
+- **No persistent profile.** The humanized warm validates a first-time session
+  on its own, so the "returning visitor" a saved profile used to buy is no
+  longer needed, and Camoufox's fingerprint is in fact weaker in persistent-context
+  mode (enough that Lowe's denies it). Each launch is a fresh browser.
 
-None of this is IP-related. It was all measured from a residential connection.
+This is not IP-related: it reproduces from a residential connection and a
+datacenter one alike, and the fix is the browser, not the egress.
 
 ## Running it
 
@@ -38,23 +47,16 @@ Requires Python 3.11+ and a Linux box with a display or Xvfb.
 cd sidecar/home_depot
 python -m venv .venv && . .venv/bin/activate
 pip install -r requirements.txt
-patchright install chromium
+python -m camoufox fetch          # downloads the patched Firefox
 
 # Run as a normal user, not root.
 export HD_SIDECAR_TOKEN="$(python -c 'import secrets;print(secrets.token_urlsafe(32))')"
 xvfb-run -a python -m uvicorn sidecar:app --host 0.0.0.0 --port 8899
 ```
 
-On a headless arm64 box, Playwright has no official build. Force the Ubuntu
-24.04 arm64 one:
-
-```bash
-PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-arm64 patchright install chromium
-PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-arm64 patchright install-deps chromium
-PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-arm64 \
-  PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1 \
-  xvfb-run -a python -m uvicorn sidecar:app --host 0.0.0.0 --port 8899
-```
+Camoufox publishes arm64 builds, so an arm64 box needs no platform override. If
+`python -m camoufox fetch` reports an unsupported OS, it still downloads a
+working fallback build.
 
 Startup warms the browser on the homepage, which takes a few seconds. After
 that a search costs roughly a second.
@@ -64,34 +66,28 @@ that a search costs roughly a second.
 | Variable | Default | Purpose |
 |---|---|---|
 | `HD_SIDECAR_TOKEN` | | Shared bearer token. Empty disables auth, which is only safe on loopback. |
-| `HD_PROFILE_DIR` | `~/.hd-sidecar-profile` | Persistent browser profile. Keep it between runs. |
 | `HD_WARM_SECONDS` | `7` | Homepage settle time before serving. |
-| `HD_IDLE_SECONDS` | `3600` | Close Chromium after this many idle seconds. The next request warms a fresh browser. Set to `0` to keep it open. |
+| `HD_IDLE_SECONDS` | `3600` | Close the browser after this many idle seconds. The next request warms a fresh one. Set to `0` to keep it open. |
 | `HD_REQUEST_BUDGET_SECONDS` | `25` | How long one request may drive a retailer's page once it holds that retailer's lock. Must stay below the client's 35s timeout: a request that outlives its caller holds the lock with nobody waiting for the answer. |
+| `HD_HEADLESS` | | Set to `1` to run Camoufox headless (no display). For local fingerprint debugging only; leave unset in production, where the humanized warm needs a real display via Xvfb. |
 
 ## Running it in a container
 
 ```bash
 docker build -t hd-sidecar sidecar/home_depot
-docker run --rm -p 8899:8899 -v hd-profile:/data -e HD_SIDECAR_TOKEN=secret hd-sidecar
+docker run --rm -p 8899:8899 -e HD_SIDECAR_TOKEN=secret hd-sidecar
 ```
 
-Mount something at `/data`. The browser profile lives there, and without a mount
-it is rebuilt on every restart, which makes each boot look like a first-time
-visitor to Home Depot. There is no `VOLUME` instruction in the Dockerfile
-because Railway's builder rejects it, so persistence is always the deployer's
-call.
+Nothing to mount: the sidecar keeps no state between runs. A fresh browser plus
+the humanized warm looks like a first-time visitor every boot, which is fine.
+The Camoufox browser is baked into the image at build time.
 
-The container starts as root purely to take ownership of that mount, then drops
-to an unprivileged user before starting Chromium. That handover also has to set
-`HOME`: `setpriv` changes uid but leaves the environment alone, and a `HOME` the
-new user cannot write makes Chromium's crashpad handler fail with `--database is
-required` and kill the browser with SIGTRAP before it opens a page. It cost a
-deploy to find, because `su` sets `HOME` and local testing used `su`.
-
-Running as a normal user is hygiene rather than a bot-detection requirement.
-patchright passes `--no-sandbox` by default, so Chromium's sandbox is off either
-way, and every working measurement here was taken that way.
+The container starts as root only to drop to an unprivileged user before
+starting the browser. That handover has to set `HOME`: `setpriv` changes uid but
+leaves the environment alone, and a `HOME` the new user cannot write breaks
+Firefox startup. `XDG_CACHE_HOME` follows `HOME` for the same reason, and it is
+where Camoufox looks for the browser fetched at build time, so the two have to
+agree. Running as a normal user is hygiene, not a bot-detection requirement.
 
 ### Railway
 
@@ -113,13 +109,14 @@ public once or give Railway a registry credential.
 
 Then, on the service:
 
-- Add a volume with mount path `/data`.
 - Set `HD_SIDECAR_TOKEN`, and set `PORT=8899` so the listening port is
   predictable. Railway injects its own `PORT`, which the entrypoint honours, so
   without pinning it the internal URL below will not match.
 - Give it ~1GB of memory and point the healthcheck at `/health`.
 - Do not assign a public domain. Reach it over the private network instead:
   `http://<service>.railway.internal:8899`.
+
+No volume is needed: the sidecar is stateless.
 
 Confirm `/search` returns products before wiring the app to it: `/health` going
 green only means the port is up and the browser launched, not that Home Depot is
@@ -135,7 +132,7 @@ search or store lookup waits for a fresh warm-up before running:
 {"ok": true,  "state": "ready",    "error": null}
 {"ok": false, "state": "starting", "error": null}
 {"ok": false, "state": "idle",     "error": null}
-{"ok": false, "state": "failed",   "error": "Error: Failed to move to new namespace..."}
+{"ok": false, "state": "failed",   "error": "Error: Failed to launch: no DISPLAY..."}
 ```
 
 `ok` round-trips an expression through the page, so a crashed browser reports
@@ -202,18 +199,13 @@ again, reporting `geocoded: true` when it did.
 
 ## Lowe's
 
-Same wall, one extra step. Lowe's runs the same Akamai Bot Manager, and its
-`/search`, `/Search=` and `/store/api/search` routes are all refused with a 403
-edge deny (`errors.edgesuite.net`, `Reference #18.…`) rather than a solvable
-challenge. Ruled out as causes, each measured: profile freshness, cookies, the
-`X11; Linux` User-Agent, client hints overridden via CDP to claim macOS,
-navigation versus in-page XHR, and the egress IP.
-
-What actually matters is **warming with a real click**. A homepage visit alone
-still gets the deny; one organic click into a category first, and `/search`
-returns results. That is why `_lowes_page` clicks a `/pl/` link before serving
-anything, and why a page that never got one is closed rather than cached: keeping
-it would pin every later search to a session the edge refuses.
+Lowe's runs Akamai's standard tier only, so it never needed the Camoufox switch
+that Home Depot's advanced tier forced; patchright cleared it. It shares the
+migration anyway, because the humanized warm is what validates the session for
+both. A homepage visit that never touches the mouse is refused with a 403 edge
+deny at `/search`; the pointer movement in the warm flips it, and the same
+navigation is served. Under Chromium this took an organic click into a `/pl/`
+category first; the humanized warm replaces that step.
 
 Results come from `window['__PRELOADED_STATE__']`, not the DOM. The payload is
 ~400KB and carries `itemList` with price, per-store on-hand quantity, brand,
@@ -254,3 +246,9 @@ validate a rewrite against, so do not hand-trim it. To refresh, capture the
 
 Expect this to need occasional attention. Bot detection changes, and when it
 does the symptom is product search returning blocks while `/health` stays green.
+When it comes to that, the levers are: bump the `camoufox` pin (its fingerprint
+tracks Firefox releases), lengthen `HD_WARM_SECONDS` so the humanized warm feeds
+the sensor more, or, if a retailer escalates its tier the way Home Depot did, a
+different browser engine. Do not "fix" a `206` by accepting it: the body parses
+as valid JSON, so relaxing the status check turns a visible failure into a silent
+"No products found" for every search.

--- a/sidecar/home_depot/docker-entrypoint.sh
+++ b/sidecar/home_depot/docker-entrypoint.sh
@@ -1,13 +1,11 @@
 #!/bin/sh
-# Take ownership of the mounted profile volume, start a display, then run the
-# app unprivileged.
+# Start a display, then run the app unprivileged.
 #
-# Platform volumes (Railway, Fly, plain `docker run -v`) mount root-owned and
-# empty, so a bare USER directive in the Dockerfile leaves the app unable to
-# write its browser profile. Start as root, hand the volume to the runtime user,
-# and drop privileges before exec'ing. Running the browser as a normal user is
-# ordinary hygiene here rather than a requirement: patchright passes
-# --no-sandbox by default, so Chromium's sandbox is off either way.
+# There is no profile volume any more: Camoufox runs a fresh browser each launch
+# and validates the session with a humanized warm, so there is nothing to mount
+# or chown. The container still starts as root only to drop to the runtime user
+# with a writable HOME before exec'ing (see the setpriv handover below); running
+# the browser as a normal user is hygiene, not a bot-detection requirement.
 #
 # Every step announces itself. A container that dies silently between "Starting
 # Container" and the first uvicorn line is otherwise undiagnosable from a
@@ -26,22 +24,15 @@ set -eu
 # (xvfb-run's) showed up while nothing else did.
 log() { echo "[entrypoint] $*" >&2; }
 
-PROFILE_DIR="${HD_PROFILE_DIR:-/data/profile}"
 RUN_AS="${HD_RUN_AS_USER:-sidecar}"
 PORT="${PORT:-8899}"
 DISPLAY_NUM="${HD_DISPLAY:-99}"
 
-log "uid=$(id -u) run_as=$RUN_AS port=$PORT profile=$PROFILE_DIR"
-
-mkdir -p "$PROFILE_DIR"
-log "profile dir present"
-
-if [ "$(id -u)" -eq 0 ]; then
-    chown -R "$RUN_AS:$RUN_AS" "$(dirname "$PROFILE_DIR")"
-    log "volume ownership handed to $RUN_AS"
-else
-    log "not root, skipping chown"
-fi
+# No persistent profile to own: Camoufox runs a fresh browser each launch and
+# validates the session with a humanized warm, so there is no volume to mount or
+# chown. The runtime user still needs a writable HOME; that is set at the
+# privilege drop below.
+log "uid=$(id -u) run_as=$RUN_AS port=$PORT"
 
 log "python: $(python --version 2>&1)"
 
@@ -74,10 +65,11 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 # setpriv switches uid/gid but leaves the environment alone, so HOME would stay
-# /root: a directory the unprivileged user cannot write. Chromium's crashpad
-# handler then fails with "--database is required" and the browser dies with
-# SIGTRAP before it ever opens a page. `su` sets HOME, which is why this only
-# broke under setpriv. XDG_* follow HOME for the same reason.
+# /root: a directory the unprivileged user cannot write, which breaks Firefox
+# startup. `su` sets HOME, which is why this kind of bug only shows up under
+# setpriv. XDG_CACHE_HOME follows HOME because that is where Camoufox looks for
+# the browser fetched at build time (~/.cache/camoufox); the image fetches it as
+# this same user, so the paths line up.
 RUN_HOME="$(getent passwd "$RUN_AS" | cut -d: -f6)"
 RUN_HOME="${RUN_HOME:-/home/$RUN_AS}"
 mkdir -p "$RUN_HOME"

--- a/sidecar/home_depot/requirements.txt
+++ b/sidecar/home_depot/requirements.txt
@@ -1,6 +1,11 @@
-# Home Depot search sidecar. Deliberately separate from the main project's
+# Retail search sidecar. Deliberately separate from the main project's
 # dependencies so the browser stack never ships with the Clawbolt server.
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.0
-patchright>=1.49
+# Camoufox is a hardened Firefox with a non-automated fingerprint and no CDP
+# surface. That is what clears Home Depot's advanced Akamai tier, which
+# fingerprints the CDP transport every Chromium driver (patchright included)
+# speaks over (issue #1498). The browser binary is fetched at image build time
+# with `python -m camoufox fetch`, not pulled from PyPI.
+camoufox>=0.5.4

--- a/sidecar/home_depot/sidecar.py
+++ b/sidecar/home_depot/sidecar.py
@@ -1,24 +1,28 @@
-"""Home Depot sidecar: product search and store lookup, via a real browser.
+"""Retail sidecar: product search and store lookup, via a real browser.
 
-Runs a browser and exposes Home Depot over a small HTTP API so a remotely
-hosted Clawbolt can query it. See README.md for why this exists and how to run
-it.
+Runs a browser and exposes Home Depot and Lowe's over a small HTTP API so a
+remotely hosted Clawbolt can query it. See README.md for why this exists and how
+to run it.
 
-Home Depot's bot manager rejects plain HTTP clients, and also rejects a stock
-Playwright Chromium. What it accepts is a browser with no automation tells:
-patchright (which patches the CDP ``Runtime.enable`` leak) and a persistent
-profile that accumulates normal cookies. Requests must be issued *by that browser*.
-Exporting its cookies to a plain HTTP client does not work, which is why this is
-a long-lived process rather than a cookie vendor.
+Both retailers reject plain HTTP clients and a stock Playwright Chromium. They
+run Akamai Bot Manager, and Home Depot runs its *advanced* tier, which
+fingerprints the CDP automation protocol every Chromium driver speaks over,
+patchright included: it validated Akamai's behavioral sensor and still answered a
+``206`` wrapping ``{"GenericError": null}`` on every product and store call
+(issue #1498). What clears both is Camoufox, a hardened Firefox that is not
+driven over CDP, so the tell is absent. A persistent profile that accumulates
+normal cookies and a warm-up that moves the mouse are what let the behavioral
+sensor validate the session. Requests must be issued *by that browser*: exporting
+its cookies to a plain HTTP client does not work, which is why this is a
+long-lived process rather than a cookie vendor.
 
-The store locator served a TLS-impersonating HTTP client for a while, so an
-earlier version of this integration queried it directly and skipped the browser.
-That stopped working: the locator now answers such clients with a ``206``
-carrying ``{"GenericError": null}`` while serving the browser normally from the
-same address. Store lookup therefore goes through here too.
+The two retailers differ only in the final fetch, because Home Depot exposes a
+GraphQL gateway reachable from inside the page while Lowe's does not: Home Depot
+answers an in-page GraphQL call (and the store locator the same way), and Lowe's
+results are read out of the search page's embedded state. The warm-up is shared.
 
 The browser is warmed once on startup and reused, so a request costs about a
-second rather than the seven a cold start takes.
+second rather than the seconds a cold start takes.
 """
 
 from __future__ import annotations
@@ -37,8 +41,8 @@ from pathlib import Path
 from typing import Any
 
 import lowes
+from camoufox.async_api import AsyncCamoufox
 from fastapi import Depends, FastAPI, Header, HTTPException, Query
-from patchright.async_api import async_playwright
 from pydantic import BaseModel
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -48,12 +52,11 @@ ORIGIN = "https://www.homedepot.com"
 QUERY_PATH = Path(__file__).with_name("search_model.graphql")
 SEARCH_MODEL_QUERY = QUERY_PATH.read_text()
 
-PROFILE_DIR = os.environ.get("HD_PROFILE_DIR", str(Path.home() / ".hd-sidecar-profile"))
 AUTH_TOKEN = os.environ.get("HD_SIDECAR_TOKEN", "")
 WARM_SECONDS = float(os.environ.get("HD_WARM_SECONDS", "7"))
 # Keeping retailer pages open lets their JavaScript keep allocating even when no
-# one is searching. Close Chromium after an idle period and warm a fresh context
-# only when the next request arrives. Set to 0 to keep the browser open.
+# one is searching. Close the browser after an idle period and warm a fresh
+# context only when the next request arrives. Set to 0 to keep the browser open.
 IDLE_SECONDS = float(os.environ.get("HD_IDLE_SECONDS", "3600"))
 
 # How long one request may spend driving a retailer's page once it holds that
@@ -71,6 +74,12 @@ REQUEST_BUDGET_SECONDS = float(os.environ.get("HD_REQUEST_BUDGET_SECONDS", "25")
 # being the obvious one, so `evaluate` itself has to be cut loose. Kept small
 # enough that budget plus grace still lands under the client's 35s.
 _EVALUATE_GRACE_SECONDS = 5.0
+
+# Camoufox runs headful against a display (Xvfb in the container). Its behavioral
+# engine (humanize) turns the pointer moves the warm-up issues into realistic
+# curves, which is what validates Akamai's sensor; a teleported cursor does not.
+# Set HD_HEADLESS=1 only for local fingerprint debugging, never in production.
+HEADLESS: bool | str = os.environ.get("HD_HEADLESS", "").lower() in ("1", "true", "yes")
 
 # Lowe's results are server-rendered into the page, so the wait is a poll for the
 # payload rather than a fixed settle. Roughly 6s of headroom in total.
@@ -202,7 +211,10 @@ class BrowserBackedSearch:
     """Owns the long-lived browser and serializes searches through it."""
 
     def __init__(self) -> None:
-        self._pw: Any = None
+        # The AsyncCamoufox handle owns the Playwright driver and the Firefox
+        # process; entering it yields the persistent context. Kept so shutdown and
+        # idle eviction can tear the whole thing down and rebuild it.
+        self._cf: AsyncCamoufox | None = None
         self._ctx: Any = None
         self._page: Any = None
         # One page per site, each parked on its own origin. Home Depot's search
@@ -218,9 +230,9 @@ class BrowserBackedSearch:
         # A lock per site, not one shared lock. Requests to one retailer must
         # serialize against each other because they drive that retailer's single
         # page, but they have no reason to block the other retailer. Sharing one
-        # lock made the Lowe's pre-warm (a homepage load, a click, and two settle
-        # waits, ~17s) hold off every Home Depot request right after startup,
-        # close to the client's 20s timeout.
+        # lock made the Lowe's pre-warm (a homepage load and a humanized settle,
+        # ~17s) hold off every Home Depot request right after startup, close to
+        # the client's 20s timeout.
         self._locks: dict[str, asyncio.Lock] = {}
         # Lifecycle changes must wait for all active searches, but searches for
         # different retailers must remain concurrent. This lock protects only
@@ -308,7 +320,7 @@ class BrowserBackedSearch:
     def start_background(self) -> None:
         """Launch the browser without blocking the caller.
 
-        Startup takes 15-25s: Chromium has to launch and load the homepage. Doing
+        Startup takes 15-25s: Firefox has to launch and load the homepage. Doing
         that inside the ASGI lifespan means the port is not listening yet, so a
         platform healthcheck sees a dead container and a failure produces no HTTP
         response at all, only container logs. Binding first and reporting status
@@ -321,36 +333,42 @@ class BrowserBackedSearch:
             try:
                 await self._launch_browser()
             except Exception as exc:
-                # Chromium failing to launch lands here. Keep the message verbatim:
+                # Firefox failing to launch lands here. Keep the message verbatim:
                 # it is the only signal a remote operator gets, and the causes are
-                # unobvious (an unwritable HOME breaks the crashpad handler, for
-                # instance).
+                # unobvious (a missing display, an unwritable HOME).
                 await self._close_browser()
                 self.state = "failed"
                 self.error = f"{type(exc).__name__}: {exc}"
                 logger.exception("browser startup failed")
 
     async def _launch_browser(self) -> None:
-        """Launch and warm a fresh persistent browser context."""
-        if self._pw is None:
-            self._pw = await async_playwright().start()
-        self._ctx = await self._pw.chromium.launch_persistent_context(
-            user_data_dir=PROFILE_DIR,
-            channel="chromium",
-            headless=False,
-            no_viewport=True,
-            locale="en-US",
-            timezone_id="America/New_York",
-        )
-        self._page = self._ctx.pages[0] if self._ctx.pages else await self._ctx.new_page()
+        """Launch and warm a fresh browser.
+
+        Camoufox is a hardened Firefox with a consistent, non-automated
+        fingerprint and no CDP surface, which is what gets past Home Depot's
+        advanced bot tier (issue #1498). ``humanize`` turns the pointer moves the
+        warm-up issues into realistic curves, which is what validates the
+        behavioral sensor.
+
+        Deliberately not a persistent context. Camoufox's fingerprint injection
+        is weaker in ``persistent_context`` mode, enough that Lowe's standard
+        Akamai denies it while Home Depot's stricter tier still passes. The
+        humanized warm validates a first-time session on its own, so the returning
+        visitor a profile used to buy is no longer needed, and dropping it removes
+        the profile volume entirely. Each retailer's page is a separate one-off
+        context, so their cookies stay isolated.
+        """
+        self._cf = AsyncCamoufox(headless=HEADLESS, humanize=True, locale="en-US")
+        self._ctx = await self._cf.__aenter__()
+        self._page = await self._ctx.new_page()
         self._site_pages["home_depot"] = self._page
         await self._warm()
         self.state = "ready"
         self.error = None
         self._last_used = time.monotonic()
         self._idle_changed.set()
-        # Pre-warm Lowe's too. Its warm costs a homepage load plus a click, so
-        # the first Lowe's query would otherwise pay ~19s while Home Depot
+        # Pre-warm Lowe's too. Its warm costs a second homepage load and settle,
+        # so the first Lowe's query would otherwise pay ~19s while Home Depot
         # answers in one. Doing it after state=ready keeps Home Depot available
         # immediately, and a failure here is not fatal: the lazy path in
         # _lowes_page still runs on demand.
@@ -359,12 +377,23 @@ class BrowserBackedSearch:
             self._idle_task = asyncio.create_task(self._idle_recycler())
 
     async def _close_browser(self) -> None:
-        """Close the current Chromium context while retaining the Playwright driver."""
+        """Tear down the Firefox context and its driver.
+
+        Entering ``AsyncCamoufox`` started the Playwright driver, so exiting it is
+        what stops the driver process; there is no lighter close that keeps the
+        driver alive across an idle eviction, unlike the old Chromium path. The
+        ``_ctx`` fallback is for tests that inject a context directly without a
+        camoufox handle.
+        """
+        handle, self._cf = self._cf, None
         context, self._ctx = self._ctx, None
         self._page = None
         self._site_pages.clear()
         self._lowes_failures = 0
-        if context is not None:
+        if handle is not None:
+            with contextlib.suppress(Exception):
+                await handle.__aexit__(None, None, None)
+        elif context is not None:
             with contextlib.suppress(Exception):
                 await context.close()
 
@@ -394,7 +423,7 @@ class BrowserBackedSearch:
                     self._idle_changed.set()
 
     async def _evict_if_idle(self) -> bool:
-        """Close Chromium when no search has used it for the configured interval."""
+        """Close the browser when no search has used it for the configured interval."""
         async with self._lifecycle_lock:
             if (
                 self.state != "ready"
@@ -410,7 +439,7 @@ class BrowserBackedSearch:
             return True
 
     async def _idle_recycler(self) -> None:
-        """Wait for idle time to elapse, then release Chromium's memory."""
+        """Wait for idle time to elapse, then release the browser's memory."""
         while True:
             async with self._lifecycle_lock:
                 if self.state != "ready":
@@ -447,17 +476,46 @@ class BrowserBackedSearch:
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await task
+        # Tears down the context and the Playwright driver in one step; there is
+        # no separate driver handle to stop under Camoufox.
         await self._close_browser()
-        if self._pw is not None:
+
+    @staticmethod
+    async def _humanize(page: Any) -> None:
+        """Move the pointer and scroll so Akamai's behavioral sensor validates.
+
+        Both retailers keep their session unvalidated, and refuse protected paths
+        (Home Depot's GraphQL, Lowe's /search), until the sensor has seen
+        human-like input. A homepage load that never touches the mouse leaves it
+        unvalidated. Camoufox's ``humanize`` renders these moves as realistic
+        curves, so issuing a handful along a path is what actually flips the
+        session; a teleported cursor is not enough. Cheap and side-effect-free,
+        so it runs on every warm.
+        """
+        for x, y in ((300, 250), (620, 400), (880, 300), (500, 520), (700, 220)):
             with contextlib.suppress(Exception):
-                await self._pw.stop()
-            self._pw = None
+                await page.mouse.move(x, y)
+                await page.wait_for_timeout(200)
+        with contextlib.suppress(Exception):
+            await page.mouse.wheel(0, 700)
+            await page.wait_for_timeout(400)
+
+    async def _warm_page(self, page: Any, origin: str, label: str) -> None:
+        """Land on a retailer's homepage and validate the session with movement.
+
+        Shared by both retailers: Home Depot on its page, Lowe's on its own. The
+        homepage sits outside the strict bot rule, so it loads for an unvalidated
+        session; the humanized movement then validates it, which is what lets the
+        follow-up search through.
+        """
+        await page.goto(f"{origin}/", wait_until="domcontentloaded", timeout=90_000)
+        await page.wait_for_timeout(int(WARM_SECONDS * 1000))
+        await self._humanize(page)
+        logger.info("%s page warmed: %s", label, await page.title())
 
     async def _warm(self) -> None:
-        """Land on the homepage so the bot manager sees a normal entry point."""
-        await self._page.goto(f"{ORIGIN}/", wait_until="domcontentloaded", timeout=90_000)
-        await self._page.wait_for_timeout(int(WARM_SECONDS * 1000))
-        logger.info("browser warmed: %s", await self._page.title())
+        """Warm the Home Depot page on startup."""
+        await self._warm_page(self._page, ORIGIN, "home_depot")
 
     async def _note_lowes_failure(self) -> None:
         """Drop a Lowe's session that has failed repeatedly so the next call re-warms.
@@ -488,13 +546,12 @@ class BrowserBackedSearch:
     async def _lowes_page(self) -> Any:
         """Return a page warmed for Lowe's, creating and warming it on first use.
 
-        Lowe's needs more than a homepage visit. Navigating to /search from a
-        session warmed only by the homepage is refused with a 403 edge deny; one
-        organic click into a category first, and the same navigation is served.
-        The click is the load-bearing step, so a page that never got one is not
-        cached: keeping it would pin every later search to a session the edge
-        refuses, with no way back short of a restart. Discard it instead and let
-        the next request try the whole warm again.
+        Under Chromium, Lowe's needed an organic click into a category before it
+        would serve /search; the humanized warm replaces that. A homepage load
+        plus pointer movement validates the session, and the same /search that a
+        cold session is denied is then served. The page is cached; a session that
+        later goes stale is dropped by ``_note_lowes_failure`` so the next call
+        re-warms.
         """
         page = self._site_pages.get("lowes")
         if page is not None:
@@ -502,22 +559,7 @@ class BrowserBackedSearch:
 
         page = await self._ctx.new_page()
         try:
-            await page.goto(f"{lowes.ORIGIN}/", wait_until="domcontentloaded", timeout=90_000)
-            await page.wait_for_timeout(int(WARM_SECONDS * 1000))
-
-            clicked = False
-            try:
-                link = page.locator("a[href*='/pl/']").first
-                if await link.count():
-                    await link.click()
-                    await page.wait_for_timeout(int(WARM_SECONDS * 1000))
-                    clicked = True
-            except Exception:
-                logger.warning("lowes: organic warm click failed", exc_info=True)
-            if not clicked:
-                raise HTTPException(503, "Lowe's warm-up found no category link to click")
-
-            logger.info("lowes page warmed: %s", await page.title())
+            await self._warm_page(page, lowes.ORIGIN, "lowes")
         except BaseException:
             with contextlib.suppress(Exception):
                 await page.close()

--- a/tests/test_sidecar_locks.py
+++ b/tests/test_sidecar_locks.py
@@ -2,7 +2,7 @@
 
 The sidecar lives outside the installed package because it carries the browser
 stack, and it was previously assumed untestable for that reason. It is not:
-stubbing ``patchright.async_api`` in ``sys.modules`` is enough to import it with
+stubbing ``camoufox.async_api`` in ``sys.modules`` is enough to import it with
 no browser and no extra dependency. That assumption is what let a transposed
 lock mapping ship, so the mapping is asserted here directly.
 
@@ -11,8 +11,8 @@ Two properties matter, and one of them is not obvious:
 * Requests for one retailer must serialize against each other, because they
   drive that retailer's single page.
 * Requests for different retailers must not, or the Lowe's pre-warm (a homepage
-  load, a click, and two settle waits) blocks every Home Depot request for
-  roughly 20 seconds right after startup.
+  load and a humanized settle) blocks every Home Depot request for roughly 20
+  seconds right after startup.
 """
 
 import ast
@@ -29,15 +29,20 @@ _SIDECAR_DIR = Path(__file__).resolve().parents[1] / "sidecar" / "home_depot"
 
 
 def _load_sidecar() -> Any:
-    """Import the sidecar module with the browser stack stubbed out."""
-    stub_root = types.ModuleType("patchright")
-    stub_api = types.ModuleType("patchright.async_api")
-    stub_api.async_playwright = lambda: None  # type: ignore[attr-defined]
+    """Import the sidecar module with the browser stack stubbed out.
+
+    Stubbing ``camoufox.async_api`` in ``sys.modules`` is enough to import the
+    sidecar with no browser and no heavy dependency, which is what lets the
+    locking and budget behaviour be tested without launching Firefox.
+    """
+    stub_root = types.ModuleType("camoufox")
+    stub_api = types.ModuleType("camoufox.async_api")
+    stub_api.AsyncCamoufox = object  # type: ignore[attr-defined]
     stub_root.async_api = stub_api  # type: ignore[attr-defined]
 
-    saved = {k: sys.modules.get(k) for k in ("patchright", "patchright.async_api")}
-    sys.modules["patchright"] = stub_root
-    sys.modules["patchright.async_api"] = stub_api
+    saved = {k: sys.modules.get(k) for k in ("camoufox", "camoufox.async_api")}
+    sys.modules["camoufox"] = stub_root
+    sys.modules["camoufox.async_api"] = stub_api
     sys.path.insert(0, str(_SIDECAR_DIR))
     try:
         import importlib
@@ -132,6 +137,99 @@ class TestLockIsolation:
         async with engine._lock_for("home_depot"):
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(engine._lock_for("home_depot").acquire(), timeout=0.1)
+
+
+class _WarmFakeMouse:
+    def __init__(self, record: dict[str, list]) -> None:
+        self._record = record
+
+    async def move(self, x: int, y: int, steps: int | None = None) -> None:
+        self._record["moves"].append((x, y))
+
+    async def wheel(self, dx: int, dy: int) -> None:
+        self._record["wheels"].append((dx, dy))
+
+
+class _WarmFakePage:
+    """A page that records the calls the warm makes, so the behavioral warm can
+    be asserted without a browser."""
+
+    def __init__(self, *, move_raises: bool = False) -> None:
+        self.record: dict[str, list] = {"moves": [], "wheels": [], "gotos": [], "order": []}
+        self.mouse = _WarmFakeMouse(self.record)
+        self._move_raises = move_raises
+        if move_raises:
+
+            async def _boom(*_a: Any, **_k: Any) -> None:
+                raise RuntimeError("pointer move failed")
+
+            self.mouse.move = _boom  # type: ignore[method-assign]
+
+    async def goto(self, url: str, **_kwargs: Any) -> None:
+        self.record["gotos"].append(url)
+        self.record["order"].append("goto")
+
+    async def wait_for_timeout(self, _ms: int) -> None:
+        return None
+
+    async def title(self) -> str:
+        return "Fake Retailer"
+
+
+class TestHumanizedWarm:
+    """The humanized warm is what validates Akamai's sensor for both retailers.
+
+    A bare homepage load without pointer movement leaves the session unvalidated
+    and every search is denied (issue #1498), so the warm moving the mouse is the
+    load-bearing behaviour and is asserted directly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_humanize_moves_the_pointer_and_scrolls(self) -> None:
+        page = _WarmFakePage()
+        await sidecar.BrowserBackedSearch._humanize(page)
+        assert len(page.record["moves"]) >= 3, "the warm must move the pointer along a path"
+        assert page.record["wheels"], "the warm must scroll"
+
+    @pytest.mark.asyncio
+    async def test_humanize_survives_a_failing_move(self) -> None:
+        """A single failed pointer move must not abort the warm."""
+        page = _WarmFakePage(move_raises=True)
+        await sidecar.BrowserBackedSearch._humanize(page)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_warm_page_loads_the_homepage_then_humanizes(self) -> None:
+        """Order matters: the pointer has to move on a loaded page, not before."""
+        engine = sidecar.BrowserBackedSearch()
+        page = _WarmFakePage()
+        await engine._warm_page(page, "https://example.com", "example")
+        assert page.record["gotos"] == ["https://example.com/"]
+        assert page.record["order"][0] == "goto"
+        assert page.record["moves"], "the warm must humanize after loading"
+
+    @pytest.mark.asyncio
+    async def test_lowes_page_uses_the_shared_warm(self) -> None:
+        """Lowe's and Home Depot must warm through the same path, on Lowe's origin."""
+        engine = sidecar.BrowserBackedSearch()
+        warmed: list[tuple[str, str]] = []
+
+        async def fake_warm(page: Any, origin: str, label: str) -> None:
+            warmed.append((origin, label))
+
+        new_page = _WarmFakePage()
+
+        class FakeCtx:
+            async def new_page(self) -> Any:
+                return new_page
+
+        engine._ctx = FakeCtx()
+        engine._warm_page = fake_warm
+
+        page = await engine._lowes_page()
+
+        assert page is new_page
+        assert warmed == [(sidecar.lowes.ORIGIN, "lowes")]
+        assert engine._site_pages["lowes"] is new_page
 
 
 class TestStaleSessionRecovery:


### PR DESCRIPTION
## Description

Home Depot upgraded to Akamai Bot Manager Advanced around when the 206s began (#1498). That tier fingerprints the CDP automation protocol every Chromium driver speaks over, patchright included: the behavioral sensor validated and the block held anyway, on a residential egress and a datacenter one alike, so it was never IP-related. Lowe's runs only the standard tier and still worked.

This switches the sidecar browser from patchright/Chromium to Camoufox, a hardened Firefox with no CDP surface, which clears both retailers. Verified end to end through the real sidecar: Home Depot 529 products plus store lookup, Lowe's 452 products.

Two things fall out of the switch, both simplifications:

- **Unified warm.** Both retailers keep the Akamai session unvalidated until the sensor sees human input, so a shared humanized warm moves the pointer and scrolls (Camoufox renders those as realistic curves). This replaces Lowe's fragile organic /pl/ click, so the paths now differ only in the final fetch, which is inherent.
- **No persistent profile.** Camoufox's fingerprint is weaker in persistent-context mode, enough that Lowe's denies it, and the humanized warm validates a first-time session on its own. That drops the /data volume, the profile-ownership dance in the entrypoint, and HD_PROFILE_DIR.

The image fetches Camoufox as the runtime user so its cache lines up with the entrypoint's XDG_CACHE_HOME; Firefox libs come from `playwright install-deps firefox` (playwright ships as a Camoufox dependency).

One caveat: the Docker image could not be built in the dev sandbox (no daemon), so the runtime code is verified live but the Dockerfile and entrypoint changes are reasoned, not executed. The first CI image build exercises them.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) 3187 passed, 2 skipped
- [x] Lint passes (`ruff check` and `ruff format --check`, plus `sidecar/`, and `ty` clean)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Regression tests cover the humanized warm (the load-bearing behavior) and the unified Lowe's warm path.

## AI Usage
- [x] AI-assisted (describe how)

Investigation, patch, and tests written by Claude Fable 5, an Anthropic model, via back-and-forth with @njbrake, working from live probes against both retailers in the dev sandbox. The reasoning and decisions are his.
- [ ] No AI used

Fixes #1498


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced Patchright/Chromium with Camoufox/Firefox to reduce Home Depot bot blocking.
- Added a shared warm-up flow for Home Depot and Lowe’s with pointer movement and scrolling.
- Removed persistent browser profiles, profile volumes, and related startup configuration.
- Updated the Docker image, dependencies, documentation, and browser shutdown handling.
- Added regression tests for warm-up behavior and Lowe’s page loading.

## Benefits

- Reduces exposure to Chromium CDP detection.
- Keeps browser sessions stateless.
- Uses the same warm-up behavior across retailers.
- Preserves blocked-response handling and improves test coverage.
- End-to-end checks returned results for both retailers.

## Further enhancement

- Run the Docker image checks when a Docker daemon is available.
- Continue monitoring browser fingerprints, warm-up duration, and `206` responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->