### PR TITLE
refactor(admin): drop heartbeat_directives_count from the shared-data export

### DIFF
--- a/backend/app/routers/admin_shared_data.py
+++ b/backend/app/routers/admin_shared_data.py
@@ -54,7 +54,7 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func as sa_func
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.app.agent.approval import get_approval_event_store
@@ -1076,9 +1076,8 @@ async def export_shared_data_user(
             "Window size in days, ending now. Scopes the time-bucketed "
             "subresources (conversations, heartbeat-logs, compaction-events, "
             "LLM-usage, reports, and the tool-call rollup). Identity, "
-            "profile, memory, and the configured-directives count "
-            "(``heartbeat_directives_count``) are point-in-time and not "
-            "scoped by the window."
+            "profile, and memory are point-in-time and not scoped by the "
+            "window."
         ),
     ),
     include_turns: bool = Query(
@@ -1283,28 +1282,6 @@ async def export_shared_data_user(
             )
         )
     ).scalar_one() or 0
-    # heartbeat_items has no OSS ORM model yet; one COUNT via raw SQL.
-    # Point-in-time, not windowed: this is "how many directives are
-    # configured right now?", which is the load-bearing question for
-    # debugging "why is the agent never proactive?". A windowed count
-    # would mean "directives created in the last N days" which is a
-    # weaker signal. See SharedDataExportSummary.heartbeat_directives_count.
-    # Defensive: the test DB uses create_all() against ORM models, so
-    # the table is absent there. Wrap in a SAVEPOINT so the failure
-    # rolls back ONLY the count probe, leaving the outer transaction
-    # (and our already-loaded ``user`` row) intact. The count is
-    # informational, not load-bearing.
-    hb_dir_count = 0
-    try:
-        async with db.begin_nested():
-            hb_dir_count = (
-                await db.execute(
-                    text("SELECT COUNT(*) FROM heartbeat_items WHERE user_id = :uid"),
-                    {"uid": user.id},
-                )
-            ).scalar() or 0
-    except Exception:
-        hb_dir_count = 0
 
     summary = SharedDataExportSummary(
         session_count=session_count,
@@ -1324,7 +1301,6 @@ async def export_shared_data_user(
         tool_calls_error_count=tool_calls_error_count,
         tool_calls_top=tool_calls_top,
         reports_total=int(reports_total),
-        heartbeat_directives_count=int(hb_dir_count),
     )
 
     # ---- per-session conversation list (no bodies) -------------------

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1603,13 +1603,6 @@ class SharedDataExportSummary(BaseModel):
     # here lines up with the other time-bucketed counts in this rollup
     # (heartbeats_total, message_count, llm_calls_total).
     reports_total: int
-    # Point-in-time count of rows in the heartbeat_items table for this
-    # user, NOT scoped to the window. Zero means the Phase-1 heartbeat
-    # LLM has nothing to evaluate, so every cycle skips, useful signal
-    # for "why is the agent never proactive?". The full row contents
-    # are not in this schema yet because OSS lacks a HeartbeatItem ORM
-    # model; surface the count via raw SQL until the model lands.
-    heartbeat_directives_count: int
 
 
 class SharedDataExportResponse(BaseModel):
@@ -1619,9 +1612,7 @@ class SharedDataExportResponse(BaseModel):
     * ``user``: identity + profile config (timezone, channel, consent
       timestamp).
     * ``window``: the date range applied to time-windowed sub-resources.
-    * ``summary``: the aggregate-counts rollup, including
-      ``heartbeat_directives_count`` for "is this user even configured
-      to receive proactive messages?".
+    * ``summary``: the aggregate-counts rollup.
     * ``conversations``: per-session metadata for sessions active in
       the window (no bodies; bodies live in ``turns`` if requested).
     * ``heartbeat_logs``: per-event rows including PII-redacted

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3778,11 +3778,11 @@
               "type": "integer",
               "maximum": 90,
               "minimum": 1,
-              "description": "Window size in days, ending now. Scopes the time-bucketed subresources (conversations, heartbeat-logs, compaction-events, LLM-usage, reports, and the tool-call rollup). Identity, profile, memory, and the configured-directives count (``heartbeat_directives_count``) are point-in-time and not scoped by the window.",
+              "description": "Window size in days, ending now. Scopes the time-bucketed subresources (conversations, heartbeat-logs, compaction-events, LLM-usage, reports, and the tool-call rollup). Identity, profile, and memory are point-in-time and not scoped by the window.",
               "default": 7,
               "title": "Days"
             },
