### PR TITLE
chore: retire PREMIUM_PLUGIN and adopt the wrapper's leftovers

### DIFF
--- a/backend/app/agent/ingestion.py
+++ b/backend/app/agent/ingestion.py
@@ -163,18 +163,19 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
 
     1. **Channel route exists** -- the sender has messaged before on this
        channel.  Return the linked user immediately.  This is the common
-       path for both OSS and premium.
+       path in both auth modes.
 
-    2. **Single-tenant reuse (OSS only)** -- exactly one user exists and
-       ``settings.premium_plugin`` is not set.  Link the new channel to
-       the existing user so that sessions from every channel are visible
-       in the dashboard.  Skipped in premium mode to prevent cross-tenant
-       linking.
+    2. **Single-tenant reuse (``single_user`` only)** -- exactly one user
+       exists and the deployment is single-tenant.  Link the new channel
+       to the existing user so that sessions from every channel are
+       visible in the dashboard.  Skipped under ``multi_user``, where an
+       unrecognized sender is a stranger rather than the operator on a
+       new channel, and linking would hand them another tenant's account.
 
-    3. **Sender ID matches an existing user PK (premium only)** -- the
-       webchat sends ``sender_id = user.id`` (the UUID primary key).
+    3. **Sender ID matches an existing user PK (``multi_user`` only)** --
+       the webchat sends ``sender_id = user.id`` (the UUID primary key).
        Link the existing user to this channel and provision defaults.
-       This avoids creating a duplicate account when a premium user
+       This avoids creating a duplicate account when a signed-in user
        first opens the webchat.
 
     If none of the above match, a new ``User`` and ``ChannelRoute`` are
@@ -228,12 +229,14 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
                 db.expunge(user)
                 return user
 
-        # Reuse the sole existing user (single-tenant OSS) so sessions from
-        # every channel are visible in the dashboard.  Skip this in
-        # multi-tenant (premium) mode to avoid linking a new sender's
-        # messages to an existing user's account.
+        # Reuse the sole existing user (single-tenant) so sessions from
+        # every channel are visible in the dashboard.  Gated on the auth
+        # mode itself: under ``multi_user`` this would link a new sender's
+        # messages to whichever account happens to be the only one, which
+        # is a cross-tenant leak on a deployment early enough to have one
+        # user.
         all_users = (await db.execute(select(User))).scalars().all()
-        if len(all_users) == 1 and not settings.premium_plugin:
+        if len(all_users) == 1 and settings.auth_mode == "single_user":
             user = all_users[0]
             logger.debug("_get_or_create_user: single-tenant reuse -> user %s", user.id)
             # Remove stale routes for this user+channel before adding the new one.
@@ -256,7 +259,7 @@ async def _get_or_create_user(channel: str, sender_id: str) -> User:
             db.expunge(user)
             return user
 
-        # In premium mode the webchat sends sender_id = user.id (the PK).
+        # Under multi_user the webchat sends sender_id = user.id (the PK).
         # Link the existing user to this channel instead of creating a
         # duplicate account.
         existing = (await db.execute(select(User).filter_by(id=sender_id))).scalar_one_or_none()

--- a/backend/app/auth/loader.py
+++ b/backend/app/auth/loader.py
@@ -1,6 +1,3 @@
-import importlib
-from types import ModuleType
-
 from backend.app.auth.base import AuthBackend
 from backend.app.auth.oauth_backend import OAuthBackend
 from backend.app.config import settings
@@ -12,34 +9,17 @@ _loaded: bool = False
 _kek_provider: KEKProvider | None = None
 
 
-def load_plugin_module() -> ModuleType | None:
-    """Import the configured ``PREMIUM_PLUGIN`` module, or return ``None``.
-
-    The single place OSS reaches for the plugin. Callers that only need
-    the module's import side effects (a plugin registering itself through
-    a module-level setter) use this directly rather than going through a
-    hook that would also require the plugin to expose that hook.
-    """
-    if not settings.premium_plugin:
-        return None
-    return importlib.import_module(settings.premium_plugin)
-
-
 def get_auth_backend() -> AuthBackend | None:
     """Return the auth backend the frontend should render a login for.
 
-    A plugin wins if one is configured. Otherwise ``multi_user`` mode uses
-    the built-in Google OAuth backend, and ``single_user`` has no backend
-    at all, which is how ``/api/auth/config`` tells the SPA that no login
-    is required.
+    ``multi_user`` mode uses the built-in Google OAuth backend, and
+    ``single_user`` has no backend at all, which is how
+    ``/api/auth/config`` tells the SPA that no login is required.
     """
     global _backend, _loaded
     if _loaded:
         return _backend
-    module = load_plugin_module()
-    if module is not None:
-        _backend = module.get_auth_backend()
-    elif settings.auth_mode == "multi_user":
+    if settings.auth_mode == "multi_user":
         _backend = OAuthBackend()
     _loaded = True
     return _backend
@@ -50,11 +30,8 @@ def get_kek_provider() -> KEKProvider:
 
     Resolution order, first match wins:
 
-    1. A plugin's ``get_kek_provider()``, when one is configured and
-       returns something. A plugin may return ``None`` to decline at
-       runtime, in which case resolution continues here.
-    2. KMS envelope encryption, when ``KMS_KEY_ARN`` is set.
-    3. ``LocalKEKProvider``, wrapping with a key derived from
+    1. KMS envelope encryption, when ``KMS_KEY_ARN`` is set.
+    2. ``LocalKEKProvider``, wrapping with a key derived from
        ``ENCRYPTION_KEY``.
 
     This function is load-bearing for data, not just for startup:
@@ -65,16 +42,9 @@ def get_kek_provider() -> KEKProvider:
     global _kek_provider
     if _kek_provider is not None:
         return _kek_provider
-    module = load_plugin_module()
-    if module is not None and hasattr(module, "get_kek_provider"):
-        plugin_provider = module.get_kek_provider()
-        if plugin_provider is not None:
-            _kek_provider = plugin_provider
-            return _kek_provider
     if settings.kms_key_arn:
         # Imported here rather than at module scope so deployments without
