### PR TITLE
fix(appfolio): stop sending files alongside line items on invoice POSTs

### DIFF
--- a/backend/app/integrations/appfolio_vendor/SKILL.md
+++ b/backend/app/integrations/appfolio_vendor/SKILL.md
@@ -16,7 +16,7 @@ AppFolio Vendor Portal.
 | appfolio_list_notes | List notes on a work order | Auto |
 | appfolio_add_note | Add a note (with optional photos) | Ask |
 | appfolio_update_note | Edit an existing note | Ask |
-| appfolio_create_invoice | Build a line-itemized invoice with photos | Ask |
+| appfolio_create_invoice | Build a line-itemized invoice (no photos) | Ask |
 | appfolio_upload_invoice_pdf | Upload a pre-built invoice PDF | Ask |
 
 Common status codes: `0` = new, `4` = in progress, `8` = completed.
@@ -34,6 +34,14 @@ reused without re-searching.
 
 See the ``analyze_photo`` tool description for the ``media_XXXXXX`` handle
 convention. AppFolio receives photo bytes inline as base64 in the JSON body.
+
+`appfolio_create_invoice` takes no photos. AppFolio rejects an invoice
+that carries line items and files in one request, so a receipt or a
+photo of the finished work goes on the work order with
+`appfolio_add_note`. Post the note first, then the invoice, and tell the
+user where each landed. `appfolio_upload_invoice_pdf` is the one invoice
+path that carries files, and it replaces line items rather than
+accompanying them.
 
 ## Connecting
 

--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -3,12 +3,18 @@
 Two write paths share one endpoint:
 
 * ``appfolio_create_invoice`` — line-itemized invoice built inside the
-  portal. Supports inline photo attachments via ``media_refs``.
+  portal. Line items only, never files (see below).
 * ``appfolio_upload_invoice_pdf`` — single invoice constructed from one
   or more pre-built PDFs the user already has.
 
 Both bodies POST to ``/maintenance/api/invoices``; AppFolio
-disambiguates by the presence of ``lineItems`` vs ``files`` only.
+disambiguates by the presence of ``line_items`` vs ``files`` only. The
+two are mutually exclusive: a body carrying both draws HTTP 500 with an
+empty response body, confirmed in production where six line-items-only
+invoices succeeded and three otherwise identical bodies with one
+``files`` entry all failed. Photos that belong
+with an invoice go up through ``appfolio_add_note``, which takes the same
+bytes on an endpoint that accepts them.
 """
 
 from __future__ import annotations
@@ -284,7 +290,6 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
         work_order_id: str,
         line_items: list[dict[str, Any]],
         reference_number: str = "",
-        media_refs: list[str] | None = None,
     ) -> ToolResult:
         # Pydantic-coerce raw dicts the LLM emits into the typed shape.
         try:
@@ -305,10 +310,6 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
                 is_error=True,
                 error_kind=ToolErrorKind.VALIDATION,
             )
-        files_or_err = await resolve_staged_files(ctx, media_refs or [])
-        if isinstance(files_or_err, ToolResult):
-            return files_or_err
-        files = files_or_err
         address_or_err = await _fetch_invoice_address(service, customer_id, work_order_id)
         if isinstance(address_or_err, ToolResult):
             return address_or_err
@@ -320,7 +321,6 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
                 line_items=_line_items_to_payload(typed_items),
                 address=address or None,
                 reference_number=reference_number,
-                files=files or None,
             )
         except Exception as exc:
             return service_error_to_tool_result("creating invoice", exc)
@@ -329,16 +329,15 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
         if isinstance(result, dict):
             invoice_id = str(result.get("id") or result.get("invoice", {}).get("id") or "")
         total = _line_items_total(typed_items)
-        photo_phrase = f" with {len(files)} attachment(s)" if files else ""
         invoice_phrase = f" | invoice Id: {invoice_id}" if invoice_id else ""
         return ToolResult(
             content=(
                 f"ok | work order: #{work_order_id} | total: ${total:.2f}"
-                f" | line items: {len(typed_items)}{photo_phrase}{invoice_phrase}"
+                f" | line items: {len(typed_items)}{invoice_phrase}"
             ),
             receipt=ToolReceipt(
                 action="Created AppFolio invoice",
-                target=f"#{work_order_id} ${total:.2f}{photo_phrase}",
+                target=f"#{work_order_id} ${total:.2f}",
             ),
         )
 
@@ -395,8 +394,8 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
         Tool(
             name=ToolName.APPFOLIO_CREATE_INVOICE,
             description=(
-                "Build a line-itemized invoice on an AppFolio work order"
-                " (with optional photo attachments)."
+                "Build a line-itemized invoice on an AppFolio work order."
+                " Cannot carry photos; attach those with appfolio_add_note."
             ),
             function=appfolio_create_invoice,
             params_model=AppFolioCreateInvoiceParams,
@@ -404,6 +403,9 @@ def build_invoice_tools(service: AppFolioVendorService, ctx: ToolContext) -> lis
             usage_hint=(
                 "Confirm each line item's description, quantity, and amount"
                 " with the user before submitting; this is a billing action."
+                " To put a receipt or photo on the record, call"
+                " appfolio_add_note on the same work order; AppFolio rejects"
+                " an invoice that carries line items and files together."
             ),
             approval_policy=ApprovalPolicy(
                 default_level=PermissionLevel.ASK,

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -133,13 +133,6 @@ class AppFolioCreateInvoiceParams(BaseModel):
             " empty to let AppFolio generate one."
         ),
     )
-    media_refs: list[str] = Field(
-        default_factory=list,
-        description=(
-            "Optional photo or document references from the conversation"
-            " to attach as supporting evidence (same shape as appfolio_add_note)."
-        ),
-    )
 
 
 class AppFolioUploadInvoicePdfParams(BaseModel):

--- a/backend/app/integrations/appfolio_vendor/service.py
+++ b/backend/app/integrations/appfolio_vendor/service.py
@@ -970,7 +970,6 @@ class AppFolioVendorService:
         line_items: list[dict[str, Any]],
         address: dict[str, Any] | None = None,
         reference_number: str = "",
-        files: list[FileUpload] | None = None,
     ) -> Any:
         """Create a line-itemized invoice tied to a work order.
 
