### PR TITLE
feat(auth): add AUTH_MODE with a single_user default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@
 CORS_ORIGINS=http://localhost:3000,http://localhost:8000
 
 # Auth
+# AUTH_MODE=single_user is the self-hosted default: no credentials, every
+# request resolves to the one user in the database. multi_user requires a
+# plugin that registers a resolver (OAuth, JWT) and refuses to boot without
+# one, so do not set it unless PREMIUM_PLUGIN below supplies that resolver.
+# AUTH_MODE=single_user
 JWT_SECRET=change-me-in-production
 JWT_EXPIRY_MINUTES=15
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ When you need realistic-looking data, use clearly synthetic values: `jane.doe@ex
 ## Architecture
 
 - **PostgreSQL storage**: all structured data in PostgreSQL via SQLAlchemy 2.0 ORM. See `backend/app/database.py` and `backend/app/models.py`. Store modules in `backend/app/agent/` provide CRUD APIs.
-- **Auth plugin infrastructure**: base.py (ABC), loader.py (dynamic import), dependencies.py (get_current_user), scoping.py (row-level auth). OSS is single-tenant; premium adds multi-tenant auth via plugin.
+- **Auth plugin infrastructure**: base.py (ABC), loader.py (dynamic import), dependencies.py (get_current_user), scoping.py (row-level auth). `AUTH_MODE` selects the model: `single_user` (default) resolves every request to the one user in the database; `multi_user` delegates to a resolver registered via `set_current_user_resolver()` and never falls back to the single-user path, since that would serve one tenant's data to an unauthenticated caller.
 - **`user_id` scoping** on every data class and endpoint from day one
 - **Message bus**: async inbound/outbound queues in `bus.py`. Channels publish inbound messages; the agent publishes outbound replies. The ``ChannelManager`` dispatches outbound messages to the correct channel.
 - **Agent loop**: channel webhook -> media pipeline -> tool-calling loop (any-llm `amessages`) -> tool execution -> reply

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,16 +1,65 @@
-from fastapi import Depends
+import logging
+from collections.abc import Awaitable, Callable
+
+from fastapi import Depends, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.agent.user_db import provision_user
+from backend.app.config import settings
 from backend.app.database import get_async_db
 from backend.app.models import User
 
+logger = logging.getLogger(__name__)
+
 LOCAL_USER_ID = "local@clawbolt.local"
 
+CurrentUserResolver = Callable[[Request], Awaitable[User]]
 
-async def get_current_user(db: AsyncSession = Depends(get_async_db)) -> User:
-    """OSS mode: return the single user, no auth required.
+# Set by ``set_current_user_resolver`` when AUTH_MODE=multi_user. Mirrors
+# the module-level setter pattern used by ``set_pipeline_override`` and
+# ``set_llm_request_observer``.
+_current_user_resolver: CurrentUserResolver | None = None
+
+
+def set_current_user_resolver(resolver: CurrentUserResolver | None) -> None:
+    """Register the resolver that authenticates requests in multi_user mode.
+
+    The resolver receives the request and returns the authenticated
+    ``User``, or raises ``HTTPException(401)``. It owns its own database
+    access: ``get_current_user`` does not hand it a session, because the
+    credential it reads (a header, a cookie) may not require one.
+
+    Pass ``None`` to clear, which tests use to restore the default.
+    """
+    global _current_user_resolver
+    _current_user_resolver = resolver
+
+
+def get_current_user_resolver() -> CurrentUserResolver | None:
+    """Return the registered multi_user resolver, or ``None`` if unset."""
+    return _current_user_resolver
+
+
+def validate_auth_mode() -> None:
+    """Reject startup when multi_user is requested with no resolver.
+
+    Called from the lifespan, after plugin import has had its chance to
+    register one. Failing here turns a silent authentication gap into a
+    boot failure: without this, every request would take the
+    ``HTTPException(500)`` branch in ``get_current_user`` and the
+    operator would learn about it from user reports.
+    """
+    if settings.auth_mode == "multi_user" and _current_user_resolver is None:
+        raise RuntimeError(
+            "AUTH_MODE=multi_user but no current-user resolver is registered. "
+            "Load a plugin that calls set_current_user_resolver(), or set "
+            "AUTH_MODE=single_user."
+        )
+
+
+async def resolve_single_user(db: AsyncSession) -> User:
+    """Return the single user, no auth required.
 
     In single-tenant mode there should be exactly one user. If Telegram
     (or another channel) already created one, return that user so the
@@ -30,3 +79,34 @@ async def get_current_user(db: AsyncSession = Depends(get_async_db)) -> User:
     # session.
     await provision_user(user)
     return user
+
+
+async def get_current_user(
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+) -> User:
+    """Resolve the caller according to AUTH_MODE.
+
+    single_user (the default) is unchanged self-hosted behavior. multi_user
+    delegates to the registered resolver and never falls back to the
+    single-user path: a missing resolver is a misconfiguration, and
+    serving the first row in ``users`` to an unauthenticated caller would
+    be an authentication bypass rather than a degraded mode.
+
+    ``db`` stays a dependency so the single_user path keeps using the
+    request-scoped session it has always used. multi_user therefore
+    acquires a pooled session it does not use; that is deliberate for now,
+    since preserving the default path matters more than the pool slot, and
+    mozilla-ai/clawbolt#1510 can revisit it once the multi-user
+    implementation actually lives here.
+    """
+    if settings.auth_mode == "multi_user":
+        resolver = _current_user_resolver
+        if resolver is None:
+            logger.error(
+                "AUTH_MODE=multi_user but no current-user resolver is registered; "
+                "refusing the request rather than falling back to single-user auth."
+            )
+            raise HTTPException(status_code=500, detail="Authentication is not configured")
+        return await resolver(request)
+    return await resolve_single_user(db)

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.agent.user_db import provision_user
+from backend.app.auth.loader import load_plugin_module
 from backend.app.config import settings
 from backend.app.database import get_async_db
 from backend.app.models import User
@@ -30,6 +31,12 @@ def set_current_user_resolver(resolver: CurrentUserResolver | None) -> None:
     access: ``get_current_user`` does not hand it a session, because the
     credential it reads (a header, a cookie) may not require one.
 
+    ``get_current_user`` awaits the resolver directly, so FastAPI's
+    dependency injection never runs on it. Declare no ``Depends``,
+    ``Header``, or ``Query`` parameters: they keep their sentinel default
+    object instead of a value, which fails at attribute access rather
+    than returning a 401. Read what you need off ``request``.
+
     Pass ``None`` to clear, which tests use to restore the default.
     """
     global _current_user_resolver
@@ -44,13 +51,22 @@ def get_current_user_resolver() -> CurrentUserResolver | None:
 def validate_auth_mode() -> None:
     """Reject startup when multi_user is requested with no resolver.
 
-    Called from the lifespan, after plugin import has had its chance to
-    register one. Failing here turns a silent authentication gap into a
-    boot failure: without this, every request would take the
+    Called from the lifespan. Failing here turns a silent authentication
+    gap into a boot failure: without this, every request would take the
     ``HTTPException(500)`` branch in ``get_current_user`` and the
     operator would learn about it from user reports.
+
+    Nothing in the lifespan imports ``PREMIUM_PLUGIN`` on its own, so a
+    plugin that registers its resolver as an import side effect may not
+    have run yet: ``get_settings_store()`` only reaches the plugin on the
+    ``SETTINGS_STORE=db`` path, via ``get_kek_provider()``. Force the
+    import here so the check does not depend on an unrelated setting.
     """
-    if settings.auth_mode == "multi_user" and _current_user_resolver is None:
+    if settings.auth_mode != "multi_user":
+        return
+    if _current_user_resolver is None:
+        load_plugin_module()
+    if _current_user_resolver is None:
         raise RuntimeError(
             "AUTH_MODE=multi_user but no current-user resolver is registered. "
             "Load a plugin that calls set_current_user_resolver(), or set "
@@ -95,10 +111,10 @@ async def get_current_user(
 
     ``db`` stays a dependency so the single_user path keeps using the
     request-scoped session it has always used. multi_user therefore
-    acquires a pooled session it does not use; that is deliberate for now,
-    since preserving the default path matters more than the pool slot, and
-    mozilla-ai/clawbolt#1510 can revisit it once the multi-user
-    implementation actually lives here.
+    constructs a session it never touches, which costs an object rather
+    than a pool connection, since SQLAlchemy checks a connection out on
+    first use. mozilla-ai/clawbolt#1510 can revisit it once the
+    multi-user implementation actually lives here.
     """
     if settings.auth_mode == "multi_user":
         resolver = _current_user_resolver

--- a/backend/app/auth/loader.py
+++ b/backend/app/auth/loader.py
@@ -1,4 +1,5 @@
 import importlib
+from types import ModuleType
 
 from backend.app.auth.base import AuthBackend
 from backend.app.config import settings
@@ -10,12 +11,25 @@ _loaded: bool = False
 _kek_provider: KEKProvider | None = None
 
 
+def load_plugin_module() -> ModuleType | None:
+    """Import the configured ``PREMIUM_PLUGIN`` module, or return ``None``.
+
+    The single place OSS reaches for the plugin. Callers that only need
+    the module's import side effects (a plugin registering itself through
+    a module-level setter) use this directly rather than going through a
+    hook that would also require the plugin to expose that hook.
+    """
+    if not settings.premium_plugin:
+        return None
+    return importlib.import_module(settings.premium_plugin)
+
+
 def get_auth_backend() -> AuthBackend | None:
     global _backend, _loaded
     if _loaded:
         return _backend
-    if settings.premium_plugin:
-        module = importlib.import_module(settings.premium_plugin)
+    module = load_plugin_module()
+    if module is not None:
         _backend = module.get_auth_backend()
     _loaded = True
     return _backend
@@ -35,13 +49,12 @@ def get_kek_provider() -> KEKProvider:
     global _kek_provider
     if _kek_provider is not None:
         return _kek_provider
-    if settings.premium_plugin:
-        module = importlib.import_module(settings.premium_plugin)
-        if hasattr(module, "get_kek_provider"):
-            plugin_provider = module.get_kek_provider()
-            if plugin_provider is not None:
-                _kek_provider = plugin_provider
-                return _kek_provider
+    module = load_plugin_module()
+    if module is not None and hasattr(module, "get_kek_provider"):
+        plugin_provider = module.get_kek_provider()
+        if plugin_provider is not None:
+            _kek_provider = plugin_provider
+            return _kek_provider
     _kek_provider = LocalKEKProvider()
     return _kek_provider
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -86,6 +86,13 @@ class Settings(BaseSettings):
     # database. "multi_user" requires a registered resolver (OAuth, JWT)
     # and rejects requests that do not carry one; see
     # ``backend/app/auth/dependencies.py``.
+    #
+    # Not yet the tenancy switch. Premium still replaces the auth
+    # dependency through ``app.dependency_overrides`` and leaves this at
+    # the default, so a multi-tenant deployment reads "single_user" here
+    # until mozilla-ai/clawbolt#1510 lands. Code that needs to know
+    # whether more than one tenant exists must keep testing
+    # ``premium_plugin``, the way ``agent/ingestion.py`` does.
     auth_mode: Literal["single_user", "multi_user"] = "single_user"
     # Backend for runtime-configurable settings: "db" (default) stores in
     # the app_settings table; "file" keeps the legacy data/config.json

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -81,6 +81,12 @@ class Settings(BaseSettings):
     jwt_secret: str = "change-me-in-production"
     jwt_expiry_minutes: int = Field(default=15, ge=1)
     premium_plugin: str | None = None
+    # Who the app authenticates. "single_user" is the self-hosted default:
+    # no credentials, every request resolves to the one user in the
+    # database. "multi_user" requires a registered resolver (OAuth, JWT)
+    # and rejects requests that do not carry one; see
+    # ``backend/app/auth/dependencies.py``.
+    auth_mode: Literal["single_user", "multi_user"] = "single_user"
     # Backend for runtime-configurable settings: "db" (default) stores in
     # the app_settings table; "file" keeps the legacy data/config.json
     # behavior for file-based deployments.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from backend.app.agent.approval import cleanup_orphaned_approvals
 from backend.app.agent.compaction_recovery import recover_pending_compactions
 from backend.app.agent.heartbeat import heartbeat_scheduler
 from backend.app.agent.inbound_recovery import recover_orphan_inbound_messages
+from backend.app.auth.dependencies import validate_auth_mode
 from backend.app.bus import message_bus
 from backend.app.channels import get_manager, register_channel
 from backend.app.channels.bluebubbles import BlueBubblesChannel
@@ -228,6 +229,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
 
     await _enforce_single_channel()
     validate_imessage_backend()
+    validate_auth_mode()
     log_config_warnings()
 
     # Warm the Intuit discovery document cache so QuickBooks OAuth

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -23,6 +23,7 @@ All available settings are listed in `.env.example` with defaults and comments. 
 | `DATABASE_URL` | `postgresql://clawbolt:clawbolt@localhost:5432/clawbolt` | PostgreSQL connection URL |
 | `SETTINGS_STORE` | `db` | Backend for runtime-configurable settings (admin UI values). `db` writes to the `app_settings` table; `file` keeps the legacy `data/config.json` flow for file-based deployments |
 | `CORS_ORIGINS` | `http://localhost:3000,http://localhost:8000` | Comma-separated list of allowed CORS origins |
