### PR TITLE
feat(frontend): collapsible nav groups for extension sidebar items

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
   getDefaultSettingsTab,
   shouldRedirectRootToApp,
   getAdminPageElement,
+  getDefaultAppPath,
 } from '@/extensions';
 
 const DashboardPage = lazy(() => import('@/pages/DashboardPage'));
@@ -31,7 +32,14 @@ const GetStartedPage = lazy(() => import('@/pages/GetStartedPage'));
  * its BOOTSTRAP.md conversation.
  */
 function DefaultRedirect() {
-  const { profile } = useOutletContext<AppShellContext>();
+  const { profile, isAdmin } = useOutletContext<AppShellContext>();
+  // Extensions may claim the landing slot for a role (premium sends admins to
+  // the admin overview). Onboarding still wins: a half-configured account
+  // needs the wizard before anything else.
+  const extensionPath = getDefaultAppPath(isAdmin);
+  if (extensionPath && profile?.onboarding_complete) {
+    return <Navigate to={extensionPath} replace />;
+  }
   if (profile && !profile.onboarding_complete) {
     let dismissed = false;
     try { dismissed = sessionStorage.getItem('getStartedDismissed') === '1'; } catch { /* ignore */ }
@@ -93,7 +101,10 @@ export default function App() {
           <Route path="permissions" element={<PermissionsPage />} />
           <Route path="tools" element={<ToolsPage />} />
           <Route path="oauth/callback" element={<OAuthCallbackPage />} />
-          <Route path="admin" element={<AdminRoute />} />
+          {/* Wildcard: the admin surface owns its own sub-routes (Users,
+              Config, Access, ...) so each one can be a real URL with a
+              sidebar entry rather than a hash fragment. */}
+          <Route path="admin/*" element={<AdminRoute />} />
           {/* Approvals moved out of Settings to its own sidebar page; redirect old bookmarks. */}
           <Route path="settings/approvals" element={<Navigate to="/app/permissions" replace />} />
           <Route path="settings/:tab" element={<SettingsPage />} />

--- a/frontend/src/extensions/admin-nav-item.ts
+++ b/frontend/src/extensions/admin-nav-item.ts
@@ -6,6 +6,14 @@ export interface NavExtensionItem {
   icon: ComponentType;
   /** Fired in addition to navigation, so extensions can reset internal state (e.g. hash-routed tabs). */
   onClick?: () => void;
+  /**
+   * Sub-pages rendered as an indented, collapsible fold under this item,
+   * matching the built-in "Personalize" group. The parent stays a real link:
+   * clicking it navigates AND expands. The fold auto-opens whenever the
+   * current URL is inside the parent's path, so a deep link lands with the
+   * group already open.
+   */
+  children?: NavExtensionItem[];
 }
 
 function AdminIcon() {

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -4,6 +4,7 @@ export {
   getLoginPageElement,
   getDefaultSettingsTab,
   shouldRedirectRootToApp,
+  getDefaultAppPath,
   getFeatureRequestUrl,
   getReportIssueUrl,
   getDocsUrl,

--- a/frontend/src/extensions/routes.tsx
+++ b/frontend/src/extensions/routes.tsx
@@ -18,6 +18,15 @@ export function shouldRedirectRootToApp(_isPremium: boolean): boolean {
   return true;
 }
 
+/**
+ * Landing path for ``/app``, or null to keep the default (get-started /
+ * dashboard). Lets an extension route a role somewhere else on login;
+ * premium sends admins to the admin overview.
+ */
+export function getDefaultAppPath(_isAdmin: boolean): string | null {
+  return null;
+}
+
 export function getFeatureRequestUrl(): string {
   return 'https://github.com/mozilla-ai/clawbolt/issues/new?title=Feature+request:+&labels=enhancement';
 }

--- a/frontend/src/layouts/AppShell.navgroup.test.tsx
+++ b/frontend/src/layouts/AppShell.navgroup.test.tsx
@@ -1,0 +1,186 @@
+import { createElement } from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '@/test/test-utils';
+import AppShell from '@/layouts/AppShell';
+import type { NavExtensionItem } from '@/extensions';
+
+// Nav-group behavior is driven entirely by what an extension returns from
+// getExtraNavItems, so this file mocks that one export and leaves the rest of
+// the extension surface at its OSS defaults.
+
+const CHILD_ITEMS: NavExtensionItem[] = [
+  { to: '/app/admin', label: 'Overview', icon: StubIcon },
+  { to: '/app/admin/users', label: 'Users', icon: StubIcon },
+  { to: '/app/admin/config', label: 'Config', icon: StubIcon },
+];
+
+function StubIcon() {
+  return createElement('svg', { className: 'w-5 h-5 shrink-0' });
+}
+
+const groupedItem: NavExtensionItem = {
+  to: '/app/admin',
+  label: 'Admin',
+  icon: StubIcon,
+  children: CHILD_ITEMS,
+};
+
+vi.mock('@/extensions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/extensions')>();
+  return {
+    ...actual,
+    getExtraNavItems: () => [groupedItem],
+  };
+});
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    authState: 'ready',
+    currentAuthUser: { id: 1, name: 'Test User', role: 'admin' },
+    authConfig: { required: false },
+    isPremium: true,
+    handleLogin: vi.fn(),
+    handleLogout: vi.fn(),
+  }),
+}));
+
+vi.mock('@/api', () => ({
+  default: {
+    getProfile: vi.fn(),
+    subscribeToActivity: vi.fn().mockReturnValue(new AbortController()),
+  },
+}));
+
+import api from '@/api';
+const mockApi = vi.mocked(api);
+
+const PROFILE_RESPONSE = {
+  id: '1',
+  user_id: 'admin@example.com',
+  phone: '+15555550123',
+  timezone: 'America/Los_Angeles',
+  soul_text: '',
+  user_text: '',
+  heartbeat_text: '',
+  preferred_channel: 'telegram',
+  channel_identifier: '',
+  heartbeat_opt_in: true,
+  heartbeat_frequency: 'daily',
+  onboarding_complete: true,
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  mockApi.getProfile.mockResolvedValue(
+    PROFILE_RESPONSE as unknown as Awaited<ReturnType<typeof api.getProfile>>,
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AppShell extension nav groups', () => {
+  it('collapses the group when the route is outside it', async () => {
+    renderWithRouter(<AppShell />, { route: '/app/dashboard' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Users')).not.toBeInTheDocument();
+    expect(screen.queryByText('Config')).not.toBeInTheDocument();
+  });
+
+  it('expands via the chevron without navigating away', async () => {
+    renderWithRouter(<AppShell />, { route: '/app/dashboard' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin')).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Expand Admin' }));
+
+    expect(screen.getByText('Users')).toBeInTheDocument();
+    expect(screen.getByText('Config')).toBeInTheDocument();
+    // The parent link is still a link, and the chevron flipped to Collapse.
+    expect(screen.getByRole('link', { name: /Admin/ })).toHaveAttribute('href', '/app/admin');
+    expect(screen.getByRole('button', { name: 'Collapse Admin' })).toBeInTheDocument();
+  });
+
+  it('auto-expands when the current route is inside the group', async () => {
+    renderWithRouter(<AppShell />, { route: '/app/admin/users' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Users')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Config')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Collapse Admin' })).toBeInTheDocument();
+  });
+
+  it('auto-expands on a route deeper than a child (e.g. a user detail page)', async () => {
+    renderWithRouter(<AppShell />, { route: '/app/admin/users/abc-123' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Users')).toBeInTheDocument();
+    });
+    // The Users child stays highlighted for its own descendants.
+    expect(screen.getByRole('link', { name: /Users/ })).toHaveClass('bg-selected-bg');
+  });
+
+  it('does not keep the parent highlighted while a child route is active', async () => {
+    renderWithRouter(<AppShell />, { route: '/app/admin/config' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Config')).toBeInTheDocument();
+    });
+    const parent = screen
+      .getAllByRole('link')
+      .find(a => a.getAttribute('href') === '/app/admin' && a.textContent?.includes('Admin'));
+    expect(parent).toBeDefined();
+    expect(parent).not.toHaveClass('bg-selected-bg');
+  });
+
+  it('moves the highlight onto the parent once the group is collapsed', async () => {
+    renderWithRouter(<AppShell />, { route: '/app/admin/config' });
+
+    await waitFor(() => expect(screen.getByText('Config')).toBeInTheDocument());
+    const parent = () =>
+      screen
+        .getAllByRole('link')
+        .find(a => a.getAttribute('href') === '/app/admin' && a.textContent?.includes('Admin'))!;
+    expect(parent()).not.toHaveClass('bg-selected-bg');
+
+    // Collapsed, the active child is hidden, so nothing would show where the
+    // user is unless the parent picks the highlight up.
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Collapse Admin' }));
+    expect(screen.queryByText('Config')).not.toBeInTheDocument();
+    expect(parent()).toHaveClass('bg-selected-bg');
+  });
+
+  it('leaves the parent unhighlighted when collapsed outside the group', async () => {
+    renderWithRouter(<AppShell />, { route: '/app/dashboard' });
+
+    await waitFor(() => expect(screen.getByText('Admin')).toBeInTheDocument());
+    const parent = screen
+      .getAllByRole('link')
+      .find(a => a.getAttribute('href') === '/app/admin' && a.textContent?.includes('Admin'));
+    expect(parent).not.toHaveClass('bg-selected-bg');
+  });
+
+  it('still lets the user collapse a group they are inside', async () => {
+    renderWithRouter(<AppShell />, { route: '/app/admin/users' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Users')).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Collapse Admin' }));
+
+    expect(screen.queryByText('Config')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useEffect } from 'react';
-import { Outlet, NavLink, Navigate } from 'react-router-dom';
+import { useState, useCallback, useEffect, type ComponentType } from 'react';
+import { Outlet, NavLink, Navigate, useLocation } from 'react-router-dom';
 import { ToastProvider } from '@heroui/toast';
 import { useQueryClient } from '@tanstack/react-query';
 import Button from '@/components/ui/button';
@@ -11,7 +11,7 @@ import { ChatActivityProvider } from '@/contexts/ChatActivityContext';
 import { Tooltip } from '@heroui/tooltip';
 import { Link } from '@heroui/link';
 import { Divider } from '@heroui/divider';
-import { getFeatureRequestUrl, getReportIssueUrl, getDocsUrl, getExtraNavItems, renderSidebarFooter, renderHeaderBadge } from '@/extensions';
+import { getFeatureRequestUrl, getReportIssueUrl, getDocsUrl, getExtraNavItems, renderSidebarFooter, renderHeaderBadge, type NavExtensionItem } from '@/extensions';
 import useSwipeSidebar from '@/hooks/useSwipeSidebar';
 import { useProfile } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
@@ -46,6 +46,135 @@ const NAV_BOTTOM = [
   { to: '/app/chat', label: 'Chat', icon: ChatIcon, end: false },
 ] as const;
 
+// ---------------------------------------------------------------------------
+// Nav primitives
+// ---------------------------------------------------------------------------
+
+/** Row styling for every sidebar link, so top-level and nested rows stay in sync. */
+function navRowClass(isActive: boolean, indented = false): string {
+  return `flex items-center gap-3 px-3 ${indented ? 'pl-6' : ''} py-2 rounded-md text-sm transition-all duration-150 ${
+    isActive
+      ? 'bg-selected-bg text-primary font-medium border-l-2 border-primary'
+      : 'text-muted-foreground border-l-2 border-transparent can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground'
+  }`;
+}
+
+function NavItemLink({
+  item,
+  indented = false,
+  end = false,
+  onNavigate,
+}: {
+  item: NavExtensionItem;
+  indented?: boolean;
+  end?: boolean;
+  onNavigate: () => void;
+}) {
+  const Icon = item.icon;
+  return (
+    <NavLink
+      to={item.to}
+      end={end}
+      onClick={() => {
+        item.onClick?.();
+        onNavigate();
+      }}
+      className={({ isActive }) => navRowClass(isActive, indented)}
+    >
+      <Icon />
+      {item.label}
+    </NavLink>
+  );
+}
+
+/** True when ``pathname`` is ``to`` or a descendant of it. */
+function isWithin(pathname: string, to: string): boolean {
+  return pathname === to || pathname.startsWith(`${to}/`);
+}
+
+/**
+ * Collapsible sidebar fold. Two shapes, one implementation:
+ *
+ * - No ``to``: the header is a pure toggle (the built-in "Personalize" group).
+ * - With ``to``: the header is a real link plus a separate chevron button, so
+ *   clicking the label navigates to the section landing page while the chevron
+ *   expands/collapses without navigating.
+ *
+ * The fold auto-opens whenever the current URL is inside the group, so a deep
+ * link lands with the group already open. It stays collapsible after that.
+ */
+function NavGroup({
+  label,
+  icon: Icon,
+  to,
+  items,
+  onNavigate,
+}: {
+  label: string;
+  icon?: ComponentType;
+  to?: string;
+  items: NavExtensionItem[];
+  onNavigate: () => void;
+}) {
+  const { pathname } = useLocation();
+  const containsActive =
+    (to != null && isWithin(pathname, to)) ||
+    items.some(child => isWithin(pathname, child.to));
+  const [open, setOpen] = useState(containsActive);
+
+  useEffect(() => {
+    if (containsActive) setOpen(true);
+  }, [containsActive]);
+
+  const toggle = useCallback(() => setOpen(v => !v), []);
+
+  return (
+    <>
+      {to == null ? (
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={open}
+          className="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-muted-foreground border-l-2 border-transparent can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground transition-all duration-150 w-full"
+        >
+          <ChevronIcon open={open} />
+          {label}
+        </button>
+      ) : (
+        <div className="flex items-center">
+          <NavLink
+            to={to}
+            end
+            onClick={onNavigate}
+            // Collapsed, the children are hidden, so the parent has to carry
+            // the "you are here" highlight for the whole section. Expanded,
+            // the active child carries it and the parent stays quiet.
+            className={({ isActive }) =>
+              `${navRowClass(isActive || (!open && containsActive))} flex-1 min-w-0`
+            }
+          >
+            {Icon && <Icon />}
+            {label}
+          </NavLink>
+          <button
+            type="button"
+            onClick={toggle}
+            aria-expanded={open}
+            aria-label={`${open ? 'Collapse' : 'Expand'} ${label}`}
+            className="p-1 mr-1 rounded-md text-muted-foreground can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground transition-all duration-150"
+          >
+            <ChevronIcon open={open} />
+          </button>
+        </div>
+      )}
+      {open &&
+        items.map(child => (
+          <NavItemLink key={child.to} item={child} indented onNavigate={onNavigate} />
+        ))}
+    </>
+  );
+}
+
 export default function AppShell() {
   const { authState, currentAuthUser, isPremium, handleLogout } = useAuth();
   const queryClient = useQueryClient();
@@ -60,7 +189,6 @@ export default function AppShell() {
     refetch: refetchProfile,
   } = useProfile({ enabled: authState === 'ready' });
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [personalizeOpen, setPersonalizeOpen] = useState(false);
 
   const openSidebar = useCallback(() => setSidebarOpen(true), []);
   const closeSidebar = useCallback(() => setSidebarOpen(false), []);
@@ -141,109 +269,31 @@ export default function AppShell() {
         </div>
 
         <nav className="p-2 space-y-0.5">
-          {NAV_TOP.map(({ to, label, icon: Icon, end }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={end}
-              onClick={closeSidebar}
-              className={({ isActive }) =>
-                `flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-all duration-150 ${
-                  isActive
-                    ? 'bg-selected-bg text-primary font-medium border-l-2 border-primary'
-                    : 'text-muted-foreground border-l-2 border-transparent can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground'
-                }`
-              }
-            >
-              <Icon />
-              {label}
-            </NavLink>
+          {NAV_TOP.map(item => (
+            <NavItemLink key={item.to} item={item} end={item.end} onNavigate={closeSidebar} />
           ))}
           <Divider className="my-1" />
-          {NAV_MAIN.map(({ to, label, icon: Icon, end }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={end}
-              onClick={closeSidebar}
-              className={({ isActive }) =>
-                `flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-all duration-150 ${
-                  isActive
-                    ? 'bg-selected-bg text-primary font-medium border-l-2 border-primary'
-                    : 'text-muted-foreground border-l-2 border-transparent can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground'
-                }`
-              }
-            >
-              <Icon />
-              {label}
-            </NavLink>
+          {NAV_MAIN.map(item => (
+            <NavItemLink key={item.to} item={item} end={item.end} onNavigate={closeSidebar} />
           ))}
-          {extraNavItems.map(({ to, label, icon: Icon, onClick: onExtensionClick }) => (
-            <NavLink
-              key={to}
-              to={to}
-              onClick={() => {
-                onExtensionClick?.();
-                closeSidebar();
-              }}
-              className={({ isActive }) =>
-                `flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-all duration-150 ${
-                  isActive
-                    ? 'bg-selected-bg text-primary font-medium border-l-2 border-primary'
-                    : 'text-muted-foreground border-l-2 border-transparent can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground'
-                }`
-              }
-            >
-              <Icon />
-              {label}
-            </NavLink>
-          ))}
-          <button
-            type="button"
-            onClick={() => setPersonalizeOpen((v) => !v)}
-            aria-expanded={personalizeOpen}
-            className="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-muted-foreground border-l-2 border-transparent can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground transition-all duration-150 w-full"
-          >
-            <ChevronIcon open={personalizeOpen} />
-            Personalize
-          </button>
-          {personalizeOpen &&
-            NAV_PERSONALIZE.map(({ to, label, icon: Icon, end }) => (
-              <NavLink
-                key={to}
-                to={to}
-                end={end}
-                onClick={closeSidebar}
-                className={({ isActive }) =>
-                  `flex items-center gap-3 px-3 py-2 pl-6 rounded-md text-sm transition-all duration-150 ${
-                    isActive
-                      ? 'bg-selected-bg text-primary font-medium border-l-2 border-primary'
-                      : 'text-muted-foreground border-l-2 border-transparent can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground'
-                  }`
-                }
-              >
-                <Icon />
-                {label}
-              </NavLink>
-            ))}
+          {extraNavItems.map(item =>
+            item.children && item.children.length > 0 ? (
+              <NavGroup
+                key={item.to}
+                label={item.label}
+                icon={item.icon}
+                to={item.to}
+                items={item.children}
+                onNavigate={closeSidebar}
+              />
+            ) : (
+              <NavItemLink key={item.to} item={item} onNavigate={closeSidebar} />
+            ),
+          )}
+          <NavGroup label="Personalize" items={[...NAV_PERSONALIZE]} onNavigate={closeSidebar} />
           <Divider className="my-1" />
-          {NAV_BOTTOM.map(({ to, label, icon: Icon, end }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={end}
-              onClick={closeSidebar}
-              className={({ isActive }) =>
-                `flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-all duration-150 ${
-                  isActive
-                    ? 'bg-selected-bg text-primary font-medium border-l-2 border-primary'
-                    : 'text-muted-foreground border-l-2 border-transparent can-hover:hover:bg-secondary-hover can-hover:hover:text-foreground'
-                }`
-              }
-            >
-              <Icon />
-              {label}
-            </NavLink>
+          {NAV_BOTTOM.map(item => (
+            <NavItemLink key={item.to} item={item} end={item.end} onNavigate={closeSidebar} />
           ))}
         </nav>
 


### PR DESCRIPTION
## Description

Adds collapsible nav groups for extension sidebar items so the premium admin surface can expose its sub-pages in the sidebar instead of behind hash fragments. No behavior change for OSS users.

The `frontend` unit tests, typecheck, and knip all pass; OSS `backend/` is untouched.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted

Co-Authored-By: DeepSeek V4 Flash <noreply@deepseek.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added collapsible navigation groups for extension sidebar items.
- Kept parent items as navigable links with separate expand and collapse controls.
- Added automatic expansion and active highlighting for nested routes.
- Reused shared navigation components for the “Personalize” section.
- Updated admin routing to support nested paths.
- Added the `getDefaultAppPath(isAdmin)` extension hook for role-specific app landing paths.
- Preserved existing OSS behavior and onboarding redirect precedence.
- Added tests for navigation group states, route matching, highlighting, and collapse behavior.

## Benefits

Extension admin pages can now appear as clear sidebar routes instead of hash fragments. The shared navigation components reduce duplicated UI logic and make future sidebar changes easier to maintain.

## Further enhancement

Additional coverage could verify custom `getDefaultAppPath` implementations for different user roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->