### PR TITLE
fix(frontend): restore the "Not configured" state on the Tools page, run vitest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,11 @@ jobs:
         run: npm run typecheck
       - working-directory: frontend
         run: npm run deadcode
+      # Vitest rides along in this job rather than getting its own: the npm
+      # install is the expensive part and it is already done here. A suite
+      # nothing runs rots, and this one did, silently, for four months.
+      - working-directory: frontend
+        run: npm run test
 
   docker:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,7 @@ uv run ruff format --check backend/ tests/ alembic/        # format passes
 uv run ty check --python .venv backend/ tests/ alembic/    # type checking passes
 cd frontend && npm run typecheck                   # TypeScript type checking passes
 cd frontend && npm run deadcode                    # no dead JS/TS code (knip)
+cd frontend && npm run test                        # vitest suite passes
 ```
 
 ### Frontend generated types

--- a/frontend/src/pages/ToolsPage.test.tsx
+++ b/frontend/src/pages/ToolsPage.test.tsx
@@ -246,6 +246,11 @@ describe('ToolsPage', () => {
       expect(screen.getByText('ServiceTitan')).toBeInTheDocument();
     });
     expect(screen.getByText('Not connected')).toBeInTheDocument();
+    // Not dimmed, and not labelled "Not configured": unlike an OAuth
+    // integration the deployment never set credentials for, an unconnected
+    // connect_form tool is something the user can act on right here.
+    expect(screen.queryByText('Not configured')).not.toBeInTheDocument();
+    expect(screen.getByText('ServiceTitan').closest('.opacity-50')).toBeNull();
 
     fireEvent.click(screen.getByText('Connect'));
 

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -145,8 +145,18 @@ export default function ToolsPage() {
               const oauthIntegration = tool.oauth_name;
               const { needsOAuth, isConfigured, isConnected } = getToolOAuthStatus(oauthIntegration, oauthMap, tool.configured);
 
+              // ``isConfigured`` means two different things depending on the
+              // branch getToolOAuthStatus took. For an OAuth integration it is
+              // an operator-level fact: the deployment has no client id and
+              // secret, so /oauth/{integration}/authorize returns 400 and no
+              // amount of clicking will connect it. For a connect_form or
+              // plain tool it mirrors the per-user auth_check, where "not
+              // configured" just means "not connected yet" and the Connect
+              // button is the whole point. Only the first case is dead ground.
+              const operatorUnconfigured = needsOAuth && !isConfigured;
+
               return (
-                <Card key={tool.name}>
+                <Card key={tool.name} className={operatorUnconfigured ? 'opacity-50' : undefined}>
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex items-start gap-3 flex-1 min-w-0">
                       <IntegrationIcon name={tool.name} />
@@ -163,7 +173,7 @@ export default function ToolsPage() {
                           ) : (
                             <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
                               <span className="size-1.5 rounded-full inline-block shrink-0 bg-neutral-300" />
-                              Not connected
+                              {operatorUnconfigured ? 'Not configured' : 'Not connected'}
                             </span>
                           )}
                         </div>
@@ -173,7 +183,7 @@ export default function ToolsPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-3 shrink-0">
-                      {needsOAuth && isConnected && (
+                      {needsOAuth && isConfigured && isConnected && (
                         <Button
                           variant="secondary"
                           size="sm"
@@ -183,7 +193,7 @@ export default function ToolsPage() {
                           Disconnect
                         </Button>
                       )}
-                      {needsOAuth && !isConnected && (
+                      {needsOAuth && isConfigured && !isConnected && (
                         <Button
                           size="sm"
                           onClick={() => void handleConnect(oauthIntegration)}


### PR DESCRIPTION
## Description

`ToolsPage.test.tsx` has been failing since April and nothing ran it. The `frontend-lint` job did typecheck and knip but never vitest, so the suite rotted unnoticed. This PR fixes the bug the test was pointing at and wires `npm run test` into that job.

The bug: #965 restructured the integration card to add the icon and the token connect flow, and dropped the `isConfigured` gate as collateral. Since then an OAuth integration the deployment holds no client credentials for renders as "Not connected" with a live Connect button, which sends the user to an endpoint that answers `400 Integration not configured`. `DashboardPage` kept the old behavior, so the two pages disagreed about the same tool.

The gate is back, narrowed to the case it was always about. `isConfigured` carries two meanings depending on the branch `getToolOAuthStatus` takes: for an OAuth integration it is an operator-level fact the user cannot act on, and for a `connect_form` or plain tool it mirrors the per-user `auth_check`, where "not configured" is only "not connected yet". Only the first dims the card and drops the button. The ServiceTitan test picks up two assertions pinning that distinction, since it is the half a naive revert would get wrong.

Vitest rides in `frontend-lint` rather than a new job: the npm install is the expensive part and is already paid for there, and an existing required check enforces it without a branch-protection change.

371 tests pass across 37 files.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [x] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`npm run test`: 371 passed; no backend files touched)
- [x] Lint passes (`npm run typecheck`, `npm run deadcode`)
- [ ] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (written by Claude Opus 5 via back-and-forth with @njbrake; the reasoning and decisions are his)
- [ ] No AI used