+| `AUTH_MODE` | `single_user` | Who the app authenticates. `single_user` needs no credentials and resolves every request to the one user in the database. `multi_user` requires a plugin that registers a resolver and refuses to start without one |
 | `JWT_SECRET` | `change-me-in-production` | Secret key for JWT signing. **Change this in production** |
 | `JWT_EXPIRY_MINUTES` | `15` | JWT token expiry time in minutes |
 | `PREMIUM_PLUGIN` | (empty) | Python import path for premium auth plugin. Leave empty for OSS single-tenant mode |

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
@@ -14,13 +14,18 @@ from backend.app.database import db_session_async
 from backend.app.models import User
 
 
+def _request() -> Request:
+    """A minimal ASGI request. single_user auth reads nothing off it."""
+    return Request({"type": "http", "method": "GET", "path": "/api/me", "headers": []})
+
+
 @pytest.mark.asyncio()
 async def test_get_current_user_creates_local_user(
     async_db: async_sessionmaker,
 ) -> None:
     """OSS mode should auto-create a local user when store is empty."""
     async with async_db() as db:
-        user = await get_current_user(db)
+        user = await get_current_user(_request(), db)
         assert user.user_id == LOCAL_USER_ID
         assert user.id is not None
 
@@ -31,7 +36,7 @@ async def test_local_user_needs_onboarding(
 ) -> None:
     """New local user should trigger onboarding (regression for #521)."""
     async with async_db() as db:
