### PR TITLE
fix: disable reasoning for vision analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,7 +83,7 @@ LLM_MODEL=
 # LLM token limits
 # LLM_MAX_TOKENS_AGENT=8192
 # LLM_MAX_TOKENS_HEARTBEAT=12000
-# LLM_MAX_TOKENS_VISION=1000
+# LLM_MAX_TOKENS_VISION=12000
 
 # LLM Provider API Keys — uncomment and set the key for your chosen provider.
 # The any-llm SDK reads these from the environment automatically.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -124,7 +124,7 @@ class Settings(BaseSettings):
     # turn, which is what ``_MAX_TOKENS_CEILING`` bounds.
     llm_max_tokens_agent: int = Field(default=8192, ge=1)
     llm_max_tokens_heartbeat: int = Field(default=12000, ge=1)
-    llm_max_tokens_vision: int = Field(default=1000, ge=1)
+    llm_max_tokens_vision: int = Field(default=12000, ge=1)
 
     # Storage: per-user Google Drive via OAuth. The deployment supplies the
     # OAuth client credentials; each user grants ``drive.file`` scope through

--- a/backend/app/media/vision.py
+++ b/backend/app/media/vision.py
@@ -9,10 +9,7 @@ from PIL import Image
 
 from backend.app.agent.llm_parsing import get_response_text
 from backend.app.config import settings
-from backend.app.services.llm_service import (
-    prepare_system_with_caching,
-    reasoning_effort_to_thinking,
-)
+from backend.app.services.llm_service import prepare_system_with_caching
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +130,7 @@ async def analyze_image(image_bytes: bytes, mime_type: str, context: str = "") -
                 {"role": "user", "content": user_content},
             ],
             max_tokens=settings.llm_max_tokens_vision,
-            thinking=reasoning_effort_to_thinking(settings.reasoning_effort),
+            thinking={"type": "disabled"},
         ),
     )
     logger.debug("Vision LLM response received for mime_type=%s", mime_type)

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -134,7 +134,7 @@ Photos and files the user sends over a messaging channel are cached on disk whil
 |----------|---------|-------------|
 | `LLM_MAX_TOKENS_AGENT` | `8192` | Max tokens per agent loop LLM response. A turn truncated at this limit is retried once with a doubled budget and then discarded rather than delivered, so sizing this too low costs a wasted round. |
 | `LLM_MAX_TOKENS_HEARTBEAT` | `12000` | Max tokens per heartbeat LLM response |
-| `LLM_MAX_TOKENS_VISION` | `1000` | Max tokens per vision/image analysis response |
+| `LLM_MAX_TOKENS_VISION` | `12000` | Max tokens per vision/image analysis response |
 
 ## Agent loop
 

--- a/tests/integration/test_vision_integration.py
+++ b/tests/integration/test_vision_integration.py
@@ -65,7 +65,7 @@ async def test_analyze_image_returns_description() -> None:
         mock_settings.vision_provider = ""
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
-        mock_settings.llm_max_tokens_vision = 1000
+        mock_settings.llm_max_tokens_vision = 12000
 
         result = await analyze_image(png_bytes, "image/png")
 
@@ -85,7 +85,7 @@ async def test_analyze_image_with_context() -> None:
         mock_settings.vision_provider = ""
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
-        mock_settings.llm_max_tokens_vision = 1000
+        mock_settings.llm_max_tokens_vision = 12000
 
         result = await analyze_image(
             png_bytes,
@@ -154,7 +154,7 @@ async def test_mime_mismatch_raises_error() -> None:
         mock_settings.vision_provider = ""
         mock_settings.llm_provider = "anthropic"
         mock_settings.llm_api_base = None
-        mock_settings.llm_max_tokens_vision = 1000
+        mock_settings.llm_max_tokens_vision = 12000
 
         # PNG bytes declared as JPEG — Claude validates and rejects this
         await analyze_image(png_bytes, "image/jpeg")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -70,6 +70,7 @@ class TestFieldConstraints:
         s = Settings()
         assert s.max_tool_rounds == 10
         assert s.message_batch_window_ms == 1500
+        assert s.llm_max_tokens_vision == s.llm_max_tokens_heartbeat == 12000
 
 
 class TestLogConfigWarnings:

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -32,6 +32,18 @@ async def test_analyze_image_returns_description(mock_amessages: object) -> None
 
 @pytest.mark.asyncio()
 @patch("backend.app.media.vision.amessages")
+async def test_analyze_image_disables_thinking(mock_amessages: object) -> None:
+    """Vision output should never compete with reasoning for the token budget."""
+    mock_amessages.return_value = make_vision_response("A damaged roof.")  # type: ignore[union-attr]
+
+    await analyze_image(b"fake-jpeg-bytes", "image/jpeg")
+
+    call_args = mock_amessages.call_args  # type: ignore[union-attr]
+    assert call_args.kwargs["thinking"] == {"type": "disabled"}
+
+
+@pytest.mark.asyncio()
+@patch("backend.app.media.vision.amessages")
 async def test_analyze_image_includes_context(mock_amessages: object) -> None:
     """analyze_image should include context in the request."""
     mock_amessages.return_value = make_vision_response("Deck damage visible.")  # type: ignore[union-attr]


### PR DESCRIPTION
## Description
Raises the vision response ceiling to 12,000 tokens, matching heartbeat, and explicitly disables provider reasoning on image analysis calls so descriptions do not compete with hidden reasoning tokens.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`: 3,217 passed, 2 skipped)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted: implemented the change, added regression coverage, and verified the real vision path against the configured gateway.
- [ ] No AI used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Increased the default vision token limit from 1,000 to 12,000.
- Disabled provider reasoning during image analysis so tokens focus on image descriptions.
- Updated configuration documentation and integration settings.
- Added regression tests for the token limit and disabled reasoning behavior.

## Benefits

Vision analysis can now produce longer, more complete descriptions without hidden reasoning consuming the response budget.

## Validation

- 3,217 tests passed.
- 2 tests skipped.
- Lint and formatting checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->