-        # KMS do not pay the boto3 import cost, which is the same reason
-        # the premium plugin deferred it before the move.
+        # KMS do not pay the boto3 import cost.
         from backend.app.security.kms import KMSEnvelopeKEKProvider
 
         _kek_provider = KMSEnvelopeKEKProvider(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -80,7 +80,6 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:3000,http://localhost:8000"
     jwt_secret: str = "change-me-in-production"
     jwt_expiry_minutes: int = Field(default=15, ge=1)
-    premium_plugin: str | None = None
     # Who the app authenticates, and the deployment's tenancy switch.
     #
     # "single_user" is the self-hosted default: no credentials, every

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -7,11 +7,10 @@ import-time timestamp, so we do not depend on commit env vars being stamped
 to detect a deploy. The commit / version fields are display-only.
 
 The ``premium_*`` fields describe the deploy wrapper: mozilla.ai's hosted
-deployment builds this repo inside ``clawbolt-premium``, which pins the
-commit it ships in ``OSS_REF`` / ``OSS_VERSION`` and installs itself as the
-``clawbolt-premium`` distribution. A plain self-host has neither, so both
-fields report their unknown values and the admin UI renders the OSS side
-only.
+deployment builds this repo inside ``clawbolt-premium``, which stamps the
+commit it ships into ``OSS_REF`` / ``OSS_VERSION`` and its own release into
+``PREMIUM_VERSION``. A plain self-host has none of them, so both fields
+report their unknown values and the admin UI renders the OSS side only.
 """
 
 from __future__ import annotations
@@ -47,6 +46,16 @@ _OSS_VERSION_CANDIDATES = (
     Path.cwd() / "OSS_VERSION",
 )
 
+# The wrapper's own release version, stamped next to the two files above.
+# It used to be read from the installed ``clawbolt-premium`` distribution,
+# but the wrapper stopped shipping a Python package once the last of its
+# code moved into this repo, so the number travels as a file like the rest
+# of the build metadata.
+_PREMIUM_VERSION_CANDIDATES = (
+    Path("/app/PREMIUM_VERSION"),
+    Path.cwd() / "PREMIUM_VERSION",
+)
+
 
 def _read_first_nonempty(candidates: tuple[Path, ...], default: str) -> str:
     for candidate in candidates:
@@ -61,6 +70,11 @@ def _read_first_nonempty(candidates: tuple[Path, ...], default: str) -> str:
 
 @lru_cache(maxsize=1)
 def _premium_version() -> str:
+    from_file = _read_first_nonempty(_PREMIUM_VERSION_CANDIDATES, default="")
+    if from_file:
+        return from_file
+    # Wrapper images built before the file existed still install the
+    # package. Drop this branch once no such image can be deployed.
     try:
         return _pkg_version("clawbolt-premium")
     except PackageNotFoundError:

--- a/docs/self-host/README.md
+++ b/docs/self-host/README.md
@@ -66,4 +66,5 @@ Send a message to your assistant and Clawbolt will respond. If you configured an
 - [Configuration](./configuration.md) -- full list of environment variables
 - [Docker](./docker.md) -- Docker Compose details and troubleshooting
 - [Google Drive Setup](./google-drive-setup.md) -- file storage integration, per-user OAuth
+- [Monitoring and alerting](./monitoring.md) -- error alerts and health probes (multi-user mode)
 - [Contributing](../../CONTRIBUTING.md) -- local development setup, tests, and PR guidelines

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -299,6 +299,8 @@ The agent gets one specialist tool here: `supplier_search_products`, which retur
 
 Everything in this section is inert unless `AUTH_MODE=multi_user`. That mode turns one process into a hosted, multi-tenant deployment: users sign in with Google, sessions are JWTs, each tenant gets its own message and token quota, admins get a console at `/app/admin`, and the operator gets health probes and error alerts by email. A single-user self-host can skip the whole section.
 
+The operator runbook for the alerting and probe stack is [Monitoring and alerting](./monitoring.md).
+
 Two things behave differently in this mode beyond the settings below. Channel senders are approved by linking a channel to an account (a `channel_routes` row) rather than by the `*_ALLOWED_NUMBERS` env vars, which are not read. And FastAPI's `/docs`, `/redoc`, and `/openapi.json` are not served, because `/docs` is the SPA's user guide.
 
 ### Sign-in

--- a/docs/self-host/monitoring.md
+++ b/docs/self-host/monitoring.md
@@ -1,0 +1,297 @@
+# Monitoring and alerting
+
+Everything here requires `AUTH_MODE=multi_user`. A single-user self-host mounts
+neither the alerting stack nor the `/api/monitoring` router.
+
+Two layers live in the app, and each catches failures the other structurally
+cannot:
+
+| Layer | Catches | Blind to |
+|---|---|---|
+| 1. Error alerts | Anything logged at `ERROR`: exceptions, failed tool calls, unhandled 500s | Failures that do not raise; the app being down |
+| 2. Health probes | Silent breakage: dead bridge, stale scraper, expired token, unreachable provider | The app being down |
+
+Both go silent when the process dies, so a deployment also needs an external
+uptime check. That one cannot be code in this repo; see your deployment's own
+runbook.
+
+## Prerequisites
+
+All in-app alerting is dormant until both are true:
+
+1. `SMTP_HOST` and `SMTP_FROM_EMAIL` are set. Setting only one fails startup by
+   design, so a typo cannot silently disable email.
+2. A recipient resolves: `ALERT_EMAIL`, falling back to `ADMIN_EMAIL`.
+
+Verify with `GET /api/monitoring/status` (admin auth required):
+
+```json
+{
+  "alerts": {"enabled": true, "pending_groups": 0, "dedupe_minutes": 30},
+  "health_monitor": {"enabled": true, "interval_seconds": 300, "probes": {...}},
+  "recipient_configured": true
+}
+```
+
+Then send a synthetic alert to confirm delivery end to end, rather than
+discovering an `ALERT_EMAIL` typo during a real incident:
+
+```bash
+curl -X POST https://your-domain/api/monitoring/test-alert \
+  -H "Authorization: Bearer $ADMIN_API_KEY"
+```
+
+A failed test alert returns the transport's own explanation (blocked port,
+rejected credentials, unverified sender), not a bare "not sent".
+
+### When no email arrives at all
+
+`POST /api/monitoring/diagnose-email`, or `Diagnose delivery` in the admin
+Monitoring tab, probes the mail path from inside the running container: TCP
+reachability for every candidate SMTP port, then a full EHLO / STARTTLS / login
+handshake against the configured one. No message is sent. It exists to separate
+two failures that look identical from the outside:
+
+- **Nothing is reachable.** The platform is blocking outbound SMTP. Some hosts
+  permit it only on paid tiers, in which case no `SMTP_PORT` value will work and
+  alerting needs an HTTPS email API instead.
+- **Only the configured port is blocked.** SES publishes `2587` as a STARTTLS
+  alternate for networks that filter `587`; the diagnostic names the reachable
+  ports so this is a one-line config fix. Ports 465 and 2465 expect TLS from
+  the first byte and are not supported by this sender.
+- **The port is open but the session is refused.** Then it is a credential,
+  sender-identity, or SES-sandbox problem, and the handshake error says which.
+
+`SMTP_TIMEOUT_SECONDS` (default 10) bounds one SMTP operation, and a send is
+capped at twice that. The cap matters because `socket.create_connection` retries
+every address the SMTP host resolves to: at a 15s timeout, a blocked port on a
+three-A-record host such as SES held the caller for 45s before reporting
+anything.
+
+The Monitoring tab's Email delivery card shows the configured endpoint, the last
+successful send, and the last failure with its explanation, so a dead transport
+is visible without anyone clicking a test.
+
+## Layer 1: error alerts
+
+A logging handler on the `backend` and `uvicorn.error` trees turns every `ERROR`
+record into an alert. No call-site changes are needed to cover a new failure
+path, because `logger.exception(...)` is already the convention.
+
+**Grouping.** Alerts collapse on `(logger, exception type, log template)`. The
+unformatted template is the key, so `"LLM failed for user %s"` with a thousand
+different user ids is one alert with `count: 1000`, not a thousand emails.
+
+**Throttling.** Each group emails at most once per `ALERT_DEDUPE_MINUTES`
+(default 30), carrying the suppressed occurrence count. A global
+`ALERT_MAX_EMAILS_PER_HOUR` (default 20) caps the worst case. Held-back alerts
+keep accumulating rather than being discarded, and a failed send deliberately
+does not start the cooldown, so a transient SES outage does not silence a
+fingerprint for half an hour.
+
+**What it will not catch.** Anything that does not raise or log at `ERROR`. A
+scraper returning zero results, a channel that quietly stops delivering, an
+OAuth token that expired but has not been used yet. That is layer 2's job.
+
+## Layer 2: health probes
+
+Runs every `HEALTH_CHECK_INTERVAL_SECONDS` (default 300) and emails on **status
+transitions**, not on state. A six-hour outage is two emails (down, then
+recovered), not seventy-two. `HEALTH_FAILURE_THRESHOLD` consecutive failures
+(default 2) are required before declaring DOWN, so one timed-out request to a
+residential host is not an incident.
+
+| Probe | Mechanism | Detects |
+|---|---|---|
+| `database` | Calls the `/health` handler | Postgres unreachable |
+| `llm` | Single-token `amessages` call against the primary model | Revoked key, retired model, provider outage |
+| `bluebubbles` | Three checks in order: the channel's `/api/v1/server/info` result, the send-readiness flags in it, then webhook registration | Bridge asleep, rejected password, Mac signed out of iMessage, inbound webhook missing |
+| `supplier_sidecar` | Sidecar `/health` browser round-trip, with no retailer request | Crashed, unreachable, or warming browser |
+| `integration:<name>:<user_id>` | Each factory's `auth_check` per user | Expired refresh token, revoked grant |
+| `integration_check:<user_id>` | Whether that user's sweep answered at all | A stuck or exploding `auth_check`, which leaves every integration under it unknown |
+
+Probes for unconfigured dependencies are not registered, so an unused
+integration is not a permanently-red check.
+
+Every probe is capped at `HEALTH_PROBE_TIMEOUT_SECONDS` (default 45, floor 5),
+including each user's turn in the integration sweep. A probe past its budget is
+abandoned and reported DOWN with a timeout detail, which is the honest reading: a
+dependency that cannot answer in 45s is not healthy. Without the cap one wedged
+socket, typically a residential BlueBubbles host or the scraping sidecar, stalls
+the entire run.
+
+### The BlueBubbles probe, and why reachable is not enough
+
+The bridge answering is necessary and nowhere near sufficient. Three distinct
+failures leave it answering normally while messages stop:
+
+1. **A rejected password.** `/api/v1/server/info` returns 401. The old
+   reachability check accepted any status below 500, so this read as healthy.
+   Now `reachable` and `authenticated` are tracked separately and the alert
+   names the misconfiguration.
+2. **A Mac signed out of iMessage.** The server reports no iCloud account, so
+   every send fails. The probe reads that flag rather than only the status
+   code. `BLUEBUBBLES_SEND_METHOD=private-api` additionally requires the
+   Private API to be enabled and its helper connected.
+3. **No inbound webhook.** This is the one nothing else catches. Registration
+   is attempted once per deploy in a background task; if the Mac is asleep at
+   that moment the attempt fails, is never retried, and the bridge later comes
+   back with every reachability signal green while inbound stays dead. A
+   changed `APP_BASE_URL` produces the same silence, leaving the old
+   registration pointed at a URL that no longer answers.
+
+**Case 3 self-repairs.** When the webhook is missing or carries a token from a
+previous password, the probe re-registers it against the current
+`APP_BASE_URL` and emails a separate "REPAIRED" notice, throttled by
+`ALERT_DEDUPE_MINUTES`. The notice is separate because the repair resolves the
+failure before `HEALTH_FAILURE_THRESHOLD` consecutive failures accumulate, so
+no DOWN alert would ever fire for it: without its own email, inbound would keep
+breaking and silently fixing itself with nobody the wiser.
+
+Three guards keep that self-repair from becoming its own problem, because
+registration is delete-then-POST and each attempt reopens a window with no
+webhook registered at all:
+
+- **It never repairs on a guess.** If the webhook list cannot be retrieved, that
+  is reported as unverified rather than treated as missing, and nothing is
+  written to the operator's Mac.
+- **It stops after three consecutive attempts** that do not stick. Past that the
+  probe reports a plain failure and escalates through the ordinary DOWN alert,
+  rather than rewriting the registration every tick while the email cooldown
+  keeps the operator from hearing about it again. A passing check resets the
+  budget.
+- **It skips the process's first tick,** because the lifespan registers this
+  webhook in a background task and a check landing inside that window would
+  repair and email about a deploy where nothing was wrong.
+
+**One writer per bridge.** Every replica runs its own monitor, so more than one
+replica means several independent delete-and-register cycles against one
+BlueBubbles server. The same applies to any staging or preview environment that
+shares `BLUEBUBBLES_SERVER_URL` with production but has its own `APP_BASE_URL`:
+it will now assert its own registration on a schedule instead of failing once at
+boot, and the two environments will fight over the bridge. Point non-production
+environments at their own bridge, or leave `BLUEBUBBLES_SERVER_URL` unset there
+so the probe is not registered at all.
+
+Readiness flags are tri-state. Older BlueBubbles builds omit them, and a
+missing field is treated as unknown rather than as an outage.
+
+### Admin Monitoring tab
+
+`Admin -> Monitoring` in the web app shows every probe, not just BlueBubbles:
+current status and detail, when each was last checked, consecutive failures,
+and an activity log of status changes and self-repairs. `Run probes now` is the
+one action at the top; `Send test alert` and `Diagnose delivery` sit in the Email
+delivery card at the bottom, where a failure is explained rather than merely
+reported.
+
+**Runs are started, not awaited.** `POST /api/monitoring/run-probes` schedules a
+run and returns immediately with its step list, all pending. The tab polls
+`GET /api/monitoring/status` and reads `health_monitor.run`, showing each step as
+queued, checking, passed, or failed with its elapsed time. Awaiting the run
+instead meant a request open for minutes on a large tenant count, a tab stuck on
+"Running" with no way to tell a slow probe from a wedged one, and a lost result
+whenever a proxy timed out first. A run also reports the alert email as its own
+step, so a transition that could not be delivered is visible rather than silent.
+
+Only one run happens at a time: an operator's run and the timer tick serialize on
+a lock, and a second `run-probes` request returns `started: false` and watches the
+run already in flight. Two overlapping passes would double every outbound call and
+race on the transition bookkeeping.
+
+**Per-user integrations are grouped by user, one row per account.** A flat list
+of every (user, integration) pair answers "is anything broken"; the question an
+admin actually has is "whose account is broken", and several hundred rows sorted
+by probe key cannot answer it without scrolling and grouping in your head. Each
+user gets a single verdict, worst first:
+
+| Verdict | Meaning |
+|---|---|
+| `N not working` | At least one integration that used to work is DOWN |
+| `Status unknown` | The sweep could not check this user, so nothing below can be claimed |
+| `N unknown` | A failure that has not yet reached `HEALTH_FAILURE_THRESHOLD` |
+| `All N working` | Every connected integration authenticates |
+| `Nothing connected` | This user has connected nothing |
+
+Users are named by their subscription email rather than by `users.id`, because a
+UUID says something is broken without saying whose account to go fix. Rows expand
+under each user with the detail and timings, and accounts with a problem expand
+themselves. Only users with a problem are listed by default; `Show all N users`
+reveals the rest.
+
+An integration nobody ever connected shows as "Not connected" and is excluded
+from the verdict: baseline seeding records those as DOWN so a later disconnect is
+still reportable, but they are not breakage, and with 8 specialist integrations
+across `HEALTH_PROBE_MAX_USERS` accounts they would otherwise read as several
+hundred failures on a completely healthy deployment.
+
+The activity log lives in process memory, so a deploy resets it and each
+replica has its own. The alert emails are the durable record.
+
+### Supplier monitoring never searches retailers in the background
+
+The monitor checks the sidecar's browser health endpoint only. It deliberately
+does not replay a fixed Home Depot or Lowe's query: repeated automated searches
+from one cloud egress are themselves bot-detection traffic and can impair real
+user searches. Product searches are exercised by actual user requests, whose
+failures enter the normal application error alerting path.
+
+Set a known-good query if you do want product probes, using a product that must
+return results in the location you operate:
+
+```bash
+HEALTH_PROBE_SUPPLIER_QUERY="2x4 lumber"
+HEALTH_PROBE_SUPPLIER_ZIP="97201"
+```
+
+Each retailer is reported separately. A probe is DOWN if its browser cannot
+warm, its request fails, or its known-good query returns zero rows. Product
+probes run once per hour by default, independently of the five-minute system
+sweep, so health monitoring does not generate bot-like retailer traffic.
+
+### Per-user integration checks are baseline-silent
+
+An integration a user never connected reports the same "not authenticated"
+reason as one whose token just expired. Alerting on the former would be constant
+noise, so these keys establish their baseline silently and alert only on a
+genuine UP to DOWN transition: it worked, then it stopped. Recoveries are always
+reported. That transition is the email you get when a tenant's connection
+breaks, and it names the tenant by email, not by user id.
+
+**The sweep reports on itself, and that key is not baseline-silent.** A user
+whose `auth_check` times out or raises used to be skipped in silence. Their probe
+states then kept their last known status forever, so an integration that broke
+while the check was failing produced no transition and no email. Now that user
+gets an `integration_check:<user_id>` failure, which alerts like any
+infrastructure probe: a check that cannot run has no legitimate steady state,
+unlike a connection the user never made.
+
+**Known gap: a deploy reseeds every baseline.** Probe state lives in process
+memory, and `ever_up` with it. An integration that lapses while the process is
+being replaced comes back as a first observation, so it is recorded silently and
+shows as "Not connected" rather than as breakage, which is indistinguishable
+from a user who never connected it. Closing that needs the "has this ever
+authenticated" bit persisted, which is not implemented.
+
+Start a run on demand instead of waiting out the interval, then poll for its
+progress:
+
+```bash
+curl -X POST https://your-domain/api/monitoring/run-probes \
+  -H "Authorization: Bearer $ADMIN_API_KEY"
+curl -s https://your-domain/api/monitoring/status \
+  -H "Authorization: Bearer $ADMIN_API_KEY" | jq .health_monitor.run
+```
+
+## Tuning noise
+
+If alert volume is too high:
+
+1. Raise `ALERT_DEDUPE_MINUTES` before disabling anything.
+2. Raise `HEALTH_FAILURE_THRESHOLD` if a flaky dependency flaps.
+3. Check whether an existing `logger.error` call is actually routine and should
+   be a `logger.warning`. That fixes the noise at the source, and warnings are
+   not captured.
+
+Lower `ALERT_MAX_EMAILS_PER_HOUR` as a blunt ceiling only if the above is not
+enough; held-back alerts are counted but their detail is dropped.

--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -3,8 +3,8 @@ import { expect } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
 
 /**
- * Wait for the OSS app to be fully loaded.
- * In OSS mode, / redirects to /app, which loads the AppShell with sidebar nav.
+ * Wait for the app to be fully loaded in single_user mode.
+ * There, / redirects to /app, which loads the AppShell with sidebar nav.
  * We wait for the sidebar "Dashboard" link to render as a sign the app is ready.
  */
 export async function waitForAppReady(page: Page): Promise<void> {
@@ -60,4 +60,54 @@ export function createTestPng(): Buffer {
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
     'base64'
   );
+}
+
+/**
+ * Wait for the marketing homepage to render.
+ * Under multi_user, / serves marketing rather than redirecting to /app.
+ */
+export async function waitForHomepage(page: Page): Promise<void> {
+  await expect(
+    page.getByRole('link', { name: /clawbolt/i })
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Wait for the sign-in page to be visible (multi_user only).
+ */
+export async function waitForLoginPage(page: Page): Promise<void> {
+  await expect(
+    page.getByRole('button', { name: /google/i })
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Collect all browser console messages during a callback.
+ * Returns arrays of errors and CSP violations.
+ */
+export async function collectConsoleErrors(
+  page: Page,
+  action: () => Promise<void>
+): Promise<{ errors: string[]; cspViolations: string[] }> {
+  const errors: string[] = [];
+  const cspViolations: string[] = [];
+
+  const handler = (msg: { type: () => string; text: () => string }) => {
+    const text = msg.text();
+    if (msg.type() === 'error') {
+      errors.push(text);
+      if (text.includes('Content-Security-Policy') || text.includes('content-security-policy')) {
+        cspViolations.push(text);
+      }
+    }
+  };
+
+  page.on('console', handler);
+  try {
+    await action();
+  } finally {
+    page.removeListener('console', handler);
+  }
+
+  return { errors, cspViolations };
 }

--- a/e2e/multi_user/csp.spec.ts
+++ b/e2e/multi_user/csp.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { collectConsoleErrors } from '../fixtures/test-helpers';
+
+// The security-headers middleware only mounts under multi_user, so these
+// assertions belong to this project rather than the OSS one.
+test.describe('Content Security Policy', () => {
+  test('homepage loads without CSP violations', async ({ page }) => {
+    const { cspViolations } = await collectConsoleErrors(page, async () => {
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+    });
+
+    expect(cspViolations).toEqual([]);
+  });
+
+  test('login page loads without CSP violations', async ({ page }) => {
+    const { cspViolations } = await collectConsoleErrors(page, async () => {
+      await page.goto('/app/login');
+      await page.waitForLoadState('networkidle');
+    });
+
+    expect(cspViolations).toEqual([]);
+  });
+
+  test('CSP header is present on HTML responses', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/`);
+    const csp = res.headers()['content-security-policy'];
+    expect(csp).toBeTruthy();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("img-src 'self' data: blob:");
+  });
+
+  test('CSP header includes frame-ancestors none', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/`);
+    const csp = res.headers()['content-security-policy'];
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+});

--- a/e2e/multi_user/oauth-flow.spec.ts
+++ b/e2e/multi_user/oauth-flow.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+// The Google OAuth router only mounts under multi_user. No client id is
+// configured in e2e, so the endpoints are asserted to exist and to fail
+// closed (redirect to login with an error), never to 404.
+test.describe('OAuth flow', () => {
+  test('GET /auth/oauth/google redirects (not 404)', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/api/auth/oauth/google`, {
+      maxRedirects: 0,
+    });
+    // Should be a redirect to Google OAuth or a 500 (no client_id configured)
+    // but NEVER a 404 or 405
+    expect([302, 307, 500]).toContain(res.status());
+  });
+
+  test('GET /auth/oauth/google/callback exists (not 404)', async ({ request, baseURL }) => {
+    // Callback without params should redirect to login with error, not 404
+    const res = await request.get(`${baseURL}/api/auth/oauth/google/callback`, {
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(302);
+    const location = res.headers()['location'] ?? '';
+    expect(location).toContain('/app/login#auth_error=');
+  });
+
+  test('callback with Google error redirects to login', async ({ request, baseURL }) => {
+    const res = await request.get(
+      `${baseURL}/api/auth/oauth/google/callback?error=access_denied`,
+      { maxRedirects: 0 }
+    );
+    expect(res.status()).toBe(302);
+    const location = res.headers()['location'] ?? '';
+    expect(location).toContain('/app/login#auth_error=');
+  });
+
+  test('callback with invalid state redirects to login', async ({ request, baseURL }) => {
+    const res = await request.get(
+      `${baseURL}/api/auth/oauth/google/callback?code=test&state=invalid`,
+      { maxRedirects: 0 }
+    );
+    expect(res.status()).toBe(302);
+    const location = res.headers()['location'] ?? '';
+    expect(location).toContain('/app/login#auth_error=');
+  });
+
+  test('state endpoint returns a token', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/api/auth/oauth/google/state`);
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.state).toBeTruthy();
+    expect(typeof body.state).toBe('string');
+  });
+
+  test('login page Google button triggers OAuth redirect', async ({ page }) => {
+    await page.goto('/app/login');
+    await page.waitForSelector('button:has-text("Google")', { timeout: 10_000 });
+
+    // Click the Google button and intercept the navigation
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/api/auth/oauth/google') && !resp.url().includes('/state'),
+        { timeout: 10_000 }
+      ).catch(() => null),
+      page.getByRole('button', { name: /google/i }).click(),
+    ]);
+
+    // The button should trigger navigation to the OAuth endpoint
+    // (it will fail to reach Google in tests, but the route should exist)
+    if (response) {
+      expect([302, 307, 500]).toContain(response.status());
+    }
+  });
+});

--- a/e2e/multi_user/smoke.spec.ts
+++ b/e2e/multi_user/smoke.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { waitForHomepage, waitForLoginPage } from '../fixtures/test-helpers';
+
+test.describe('Multi-user smoke tests', () => {
+  test('health endpoint returns ok', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/api/health`);
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.status).toBe('ok');
+  });
+
+  test('auth config returns oauth_google with required true', async ({ request, baseURL }) => {
+    const res = await request.get(`${baseURL}/api/auth/config`);
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body.method).toBe('oauth_google');
+    expect(body.required).toBe(true);
+  });
+
+  test('homepage renders at / (not redirected to /app)', async ({ page }) => {
+    await page.goto('/');
+    await waitForHomepage(page);
+
+    // Should be on the marketing homepage, not /app
+    expect(page.url()).not.toContain('/app');
+
+    // Logo should be visible on homepage
+    const logo = page.locator('img[src*="clawbolt"]');
+    await expect(logo.first()).toBeVisible();
+  });
+
+  test('homepage has Clawbolt branding in header', async ({ page }) => {
+    await page.goto('/');
+    await waitForHomepage(page);
+
+    // Header should have the Clawbolt name
+    await expect(page.getByRole('link', { name: /clawbolt/i })).toBeVisible();
+  });
+
+  test('login page renders at /app/login', async ({ page }) => {
+    await page.goto('/app/login');
+    await waitForLoginPage(page);
+
+    // Should show a Google sign-in button
+    await expect(page.getByRole('button', { name: /google/i })).toBeVisible();
+  });
+
+  test('unauthenticated /app redirects to login', async ({ page }) => {
+    await page.goto('/app');
+    // Should end up on the login page (no valid session)
+    await page.waitForURL('**/app/login**', { timeout: 10_000 });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "e2e": "playwright test",
-    "e2e:oss": "playwright test --project=oss"
+    "e2e:oss": "playwright test --project=oss",
+    "e2e:multi-user": "playwright test --project=multi_user"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const OSS_PORT = 8765;
+const MULTI_USER_PORT = 8766;
+
+const OSS_DATABASE_URL =
+  process.env.DATABASE_URL ??
+  'postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_e2e';
+
+// The two servers run side by side, so they cannot share a database. The OSS
+// suite owns the single user row and rewrites it (see completeOnboarding in
+// the fixtures), which is the state the multi_user suite must not observe.
+// start-server.sh creates whichever database the URL names.
+const MULTI_USER_DATABASE_URL = `${OSS_DATABASE_URL}_multi_user`;
 
 export default defineConfig({
   testDir: './e2e',
@@ -23,6 +34,13 @@ export default defineConfig({
         baseURL: `http://127.0.0.1:${OSS_PORT}`,
       },
     },
+    {
+      name: 'multi_user',
+      testDir: './e2e/multi_user',
+      use: {
+        baseURL: `http://127.0.0.1:${MULTI_USER_PORT}`,
+      },
+    },
   ],
   webServer: [
     {
@@ -31,9 +49,20 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       env: {
-        DATABASE_URL:
-          process.env.DATABASE_URL ??
-          'postgresql://clawbolt:clawbolt@localhost:5432/clawbolt_e2e',
+        DATABASE_URL: OSS_DATABASE_URL,
+      },
+    },
+    {
+      // Same entrypoint, opposite tenancy. AUTH_MODE is read once when
+      // backend.app.config is imported, so the mode has to arrive as
+      // environment rather than being flipped after boot.
+      command: `bash e2e/scripts/start-server.sh ${MULTI_USER_PORT}`,
+      port: MULTI_USER_PORT,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        AUTH_MODE: 'multi_user',
+        DATABASE_URL: MULTI_USER_DATABASE_URL,
       },
     },
   ],

--- a/tests/integration/test_dashboard_telegram.py
+++ b/tests/integration/test_dashboard_telegram.py
@@ -320,10 +320,10 @@ class TestMultiChannelSingleTenant:
             assert count == 1
 
 
-class TestPremiumWebchatIdentity:
-    """Premium webchat sends sender_id = user.id (the PK).
+class TestMultiUserWebchatIdentity:
+    """Under multi_user the webchat sends sender_id = user.id (the PK).
 
-    Regression test for the bug where premium webchat messages disappeared
+    Regression test for the bug where hosted webchat messages disappeared
     because _get_or_create_user created a phantom duplicate user instead
     of linking to the existing JWT-authenticated user.
     """
@@ -337,11 +337,8 @@ class TestPremiumWebchatIdentity:
             await db.refresh(user)
             original_id = user.id
 
-        # Premium mode: sender_id is the user's PK (UUID)
-        with patch(
-            "backend.app.agent.ingestion.settings.premium_plugin",
-            "clawbolt_premium.plugin",
-        ):
+        # multi_user: sender_id is the user's PK (UUID)
+        with patch("backend.app.agent.ingestion.settings.auth_mode", "multi_user"):
             resolved = await _get_or_create_user("webchat", original_id)
 
         assert resolved.id == original_id
@@ -360,10 +357,7 @@ class TestPremiumWebchatIdentity:
             await db.refresh(user)
             original_id = user.id
 
-        with patch(
-            "backend.app.agent.ingestion.settings.premium_plugin",
-            "clawbolt_premium.plugin",
-        ):
+        with patch("backend.app.agent.ingestion.settings.auth_mode", "multi_user"):
             await _get_or_create_user("webchat", original_id)
 
         # A ChannelRoute should now exist
@@ -387,29 +381,23 @@ class TestPremiumWebchatIdentity:
             await db.refresh(user)
             original_id = user.id
 
-        with patch(
-            "backend.app.agent.ingestion.settings.premium_plugin",
-            "clawbolt_premium.plugin",
-        ):
+        with patch("backend.app.agent.ingestion.settings.auth_mode", "multi_user"):
             first = await _get_or_create_user("webchat", original_id)
             second = await _get_or_create_user("webchat", original_id)
 
         assert first.id == second.id == original_id
 
-    async def test_premium_skips_single_tenant_reuse(self) -> None:
-        """In premium mode, a new sender should NOT reuse the sole existing user."""
+    async def test_multi_user_skips_single_tenant_reuse(self) -> None:
+        """Under multi_user, a new sender must NOT reuse the sole existing user."""
         async with db_session_async() as db:
-            user = User(user_id="existing_premium_user@example.com")
+            user = User(user_id="existing_hosted_user@example.com")
             db.add(user)
             await db.commit()
             await db.refresh(user)
             existing_id = user.id
 
         # A truly new sender (not matching any PK) should create a new user
-        with patch(
-            "backend.app.agent.ingestion.settings.premium_plugin",
-            "clawbolt_premium.plugin",
-        ):
+        with patch("backend.app.agent.ingestion.settings.auth_mode", "multi_user"):
             new_user = await _get_or_create_user("telegram", "999888777")
 
         assert new_user.id != existing_id

--- a/tests/multi_user/test_admin_role.py
+++ b/tests/multi_user/test_admin_role.py
@@ -148,7 +148,7 @@ class TestGetCurrentAdmin:
     ) -> None:
         """ADMIN_USER_IDS no longer grants admin at request time.
 
-        Operators must run ``python -m clawbolt_premium promote-env-admins`` to
+        Operators must run ``python -m backend.app.cli promote-env-admins`` to
         migrate these users into ``Subscription.role='admin'``. Until they do
         (or even if they never remove the env var), the env var is ignored;
         admin grants live exclusively in the database.

--- a/tests/multi_user/test_auth_config.py
+++ b/tests/multi_user/test_auth_config.py
@@ -5,10 +5,13 @@ frontend isPremiumAuth() check. A mismatch here silently breaks the
 entire premium frontend (homepage routing, login flow, session restore).
 """
 
