### PR TITLE
docs: remove stale and redundant guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Logging
 # LOG_LEVEL=INFO
 
-# Data directory for file-based storage (default: data/users)
+# Data directory for per-user workspace files (default: data/users)
 # DATA_DIR=data/users
 
 # PostgreSQL connection URL
@@ -28,9 +28,6 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:8000
 # AUTH_MODE=single_user
 JWT_SECRET=change-me-in-production
 JWT_EXPIRY_MINUTES=15
-
-# Premium plugin (leave empty for OSS mode)
-PREMIUM_PLUGIN=
 
 # Messaging
 MESSAGING_PROVIDER=telegram
@@ -122,26 +119,26 @@ LLM_MODEL=
 # Agent loop
 # APPROVAL_TIMEOUT_SECONDS=120  # Seconds to wait for user approval before denying
 # AGENT_PROCESSING_TIMEOUT_SECONDS=300  # Max seconds for agent processing (includes lock wait)
-# MESSAGE_BATCH_WINDOW_MS=1500  # Batch rapid-fire messages per user (0 to disable)
+# MESSAGE_BATCH_WINDOW_MS=1500  # Batch rapid-fire messages per user
 # INBOUND_RECOVERY_LOOKBACK_MINUTES=30  # Sweep for inbound messages persisted but never run on startup (0 disables)
 # COMPACTION_RETRY_LOOKBACK_MINUTES=10080  # Retry compaction events stuck in 'pending' on startup (0 disables)
 # MAX_TOOL_ROUNDS=10
 # MAX_INPUT_TOKENS=600000  # Hard ceiling on the input token budget; the trim trigger must stay at or below this
 # CONTEXT_TRIM_TARGET_TOKENS=120000  # Drop-to token budget after trimming (the primary trim governor)
 # CONTEXT_TRIM_TRIGGER_TOKENS=150000  # Trim fires when the prompt exceeds this and drops to CONTEXT_TRIM_TARGET_TOKENS, leaving headroom (token-side hysteresis)
-# CONTEXT_TRIM_TARGET_TURNS=600  # Turn-count backstop (tokens bind first). Older turns roll into MEMORY.md / USER.md / SOUL.md via compaction
+# CONTEXT_TRIM_TARGET_TURNS=200  # Turn-count backstop (tokens bind first). Older turns roll into MEMORY.md / USER.md / SOUL.md via compaction
 # CONTEXT_TRIM_TRIGGER_TURNS=  # Turn backstop fires when user-turn count exceeds this and drops to CONTEXT_TRIM_TARGET_TURNS. Defaults to target+16 if unset
 # COMPACTION_EVENT_SNAPSHOT_MAX_BYTES_PER_FILE=100000  # Per-file truncation cap for memory diff snapshots stored on compaction_events rows
 # LLM_MAX_RETRIES=3
 # LLM_CACHE_EXTENDED_TTL=true  # Use Anthropic's 1h cache TTL (vs default 5min); set false on providers that reject the ttl field
 
 # Conversation & memory
-# CONVERSATION_HISTORY_LIMIT=20
+# CONVERSATION_HISTORY_LIMIT=500
 # MEMORY_RECALL_LIMIT=20
 # COMPACTION_ENABLED=true
 # COMPACTION_MODEL=              # empty = fall back to LLM_MODEL
 # COMPACTION_PROVIDER=           # empty = fall back to LLM_PROVIDER
-# COMPACTION_MAX_TOKENS=500
+# COMPACTION_MAX_TOKENS=16000
 
 # Rate limiting
 # WEBHOOK_RATE_LIMIT_MAX_REQUESTS=30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,14 +108,14 @@ uv run pytest -v
 
 ### Test infrastructure
 
-**Store isolation:** The `_isolate_file_stores` autouse fixture patches `settings.data_dir` and calls `reset_stores()` to clear cached store singletons between tests. Each test runs in a database transaction that is rolled back after the test completes.
+**Store isolation:** The `_isolate_async_engine` autouse fixture points the app at the test database. The `_isolate_stores` fixture resets cached stores and truncates all tables after each test. Tests that need transaction-level isolation can opt into the `async_db` fixture.
 
 **Mock factories:** All external services are mocked in tests. Mock factories live in `tests/mocks/`:
 
 | Mock | What it replaces |
 |------|------------------|
 | Telegram | Telegram Bot API calls |
-| LLM | any-llm `acompletion` calls |
+| LLM | any-llm async calls |
 | Storage | `MockStorageBackend` for Google Drive operations |
 
 **Auth override:** The `get_current_user` dependency is overridden in tests to return a fixed test user, bypassing authentication.
@@ -127,7 +127,7 @@ uv run pytest -v
 - **Line length**: 100 characters
 - **Pydantic v2** for all data classes and request/response schemas
 - **Async routes**: all route handlers use `async def`
-- **LLM calls**: all LLM calls via any-llm `acompletion` (async)
+- **LLM calls**: all LLM calls use the async any-llm APIs
 
 ## Commit messages
 
@@ -149,9 +149,12 @@ Every change should pass all checks:
 
 ```bash
 uv run pytest -v                                  # tests pass
-uv run ruff check backend/ tests/                 # lint passes
-uv run ruff format --check backend/ tests/        # format passes
-uv run ty check --python .venv backend/ tests/    # type checking passes
+uv run ruff check backend/ tests/ alembic/        # lint passes
+uv run ruff format --check backend/ tests/ alembic/ # format passes
+uv run ty check --python .venv backend/ tests/ alembic/ # type checking passes
+cd frontend && npm run typecheck                  # TypeScript passes
+cd frontend && npm run deadcode                   # no dead JS/TS code
+cd frontend && npm run test                       # frontend tests pass
 ```
 
 - Bug fixes include regression tests

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Clawbolt is a messaging-first AI assistant that helps users manage their busines
 
 ## Features
 
-- **Memory** -- Clawbolt remembers your rates, clients, preferences, and past conversations
+- **Memory** -- Clawbolt remembers durable rates, preferences, and process rules
 - **Photo analysis** -- Send a job site photo and get an AI description for documentation
-- **File cataloging** -- Photos and documents auto-organized in your Google Drive
+- **File cataloging** -- Save and organize photos and documents in your Google Drive
 - **Proactive heartbeat** -- Clawbolt checks in periodically with reminders and follow-ups
 - **QuickBooks Online** -- Query, create, and send invoices and estimates via QuickBooks (experimental)
 - **Google Calendar** -- Check availability, schedule jobs, and manage events from chat (experimental)

