### PR TITLE
feat(monitoring): email the operator when agent tool calls fail

### DIFF
--- a/backend/app/agent/core.py
+++ b/backend/app/agent/core.py
@@ -85,6 +85,11 @@ from backend.app.agent.tool_errors import (
     build_error_hint,
     format_validation_error,
 )
+from backend.app.agent.tool_failure_hook import (
+    TOOL_FAILURE_SCHEMA_VERSION,
+    ToolFailurePayload,
+    report_tool_failure,
+)
 from backend.app.agent.tools.base import (
     Tool,
     ToolErrorKind,
@@ -956,6 +961,18 @@ class ClawboltAgent:
                 hint = build_error_hint(result)
                 result_str += "\n\n" + hint
                 action_label = f"Failed: {tool_name}"
+                await report_tool_failure(
+                    ToolFailurePayload(
+                        schema_version=TOOL_FAILURE_SCHEMA_VERSION,
+                        user_id=self.user.id,
+                        tool_name=tool_name,
+                        error_kind=str(result.error_kind) if result.error_kind else "",
+                        args=validated_args,
+                        # Pre-hint text: the hint is our own boilerplate and
+                        # would make every group's sample look identical.
+                        result_text=result.content,
+                    )
+                )
             else:
                 action_label = f"Called {tool_name}"
             stored_receipt = None
@@ -998,6 +1015,20 @@ class ClawboltAgent:
             result_str = f"Error: tool {tool_name} raised {err_text}\n\n{hint}"[:1500]
             is_error = True
             action_label = f"Failed: {tool_name}"
+            # The logger.exception above already feeds the ERROR-log alerting
+            # path, but that fingerprints on the log template, so every tool
+            # that raises collapses into one group. This reports which tool it
+            # actually was, and for whom.
+            await report_tool_failure(
+                ToolFailurePayload(
+                    schema_version=TOOL_FAILURE_SCHEMA_VERSION,
+                    user_id=self.user.id,
+                    tool_name=tool_name,
+                    error_kind=str(ToolErrorKind.INTERNAL),
+                    args=validated_args,
+                    result_text=err_text,
+                )
+            )
             record = StoredToolInteraction(
                 tool_call_id=tc_req.id,
                 name=tool_name,

--- a/backend/app/agent/tool_failure_hook.py
+++ b/backend/app/agent/tool_failure_hook.py
@@ -1,0 +1,86 @@
+"""Hook for reporting failed tool calls to an out-of-band consumer.
+
+Mirrors the module-level setter pattern used by ``set_pipeline_override`` in
+``backend.app.agent.router`` and ``install_llm_payload_capture``. The agent
+loop calls :func:`report_tool_failure` at every tool failure site; with no
+handler installed the call is a branch and a return, so single-user
+deployments and CI pay nothing.
+
+Why a hook rather than the existing ERROR-log alerting: only the ``INTERNAL``
+case (a tool raising) logs at ERROR, and it does so through one template,
+``"Tool call failed: %s"``. ``admin_alerts`` fingerprints on the *template*,
+so every crashing tool in the system collapses into a single alert group whose
+formatted message names only the most recent one. ``SERVICE`` and ``AUTH``
+failures, where an integration is down or a token has been revoked, log at
+WARNING and never reach the alerting path at all. Per-tool attribution and
+those two kinds are the new information.
+
+The handler runs inline in a user-facing turn, so it must not block. Doing I/O
+here adds latency to a reply somebody is waiting on.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Bumped when fields are added, so a handler compiled against an older build
+# can tell what it is looking at. Handlers should read fields by name and
+# tolerate unknown ones.
+TOOL_FAILURE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ToolFailurePayload:
+    """Versioned snapshot of one failed tool call.
+
+    ``args`` is the validated argument dict passed to the tool and ``result_text``
+    is what the model was shown. Both can carry user data, so a consumer is
+    responsible for gating them on consent and redacting before they leave the
+    process. The remaining fields are safe to aggregate for any user.
+    """
+
+    schema_version: int
+    user_id: str
+    tool_name: str
+    # ``ToolErrorKind`` value. Kept as a plain string so the hook does not drag
+    # the tools package into every consumer's import graph.
+    error_kind: str
+    args: dict[str, Any] = field(default_factory=dict)
+    result_text: str = ""
+
+
+ToolFailureHandler = Callable[[ToolFailurePayload], Awaitable[None]]
+
+_handler: ToolFailureHandler | None = None
+
+
+def set_tool_failure_handler(handler: ToolFailureHandler | None) -> None:
+    """Install (or clear, with ``None``) the process-wide failure handler."""
+    global _handler
+    _handler = handler
+
+
+def get_tool_failure_handler() -> ToolFailureHandler | None:
+    """Return the installed handler, or None. For tests and diagnostics."""
+    return _handler
+
+
+async def report_tool_failure(payload: ToolFailurePayload) -> None:
+    """Dispatch one tool failure. Never raises, never blocks meaningfully.
+
+    Exceptions are swallowed at DEBUG rather than ERROR on purpose: this runs
+    under the alerting stack, and logging an ERROR from the path that feeds
+    alerting is how a reporting bug turns into an alert storm about itself.
+    """
+    handler = _handler
+    if handler is None:
+        return
+    try:
+        await handler(payload)
+    except Exception:
+        logger.debug("Tool failure handler raised, ignoring", exc_info=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -85,6 +85,7 @@ from backend.app.services.llm_payload_capture import install_llm_payload_capture
 from backend.app.services.llm_resolver import install_user_llm_resolver
 from backend.app.services.oauth import oauth_refresh_scheduler
 from backend.app.services.telegram_webhook import discover_bot_username
+from backend.app.services.tool_failure_alerts import install_tool_failure_alerts
 
 # Whether this process runs the hosted, multi-tenant surface: OAuth
 # sign-in, the admin console, quota enforcement, and operator monitoring.
@@ -142,6 +143,11 @@ if MULTI_USER:
     # Capture LLM request payloads for users who opted into data sharing,
     # so admins can export them for offline token-efficiency analysis.
     install_llm_payload_capture()
+
+    # Route failed agent tool calls into the operator alert email. Covers the
+    # SERVICE and AUTH failures that log at WARNING and so never reach the
+    # ERROR-log alerting path at all.
+    install_tool_failure_alerts()
 
 
 async def _enforce_single_channel() -> None:

--- a/backend/app/services/admin_alerts.py
+++ b/backend/app/services/admin_alerts.py
@@ -71,6 +71,10 @@ _MAX_TRACEBACK_CHARS = 4000
 _MAX_MESSAGE_CHARS = 1000
 _MAX_PENDING_GROUPS = 200
 _MAX_GROUPS_PER_EMAIL = 25
+# Distinct argument/result samples kept per tool-failure group, and the cap on
+# each. One example of a broken call is diagnostic; twenty is a data dump.
+_MAX_SAMPLES_PER_GROUP = 3
+_MAX_SAMPLE_CHARS = 500
 
 
 def _recipient() -> str:
@@ -109,6 +113,64 @@ class AlertSummary:
     request_id: str
     first_seen: datetime
     last_seen: datetime
+
+
+@dataclass(frozen=True)
+class ToolFailureSummary:
+    """One grouped tool failure, ready to render into the operator email.
+
+    ``user_count`` counts distinct users, which is the number that separates
+    "one tenant's token expired" from "the integration is down for everyone".
+    ``samples`` carries argument and result detail and is populated only from
+    users who opted into data sharing; failures from everyone else still raise
+    ``count`` and ``user_count`` so an incident is never invisible.
+    """
+
+    tool_name: str
+    error_kind: str
+    count: int
+    user_count: int
+    consented_user_count: int
+    samples: list[str]
+    first_seen: datetime
+    last_seen: datetime
+
+
+@dataclass
+class _PendingToolFailure:
+    """Mutable accumulator for one (tool, error kind) between flushes."""
+
+    tool_name: str
+    error_kind: str
+    first_seen: datetime
+    last_seen: datetime
+    count: int = 1
+    user_ids: set[str] = field(default_factory=set)
+    consented_user_ids: set[str] = field(default_factory=set)
+    samples: list[str] = field(default_factory=list)
+
+    def merge(self, user_id: str, sample: str | None) -> None:
+        self.count += 1
+        self.last_seen = datetime.now(UTC)
+        self.user_ids.add(user_id)
+        if sample is not None:
+            self.consented_user_ids.add(user_id)
+            # Keep a bounded handful. Twenty copies of one stack of arguments
+            # tells you nothing the first one did not.
+            if len(self.samples) < _MAX_SAMPLES_PER_GROUP and sample not in self.samples:
+                self.samples.append(sample)
+
+    def to_summary(self) -> ToolFailureSummary:
+        return ToolFailureSummary(
+            tool_name=self.tool_name,
+            error_kind=self.error_kind,
+            count=self.count,
+            user_count=len(self.user_ids),
+            consented_user_count=len(self.consented_user_ids),
+            samples=list(self.samples),
+            first_seen=self.first_seen,
+            last_seen=self.last_seen,
+        )
 
 
 @dataclass
@@ -165,6 +227,7 @@ class _AlertStore:
 
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _pending: dict[str, _PendingGroup] = field(default_factory=dict)
+    _pending_tools: dict[str, _PendingToolFailure] = field(default_factory=dict)
     _last_emailed: dict[str, float] = field(default_factory=dict)
     _email_times: deque[float] = field(default_factory=deque)
     _overflow_dropped: int = 0
@@ -202,6 +265,68 @@ class _AlertStore:
                 first_seen=now,
                 last_seen=now,
             )
+
+    def record_tool_failure(
+        self,
+        tool_name: str,
+        error_kind: str,
+        user_id: str,
+        sample: str | None,
+    ) -> None:
+        """Accumulate one tool failure. Cheap, non-blocking, thread-safe.
+
+        *sample* carries argument and result detail and must already be
+        consent-gated and redacted by the caller; pass ``None`` for a user who
+        has not opted into data sharing. The occurrence still counts either
+        way, so an outage confined to non-consenting users is visible as a
+        number even when nothing about it can be shown.
+        """
+        now = datetime.now(UTC)
+        fingerprint = f"tool|{tool_name}|{error_kind}"
+        with self._lock:
+            existing = self._pending_tools.get(fingerprint)
+            if existing is not None:
+                existing.merge(user_id, sample)
+                return
+            if len(self._pending_tools) >= _MAX_PENDING_GROUPS:
+                self._overflow_dropped += 1
+                return
+            group = _PendingToolFailure(
+                tool_name=tool_name,
+                error_kind=error_kind,
+                first_seen=now,
+                last_seen=now,
+            )
+            group.user_ids.add(user_id)
+            if sample is not None:
+                group.consented_user_ids.add(user_id)
+                group.samples.append(sample)
+            self._pending_tools[fingerprint] = group
+
+    def _take_eligible_tools(self) -> list[tuple[str, _PendingToolFailure]]:
+        """Remove and return tool-failure groups past their dedupe cooldown.
+
+        Shares ``_last_emailed`` with the error groups so both kinds obey one
+        cooldown window, and shares the per-email cap so a tool-failure storm
+        cannot crowd application errors out of the message.
+        """
+        cooldown = max(0, settings.alert_dedupe_minutes) * 60
+        now = time.monotonic()
+        with self._lock:
+            # The accumulator is returned, not a summary: a failed send has to
+            # put the group back, and a summary has already collapsed the
+            # distinct-user sets into counts that cannot be merged with new
+            # arrivals without double counting.
+            eligible: list[tuple[str, _PendingToolFailure]] = []
+            for fingerprint, group in list(self._pending_tools.items()):
+                last = self._last_emailed.get(fingerprint)
+                if last is not None and now - last < cooldown:
+                    continue
+                eligible.append((fingerprint, group))
+                del self._pending_tools[fingerprint]
+                if len(eligible) >= _MAX_GROUPS_PER_EMAIL:
+                    break
+            return eligible
 
     def _take_eligible(self) -> tuple[list[tuple[str, AlertSummary]], int]:
         """Remove and return groups past their dedupe cooldown.
@@ -261,28 +386,89 @@ class _AlertStore:
         are still in the application log.
         """
         eligible, dropped = self._take_eligible()
-        if not eligible:
+        tool_eligible = self._take_eligible_tools()
+        if not eligible and not tool_eligible:
             return False
         summaries = [summary for _, summary in eligible]
-        sent = await email_service.send_admin_alert(_recipient(), summaries, dropped)
+        tool_summaries = [group.to_summary() for _, group in tool_eligible]
+        sent = await email_service.send_admin_alert(
+            _recipient(), summaries, dropped, tool_failures=tool_summaries
+        )
         if sent:
-            self._mark_emailed([fingerprint for fingerprint, _ in eligible])
+            self._mark_emailed(
+                [fingerprint for fingerprint, _ in eligible]
+                + [fingerprint for fingerprint, _ in tool_eligible]
+            )
+        else:
+            # Put the tool groups back so the next tick retries them. The error
+            # groups already behave this way by never starting their cooldown;
+            # these were removed from the pending dict, so returning them has to
+            # be explicit or the batch is lost outright.
+            self._restore_tool_groups(tool_eligible)
         return sent
+
+    def _restore_tool_groups(self, taken: list[tuple[str, _PendingToolFailure]]) -> None:
+        """Return groups to pending after a failed send, merging with new arrivals.
+
+        Without this a failed SMTP call silently discards the batch. The error
+        groups accept that loss (the underlying errors are still in the log);
+        a tool failure has no such second record, so it is put back.
+        """
+        if not taken:
+            return
+        with self._lock:
+            for fingerprint, group in taken:
+                current = self._pending_tools.get(fingerprint)
+                if current is None:
+                    self._pending_tools[fingerprint] = group
+                    continue
+                # Arrivals during the send attempt merge into the restored one.
+                current.count += group.count
+                current.first_seen = min(current.first_seen, group.first_seen)
+                current.user_ids |= group.user_ids
+                current.consented_user_ids |= group.consented_user_ids
+                for sample in group.samples:
+                    if (
+                        len(current.samples) < _MAX_SAMPLES_PER_GROUP
+                        and sample not in current.samples
+                    ):
+                        current.samples.append(sample)
 
     def pending_count(self) -> int:
         with self._lock:
-            return len(self._pending)
+            return len(self._pending) + len(self._pending_tools)
 
     def reset(self) -> None:
         """Clear all state. For tests."""
         with self._lock:
             self._pending.clear()
+            self._pending_tools.clear()
             self._last_emailed.clear()
             self._email_times.clear()
             self._overflow_dropped = 0
 
 
 _store = _AlertStore()
+
+
+def record_tool_failure(
+    tool_name: str,
+    error_kind: str,
+    user_id: str,
+    sample: str | None,
+) -> None:
+    """Accumulate one agent tool failure into the next operator email.
+
+    Module-level entry point mirroring the logging handler's ``emit``: callers
+    outside this module should not reach into the store. *sample* must already
+    be consent-gated and redacted, or ``None``.
+    """
+    _store.record_tool_failure(
+        tool_name=tool_name,
+        error_kind=error_kind,
+        user_id=user_id,
+        sample=sample[:_MAX_SAMPLE_CHARS] if sample is not None else None,
+    )
 
 
 class AdminAlertHandler(logging.Handler):

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -42,7 +42,7 @@ from backend.app.web_paths import LOGIN_PATH
 if TYPE_CHECKING:
     # Runtime import would be circular: both alert modules import this one for
     # the shared ``_send`` transport.
-    from backend.app.services.admin_alerts import AlertSummary
+    from backend.app.services.admin_alerts import AlertSummary, ToolFailureSummary
     from backend.app.services.health_monitor import HealthTransition
 
 logger = logging.getLogger(__name__)
@@ -551,8 +551,20 @@ async def send_waitlist_approved(to_email: str, name: str = "") -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _alert_subject(alerts: Sequence[AlertSummary]) -> str:
+def _alert_subject(
+    alerts: Sequence[AlertSummary],
+    tool_failures: Sequence[ToolFailureSummary] = (),
+) -> str:
     """Front-load the subject with what broke, so triage happens in the inbox."""
+    if not alerts and tool_failures:
+        if len(tool_failures) == 1:
+            t = tool_failures[0]
+            return f"[clawbolt] {t.tool_name} {t.error_kind} x{t.count} ({t.user_count} users)"
+        total = sum(t.count for t in tool_failures)
+        return f"[clawbolt] {len(tool_failures)} tool failure groups, {total} occurrences"
+    if tool_failures:
+        base = _alert_subject(alerts)
+        return f"{base} + {len(tool_failures)} tool failure group(s)"
     if len(alerts) == 1:
         alert = alerts[0]
         occurrences = f" (x{alert.count})" if alert.count > 1 else ""
@@ -561,11 +573,92 @@ def _alert_subject(alerts: Sequence[AlertSummary]) -> str:
     return f"[clawbolt] {len(alerts)} error groups, {total} occurrences"
 
 
+def _tool_failure_html(tool_failures: Sequence[ToolFailureSummary]) -> str:
+    """Render the tool-failures section for the HTML part, or empty."""
+    if not tool_failures:
+        return ""
+    rows: list[str] = []
+    for t in tool_failures:
+        window = (
+            f"{t.first_seen:%Y-%m-%d %H:%M:%S} to {t.last_seen:%H:%M:%S} UTC"
+            if t.count > 1
+            else f"{t.first_seen:%Y-%m-%d %H:%M:%S} UTC"
+        )
+        meta = (
+            f"{t.count} failure{'s' if t.count != 1 else ''} across "
+            f"{t.user_count} user{'s' if t.user_count != 1 else ''} &middot; {window}"
+        )
+        sample_html = ""
+        if t.samples:
+            joined = "\n".join(t.samples)
+            sample_html = (
+                f'<pre style="margin: 10px 0 0; padding: 10px; background-color: #F6F5F3; '
+                f"border: 1px solid {_OPS_BORDER}; border-radius: 6px; font-family: {_OPS_MONO}; "
+                f"font-size: 12px; line-height: 1.45; overflow-x: auto; white-space: pre-wrap; "
+                f'word-break: break-word; color: {_OPS_TEXT};">{html.escape(joined)}</pre>'
+            )
+        withheld = t.user_count - t.consented_user_count
+        withheld_html = (
+            f'<p style="margin: 6px 0 0; font-family: {_OPS_FONT}; font-size: 12px; color: {_OPS_MUTED};">'
+            f"{withheld} further user(s) have not opted into data sharing; counts only."
+            f"</p>"
+            if withheld > 0
+            else ""
+        )
+        rows.append(
+            f"""
+        <tr>
+          <td style="padding: 16px 0; border-bottom: 1px solid {_OPS_BORDER};">
+            <p style="margin: 0 0 4px; font-family: {_OPS_MONO}; font-size: 14px; font-weight: 700; color: {_OPS_DOWN};">
+              {html.escape(t.tool_name)} <span style="font-family: {_OPS_FONT}; font-size: 11px; letter-spacing: 1px; text-transform: uppercase;">{html.escape(t.error_kind)}</span>
+            </p>
+            <p style="margin: 0; font-family: {_OPS_FONT}; font-size: 12px; color: {_OPS_MUTED};">{meta}</p>
+            {sample_html}
+            {withheld_html}
+          </td>
+        </tr>"""
+        )
+    return f"""
+              <h2 style="margin: 24px 0 0; font-family: {_OPS_FONT}; font-size: 16px; font-weight: 700; color: {_OPS_TEXT};">
+                Tool failures
+              </h2>
+              <p style="margin: 6px 0 0; font-family: {_OPS_FONT}; font-size: 12px; color: {_OPS_MUTED};">
+                Agent tool calls that did not succeed. Validation retries and declined approval prompts are excluded.
+              </p>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                {"".join(rows)}
+              </table>"""
+
+
+def _tool_failure_text(t: ToolFailureSummary) -> str:
+    """Render one tool-failure group for the plain-text part."""
+    window = (
+        f"{t.first_seen:%Y-%m-%d %H:%M:%S} to {t.last_seen:%H:%M:%S} UTC"
+        if t.count > 1
+        else f"{t.first_seen:%Y-%m-%d %H:%M:%S} UTC"
+    )
+    lines = [
+        f"{t.tool_name} [{t.error_kind}]",
+        f"{t.count} failure{'s' if t.count != 1 else ''} "
+        f"across {t.user_count} user{'s' if t.user_count != 1 else ''}, {window}",
+    ]
+    if t.samples:
+        lines.append(f"  detail from {t.consented_user_count} consenting user(s):")
+        lines.extend(f"    {sample}" for sample in t.samples)
+    withheld = t.user_count - t.consented_user_count
+    if withheld > 0:
+        lines.append(f"  {withheld} further user(s) have not opted into data sharing; counts only.")
+    return "\n".join(lines) + "\n"
+
+
 def _admin_alert_message(
-    to_email: str, alerts: Sequence[AlertSummary], dropped: int
+    to_email: str,
+    alerts: Sequence[AlertSummary],
+    dropped: int,
+    tool_failures: Sequence[ToolFailureSummary] = (),
 ) -> EmailMessage:
     """Build the grouped error-alert email."""
-    subject = _alert_subject(alerts)
+    subject = _alert_subject(alerts, tool_failures)
 
     text_parts: list[str] = []
     html_parts: list[str] = []
@@ -624,10 +717,20 @@ def _admin_alert_message(
         else ""
     )
 
-    text_body = (
-        "Clawbolt application errors\n"
-        "===========================\n\n" + "\n".join(text_parts) + dropped_note
-    )
+    tool_text = ""
+    if tool_failures:
+        tool_text = (
+            "\n\nTool failures\n"
+            "=============\n\n"
+            + "\n".join(_tool_failure_text(t) for t in tool_failures)
+            + "\nA tool failure is a call the agent made that did not succeed. Only "
+            "INTERNAL, SERVICE and AUTH kinds are reported; validation retries and "
+            "declined approval prompts are normal and excluded.\n"
+        )
+
+    header = "Clawbolt application errors" if alerts else "Clawbolt tool failures"
+    body_parts = "\n".join(text_parts) + dropped_note if alerts else ""
+    text_body = f"{header}\n{'=' * len(header)}\n\n" + body_parts + tool_text
 
     html_body = f"""\
 <!doctype html>
@@ -654,6 +757,7 @@ def _admin_alert_message(
                 {"".join(html_parts)}
               </table>
               {dropped_html}
+              {_tool_failure_html(tool_failures)}
             </td>
           </tr>
         </table>
@@ -673,16 +777,21 @@ def _admin_alert_message(
     return msg
 
 
-async def send_admin_alert(to_email: str, alerts: Sequence[AlertSummary], dropped: int = 0) -> bool:
+async def send_admin_alert(
+    to_email: str,
+    alerts: Sequence[AlertSummary],
+    dropped: int = 0,
+    tool_failures: Sequence[ToolFailureSummary] = (),
+) -> bool:
     """Email a batch of grouped application errors to the operator.
 
     Best-effort like every sender here. Returns False on misconfiguration or
     send failure; the caller decides whether to retry (``admin_alerts`` does not
     start the dedupe cooldown on failure, so the next occurrence tries again).
     """
-    if not alerts:
+    if not alerts and not tool_failures:
         return False
-    return await _send(_admin_alert_message(to_email, alerts, dropped))
+    return await _send(_admin_alert_message(to_email, alerts, dropped, tool_failures))
 
 
 def _health_subject(transitions: Sequence[HealthTransition]) -> str:

--- a/backend/app/services/tool_failure_alerts.py
+++ b/backend/app/services/tool_failure_alerts.py
@@ -1,0 +1,182 @@
+"""Operator alerting for failed agent tool calls (multi_user only).
+
+Feeds the same ``AlertAggregator`` that carries application errors, so one
+flush produces one email covering both. What this adds over the ERROR-log path
+is the two failure kinds that never log at ERROR, ``SERVICE`` and ``AUTH``, and
+per-tool attribution: the log-based alert fingerprints on the log *template*,
+so every tool that raises collapses into a single group.
+
+Design:
+
+- **Only real faults.** ``ToolErrorKind`` distinguishes an integration being
+  down from the model passing bad arguments. ``VALIDATION`` and ``NOT_FOUND``
+  are the model self-correcting, and the error hint exists to make it retry;
+  ``PERMISSION`` and ``INTERRUPTED`` are the user declining or stopping. None
+  of those are incidents, and alerting on them trains the operator to ignore
+  the channel.
+- **Consent decides detail, not visibility.** Every qualifying failure raises
+  the group's occurrence and distinct-user counts. Arguments and result text
+  are attached only for users who opted into data sharing. An outage confined
+  to non-consenting users is therefore still visible as a number, which a
+  strict consent filter would have hidden entirely.
+- **Consent is resolved inline, from cache.** Deferring it to flush time would
+  mean holding arguments in memory for users who never consented, for the
+  whole flush interval. A short TTL cache keeps the check to a dict lookup so
+  non-consenting detail is dropped at the door.
+- **Fails closed.** A cache miss counts the failure and withholds detail rather
+  than blocking the agent loop on a database read. The cache warms in the
+  background and the next occurrence carries detail. Being one occurrence late
+  with a sample is cheaper than adding database latency to a live reply, and
+  far cheaper than showing data whose consent state was assumed.
+- **Never raises.** The hook swallows handler exceptions, but this also avoids
+  logging at ERROR: an exception here would otherwise become an application
+  alert about the alerting path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from sqlalchemy import select
+
+from backend.app.agent.tool_failure_hook import (
+    ToolFailurePayload,
+    set_tool_failure_handler,
+)
+from backend.app.agent.tools.base import ToolErrorKind
+from backend.app.database import AsyncSessionLocal
+from backend.app.models import User
+from backend.app.services import admin_alerts
+from backend.app.services.pii_redaction import redact_pii
+
+logger = logging.getLogger(__name__)
+
+# The kinds that mean something is broken rather than the agent working.
+ALERTING_KINDS: frozenset[str] = frozenset(
+    {
+        str(ToolErrorKind.INTERNAL),
+        str(ToolErrorKind.SERVICE),
+        str(ToolErrorKind.AUTH),
+    }
+)
+
+# Consent cache lifetime. Short because it bounds how long a revocation keeps
+# leaking detail: a user who opts out is still treated as consenting until
+# their entry expires.
+_CONSENT_TTL_SECONDS = 60
+_MAX_CONSENT_ENTRIES = 2000
+
+_background_tasks: set[asyncio.Task[None]] = set()
+_consent_cache: dict[str, tuple[bool, float]] = {}
+_consent_lock = asyncio.Lock()
+_warming: set[str] = set()
+
+
+def _cached_consent(user_id: str) -> bool | None:
+    """Return cached consent, or None when unknown or stale."""
+    entry = _consent_cache.get(user_id)
+    if entry is None:
+        return None
+    consented, expires_at = entry
+    if time.monotonic() >= expires_at:
+        _consent_cache.pop(user_id, None)
+        return None
+    return consented
+
+
+def _store_consent(user_id: str, consented: bool) -> None:
+    if len(_consent_cache) >= _MAX_CONSENT_ENTRIES:
+        # Cheap bound. Dropping the whole cache costs one database read per
+        # active user afterwards, which beats tracking an LRU for a value that
+        # expires in a minute anyway.
+        _consent_cache.clear()
+    _consent_cache[user_id] = (consented, time.monotonic() + _CONSENT_TTL_SECONDS)
+
+
+async def _warm_consent(user_id: str) -> None:
+    """Populate the consent cache for *user_id* off the request path."""
+    try:
+        db = AsyncSessionLocal()
+        try:
+            consented = (
+                await db.execute(select(User.data_sharing_consent).where(User.id == user_id))
+            ).scalar_one_or_none()
+        finally:
+            await db.close()
+        _store_consent(user_id, bool(consented))
+    except Exception:
+        logger.debug("Consent warm failed for %s", user_id, exc_info=True)
+    finally:
+        async with _consent_lock:
+            _warming.discard(user_id)
+
+
+# Per-side clip before admin_alerts applies its own overall cap.
+_MAX_SIDE_CHARS = 240
+
+
+def _format_sample(payload: ToolFailurePayload) -> str:
+    """Render one failure's detail, redacted.
+
+    Arguments are the highest-PII surface the agent touches (customer names,
+    addresses, invoice contents), so even a consenting user's detail goes
+    through the same redaction the admin console uses.
+    """
+    args = redact_pii(_compact(payload.args))[:_MAX_SIDE_CHARS]
+    result = redact_pii(payload.result_text)[:_MAX_SIDE_CHARS]
+    return f"args={args} -> {result}"
+
+
+def _compact(args: dict[str, Any]) -> str:
+    """One-line repr of tool arguments, with long values clipped."""
+    parts: list[str] = []
+    for key, value in args.items():
+        text = str(value)
+        if len(text) > 120:
+            text = text[:120] + "..."
+        parts.append(f"{key}={text}")
+    return "{" + ", ".join(parts) + "}"
+
+
+async def handle_tool_failure(payload: ToolFailurePayload) -> None:
+    """Record one tool failure for the operator alert email."""
+    if payload.error_kind not in ALERTING_KINDS:
+        return
+    if not admin_alerts.is_enabled():
+        return
+
+    consented = _cached_consent(payload.user_id)
+    if consented is None:
+        # Fail closed and warm in the background, at most one task per user.
+        async with _consent_lock:
+            if payload.user_id not in _warming:
+                _warming.add(payload.user_id)
+                task = asyncio.create_task(_warm_consent(payload.user_id))
+                # Hold a reference so the task is not garbage collected mid-flight.
+                _background_tasks.add(task)
+                task.add_done_callback(_background_tasks.discard)
+        consented = False
+
+    sample = _format_sample(payload) if consented else None
+    admin_alerts.record_tool_failure(
+        tool_name=payload.tool_name,
+        error_kind=payload.error_kind,
+        user_id=payload.user_id,
+        sample=sample,
+    )
+
+
+def install_tool_failure_alerts() -> None:
+    """Route agent tool failures into the operator alert email."""
+    set_tool_failure_handler(handle_tool_failure)
+    logger.info("Tool failure alerting installed")
+
+
+def reset_for_tests() -> None:
+    """Clear cache and in-flight state. For tests."""
+    _consent_cache.clear()
+    _warming.clear()
+    _background_tasks.clear()

--- a/docs/self-host/monitoring.md
+++ b/docs/self-host/monitoring.md
@@ -3,13 +3,14 @@
 Everything here requires `AUTH_MODE=multi_user`. A single-user self-host mounts
 neither the alerting stack nor the `/api/monitoring` router.
 
-Two layers live in the app, and each catches failures the other structurally
+Three layers live in the app, and each catches failures the others structurally
 cannot:
 
 | Layer | Catches | Blind to |
 |---|---|---|
-| 1. Error alerts | Anything logged at `ERROR`: exceptions, failed tool calls, unhandled 500s | Failures that do not raise; the app being down |
-| 2. Health probes | Silent breakage: dead bridge, stale scraper, expired token, unreachable provider | The app being down |
+| 1. Error alerts | Anything logged at `ERROR`: exceptions, unhandled 500s | Failures that do not raise; the app being down |
+| 2. Tool failures | Agent tool calls that failed: an integration down, a revoked token, a tool raising | Failures outside a tool call |
+| 3. Health probes | Silent breakage: dead bridge, expired token, unreachable provider | The app being down |
 
 Both go silent when the process dies, so a deployment also needs an external
 uptime check. That one cannot be code in this repo; see your deployment's own
@@ -90,10 +91,41 @@ does not start the cooldown, so a transient SES outage does not silence a
 fingerprint for half an hour.
 
 **What it will not catch.** Anything that does not raise or log at `ERROR`. A
-scraper returning zero results, a channel that quietly stops delivering, an
-OAuth token that expired but has not been used yet. That is layer 2's job.
+channel that quietly stops delivering, or an OAuth token that expired but has
+not been used yet: that is layer 3's job. Tool calls that failed without
+raising are layer 2's.
 
-## Layer 2: health probes
+## Layer 2: tool failures
+
+Failed agent tool calls, reported from the agent loop rather than from a log
+record. This exists because the two most operationally interesting failures
+never reach layer 1: a tool returning `SERVICE` (the integration is down) or
+`AUTH` (the token was revoked) logs at `WARNING`. Only a tool *raising* logs at
+`ERROR`, and layer 1 fingerprints on the log template, so every crashing tool in
+the system collapses into one group naming whichever ran most recently.
+
+**What counts.** Only `INTERNAL`, `SERVICE` and `AUTH`. The other
+`ToolErrorKind` values are the product working: `VALIDATION` and `NOT_FOUND` are
+the model self-correcting (the error hint exists to make it retry), and
+`PERMISSION` and `INTERRUPTED` are the user declining an approval prompt or
+stopping a turn. Alerting on those trains you to ignore the channel.
+
+**Grouping.** Collapses on `(tool, error kind)`, carrying the occurrence count
+and the number of distinct users affected. One revoked QuickBooks token hitting
+forty users for an hour is one line reading `qb_query auth x340 across 40
+users`. Grouping, throttling and delivery are shared with layer 1, so both
+arrive in a single email per flush.
+
+**Consent gates detail, not visibility.** Every qualifying failure raises the
+occurrence and distinct-user counts, whatever the user's data-sharing setting.
+Tool arguments and result text are attached only for users who opted in, and are
+run through the same PII redaction the admin console uses before they are. An
+outage confined to users who have not opted in is still visible as a number;
+only the diagnostic detail is withheld. Consent is read through a 60-second
+cache, and an unknown user is treated as not consenting until it warms, so a
+failure can occasionally be one occurrence late in carrying a sample.
+
+## Layer 3: health probes
 
 Runs every `HEALTH_CHECK_INTERVAL_SECONDS` (default 300) and emails on **status
 transitions**, not on state. A six-hour outage is two emails (down, then

--- a/tests/multi_user/test_tool_failure_alerts.py
+++ b/tests/multi_user/test_tool_failure_alerts.py
@@ -1,0 +1,382 @@
+"""Tests for routing failed agent tool calls into the operator alert email.
+
+Covers the three decisions the feature turns on: which ``ToolErrorKind`` values
+count as incidents, how data-sharing consent gates detail without hiding the
+occurrence, and that a storm collapses into one grouped line.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.app.agent.tool_failure_hook import (
+    TOOL_FAILURE_SCHEMA_VERSION,
+    ToolFailurePayload,
+    get_tool_failure_handler,
+    report_tool_failure,
+    set_tool_failure_handler,
+)
+from backend.app.agent.tools.base import ToolErrorKind
+from backend.app.services import admin_alerts, tool_failure_alerts
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Generator[None]:
+    admin_alerts.reset_for_tests()
+    tool_failure_alerts.reset_for_tests()
+    set_tool_failure_handler(None)
+    yield
+    admin_alerts.reset_for_tests()
+    tool_failure_alerts.reset_for_tests()
+    set_tool_failure_handler(None)
+
+
+@pytest.fixture
+def alerts_configured() -> Generator[None]:
+    with (
+        patch.object(admin_alerts.settings, "alerts_enabled", True),
+        patch.object(admin_alerts.settings, "smtp_host", "smtp.example.com"),
+        patch.object(admin_alerts.settings, "smtp_from_email", "ops@example.com"),
+        patch.object(admin_alerts.settings, "alert_email", "admin@example.com"),
+        patch.object(admin_alerts.settings, "alert_dedupe_minutes", 30),
+        patch.object(admin_alerts.settings, "alert_max_emails_per_hour", 20),
+    ):
+        yield
+
+
+@pytest.fixture
+def send_mock(alerts_configured: None) -> Generator[AsyncMock]:
+    with patch.object(
+        admin_alerts.email_service, "send_admin_alert", new_callable=AsyncMock
+    ) as mock:
+        mock.return_value = True
+        yield mock
+
+
+def _payload(
+    *,
+    user_id: str = "user-1",
+    tool_name: str = "qb_query",
+    kind: ToolErrorKind = ToolErrorKind.SERVICE,
+    args: dict | None = None,
+    result: str = "QuickBooks returned 503",
+) -> ToolFailurePayload:
+    return ToolFailurePayload(
+        schema_version=TOOL_FAILURE_SCHEMA_VERSION,
+        user_id=user_id,
+        tool_name=tool_name,
+        error_kind=str(kind),
+        args=args if args is not None else {"entity": "Invoice"},
+        result_text=result,
+    )
+
+
+def _consent(user_id: str, consented: bool) -> None:
+    """Seed the consent cache so no database read is needed."""
+    tool_failure_alerts._store_consent(user_id, consented)
+
+
+# ---------------------------------------------------------------------------
+# The hook seam
+# ---------------------------------------------------------------------------
+
+
+class TestHook:
+    @pytest.mark.asyncio
+    async def test_reporting_without_a_handler_is_a_no_op(self) -> None:
+        """Single-user deployments and CI must pay nothing for this."""
+        await report_tool_failure(_payload())  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_a_raising_handler_never_reaches_the_agent_loop(self) -> None:
+        """A reporting bug must not break the user's turn."""
+
+        async def boom(payload: ToolFailurePayload) -> None:
+            raise RuntimeError("handler is broken")
+
+        set_tool_failure_handler(boom)
+        await report_tool_failure(_payload())  # must not raise
+
+    def test_install_registers_the_handler(self) -> None:
+        tool_failure_alerts.install_tool_failure_alerts()
+        assert get_tool_failure_handler() is tool_failure_alerts.handle_tool_failure
+
+
+# ---------------------------------------------------------------------------
+# Which failures count
+# ---------------------------------------------------------------------------
+
+
+class TestKindFiltering:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kind", [ToolErrorKind.INTERNAL, ToolErrorKind.SERVICE, ToolErrorKind.AUTH]
+    )
+    async def test_real_faults_are_recorded(
+        self, kind: ToolErrorKind, alerts_configured: None
+    ) -> None:
+        _consent("user-1", False)
+        await tool_failure_alerts.handle_tool_failure(_payload(kind=kind))
+        assert admin_alerts._store.pending_count() == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kind",
+        [
+            ToolErrorKind.VALIDATION,
+            ToolErrorKind.NOT_FOUND,
+            ToolErrorKind.PERMISSION,
+            ToolErrorKind.INTERRUPTED,
+        ],
+    )
+    async def test_agent_and_user_driven_kinds_are_ignored(
+        self, kind: ToolErrorKind, alerts_configured: None
+    ) -> None:
+        """VALIDATION fires constantly by design (the hint tells the model to
+        retry) and PERMISSION is the user declining. Alerting on either trains
+        the operator to ignore the channel."""
+        _consent("user-1", True)
+        await tool_failure_alerts.handle_tool_failure(_payload(kind=kind))
+        assert admin_alerts._store.pending_count() == 0
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_recorded_when_alerting_is_unconfigured(self) -> None:
+        _consent("user-1", True)
+        await tool_failure_alerts.handle_tool_failure(_payload())
+        assert admin_alerts._store.pending_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Consent gating
+# ---------------------------------------------------------------------------
+
+
+class TestConsentGating:
+    @pytest.mark.asyncio
+    async def test_consenting_user_contributes_detail(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        _consent("user-1", True)
+        await tool_failure_alerts.handle_tool_failure(
+            _payload(args={"entity": "Invoice"}, result="token revoked")
+        )
+        await admin_alerts._store.flush()
+
+        failures = send_mock.call_args.kwargs["tool_failures"]
+        assert failures[0].samples
+        assert "Invoice" in failures[0].samples[0]
+        assert failures[0].consented_user_count == 1
+
+    @pytest.mark.asyncio
+    async def test_non_consenting_user_counts_but_shows_nothing(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        """The whole point of counting them: an outage confined to
+        non-consenting users must not be invisible."""
+        _consent("user-1", False)
+        await tool_failure_alerts.handle_tool_failure(
+            _payload(args={"entity": "SecretCustomer"}, result="token revoked")
+        )
+        await admin_alerts._store.flush()
+
+        failures = send_mock.call_args.kwargs["tool_failures"]
+        assert failures[0].count == 1
+        assert failures[0].user_count == 1
+        assert failures[0].consented_user_count == 0
+        assert failures[0].samples == []
+
+    @pytest.mark.asyncio
+    async def test_no_argument_text_leaks_for_a_non_consenting_user(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        """Assert on the rendered email, not just the summary: this is the
+        thing that would actually be a privacy incident."""
+        from backend.app.services.email_service import _admin_alert_message
+
+        _consent("user-1", False)
+        await tool_failure_alerts.handle_tool_failure(
+            _payload(args={"customer": "Wayne Enterprises"}, result="boom")
+        )
+        await admin_alerts._store.flush()
+
+        failures = send_mock.call_args.kwargs["tool_failures"]
+        rendered = str(_admin_alert_message("admin@example.com", [], 0, failures))
+        assert "Wayne Enterprises" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_unknown_consent_fails_closed(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        """A cache miss withholds detail rather than blocking the agent loop
+        on a database read or assuming consent."""
+        with patch.object(tool_failure_alerts, "_warm_consent", new_callable=AsyncMock):
+            await tool_failure_alerts.handle_tool_failure(
+                _payload(user_id="never-seen", args={"customer": "Acme"})
+            )
+        await admin_alerts._store.flush()
+
+        failures = send_mock.call_args.kwargs["tool_failures"]
+        assert failures[0].count == 1
+        assert failures[0].samples == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_consent_reports_both_populations(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        _consent("yes-1", True)
+        _consent("no-1", False)
+        _consent("no-2", False)
+        for uid in ("yes-1", "no-1", "no-2"):
+            await tool_failure_alerts.handle_tool_failure(_payload(user_id=uid))
+        await admin_alerts._store.flush()
+
+        summary = send_mock.call_args.kwargs["tool_failures"][0]
+        assert summary.count == 3
+        assert summary.user_count == 3
+        assert summary.consented_user_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Grouping and storm control
+# ---------------------------------------------------------------------------
+
+
+class TestGrouping:
+    @pytest.mark.asyncio
+    async def test_a_storm_collapses_into_one_group(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        """40 users hitting one revoked token is one line, not 40 emails."""
+        for i in range(40):
+            _consent(f"user-{i}", False)
+            await tool_failure_alerts.handle_tool_failure(
+                _payload(user_id=f"user-{i}", kind=ToolErrorKind.AUTH)
+            )
+        await admin_alerts._store.flush()
+
+        assert send_mock.call_count == 1
+        failures = send_mock.call_args.kwargs["tool_failures"]
+        assert len(failures) == 1
+        assert failures[0].count == 40
+        assert failures[0].user_count == 40
+
+    @pytest.mark.asyncio
+    async def test_distinct_tools_are_distinct_groups(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        """The gap this feature fills: the ERROR-log path fingerprints on the
+        log template, so every crashing tool collapses into one group."""
+        _consent("user-1", True)
+        await tool_failure_alerts.handle_tool_failure(_payload(tool_name="qb_query"))
+        await tool_failure_alerts.handle_tool_failure(_payload(tool_name="web_search"))
+        await admin_alerts._store.flush()
+
+        names = {f.tool_name for f in send_mock.call_args.kwargs["tool_failures"]}
+        assert names == {"qb_query", "web_search"}
+
+    @pytest.mark.asyncio
+    async def test_same_tool_different_kinds_are_distinct_groups(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        _consent("user-1", True)
+        await tool_failure_alerts.handle_tool_failure(_payload(kind=ToolErrorKind.AUTH))
+        await tool_failure_alerts.handle_tool_failure(_payload(kind=ToolErrorKind.SERVICE))
+        await admin_alerts._store.flush()
+
+        kinds = {f.error_kind for f in send_mock.call_args.kwargs["tool_failures"]}
+        assert kinds == {str(ToolErrorKind.AUTH), str(ToolErrorKind.SERVICE)}
+
+    @pytest.mark.asyncio
+    async def test_samples_are_bounded(self, send_mock: AsyncMock, alerts_configured: None) -> None:
+        """Twenty copies of one broken call tells you nothing the first did."""
+        for i in range(20):
+            _consent(f"user-{i}", True)
+            await tool_failure_alerts.handle_tool_failure(
+                _payload(user_id=f"user-{i}", args={"entity": f"Invoice{i}"})
+            )
+        await admin_alerts._store.flush()
+
+        summary = send_mock.call_args.kwargs["tool_failures"][0]
+        assert summary.count == 20
+        assert len(summary.samples) <= admin_alerts._MAX_SAMPLES_PER_GROUP
+
+    @pytest.mark.asyncio
+    async def test_identical_samples_are_not_repeated(
+        self, send_mock: AsyncMock, alerts_configured: None
+    ) -> None:
+        _consent("user-1", True)
+        for _ in range(5):
+            await tool_failure_alerts.handle_tool_failure(_payload())
+        await admin_alerts._store.flush()
+
+        assert len(send_mock.call_args.kwargs["tool_failures"][0].samples) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failed_send_puts_the_group_back(self, alerts_configured: None) -> None:
+        """Unlike an ERROR log, a tool failure has no second record anywhere,
+        so a dropped batch is the only copy."""
+        _consent("user-1", True)
+        await tool_failure_alerts.handle_tool_failure(_payload())
+
+        with patch.object(
+            admin_alerts.email_service, "send_admin_alert", new_callable=AsyncMock
+        ) as failing:
+            failing.return_value = False
+            assert await admin_alerts._store.flush() is False
+
+        assert admin_alerts._store.pending_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Email rendering
+# ---------------------------------------------------------------------------
+
+
+class TestRendering:
+    def _summary(self, **kw: object) -> admin_alerts.ToolFailureSummary:
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        base: dict = {
+            "tool_name": "qb_query",
+            "error_kind": "auth",
+            "count": 14,
+            "user_count": 4,
+            "consented_user_count": 1,
+            "samples": ["args={entity=Invoice} -> token revoked"],
+            "first_seen": now,
+            "last_seen": now,
+        }
+        base.update(kw)
+        return admin_alerts.ToolFailureSummary(**base)
+
+    def test_tool_only_email_renders_without_application_errors(self) -> None:
+        from backend.app.services.email_service import _admin_alert_message
+
+        msg = _admin_alert_message("admin@example.com", [], 0, [self._summary()])
+        rendered = str(msg)
+        assert "qb_query" in rendered
+        assert "Tool failures" in rendered
+
+    def test_subject_names_the_tool_when_it_is_the_only_problem(self) -> None:
+        from backend.app.services.email_service import _alert_subject
+
+        subject = _alert_subject([], [self._summary()])
+        assert "qb_query" in subject
+        assert "x14" in subject
+
+    def test_withheld_user_count_is_stated(self) -> None:
+        from backend.app.services.email_service import _admin_alert_message
+
+        msg = _admin_alert_message("admin@example.com", [], 0, [self._summary()])
+        # 4 users seen, 1 consented, so 3 are counted but not shown.
+        assert "3 further user(s) have not opted into data sharing" in str(msg)
+
+    @pytest.mark.asyncio
+    async def test_send_is_skipped_when_there_is_nothing_to_report(self) -> None:
+        from backend.app.services.email_service import send_admin_alert
+
+        assert await send_admin_alert("admin@example.com", [], 0, []) is False

--- a/tests/test_tool_failure_hook.py
+++ b/tests/test_tool_failure_hook.py
@@ -1,0 +1,187 @@
+"""Tests for the tool-failure hook seam in the agent loop.
+
+The consumer side (consent gating, grouping, email) is covered in
+``tests/multi_user/test_tool_failure_alerts.py``. What matters here is that the
+agent loop actually reaches the hook, for both failure shapes, and that a
+handler can never break a user's turn. Without these, the call sites in
+``core.py`` could be deleted and the consumer suite would stay green.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from backend.app.agent.core import ClawboltAgent
+from backend.app.agent.tool_failure_hook import (
+    ToolFailurePayload,
+    set_tool_failure_handler,
+)
+from backend.app.agent.tools.base import Tool, ToolErrorKind, ToolResult
+from backend.app.models import User
+from tests.mocks.llm import make_text_response, make_tool_call_response
+
+
+class _EmptyParams(BaseModel):
+    """Minimal params model for tools with no parameters."""
+
+
+@pytest.fixture(autouse=True)
+def _clear_handler() -> Generator[None]:
+    set_tool_failure_handler(None)
+    yield
+    set_tool_failure_handler(None)
+
+
+@pytest.fixture
+def captured() -> Generator[list[ToolFailurePayload]]:
+    """Install a recording handler and hand back what it saw."""
+    seen: list[ToolFailurePayload] = []
+
+    async def handler(payload: ToolFailurePayload) -> None:
+        seen.append(payload)
+
+    set_tool_failure_handler(handler)
+    yield seen
+
+
+def _tool(fn: object, name: str = "broken_tool") -> Tool:
+    return Tool(
+        name=name,
+        description="A tool for testing failures",
+        function=fn,  # type: ignore[arg-type]
+        params_model=_EmptyParams,
+    )
+
+
+async def _run(agent: ClawboltAgent, tool: Tool, mock_llm: AsyncMock) -> None:
+    """Drive one tool-calling round followed by a text reply."""
+    agent.register_tools([tool])
+    mock_llm.side_effect = [
+        make_tool_call_response([{"name": tool.name, "arguments": {}}]),
+        make_text_response("done"),
+    ]
+    await agent.process_message(message_context="go")
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
+@patch("backend.app.agent.core.amessages")
+async def test_tool_returning_an_error_reaches_the_hook(
+    mock_llm: AsyncMock,
+    mock_prompt: AsyncMock,
+    test_user: User,
+    captured: list[ToolFailurePayload],
+) -> None:
+    mock_prompt.return_value = ("system", "")
+
+    async def failing() -> ToolResult:
+        return ToolResult(
+            content="QuickBooks returned 503",
+            is_error=True,
+            error_kind=ToolErrorKind.SERVICE,
+        )
+
+    await _run(ClawboltAgent(user=test_user), _tool(failing), mock_llm)
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload.tool_name == "broken_tool"
+    assert payload.error_kind == str(ToolErrorKind.SERVICE)
+    assert payload.user_id == test_user.id
+    assert payload.result_text == "QuickBooks returned 503"
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
+@patch("backend.app.agent.core.amessages")
+async def test_result_text_excludes_our_own_error_hint(
+    mock_llm: AsyncMock,
+    mock_prompt: AsyncMock,
+    test_user: User,
+    captured: list[ToolFailurePayload],
+) -> None:
+    """The hint is boilerplate we append. Including it would make every group's
+    sample look alike and waste the sample budget."""
+    mock_prompt.return_value = ("system", "")
+
+    async def failing() -> ToolResult:
+        return ToolResult(content="upstream down", is_error=True, error_kind=ToolErrorKind.SERVICE)
+
+    await _run(ClawboltAgent(user=test_user), _tool(failing), mock_llm)
+
+    assert captured[0].result_text == "upstream down"
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
+@patch("backend.app.agent.core.amessages")
+async def test_tool_raising_reaches_the_hook_as_internal(
+    mock_llm: AsyncMock,
+    mock_prompt: AsyncMock,
+    test_user: User,
+    captured: list[ToolFailurePayload],
+) -> None:
+    mock_prompt.return_value = ("system", "")
+
+    async def exploding() -> ToolResult:
+        raise RuntimeError("kaboom")
+
+    await _run(ClawboltAgent(user=test_user), _tool(exploding), mock_llm)
+
+    assert len(captured) == 1
+    assert captured[0].error_kind == str(ToolErrorKind.INTERNAL)
+    assert "kaboom" in captured[0].result_text
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
+@patch("backend.app.agent.core.amessages")
+async def test_successful_tool_does_not_reach_the_hook(
+    mock_llm: AsyncMock,
+    mock_prompt: AsyncMock,
+    test_user: User,
+    captured: list[ToolFailurePayload],
+) -> None:
+    mock_prompt.return_value = ("system", "")
+
+    async def fine() -> ToolResult:
+        return ToolResult(content="all good")
+
+    await _run(ClawboltAgent(user=test_user), _tool(fine, name="good_tool"), mock_llm)
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+@patch("backend.app.agent.core.build_agent_system_prompt_parts", new_callable=AsyncMock)
+@patch("backend.app.agent.core.amessages")
+async def test_a_raising_handler_does_not_break_the_turn(
+    mock_llm: AsyncMock,
+    mock_prompt: AsyncMock,
+    test_user: User,
+) -> None:
+    """The reply must still be produced when the alerting path is broken."""
+    mock_prompt.return_value = ("system", "")
+
+    async def handler(payload: ToolFailurePayload) -> None:
+        raise RuntimeError("alerting is down")
+
+    set_tool_failure_handler(handler)
+
+    async def failing() -> ToolResult:
+        return ToolResult(content="nope", is_error=True, error_kind=ToolErrorKind.AUTH)
+
+    agent = ClawboltAgent(user=test_user)
+    agent.register_tools([_tool(failing)])
+    mock_llm.side_effect = [
+        make_tool_call_response([{"name": "broken_tool", "arguments": {}}]),
+        make_text_response("handled it"),
+    ]
+
+    response = await agent.process_message(message_context="go")
+
+    assert "handled it" in response.reply_text


### PR DESCRIPTION
## Description

Emails the operator when agent tool calls fail, batched into the alert email `admin_alerts` already sends.

**Why this is not already covered.** A tool returning `SERVICE` (integration down) or `AUTH` (token revoked) logs at `WARNING`, so it never reached the alerting path. Only a tool *raising* logs at `ERROR`, and `admin_alerts` fingerprints on the log template, so every crashing tool in the system collapsed into one group naming whichever ran most recently.

**Seam.** `agent/tool_failure_hook.py` is a no-op unless a handler is installed, following the `set_pipeline_override` / `install_llm_payload_capture` pattern, so single-user and CI pay nothing. The `multi_user` handler feeds the existing `AlertAggregator`, so grouping, throttling and delivery are shared and one flush is still one email.

**What counts.** Only `INTERNAL`, `SERVICE`, `AUTH`. The rest are the product working: `VALIDATION` and `NOT_FOUND` are the model self-correcting, `PERMISSION` and `INTERRUPTED` are the user declining or stopping.

**Consent gates detail, not visibility.** Every qualifying failure raises the occurrence and distinct-user counts whatever the user's setting; arguments and result text attach only for users who opted in, redacted through `pii_redaction`. A strict filter would have made an outage confined to non-consenting users invisible. Consent resolves inline from a 60s cache so non-consenting detail is dropped at the door rather than held until flush, and a miss fails closed rather than adding a DB read to a live reply.

**Storm control.** Grouped on `(tool, error kind)`: one revoked token hitting 40 users is one line with a count. A failed send puts the batch back, since unlike an ERROR log a tool failure has no second record anywhere.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

42 new tests. `tests/test_tool_failure_hook.py` proves the agent loop reaches the hook for both failure shapes, so the call sites cannot be deleted silently; `tests/multi_user/test_tool_failure_alerts.py` covers kind filtering, consent gating (including asserting no argument text reaches the rendered email for a non-consenting user), grouping and failed-send recovery. Suite 4013 passed. `ty`, frontend typecheck and vitest green. No OpenAPI change.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Designed and implemented by Claude Opus 5 via the Claude Code CLI, through back-and-forth with @njbrake. The three product decisions (which error kinds count, consent gating detail rather than visibility, one email rather than two) are his; the code and prose are the model's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds operator email alerts for qualifying agent tool-call failures.

- Reports `INTERNAL`, `SERVICE`, and `AUTH` failures.
- Groups repeated failures by tool and error kind.
- Preserves failure and user counts regardless of consent.
- Includes redacted arguments and results only for consenting users.
- Restores alert batches when email delivery fails.
- Adds a safe, no-op reporting hook for agent tool execution.
- Installs alert handling during multi-user startup.
- Updates monitoring documentation with the new tool-failure alert layer.
- Adds 42 tests for routing, filtering, consent, grouping, redaction, and retry recovery.

## Benefits

Operators receive clearer failure signals without exposing non-consenting users’ details. Alert grouping reduces email noise, and failed deliveries remain available for retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->