@@ -991,6 +990,13 @@ class AppFolioVendorService:
         property block. ``reference_number`` is the vendor-side invoice
         number (the SPA auto-suggests one based on the WO).
 
+        There is deliberately no ``files`` parameter. AppFolio answers
+        HTTP 500 with an empty body when one request carries both
+        ``line_items`` and ``files``; :meth:`upload_invoice_pdf` is the
+        files-only path, and photos that accompany a line-itemized
+        invoice belong on a work-order note. See the module docstring of
+        ``invoices.py`` for the production evidence.
+
         ``customer_id`` is optional. Pass ``None`` to resolve the canonical
         property-manager ID from ``/profiles/me``; this is the safe default
         when the agent's only signal is a search response (which can carry
@@ -1007,8 +1013,6 @@ class AppFolioVendorService:
             body["address"] = address
         if reference_number:
             body["reference_number"] = reference_number
-        if files:
-            body["files"] = _encode_files(files)
         return await self.post("/maintenance/api/invoices", json_body=body)
 
     async def upload_invoice_pdf(

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -1617,7 +1617,7 @@ def test_address_from_work_order_unwraps_camelcase_envelope() -> None:
     """Regression: production WO GET returns ``{"workOrder": {...}}``.
 
     The diagnostic warning from the previous deploy logged
-    ``top_keys=['workOrder']`` for jesse's failing invoice. Pin a
+    ``top_keys=['workOrder']`` for a production user's failing invoice. Pin a
     regression test to that exact envelope key so we don't lose it.
     """
     from backend.app.integrations.appfolio_vendor.invoices import (

--- a/tests/test_appfolio_vendor.py
+++ b/tests/test_appfolio_vendor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import inspect
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1367,8 +1368,6 @@ def _patch_request(response: httpx.Response) -> Any:
 
 @pytest.mark.asyncio()
 async def test_create_invoice_serializes_line_items() -> None:
-    from backend.app.integrations.appfolio_vendor.service import FileUpload
-
     service = AppFolioVendorService(_credential(), api_base="https://api.test")
     response = _mock_response(json_data={"id": "inv-1"})
     with patch("backend.app.integrations.appfolio_vendor.service.httpx.AsyncClient") as cls:
@@ -1386,7 +1385,6 @@ async def test_create_invoice_serializes_line_items() -> None:
                 "address_1": "123 Example Street",
             },
             reference_number="REF-001",
-            files=[FileUpload(name="receipt.pdf", data=b"%PDF-fake")],
         )
     args, kwargs = client.request.call_args
     assert args[0] == "POST"
@@ -1399,7 +1397,39 @@ async def test_create_invoice_serializes_line_items() -> None:
     assert payload["line_items"][0]["amount"] == 75.0
     assert payload["address"]["address_1"] == "123 Example Street"
     assert payload["reference_number"] == "REF-001"
-    assert len(payload["files"]) == 1
+    # AppFolio 500s on a body carrying both ``line_items`` and ``files``.
+    assert "files" not in payload
+
+
+@pytest.mark.asyncio()
+async def test_create_invoice_has_no_files_parameter() -> None:
+    """Regression: the line-itemized invoice path must not carry files.
+
+    Production took six line-items-only invoices successfully, then
+    answered HTTP 500 with an empty body three times running once a
+    single ``files`` entry rode along. The same photo bytes had POSTed
+    fine to the work-order notes endpoint 101 seconds before the first
+    failure, so the file itself was never the problem: AppFolio treats
+    ``line_items`` and ``files`` as mutually exclusive on
+    ``POST /maintenance/api/invoices``.
+
+    Pin the constraint at the signature so a future caller cannot
+    rebuild the rejected shape. ``upload_invoice_pdf`` stays the
+    files-only path.
+    """
+    from backend.app.integrations.appfolio_vendor.invoices import build_invoice_tools
+
+    assert "files" not in inspect.signature(AppFolioVendorService.create_invoice).parameters
+
+    service = AppFolioVendorService(_credential(), api_base="https://api.test")
+    ctx = MagicMock()
+    ctx.user.id = "u1"
+    ctx.downloaded_media = []
+    tools = build_invoice_tools(service, ctx)
+    create = next(t for t in tools if t.name == "appfolio_create_invoice")
+
+    assert "media_refs" not in inspect.signature(create.function).parameters
+    assert "media_refs" not in create.params_model.model_fields
 
 
 @pytest.mark.asyncio()