--- a/backend/app/agent/compaction.py
+++ b/backend/app/agent/compaction.py
@@ -441,26 +441,9 @@ async def compact_session(
     # equal to ``current_history`` when no entry was appended this event.
     new_history: str = current_history
 
-    # Write updated MEMORY.md only when the rewrite actually differs.
-    # An LLM that returns a rewrite over the bounded-growth byte budget
-    # (see ``backend/app/agent/markdown_registry.py``) is treated as a
-    # failed compaction for that file: log a warning and keep the
-    # current memory rather than truncating mid-sentence and producing
-    # silently corrupt durable state. The conversation that triggered
-    # this compaction will still trim, and the next compaction will get
-    # another chance to produce an in-budget rewrite.
-    #
-    # All three writes are compare-and-swap against the value read at the
-    # top of this function (issue #1429). The LLM call between the read
-    # and the write takes tens of seconds, and the conversation keeps
-    # running: the agent's workspace tools can write a new fact in that
-    # window, and a second compaction for the same user can land first.
-    # A full rewrite computed from the stale read would silently clobber
-    # the newer value. On a CAS miss we keep the newer value and skip
-    # this rewrite: losing one batch's extraction is recoverable (the
-    # conversation that was sent to the LLM is preserved in the event
-    # row's ``prompt_text`` audit column), while clobbering a durable
-    # file, possibly holding an explicit user save, is not.
+    # Keep the prior file when a rewrite is oversize. Compare-and-swap all
+    # rewrites against their pre-LLM values so concurrent user or compaction
+    # writes win instead of being overwritten by stale output.
     if memory_changed:
         try:
             wrote = await memory_store.write_memory_async(
@@ -589,16 +572,8 @@ async def compact_session(
         _memory_lines_removed,
     )
 
-    # Compute "after" snapshots deterministically from what was written
-    # rather than re-reading the memory store. Two compact_session tasks
-    # for the same user can run concurrently (e.g. burst traffic crosses
-    # the trigger again during a still-running LLM compaction call), and
-    # they share ``get_memory_store(user_id)``. A re-read could pick up the
-    # other task's write and record a misleading "after" in this row's
-    # audit log. The compaction prompt returns full rewrites for memory /
-    # user / soul, and ``append_history`` returns the row's new full
-    # plaintext under the same row-level lock that wrote it, so all four
-    # "after" values are computable without re-reading.
+    # Build audit snapshots from this task's writes. A re-read could capture a
+    # concurrent compaction and record the wrong "after" value.
     new_memory = result.memory_update if memory_changed else current_memory
     new_user = result.user_profile_update if user_changed else current_user_profile
     new_soul = result.soul_update if soul_changed else current_soul

--- a/backend/app/agent/context.py
+++ b/backend/app/agent/context.py
@@ -32,8 +32,8 @@ logger = logging.getLogger(__name__)
 # Canonical trailers that ``format_approval_message`` /
 # ``format_plan_message`` append to every system-issued approval prompt.
 # Used to identify approval-prompt rows in stored history so they can be
-# filtered out before the LLM sees them (see ``load_history`` for the
-# rationale — persisted prompts trained the LLM to produce them as
+# filtered out before the LLM sees them. See ``load_history`` for the
+# rationale. Persisted prompts trained the LLM to produce them as
 # prose, creating an infinite-loop UX bug). The list is "old + current"
 # on purpose: rows persisted before the prompt rewording need to keep
 # matching after the new wording ships, otherwise the issue #1049 fix
@@ -65,26 +65,10 @@ def _is_approval_prompt(content: str) -> bool:
 
 DEFAULT_HISTORY_LIMIT = settings.conversation_history_limit
 
-# Hysteresis for the window-overflow compaction path in
-# ``load_conversation_history``: when rows fall outside the loader window,
-# this many additional rows (oldest first) are compacted along with them.
-# Without the headroom, every message after the first overflow would push
-# one more row out of the window and re-fire compaction per message, the
-# exact churn the trim path's trigger/target gap exists to prevent. 32
-# rows is the row-equivalent of the trim path's default 16-turn trigger
-# buffer (a user turn is typically an inbound + outbound row pair).
+# Extra rows compacted at window overflow to avoid re-running on every message.
 _WINDOW_OVERFLOW_BATCH_ROWS = 32
 
-# Upper bound on rows compacted per turn by the window-overflow path. A
-# legacy session can arrive with a multi-thousand-row backlog above the
-# watermark (compaction disabled for a while, or rows accumulated before
-# the overflow path shipped). Compacting the whole backlog in one go
-# would feed the entire thing into a single compaction LLM call and blow
-# its context. The batch is always a contiguous prefix starting at the
-# oldest row above the watermark, so capping it is safe: the watermark
-# advances to the end of the capped batch and the next message picks up
-# the next chunk, converging over a handful of turns. At a token-light
-# ~300 tokens/row, 200 rows is roughly 60K tokens of compaction input.
+# Bound one compaction call; subsequent turns consume the remaining backlog.
 _WINDOW_OVERFLOW_MAX_ROWS_PER_TURN = 200
 
 # Strong references to fire-and-forget background tasks so they are not
@@ -525,19 +509,8 @@ async def load_conversation_history(
         all_messages = [m for m in all_messages if m.seq > session.last_trim_seq]
     total_count = len(all_messages)
 
-    # Window-overflow compaction (issue #1427). Rows older than the
-    # ``limit`` window never reach ``trim_messages``, so the trim-driven
-    # compaction path cannot see them, and a token-light conversation can
-    # grow past the row cap while staying under the token trigger forever.
-    # Route the overflowed rows, plus a headroom batch so this does not
-    # re-fire on every subsequent message, through the same watermark +
-    # compaction machinery the trim path uses. The batch is still returned
-    # in this turn's history; the advanced watermark filters it from the
-    # next turn, mirroring trim semantics (dropped messages are visible on
-    # the turn that drops them, gone afterwards). PR #843 removed the old
-    # loader-driven compaction because it re-fired per message; the
-    # watermark advance plus headroom batching is what makes this
-    # reintroduction safe.
+    # Compact rows beyond the loader window plus headroom. They remain visible
+    # this turn; the advanced watermark removes them from the next turn.
     if total_count > limit and settings.compaction_enabled:
         compact_count = min(
             total_count - 1,

--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -119,53 +119,17 @@ MAX_INPUT_TOKENS = settings.max_input_tokens
 # context poisoning.
 _VALID_STOP_REASONS: set[str | None] = {"end_turn", "max_tokens", "tool_use", "stop_sequence", None}
 
-# Ceiling for the truncation auto-recovery ladder. A turn that keeps hitting
-# ``max_tokens`` doubles its budget each round (8192 -> 16384) and then gives
-# up rather than growing without bound.
-#
-# The bound is a *latency* budget, not a cost one: ``max_tokens`` is a ceiling
-# rather than a spend, so raising it is free on turns that finish early (the
-# common case runs 300-800 output tokens). It is only ever reached by a
-# degenerate turn that generates until something stops it, and there the cap
-# is the whole bill. Measured against a DeepSeek-family model: a runaway takes
-# ~30s to fill 8192 tokens and ~78s to fill 16384. Two rungs is therefore the
-# most a user should be asked to wait before we give up on the turn.
+# Maximum budget for retries after a response is truncated at ``max_tokens``.
 _MAX_TOKENS_CEILING = 16384
 
 _LLM_ERROR_FALLBACK = "I'm having trouble thinking right now. Can you try again in a moment?"
 
-# How often to re-send the typing indicator while the agent is blocked on a
-# slow operation. Clients that render an indicator expire it on their own once
-# refreshes stop, so the single indicator fired before an LLM call or tool round
-# goes stale partway through and the user is left with no signal for the rest of
-# the wait.
-#
-# The keepalive is channel-agnostic, so the interval has to stay under the
-# shortest expiry of any channel that renders one. Telegram is both the tightest
-# and the only one that documents a number: ``sendChatAction`` holds the status
-# for "5 seconds or less". iMessage sits at the other end and clears slowly
-# rather than promptly, which is why ``stop_typing_indicator`` exists to cancel
-# it explicitly; its expiry has not been measured, so Telegram is the binding
-# constraint here. Also short enough that a self-hosted bridge dropping one
-# request self-heals on the next tick.
+# Telegram expires typing status within five seconds, the shortest documented
+# channel window. Refresh beneath that limit; explicit stop handles slow-clearing channels.
 _TYPING_KEEPALIVE_SECONDS = 4.0
 
-# Provider phrasings for "this prompt is longer than the model's context window"
-# that any-llm does NOT classify as ``ContextLengthExceededError``. Its
-# ``convert_exception`` matches ``context.*length``, ``length.*context``,
-# ``token limit``, and ``maximum.*length``; Anthropic's actual message,
-# "prompt is too long: 214231 tokens > 200000 maximum", matches none of them, so
-# a real overflow arrives as the more generic ``InvalidRequestError`` and would
-# skip the trim-and-retry recovery entirely.
-#
-# Kept narrow on purpose. A false positive here turns a genuinely malformed
-# request (an orphaned tool_use block, a bad tool schema) into a silent retry
-# with a shorter prompt, which hides the real error and burns a second call.
-#
-# Not every probe is strictly required: any-llm's regex already catches the two
-# entries containing "context_length" / "length of the messages", so those can
-# only arrive here if a provider rewords around it. They stay as defense in
-# depth. The first two are the ones any-llm genuinely misses today.
+# Narrow provider phrases that any-llm may not classify as context overflow.
+# False positives would hide malformed requests behind a trim-and-retry cycle.
 _CONTEXT_OVERFLOW_PROBES = (
     "prompt is too long",  # anthropic
     "input is too long",  # anthropic, older wording
@@ -195,17 +159,8 @@ def _is_context_overflow(exc: AnyLLMError) -> bool:
     return any(probe in haystack for probe in _CONTEXT_OVERFLOW_PROBES)
 
 
-# Last API-reported prompt size per user (input + cache-read +
-# cache-creation tokens, since ``usage.input_tokens`` alone excludes the
-# cached slice under prompt caching), surviving across agent
-# instances. A fresh ClawboltAgent is constructed per message, so without
-# this the proactive trim at the top of ``process_message`` always falls
-# back to the chars/4 + flat-overhead heuristic, which ignores tool
-# schemas and the real system prompt size and therefore fires later than
-# configured (issue #1433). Process-local by design: after a restart the
-# first message per user falls back to the heuristic once, then the real
-# count takes over. Bounded LRU so a multi-tenant deployment cannot grow
-# it without limit.
+# Bounded process-local cache of full API-reported prompt size per user.
+# The first turn after restart falls back to the token estimate.
 _LAST_INPUT_TOKENS: OrderedDict[str, int] = OrderedDict()
 _LAST_INPUT_TOKENS_MAX = 1024
 
@@ -965,16 +920,7 @@ class ClawboltAgent:
                     target=result.receipt.target,
                     url=result.receipt.url,
                 )
-                # We do not echo the rendered receipt into result_str.
-                # The earlier design appended a "the user already sees
-                # this" preview hoping the LLM would skip restating it;
-                # the LLM restated it anyway and ``append_receipts``
-                # then added a second copy at dispatch, doubling every
-                # receipt block in the outbound message. Migration 037
-                # also closes the cross-turn version of this loop by
-                # storing the LLM's pre-receipt prose in
-                # ``messages.llm_reply_text`` so the history rebuilder
-                # does not train the model on its own appended receipts.
+                # Receipts render at dispatch and stay out of LLM-facing tool results.
             record = StoredToolInteraction(
                 tool_call_id=tc_req.id,
                 name=tool_name,
@@ -1658,17 +1604,8 @@ class ClawboltAgent:
             # Parse tool calls via shared parser
             parsed_raw = parse_tool_calls(response)
 
-            # Guard: a turn truncated by ``max_tokens`` that yielded no tool
-            # call is a partial emission, not a reply. Providers that render
-            # tool calls as markup in the completion text (rather than as
-            # structured tool_call objects) rely on a server-side parser to
-            # extract them; when generation is cut before the block closes,
-            # that parser fails open and the raw markup arrives as ordinary
-            # content. Shipping it would both show the user provider
-            # internals and, once persisted, teach the model on the next turn
-            # that emitting markup-as-text is in-distribution here. Retry with
-            # a larger budget instead, and discard the partial output if the
-            # ceiling is already reached.
+            # An unparsed max-token response may contain incomplete tool markup.
+            # Retry at a larger budget instead of delivering or persisting it.
             if not parsed_raw and response.stop_reason == "max_tokens":
                 effective = max_tokens or settings.llm_max_tokens_agent
                 if effective < _MAX_TOKENS_CEILING:
@@ -1752,17 +1689,8 @@ class ClawboltAgent:
                 response_truncated=response_truncated,
             )
 
-            # If the response was truncated, auto-increase max_tokens for the
-            # next round so the LLM has enough room to finish the tool call
-            # payload. This is deliberately not gated on the round producing a
-            # validation error: truncation always means the model had more to
-            # say, and a truncated round whose tool calls happened to validate
-            # is just as likely to truncate again on the next one. The
-            # ``_MAX_TOKENS_CEILING`` cap bounds the ladder
-            # (8192 -> 16384) before we give up. The outer ``max`` keeps the
-            # cap from *lowering* a budget an operator (or the heartbeat
-            # caller) deliberately set above the ceiling: this branch only
-            # ever raises.
+            # Raise the next-round budget after truncation. Never lower an
+            # operator-supplied budget that already exceeds the recovery ceiling.
             if response_truncated:
                 effective = max_tokens or settings.llm_max_tokens_agent
                 max_tokens = max(effective, min(effective * 2, _MAX_TOKENS_CEILING))

--- a/backend/app/agent/heartbeat.py
+++ b/backend/app/agent/heartbeat.py
@@ -708,30 +708,17 @@ async def execute_heartbeat_tasks(
     # compose detailed reports (the default agent max_tokens may be lower).
     heartbeat_max_tokens = max(settings.llm_max_tokens_agent, 1024)
 
-    # Prefix the task so the agent knows to execute it rather than
-    # treating it as a user conversation message. Two task shapes are
-    # possible. Real-world action followed by post-cleanup (shape 1) is
-    # the durable counterpart to the Phase 1 stale-item rule; cleanup-
-    # only (shape 2) is what Phase 1 routes when the dated item is
-    # already past its window. Distinguishing them in the prompt
-    # prevents the agent from "doubling up" by performing the action
-    # AND issuing the cleanup, which would re-fire side effects on a
-    # date the user no longer cares about.
-    #
-    # Partial-state failures are acceptable: if the agent finishes the
-    # real-world action but errors before update_heartbeat lands, the
-    # line stays in HEARTBEAT.md and the next tick re-evaluates it via
-    # the Phase 1 stale-item rule (with its 24-hour dedup). Better a
-    # stale line for a few ticks than skipping the user-visible action.
+    # Distinguish real actions from cleanup-only work so removing a stale item
+    # cannot replay its side effect. Failed post-action cleanup is retried later.
     task_context = (
         f"{SCHEDULED_TASK_PREFIX} and write the result to the user.\n\n"
         "Two task shapes:\n\n"
-        '1. Real-world action ("Send the Smith estimate", '
+        '1. Real-world action ("Send the Test Customer estimate", '
         '"Follow up with the customer"): perform the action. If it '
         "corresponded to a one-time dated HEARTBEAT.md item, call "
         "update_heartbeat to delete that line. Recurring patterns "
         '("every morning", "Mondays", "weekly") must stay.\n\n'
-        '2. HEARTBEAT.md cleanup task ("Remove the stale Smith '
+        '2. HEARTBEAT.md cleanup task ("Remove the stale Test Customer '
         'follow-up"): call update_heartbeat to delete the named line '
         "and stop. Do not perform any underlying real-world action; "
         "the date has passed and the user did not ask for it again. "
@@ -943,20 +930,7 @@ async def run_heartbeat_for_user(
         )
         return None
 
-    # Gate: no heartbeat items configured. If the user has no items in their
-    # HEARTBEAT.md, there is nothing for the evaluator to act on. Skip the
-    # LLM call entirely to save tokens and avoid the LLM hallucinating tasks
-    # from conversation history or past heartbeat activity.
-    #
-    # The check looks for any non-heading, non-blank line. The earlier
-    # ``.strip()`` test let header-only documents like "# Reminders\n"
-    # pass — Phase 2 would rewrite the file to that header after handling
-    # one-time items (#1116), and the next 30m tick would call the LLM
-    # to evaluate an empty list and return skip. Production telemetry
-    # showed one user burning ~48 LLM calls/day on a header-only file.
-    # Treating header-only as empty fixes that without changing
-    # ``read_heartbeat_md``, which is also called by compaction and the
-    # heartbeat tools where the raw text is the right return.
+    # Skip empty and heading-only heartbeat files so they cannot trigger work.
     heartbeat_store = HeartbeatStore(user.id)
     heartbeat_text = await heartbeat_store.read_heartbeat_md_async()
     if not _has_actionable_heartbeat_content(heartbeat_text):
@@ -1012,19 +986,8 @@ async def run_heartbeat_for_user(
         )
 
         if not response or (not response.reply_text and not sent_reply):
-            # Phase 2 ran but produced no user-facing message: this is the
-            # cleanup-only path (e.g. heartbeat fired purely to prune a
-            # stale one-time item from HEARTBEAT.md, see #1116). We still
-            # need to record it so the next tick's heartbeat history
-            # shows the removal attempt; without that line, the Phase 1
-            # 24-hour dedup rule has no signal to dedup against and the
-            # LLM keeps re-issuing the same cleanup task.
-            #
-            # ``action_type="cleanup"`` is distinct from "skip" (which
-            # means Phase 1 took no action) and from "send" (which would
-            # count toward the daily nudge budget). ``get_daily_count``
-            # excludes both "skip" and "cleanup" so this log entry is
-            # purely an audit + dedup signal, not a budget consumer.
+            # Record silent cleanup for audit and dedup without consuming the
+            # proactive-message budget.
             if response is not None:
                 heartbeat_store = HeartbeatStore(user.id)
                 await heartbeat_store.log_heartbeat(
@@ -1067,19 +1030,8 @@ async def run_heartbeat_for_user(
                     priority=3,
                 )
 
-        # Record outbound message in session history. Serialize the
-        # full tool-call list so the admin conversation view can
-        # render heartbeat-driven turns with the same fidelity as
-        # user-driven turns; without this, a heartbeat that ran
-        # qb_send / qb_update / etc. shows up as a "Done, ..." outbound
-        # with zero tool calls and is indistinguishable from a
-        # hallucinated success. Mirrors ``router.py:persist_outbound``.
-        #
-        # ``mode="json"`` coerces non-JSON-native values inside ``args``
-        # (datetime, set, UUID, etc.) to their JSON forms so
-        # ``json.dumps`` cannot trip on a tool that puts a richly typed
-        # value in its arguments. Without it, one bad arg would raise
-        # ``TypeError`` and lose the entire outbound persist.
+        # Persist tool calls with heartbeat replies so admin history can verify
+        # actions. JSON mode converts typed arguments before serialization.
         tool_interactions = ""
         if response and response.tool_calls:
             tool_interactions = json.dumps(
@@ -1292,7 +1244,7 @@ class HeartbeatScheduler:
         for queued inbound messages to drain through normal processing.
         Without this gate, a Phase 1 LLM that fires within seconds of
         boot can decide to "complete" a request the previous container
-        was already partway through — risking double execution of
+        was already partway through, risking double execution of
         side-effecting tools (qb_send, qb_create, etc.).
         """
         warmup = settings.heartbeat_startup_warmup_seconds

--- a/backend/app/agent/markdown_registry.py
+++ b/backend/app/agent/markdown_registry.py
@@ -1,25 +1,7 @@
-"""Bounded-growth registry for agent-managed markdown surfaces.
+"""Storage, write-mode, prompt-exposure, and size policies for agent markdown.
 
-Single source of truth for every markdown file the agent can read or
-write. Each surface declares:
-
-- where it is stored (which DB column or disk path);
-- how it is written (full rewrite, append, transient);
-- whether the contents are injected into an LLM prompt;
-- a hard byte budget enforced at write time;
-- a one-line description of what the file is for.
-
-The point of this registry is not just data: it is the integration
-seam used by the write paths (``workspace_tools``, ``memory_db``,
-``stores``), the read paths (``system_prompt`` builders), and the
-regression tests. Adding a new agent-mutable markdown surface without
-adding it here will fail the ``test_markdown_registry`` consistency
-tests, which is the mechanism that prevents future features from
-silently re-introducing unbounded growth.
-
-See ``docs/markdown_growth_policies.md`` for the per-surface rationale
-and the prior-art references the policies are based on (Claude Code's
-25 KB MEMORY.md cap, Letta / MemGPT's per-block character limits).
+Write paths, prompt builders, and consistency tests all consume this registry.
+See ``docs/markdown_growth_policies.md`` for the operational policy.
 """
 
 from __future__ import annotations
@@ -109,12 +91,7 @@ class BudgetExceededError(ValueError):
 # ---------------------------------------------------------------------------
 
 
-# 25 KiB across the board. Matches Claude Code's MEMORY.md cap and the
-# existing ``compaction_event_snapshot_max_bytes_per_file`` audit cap,
-# so any in-budget surface fits in audit rows without truncation. The
-# uniform value is deliberate: it makes the policy memorable and avoids
-# bikeshedding per file. Tune individual surfaces only when there is
-# evidence that a tighter or looser bound is needed.
+# One limit keeps enforcement predictable and fits below the audit snapshot cap.
 DEFAULT_BUDGET: int = 25 * 1024
 
 

--- a/backend/app/agent/memory_db.py
+++ b/backend/app/agent/memory_db.py
@@ -1,9 +1,4 @@
-"""Database-backed memory store.
-
-Replaces FileMemoryStore from file_store.py. Uses MemoryDocument ORM model
-for MEMORY.md and HISTORY.md content, and User ORM model for soul_text and
-user_text.
-"""
+"""Database-backed storage for memory, history, user, and soul text."""
 
 from __future__ import annotations
 
@@ -31,13 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Pure typed builders shared by every async store method.
-#
-# Originally introduced as the dual sync/async pilot from issue #1150 /
-# PR #1199; the sync surface has since been removed (issue #1160 final
-# pass). Builders stay because they keep query construction in one place
-# and return concretely-typed SQLAlchemy core constructs that ``ty`` can
-# verify end-to-end without ``Any``.
+# Typed query builders shared by store methods.
 # ---------------------------------------------------------------------------
 
 
@@ -123,14 +112,7 @@ def _strip_section_prefix(raw: str, prefix: str) -> str:
 
 
 class MemoryStore:
-    """Database-backed memory storage using MemoryDocument ORM model.
-
-    Async-only API after the issue #1160 final pass. The dual sync/async
-    surface from issue #1153 (PR #1199 pilot) has been collapsed: only the
-    ``*_async`` peers remain, plus ``append_history`` which keeps its
-    historical plain name (issue #1221). Premium and OSS callers all reach
-    for the async API directly.
-    """
+    """Database-backed workspace-text storage for one user."""
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id

--- a/backend/app/agent/prompts/compaction.md
+++ b/backend/app/agent/prompts/compaction.md
@@ -2,7 +2,7 @@ You are a memory consolidation agent for Clawbolt, an AI assistant for trades co
 
 ## Operating principle
 
-Clawbolt is **not the system of record**. The contractor's authoritative data lives in their integrations:
+Clawbolt is **not the system of record**. Authoritative, changeable data lives in integrations:
 
 | Source of truth | What it owns |
 | --- | --- |
@@ -12,11 +12,7 @@ Clawbolt is **not the system of record**. The contractor's authoritative data li
 | Google Calendar / heartbeat | time-bounded reminders, recurring tasks |
 | Google Drive | saved files, receipt images |
 
-A fact owned by an integration can change inside that integration without telling Clawbolt. Phone numbers, emails, statuses, amounts, IDs, addresses can all be edited, rotated, or replaced upstream at any time. Memorizing them creates a stale-cache risk: a value that was correct when written can become wrong, even dangerously wrong, by the time the agent reads it next.
-
-**Worked example:** AppFolio rotates tenant contact phone numbers every few days for privacy. A memorized number quoted back next week now belongs to a different tenant, and the contractor calls a stranger. Look these values up live, every time. Never memorize a value the source system can change without telling Clawbolt.
-
-Memory exists for cross-system knowledge that lives nowhere else.
+Do not memorize values that can change upstream. Memory is for durable cross-system knowledge that lives nowhere else.
 
 ## Inputs
 
@@ -48,7 +44,7 @@ One terse 1 to 3 sentence breadcrumb entry per event, one per line.
 
 Take each event's time from the nearest marker at or before it, in 24-hour form. A marker can sit far above the event it precedes, so when the nearest one is hours off, drop the time and stamp the date alone; never copy one marker's time onto every event under it. With no marker visible, write the literal `[TIMESTAMP]` and the system fills in the current time.
 
-**Resolve every relative time reference to an absolute date in the prose.** "today", "tomorrow", "this Friday", "earlier" are wrong when this breadcrumb is read days later. Write "scheduled the Miller job for June 3-5", never "added Miller today".
+**Resolve every relative time reference to an absolute date in the prose.** "today", "tomorrow", "this Friday", and "earlier" become ambiguous later. Write "scheduled the Test Customer job for June 3-5", never "added Test Customer today".
 
 Pointers over numbers. Drop deep links, draft IDs, and dollar amounts (unless the dollar is genuinely the news). Skip trivial small talk. Return an empty string when nothing noteworthy happened.
 
@@ -68,14 +64,11 @@ Pointers over numbers. Drop deep links, draft IDs, and dollar amounts (unless th
 
 **Explicit user save requests override these exclusion rules.** If the conversation contains a clear directive to save a fact ("remember X", "save this", "make a note that..."), preserve that fact in MEMORY.md, even when it overlaps with what an integration owns. The contractor has chosen to memorialize it; trust that. The base agent is responsible for warning the contractor about staleness risk on mutating values at save time, so by the time the conversation reaches you, an explicit save is intentional.
 
-**Compliance audit rule.** Delete every line that violates the "Do not include" list above. This applies even if the line was written by a previous compaction, and even if no `<conversation>` was provided. Exclusion-list violations must be removed regardless of relevance. A line that was explicitly saved by the user (see override above) is not a violation.
-
 ## USER.md: the contractor themselves
 
 - Name, business name, trade, crew composition
 - Default rates (day rate, hourly), service area, timezone
 - Working-hours and communication preferences
-- Which integrations the contractor has connected on the Clawbolt side
 
 Client-specific pricing or billing rules belong in MEMORY.md, not here. Preserve every existing field on rewrite; only change a field the conversation contradicts. Return an empty string when nothing profile-relevant changed.
 

--- a/backend/app/agent/prompts/instructions.md
+++ b/backend/app/agent/prompts/instructions.md
@@ -30,21 +30,18 @@ Changeable values (balances, statuses, schedules, etc) live in the integrations,
 Durable facts you deliberately saved (rate cards, process rules) do not need re-checking.
 
 ## Keeping files up to date
-Update these files proactively as you learn new things. Do not ask permission. Just do it naturally as part of the conversation.
+Update these files proactively as you learn durable facts. Do not ask permission.
 
 You are not the system of record for the contractor; the integrations are. Look them up live for current values instead of mirroring them into your files where they can go stale.
 
-- **SOUL.md**: Your personality, communication style, and identity. Update when the user gives you feedback about how to talk ("be more blunt", "stop using emojis") or when your working relationship evolves. This file defines who you are.
-- **USER.md**: The user's business profile: name, business name, trade, crew size, default day/hourly rate, geographic area, timezone, working-hours preferences. Client-specific pricing rules live in MEMORY.md, not here. Never record integration connection state in USER.md (e.g. "Google Drive: connected"); the "Connected Integrations" section is the live source of truth and your copy will drift the moment the user OAuths or revokes.
-- **MEMORY.md**: Durable cross-system knowledge that lives nowhere else: pricing rules and rate cards keyed by client, communication conventions, cross-system relationships ("X is billed through Y, not a direct customer"), disambiguation guidance, persistent process rules. Do not write customer contact details, invoice contents, project addresses, or work-order state here: those live in the integrations, can change without telling you, and looking them up live is more reliable than recalling them.
-- **HEARTBEAT.md**: Recurring things to check on: unpaid invoices, pending estimates, ongoing follow-ups, active job deadlines. Items surface within a window, not at an exact clock time, so don't write time-specific reminders ("at 2pm", "7:30am") here (see the Timed reminders section). Suggest adding items when the user asks about ongoing monitoring.
+- **SOUL.md**: Personality, communication style, and working-relationship norms.
+- **USER.md**: Business profile, trade, crew, default rates, service area, timezone, and working preferences. Never record integration connection state; the live integration status is authoritative.
+- **MEMORY.md**: Durable knowledge that lives nowhere else, such as pricing rules, cross-system relationships, disambiguation guidance, and process rules. Exclude customer contacts, invoice contents, project addresses, and work-order state owned by integrations.
+- **HEARTBEAT.md**: Recurring checks and ongoing follow-ups. Items run within a window, not at an exact time. Suggest it for ongoing monitoring.
 
 ## "Remember this" requests
 
-When the user explicitly says "remember X", "save this", "make a note that...", honor the request. Two cases call for a brief caveat before saving:
-
-- **The value can change in the source system.** Phone numbers, emails, statuses, balances. Save if the user insists but flag the staleness risk in one sentence ("Saving for now, but AppFolio rotates these numbers, so I'll re-check before quoting it back"), or offer to skip and look it up live each time.
-- **The fact already lives canonically in a connected integration.** Saving a duplicate creates drift between the two copies. Offer to look it up live; save if the user prefers the convenience.
+Honor explicit requests to remember or save a fact. If the value can change or already lives in an integration, briefly flag the stale-copy risk and offer to look it up live. Save it if the user still prefers.
 
 Never refuse a save request outright.
 
@@ -71,27 +68,9 @@ The system automatically saves "Always" / "Never" replies to those prompts. Do n
 Only edit PERMISSIONS.json yourself when the user asks a plain-chat question or gives a plain-chat directive -- for example, "what are my permissions?" (read_file) or "set qb_query to ask for all entities" (edit_file). Never in response to an Always / Never reply.
 
 ## File uploads
-File storage is opt-in: the user must connect Google Drive. Files land in their own Drive under a top-level Clawbolt folder.
+Google Drive storage is opt-in. When it is connected, upload new attachments without a conversational pre-check; the permission system handles approval. Organize client work under `/{Client Name [- Address]}/{photos|estimates|documents}` and otherwise use `/Inbox`.
 
-When the user sends a photo, document, or other file attachment and file storage is enabled, call upload_to_storage. Do not ask "want me to save this?" in chat first. The permission system handles the approval prompt; a conversational pre-check creates a frustrating double-confirmation.
-
-Pick folder_path from context: for client work, organize under `/{Client Name [- Address]}/{photos|estimates|documents}` (e.g. `/Acme - 123 Main Street/photos`) so future find_saved_files calls turn it up by client. Otherwise leave folder_path off (defaults to `/Inbox`) or use the path the user named.
-
-Notes:
-- If the file was already saved on a prior turn (it shows up in find_saved_files), use move_file with its storage path instead of uploading again.
-- If Drive is not connected, do not save the file. Tell the user briefly, offer manage_integration(action='connect', target='google_drive'), and continue. Other integrations like CompanyCam still work without Drive.
-
-For previously saved files:
-- Use find_saved_files to pull up older receipts, photos, or documents by filename or saved description. Each result is quoted as a path like /Acme - 123 Main Street/photos/foo.jpg.
-- Quote that path when calling move_file (from_path), analyze_saved_file (file_ref), or any cross-tool flow that takes a media reference (companycam_upload_photo, AppFolio file uploads). The path is the durable handle for a saved file; do not invent shorter ids.
+Use `find_saved_files` for older files and pass its returned storage path verbatim to other tools. Move an already-saved file instead of uploading it again. If Drive is disconnected, offer `manage_integration(action='connect', target='google_drive')` and continue without saving.
 
 ## Integrations
-You can manage integrations directly in this chat using manage_integration:
-- To see all integrations and their status: manage_integration(action="status")
-- To enable or disable a tool group: manage_integration(action="enable", target="calendar")
-- To connect an OAuth integration: manage_integration(action="connect", target="google_calendar")
-- To disconnect: manage_integration(action="disconnect", target="google_calendar")
-
-When a user asks about connecting an integration, generate a link for them.
-They can tap it to complete the setup in their browser, then come back here.
-When a user asks what tools or integrations are available, use the status action.
+Use `manage_integration` for status, enable, disable, connect, and disconnect requests. Generate a connection link when asked; use the status action when asked what is available.

--- a/backend/app/agent/session_db.py
+++ b/backend/app/agent/session_db.py
@@ -1,19 +1,4 @@
-"""Database-backed session store.
-
-Replaces FileSessionStore from file_store.py. Uses ChatSession and Message
-ORM models for persistence, while keeping SessionState and StoredMessage
-Pydantic models as in-memory DTOs.
-
-Dual-API rollout (issue #1152, part of #1139): each public sync method
-has an ``*_async`` peer with identical semantics; the two share query
-construction via the ``_*_select`` / ``_*_delete`` / ``_advisory_*``
-builders below. Mirrors the pilot in
-``backend/app/agent/stores.py::IdempotencyStore`` (issue #1150 / PR #1199).
-Sync callers (CLI, Alembic, premium during the migration window) keep
-working unchanged while OSS-internal callers migrate to the async API
-one site at a time. SessionStore is the largest single store in the
-rollout, so this file is also the largest single conversion.
-"""
+"""Database-backed session storage and its in-memory DTO conversion."""
 
 from __future__ import annotations
 
@@ -88,14 +73,10 @@ def _session_to_state(
 
 
 # ---------------------------------------------------------------------------
-# Pure typed builders shared by sync and async paths
+# Typed query builders
 # ---------------------------------------------------------------------------
 #
-# Each builder returns a fully typed ``Select`` / ``Delete`` / ``TextClause``
-# so the sync and async methods stay in lockstep without subclassing.
-# Mirrors ``backend/app/agent/stores.py``'s pilot pattern (PR #1199).
-# Builders never touch a session and never return ``Any``; ``ty`` enforces
-# this at the Definition of Done.
+# Builders keep SQLAlchemy results concrete and free of ``Any``.
 
 
 def _advisory_lock_key(user_id: str) -> str:
@@ -258,14 +239,7 @@ _MESSAGE_UPDATABLE_FIELDS: frozenset[str] = frozenset(
 
 
 class SessionStore:
-    """Database-backed session storage using ChatSession and Message ORM models.
-
-    Async-only API after the issue #1160 final pass. The dual-API surface
-    from issue #1152 has been collapsed: only the async implementations
-    remain. The bare-name methods now delegate to their ``*_async`` peers
-    to keep the public surface stable for any out-of-tree caller; OSS and
-    premium have all migrated to the suffixed names.
-    """
+    """Database-backed session storage using ChatSession and Message models."""
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
@@ -781,13 +755,7 @@ class SessionStore:
     # ------------------------------------------------------------------
 
     async def get_recent_messages_async(self, count: int | None = None) -> list[StoredMessage]:
-        """Get the most recent messages in the user's session.
-
-        NOTE: the old ``get_other_session_messages_async`` peer (and the
-        ``exclude_session_id`` plumbing) was removed in issue #1433:
-        migration 026 collapsed sessions to one per user, so excluding
-        the current session always returned the empty list.
-        """
+        """Get the most recent messages in the user's session."""
         resolved = count if count is not None else settings.heartbeat_recent_messages_count
         db = AsyncSessionLocal()
         try:

--- a/backend/app/agent/skills/file/SKILL.md
+++ b/backend/app/agent/skills/file/SKILL.md
@@ -1,6 +1,6 @@
 # File Tools (Google Drive)
 
-Clawbolt stores files in the user's Google Drive under a top-level `Clawbolt` folder. Photos, documents, and text files uploaded or created here persist across conversations and are visible via `find_saved_files`.
+Clawbolt stores persistent files in the user's Google Drive under a top-level `Clawbolt` folder.
 
 ## Available Tools
 
@@ -16,15 +16,13 @@ Clawbolt stores files in the user's Google Drive under a top-level `Clawbolt` fo
 
 ## When to use storage tools vs. workspace tools
 
-- **Storage tools** (`upload_to_storage`, `write_to_storage`, `edit_storage_file`, `read_from_storage`, `move_file`, `find_saved_files`, `analyze_saved_file`) operate on the user's Google Drive. Files here persist across conversations and are visible outside the chat (the user can open them in Drive). Use storage tools for documents, notes, photos, invoices, and any content the user may want to access outside of Clawbolt.
-
-- **Workspace tools** (`read_file`, `write_file`, `edit_file`) operate on Clawbolt's internal state files: `USER.md` (user profile), `SOUL.md` (personality), `MEMORY.md` (long-term facts), `PERMISSIONS.json` (tool permissions). These files are invisible to the user and only affect agent behavior. Use workspace tools to update what the agent knows about the user or how it behaves.
+- **Storage tools** operate on user-visible, persistent Google Drive files.
+- **Workspace tools** (`read_file`, `write_file`, `edit_file`) operate on internal behavior files such as `USER.md`, `SOUL.md`, `MEMORY.md`, and `PERMISSIONS.json`.
 
 ## Writing vs. Uploading
 
-- `write_to_storage`: Use when the user asks you to create a file from text you write (notes, summaries, documents, lists, etc.). Provide the filename and the text content. The file is created as a new file; if the name already exists, a numeric suffix is added to avoid overwriting.
-
-- `upload_to_storage`: Use when the user sends an attachment (photo, PDF, document) and asks you to save it. The tool reads the attachment bytes, not text you generate.
+- Use `write_to_storage` for text you generate.
+- Use `upload_to_storage` for an attachment the user sent.
 
 ## Editing a file
 
@@ -36,14 +34,10 @@ Clawbolt stores files in the user's Google Drive under a top-level `Clawbolt` fo
 
 If `old_text` appears more than once, the tool rejects the edit as ambiguous. Read the file again and provide more context (surrounding lines) to narrow the match.
 
-## Reading a file
-
-`read_from_storage` returns the full text content of a file. Use it before editing to see what is currently in the file, or when the user asks you to check the contents of a saved note or document.
-
 ## Finding saved files
 
 `find_saved_files` searches filenames and descriptions. Pass a query string to narrow results, or leave it empty to list the most recent files. Results include the storage path; quote that path when calling `read_from_storage`, `edit_storage_file`, `move_file`, or `analyze_saved_file`.
 
 ## Connecting
 
-The user must connect Google Drive via `manage_integration(action='connect', target='google_drive')`. Until they do, all file tools are hidden.
+Connect Google Drive with `manage_integration(action='connect', target='google_drive')`. Until then, file tools are hidden.

--- a/backend/app/agent/stores.py
+++ b/backend/app/agent/stores.py
@@ -70,10 +70,7 @@ def _tool_config_to_dto(tc: ToolConfig) -> ToolConfigEntry:
 # ---------------------------------------------------------------------------
 
 
-# Builders shared by sync and async heartbeat methods (issue #1154).
-# Same dual-API pattern as the IdempotencyStore pilot in #1199: pure
-# ``select(...)`` builders so the two paths stay in lockstep without a
-# class hierarchy.
+# Typed query builders shared by heartbeat methods.
 def _heartbeat_user_select(user_id: str) -> Select[tuple[User]]:
     """Builder shared by ``read_heartbeat_md`` / ``write_heartbeat_md`` peers."""
     return select(User).filter_by(id=user_id)
@@ -116,13 +113,7 @@ def _today_window_utc() -> tuple[datetime.datetime, datetime.datetime]:
 
 
 class HeartbeatStore:
-    """Database-backed heartbeat storage using User.heartbeat_text and HeartbeatLog ORM models.
-
-    Async-only API after the issue #1160 final pass. The sync
-    ``read_heartbeat_md`` method introduced as a transition shim in
-    issue #1154 has been removed; all OSS and premium callers use
-    :meth:`read_heartbeat_md_async`.
-    """
+    """Database-backed heartbeat text and send history for one user."""
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
@@ -251,12 +242,7 @@ class HeartbeatStore:
 _SEEN_MAX = 10_000
 
 
-# Pilot for the per-store dual-API rollout (issue #1150). Internal
-# logic is factored into pure ``select(...) / delete(...)`` builders
-# so the sync and async methods stay in lockstep without a class
-# hierarchy. Each public sync method has an ``*_async`` peer; both
-# forward through the same builders. Stores #1151-#1157 should
-# follow this pattern.
+# Typed query builders shared by idempotency methods.
 def _seen_select(external_id: str) -> Select[tuple[IdempotencyKey]]:
     """Builder shared by ``has_seen`` and ``has_seen_async``."""
     return select(IdempotencyKey).filter_by(external_id=external_id)
@@ -288,11 +274,7 @@ class IdempotencyStore:
     Uses the IdempotencyKey ORM model. No user_id scoping -- external_id
     is globally unique.
 
-    Async-only as of issue #1160. The webhook entry path is async, the
-    test fixtures drive it through ``httpx.AsyncClient`` so the route
-    runs on the same event loop as the test's async DB connection.
-    ``*_async`` aliases are kept as thin wrappers for any out-of-tree
-    caller still on the suffix.
+    ``*_async`` aliases remain as deprecated compatibility wrappers.
     """
 
     async def has_seen(self, external_id: str) -> bool:
@@ -439,13 +421,7 @@ def _build_llm_usage_log(
 
 
 class LLMUsageStore:
-    """Database-backed LLM usage logging using LLMUsageLog ORM model.
-
-    Async-only API after the issue #1160 final pass. The sync ``log``
-    method has been removed; ``services.llm_usage.log_llm_usage`` is
-    the canonical async entry point and threads cost computation
-    plus the unpriced-model warning through ``_build_llm_usage_log``.
-    """
+    """Database-backed LLM usage logging for one user."""
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
@@ -492,10 +468,7 @@ class LLMUsageStore:
 # ---------------------------------------------------------------------------
 
 
-# Builders shared by sync and async tool-config methods (issue #1157).
-# Pure ``select(...) / delete(...)`` builders so the two paths stay in
-# lockstep without a class hierarchy. Same pattern as the
-# IdempotencyStore pilot.
+# Typed query builders shared by tool-configuration methods.
 def _tool_config_load_select(user_id: str) -> Select[tuple[ToolConfig]]:
     """Builder shared by ``load`` / ``load_async``."""
     return (
@@ -555,14 +528,7 @@ def _new_disabled_tool_config(user_id: str, name: str, enabled: bool) -> ToolCon
 
 
 class ToolConfigStore:
-    """Database-backed tool configuration using ToolConfig ORM model.
-
-    Async-only API (issue #1160). The dual sync+async surface from
-    issue #1157 has been collapsed: only the async implementation
-    remains. ``*_async`` aliases stay as thin wrappers in case any
-    out-of-tree caller still depends on the suffix; the OSS callers
-    have all been migrated to the bare names.
-    """
+    """Database-backed tool configuration for one user."""
 
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id

--- a/backend/app/agent/system_prompt.py
+++ b/backend/app/agent/system_prompt.py
@@ -378,12 +378,6 @@ async def _build_agent_prompt_builder(
             dynamic=True,
         )
 
-    # NOTE: the old "Recent Activity (other channel)" cross-session section
-    # was removed (issue #1433): migration 026 collapsed sessions to one per
-    # user, so the query excluding the current session always returned
-    # empty. All channels share the single session, so channel switches are
-    # already covered by ordinary history.
-
     return builder
 
 

--- a/backend/app/agent/tool_summary.py
+++ b/backend/app/agent/tool_summary.py
@@ -113,7 +113,7 @@ _CC_TAIL_RE = re.compile(r"\s*(?:on\s+|to\s+)?companycam(?:\s+\w+)?\s*$", re.IGN
 # Generic single-noun fallback words an integration may set as
 # ``target`` when it does not have a human name for the entity
 # (archive_project, delete_photo, delete_project, etc.). These are
-# universal English nouns, not CompanyCam-specific — any future
+# universal English nouns, not CompanyCam-specific. Any future
 # integration using the same fallback approach benefits for free.
 # When grouping, prefer any real name over these.
 _GENERIC_TARGETS: frozenset[str] = frozenset(

--- a/backend/app/agent/user_db.py
+++ b/backend/app/agent/user_db.py
@@ -1,16 +1,4 @@
-"""Database-backed user store.
-
-Replaces the file-based UserStore from the old file_store.py. Uses the User
-ORM model for persistence, while keeping UserData Pydantic model as the public
-API surface for backward compatibility with premium.
-
-Uses ``AsyncSessionLocal`` / ``db_session_async()`` for all UserStore methods.
-The dual sync+async API from the migration window (issue #1151) has been
-collapsed: only the async implementation remains, and the public method
-names are unsuffixed. ``*_async`` aliases are kept as thin wrappers so
-the premium layer continues to compile against this store while it
-finishes dropping the suffix on its own callers.
-"""
+"""Database-backed user store exposing UserData DTOs."""
 
 from __future__ import annotations
 
@@ -163,11 +151,7 @@ _USER_UPDATABLE_FIELDS: frozenset[str] = frozenset(
 )
 
 
-# Dual-API collapse (issue #1160, originally introduced in #1151 as part
-# of the OSS-wide async-DB rollout). Each public method now uses native
-# async access via ``AsyncSessionLocal``; the pure ``select(...)``
-# builders below survive because they document the shared shapes and
-# keep ``ty`` happy when the same query is reused across helpers.
+# Typed query builders shared by user-store methods.
 def _user_by_id_select(user_id: str | int) -> Select[tuple[User]]:
     """Builder for ``get_by_id`` and the update paths."""
     return select(User).filter_by(id=str(user_id))
@@ -195,14 +179,7 @@ def _apply_updates(user: User, fields: dict[str, Any]) -> None:
 
 
 class UserStore:
-    """Database-backed user storage using User ORM model.
-
-    Async-only API (issue #1160). The dual sync+async surface from the
-    migration window (issue #1151, PR #1199 pilot) has been collapsed
-    to a single async implementation. ``*_async`` aliases are kept as
-    thin wrappers so premium continues to compile while it drops the
-    suffix on its own callers.
-    """
+    """Database-backed user storage using the User model."""
 
     async def get_by_id(self, user_id: str | int) -> UserData | None:
         """Look up a user by primary key (id)."""

--- a/backend/app/channel_state.py
+++ b/backend/app/channel_state.py
@@ -67,12 +67,7 @@ def realign_preferred_channel(db: Session, user: User) -> None:
 
 
 async def realign_preferred_channel_async(db: AsyncSession, user: User) -> None:
-    """Async peer of :func:`realign_preferred_channel`.
-
-    Same semantics; mirrors the dual-API store pattern (issue #1150) so
-    async write paths in OSS and premium can call the helper without
-    blocking on a sync session.
-    """
+    """Async peer of :func:`realign_preferred_channel`."""
     await db.flush()
     existing = (await db.execute(_preferred_match_select(user))).scalar_one_or_none()
     if existing is not None:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,41 +9,9 @@ from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 
-# Opt in to any-llm's unified exception family.
-#
-# any-llm still defaults to re-raising the raw provider SDK exception and only
-# converts to ``any_llm.exceptions`` types when this variable is truthy (see
-# ``any_llm.utils.exception_handler._handle_exception``). Without it, every
-# unified-exception handler in this codebase is dead code, because an
-# ``anthropic.RateLimitError`` is not an ``any_llm.RateLimitError``:
-#
-#   * ``core.py::_call_llm_with_retry`` never backs off on a rate limit, never
-#     trims and retries on a context overflow, and never logs the specific
-#     content-filter or auth diagnostics.
-#   * ``router.py::run_agent`` never returns ``CONTENT_FILTER_FALLBACK`` or
-#     ``AUTH_ERROR_FALLBACK``.
-#
-# Every failure instead lands in the generic ``except Exception`` and the user
-# gets "I'm having trouble thinking right now" with no retry. Observed in
-# production: an upstream 400 arrived as a raw ``anthropic.BadRequestError`` and
-# reached ``run_agent``'s generic handler.
-#
-# ``setdefault`` so an operator can opt out with
-# ``ANY_LLM_UNIFIED_EXCEPTIONS=0``, but note that has to be a real environment
-# variable: pydantic-settings reads ``.env`` into the ``Settings`` model without
-# writing it back to ``os.environ``, so a ``.env`` entry is invisible here. It
-# does work via ``docker compose`` ``env_file`` and on a platform's env config,
-# both of which inject real variables.
-#
-# any-llm reads the variable inside ``_handle_exception``, i.e. per raise rather
-# than at import time, so this does not depend on import ordering; config is
-# nonetheless imported by every module that calls ``amessages``.
-#
-# One conversion is load-bearing elsewhere: with this on, a provider that cannot
-# enumerate models raises ``NotImplementedError`` from inside any-llm's decorator
-# and arrives wrapped, which would silently kill the ``except
-# NotImplementedError`` branch callers use to render a free-text model field.
-# ``llm_service.get_models`` unwraps it so that signal survives.
+# Use any-llm's provider-independent exception types so retry and fallback logic
+# can handle rate limits, context overflow, auth failures, and content filters.
+# ``setdefault`` preserves an operator's explicit process-level override.
 os.environ.setdefault("ANY_LLM_UNIFIED_EXCEPTIONS", "1")
 
 # Default hysteresis buffer for the turn-count trim backstop: when
@@ -80,18 +48,8 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:3000,http://localhost:8000"
     jwt_secret: str = "change-me-in-production"
     jwt_expiry_minutes: int = Field(default=15, ge=1)
-    # Who the app authenticates, and the deployment's tenancy switch.
-    #
-    # "single_user" is the self-hosted default: no credentials, every
-    # request resolves to the one user in the database, and none of the
-    # hosted-deployment surface below is reachable.
-    #
-    # "multi_user" turns on Google OAuth sign-in, JWT sessions, the admin
-    # console, per-tenant quota enforcement, and the operator monitoring
-    # stack. It requires a registered current-user resolver and rejects
-    # requests that do not carry one; see
-    # ``backend/app/auth/dependencies.py``. The settings from
-    # "Multi-user deployment" onward only matter in this mode.
+    # Tenancy switch. Multi-user mode enables authenticated hosted surfaces;
+    # single-user mode resolves requests to the deployment's sole user.
     auth_mode: Literal["single_user", "multi_user"] = "single_user"
     # Backend for runtime-configurable settings: "db" (default) stores in
     # the app_settings table; "file" keeps the legacy data/config.json
@@ -111,29 +69,8 @@ class Settings(BaseSettings):
     vision_model: str = ""  # empty = fall back to llm_model
     vision_provider: str = ""  # empty = fall back to llm_provider
     reasoning_effort: str = "auto"  # none, minimal, low, medium, high, xhigh, auto
-    # Sized to fit a typical multi-tool turn (one ~200-token reply plus a tool
-    # call whose JSON args can run 500-1500 tokens for nested entity payloads
-    # in the QuickBooks / CompanyCam tools) *plus* the reasoning tokens a
-    # thinking-by-default model spends before it emits anything at all.
-    #
-    # Raised 2048 -> 8192: reasoning models bill their chain-of-thought against
-    # this same budget, so 2048 left almost no headroom, and this path had the
-    # tightest budget in the file despite being the most tool-heavy one
-    # (heartbeat already gets 12000, compaction 16000).
-    #
-    # Truncation is not a benign "reply got cut short": a provider that renders
-    # tool calls as markup in the completion text needs the closing token to
-    # parse them, so a cut mid-block yields zero tool calls and leaks the raw
-    # markup as content (the ``core.py`` guard now discards that rather than
-    # delivering it). Measured against a DeepSeek-family model on a two-event
-    # calendar request: at 2048, 3 of 6 turns truncated and leaked; a
-    # *successful* turn consumed 1817 output tokens; and one turn needed more
-    # than 4096, recovering only on the ladder's second rung.
-    #
-    # Raising this is close to free. ``max_tokens`` is a ceiling, not a spend,
-    # and healthy turns here run 300-800 output tokens, so the higher default
-    # changes nothing about what they cost. It is only reached by a degenerate
-    # turn, which is what ``_MAX_TOKENS_CEILING`` bounds.
+    # Allows reasoning plus nested tool payloads without truncating a tool call.
+    # ``core.py`` applies a separate recovery ceiling to runaway generations.
     llm_max_tokens_agent: int = Field(default=8192, ge=1)
     llm_max_tokens_heartbeat: int = Field(default=12000, ge=1)
     llm_max_tokens_vision: int = Field(default=12000, ge=1)
@@ -145,108 +82,36 @@ class Settings(BaseSettings):
     google_drive_client_id: str = ""
     google_drive_client_secret: str = ""
 
-    # Inbound media staging: bytes for photos/files the user sends over the
-    # messaging channel land here until the agent uploads them somewhere
-    # durable (CompanyCam, Drive) or the 7-day TTL expires. Point this at a
-    # persistent volume in production; the bytes survive process restarts so
-    # the agent can still reference photos from days ago. Metadata lives in
-    # the ``staged_media`` Postgres table.
-    #
-    # MULTI-REPLICA WARNING: this path must be writable by exactly one
-    # application instance. If clawbolt is ever deployed across multiple
-    # replicas, the on-disk bytes are no longer shared and the staging cache
-    # needs to move to Postgres BYTEA or an object store. Tracked at
-    # https://github.com/mozilla-ai/clawbolt/issues/1336.
+    # Persistent staging for inbound media bytes; metadata is in Postgres.
+    # One application instance must own this path. See issue #1336.
     media_staging_base_dir: str = "data/staged_media"
 
     # Agent loop
     approval_timeout_seconds: int = Field(default=120, ge=1)
     agent_processing_timeout_seconds: float = Field(default=300.0, gt=0)
     message_batch_window_ms: int = Field(default=1500, ge=100)
-    # Inbound messages are persisted before MessageBatcher schedules an
-    # in-memory flush task. If the worker dies during that window the
-    # message lives in the DB but never reaches the agent. On startup we
-    # sweep for inbound rows from the last N minutes that have no
-    # outbound after them and re-dispatch each. Older orphans are
-    # unlikely to still be relevant; tune up if you have evidence
-    # otherwise. 0 disables the sweep entirely.
+    # Redispatch recently persisted inbound messages that lack an outbound reply.
+    # Zero disables startup recovery.
     inbound_recovery_lookback_minutes: int = Field(default=30, ge=0)
-    # Startup sweep for ``compaction_events`` rows stuck in ``'pending'``:
-    # the async compaction LLM call crashed (deploy restart, provider
-    # outage) after the trim watermark advanced, so the seq range's facts
-    # were never extracted into MEMORY.md. Rows older than a 10-minute
-    # grace floor and younger than this lookback are retried on boot
-    # (max 3 attempts per row, tracked in ``retry_count``). Unlike
-    # orphaned inbounds, a stale compaction stays fully recoverable for
-    # as long as the message rows exist, so the default lookback is a
-    # week rather than minutes. 0 disables the sweep entirely.
+    # Retry recent pending compactions at startup. Zero disables recovery.
     compaction_retry_lookback_minutes: int = Field(default=10_080, ge=0)
     max_tool_rounds: int = Field(default=10, ge=1)
     max_input_tokens: int = Field(default=600_000, ge=1)
-    # Primary trim governor: the raw conversation window is bounded by
-    # tokens, not turns. Trim fires when the prompt exceeds
-    # ``context_trim_trigger_tokens`` and drops the oldest turns until it
-    # is back under ``context_trim_target_tokens``. The gap between the two
-    # is hysteresis: a single threshold (target == trigger) would re-fire
-    # compaction on every message once the resting state sits at the
-    # ceiling. ~30K of headroom spaces trims a few active days apart for a
-    # token-light messaging user. Lower the target to trade raw recall for
-    # per-turn cost; the full window is sent every turn.
+    # Primary trim governor. Trigger above the target to provide hysteresis.
     context_trim_target_tokens: int = Field(default=120_000, ge=1)
     context_trim_trigger_tokens: int = Field(default=150_000, ge=1)
-    # Turn-count backstop. Tokens bind first for token-heavy users (150K
-    # is reached well before this cap when messages carry tool traffic);
-    # this cap is what protects token-light users, whose conversations
-    # can grow past ``conversation_history_limit`` rows while staying
-    # under the token trigger forever. The backstop must therefore be
-    # reachable inside the loader window: a user turn is typically an
-    # inbound + outbound row pair, so the effective trigger needs about
-    # 2x its value in rows, and ``log_config_warnings`` warns when
-    # ``2 * (trigger + 1) > conversation_history_limit`` (issue #1427).
-    # Trimming oldest turns past this cap rolls them through compaction
-    # into MEMORY.md / USER.md / SOUL.md. ge=2 so at least one prior turn
-    # is always retained; not ``None``, which would disable the guard
-    # entirely.
+    # Backstop for many token-light turns. Must remain reachable inside
+    # ``conversation_history_limit``; ``log_config_warnings`` enforces this.
     context_trim_target_turns: int = Field(default=200, ge=2)
-    # Turn-backstop trigger threshold: the turn cap fires only when the
-    # user-turn count exceeds this, then drops to
-    # ``context_trim_target_turns`` (same hysteresis rationale as the token
-    # path). When ``None``, defaults to ``context_trim_target_turns +
-    # CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS`` inside ``trim_messages``.
+    # None resolves to target plus CONTEXT_TRIM_DEFAULT_TRIGGER_BUFFER_TURNS.
     context_trim_trigger_turns: int | None = Field(default=None)
-    # Per-file truncation cap for memory-text snapshots persisted on
-    # ``compaction_events`` rows. A user with a 500KB MEMORY.md would
-    # otherwise produce ~4MB rows once before/after for all four files
-    # (memory, history, user, soul) is included. When a file exceeds the
-    # cap, the snapshot column stores a structured truncation record
-    # (head, tail, size, sha256) rather than the full text. Bounds the
-    # worst-case row size while keeping admin diff visibility intact.
+    # Per-file cap for compaction-event snapshots. Oversize content is stored
+    # as a head/tail/hash record rather than full text.
     compaction_event_snapshot_max_bytes_per_file: int = Field(default=100_000, ge=1024)
     llm_max_retries: int = Field(default=3, ge=1)
-    # Use Anthropic's 1-hour extended-TTL cache instead of the default
-    # 5-minute ephemeral cache. Inactive users with conversation gaps
-    # >5 min currently always miss the prompt cache on their first
-    # turn after returning. The 1h TTL covers their typical re-engage
-    # pattern at a 1.5x cache_create premium (vs 1.25x for 5min);
-    # the read cost is unchanged. Net cost goes down for any user
-    # whose median inter-message gap is more than ~5 min.
-    # Set to ``False`` to opt back into the default 5-minute TTL,
-    # e.g. if a non-Anthropic provider rejects the ttl field.
+    # Use Anthropic's one-hour cache TTL instead of the five-minute default.
     llm_cache_extended_ttl: bool = True
-    # Whether the agent may stamp Anthropic ``cache_control`` breakpoints.
-    #   "auto"   (default) stamp them for providers that serve the Messages API
-    #            natively, including through a custom ``llm_api_base``.
-    #   "never"  never stamp them, forgoing prompt caching entirely.
-    # A kill switch rather than a tuning knob: a marker the downstream cannot use
-    # is discarded in conversion, so "auto" is safe against a gateway whose
-    # models are not all Anthropic-backed. The one case that still needs "never"
-    # is a gateway running any-llm < 1.24, which rejects a marked request instead
-    # of dropping the marker (any-llm#1228).
-    # The former "always" value is gone: it existed only to override an endpoint
-    # check that no longer exists. It was never anything but a widening of
-    # "auto", so "auto" is the drop-in replacement.
-    # ``provider_honors_cache_control`` in ``services/llm_service.py`` owns the
-    # decision this feeds.
+    # "auto" stamps supported Anthropic cache breakpoints; "never" disables them.
     llm_prompt_cache: Literal["auto", "never"] = "auto"
 
     # Conversation & memory
@@ -425,25 +290,9 @@ class Settings(BaseSettings):
     heartbeat_provider: str = ""  # empty = fall back to llm_provider
     heartbeat_concurrency: int = Field(default=5, ge=1)
     heartbeat_recent_messages_count: int = Field(default=5, ge=1)
-    # Skip the heartbeat LLM call for a user who messaged recently. The
-    # scheduler ticks every ``heartbeat_interval_minutes`` regardless of
-    # user activity; without this gate, an active conversation produces
-    # a tick → LLM call → "skip" decision every interval, burning tokens
-    # for no user value. The default 5-minute window is short enough not
-    # to delay genuinely overdue nudges and long enough to absorb a
-    # multi-turn back-and-forth. Set to 0 to disable the throttle.
+    # Skip heartbeat evaluation during an active conversation. Zero disables.
     heartbeat_user_quiet_period_minutes: int = Field(default=5, ge=0)
-    # Delay the first scheduler tick after process start. Without this,
-    # a deploy mid-conversation produces a tick on the new container
-    # within ~2 seconds of boot, before any in-flight work on the old
-    # container has had a chance to settle, and before any queued
-    # inbound messages have drained from the bus into normal processing.
-    # The Phase 1 LLM then sees the user's pending request in recent
-    # context and decides to act, racing the agent path that would have
-    # handled it normally. 60 seconds is short enough not to delay
-    # genuine proactive nudges in long-running deployments and long
-    # enough to absorb the post-restart settle window. Set to 0 to
-    # disable the warmup (the previous behavior).
+    # Let queued inbound work settle before the first post-start heartbeat tick.
     heartbeat_startup_warmup_seconds: int = Field(default=60, ge=0)
 
     # Observability
@@ -452,12 +301,7 @@ class Settings(BaseSettings):
     # as a top-level key for log aggregators.
     log_format: str = "text"
 
-    # Web chat UI: whether the chat page shows the file attachment affordance
-    # (paperclip button + hidden file input). Defaults to True for OSS, where
-    # uploads land directly on the FastAPI worker. Deployments behind a proxy
-    # or CDN that caps request body size (e.g. CloudFront's 1 MB default on
-    # premium) set this to False until the upload path is fixed, so users do
-    # not see an affordance that silently fails.
+    # Hide attachments when an upstream proxy cannot accept typical photo sizes.
     chat_web_attachments_enabled: bool = True
 
     # -----------------------------------------------------------------
@@ -516,46 +360,22 @@ class Settings(BaseSettings):
     smtp_password: str = ""
     smtp_from_email: str = ""
 
-    # Socket timeout for one SMTP operation. Kept short because the failure
-    # mode is a silently dropped SYN (a platform that blocks outbound SMTP,
-    # a firewalled relay), and ``socket.create_connection`` retries every
-    # address the host resolves to: at 15s, a three-A-record host held an
-    # admin request for 45s before reporting anything. The send is
-    # additionally bounded by twice this value so a multi-address retry
-    # cannot outlive it.
+    # One SMTP operation timeout; the complete send is capped at twice this value.
     smtp_timeout_seconds: int = Field(default=10, ge=1)
 
-    # Operator error alerting. Routes ERROR-level application logs to the
-    # operator's inbox via the SMTP sender above. Dormant unless SMTP is
-    # configured AND a recipient resolves (alert_email, else admin_email),
-    # so dev/local and CI never send.
-    #
-    # Throttling exists because a single broken integration can log
-    # thousands of identical errors a minute. Alerts are grouped by
-    # fingerprint (logger + exception type + log template); each
-    # fingerprint emails at most once per alert_dedupe_minutes, carrying
-    # the suppressed occurrence count.
+    # Grouped and throttled ERROR-log email alerts. Requires SMTP and a recipient.
     alerts_enabled: bool = True
     alert_email: str = ""
     alert_flush_interval_seconds: int = Field(default=60, ge=1)
     alert_dedupe_minutes: int = Field(default=30, ge=1)
     alert_max_emails_per_hour: int = Field(default=20, ge=1)
 
-    # Proactive health monitoring. Probes each dependency on a timer and
-    # emails the operator on state transitions (OK -> DOWN, DOWN -> OK)
-    # rather than on every failing tick, so a multi-hour outage is two
-    # emails, not hundreds.
-    #
-    # health_failure_threshold requires N consecutive failures before
-    # declaring DOWN. A single timed-out probe against a residential
-    # BlueBubbles host is noise, not an outage.
+    # Dependency probes alert after the failure threshold and on recovery.
     health_monitor_enabled: bool = True
     health_check_interval_seconds: int = Field(default=300, ge=1)
     health_failure_threshold: int = Field(default=2, ge=1)
 
-    # The LLM probe spends real tokens (a single-token completion per
-    # tick). At the 300s default that is ~288 calls/day, negligible cost,
-    # but it is opt-outable for anyone who would rather not pay it.
+    # The LLM probe makes one single-token completion per tick.
     health_probe_llm: bool = True
 
     # Cap on users checked per tick by the integration probe. Each user

--- a/backend/app/config_store.py
+++ b/backend/app/config_store.py
@@ -176,23 +176,14 @@ class SettingsStore(Protocol):
 # ---------------------------------------------------------------------------
 
 
-# Dual-API rollout (issue #1175, follows the IdempotencyStore pilot in
-# #1199). Internal logic is factored into pure module-level helpers so
-# the sync and async methods stay in lockstep without a class
-# hierarchy. Each existing public method keeps its plain name; the new
-# ``*_async`` peer uses real async DB access via the configured async
-# session factory (default: ``AsyncSessionLocal``).
-#
-# These helpers are intentionally not parameterized over the bind type:
-# they return raw-SQL TextClauses and pure Python payloads, which both
-# ``Session.execute`` and ``AsyncSession.execute`` accept.
+# SQL builders shared by the database-backed store methods.
 def _load_select_sql() -> TextClause:
-    """Builder shared by ``load`` / ``load_async``."""
+    """Build the query that loads all persisted settings."""
     return text("SELECT key, value, is_secret FROM app_settings")
 
 
 def _save_upsert_sql() -> TextClause:
-    """Builder shared by ``save`` / ``save_async``.
+    """Build the batch settings upsert.
 
     One round-trip: ON CONFLICT upsert for the whole batch.
     """
@@ -210,16 +201,12 @@ def _save_upsert_sql() -> TextClause:
 
 
 def _delete_sql() -> TextClause:
-    """Builder shared by ``delete`` / ``delete_async``."""
+    """Build the settings deletion query."""
     return text("DELETE FROM app_settings WHERE key = ANY(:keys)")
 
 
 def _encryption_context() -> _encryption.EncryptionContext:
-    """Encryption context shared by both sync and async paths.
-
-    Module-level so the sync and async methods see identical (table,
-    column) bindings without going through an instance method.
-    """
+    """Return the stable table and column binding for encrypted values."""
     return {"table": "app_settings", "column": "value"}
 
 
@@ -293,11 +280,8 @@ class DbSettingsStore:
     the configured ``KEKProvider`` before insertion. Decryption happens
     on read. Non-secret keys are stored verbatim.
 
-    Async-only as of issue #1160. The store resolves
-    ``AsyncSessionLocal`` lazily so a store instantiated at import time
-    picks up test rebinding of the ``async_db`` fixture's session
-    factory. ``*_async`` aliases are kept as thin wrappers in case
-    out-of-tree callers still reference the suffix.
+    ``AsyncSessionLocal`` resolves lazily so import-time instances pick up
+    test rebinding. ``*_async`` methods are deprecated aliases.
     """
 
     _CONTEXT_TABLE = "app_settings"

--- a/backend/app/integrations/appfolio_vendor/factory.py
+++ b/backend/app/integrations/appfolio_vendor/factory.py
@@ -1,18 +1,8 @@
 """AppFolio Vendor Portal tool registration and factories.
 
-Picked up by the registry's ``ensure_tool_modules_imported`` scan; the
-``_register()`` call at the bottom installs the ``appfolio_vendor``
-specialist factory at module-import time: the data tools (work-order reads +
-status updates, notes with photos, invoices). When the user is not yet
-connected, ``_appfolio_vendor_auth_check`` returns a reason string so the
-registry surfaces it under "Not connected" rather than letting the LLM
-believe AppFolio is ready to use. That closed a prod bug where the agent
-told users "AppFolio is connected" before they had connected.
-
-Connecting happens in the Clawbolt web app, not over chat: the magic link
-is a single-use secret, and pasting it into a chat thread would leave it in
-the user's message history (issue #1337). The connect form lives on the
-Integrations page and posts to ``/api/integrations/appfolio_vendor``.
+The specialist includes work-order reads and status updates, notes with photos,
+and invoices. Authentication status gates the tools. Users enter the single-use
+magic link on the Integrations page, never in chat history.
 """
 
 from __future__ import annotations

--- a/backend/app/integrations/appfolio_vendor/invoices.py
+++ b/backend/app/integrations/appfolio_vendor/invoices.py
@@ -2,9 +2,9 @@
 
 Two write paths share one endpoint:
 
-* ``appfolio_create_invoice`` — line-itemized invoice built inside the
+* ``appfolio_create_invoice``: line-itemized invoice built inside the
   portal. Line items only, never files (see below).
-* ``appfolio_upload_invoice_pdf`` — single invoice constructed from one
+* ``appfolio_upload_invoice_pdf``: single invoice constructed from one
   or more pre-built PDFs the user already has.
 
 Both bodies POST to ``/maintenance/api/invoices``; AppFolio

--- a/backend/app/integrations/appfolio_vendor/media_resolver.py
+++ b/backend/app/integrations/appfolio_vendor/media_resolver.py
@@ -46,7 +46,7 @@ async def resolve_staged_files(
     agent gets a deterministic "no photo found" message instead of a
     half-attached payload.
 
-    An empty ``media_refs`` returns an empty list — tools that want a
+    An empty ``media_refs`` returns an empty list. Tools that want a
     no-photo path should branch on the input rather than the output.
     """
     if not media_refs:

--- a/backend/app/integrations/appfolio_vendor/params.py
+++ b/backend/app/integrations/appfolio_vendor/params.py
@@ -37,7 +37,7 @@ class AppFolioListWorkOrdersParams(BaseModel):
 class AppFolioSearchWorkOrdersParams(BaseModel):
     search_term: str = Field(
         description=(
-            "Search query — work order number, address, unit, or any free text."
+            "Search query: work order number, address, unit, or any free text."
             " Matches AppFolio's universal vendor-portal search."
         ),
     )

--- a/backend/app/integrations/appfolio_vendor/work_order_writes.py
+++ b/backend/app/integrations/appfolio_vendor/work_order_writes.py
@@ -1,15 +1,6 @@
-"""Write tools for AppFolio work-order status.
+"""AppFolio work-order status update and undo tools.
 
-Limited surface: status update and undo. Note writes live in
-:mod:`notes`; invoice writes in :mod:`invoices`. The accept/schedule
-and tenant-messaging tools that previously lived here were dropped in
-#1331 ("trim tool surface to reads, notes, and invoices") and are not
-restored.
-
-Brought back the status tools after vendor feedback: marking a work
-order complete from inside the assistant is the one write the trim
-left without a workaround, and users now have to flip status in the
-AppFolio UI by hand.
+Note writes live in :mod:`notes`; invoice writes live in :mod:`invoices`.
 """
 
 from __future__ import annotations

--- a/backend/app/integrations/calendar/SKILL.md
+++ b/backend/app/integrations/calendar/SKILL.md
@@ -1,6 +1,6 @@
 # Google Calendar
 
-You now have access to Google Calendar tools. Here is how to use them effectively.
+Google Calendar stores calendars, events, and availability. This integration reads schedules and manages events on calendars the user enabled.
 
 ## Available Tools
 
@@ -29,9 +29,7 @@ For job-related events, use this format:
 - Location: the job site address
 - Description: scope of work, materials needed, or other notes
 
-Examples:
-- `Job: Smith - Kitchen Remodel` at `123 Oak St, Portland OR`
-- `Job: Jones - Roof Repair` at `456 Elm Ave, Seattle WA`
+Example: `Job: Test Customer - Kitchen Remodel` at `123 Main Street`
 
 ## Finding an event
 
@@ -65,7 +63,7 @@ When `calendar_list_calendars` returns more than one row, check the target calen
 1. `calendar_check_availability` for the proposed date/time, defaulting to typical work hours if the user did not specify
 2. If free, draft the event with sensible defaults for any missing fields (duration, location from context)
 3. `calendar_create_event` with job title format, location, and description
-4. Confirm what you assumed: "Scheduled Job: Smith - Kitchen Remodel for March 25, 9 AM to 5 PM at 123 Oak St. Change anything?"
+4. Confirm what you assumed: "Scheduled Job: Test Customer - Kitchen Remodel for March 25, 9 AM to 5 PM at 123 Main Street. Change anything?"
 
 ### Check the week's schedule
 1. `calendar_list_events` for the current week (Monday to Sunday)

--- a/backend/app/integrations/quickbooks/SKILL.md
+++ b/backend/app/integrations/quickbooks/SKILL.md
@@ -1,6 +1,6 @@
 # QuickBooks Online
 
-You now have access to QuickBooks Online tools. Here is how to use them effectively.
+QuickBooks Online stores customers, items, estimates, invoices, bills, and payments. This integration queries those records and manages supported customers and sales transactions.
 
 ## Available Tools
 
@@ -68,8 +68,8 @@ Example:
 {
   "entity_type": "Customer",
   "data": {
-    "DisplayName": "Jane Smith",
-    "PrimaryEmailAddr": {"Address": "jane@example.com"},
+    "DisplayName": "Test Customer",
+    "PrimaryEmailAddr": {"Address": "test.customer@example.com"},
     "PrimaryPhone": {"FreeFormNumber": "555-0199"}
   }
 }
@@ -193,7 +193,7 @@ This is the primary workflow for users who dictate job details from the field:
 3. `qb_query` Customer to check if the client exists
 4. If new client: `qb_create` Customer
 5. `qb_create` Estimate with line items (typically labor + materials)
-6. Summarize what you drafted and what you assumed in one line: "Drafted estimate for Smith: 8 hr labor at $50, materials $200, expires in 30 days. Change anything?"
+6. Summarize what you drafted and what you assumed in one line: "Drafted estimate for Test Customer: 8 hr labor at $50, materials $200, expires in 30 days. Change anything?"
 7. User comes back later to refine: `qb_query` the estimate (note the SyncToken in the results)
 8. `qb_update` Estimate with revised line items (include Id and SyncToken)
 9. When user says it's ready: `qb_send` Estimate to the client's email

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -367,9 +367,9 @@ def _mask_channel_identifier(identifier: str) -> str:
     """Mask the user-routing identifier (phone, email, Telegram chat id).
 
     Channel identifiers are PII (phone numbers, iMessage emails, Telegram
-    chat IDs). Admins legitimately need to *recognize* a route — to
+    chat IDs). Admins legitimately need to *recognize* a route, to
     confirm "this is the user from ticket #123" or to verify the right
-    last-4 digits with the user — but they don't need the raw value at a
+    last-4 digits with the user, but they don't need the raw value at a
     glance. We show a prefix + suffix that's enough for recognition and
     last-4 confirmation, never enough to dial / message directly off the
     admin panel without going through user search.
@@ -390,7 +390,7 @@ def _mask_channel_identifier(identifier: str) -> str:
        than ~30% of any value.
 
     Identifiers shorter than the smallest meaningful mask are returned
-    verbatim — there's nothing useful to mask in 3-4 chars.
+    verbatim. There's nothing useful to mask in 3-4 chars.
     """
     if not identifier:
         return identifier
@@ -402,7 +402,7 @@ def _mask_channel_identifier(identifier: str) -> str:
     if len(identifier) > _MAX_IDENTIFIER_LEN:
         identifier = identifier[:_MAX_IDENTIFIER_LEN]
 
-    # Email-shaped (``foo@example.com``) — fires only when the domain has
+    # Email-shaped (``foo@example.com``). Fires only when the domain has
     # a ``.``; bare ``@handle`` values fall through to the generic mask.
     if "@" in identifier:
         local, _, domain = identifier.partition("@")
@@ -416,7 +416,7 @@ def _mask_channel_identifier(identifier: str) -> str:
             else:
                 masked_local = (local[:1] + "***") if local else "***"
             masked_host = (host[:1] + "***") if host else "***"
-            # TLD is masked too — custom enterprise / staging TLDs would
+            # TLD is masked too. Custom enterprise / staging TLDs would
             # otherwise leak the company name. Keep the leading char as a
             # weak hint (``.com``-shape vs ``.local``) without exposing
             # the full label.
@@ -432,7 +432,7 @@ def _mask_channel_identifier(identifier: str) -> str:
         return identifier[:4] + "·" * (len(identifier) - 8) + identifier[-4:]
 
     # Generic head+tail mask for handles, numeric IDs, short emails. The
-    # head/tail size scales down for shorter identifiers — a 5-char value
+    # head/tail size scales down for shorter identifiers. A 5-char value
     # masked at head=2+tail=2 leaves only 1 char hidden (40% leak); we
     # use head=1+tail=2 for short inputs and head=2+tail=2 only when the
     # identifier is at least 10 chars (so the leak ratio drops to ≤30%).
@@ -492,9 +492,9 @@ async def get_user_detail(
     Slimmed in #325 work item 2: user-authored content (memory, soul,
     user text, heartbeat directives, message bodies, tool-call args /
     results) was removed from this default response. Content surfaces
-    only via the consent-gated paths — ``/admin/reported-conversations``
+    only via the consent-gated paths. ``/admin/reported-conversations``
     (after a user reports a conversation) or ``/admin/shared-data``
-    (when a user opted into data sharing) — once items 3 + 4 land.
+    (when a user opted into data sharing) once items 3 + 4 land.
 
     Eager-loads ``tool_configs`` and ``channel_routes`` via selectinload
     so we make one round-trip instead of three.
@@ -533,7 +533,7 @@ async def get_user_detail(
 
     # Sort channels by last_inbound_at desc, nulls last. Frontend
     # elevates the first row visually; populated routes come first,
-    # most recent at the top. Identifier is masked — see
+    # most recent at the top. Identifier is masked; see
     # ``_mask_channel_identifier`` for why.
     routes_with_inbound = [c for c in user.channel_routes if c.last_inbound_at is not None]
     routes_without_inbound = [c for c in user.channel_routes if c.last_inbound_at is None]
@@ -583,7 +583,7 @@ async def activate_user(
     admin: User = Depends(get_current_admin),
 ) -> UserActiveResponse:
     """Re-activate a deactivated user."""
-    # ctx.target_user_id is set only after the existence check passes —
+    # ctx.target_user_id is set only after the existence check passes.
     # the column is FK-constrained, so writing an unknown UUID fails the
     # audit insert and leaves the row unrecorded entirely.
     ctx.resource_type = "user"

--- a/backend/app/routers/admin_shared_data.py
+++ b/backend/app/routers/admin_shared_data.py
@@ -41,7 +41,7 @@ already has the audit infrastructure in place from PR #330.
 Non-consenting users return 403 even when the calling admin has
 permission; consent is the gate, not admin role. A user who toggles
 consent off mid-investigation will start returning 403 on the next
-admin read, which is the correct behavior — admins lose access the
+admin read, which is the correct behavior. Admins lose access the
 moment the user revokes.
 """
 
@@ -258,7 +258,7 @@ async def get_shared_data_summary(
     # Open reports: dismissed_at is null for an open report. Not
     # restricted to consenting users because reports are admin triage
     # signal independent of consent (the report row itself does not
-    # surface message bodies — those are still gated).
+    # surface message bodies; those are still gated).
     open_reports_count = (
         await db.execute(
             select(sa_func.count(ReportedConversation.id)).where(
@@ -736,7 +736,7 @@ async def list_shared_data_heartbeat_logs(
     only metadata (id, action_type, channel, created_at) since #336.
     For consenting users the full content surfaces here: ``message_text``
     (what the agent sent on this tick), ``reasoning`` (why it sent /
-    skipped — often quotes the user back to themselves), and ``tasks``
+    skipped because it often quotes the user back to themselves), and ``tasks``
     (the serialized task state the LLM was deciding from). All three
     columns are envelope-encrypted at rest; ORM reads decrypt
     transparently and we redact PII shapes before serialization.
@@ -808,7 +808,7 @@ async def get_shared_data_memory(
 
     Both columns are envelope-encrypted at rest. A user with no
     document yet (never compacted, never wrote memory) returns empty
-    strings rather than 404 — consenting and "no memory yet" is a
+    strings rather than 404. Consenting and "no memory yet" is a
     valid combined state.
     """
     user = await _require_consenting_user(db, user_id)

--- a/backend/app/routers/google_oauth.py
+++ b/backend/app/routers/google_oauth.py
@@ -39,8 +39,7 @@ router = APIRouter(prefix="/auth/oauth", tags=["oauth"])
 
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 
-# Temporary copy used while a parallel deployment is migrating users.
-# Replace with a generic deactivation message once the migration window closes.
+# Deactivated migrated accounts sign in through the hosted service.
 _DEACTIVATED_LOGIN_MESSAGE = "Your account has moved to clawbolt.ai. Sign in there to access it."
 
 # Enforce the Secure flag on cookies when the deployment uses HTTPS.
@@ -176,7 +175,7 @@ async def oauth_google_callback(
     try:
         # Pass the same redirect_uri we used in the auth redirect.
         # Google rejects the token exchange with HTTP 400 if these
-        # differ — historically this was the source of "OAuth works
+        # differ. Historically this was the source of "OAuth works
         # locally but breaks on prod" because each side read a
         # different setting (router: APP_BASE_URL, exchange: legacy
         # GOOGLE_REDIRECT_URI). One source of truth now.

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -692,7 +692,7 @@ class AdminUserDetailResponse(BaseModel):
     items 3 + 4 land. Until then, admins debugging an incident see the
     metadata + integrations here, plus the audit log of who looked.
 
-    Channel routes carry a *masked* ``channel_identifier`` — phone
+    Channel routes carry a *masked* ``channel_identifier``. Phone
     numbers / iMessage emails / Telegram chat IDs are PII the admin
     rarely needs in full. The route applies ``_mask_channel_identifier``
     so admins see enough to recognize a route and confirm last-4 digits,
@@ -1058,7 +1058,7 @@ class AdminHeartbeatLogItem(BaseModel):
     """Heartbeat log metadata only.
 
     Content fields (``message_text``, ``reasoning``, ``tasks``) were
-    removed in #325 work item 2 — they were user-facing content the
+    removed in #325 work item 2. They were user-facing content the
     user-detail response also stripped. They surface only via the
     consent-gated paths once items 3 + 4 land.
     """
@@ -1301,11 +1301,7 @@ class SharedDataMessageItem(BaseModel):
 # Admin: turn-grouped conversation inspector (design 2026-05-01)
 # ---------------------------------------------------------------------------
 #
-# ``SharedDataMessageItem`` above is retained because the turn schema
-# nests it inside each turn for the user message and agent reply. The
-# flat ``GET /conversations/{id}/messages`` endpoint that originally
-# motivated it was retired in #361's follow-up: Turns covers every
-# real read pattern, and the second endpoint had no callers.
+# Turns nest ``SharedDataMessageItem`` for the user message and agent reply.
 
 
 class SharedDataReceipt(BaseModel):

--- a/backend/app/services/llm_payload_capture.py
+++ b/backend/app/services/llm_payload_capture.py
@@ -1,41 +1,10 @@
-"""Capture LLM request payloads for consenting users.
+"""Capture two eras of agent-main LLM requests for consenting users.
 
-Implements the observer that the agent dispatches to via the
-``set_llm_request_observer`` hook. The observer:
-
-1. Filters to ``purpose == PURPOSE_AGENT_MAIN`` -- the post-trim
-   follow-up, compaction, and heartbeat dispatches are not captured
-   here. Mixing them into the rotation would be wrong because they
-   carry no meaningful era marker (or a fake one), so they would
-   ping-pong against agent-main captures.
-2. Returns immediately and fires the actual work onto an ``asyncio``
-   task: the agent loop is on the user-facing latency hot path and
-   must not wait for a DB round-trip + JSONB upsert per LLM call.
-3. Inside the background task: skips users without
-   ``data_sharing_consent``, drops payloads that exceed a hard byte
-   cap (``MAX_CAPTURE_BYTES``, sized off the OSS trim ceiling so a
-   normal heavy user is captured and only a genuine runaway is
-   dropped), then persists exactly two payload slots
-   per user (current / previous era) via a single ``INSERT ... ON
-   CONFLICT`` upsert that rotates atomically. The era marker is the
-   ``min_message_seq_in_prompt`` field on the payload; when it
-   changes between captures, the existing current row is rotated
-   into the previous slot before the new payload overwrites current.
-
-Single-session assumption: this design relies on OSS migration 026
-("Collapse the sessions table to one row per user"), which enforces
-``UNIQUE(user_id)`` on ``chat_sessions``. With multiple concurrent
-sessions per user, two parallel agent loops would compete for the same
-``llm_payload_captures`` row with potentially different era markers,
-ping-ponging the rotation and silently destroying the "previous era"
-semantic. The PK on ``llm_payload_captures.user_id`` is sized for the
-one-session-per-user world; if OSS ever reintroduces multi-session, the
-PK must become ``(user_id, session_id)`` and the migration must
-backfill.
-
-The observer never raises -- OSS catches exceptions, and the background
-task body is wrapped in try/except so a transient DB error logs and
-moves on without crashing the worker task.
+The observer filters other LLM purposes, returns before its background DB write,
+drops oversize payloads, and atomically rotates current and previous captures by
+``min_message_seq_in_prompt``. The one-row-per-user design assumes one chat session
+per user; multi-session support would require a ``(user_id, session_id)`` key.
+Capture failures are logged and never reach the agent loop.
 """
 
 from __future__ import annotations
@@ -68,40 +37,11 @@ from backend.app.models import LLMPayloadCapture
 
 logger = logging.getLogger(__name__)
 
-# Hard cap on a single capture's serialized JSON size. Captures larger than
-# this are dropped.
-#
-# Was 256 KB, which dropped every capture for exactly the users worth
-# capturing. A real production payload for an active user measured 520 KB: a
-# ~113k-token prompt plus 61 tool schemas (39 KB) and the system prompt
-# (13 KB). Their newest stored capture was two days stale during an incident,
-# because every agent-main call since had logged "dropped (oversize)".
-#
-# 2 MiB is sized off the trim ceiling rather than that one observation. OSS
-# trims the prompt once it exceeds ``context_trim_trigger_tokens`` (default
-# 150k) and drops it back to ``context_trim_target_tokens`` (default 120k), so
-# at roughly 4 bytes per token a heavy user rests near 480 KB and peaks near
-# 600 KB, plus tool schemas and system prompt. 2 MiB leaves ~3x headroom over
-# that peak while still catching a genuine runaway.
-#
-# The trim thresholds bound the round-0 prompt, not every capture: the agent's
-# tool-round loop appends tool results without re-trimming (up to
-# ``max_tool_rounds``), and each round emits its own agent-main payload. The
-# real backstop for those is the model's context window, so re-check this
-# constant when switching to a much larger-context model.
-#
-# Storage: the cap applies independently to the request and response halves of
-# each of the two eras, so a single user's row bounds at 4 x 2 MiB = 8 MiB
-# worst case (responses are output-token-bounded in practice, so realistically
-# far less). Postgres stores those JSONB values out-of-line via TOAST.
+# Per-request or response JSON cap. Sized above the normal trimmed prompt plus
+# tool schemas; larger captures are dropped. A full row holds at most four halves.
 MAX_CAPTURE_BYTES = 2 * 1024 * 1024
 
-# Bounded retry for pairing a response with its request capture. The
-# request and response observers each spawn their own background task,
-# so a fast LLM round can fire the response task before the request
-# task has committed. Three attempts on exponential backoff (50ms,
-# 100ms, 200ms) covers the realistic commit latency without delaying
-# the captures' background-task work meaningfully.
+# Response observers can race the request commit, so pair with bounded backoff.
 _RESPONSE_PAIRING_ATTEMPTS = 3
 _RESPONSE_PAIRING_BACKOFF_S = 0.05
 
@@ -284,9 +224,7 @@ async def _observer_entrypoint(payload: LLMRequestPayload) -> None:
     """
     if payload.purpose != PURPOSE_AGENT_MAIN:
         # Compaction / heartbeat / agent-followup don't carry a meaningful
-        # era marker; capturing them would corrupt the rotation. The capture
-        # can grow per-purpose capture surfaces in a follow-up if there's
-        # demand.
+        # era marker; capturing them would corrupt the rotation.
         return
     task = asyncio.create_task(capture_llm_request(payload))
     _pending_tasks.add(task)

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -45,56 +45,16 @@ _LOCAL_PROVIDERS = {"ollama", "llamafile", "llamacpp", "lmstudio", "vllm"}
 # Meta-providers that proxy to other providers and should not be directly selectable.
 _HIDDEN_PROVIDERS = {"platform", "gateway"}
 
-# Providers that serve the Anthropic Messages API natively, so a ``cache_control``
-# marker survives to the wire. Every other provider reaches the wire through
-# any-llm's Messages-to-Completions bridge, which rebuilds every block and drops
-# the markers in the process, so stamping one for them buys nothing.
-#
-# This is an optimization, not a correctness requirement. It used to be the
-# latter: the bridge forwarded a block-list ``system`` verbatim into
-# ``messages[0].content`` and a strict OpenAI-compatible backend answered 400
-# ("Input should be a valid string, field: 'messages[0].content.str'") rather
-# than ignoring a marker it could not use. any-llm#1228 fixed that in 1.24.0 by
-# flattening ``system`` to a plain string, which is why the floor in
-# pyproject.toml is >=1.24: below it, an unhonored marker is fatal rather than
-# wasteful. Keep the set anyway, since serializing markers a provider will
-# discard is pointless work.
-#
-# Gateway provider names (``otari``, ``gateway``, ``mzai``) stay out, which is now
-# an inconsistency worth naming rather than a rule. any-llm's otari provider
-# forwards Messages natively (it exists to preserve exactly these markers), so a
-# marker would reach the gateway intact, the same as it does for ``anthropic``
-# pointed at a gateway base, which this set does mark. The two paths end at the
-# same place and are treated differently.
-#
-# Left as-is because #1484 scoped itself to dropping the endpoint check, and
-# widening the set is a behavior change that deserves its own measurement: it
-# would start marking for every operator who names a gateway provider directly.
-# Revisit once gateway deployments have real cache-hit numbers from the
-# ``anthropic``-plus-base path.
+# Providers whose Anthropic Messages path preserves ``cache_control`` markers.
+# Other provider bridges discard the markers, so stamping them adds no value.
 _CACHE_CONTROL_PROVIDERS = {"anthropic", "azureanthropic", "vertexaianthropic"}
 
 
 def provider_honors_cache_control(provider: str) -> bool:
-    """True when the agent should stamp a ``cache_control`` marker for *provider*.
+    """Return whether cache markers are enabled and useful for *provider*.
 
-    Gates every cache breakpoint the agent stamps. A marker a provider cannot use
-    is now discarded in conversion rather than rejected (any-llm#1228, released in
-    1.24.0), so this is a cost decision and no longer a correctness one.
-
-    The endpoint is deliberately not consulted. It used to be: a ``custom
-    llm_api_base`` on the ``anthropic`` provider meant a proxy or gateway, whose
-    real downstream is encoded in the model string and unreadable from here, and a
-    gateway fronting a non-Anthropic model answered a marked request with
-    ``Extra inputs are not permitted, field: 'messages[0].content.list[...]
-    .cache_control'``. That is a gateway-side conversion failure, not any-llm's, so
-    it needs the *gateway* to be running any-llm >= 1.24 to be fixed. Once it is,
-    an Anthropic downstream honors the marker and any other downstream drops it in
-    the same bridge, so the endpoint stops carrying information and gateway
-    deployments get prompt caching back.
-
-    ``llm_prompt_cache`` is a kill switch: ``"never"`` disables marking outright,
-    for an operator whose gateway is older than that and 400s on a marked request.
+    The endpoint is not consulted because it does not reveal a gateway's downstream
+    provider. ``llm_prompt_cache='never'`` supports older gateways that reject markers.
     """
     if settings.llm_prompt_cache == "never":
         return False

--- a/backend/app/services/pii_redaction.py
+++ b/backend/app/services/pii_redaction.py
@@ -44,7 +44,7 @@ def redact_pii(text: str) -> str:
 
     Matches are replaced with bracketed labels so the surrounding
     sentence stays readable: ``"Call me at [PHONE]"`` instead of just
-    silent removal. This is intentional — admins reading shared
+    silent removal. This is intentional. Admins reading shared
     conversations need to know that PII *was* there even when the
     value itself is masked.
     """

--- a/docs/markdown_growth_policies.md
+++ b/docs/markdown_growth_policies.md
@@ -1,177 +1,41 @@
-# Bounded-growth policies for agent-managed markdown surfaces
+# Bounded growth for agent-managed markdown
 
-This document is the source of truth for the growth policy of every
-markdown file the Clawbolt agent can read or write. It is the
-human-readable companion to `backend/app/agent/markdown_registry.py`,
-which encodes the same policies in code so they can be enforced at
-write time and verified by tests.
+`backend/app/agent/markdown_registry.py` is the executable source of truth for every markdown surface the agent can read or write. This document explains the shared policy and how to add a surface.
 
-The motivation is issue #1244 (follow-up to #1243): without explicit
-bounds, a long-lived user's `MEMORY.md`, `USER.md`, `SOUL.md`,
-`HEARTBEAT.md`, and `HISTORY.md` can grow without limit, bloating
-every prompt and degrading both cost and response quality. Some
-surfaces are injected directly into the system prompt; others (like
-`HISTORY.md`) accumulate compaction summaries forever and were not
-windowed at all before this change.
-
-The pattern adopted here mirrors prior art:
-
-- **Claude Code** caps `MEMORY.md` at ~25 KB injected into the
-  sub-agent prompt and instructs the agent to curate the file when it
-  exceeds that limit.
-- **MemGPT / Letta** enforces a per-block character limit on core
-  memory and forces eviction to archival memory on overflow.
-- **Anthropic harness guidance (2025)** treats prompt-size management
-  as the harness's responsibility, not the model's.
-
-A **uniform 25 KiB byte budget** is applied to every surface. The
-uniform value matches the existing
-`compaction_event_snapshot_max_bytes_per_file` audit cap (so any
-in-budget surface fits in a single audit row without truncation) and
-is generous enough for normal use while still catching catastrophic
-growth.
+Every surface has a 25 KiB UTF-8 byte budget. The cap bounds prompt cost and storage growth, and ensures an in-budget surface fits inside the compaction audit snapshot limit.
 
 ## Surface inventory
 
-| Surface | Storage | Write mode | Injected | Byte budget | Enforcement |
-|---|---|---|---|---|---|
-| `USER.md` | `users.user_text` (Text) | full rewrite | yes (every prompt) | 25 KiB | write-time hard cap; read-side tail truncation |
-| `SOUL.md` | `users.soul_text` (Text) | full rewrite | yes (every prompt) | 25 KiB | write-time hard cap; read-side tail truncation |
-| `HEARTBEAT.md` | `users.heartbeat_text` (Text) | full rewrite | yes (heartbeat prompt) | 25 KiB | write-time hard cap; read-side tail truncation |
-| `MEMORY.md` | `memory_documents.memory_text` (encrypted) | full rewrite | yes (every prompt) | 25 KiB | write-time hard cap; read-side tail truncation |
-| `HISTORY.md` | `memory_documents.history_text` (encrypted) | append | no (audit only) | 25 KiB | append-with-window: oldest entries dropped FIFO; `write_file` rejected |
-| `BOOTSTRAP.md` | disk: `data/users/{user_id}/BOOTSTRAP.md` | transient | no | 25 KiB | deleted by `OnboardingSubscriber` on completion |
+| Surface | Storage | Write mode | Prompt use | Enforcement |
+|---|---|---|---|---|
+| `USER.md` | `users.user_text` | Rewrite | Main agent | Write cap and read-side tail truncation |
+| `SOUL.md` | `users.soul_text` | Rewrite | Main agent | Write cap and read-side tail truncation |
+| `HEARTBEAT.md` | `users.heartbeat_text` | Rewrite | Heartbeat agent | Write cap and read-side tail truncation |
+| `MEMORY.md` | `memory_documents.memory_text` | Rewrite | Main agent | Write cap and read-side tail truncation |
+| `HISTORY.md` | `memory_documents.history_text` | Append | Audit only | Append with oldest-entry eviction |
+| `BOOTSTRAP.md` | `data/users/{user_id}/BOOTSTRAP.md` | Transient | Onboarding | Write cap; removed after onboarding |
 
-Audit details (column types, encryption, prior compaction behavior)
-live in inline docstrings on each surface in the registry module.
+## Rewrite surfaces
 
-## Per-surface rationale
+Workspace tools and store methods reject content over the budget with `BudgetExceededError`. Compaction leaves the prior content unchanged when a rewrite is too large.
 
-### `USER.md`, `SOUL.md`, `MEMORY.md`
+Read-side truncation protects prompts from legacy or manually inserted oversize rows. It retains the newest tail and adds a marker so the agent can curate the file.
 
-These are the three markdown surfaces injected into the **main agent
-system prompt on every turn**. The 25 KiB cap serves two purposes:
+## HISTORY.md
 
-1. **Write-time hard cap.** `workspace_tools.write_file` /
-   `workspace_tools.edit_file`, `MemoryStore.write_memory_async`,
-   `MemoryStore.write_user_async`, and
-   `MemoryStore.write_soul_async` all reject content over 25 KiB
-   with a `BudgetExceededError`. The agent gets a tool error
-   describing the actual size and the cap so it can rewrite smaller.
-   Compaction (`compact_session`) catches the same error, logs a
-   warning, and leaves the previous file in place; the next
-   compaction gets another chance.
+`HISTORY.md` is append-only. Each append drops the oldest complete timestamped entries until the file fits the budget. The full compaction audit remains in `compaction_events`.
 
-2. **Read-time tail truncation.** A row that pre-dates the cap (or
-   was inserted via raw SQL) would otherwise still bloat every
-   prompt. The system-prompt builders (`build_user_section`,
-   `build_soul_prompt`, `build_memory_section`) run the value through
-   `truncate_for_injection` before handing it to the LLM. The tail
-   is kept (most-recent content) with a one-line marker so the agent
-   can detect it was clipped and rewrite the file smaller.
+Workspace `write_file` and `edit_file` reject `HISTORY.md` so callers cannot bypass append locking and windowing.
 
-### `HEARTBEAT.md`
+## Adding a surface
 
-Same enforcement model as `USER.md` / `SOUL.md` / `MEMORY.md`, but
-the heartbeat content is only injected into the heartbeat
-sub-system's prompt (not the main agent prompt). The cap is the
-same 25 KiB because the heartbeat call is no less expensive per
-token, and a runaway list of stale tasks creates the same
-context-bloat problem.
+1. Add a `MarkdownPolicy` in `backend/app/agent/markdown_registry.py` with its storage, write mode, prompt exposure, and byte budget.
+2. For column-backed storage, add the column to `COLUMN_TO_SURFACE`.
+3. For append mode, implement an explicit windowing strategy.
+4. Update `tests/test_markdown_registry.py` and the inventory above.
 
-### `HISTORY.md`
+## Operator signals
 
-Append-only by design (compaction summaries are timestamped
-breadcrumbs). The risk profile is different from the other
-surfaces:
-
-- It is **not injected** into the agent prompt, so unbounded growth
-  affects storage cost and admin tool latency, not LLM cost.
-- It is **append-only** with row-level lock semantics for integrity
-  (issue #1243 / PR #1273), and a full rewrite would silently bypass
-  that invariant.
-
-The policy is **append-with-window**: each call to `append_history`
-appends the new entry, then drops the oldest entries (whole, on
-timestamped boundaries) until the post-append text fits within 25
-KiB. The full archive of compaction events is still preserved in
-`compaction_events` rows for admin observability; HISTORY.md itself
-just keeps the most recent window. `workspace_tools.write_file` and
-`workspace_tools.edit_file` reject HISTORY.md outright so the
-windowing invariant cannot be circumvented.
-
-### `BOOTSTRAP.md`
-
-A transient file written on user provisioning and deleted by
-`OnboardingSubscriber` when onboarding completes. It is not edited
-post-provision and is not injected into any prompt. The 25 KiB cap
-is enforced on disk writes via `workspace_tools.write_file` for
-defense in depth, but in practice the file lives only as long as
-onboarding does and is never modified by the agent.
-
-## Adding a new markdown surface
-
-If a future feature introduces a new markdown surface that the agent
-can mutate or that is injected into a prompt:
-
-1. Add a `MarkdownPolicy` entry in
-   `backend/app/agent/markdown_registry.py` declaring the storage,
-   write mode, prompt exposure, and byte budget.
-2. If it is column-backed, add the column to
-   `COLUMN_TO_SURFACE` so the store-write helpers route through
-   the cap.
-3. If it is append-mode, decide on a windowing strategy (the
-   `test_history_md_is_the_only_append_surface` registry test will
-   force you to update it explicitly).
-4. The `tests/test_markdown_registry.py` consistency tests will
-   catch missing or inconsistent entries.
-
-The intent is to make adding a new unbounded markdown surface
-either impossible (the integration paths route through the
-registry) or noisily test-failing.
-
-## Observability
-
-The current observability surfaces are intentionally minimal:
-
-- **Per-write rejection log.** Compaction logs at `WARNING` when an
-  LLM rewrite exceeds the cap, including the surface name, the
-  attempted size, and the budget. Operators can grep for "skipping
-  ... update for user" to find users whose compaction is failing the
-  cap.
-- **Per-injection truncation log.** `truncate_for_injection` logs at
-  `INFO` when a legacy over-budget row is tail-truncated for prompt
-  injection. INFO rather than WARNING because this fires every turn
-  for the affected user until the agent rewrites the file, and a
-  per-turn WARNING would crowd out actionable signals.
-- **`compaction_events` audit rows.** Every compaction event already
-  records the before / after snapshot for each surface (capped at
-  100 KB per file in the audit row); the existing admin compaction
-  feed surfaces these.
-
-A dedicated admin dashboard for tracking per-user file sizes over
-time is a useful follow-up but is out of scope here. A reasonable
-shape would be a histogram of stored bytes per surface plus a
-counter for `BudgetExceededError` events, both exposed from the
-existing admin observability surface.
-
-## What this PR deliberately does not do
-
-- **Periodic / size-triggered compaction of working memory.** The
-  current design only triggers compaction on conversation trim. A
-  size-triggered rewrite (e.g. "compact when MEMORY.md exceeds 80%
-  of its budget") is a reasonable follow-up but is out of scope for
-  this PR. Until it lands, an agent that grows MEMORY.md to the cap
-  will start receiving budget errors on the next write and have to
-  curate the file itself.
-- **Importance-based compaction.** Stanford's Generative Agents
-  pattern ranks observations by importance and reflects only when the
-  cumulative score crosses a threshold. Worth exploring; out of scope
-  here.
-- **Admin observability dashboard for surface sizes.** See the
-  Observability section above for the current state and the shape
-  of a follow-up.
-- **Rewriting the SOUL.md / USER.md / HEARTBEAT.md compaction
-  prompts.** Issue #1243 already tightened the durable-memory
-  rules; this PR is about adding policy enforcement, not rewriting
-  the prompts.
+- Compaction logs a warning when a rewrite exceeds its budget.
+- Prompt builders log at info when they truncate a legacy oversize row.
+- `compaction_events` retains bounded before-and-after snapshots for audits.

--- a/docs/self-host/README.md
+++ b/docs/self-host/README.md
@@ -31,7 +31,6 @@ Edit `.env` and fill in the required credentials. See [Configuration](./configur
 
 At minimum you need:
 - An LLM API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
-- `VISION_MODEL` (the model used for image analysis, defaults to `LLM_MODEL` if not set)
 - At least one messaging channel configured:
   - **iMessage (recommended):** choose one backend. Hosted iMessage/RCS/SMS via [Linq](./linq-setup.md) (`LINQ_API_TOKEN` + `LINQ_FROM_NUMBER`), or self-hosted iMessage via [BlueBubbles](./bluebubbles-setup.md) (`BLUEBUBBLES_SERVER_URL` + `BLUEBUBBLES_PASSWORD`). The app surfaces whichever backend you configure as a single "iMessage" channel to end users. Configuring both at once is not supported.
   - **Telegram:** `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_CHAT_ID`, see [Telegram Setup](./telegram-setup.md)

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -19,14 +19,13 @@ All available settings are listed in `.env.example` with defaults and comments. 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `LOG_LEVEL` | `INFO` | Python log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `DATA_DIR` | `data/users` | Directory for file-based user data storage |
+| `DATA_DIR` | `data/users` | Directory for per-user workspace files such as `BOOTSTRAP.md` |
 | `DATABASE_URL` | `postgresql://clawbolt:clawbolt@localhost:5432/clawbolt` | PostgreSQL connection URL |
 | `SETTINGS_STORE` | `db` | Backend for runtime-configurable settings (admin UI values). `db` writes to the `app_settings` table; `file` keeps the legacy `data/config.json` flow for file-based deployments |
 | `CORS_ORIGINS` | `http://localhost:3000,http://localhost:8000` | Comma-separated list of allowed CORS origins |
 | `AUTH_MODE` | `single_user` | Who the app authenticates, and the deployment's tenancy switch. `single_user` needs no credentials and resolves every request to the one user in the database. `multi_user` turns on the hosted surface described under [Multi-user deployment](#multi-user-deployment) |
 | `JWT_SECRET` | `change-me-in-production` | Secret key for JWT signing. **Change this in production** |
 | `JWT_EXPIRY_MINUTES` | `15` | JWT token expiry time in minutes |
-| `PREMIUM_PLUGIN` | (empty) | Python import path for premium auth plugin. Leave empty for OSS single-tenant mode |
 
 ## LLM configuration
 
@@ -143,30 +142,30 @@ Photos and files the user sends over a messaging channel are cached on disk whil
 |----------|---------|-------------|
 | `APPROVAL_TIMEOUT_SECONDS` | `120` | Seconds to wait for user approval of a tool call before automatically denying |
 | `AGENT_PROCESSING_TIMEOUT_SECONDS` | `300` | Maximum seconds for a single message's agent processing (includes waiting for the per-user lock). Prevents one hung LLM call from blocking all subsequent messages for the same user |
-| `MESSAGE_BATCH_WINDOW_MS` | `1500` | Milliseconds to wait for more messages before processing. Groups rapid-fire messages into one agent call. Set to `0` to disable |
+| `MESSAGE_BATCH_WINDOW_MS` | `1500` | Milliseconds to wait for more messages before processing. Groups rapid-fire messages into one agent call |
 | `INBOUND_RECOVERY_LOOKBACK_MINUTES` | `30` | On startup, sweep for inbound messages persisted but never dispatched to the agent (worker died during the batcher window). Re-dispatch each one. Older orphans are skipped. Set to `0` to disable |
 | `COMPACTION_RETRY_LOOKBACK_MINUTES` | `10080` | On startup, retry compaction events stuck in `pending` (the background compaction LLM call crashed or the process restarted mid-call). Rows older than a week or already retried 3 times are skipped. Set to `0` to disable |
 | `MAX_TOOL_ROUNDS` | `10` | Maximum tool-calling rounds per agent invocation |
 | `MAX_INPUT_TOKENS` | `600000` | Hard ceiling on the input token budget; the trim trigger must stay at or below this |
-| `CONTEXT_TRIM_TARGET_TOKENS` | `120000` | Drop-to token budget after trimming. The token budget is the primary trim governor: the raw conversation window is bounded by tokens, not turns. Lower this to trade raw recall for per-turn cost, since the full window is sent every turn |
-| `CONTEXT_TRIM_TRIGGER_TOKENS` | `150000` | Trim fires when the estimated prompt token count exceeds this threshold and drops down to `CONTEXT_TRIM_TARGET_TOKENS`, leaving headroom before the next trim. Without this hysteresis (single threshold), the resting state sits at the cap and every subsequent message re-fires trim plus the downstream compaction LLM call. Invariant: `CONTEXT_TRIM_TARGET_TOKENS < CONTEXT_TRIM_TRIGGER_TOKENS <= MAX_INPUT_TOKENS` |
-| `CONTEXT_TRIM_TARGET_TURNS` | `600` | Turn-count backstop, not the primary governor. Tokens bind first in normal use; this only catches pathological message-count bloat (many tiny messages). Trims oldest turns past the cap and rolls them through compaction into `MEMORY.md`, `USER.md`, and `SOUL.md` |
-| `CONTEXT_TRIM_TRIGGER_TURNS` | unset (defaults to `CONTEXT_TRIM_TARGET_TURNS + 16`) | The turn backstop fires when user-turn count exceeds this threshold and drops down to `CONTEXT_TRIM_TARGET_TURNS`, leaving headroom (same hysteresis rationale as the token path). Set to `None` (omit the env var entirely) for the default 16-turn buffer |
-| `COMPACTION_EVENT_SNAPSHOT_MAX_BYTES_PER_FILE` | `100000` | Per-file truncation cap for memory-text snapshots persisted on `compaction_events` rows. When `MEMORY.md` / `HISTORY.md` / `USER.md` / `SOUL.md` exceeds this size, the snapshot column stores a structured truncation record (head, tail, size, sha256) so admin diff visibility is preserved while bounding worst-case row size |
+| `CONTEXT_TRIM_TARGET_TOKENS` | `120000` | Token budget to retain after trimming |
+| `CONTEXT_TRIM_TRIGGER_TOKENS` | `150000` | Token threshold that triggers trimming. Must be above the target and at or below `MAX_INPUT_TOKENS` |
+| `CONTEXT_TRIM_TARGET_TURNS` | `200` | Turn-count backstop for conversations with many small messages |
+| `CONTEXT_TRIM_TRIGGER_TURNS` | unset (target + 16) | Turn threshold that triggers trimming to `CONTEXT_TRIM_TARGET_TURNS` |
+| `COMPACTION_EVENT_SNAPSHOT_MAX_BYTES_PER_FILE` | `100000` | Per-file cap for compaction snapshots. Oversize content is represented by its head, tail, size, and hash |
 | `LLM_MAX_RETRIES` | `3` | Maximum number of retry attempts on rate limit errors |
 | `LLM_CACHE_EXTENDED_TTL` | `true` | Use Anthropic's 1-hour extended cache TTL instead of the default 5 minutes. Reduces cold-start cache misses for users with multi-hour gaps between messages. Set to `false` on non-Anthropic providers that reject the `ttl` field |
-| `LLM_PROMPT_CACHE` | `auto` | Whether to stamp Anthropic `cache_control` breakpoints: `auto` or `never`. `auto` marks whenever the provider serves the Messages API natively (`anthropic`, `azureanthropic`, `vertexaianthropic`), including through a custom `LLM_API_BASE`, since a downstream that cannot use the marker discards it during conversion. Set `never` if you front the `anthropic` provider with a gateway running any-llm older than 1.24, which rejects a marked request with `Extra inputs are not permitted ... cache_control` instead of dropping the marker. Marking is skipped for every other provider regardless, because any-llm's Messages-to-Completions bridge discards the markers anyway |
+| `LLM_PROMPT_CACHE` | `auto` | `auto` adds cache breakpoints for supported Anthropic Messages providers; `never` disables them. Use `never` with gateways running any-llm older than 1.24 |
 
 ## Conversation and memory
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CONVERSATION_HISTORY_LIMIT` | `20` | Max messages included in LLM context |
+| `CONVERSATION_HISTORY_LIMIT` | `500` | Maximum message rows loaded while building LLM context |
 | `MEMORY_RECALL_LIMIT` | `20` | Max memory facts recalled per query |
 | `COMPACTION_ENABLED` | `true` | Enable automatic conversation compaction |
 | `COMPACTION_MODEL` | (same as `LLM_MODEL`) | Model used for compaction |
 | `COMPACTION_PROVIDER` | (same as `LLM_PROVIDER`) | Provider used for compaction |
-| `COMPACTION_MAX_TOKENS` | `500` | Max tokens per compaction response |
+| `COMPACTION_MAX_TOKENS` | `16000` | Max tokens per compaction response |
 
 ## Rate limiting
 
@@ -204,7 +203,7 @@ Photos and files the user sends over a messaging channel are cached on disk whil
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CHAT_WEB_ATTACHMENTS_ENABLED` | `true` | Show the paperclip / file-input affordance on the chat page. Set to `false` behind proxies or CDNs that cap request body size below the typical photo upload (e.g. CloudFront's 1 MB default) so users do not see an attach button that silently 413s. Premium flips this off automatically. |
+| `CHAT_WEB_ATTACHMENTS_ENABLED` | `true` | Show the web-chat attachment control. Disable it behind proxies that reject typical photo sizes |
 
 ## OAuth
 
@@ -258,7 +257,7 @@ When both are set, users can connect CompanyCam via OAuth on the Tools page or t
 | `APPFOLIO_VENDOR_API_BASE` | `https://vendor.appf.io` | Base URL of the AppFolio Vendor Portal API. Override only for staging or test environments. |
 | `APPFOLIO_VENDOR_WEB_BASE` | `https://vendor.appfolio.com` | Web base shown to users when prompting them to request a magic link. |
 
-The integration uses passwordless magic-link auth: users paste the URL from their AppFolio email and the agent exchanges it for a Bearer JWT. No client ID or secret to configure. Once connected, the agent gains tools like `appfolio_list_work_orders`, `appfolio_search_work_orders`, and `appfolio_list_payments`.
+The integration uses passwordless magic-link authentication. Users enter the link from their AppFolio email on the Integrations page so the credential is not stored in chat history. No operator client ID or secret is required.
 
 ## ServiceTitan
 
@@ -269,7 +268,7 @@ The integration uses passwordless magic-link auth: users paste the URL from thei
 | `SERVICETITAN_AUTH_BASE_URL` | `https://auth.servicetitan.io` | Base URL of the ServiceTitan auth host that serves `/connect/token`. Distinct from the resource host. Override to `https://auth-integration.servicetitan.io` for the integration sandbox; flip both `API_BASE_URL` and `AUTH_BASE_URL` together when switching environments. |
 | `SERVICETITAN_USE_FAKE` | `true` | When true, route every call through the in-process fake backend (deterministic seed data, no real network). Flip to false once a real tenant is available. |
 
-ServiceTitan uses OAuth 2.0 client credentials (machine-to-machine), one set per tenant. The operator wires the integrator's app-level App Key here; each tenant pastes their own tenant ID, client ID, and client secret through the `connect_servicetitan` tool in chat. Stored credentials are envelope-encrypted at rest. ServiceTitan splits auth and resource traffic across two hosts, so `AUTH_BASE_URL` and `API_BASE_URL` are independent settings.
+ServiceTitan uses OAuth 2.0 client credentials, one set per tenant. The operator configures the app-level key; each tenant enters its tenant ID, client ID, and client secret on the Integrations page. Credentials are envelope-encrypted at rest. Auth and resource traffic use separate hosts.
 
 ## Web search
 
@@ -377,7 +376,7 @@ Neither threshold does anything on its own. Run `python -m backend.app.cli clean
 | `SMTP_FROM_EMAIL` | | Envelope sender |
 | `SMTP_TIMEOUT_SECONDS` | `10` | Per-operation socket timeout |
 
-Set `SMTP_HOST` and `SMTP_FROM_EMAIL` together or not at all: a partial config is rejected at startup rather than silently no-opping, because the usual cause is a typo and the usual symptom is users reporting missing email months later. The timeout is deliberately short: `socket.create_connection` retries every address a host resolves to, so a blocked outbound port on a three-record host would otherwise hold an admin request for three times as long.
+Set `SMTP_HOST` and `SMTP_FROM_EMAIL` together; partial configuration fails startup. See [Monitoring and alerting](./monitoring.md) for delivery diagnostics.
 
 ### Operator alerting
 
@@ -389,7 +388,7 @@ Set `SMTP_HOST` and `SMTP_FROM_EMAIL` together or not at all: a partial config i
 | `ALERT_DEDUPE_MINUTES` | `30` | Minimum gap between emails for the same fingerprint |
 | `ALERT_MAX_EMAILS_PER_HOUR` | `20` | Hard ceiling on outbound alert volume |
 
-Dormant unless SMTP is configured and a recipient resolves, so dev and CI never send. Alerts group by fingerprint (logger, exception type, log template) and carry a suppressed-occurrence count, so one broken integration logging thousands of identical errors a minute produces one email, not thousands. `POST /api/monitoring/test-alert` verifies the wiring; `POST /api/monitoring/diagnose-email` reports whether the relay is refusing or nothing is leaving the container at all.
+Alerts require SMTP and a recipient. They group repeated errors, enforce per-group cooldowns, and cap hourly sends. See [Monitoring and alerting](./monitoring.md) for testing and diagnostics.
 
 ### Health monitoring
 
@@ -402,7 +401,7 @@ Dormant unless SMTP is configured and a recipient resolves, so dev and CI never 
 | `HEALTH_PROBE_MAX_USERS` | `50` | Cap on users checked per tick by the integration probe |
 | `HEALTH_PROBE_TIMEOUT_SECONDS` | `45` | Per-probe wall-clock ceiling |
 
-Email goes out on state transitions (OK to DOWN, DOWN to OK), not on every failing tick, so a multi-hour outage is two emails. The failure threshold exists because one timed-out probe against a residential iMessage bridge is noise, not an outage. Current state is at `GET /api/monitoring/status`.
+Health email is sent on DOWN and recovery transitions after the configured failure threshold. Current state is available at `GET /api/monitoring/status`.
 
 ### KMS envelope encryption
 

--- a/docs/self-host/docker.md
+++ b/docs/self-host/docker.md
@@ -32,7 +32,7 @@ On startup, the app:
 
 Structured data (users, messages, memory, etc.) is stored in PostgreSQL. The Docker Compose file includes a PostgreSQL service with a named volume for persistence.
 
-File uploads and media are stored under the `data/` directory. By default, Docker Compose bind-mounts `./data` from your host into the container at `/app/data`.
+The `data/` bind mount holds staged inbound media and per-user workspace files. Saved user files live in each user's Google Drive.
 
 ## Verify it's running
 
@@ -58,14 +58,7 @@ docker compose build --no-cache
 # Stop existing containers
 docker compose down
 
-# Or use a different port
-docker compose up --build -e APP_PORT=8080
-```
-
-### Reset all data
-
-```bash
-# Remove all user data
-rm -rf data/users/
+# Or change the host side of the app mapping in docker-compose.yml,
+# for example "8080:8000", then start again
 docker compose up --build
 ```

--- a/docs/self-host/monitoring.md
+++ b/docs/self-host/monitoring.md
@@ -1,275 +1,131 @@
 # Monitoring and alerting
 
-Everything here requires `AUTH_MODE=multi_user`. A single-user self-host mounts
-neither the alerting stack nor the `/api/monitoring` router.
-
-Two layers live in the app, and each catches failures the other structurally
-cannot:
+Monitoring requires `AUTH_MODE=multi_user`. Single-user deployments do not mount the alerting stack or `/api/monitoring` routes.
 
 | Layer | Catches | Blind to |
 |---|---|---|
-| 1. Error alerts | Anything logged at `ERROR`: exceptions, failed tool calls, unhandled 500s | Failures that do not raise; the app being down |
-| 2. Health probes | Silent breakage: dead bridge, stale scraper, expired token, unreachable provider | The app being down |
+| Error alerts | Exceptions, failed tool calls, and other `ERROR` logs | Silent failures and process outages |
+| Health probes | Unreachable or unhealthy dependencies | Process outages |
 
-Both go silent when the process dies, so a deployment also needs an external
-uptime check. That one cannot be code in this repo; see your deployment's own
-runbook.
+Use an external uptime check as well. In-process monitoring cannot report that its own process is down.
 
 ## Prerequisites
 
-All in-app alerting is dormant until both are true:
+Alerting is enabled when:
 
-1. `SMTP_HOST` and `SMTP_FROM_EMAIL` are set. Setting only one fails startup by
-   design, so a typo cannot silently disable email.
-2. A recipient resolves: `ALERT_EMAIL`, falling back to `ADMIN_EMAIL`.
+1. `SMTP_HOST` and `SMTP_FROM_EMAIL` are both set.
+2. `ALERT_EMAIL`, or its `ADMIN_EMAIL` fallback, resolves to a recipient.
 
-Verify with `GET /api/monitoring/status` (admin auth required):
+Check the current state with `GET /api/monitoring/status` using admin authentication:
 
 ```json
 {
   "alerts": {"enabled": true, "pending_groups": 0, "dedupe_minutes": 30},
-  "health_monitor": {"enabled": true, "interval_seconds": 300, "probes": {...}},
+  "health_monitor": {"enabled": true, "interval_seconds": 300, "probes": {}},
   "recipient_configured": true
 }
 ```
 
-Then send a synthetic alert to confirm delivery end to end, rather than
-discovering an `ALERT_EMAIL` typo during a real incident:
+Send a test alert after configuring email:
 
 ```bash
-curl -X POST https://your-domain/api/monitoring/test-alert \
+curl -X POST https://your-domain.example/api/monitoring/test-alert \
   -H "Authorization: Bearer $ADMIN_API_KEY"
 ```
 
-A failed test alert returns the transport's own explanation (blocked port,
-rejected credentials, unverified sender), not a bare "not sent".
+### Diagnose email delivery
 
-### When no email arrives at all
+`POST /api/monitoring/diagnose-email`, also available as **Diagnose delivery** in the admin Monitoring tab, checks TCP, EHLO, STARTTLS, and login from inside the application container without sending a message.
 
-`POST /api/monitoring/diagnose-email`, or `Diagnose delivery` in the admin
-Monitoring tab, probes the mail path from inside the running container: TCP
-reachability for every candidate SMTP port, then a full EHLO / STARTTLS / login
-handshake against the configured one. No message is sent. It exists to separate
-two failures that look identical from the outside:
+Its result distinguishes:
 
-- **Nothing is reachable.** The platform is blocking outbound SMTP. Some hosts
-  permit it only on paid tiers, in which case no `SMTP_PORT` value will work and
-  alerting needs an HTTPS email API instead.
-- **Only the configured port is blocked.** SES publishes `2587` as a STARTTLS
-  alternate for networks that filter `587`; the diagnostic names the reachable
-  ports so this is a one-line config fix. Ports 465 and 2465 expect TLS from
-  the first byte and are not supported by this sender.
-- **The port is open but the session is refused.** Then it is a credential,
-  sender-identity, or SES-sandbox problem, and the handshake error says which.
+- No candidate port is reachable: the hosting platform or network blocks SMTP.
+- Another STARTTLS port is reachable: change `SMTP_PORT`. Amazon SES also supports `2587`.
+- The configured port is reachable but login fails: check credentials, sender verification, and SES sandbox restrictions.
 
-`SMTP_TIMEOUT_SECONDS` (default 10) bounds one SMTP operation, and a send is
-capped at twice that. The cap matters because `socket.create_connection` retries
-every address the SMTP host resolves to: at a 15s timeout, a blocked port on a
-three-A-record host such as SES held the caller for 45s before reporting
-anything.
+Ports 465 and 2465 require implicit TLS and are not supported. `SMTP_TIMEOUT_SECONDS` bounds each operation; the overall send is capped at twice that value.
 
-The Monitoring tab's Email delivery card shows the configured endpoint, the last
-successful send, and the last failure with its explanation, so a dead transport
-is visible without anyone clicking a test.
+## Error alerts
 
-## Layer 1: error alerts
+A logging handler watches the `backend` and `uvicorn.error` trees. Every `ERROR` record enters the alert pipeline.
 
-A logging handler on the `backend` and `uvicorn.error` trees turns every `ERROR`
-record into an alert. No call-site changes are needed to cover a new failure
-path, because `logger.exception(...)` is already the convention.
+Alerts group by logger, exception type, and unformatted log template. Each group sends at most once per `ALERT_DEDUPE_MINUTES`, including the number of suppressed occurrences. `ALERT_MAX_EMAILS_PER_HOUR` caps total sends. A failed email does not start the cooldown.
 
-**Grouping.** Alerts collapse on `(logger, exception type, log template)`. The
-unformatted template is the key, so `"LLM failed for user %s"` with a thousand
-different user ids is one alert with `count: 1000`, not a thousand emails.
+Failures that do not raise or log at `ERROR` require a health probe.
 
-**Throttling.** Each group emails at most once per `ALERT_DEDUPE_MINUTES`
-(default 30), carrying the suppressed occurrence count. A global
-`ALERT_MAX_EMAILS_PER_HOUR` (default 20) caps the worst case. Held-back alerts
-keep accumulating rather than being discarded, and a failed send deliberately
-does not start the cooldown, so a transient SES outage does not silence a
-fingerprint for half an hour.
+## Health probes
 
-**What it will not catch.** Anything that does not raise or log at `ERROR`. A
-scraper returning zero results, a channel that quietly stops delivering, an
-OAuth token that expired but has not been used yet. That is layer 2's job.
+Probes run every `HEALTH_CHECK_INTERVAL_SECONDS` and alert on status transitions. `HEALTH_FAILURE_THRESHOLD` consecutive failures are required before a probe becomes DOWN. Each probe is capped by `HEALTH_PROBE_TIMEOUT_SECONDS`.
 
-## Layer 2: health probes
-
-Runs every `HEALTH_CHECK_INTERVAL_SECONDS` (default 300) and emails on **status
-transitions**, not on state. A six-hour outage is two emails (down, then
-recovered), not seventy-two. `HEALTH_FAILURE_THRESHOLD` consecutive failures
-(default 2) are required before declaring DOWN, so one timed-out request to a
-residential host is not an incident.
-
-| Probe | Mechanism | Detects |
+| Probe | Check | Detects |
 |---|---|---|
-| `database` | Calls the `/health` handler | Postgres unreachable |
-| `llm` | Single-token `amessages` call against the primary model | Revoked key, retired model, provider outage |
-| `bluebubbles` | Three checks in order: the channel's `/api/v1/server/info` result, the send-readiness flags in it, then webhook registration | Bridge asleep, rejected password, Mac signed out of iMessage, inbound webhook missing |
-| `integration:<name>:<user_id>` | Each factory's `auth_check` per user | Expired refresh token, revoked grant |
-| `integration_check:<user_id>` | Whether that user's sweep answered at all | A stuck or exploding `auth_check`, which leaves every integration under it unknown |
+| `database` | Calls the `/health` handler | Unreachable Postgres |
+| `llm` | Sends a single-token `amessages` request | Invalid credentials, retired model, provider outage |
+| `bluebubbles` | Checks server info, send readiness, and webhook registration | Sleeping bridge, rejected password, signed-out Mac, missing webhook |
+| `integration:<name>:<user_id>` | Runs the integration's `auth_check` | Expired or revoked user grant |
+| `integration_check:<user_id>` | Tracks whether a user's integration sweep completed | Timed-out or failed `auth_check` |
 
-Probes for unconfigured dependencies are not registered, so an unused
-integration is not a permanently-red check.
+Unconfigured dependencies are not registered as probes.
 
-Every probe is capped at `HEALTH_PROBE_TIMEOUT_SECONDS` (default 45, floor 5),
-including each user's turn in the integration sweep. A probe past its budget is
-abandoned and reported DOWN with a timeout detail, which is the honest reading: a
-dependency that cannot answer in 45s is not healthy. Without the cap one wedged
-socket, typically a residential BlueBubbles host or the scraping sidecar, stalls
-the entire run.
+### BlueBubbles
 
-### The BlueBubbles probe, and why reachable is not enough
+The BlueBubbles probe verifies three independent conditions:
 
-The bridge answering is necessary and nowhere near sufficient. Three distinct
-failures leave it answering normally while messages stop:
+1. The server accepts the configured password.
+2. iMessage is signed in and the configured send method is ready.
+3. A webhook targets the current `APP_BASE_URL` with the current credential.
 
-1. **A rejected password.** `/api/v1/server/info` returns 401. The old
-   reachability check accepted any status below 500, so this read as healthy.
-   Now `reachable` and `authenticated` are tracked separately and the alert
-   names the misconfiguration.
-2. **A Mac signed out of iMessage.** The server reports no iCloud account, so
-   every send fails. The probe reads that flag rather than only the status
-   code. `BLUEBUBBLES_SEND_METHOD=private-api` additionally requires the
-   Private API to be enabled and its helper connected.
-3. **No inbound webhook.** This is the one nothing else catches. Registration
-   is attempted once per deploy in a background task; if the Mac is asleep at
-   that moment the attempt fails, is never retried, and the bridge later comes
-   back with every reachability signal green while inbound stays dead. A
-   changed `APP_BASE_URL` produces the same silence, leaving the old
-   registration pointed at a URL that no longer answers.
+When the webhook is missing or stale, the probe attempts to register it and emits a throttled REPAIRED notice. Repair follows these limits:
 
-**Case 3 self-repairs.** When the webhook is missing or carries a token from a
-previous password, the probe re-registers it against the current
-`APP_BASE_URL` and emails a separate "REPAIRED" notice, throttled by
-`ALERT_DEDUPE_MINUTES`. The notice is separate because the repair resolves the
-failure before `HEALTH_FAILURE_THRESHOLD` consecutive failures accumulate, so
-no DOWN alert would ever fire for it: without its own email, inbound would keep
-breaking and silently fixing itself with nobody the wiser.
+- It does not modify registration when the webhook list cannot be read.
+- It stops after three consecutive unsuccessful repair attempts.
+- It skips repair on the process's first probe tick while startup registration may still be running.
 
-Three guards keep that self-repair from becoming its own problem, because
-registration is delete-then-POST and each attempt reopens a window with no
-webhook registered at all:
+Only one deployment should manage a given bridge. Multiple replicas or environments pointed at the same `BLUEBUBBLES_SERVER_URL` will compete over its single webhook registration. Leave the bridge unset in non-production environments or give each environment its own bridge.
 
-- **It never repairs on a guess.** If the webhook list cannot be retrieved, that
-  is reported as unverified rather than treated as missing, and nothing is
-  written to the operator's Mac.
-- **It stops after three consecutive attempts** that do not stick. Past that the
-  probe reports a plain failure and escalates through the ordinary DOWN alert,
-  rather than rewriting the registration every tick while the email cooldown
-  keeps the operator from hearing about it again. A passing check resets the
-  budget.
-- **It skips the process's first tick,** because the lifespan registers this
-  webhook in a background task and a check landing inside that window would
-  repair and email about a deploy where nothing was wrong.
-
-**One writer per bridge.** Every replica runs its own monitor, so more than one
-replica means several independent delete-and-register cycles against one
-BlueBubbles server. The same applies to any staging or preview environment that
-shares `BLUEBUBBLES_SERVER_URL` with production but has its own `APP_BASE_URL`:
-it will now assert its own registration on a schedule instead of failing once at
-boot, and the two environments will fight over the bridge. Point non-production
-environments at their own bridge, or leave `BLUEBUBBLES_SERVER_URL` unset there
-so the probe is not registered at all.
-
-Readiness flags are tri-state. Older BlueBubbles builds omit them, and a
-missing field is treated as unknown rather than as an outage.
+Older BlueBubbles versions may omit readiness flags. Missing flags are treated as unknown, not as a failure.
 
 ### Admin Monitoring tab
 
-`Admin -> Monitoring` in the web app shows every probe, not just BlueBubbles:
-current status and detail, when each was last checked, consecutive failures,
-and an activity log of status changes and self-repairs. `Run probes now` is the
-one action at the top; `Send test alert` and `Diagnose delivery` sit in the Email
-delivery card at the bottom, where a failure is explained rather than merely
-reported.
+`Admin -> Monitoring` shows current probe state, details, last-check time, consecutive failures, and recent transitions or repairs.
 
-**Runs are started, not awaited.** `POST /api/monitoring/run-probes` schedules a
-run and returns immediately with its step list, all pending. The tab polls
-`GET /api/monitoring/status` and reads `health_monitor.run`, showing each step as
-queued, checking, passed, or failed with its elapsed time. Awaiting the run
-instead meant a request open for minutes on a large tenant count, a tab stuck on
-"Running" with no way to tell a slow probe from a wedged one, and a lost result
-whenever a proxy timed out first. A run also reports the alert email as its own
-step, so a transition that could not be delivered is visible rather than silent.
+`POST /api/monitoring/run-probes` starts a run and returns immediately. Poll `GET /api/monitoring/status` for queued, checking, passed, or failed steps and elapsed times. Only one run executes at a time; a second request watches the run already in progress.
 
-Only one run happens at a time: an operator's run and the timer tick serialize on
-a lock, and a second `run-probes` request returns `started: false` and watches the
-run already in flight. Two overlapping passes would double every outbound call and
-race on the transition bookkeeping.
-
-**Per-user integrations are grouped by user, one row per account.** A flat list
-of every (user, integration) pair answers "is anything broken"; the question an
-admin actually has is "whose account is broken", and several hundred rows sorted
-by probe key cannot answer it without scrolling and grouping in your head. Each
-user gets a single verdict, worst first:
+Per-user integrations are grouped by account with these summary states:
 
 | Verdict | Meaning |
 |---|---|
-| `N not working` | At least one integration that used to work is DOWN |
-| `Status unknown` | The sweep could not check this user, so nothing below can be claimed |
-| `N unknown` | A failure that has not yet reached `HEALTH_FAILURE_THRESHOLD` |
+| `N not working` | At least one previously working integration is DOWN |
+| `Status unknown` | The account's sweep did not complete |
+| `N unknown` | Failures have not reached the threshold |
 | `All N working` | Every connected integration authenticates |
-| `Nothing connected` | This user has connected nothing |
+| `Nothing connected` | No integration is connected |
 
-Users are named by their subscription email rather than by `users.id`, because a
-UUID says something is broken without saying whose account to go fix. Rows expand
-under each user with the detail and timings, and accounts with a problem expand
-themselves. Only users with a problem are listed by default; `Show all N users`
-reveals the rest.
+Problem accounts appear first and expand automatically. The activity log is process-local and resets on deploy; alert emails are the durable record.
 
-An integration nobody ever connected shows as "Not connected" and is excluded
-from the verdict: baseline seeding records those as DOWN so a later disconnect is
-still reportable, but they are not breakage, and with 8 specialist integrations
-across `HEALTH_PROBE_MAX_USERS` accounts they would otherwise read as several
-hundred failures on a completely healthy deployment.
+### Per-user integration baselines
 
-The activity log lives in process memory, so a deploy resets it and each
-replica has its own. The alert emails are the durable record.
+An integration that was never connected and one with an expired token can both report "not authenticated." Initial integration observations are therefore silent; alerts begin after a genuine UP to DOWN transition. Recoveries are reported.
 
-### Per-user integration checks are baseline-silent
+`integration_check:<user_id>` is not baseline-silent. It reports when the user's integration sweep cannot run, preventing stale probe states from looking healthy.
 
-An integration a user never connected reports the same "not authenticated"
-reason as one whose token just expired. Alerting on the former would be constant
-noise, so these keys establish their baseline silently and alert only on a
-genuine UP to DOWN transition: it worked, then it stopped. Recoveries are always
-reported. That transition is the email you get when a tenant's connection
-breaks, and it names the tenant by email, not by user id.
+Probe state is process-local. A deploy resets whether an integration was previously UP, so a grant that lapses during replacement can appear as an initial disconnected state. Persisting that history remains a known gap.
 
-**The sweep reports on itself, and that key is not baseline-silent.** A user
-whose `auth_check` times out or raises used to be skipped in silence. Their probe
-states then kept their last known status forever, so an integration that broke
-while the check was failing produced no transition and no email. Now that user
-gets an `integration_check:<user_id>` failure, which alerts like any
-infrastructure probe: a check that cannot run has no legitimate steady state,
-unlike a connection the user never made.
-
-**Known gap: a deploy reseeds every baseline.** Probe state lives in process
-memory, and `ever_up` with it. An integration that lapses while the process is
-being replaced comes back as a first observation, so it is recorded silently and
-shows as "Not connected" rather than as breakage, which is indistinguishable
-from a user who never connected it. Closing that needs the "has this ever
-authenticated" bit persisted, which is not implemented.
-
-Start a run on demand instead of waiting out the interval, then poll for its
-progress:
+Run probes manually and inspect progress with:
 
 ```bash
-curl -X POST https://your-domain/api/monitoring/run-probes \
+curl -X POST https://your-domain.example/api/monitoring/run-probes \
   -H "Authorization: Bearer $ADMIN_API_KEY"
-curl -s https://your-domain/api/monitoring/status \
+curl -s https://your-domain.example/api/monitoring/status \
   -H "Authorization: Bearer $ADMIN_API_KEY" | jq .health_monitor.run
 ```
 
-## Tuning noise
+## Tuning alert volume
 
 If alert volume is too high:
 
-1. Raise `ALERT_DEDUPE_MINUTES` before disabling anything.
-2. Raise `HEALTH_FAILURE_THRESHOLD` if a flaky dependency flaps.
-3. Check whether an existing `logger.error` call is actually routine and should
-   be a `logger.warning`. That fixes the noise at the source, and warnings are
-   not captured.
+1. Raise `ALERT_DEDUPE_MINUTES`.
+2. Raise `HEALTH_FAILURE_THRESHOLD` for flaky dependencies.
+3. Change routine `logger.error` calls to `logger.warning` at the source.
 
-Lower `ALERT_MAX_EMAILS_PER_HOUR` as a blunt ceiling only if the above is not
-enough; held-back alerts are counted but their detail is dropped.
+Lower `ALERT_MAX_EMAILS_PER_HOUR` only as a final ceiling. Held-back alerts retain counts but discard individual details.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1778,7 +1778,7 @@
           "admin"
         ],
         "summary": "Get User Detail",
-        "description": "Return identity, subscription, profile config, and integrations.\n\nSlimmed in #325 work item 2: user-authored content (memory, soul,\nuser text, heartbeat directives, message bodies, tool-call args /\nresults) was removed from this default response. Content surfaces\nonly via the consent-gated paths \u2014 ``/admin/reported-conversations``\n(after a user reports a conversation) or ``/admin/shared-data``\n(when a user opted into data sharing) \u2014 once items 3 + 4 land.\n\nEager-loads ``tool_configs`` and ``channel_routes`` via selectinload\nso we make one round-trip instead of three.",
+        "description": "Return identity, subscription, profile config, and integrations.\n\nSlimmed in #325 work item 2: user-authored content (memory, soul,\nuser text, heartbeat directives, message bodies, tool-call args /\nresults) was removed from this default response. Content surfaces\nonly via the consent-gated paths. ``/admin/reported-conversations``\n(after a user reports a conversation) or ``/admin/shared-data``\n(when a user opted into data sharing) once items 3 + 4 land.\n\nEager-loads ``tool_configs`` and ``channel_routes`` via selectinload\nso we make one round-trip instead of three.",
         "operationId": "get_user_detail_api_admin_users__user_id__get",
         "parameters": [
           {
@@ -3442,7 +3442,7 @@
           "admin"
         ],
         "summary": "List Shared Data Heartbeat Logs",
-        "description": "Return heartbeat scheduler runs with their content fields.\n\nThe non-consent variant ``/admin/users/{id}/heartbeat-logs`` returns\nonly metadata (id, action_type, channel, created_at) since #336.\nFor consenting users the full content surfaces here: ``message_text``\n(what the agent sent on this tick), ``reasoning`` (why it sent /\nskipped \u2014 often quotes the user back to themselves), and ``tasks``\n(the serialized task state the LLM was deciding from). All three\ncolumns are envelope-encrypted at rest; ORM reads decrypt\ntransparently and we redact PII shapes before serialization.",
+        "description": "Return heartbeat scheduler runs with their content fields.\n\nThe non-consent variant ``/admin/users/{id}/heartbeat-logs`` returns\nonly metadata (id, action_type, channel, created_at) since #336.\nFor consenting users the full content surfaces here: ``message_text``\n(what the agent sent on this tick), ``reasoning`` (why it sent /\nskipped because it often quotes the user back to themselves), and ``tasks``\n(the serialized task state the LLM was deciding from). All three\ncolumns are envelope-encrypted at rest; ORM reads decrypt\ntransparently and we redact PII shapes before serialization.",
         "operationId": "list_shared_data_heartbeat_logs_api_admin_shared_data_users__user_id__heartbeat_logs_get",
         "parameters": [
           {
@@ -3533,7 +3533,7 @@
           "admin"
         ],
         "summary": "Get Shared Data Memory",
-        "description": "Return the consenting user's MemoryDocument (memory + history).\n\n``memory_text`` is the agent's working memory file (persistent\nnotes, reminders, current context). ``history_text`` is the\naccumulated output of session compactions: each time a long\nsession compacts, the LLM extracts durable facts and appends them\nhere. Reading ``history_text`` is the closest persisted surface to\na per-event compaction stream; per-event timing lives in\n``logger.info(\"compaction.summary user=...\")`` lines only and is\nnot yet queryable.\n\nBoth columns are envelope-encrypted at rest. A user with no\ndocument yet (never compacted, never wrote memory) returns empty\nstrings rather than 404 \u2014 consenting and \"no memory yet\" is a\nvalid combined state.",
+        "description": "Return the consenting user's MemoryDocument (memory + history).\n\n``memory_text`` is the agent's working memory file (persistent\nnotes, reminders, current context). ``history_text`` is the\naccumulated output of session compactions: each time a long\nsession compacts, the LLM extracts durable facts and appends them\nhere. Reading ``history_text`` is the closest persisted surface to\na per-event compaction stream; per-event timing lives in\n``logger.info(\"compaction.summary user=...\")`` lines only and is\nnot yet queryable.\n\nBoth columns are envelope-encrypted at rest. A user with no\ndocument yet (never compacted, never wrote memory) returns empty\nstrings rather than 404. Consenting and \"no memory yet\" is a\nvalid combined state.",
         "operationId": "get_shared_data_memory_api_admin_shared_data_users__user_id__memory_get",
         "parameters": [
           {
@@ -5122,7 +5122,7 @@
           "created_at"
         ],
         "title": "AdminHeartbeatLogItem",
-        "description": "Heartbeat log metadata only.\n\nContent fields (``message_text``, ``reasoning``, ``tasks``) were\nremoved in #325 work item 2 \u2014 they were user-facing content the\nuser-detail response also stripped. They surface only via the\nconsent-gated paths once items 3 + 4 land."
+        "description": "Heartbeat log metadata only.\n\nContent fields (``message_text``, ``reasoning``, ``tasks``) were\nremoved in #325 work item 2. They were user-facing content the\nuser-detail response also stripped. They surface only via the\nconsent-gated paths once items 3 + 4 land."
       },
       "AdminHeartbeatLogListResponse": {
         "properties": {
@@ -5477,7 +5477,7 @@
           "permissions"
         ],
         "title": "AdminUserDetailResponse",
-        "description": "Identity, account state, and configuration metadata for one user.\n\nUser-authored content (memory, soul, user text, heartbeat directives,\nmessage bodies, tool-call args/results) was removed in #325 work\nitem 2. The plan: content surfaces only via the consent-gated paths\n(``/admin/reported-conversations`` and ``/admin/shared-data``) once\nitems 3 + 4 land. Until then, admins debugging an incident see the\nmetadata + integrations here, plus the audit log of who looked.\n\nChannel routes carry a *masked* ``channel_identifier`` \u2014 phone\nnumbers / iMessage emails / Telegram chat IDs are PII the admin\nrarely needs in full. The route applies ``_mask_channel_identifier``\nso admins see enough to recognize a route and confirm last-4 digits,\nnot enough to dial / message directly from the admin panel."
+        "description": "Identity, account state, and configuration metadata for one user.\n\nUser-authored content (memory, soul, user text, heartbeat directives,\nmessage bodies, tool-call args/results) was removed in #325 work\nitem 2. The plan: content surfaces only via the consent-gated paths\n(``/admin/reported-conversations`` and ``/admin/shared-data``) once\nitems 3 + 4 land. Until then, admins debugging an incident see the\nmetadata + integrations here, plus the audit log of who looked.\n\nChannel routes carry a *masked* ``channel_identifier``. Phone\nnumbers / iMessage emails / Telegram chat IDs are PII the admin\nrarely needs in full. The route applies ``_mask_channel_identifier``\nso admins see enough to recognize a route and confirm last-4 digits,\nnot enough to dial / message directly from the admin panel."
       },
       "AdminUserLLMOverrideResponse": {
         "properties": {

--- a/frontend/src/docs-content/features/calendar.md
+++ b/frontend/src/docs-content/features/calendar.md
@@ -4,14 +4,15 @@
 >
 > The Google Calendar integration is experimental. Use with caution while this feature is being developed. Double-check events created or modified by the assistant before relying on them.
 
-Clawbolt can connect to your Google Calendar so you can manage your schedule from the chat. Ask questions like "am I free Thursday afternoon?" or "schedule a site visit at the Johnson place for 9am tomorrow" and Clawbolt handles it.
+Clawbolt can connect to your Google Calendar so you can manage your schedule from chat. Ask "am I free Thursday afternoon?" or "schedule a site visit at 123 Main Street for 9am tomorrow."
 
 ## What it can do
 
-The integration provides five tools the agent uses to interact with Google Calendar:
+The integration provides six tools the agent uses to interact with Google Calendar:
 
 | Tool | Purpose | Approval |
 |------|---------|----------|
+| `calendar_list_calendars` | List enabled calendars and access roles | Automatic |
 | `calendar_list_events` | List events in a date range | Automatic |
 | `calendar_create_event` | Create a new event | Asks permission |
 | `calendar_update_event` | Update an existing event | Asks permission |
@@ -60,44 +61,7 @@ Users can connect their Google account in two ways:
 
 Once connected, the calendar tools become available to the agent.
 
-## Example conversations
-
-### Checking your schedule
-```
-You: What do I have tomorrow?
-
-Clawbolt: Here's your schedule for tomorrow (March 25):
-          - 8:00 AM: Site visit at Johnson residence
-          - 11:30 AM: Lunch with supplier
-          - 2:00 PM: Estimate walkthrough at 42 Oak St
-```
-
-### Scheduling a job
-```
-You: Schedule a bathroom remodel at the Davis place for next
-     Monday 8am to 4pm
-
-Clawbolt: I'd like to create this event:
-          "Job: Davis - Bathroom remodel"
-          Monday March 30, 8:00 AM - 4:00 PM
-          Approve?
-
-You: Yes
-
-Clawbolt: Done! Event created on your calendar.
-```
-
-### Checking availability
-```
-You: Am I free Friday afternoon?
-
-Clawbolt: You have a gap from 1:00 PM to 5:00 PM on Friday.
-          Want me to schedule something?
-```
-
-## Timezone handling
-
-Clawbolt uses your timezone (set in your user profile) when interpreting times. If you say "9am tomorrow", it means 9 AM in your local time, not UTC.
+For chat examples, timezone behavior, and approval behavior, see the [Calendar guide](/docs/guide/calendar).
 
 ## Disconnecting
 

--- a/frontend/src/docs-content/features/file-cataloging.md
+++ b/frontend/src/docs-content/features/file-cataloging.md
@@ -14,7 +14,7 @@ Files land under your Drive's `Clawbolt` folder. The agent organizes by context:
 
 ```
 Clawbolt/
-├── John Smith - 123 Main Street/
+├── Test Customer - 123 Main Street/
 │   ├── photos/
 │   │   ├── kitchen-before_001.jpg
 │   │   └── kitchen-after_002.jpg
@@ -37,7 +37,7 @@ When you send media, the agent uses these tools:
 3. `find_saved_files` searches your saved files by filename or description.
 4. `analyze_saved_file` runs vision analysis on a previously saved image without asking you to resend it.
 
-The agent references saved files by their storage path (e.g. `/John Smith - 123 Main Street/photos/kitchen-before_001.jpg`). Drive is the source of truth: filenames, locations, and descriptions live on the file in your Drive, not in a separate Clawbolt database.
+The agent references saved files by their storage path (e.g. `/Test Customer - 123 Main Street/photos/kitchen-before_001.jpg`). Drive is the source of truth: filenames, locations, and descriptions live on the file in your Drive, not in a separate Clawbolt database.
 
 ## Operator setup (self-hosted only)
 

--- a/frontend/src/docs-content/features/heartbeat.md
+++ b/frontend/src/docs-content/features/heartbeat.md
@@ -4,19 +4,17 @@ The heartbeat system lets Clawbolt proactively reach out with reminders and foll
 
 ## How it works
 
-The heartbeat runs on a timer and uses a two-stage design: **cheap checks first, LLM only when needed**.
+The heartbeat runs on a timer and uses a two-stage evaluation.
 
-### Stage 1: Deterministic checks (no LLM cost)
+Before either stage, Clawbolt skips users who have not opted in, have no heartbeat items, recently sent a message, or reached their daily proactive-message limit.
 
-Fast checks look for actionable items:
+### Stage 1: Lightweight evaluation
 
-- **Time-sensitive memory facts**: Facts containing keywords like "remind", "follow-up", "deadline"
-- **Idle users**: No inbound messages for a configurable number of days
-- **Heartbeat notes**: User-defined notes stored via the `update_heartbeat` tool
+A small LLM call reviews the user's heartbeat items, recent activity, and prior heartbeat history. It decides whether an item is actionable now.
 
-### Stage 2: LLM evaluation (only if flags found)
+### Stage 2: Task execution
 
-If any checks return results, the LLM composes an appropriate message. It can decide to send the message or take no action, based on priority and context.
+When Stage 1 selects work, the full agent executes the task and sends any useful result. If nothing is due, no message is sent.
 
 ## Quiet by default
 

--- a/frontend/src/docs-content/features/memory.md
+++ b/frontend/src/docs-content/features/memory.md
@@ -1,10 +1,10 @@
 # Memory
 
-Clawbolt has a persistent memory system that stores facts about your business across conversations. It remembers your rates, client details, job preferences, and anything else you tell it.
+Clawbolt keeps durable business knowledge across conversations: rates, preferences, shorthand, and process rules. Current customer details, balances, schedules, and job status stay in their connected systems so Clawbolt can look them up instead of relying on a stale copy.
 
 ## How it works
 
-Memory is stored as freeform text in a per-user `MEMORY.md` file managed by the agent. The agent reads and writes this file using workspace tools (`read_file`, `write_file`, `edit_file`). When conversations get long, automatic compaction summarizes key facts back into `MEMORY.md` and appends a timestamped summary to `HISTORY.md`.
+Memory is exposed to the agent as a per-user `MEMORY.md` workspace document and stored in PostgreSQL. The agent manages it with workspace tools. When conversations get long, automatic compaction updates `MEMORY.md` and appends timestamped breadcrumbs to `HISTORY.md`.
 
 ## Saving facts
 
@@ -22,9 +22,9 @@ Clawbolt: Got it! I've saved that your hourly rate for electrical
 Clawbolt's memory is always available in context. You can ask directly:
 
 ```
-You: What's Mrs. Johnson's address?
+You: What's my standard plumbing rate?
 
-Clawbolt: Mrs. Johnson's address is 42 Oak Street, Austin, TX 78701.
+Clawbolt: Your standard plumbing rate is $95 per hour.
 ```
 
 ## Forgetting facts

--- a/frontend/src/docs-content/features/photos.md
+++ b/frontend/src/docs-content/features/photos.md
@@ -7,7 +7,7 @@ Send a photo to Clawbolt and it will analyze it using vision AI, providing a des
 1. **Send a photo**: Take a picture at the job site and send it to Clawbolt
 2. **AI analysis**: The image is processed by the LLM's vision capabilities
 3. **Description generated**: Clawbolt provides a text description of what it sees
-4. **Stored and organized**: If you have connected [Google Drive](https://github.com/mozilla-ai/clawbolt/blob/main/docs/self-host/google-drive-setup.md), the photo lands in your own Drive, organized by date and client
+4. **Optionally stored**: With Google Drive connected, the assistant can save the photo under the top-level `Clawbolt` folder
 
 ## Use cases
 
@@ -16,15 +16,4 @@ Send a photo to Clawbolt and it will analyze it using vision AI, providing a des
 - **Material identification**: Get help identifying materials, fixtures, or parts
 - **Progress tracking**: Document job progress with timestamped, described photos
 
-## Storage organization
-
-When [file cataloging](/docs/features/file-cataloging) is configured, photos are automatically organized:
-
-```
-Job Photos/
-├── 2026-02-28/
-│   ├── site-front.jpg
-│   └── site-back.jpg
-└── 2026-03-01/
-    └── kitchen-demo.jpg
-```
+See [File Cataloging](/docs/features/file-cataloging) for storage behavior and folder organization.

--- a/frontend/src/docs-content/features/quickbooks.md
+++ b/frontend/src/docs-content/features/quickbooks.md
@@ -4,7 +4,7 @@
 >
 > The QuickBooks integration is experimental. Do not connect it to a production QuickBooks account. Use a sandbox company only while this feature is being developed.
 
-Clawbolt can connect to QuickBooks Online so you can manage invoices, estimates, and customers directly from the chat. Ask a question like "what invoices do I have for Amy?" or dictate a job description and Clawbolt will create a draft estimate in QuickBooks.
+Clawbolt can connect to QuickBooks Online so you can manage invoices, estimates, and customers directly from chat. Ask what invoices exist for a test customer, or dictate a job description and Clawbolt will create a draft estimate in QuickBooks.
 
 ## What it can do
 
@@ -13,8 +13,8 @@ The integration provides four tools that the agent uses to interact with QuickBo
 | Tool | Purpose |
 |------|---------|
 | `qb_query` | Look up invoices, estimates, customers, items, payments, and more |
-| `qb_create` | Create new customers, estimates, or invoices |
-| `qb_update` | Update existing customers, estimates, or invoices |
+| `qb_create` | Create customers, estimates, invoices, or items |
+| `qb_update` | Update customers, estimates, invoices, or items |
 | `qb_send` | Email an invoice or estimate to a customer |
 
 The agent handles the queries and API calls itself, so you just talk in plain language.
@@ -51,82 +51,36 @@ Go to [developer.intuit.com](https://developer.intuit.com) and sign up (or sign 
 2. Under **Development** (for sandbox testing), copy:
    - **Client ID**
    - **Client Secret**
-3. Add a redirect URI (use `https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl` for the playground)
+3. Add `https://<your-domain>/api/oauth/callback` as a redirect URI
 
-### 4. Note your sandbox company ID
-
-Intuit automatically creates a sandbox company with sample data (customers, items, invoices). Find the **Company ID** (also called **Realm ID**) in the sandbox section of the developer dashboard.
-
-### 5. Get OAuth tokens via the playground
-
-The OAuth 2.0 Playground is the easiest way to get your initial tokens without building a callback flow:
-
-1. From your app dashboard, click **Test connect to app (OAuth)** or open the OAuth 2.0 Playground directly
-2. Select your app and the **Accounting** scope
-3. Click **Connect to QuickBooks**
-4. Sign in and authorize the sandbox company
-5. The playground will show your **Access Token** and **Refresh Token**
-
-### 6. Configure Clawbolt
+### 4. Configure Clawbolt
 
 Add these to your `.env` file:
 
 ```bash
 QUICKBOOKS_CLIENT_ID=your_client_id
 QUICKBOOKS_CLIENT_SECRET=your_client_secret
-QUICKBOOKS_REALM_ID=your_company_id
-QUICKBOOKS_ACCESS_TOKEN=your_access_token
-QUICKBOOKS_REFRESH_TOKEN=your_refresh_token
 QUICKBOOKS_ENVIRONMENT=sandbox
+APP_BASE_URL=https://your-clawbolt-domain.example
 ```
 
-Restart Clawbolt and the QuickBooks tools will appear as a specialist capability.
+Restart Clawbolt. Users authorize their own company through Clawbolt's OAuth flow; tokens and company IDs are stored per user.
 
 Once the admin credentials are configured, users can connect their QuickBooks account in two ways:
 
 - **Over chat (preferred):** Ask the assistant "connect my QuickBooks" and it will generate an authorization link.
 - **From the dashboard:** Open the **Tools** page and connect from there.
 
-## Example conversations
-
-### Looking up data
-```
-You: Do I have any invoices for Amy's Bird Sanctuary?
-
-Clawbolt: Found 4 invoices for Amy's Bird Sanctuary:
-          - #1036 | $315.00 (Paid) | Date: 2024-01-10
-          - #1012 | $650.00 (Open, $400 paid) | Due: 2024-03-15
-          - #1009 | $1,250.00 (Paid) | Date: 2023-11-20
-          - #1003 | $475.00 (Paid) | Date: 2023-09-05
-```
-
-### Creating an estimate from a dictation
-```
-You: Just left the Johnson place. They want the bathroom remodeled.
-     About 3 days of labor at 65 an hour, plus around 800 in materials
-     for tile and fixtures.
-
-Clawbolt: I created a draft estimate for Johnson in QuickBooks:
-          - Labor (3 days @ $65/hr): $1,560.00
-          - Materials (tile & fixtures): $800.00
-          - Total: $2,360.00
-          Want to review or adjust anything?
-```
-
-## Token lifecycle
-
-- **Access tokens** expire after 1 hour. Clawbolt automatically refreshes them using the refresh token when it gets a 401 response.
-- **Refresh tokens** expire after 101 days. Each time a token is refreshed, Intuit issues a new refresh token and invalidates the old one.
-- Refreshed tokens are automatically persisted to the database (`oauth_tokens` table) and survive restarts. When `ENCRYPTION_KEY` is configured, tokens are encrypted at rest.
+For user workflows and chat examples, see [Estimates and Invoicing](/docs/guide/estimates).
 
 ## Troubleshooting
 
 | Problem | Fix |
 |---------|-----|
 | Tools don't appear | Check that `QUICKBOOKS_CLIENT_ID` and `QUICKBOOKS_CLIENT_SECRET` are set. The integration is disabled when these are empty. |
-| 401 Unauthorized | Your access token has expired and the refresh token may be stale. Get fresh tokens from the OAuth playground. |
+| 401 Unauthorized | Reconnect QuickBooks from the Tools page to replace an expired or revoked grant. |
 | 400 Bad Request | The query syntax may be invalid. Check the Clawbolt logs for the full error. QBO does not support subqueries. |
-| Wrong company data | Verify `QUICKBOOKS_REALM_ID` is the numeric company ID (no letters). |
+| Wrong company data | Disconnect and reconnect, then authorize the intended QuickBooks company. |
 
 ## Reference
 

--- a/frontend/src/docs-content/guide/calendar.md
+++ b/frontend/src/docs-content/guide/calendar.md
@@ -8,17 +8,17 @@ With Google Calendar connected, you can check your schedule, book jobs, and mana
 You: What do I have tomorrow?
 
 Clawbolt: Here's your schedule for tomorrow (Tuesday):
-          - 8:00 AM: Site visit at Johnson residence
+          - 8:00 AM: Test Customer site visit
           - 11:30 AM: Lunch with supplier
-          - 2:00 PM: Estimate walkthrough at 42 Oak St
+          - 2:00 PM: Estimate walkthrough at 123 Main Street
 ```
 
 ```
-You: Schedule a bathroom remodel at the Davis place
+You: Schedule a bathroom remodel for Test Customer
      for next Monday 8am to 4pm
 
 Clawbolt: I'd like to create this event:
-          "Job: Davis - Bathroom remodel"
+          "Job: Test Customer - Bathroom remodel"
           Monday March 30, 8:00 AM - 4:00 PM
           Approve?
 
@@ -35,14 +35,4 @@ Your assistant uses your timezone when interpreting times. Make sure it's set co
 
 ## Getting connected
 
-Ask your assistant to connect Google Calendar:
-
-```
-You: Connect my Google Calendar
-
-Clawbolt: Here's a link to connect your Google account:
-          [link]
-          Tap it, sign in, and grant calendar access.
-```
-
-You can also connect from the Tools page in the web dashboard. You can control which calendar actions are enabled (list, create, update, delete) from there. See [Google Calendar](/docs/features/calendar) for technical setup details.
+Ask your assistant to connect Google Calendar, or use the Tools page in the web dashboard. See [Integrations](/docs/guide/integrations) for the connection flow and [Google Calendar](/docs/features/calendar) for operator setup.

--- a/frontend/src/docs-content/guide/dashboard.md
+++ b/frontend/src/docs-content/guide/dashboard.md
@@ -1,8 +1,6 @@
 # Dashboard
 
-Everything in Clawbolt is designed to be managed through chat. Your assistant automatically updates your memory, heartbeat, personality, and profile as you talk to it. You never need to log into the dashboard.
-
-That said, the dashboard is there if you want a visual overview or prefer to make bulk edits.
+Most Clawbolt settings can be managed through chat. The dashboard provides a visual overview, bulk editing, permissions, and forms for integrations whose credentials should not enter chat history.
 
 ## Dashboard cards
 

--- a/frontend/src/docs-content/guide/estimates.md
+++ b/frontend/src/docs-content/guide/estimates.md
@@ -7,11 +7,11 @@ With QuickBooks connected, you can create estimates, look up invoices, and manag
 Dictate a job description from your phone and your assistant drafts an estimate in QuickBooks:
 
 ```
-You: Just left the Davis place. They want the master bathroom
+You: Just left the Test Customer job. They want the master bathroom
      remodeled. About 3 days of labor at 65 an hour, plus
      around 800 in materials for tile and fixtures.
 
-Clawbolt: I created a draft estimate for Davis in QuickBooks:
+Clawbolt: I created a draft estimate for Test Customer in QuickBooks:
           - Labor (3 days x 8 hrs x $65/hr): $1,560
           - Materials (tile & fixtures): $800
           - Total: $2,360
@@ -23,9 +23,9 @@ No laptop required. No "computer time" at the end of the day.
 ## Looking up invoices
 
 ```
-You: What invoices do I have for Amy's Bird Sanctuary?
+You: What invoices do I have for Test Customer?
 
-Clawbolt: Found 4 invoices for Amy's Bird Sanctuary:
+Clawbolt: Found 4 invoices for Test Customer:
           - #1036 | $315.00 (Paid)
           - #1012 | $650.00 (Open, $400 paid)
           - #1009 | $1,250.00 (Paid)
@@ -38,14 +38,4 @@ Ask your assistant to send estimates or invoices to clients, or create and updat
 
 ## Getting connected
 
-Ask your assistant to connect QuickBooks:
-
-```
-You: Connect my QuickBooks
-
-Clawbolt: Here's a link to connect your QuickBooks account:
-          [link]
-          Tap it, sign in, and you're all set.
-```
-
-You can also connect from the Tools page in the web dashboard. See [QuickBooks](/docs/features/quickbooks) for technical setup details.
+Ask your assistant to connect QuickBooks, or use the Tools page in the web dashboard. See [Integrations](/docs/guide/integrations) for the connection flow and [QuickBooks](/docs/features/quickbooks) for operator setup.

--- a/frontend/src/docs-content/guide/getting-started.md
+++ b/frontend/src/docs-content/guide/getting-started.md
@@ -25,11 +25,11 @@ Clawbolt: Got it! I've saved your electrical rate at $95/hour.
 
 ## Everything happens through chat
 
-Your assistant manages everything for you as you talk. Your memory, personality, profile, heartbeat priorities, and integrations are all updated automatically through conversation. There's a [web dashboard](/docs/guide/dashboard) if you're curious, but you never need to open it.
+Your assistant can update its memory, personality, profile, heartbeat priorities, and integrations through conversation. The [web dashboard](/docs/guide/dashboard) provides a visual way to review and manage the same settings.
 
 ## Tips for getting started
 
 - **Talk naturally.** No special commands needed.
 - **Use voice dictation.** Tap the microphone on your keyboard and talk instead of typing.
-- **Teach it as you go.** Every time you mention a client, rate, or preference, it remembers.
+- **Teach it durable preferences.** Tell it your rates, shorthand, and process rules. It looks up changing customer and job data in connected systems.
 - **Connect integrations over chat.** Ask "connect my Google Calendar" and your assistant sends you a link. [Learn more](/docs/guide/integrations)

--- a/frontend/src/docs-content/guide/heartbeat.md
+++ b/frontend/src/docs-content/guide/heartbeat.md
@@ -4,7 +4,7 @@ Heartbeat lets your assistant reach out proactively. Instead of waiting for you 
 
 ```
 Clawbolt: Hey! Quick reminder: you mentioned wanting to
-          follow up with Mrs. Johnson about the kitchen
+          follow up with Test Customer about the kitchen
           estimate by end of week. Want me to draft a
           message to send her?
 ```
@@ -14,11 +14,11 @@ Clawbolt: Hey! Quick reminder: you mentioned wanting to
 Just tell your assistant what to track. It manages your heartbeat automatically:
 
 ```
-You: Add to my heartbeat: follow up with Davis about
+You: Add to my heartbeat: follow up with Test Customer about
      the bathroom estimate by Friday
 
 Clawbolt: Added to your heartbeat. I'll remind you about
-          the Davis estimate before Friday.
+          the Test Customer estimate before Friday.
 ```
 
 ```

--- a/frontend/src/docs-content/guide/index.md
+++ b/frontend/src/docs-content/guide/index.md
@@ -1,6 +1,6 @@
 # What is Clawbolt?
 
-Clawbolt is an AI assistant for contractors, handymen, and tradespeople. You text it like you'd text a friend, and it helps you run your business: remembering client details, organizing job photos, creating estimates, managing your calendar, and following up on tasks.
+Clawbolt is an AI assistant for contractors, handymen, and tradespeople. You text it like you'd text a coworker, and it helps you manage business knowledge, job photos, estimates, schedules, and follow-ups.
 
 No app to download. No dashboard to learn. Just send a message from your phone.
 
@@ -9,14 +9,14 @@ No app to download. No dashboard to learn. Just send a message from your phone.
 Message your assistant using iMessage, SMS, RCS, Telegram, or web chat. It reads your message and texts you back.
 
 ```
-You: What's Mrs. Johnson's address?
+You: What jobs are on my calendar tomorrow?
 
-Clawbolt: 42 Oak Street, Austin, TX 78701.
+Clawbolt: You have an Acme Plumbing site visit at 9 AM.
 ```
 
 ## What it can do
 
-- **[Memory](/docs/guide/memory)** -- remembers your rates, clients, and preferences
+- **[Memory](/docs/guide/memory)** -- remembers rates, preferences, and process rules
 - **[Photos](/docs/guide/photos)** -- analyzes and organizes job site photos
 - **[Estimates](/docs/guide/estimates)** -- dictate a job description, get a QuickBooks estimate
 - **[Calendar](/docs/guide/calendar)** -- check availability, schedule jobs, get reminders

--- a/frontend/src/docs-content/guide/integrations.md
+++ b/frontend/src/docs-content/guide/integrations.md
@@ -43,8 +43,7 @@ Clawbolt: Google Calendar has been disconnected.
 
 ## Available integrations
 
-- **Google Calendar** -- check your schedule, book jobs, manage events. [Learn more](/docs/guide/calendar)
-- **QuickBooks Online** -- create estimates, look up invoices, manage customers. [Learn more](/docs/guide/estimates)
+What is available depends on which services your operator configured. Ask the assistant for integration status or check the Tools page for the current list. User guides cover [Google Calendar](/docs/guide/calendar) and [QuickBooks Online](/docs/guide/estimates).
 
 ## Dashboard alternative
 

--- a/frontend/src/docs-content/guide/memory.md
+++ b/frontend/src/docs-content/guide/memory.md
@@ -1,14 +1,14 @@
 # Memory
 
-Your assistant has long-term memory. Tell it something about your business and it saves it for future conversations. You only need to say things once.
+Your assistant keeps durable business knowledge for future conversations. It looks up changing customer and job data in connected systems instead of copying values that can go stale.
 
 ## What it remembers
 
 - Rates and pricing
-- Client details (names, addresses, phone numbers, job history)
 - Preferences (suppliers, materials, brands)
 - Business info (trade, crew size, service area, hours)
-- Job notes (measurements, specs, special instructions)
+- Persistent process rules and shorthand
+- Cross-system context, such as which account bills for a client
 
 ## Saving and recalling facts
 
@@ -21,13 +21,10 @@ Clawbolt: Done! I've saved your plumbing rate at $85/hour.
 ```
 
 ```
-You: What do I know about the Davis job?
+You: What are my standard estimate terms?
 
-Clawbolt: Here's what I have on the Davis project:
-          - Bathroom remodel at 18 Pine St
-          - Started March 10
-          - Budget: $12,000
-          - Tile: marble subway, supplier is Floor & Decor
+Clawbolt: You use net-30 terms and include a 15-day
+          acceptance window on estimates.
 ```
 
 ## Updating and forgetting

--- a/frontend/src/docs-content/guide/photos.md
+++ b/frontend/src/docs-content/guide/photos.md
@@ -1,6 +1,6 @@
 # Photos & Files
 
-Send a photo to your assistant and it will describe what it sees, store it, and organize it in your cloud storage.
+Send a photo to your assistant and it can describe what it sees. With Google Drive or CompanyCam connected, it can also save the photo where you need it.
 
 ## Sending a photo
 
@@ -17,17 +17,8 @@ Clawbolt: I can see a dated kitchen with dark wood cabinets,
 
 Great for before/after documentation, damage records, material identification, and progress tracking.
 
-## Where photos are stored
+## Saving photos
 
-Once you connect Google Drive (via the integrations panel), photos are organized into folders by date inside your own Drive under a top-level Clawbolt folder:
+With Google Drive connected, saved files live under a top-level `Clawbolt` folder. Client work can be organized under `Client - Address/photos`; files without clear job context default to `Inbox`. CompanyCam can store photos in its project structure instead.
 
-```
-Job Photos/
-  2026-03-15/
-    kitchen-before.jpg
-    kitchen-after.jpg
-  2026-03-16/
-    bathroom-tile.jpg
-```
-
-If you have not connected Google Drive, the assistant can still read and reply to photos you send, but it will not save them. Connect Drive (via the integrations panel or by asking the assistant) to turn on saving and retrieval. See [Google Drive Setup](https://github.com/mozilla-ai/clawbolt/blob/main/docs/self-host/google-drive-setup.md) for self-host operators.
+Without a storage integration, the assistant can still analyze and reply to photos but cannot save them. See [File Cataloging](/docs/features/file-cataloging) for user behavior and [Google Drive Setup](https://github.com/mozilla-ai/clawbolt/blob/main/docs/self-host/google-drive-setup.md) for operator setup.

--- a/frontend/src/docs-content/guide/tips.md
+++ b/frontend/src/docs-content/guide/tips.md
@@ -5,11 +5,11 @@
 Tap the microphone on your phone keyboard and talk. Great for dictating job descriptions from the truck, adding notes with dirty hands, or sending quick updates without typing.
 
 ```
-You: [dictated] Just finished the demo at the Davis place,
+You: [dictated] Just finished the demo at the Test Customer job,
      kitchen is gutted, plumbing looks good, electrical
      needs updating, probably add a day for that
 
-Clawbolt: Got it. I've noted the Davis kitchen demo is
+Clawbolt: Got it. I've noted the Test Customer kitchen demo is
           complete. Plumbing is good, but electrical needs
           updating, which adds about a day. Want me to
           update the estimate?
@@ -20,16 +20,16 @@ Clawbolt: Got it. I've noted the Davis kitchen demo is
 Your assistant works best with clear requests:
 
 - **Good:** "Give me a rough estimate for painting a 200 sq ft bedroom, my rate is $65/hour"
-- **Better:** "Estimate for the Miller job: paint master bedroom, 200 sq ft, 2 coats, Benjamin Moore Regal. $65/hour rate, $150 materials."
+- **Better:** "Estimate for Test Customer: paint master bedroom, 200 sq ft, 2 coats. $65/hour rate, $150 materials."
 
 ## Ask follow-up questions
 
 Your assistant remembers the conversation:
 
 ```
-You: What's the Davis estimate total?
+You: What's the Test Customer estimate total?
 
-Clawbolt: The Davis bathroom remodel estimate is $2,360.
+Clawbolt: The Test Customer bathroom remodel estimate is $2,360.
 
 You: Add $200 for the electrical update
 
@@ -37,14 +37,14 @@ Clawbolt: Updated. New total is $2,560. Want me to update
           the QuickBooks estimate too?
 ```
 
-## Clean up outdated info
+## Update durable business info
 
-If your rates or client details change, just tell your assistant. It updates automatically. You can also ask it to forget outdated info:
+If a saved rate or preference changes, tell your assistant. For customer records, estimates, schedules, and job status, it checks the connected system directly.
 
 ```
-You: Forget everything about the old Davis job, that's done
+You: My standard plumbing rate is $90 now, not $85
 
-Clawbolt: Done. Removed the Davis project details from memory.
+Clawbolt: Updated. Your standard plumbing rate is now $90/hour.
 ```
 
 ## Tell your assistant what to do with a photo
@@ -82,11 +82,11 @@ When your assistant performs a real action (uploading a photo, creating an invoi
 
 ```
 Clawbolt: Kitchen demo looks good. Added the photo to
-          Davis and drafted the Johnson invoice.
+          Test Customer and drafted the Acme Plumbing invoice.
 
-          - Uploaded photo to CompanyCam project Davis
+          - Uploaded photo to CompanyCam project Test Customer
             companycam.com/p/abc123
-          - Created QuickBooks invoice for Johnson, $2,560.00
+          - Created QuickBooks invoice for Acme Plumbing, $2,560.00
             app.qbo.intuit.com/app/invoice?txnId=4782
 ```
 
@@ -94,6 +94,6 @@ Each line is generated from the actual API response, not from anything the assis
 
 **If the reply says "done" but there is no confirmation line for what you asked about, the action did not happen.** Ask again. Your assistant will either complete it (and show the line) or explain why it can't (for example, "QuickBooks signed me out, please reconnect").
 
-Read-only questions ("What's the Davis estimate?", "Any appointments tomorrow?") don't produce a confirmation block. The data in the reply is the answer. The confirmation block is only for things that change something in CompanyCam, QuickBooks, Google Calendar, or your storage.
+Read-only questions ("What's the Test Customer estimate?", "Any appointments tomorrow?") don't produce a confirmation block. The data in the reply is the answer. The confirmation block is only for things that change something in CompanyCam, QuickBooks, Google Calendar, or your storage.
 
 The same confirmation block appears everywhere your assistant talks to you: iMessage, SMS, Telegram, and the web dashboard. Whatever thread you're reading, the evidence is the same.

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1125,9 +1125,9 @@ export interface paths {
          *     Slimmed in #325 work item 2: user-authored content (memory, soul,
          *     user text, heartbeat directives, message bodies, tool-call args /
          *     results) was removed from this default response. Content surfaces
-         *     only via the consent-gated paths — ``/admin/reported-conversations``
+         *     only via the consent-gated paths. ``/admin/reported-conversations``
          *     (after a user reports a conversation) or ``/admin/shared-data``
-         *     (when a user opted into data sharing) — once items 3 + 4 land.
+         *     (when a user opted into data sharing) once items 3 + 4 land.
          *
          *     Eager-loads ``tool_configs`` and ``channel_routes`` via selectinload
          *     so we make one round-trip instead of three.
@@ -2018,7 +2018,7 @@ export interface paths {
          *     only metadata (id, action_type, channel, created_at) since #336.
          *     For consenting users the full content surfaces here: ``message_text``
          *     (what the agent sent on this tick), ``reasoning`` (why it sent /
-         *     skipped — often quotes the user back to themselves), and ``tasks``
+         *     skipped because it often quotes the user back to themselves), and ``tasks``
          *     (the serialized task state the LLM was deciding from). All three
          *     columns are envelope-encrypted at rest; ORM reads decrypt
          *     transparently and we redact PII shapes before serialization.
@@ -2054,7 +2054,7 @@ export interface paths {
          *
          *     Both columns are envelope-encrypted at rest. A user with no
          *     document yet (never compacted, never wrote memory) returns empty
-         *     strings rather than 404 — consenting and "no memory yet" is a
+         *     strings rather than 404. Consenting and "no memory yet" is a
          *     valid combined state.
          */
         get: operations["get_shared_data_memory_api_admin_shared_data_users__user_id__memory_get"];
@@ -2891,7 +2891,7 @@ export interface components {
          * @description Heartbeat log metadata only.
          *
          *     Content fields (``message_text``, ``reasoning``, ``tasks``) were
-         *     removed in #325 work item 2 — they were user-facing content the
+         *     removed in #325 work item 2. They were user-facing content the
          *     user-detail response also stripped. They surface only via the
          *     consent-gated paths once items 3 + 4 land.
          */
@@ -3036,7 +3036,7 @@ export interface components {
          *     items 3 + 4 land. Until then, admins debugging an incident see the
          *     metadata + integrations here, plus the audit log of who looked.
          *
-         *     Channel routes carry a *masked* ``channel_identifier`` — phone
+         *     Channel routes carry a *masked* ``channel_identifier``. Phone
          *     numbers / iMessage emails / Telegram chat IDs are PII the admin
          *     rarely needs in full. The route applies ``_mask_channel_identifier``
          *     so admins see enough to recognize a route and confirm last-4 digits,

--- a/tests/multi_user/test_account_deletion.py
+++ b/tests/multi_user/test_account_deletion.py
@@ -1,11 +1,4 @@
-"""Tests for account deletion service (regression: #25).
-
-Phase C async DB migration (issue #395). The service now operates on an
-``AsyncSession``; setup and verification go through ``async_db()`` so all
-writes share the per-test connection bound by the ``async_db`` fixture.
-Mixing sync ``SessionLocal()`` with ``AsyncSessionLocal()`` here would hit
-the cross-API isolation trap documented in ``conftest.py``.
-"""
+"""Account-deletion service regression tests."""
 
 import datetime
 import uuid

--- a/tests/multi_user/test_admin_reported_conversations.py
+++ b/tests/multi_user/test_admin_reported_conversations.py
@@ -8,28 +8,6 @@ Covers:
   graceful empty list when the underlying session was deleted.
 - Dismiss endpoint: stamps dismissed_at + reviewed_admin_user_id;
   404 on unknown; 400 on already-dismissed.
-
-Async DB conversion (Phase C, issue #394). Routes use
-``Depends(get_async_db)`` and an ``AsyncSession``; tests drive them
-through ``httpx.AsyncClient`` + ``ASGITransport`` and shuttle row
-inserts through the per-test ``async_db`` fixture so the route reads
-back its own writes under READ COMMITTED.
-
-The audit dependency stays sync (it writes its own row through a
-fresh ``SessionLocal()``), and ``get_current_admin`` is overridden in
-the async client fixture to return ``async_test_user`` directly so
-the admin's row exists on the async connection where the dismiss
-route stamps ``reviewed_admin_user_id``. The sync per-test
-connection has no matching admin user, so the audit dep's FK insert
-fails best-effort here and no audit row is persisted under these
-tests; the audit dependency itself is exercised by the all-sync
-suite in ``tests/test_admin_audit.py``. The two pre-conversion tests
-that asserted on ``AdminAuditLog`` rows for these endpoints
-(``test_writes_audit_row_with_resource_id`` and
-``test_dismiss_writes_audit_row``) are dropped on conversion; if a
-regression net for those audit-context fields is needed later, add
-all-sync cases against the existing sync ``client`` fixture and the
-audit log table.
 """
 
 from __future__ import annotations

--- a/tests/multi_user/test_admin_router.py
+++ b/tests/multi_user/test_admin_router.py
@@ -1,14 +1,5 @@
 """Endpoint tests for admin router (issue #70).
 
-Phase C async migration (issue #392). The router uses ``Depends(get_async_db)``,
-so tests drive it through an ``httpx.AsyncClient`` + ``ASGITransport`` and use
-the ``async_db`` fixture to share a per-test connection with the route. Setup
-and verification go through ``async_db()`` rather than the sync ``SessionLocal()``
-because the async fixture's connection lives on a different backend connection
-from the sync ``_isolate_stores`` fixture (see the design comment in
-``conftest.py``); a row written through the sync connection is invisible to the
-async route under READ COMMITTED.
-
 Covers:
 - Admin access control (role check, 403 for non-admins)
 - GET /api/admin/users (list, search, pagination)

--- a/tests/multi_user/test_admin_shared_data.py
+++ b/tests/multi_user/test_admin_shared_data.py
@@ -6,27 +6,6 @@ Covers:
 - PII redaction: planted phone / email / card markers in message
   bodies do NOT appear in the wire response.
 - Audit logging: every read writes one ``AdminAuditLog`` row.
-
-Async DB conversion (issue #393, #429): the router runs on
-``Depends(get_async_db)`` and ``get_current_admin`` now also resolves
-through the async session, so the admin's User + Subscription must be
-visible to the per-test ASYNC connection. The ``audit_admin._try_commit``
-insert still runs sync (fresh ``SessionLocal()``) and FK-references
-``admin_audit_logs.admin_user_id`` -> ``users.id`` and
-``target_user_id`` -> ``users.id``, so the same rows must be visible
-to the sync connection too. Both bridges go through autocommit:
-``_autocommit_admin`` seeds the admin caller, ``_consenting_user``
-seeds the target users; rows commit outside both per-test transactions
-and both connections see them under READ COMMITTED.
-
-The two per-test connections (sync ``_isolate_stores`` and async
-``async_db``) are disjoint under READ COMMITTED. To bridge that, the
-``_consenting_user`` helper writes through a DIRECT engine connection
-that commits to the real DB outside both per-test transactions. Both
-transactions then read the row through the standard READ COMMITTED
-visibility rules. The rows leak between tests but UUID ids prevent
-cross-test conflicts; the session-scoped ``_pg_engine`` fixture drops
-all tables at session teardown, sweeping the leaks.
 """
 
 from __future__ import annotations

--- a/tests/multi_user/test_channels_router.py
+++ b/tests/multi_user/test_channels_router.py
@@ -1,14 +1,4 @@
-"""Tests for per-user channel linking endpoints (Telegram, Linq, BlueBubbles, Twilio).
-
-Phase C async pilot (issue #391). The router uses ``Depends(get_async_db)``,
-so tests drive it through an ``httpx.AsyncClient`` + ``ASGITransport`` and
-use the ``async_db`` fixture to share a per-test connection with the route.
-Setup and verification go through ``async_db()`` rather than the sync
-``SessionLocal()`` because the async fixture's connection lives on a
-different backend connection from the sync ``_isolate_stores`` fixture
-(see the design comment in ``conftest.py``); a row written through the
-sync connection is invisible to the async route under READ COMMITTED.
-"""
+"""Per-user channel-linking endpoint tests."""
 
 from __future__ import annotations
 

--- a/tests/test_db_settings_store_async.py
+++ b/tests/test_db_settings_store_async.py
@@ -1,12 +1,4 @@
-"""Tests for the async API of ``DbSettingsStore`` (issue #1175).
-
-Mirrors the DB-store half of ``tests/test_config_store.py`` for the
-``*_async`` peers added in the dual-API rollout. All tests opt into the
-per-test ``async_db`` fixture (see ``tests/conftest.py``) so writes are
-rolled back at teardown. Follows the IdempotencyStore async pilot
-(``tests/test_idempotency_pruning_async.py``, #1199) and the per-store
-conversions in #1200, #1201, #1203.
-"""
+"""Async database-backed settings-store tests."""
 
 from __future__ import annotations
 

--- a/tests/test_heartbeat_store_async.py
+++ b/tests/test_heartbeat_store_async.py
@@ -1,17 +1,4 @@
-"""Tests for the async API of ``HeartbeatStore`` (issue #1154).
-
-Mirrors the sync ``HeartbeatStore`` surface for the ``*_async`` peers
-added in the dual-API rollout. All tests opt into the per-test
-``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
-back at teardown. Follows the IdempotencyStore pilot pattern from
-PR #1199.
-
-User-row setup runs through the shared ``async_test_user`` fixture in
-``tests/conftest.py``; that fixture routes the insert through the
-async connection because the sync ``test_user`` fixture opens its own
-per-test transaction on a separate connection and rows committed there
-are invisible to the async store under READ COMMITTED.
-"""
+"""Async database-backed heartbeat-store tests."""
 
 from __future__ import annotations
 

--- a/tests/test_idempotency_pruning_async.py
+++ b/tests/test_idempotency_pruning_async.py
@@ -1,11 +1,4 @@
-"""Tests for the async API of ``IdempotencyStore`` (issue #1150).
-
-Mirrors ``tests/test_idempotency_pruning.py`` for the ``*_async`` peers
-added in the dual-API rollout pilot. All tests opt into the per-test
-``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
-back at teardown. Future per-store conversions (#1151-#1157) should
-mirror this file when validating their async peers.
-"""
+"""Async idempotency-store pruning and isolation tests."""
 
 from __future__ import annotations
 

--- a/tests/test_llm_usage_store_async.py
+++ b/tests/test_llm_usage_store_async.py
@@ -1,15 +1,4 @@
-"""Tests for the async API of ``LLMUsageStore`` (issue #1156).
-
-Mirrors the sync ``LLMUsageStore.log`` for the ``log_async`` peer
-added in the dual-API rollout. All tests opt into the per-test
-``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
-back at teardown. Follows the IdempotencyStore pilot pattern from
-PR #1199.
-
-This store matters for the request hot path: premium reads from
-``llm_usage_logs`` for quota enforcement, and the sync write was a
-known event-loop blocking risk.
-"""
+"""Async LLM-usage-store tests."""
 
 from __future__ import annotations
 

--- a/tests/test_memory_db_async.py
+++ b/tests/test_memory_db_async.py
@@ -1,18 +1,4 @@
-"""Tests for the async API of ``MemoryStore`` (issue #1153).
-
-Mirrors ``tests/test_memory.py`` for the ``*_async`` peers added in
-the dual-API rollout. All tests opt into the per-test ``async_db``
-fixture (see ``tests/conftest.py``) so writes are rolled back at
-teardown. Follows the IdempotencyStore pilot pattern from PR #1199.
-
-User-row setup runs through the shared ``async_test_user`` fixture in
-``tests/conftest.py``; that fixture routes the insert through the
-async connection because the sync ``test_user`` fixture opens its
-own per-test transaction on a separate connection and rows committed
-there are invisible to the async store under READ COMMITTED. This
-matches the cross-API caveat called out in the design comment block
-in ``tests/conftest.py``.
-"""
+"""Async database-backed memory-store tests."""
 
 from __future__ import annotations
 

--- a/tests/test_tool_config_store_async.py
+++ b/tests/test_tool_config_store_async.py
@@ -1,11 +1,4 @@
-"""Tests for the async API of ``ToolConfigStore`` (issue #1157).
-
-Mirrors the sync ``ToolConfigStore`` surface for the ``*_async`` peers
-added in the dual-API rollout. All tests opt into the per-test
-``async_db`` fixture (see ``tests/conftest.py``) so writes are rolled
-back at teardown. Follows the IdempotencyStore pilot pattern from
-PR #1199.
-"""
+"""Async database-backed tool-configuration store tests."""
 
 from __future__ import annotations
 

--- a/tests/test_user_db_async.py
+++ b/tests/test_user_db_async.py
@@ -1,10 +1,4 @@
-"""Tests for the async API of ``UserStore`` (issue #1151).
-
-Mirrors the sync ``UserStore`` surface for the ``*_async`` peers added
-in the dual-API rollout. All tests opt into the per-test ``async_db``
-fixture (see ``tests/conftest.py``) so writes are rolled back at
-teardown. Follows the IdempotencyStore pilot pattern from #1199.
-"""
+"""Async database-backed user-store tests."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Description

Removes or condenses stale, redundant, and migration-era guidance across project documentation, agent prompts, specialist skills, source comments, docstrings, and test commentary.

- Reduces the repository by 1,225 net lines across 69 files.
- Corrects stale defaults and setup guidance for context trimming, compaction, OAuth, Docker storage, monitoring, memory, and heartbeat behavior.
- Keeps security, locking, encryption, concurrency, and regression rationale where it still explains a non-obvious constraint.
- Preserves executable behavior. A Python AST comparison, excluding docstrings, found only two intentional runtime-string edits: synthetic heartbeat examples and punctuation in one tool description.
- Regenerates the OpenAPI spec and TypeScript API declarations for the cleaned route docstrings. Schema shapes and runtime types are unchanged.
- No automated prompt-eval harness exists in this repository, so prompt edits were covered by the full backend suite and direct review.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [x] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (not applicable, no new functionality)
- [x] Bug fixes include regression tests (not applicable, no bug fix)

## AI Usage
- [x] AI-assisted (repository-wide audit, condensation, stale-reference checks, and verification)
- [ ] No AI used

## Test plan

- [x] `uv run pytest -q -n auto` (3,982 passed, 6 skipped)
- [x] `uv run ruff check backend/ tests/ alembic/`
- [x] `uv run ruff format --check backend/ tests/ alembic/`
- [x] `uv run ty check --python .venv backend/ tests/ alembic/`
- [x] `uv run python scripts/export_openapi.py`
- [x] `cd frontend && npm run generate:api`, with no generated diff
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run deadcode`
- [x] `cd frontend && npm run test -- --run` (371 passed)
- [x] Checked changed Markdown for missing relative link targets
- [x] Checked the staged diff for whitespace errors, prohibited punctuation, and persisted PII