-            "description": "Window size in days, ending now. Scopes the time-bucketed subresources (conversations, heartbeat-logs, compaction-events, LLM-usage, reports, and the tool-call rollup). Identity, profile, memory, and the configured-directives count (``heartbeat_directives_count``) are point-in-time and not scoped by the window."
+            "description": "Window size in days, ending now. Scopes the time-bucketed subresources (conversations, heartbeat-logs, compaction-events, LLM-usage, reports, and the tool-call rollup). Identity, profile, and memory are point-in-time and not scoped by the window."
           },
           {
             "name": "include_turns",
@@ -8156,7 +8156,7 @@
           "memory"
         ],
         "title": "SharedDataExportResponse",
-        "description": "Composite per-user export.\n\nSections:\n* ``user``: identity + profile config (timezone, channel, consent\n  timestamp).\n* ``window``: the date range applied to time-windowed sub-resources.\n* ``summary``: the aggregate-counts rollup, including\n  ``heartbeat_directives_count`` for \"is this user even configured\n  to receive proactive messages?\".\n* ``conversations``: per-session metadata for sessions active in\n  the window (no bodies; bodies live in ``turns`` if requested).\n* ``heartbeat_logs``: per-event rows including PII-redacted\n  ``message_text`` / ``reasoning`` / ``tasks``.\n* ``compaction_events``: per-event metadata (no content; the\n  content is in ``memory.history_text``).\n* ``profile``: soul / user / heartbeat directives text, PII-redacted.\n* ``memory``: working memory + compacted history, PII-redacted.\n* ``turns``: turn-grouped transcripts (only when ``include_turns=true``)."
+        "description": "Composite per-user export.\n\nSections:\n* ``user``: identity + profile config (timezone, channel, consent\n  timestamp).\n* ``window``: the date range applied to time-windowed sub-resources.\n* ``summary``: the aggregate-counts rollup.\n* ``conversations``: per-session metadata for sessions active in\n  the window (no bodies; bodies live in ``turns`` if requested).\n* ``heartbeat_logs``: per-event rows including PII-redacted\n  ``message_text`` / ``reasoning`` / ``tasks``.\n* ``compaction_events``: per-event metadata (no content; the\n  content is in ``memory.history_text``).\n* ``profile``: soul / user / heartbeat directives text, PII-redacted.\n* ``memory``: working memory + compacted history, PII-redacted.\n* ``turns``: turn-grouped transcripts (only when ``include_turns=true``)."
       },
       "SharedDataExportSummary": {
         "properties": {
@@ -8236,10 +8236,6 @@
           "reports_total": {
             "type": "integer",
             "title": "Reports Total"
-          },
-          "heartbeat_directives_count": {
-            "type": "integer",
-            "title": "Heartbeat Directives Count"
           }
         },
         "type": "object",
@@ -8260,8 +8256,7 @@
           "tool_calls_total",
           "tool_calls_error_count",
           "tool_calls_top",
-          "reports_total",
-          "heartbeat_directives_count"
+          "reports_total"
         ],
         "title": "SharedDataExportSummary",
         "description": "Aggregate counts for one user over the requested window.\n\nMirrors the per-user activity rollup an admin would otherwise\nderive by walking the conversations / heartbeat-logs / compaction\nendpoints. Counts only; bodies and memory text live in the other\nfields of the export response."

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -4180,9 +4180,7 @@ export interface components {
          *     * ``user``: identity + profile config (timezone, channel, consent
          *       timestamp).
          *     * ``window``: the date range applied to time-windowed sub-resources.
-         *     * ``summary``: the aggregate-counts rollup, including
-         *       ``heartbeat_directives_count`` for "is this user even configured
-         *       to receive proactive messages?".
+         *     * ``summary``: the aggregate-counts rollup.
          *     * ``conversations``: per-session metadata for sessions active in
          *       the window (no bodies; bodies live in ``turns`` if requested).
          *     * ``heartbeat_logs``: per-event rows including PII-redacted
@@ -4264,8 +4262,6 @@ export interface components {
             tool_calls_top: components["schemas"]["SharedDataExportTopTool"][];
             /** Reports Total */
             reports_total: number;
-            /** Heartbeat Directives Count */
-            heartbeat_directives_count: number;
         };
         /**
          * SharedDataExportTopTool
@@ -7817,7 +7813,7 @@ export interface operations {
     export_shared_data_user_api_admin_shared_data_users__user_id__export_get: {
         parameters: {
             query?: {
-                /** @description Window size in days, ending now. Scopes the time-bucketed subresources (conversations, heartbeat-logs, compaction-events, LLM-usage, reports, and the tool-call rollup). Identity, profile, memory, and the configured-directives count (``heartbeat_directives_count``) are point-in-time and not scoped by the window. */
+                /** @description Window size in days, ending now. Scopes the time-bucketed subresources (conversations, heartbeat-logs, compaction-events, LLM-usage, reports, and the tool-call rollup). Identity, profile, and memory are point-in-time and not scoped by the window. */
                 days?: number;
                 /** @description When true, attach turn-grouped transcripts for every conversation in the window. Off by default because turns are expensive both to compute and to ship; flip on when you want full body content. */
                 include_turns?: boolean;

--- a/tests/multi_user/test_admin_shared_data.py
+++ b/tests/multi_user/test_admin_shared_data.py
@@ -2091,7 +2091,12 @@ class TestSharedDataExport:
             assert key in body, f"missing top-level key {key}"
         assert body["window"]["days"] == 7
         assert body["summary"]["session_count"] == 0
-        assert body["summary"]["heartbeat_directives_count"] == 0
+        # ``heartbeat_directives_count`` counted rows in ``heartbeat_items``,
+        # which OSS revision 040 dropped. The probe degraded to zero rather
+        # than erroring, so leaving it in place would have reported "this
+        # user has no directives configured" for every user forever. The
+        # directives themselves are in ``profile.heartbeat_text``.
+        assert "heartbeat_directives_count" not in body["summary"]
         # ``include_turns`` defaults to False; turns is null when omitted.
         assert body["turns"] is None
 


### PR DESCRIPTION
## Description

Revision 040 dropped the `heartbeat_items` table, and the count that read it was a raw-SQL probe wrapped in `except Exception: hb_dir_count = 0`. So it did not break, it started lying: every export now reports 0 directives for every user, and 0 is a meaningful value in this field ("nothing for the heartbeat LLM to evaluate, so every cycle skips"). An absent metric is better than one that reads as a real answer.

Nothing takes its place. The composite export already ships the directives themselves as `profile.heartbeat_text`, so a derived "is this user configured?" flag would restate a field two levels up in the same response body.

The test that asserted the count was 0 is inverted rather than deleted: `assert "heartbeat_directives_count" not in body["summary"]`. The old assertion is the one that would have passed for the wrong reason forever.

No frontend consumer, so the blast radius is one field in an admin JSON export. `openapi.json` and `api.d.ts` regenerated.

Closes mozilla-ai/clawbolt-premium#675, which was filed against the premium paths before the backend moved here.

## Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`: 4055 passed, 6 skipped, unchanged from base)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [ ] New tests added for new functionality
- [ ] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (written by Claude Opus 5 via back-and-forth with @njbrake; the reasoning and decisions are his)
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the obsolete `heartbeat_directives_count` field from the admin shared-data export.
- Removed its SQL counting logic, documentation, schema definitions, and test fixture references.
- Updated the test to confirm that the field is absent.
- Regenerated the OpenAPI and TypeScript API definitions.

## Benefits

The export no longer reports a misleading zero value after the `heartbeat_items` table removal. The change keeps the API contract accurate without adding a redundant replacement metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->