-        user = await get_current_user(db)
+        user = await get_current_user(_request(), db)
         assert not user.onboarding_complete
         # Create BOOTSTRAP.md to simulate file-store setup (still needed during hybrid period)
         user_dir = Path(settings.data_dir) / str(user.id)
@@ -46,8 +51,8 @@ async def test_get_current_user_returns_same_user(
 ) -> None:
     """Calling twice should return the same user."""
     async with async_db() as db:
-        c1 = await get_current_user(db)
-        c2 = await get_current_user(db)
+        c1 = await get_current_user(_request(), db)
+        c2 = await get_current_user(_request(), db)
         assert c1.id == c2.id
 
 
@@ -75,7 +80,7 @@ async def test_get_current_user_returns_existing_telegram_user(
         existing_id = telegram_user.id
 
     async with async_db() as db:
-        dashboard_user = await get_current_user(db)
+        dashboard_user = await get_current_user(_request(), db)
         assert dashboard_user.id == existing_id
         assert dashboard_user.user_id == "telegram_123456789"
 

--- a/tests/test_auth_mode.py
+++ b/tests/test_auth_mode.py
@@ -6,10 +6,13 @@ regression in the default is invisible to anyone who only tests the new
 mode. Half of these tests exist to pin the default in place.
 """
 
+import sys
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
-from fastapi import HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from backend.app.auth.dependencies import (
@@ -159,9 +162,77 @@ def test_validate_auth_mode_accepts_multi_user_with_resolver(
     validate_auth_mode()
 
 
+def test_validate_auth_mode_imports_the_plugin_before_deciding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard must not rely on someone else having imported the plugin.
+
+    Nothing earlier in the lifespan imports PREMIUM_PLUGIN:
+    ``get_settings_store()`` reaches it only on the SETTINGS_STORE=db path,
+    via ``get_kek_provider()``. Without the forced import here, a file-backed
+    deployment fails to boot with a perfectly good plugin installed, and the
+    error message tells the operator to install the plugin they already have.
+    """
+    module_name = "fake_auth_mode_plugin"
+    (tmp_path / f"{module_name}.py").write_text(
+        "from backend.app.auth.dependencies import set_current_user_resolver\n"
+        "from backend.app.models import User\n"
+        "\n"
+        "\n"
+        "async def _resolver(request):\n"
+        "    return User(user_id='tenant@example.com')\n"
+        "\n"
+        "\n"
+        "set_current_user_resolver(_resolver)\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(settings, "premium_plugin", module_name)
+    monkeypatch.setattr(settings, "settings_store", "file")
+    monkeypatch.setattr(settings, "auth_mode", "multi_user")
+
+    try:
+        validate_auth_mode()
+        assert get_current_user_resolver() is not None
+    finally:
+        sys.modules.pop(module_name, None)
+
+
 def test_validate_auth_mode_accepts_the_default() -> None:
     """single_user needs no resolver, which is the point of the default."""
     validate_auth_mode()
+
+
+def test_multi_user_resolves_through_a_real_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatcher still works as a FastAPI dependency, not just as a call.
+
+    Every other test here invokes ``get_current_user`` directly, which
+    proves the branching but not the wiring: ``request: Request`` has to
+    be injectable for the multi_user path to reach a resolver at all. A
+    throwaway app is enough, and keeps this off the real router, where
+    the ``client`` fixture overrides the dependency it would test.
+    """
+
+    async def _resolver(request: Request) -> User:
+        assert request.headers.get("x-token") == "secret"
+        return User(user_id="resolved@example.com")
+
+    monkeypatch.setattr(settings, "auth_mode", "multi_user")
+    set_current_user_resolver(_resolver)
+
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(user: User = Depends(get_current_user)) -> dict[str, str]:
+        return {"user_id": user.user_id}
+
+    with TestClient(app) as client:
+        response = client.get("/whoami", headers={"x-token": "secret"})
+
+    assert response.status_code == 200
+    assert response.json() == {"user_id": "resolved@example.com"}
 
 
 def test_set_current_user_resolver_round_trips() -> None:

--- a/tests/test_auth_mode.py
+++ b/tests/test_auth_mode.py
@@ -1,0 +1,175 @@
+"""AUTH_MODE dispatch: single_user default, multi_user resolver delegation.
+
+The default path carries the risk here. ``single_user`` is what every
+self-hosted deployment runs, and none of them set AUTH_MODE at all, so a
+regression in the default is invisible to anyone who only tests the new
+mode. Half of these tests exist to pin the default in place.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from fastapi import HTTPException, Request
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from backend.app.auth.dependencies import (
+    LOCAL_USER_ID,
+    get_current_user,
+    get_current_user_resolver,
+    set_current_user_resolver,
+    validate_auth_mode,
+)
+from backend.app.config import settings
+from backend.app.models import User
+
+
+def _request() -> Request:
+    """A minimal ASGI request; enough for a resolver to read headers."""
+    return Request({"type": "http", "method": "GET", "path": "/api/me", "headers": []})
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver() -> Generator[None]:
+    """Leave the module-level resolver unset, whatever the test did."""
+    set_current_user_resolver(None)
+    yield
+    set_current_user_resolver(None)
+
+
+def test_default_mode_is_single_user() -> None:
+    """No AUTH_MODE in the environment means today's behavior.
+
+    Self-hosters upgrade without touching their .env, so this default is
+    the whole compatibility contract.
+    """
+    assert settings.auth_mode == "single_user"
+
+
+@pytest.mark.asyncio()
+async def test_single_user_resolves_without_credentials(
+    async_db: async_sessionmaker,
+) -> None:
+    """The default path authenticates a request carrying no credentials."""
+    async with async_db() as db:
+        user = await get_current_user(_request(), db)
+        assert user.user_id == LOCAL_USER_ID
+
+
+@pytest.mark.asyncio()
+async def test_single_user_ignores_a_registered_resolver(
+    async_db: async_sessionmaker,
+) -> None:
+    """Mode decides, not resolver presence.
+
+    Premium registers its resolver at import time. If that registration
+    alone flipped behavior, importing the plugin would silently turn on
+    multi-user auth in a deployment that never asked for it.
+    """
+
+    async def _never(request: Request) -> User:
+        raise AssertionError("resolver must not run in single_user mode")
+
+    set_current_user_resolver(_never)
+    async with async_db() as db:
+        user = await get_current_user(_request(), db)
+        assert user.user_id == LOCAL_USER_ID
+
+
+@pytest.mark.asyncio()
+async def test_multi_user_delegates_to_the_resolver(
+    async_db: async_sessionmaker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """multi_user hands the request to the resolver and returns its user."""
+    seen: list[Request] = []
+    expected = User(user_id="resolved@example.com")
+
+    async def _resolver(request: Request) -> User:
+        seen.append(request)
+        return expected
+
+    monkeypatch.setattr(settings, "auth_mode", "multi_user")
+    set_current_user_resolver(_resolver)
+    request = _request()
+    async with async_db() as db:
+        user = await get_current_user(request, db)
+
+    assert user is expected
+    assert seen == [request], "the resolver must receive the live request"
+
+
+@pytest.mark.asyncio()
+async def test_multi_user_propagates_resolver_rejection(
+    async_db: async_sessionmaker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 401 from the resolver reaches the caller unchanged."""
+
+    async def _reject(request: Request) -> User:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    monkeypatch.setattr(settings, "auth_mode", "multi_user")
+    set_current_user_resolver(_reject)
+    async with async_db() as db:
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(_request(), db)
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid token"
+
+
+@pytest.mark.asyncio()
+async def test_multi_user_without_resolver_refuses_rather_than_falling_back(
+    async_db: async_sessionmaker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The authentication-bypass regression.
+
+    Falling back to the single-user path here would hand the first row in
+    ``users`` to an unauthenticated caller, which is worse than the 500:
+    a multi-tenant deployment would serve one tenant's data to anyone.
+    """
+    monkeypatch.setattr(settings, "auth_mode", "multi_user")
+    async with async_db() as db:
+        db.add(User(user_id="tenant@example.com"))
+        await db.commit()
+
+    async with async_db() as db:
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(_request(), db)
+    assert exc_info.value.status_code == 500
+
+
+def test_validate_auth_mode_rejects_multi_user_without_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup fails loudly instead of 500ing every request."""
+    monkeypatch.setattr(settings, "auth_mode", "multi_user")
+    with pytest.raises(RuntimeError, match="no current-user resolver"):
+        validate_auth_mode()
+
+
+def test_validate_auth_mode_accepts_multi_user_with_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _resolver(request: Request) -> User:
+        raise AssertionError("not called during validation")
+
+    monkeypatch.setattr(settings, "auth_mode", "multi_user")
+    set_current_user_resolver(_resolver)
+    validate_auth_mode()
+
+
+def test_validate_auth_mode_accepts_the_default() -> None:
+    """single_user needs no resolver, which is the point of the default."""
+    validate_auth_mode()
+
+
+def test_set_current_user_resolver_round_trips() -> None:
+    async def _resolver(request: Request) -> User:
+        raise AssertionError("not called")
+
+    assert get_current_user_resolver() is None
+    set_current_user_resolver(_resolver)
+    assert get_current_user_resolver() is _resolver
+    set_current_user_resolver(None)
+    assert get_current_user_resolver() is None


### PR DESCRIPTION
## Description

`get_current_user` becomes a dispatcher on `AUTH_MODE`. `single_user` is the default and runs today's code path, moved verbatim into `resolve_single_user`. `multi_user` delegates to a resolver registered via `set_current_user_resolver()`, matching the module-level setter pattern already used by `set_pipeline_override` and `set_llm_request_observer`.

The registry is the point rather than an extra indirection. Premium replaces the dependency through `app.dependency_overrides`, so `get_current_user` never runs in production and `AUTH_MODE` would govern nothing. Registering into one entry point that dispatches on config is what turns the replacement into a mode.

`multi_user` never falls back to the single-user path. Serving the first row in `users` to an unauthenticated caller is an authentication bypass, not a degraded mode, so a missing resolver fails the request with a 500 and fails the lifespan via `validate_auth_mode()`.

The multi-user implementation still lives in premium and arrives with #1510, so `multi_user` is the declared mode with a seam behind it. Two follow-ups that belong there, not here: premium still uses `dependency_overrides` and is untouched by this PR, and `validate_auth_mode()` runs in the OSS lifespan, which `premium_lifespan` replaces wholesale, so the startup guard does not fire under premium until the lifespans merge. Neither matters while premium stays on the default.

Half the new tests pin the default path. Nobody self-hosting sets `AUTH_MODE`, so a regression there is invisible to anyone who only exercises the new mode.

Fixes #1509.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) | 3239 passed, 2 skipped
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) | plus `ty check`
- [x] New tests added for new functionality | `tests/test_auth_mode.py`, 10 tests
- [ ] Bug fixes include regression tests | not a bug fix

`frontend/openapi.json` regenerates byte-identical, so the generated types need no update.

## AI Usage
- [x] AI-assisted (describe how) | Claude Opus 5, via back-and-forth with @njbrake, wrote the dispatcher, the fail-closed guard, and the tests, and confirmed the bypass test fails when the code is patched to fall back instead of refusing. The reasoning and decisions are his; the prose is Claude's.
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `AUTH_MODE` with `single_user` as the default.
- Moved existing authentication logic into `resolve_single_user`.
- Added `multi_user` dispatch through a registered current-user resolver.
- Added startup validation and fail-closed handling for missing resolvers.
- Documented the new configuration in environment and self-hosting guides.
- Added tests for default behavior, resolver dispatch, errors, and startup validation.

## Benefits

Self-hosted deployments keep the existing authentication behavior by default. Premium authentication can now provide multi-user behavior through a clear resolver interface. Startup checks also identify incomplete configuration early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->