--- a/tests/test_calendar_tools.py
+++ b/tests/test_calendar_tools.py
@@ -476,8 +476,9 @@ async def test_create_event_uses_primary_when_id_omitted(
     """When primary_calendar_id is set and the LLM omits calendar_id, the
     tool resolves to the primary instead of erroring on ambiguity. This
     is the case the contractor with crew sub-calendars hits constantly:
-    "add to my calendar" used to fail because Personal/Vinny/Isaac were
-    all enabled and the LLM didn't pick one.
+    "add to my calendar" used to fail because a personal calendar and
+    several per-crew-member calendars were all enabled and the LLM
+    didn't pick one.
     """
     tools = create_calendar_tools(
         cal_service,

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1058,7 +1058,7 @@ async def test_heuristic_does_not_fire_when_only_name_set_early(
                 "arguments": json.dumps(
                     {
                         "path": "USER.md",
-                        "content": "# User\n\n- Name: Jesse\n",
+                        "content": "# User\n\n- Name: Alice\n",
                     }
                 ),
             },
@@ -1067,7 +1067,7 @@ async def test_heuristic_does_not_fire_when_only_name_set_early(
     text_response = make_text_response("Saved that. What kind of work do you do?")
     mock_amessages.side_effect = [tool_response, text_response]  # type: ignore[union-attr]
 
-    current_message = StoredMessage(direction="inbound", body="i'm jesse", seq=3)
+    current_message = StoredMessage(direction="inbound", body="i'm alice", seq=3)
     session = SessionState(
         session_id="early-session",
         user_id=user.id,

--- a/tests/test_tool_summary.py
+++ b/tests/test_tool_summary.py
@@ -226,7 +226,7 @@ def test_append_strips_multiple_fabricated_bullets() -> None:
 
 
 def test_append_strips_gmail_fabricated_bullet() -> None:
-    """Regression: Jesse's transcript shipped "- Sent email to X" right next
+    """Regression: a production transcript shipped "- Sent email to X" right next
     to the canonical "- Sent email via Gmail X" because "sent" / "email"
     weren't in the hand-maintained strip vocabulary. After switching to
     auto-derived nouns (and adding "sent" to the global verb set), the


### PR DESCRIPTION
## Description

`appfolio_create_invoice` accepted `media_refs` and put the resolved photos into the same `POST /maintenance/api/invoices` body as `line_items`. AppFolio treats the two as mutually exclusive and answers HTTP 500 with an empty body, so every invoice carrying a photo failed outright.

Production evidence: six line-items-only invoices succeeded, then three otherwise identical bodies carrying one `files` entry all 500'd. The same photo bytes had POSTed fine to the work-order notes endpoint 101 seconds before the first failure, which rules out the file, its size, the base64 encoding, and the credential. The deployed build was unchanged for nine days across both the successes and the failures, so nothing shipped to cause this. The parameter had simply never been exercised until the agent passed an already-noted receipt handle through to the invoice tool.

This does not regress an intentional decision. #1254 added `media_refs` in the pre-capture era. #1277 then captured the SPA and recorded the verified shape as `{customer_id, work_order_id, line_items, address, reference_number}`, with no `files` key, and wrote "the SPA distinguishes by sending `files` without `line_items`" into `upload_invoice_pdf`'s docstring. The contradicting code path was left in place. #1288 dropped other never-verified write shapes on exactly this rationale.

Fix: drop `media_refs` from the tool and `files` from `service.create_invoice`, so the rejected shape cannot be rebuilt by a future caller. The tool description, usage hint, and SKILL.md now point photos at `appfolio_add_note`, the path that works today. `appfolio_upload_invoice_pdf` is untouched and stays the files-only invoice path.

## Type
- [x] Bug fix
- [x] Test

## Checklist
- [x] Tests pass (3959 passed, 6 skipped)
- [x] Lint passes (`ruff check` and `ruff format --check` clean; `ty check` clean)
- [x] New tests added for new functionality
- [x] Bug fix
- [x] Testes include regression tests

No frontend or schema changes, so `openapi.json` is unchanged.

## AI Usage
- [x] AI-assisted: diagnosed from Railway logs plus the admin LLM payload capture, then the change and tests were written by Claude Opus 5.

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._