+from collections.abc import Iterator
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
+from backend.app.auth import loader as auth_loader
 from backend.app.auth.oauth_backend import OAuthBackend
 
 
@@ -34,9 +37,9 @@ class TestAuthConfigContract:
         assert "google_client_id" in config
 
     def test_endpoint_returns_premium_config(self, client: TestClient) -> None:
-        """GET /api/auth/config returns the premium auth config, not OSS defaults."""
+        """GET /api/auth/config returns the multi-user auth config, not OSS defaults."""
         # Patch the loader so the endpoint uses OAuthBackend regardless of
-        # whether PREMIUM_PLUGIN env var is set (it isn't in CI).
+        # what an earlier test left in the loader's module-level cache.
         with patch(
             "backend.app.routers.auth.get_auth_backend",
             return_value=OAuthBackend(),
@@ -46,3 +49,24 @@ class TestAuthConfigContract:
         data = resp.json()
         assert data["method"] == "oauth_google"
         assert data["required"] is True
+
+
+class TestAuthBackendResolution:
+    """``AUTH_MODE`` alone decides the backend, now that plugins are gone."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_backend(self) -> Iterator[None]:
+        # Both sides: the cache is module-level, so a resolution made under
+        # a patched mode must not outlive the test that made it.
+        auth_loader.reset_auth_backend()
+        yield
+        auth_loader.reset_auth_backend()
+
+    def test_multi_user_resolves_oauth_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(auth_loader.settings, "auth_mode", "multi_user")
+        assert isinstance(auth_loader.get_auth_backend(), OAuthBackend)
+
+    def test_single_user_resolves_no_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No backend is how ``/api/auth/config`` tells the SPA no login is required."""
+        monkeypatch.setattr(auth_loader.settings, "auth_mode", "single_user")
+        assert auth_loader.get_auth_backend() is None

--- a/tests/multi_user/test_version.py
+++ b/tests/multi_user/test_version.py
@@ -58,6 +58,44 @@ class TestPremiumCommit:
         assert version_module._premium_commit() == "sha-with-whitespace"
 
 
+class TestPremiumVersion:
+    def test_reads_first_existing_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        missing = tmp_path / "missing-PREMIUM_VERSION"
+        present = tmp_path / "PREMIUM_VERSION"
+        present.write_text("0.8.0\n")
+        monkeypatch.setattr(
+            version_module,
+            "_PREMIUM_VERSION_CANDIDATES",
+            (missing, present),
+        )
+        assert version_module._premium_version() == "0.8.0"
+
+    def test_falls_back_to_package_metadata(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No file means an older wrapper image, which installs the package."""
+        monkeypatch.setattr(
+            version_module,
+            "_PREMIUM_VERSION_CANDIDATES",
+            (tmp_path / "missing",),
+        )
+        monkeypatch.setattr(version_module, "_pkg_version", lambda _name: "0.7.67")
+        assert version_module._premium_version() == "0.7.67"
+
+    def test_zero_when_neither_file_nor_package(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A plain self-host has no wrapper at all, which the UI renders as absent."""
+        monkeypatch.setattr(
+            version_module,
+            "_PREMIUM_VERSION_CANDIDATES",
+            (tmp_path / "missing",),
+        )
+        assert version_module._premium_version() == "0.0.0"
+
+
 class TestOSSCommit:
     def test_env_override_wins_over_file(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 import base64
 import importlib.util
 import secrets
-import sys
-import types
 import uuid
 from collections.abc import Generator
 from pathlib import Path
@@ -498,59 +496,6 @@ def test_get_kek_provider_defaults_to_local() -> None:
     try:
         provider = auth_loader.get_kek_provider()
         assert isinstance(provider, LocalKEKProvider)
-    finally:
-        auth_loader.reset_kek_provider()
-
-
-def _install_fake_plugin(
-    monkeypatch: pytest.MonkeyPatch, name: str, get_kek_provider: object
-) -> None:
-    """Install a fake premium plugin module that exposes ``get_kek_provider``.
-
-    Cleans up automatically when the test's monkeypatch fixture tears
-    down: the sys.modules entry and the settings override both revert.
-    """
-    fake_module = types.ModuleType(name)
-    fake_module.get_kek_provider = get_kek_provider  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, name, fake_module)
-    monkeypatch.setattr(auth_loader.settings, "premium_plugin", name)
-
-
-def test_get_kek_provider_falls_back_to_local_when_plugin_returns_none(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A premium plugin can opt out of the KEK override at runtime by
-    returning ``None`` from ``get_kek_provider()``. The loader then
-    falls back to ``LocalKEKProvider`` instead of caching ``None`` and
-    breaking subsequent reads.
-
-    Lets premium ship the KMS provider dormant: when the env vars
-    aren't set yet, the plugin returns ``None`` and OSS encryption
-    keeps working unchanged.
-    """
-    _install_fake_plugin(monkeypatch, "fake_premium_plugin_dormant", lambda: None)
-
-    auth_loader.reset_kek_provider()
-    try:
-        provider = auth_loader.get_kek_provider()
-        assert isinstance(provider, LocalKEKProvider)
-    finally:
-        auth_loader.reset_kek_provider()
-
-
-def test_get_kek_provider_uses_plugin_provider_when_returned(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When the plugin returns a real provider, the loader uses it
-    instead of the OSS default. Mirror of the dormant-fallback test
-    above, on the active branch."""
-    sentinel_provider = _RecordingProvider()
-    _install_fake_plugin(monkeypatch, "fake_premium_plugin_active", lambda: sentinel_provider)
-
-    auth_loader.reset_kek_provider()
-    try:
-        provider = auth_loader.get_kek_provider()
-        assert provider is sentinel_provider
     finally:
         auth_loader.reset_kek_provider()
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1531,7 +1531,7 @@ async def test_auto_exit_does_not_fire_without_timezone(
 async def test_oauth_user_provisioned_on_first_chat() -> None:
     """User created via OAuth (no provision_user call) should be provisioned on first chat.
 
-    Regression test: premium creates User rows during Google OAuth signup
+    Regression test: multi_user creates User rows during Google OAuth signup
     via UserStore.create(), which does NOT call provision_user(). When the
     user then sends their first webchat message, _get_or_create_user()
     found the existing user by PK but returned it without provisioning.
@@ -1558,9 +1558,9 @@ async def test_oauth_user_provisioned_on_first_chat() -> None:
     bootstrap_path = Path(app_settings.data_dir) / "oauth-premium-user" / "BOOTSTRAP.md"
     assert not bootstrap_path.exists()
 
-    # Simulate premium webchat: sender_id = user.id (the PK)
-    # Enable premium_plugin so the single-tenant reuse path is skipped
-    with patch.object(app_settings, "premium_plugin", "clawbolt_premium.plugin"):
+    # Simulate hosted webchat: sender_id = user.id (the PK)
+    # multi_user so the single-tenant reuse path is skipped
+    with patch.object(app_settings, "auth_mode", "multi_user"):
         resolved = await _get_or_create_user("webchat", "oauth-premium-user")
 
     # User should now be provisioned


### PR DESCRIPTION
## Description

Takes in the last three things the premium deploy wrapper still owned, so it can be reduced to a Dockerfile and some scripts.

**Drops the `PREMIUM_PLUGIN` mechanism.** It named a module OSS imported for an auth backend and a KEK provider. Both resolve from `AUTH_MODE` and `KMS_KEY_ARN` on their own now, and the wrapper's module only re-derived the same answers. `load_plugin_module()` and `settings.premium_plugin` go with it. Deployments can leave the env var set: Pydantic's `extra="ignore"` makes it inert.

**One real fix.** `_get_or_create_user` gated its single-tenant reuse path on `not settings.premium_plugin`, so an unrecognized sender was linked to the sole existing user whenever that variable was unset. Correct for a self-host, a cross-tenant leak for a hosted deployment, and protected only by an env var that has no other purpose left. Now gated on `auth_mode == "single_user"`, which is what the condition always meant. Narrow in practice (it needs exactly one user row) but it is the reason this lands before the wrapper deletes anything.

**`PREMIUM_VERSION`.** `_premium_version()` reads a file next to `OSS_REF` and `OSS_VERSION`, because the wrapper stops shipping a Python distribution for `importlib.metadata` to find. The package lookup stays as a fallback so an older wrapper image keeps reporting its version.

**Adopts two things from the wrapper.** The Playwright suite becomes `e2e/multi_user` (a second project on port 8766 with its own database; it asserts `/api/auth/config`, the CSP headers, the sign-in page, and the marketing homepage, all OSS code). The operator runbook for error alerts and health probes becomes `docs/self-host/monitoring.md`; the wrapper keeps only the external-uptime layer, which cannot live in the app it watches.

Follow-up in `clawbolt-premium` deletes its Python package and repoints its entrypoint at `backend.app.main:app`. It needs this released and `OSS_REF` bumped first.

## Type
- [x] Refactor
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`: 3958 passed, 6 skipped)
- [x] Lint passes (`ruff check backend/ tests/ && ruff format --check backend/ tests/`)
- [x] Type checking passes (`uv run ty check --python .venv backend/ tests/`)
- [x] New tests added for new functionality (`TestPremiumVersion` for the file lookup, `TestAuthBackendResolution` for the branch the plugin removal leaves behind)
- [x] `npx playwright test` passes both projects locally (31 tests)

## AI Usage
- [x] AI-assisted: written by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the `PREMIUM_PLUGIN` mechanism and related settings.
- Uses `AUTH_MODE` and `KMS_KEY_ARN` for authentication and encryption provider selection.
- Prevents cross-tenant user linking in multi-user mode.
- Adds `PREMIUM_VERSION` file support with package metadata fallback.
- Adds multi-user Playwright tests and separate test configuration.
- Adds self-hosted monitoring and alerting documentation.
- Updates related tests and migration references.

## Benefits

- Simplifies authentication and encryption configuration.
- Improves tenant isolation.
- Supports more reliable version reporting.
- Expands multi-user coverage and operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->