### PR TITLE
feat(web-search): let the agent choose result count and recency per call

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -218,7 +218,9 @@ LLM_MODEL=
 # WEB_SEARCH_TIMEOUT_SECONDS=10
 # How long identical queries are served from cache, in seconds.
 # WEB_SEARCH_CACHE_TTL_SECONDS=900
-# WEB_SEARCH_MAX_RESULTS=5
+# Results returned when the agent does not request a specific count.
+# The agent can ask for 1-20 per call; roughly 800 tokens per result.
+# WEB_SEARCH_MAX_RESULTS=3
 
 # OAuth
 # Public URL where this server is reachable (used for OAuth callback URLs).

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -268,7 +268,9 @@ class Settings(BaseSettings):
     # enough to save the duplicate call, short enough that a price checked
     # twice in a day is fetched twice.
     web_search_cache_ttl_seconds: int = Field(default=900, ge=0)
-    web_search_max_results: int = Field(default=5, ge=1, le=20)
+    # Default when the agent does not ask for a specific count. Each result
+    # costs roughly 800 tokens, so this is the main lever on search cost.
+    web_search_max_results: int = Field(default=3, ge=1, le=20)
 
     # OAuth
     app_base_url: str = "http://localhost:8000"  # Public URL for OAuth callbacks

--- a/backend/app/integrations/web_search/brave.py
+++ b/backend/app/integrations/web_search/brave.py
@@ -32,6 +32,14 @@ _TAG_RE = re.compile(r"<[^>]+>")
 # is waiting on a reply and a long retry chain reads as a hang. 4xx other than
 # 429 is a fault in our request and will fail identically on retry.
 _RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+# Brave's own ceiling: count=30 returns 422.
+_MAX_COUNT = 20
+
+# Recency filters Brave accepts. Brave also takes a YYYY-MM-DDtoYYYY-MM-DD
+# range, deliberately not exposed: the agent has no use for a precision it
+# cannot justify, and a malformed range is a 422.
+_FRESHNESS_CODES = frozenset({"pd", "pw", "pm", "py"})
 _MAX_ATTEMPTS = 3
 _BACKOFF_BASE_SECONDS = 0.5
 
@@ -102,21 +110,35 @@ class BraveSearchProvider:
         # Unreachable: the loop either returns, raises, or continues.
         raise SearchUnavailableError("Brave search exhausted its retries")
 
-    async def search(self, query: str, *, max_results: int = 5) -> list[dict[str, Any]]:
-        data = await self._request(
-            {
-                "q": query,
-                "count": str(max_results),
-                # Plain web results only. Brave's news/video/location clusters
-                # have their own shapes and answer a different question than the
-                # one this tool asks. Product data is unaffected: Brave attaches
-                # it to ordinary web results, which is where the prices live.
-                "result_filter": "web",
-                # No extra_snippets flag: Brave returns those passages either
-                # way, measured identical byte counts with and without it, so
-                # asking for them only implies a control that does not exist.
-            }
-        )
+    async def search(
+        self,
+        query: str,
+        *,
+        max_results: int = 3,
+        freshness: str | None = None,
+    ) -> list[dict[str, Any]]:
+        # Brave rejects count above 20 with a 422, so a caller asking for more
+        # is clamped rather than handed an error it cannot act on.
+        count = max(1, min(max_results, _MAX_COUNT))
+        params = {
+            "q": query,
+            "count": str(count),
+            # Plain web results only. Brave's news/video/location clusters
+            # have their own shapes and answer a different question than the
+            # one this tool asks. Product data is unaffected: Brave attaches
+            # it to ordinary web results, which is where the prices live.
+            "result_filter": "web",
+            # No extra_snippets flag: Brave returns those passages either
+            # way, measured identical byte counts with and without it, so
+            # asking for them only implies a control that does not exist.
+        }
+        if freshness in _FRESHNESS_CODES:
+            # Omitted entirely when unset or unrecognized. Sending an invalid
+            # value is a 422, and an unfiltered search is the right fallback:
+            # the question may well have an old but correct answer.
+            params["freshness"] = freshness
+
+        data = await self._request(params)
 
         results = (data.get("web") or {}).get("results") or []
-        return [_clean(r) for r in results[:max_results] if isinstance(r, dict)]
+        return [_clean(r) for r in results[:count] if isinstance(r, dict)]

--- a/backend/app/integrations/web_search/cache.py
+++ b/backend/app/integrations/web_search/cache.py
@@ -33,5 +33,17 @@ class SearchCache:
         self._cache.clear()
 
     @staticmethod
-    def make_key(provider: str, query: str, max_results: int) -> str:
-        return f"{provider}:{' '.join(query.split()).lower()}:{max_results}"
+    def make_key(
+        provider: str,
+        query: str,
+        max_results: int,
+        freshness: str | None = None,
+    ) -> str:
+        """Build the cache key.
+
+        ``freshness`` is part of the key because it changes the answer: without
+        it, a search restricted to the past month would be served an older
+        unfiltered hit, which is the exact staleness the caller asked to avoid.
+        """
+        normalized = " ".join(query.split()).lower()
+        return f"{provider}:{normalized}:{max_results}:{freshness or 'any'}"

--- a/backend/app/integrations/web_search/factory.py
+++ b/backend/app/integrations/web_search/factory.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import httpx
 from pydantic import BaseModel, Field
@@ -72,10 +72,33 @@ _RESULT_FOOTER = (
 )
 
 
+# Bounds on what the agent may ask for. The ceiling is the lowest limit across
+# supported providers (Brave rejects count above 20).
+_MIN_RESULTS = 1
+_MAX_RESULTS = 20
+
+
 class WebSearchParams(BaseModel):
     query: str = Field(
         max_length=400,
         description="A natural-language web search query.",
+    )
+    max_results: int | None = Field(
+        default=None,
+        description=(
+            "How many results to return, 1 to 20. Omit for the default. Ask "
+            "for fewer when checking a single fact, more when comparing "
+            "prices or options across suppliers."
+        ),
+    )
+    freshness: Literal["pd", "pw", "pm", "py"] | None = Field(
+        default=None,
+        description=(
+            "Restrict results by age: pd past day, pw past week, pm past "
+            "month, py past year. Use pm for prices and anything that moves. "
+            "Omit it for building codes, specs, and standards, where the "
+            "correct answer is often years old and filtering hides it."
+        ),
     )
 
 
@@ -101,7 +124,11 @@ def _create_web_search_tools(provider: SearchProvider, cache: SearchCache) -> li
     can drive the tool with a stub backend and a fresh cache.
     """
 
-    async def web_search(query: str) -> ToolResult:
+    async def web_search(
+        query: str,
+        max_results: int | None = None,
+        freshness: str | None = None,
+    ) -> ToolResult:
         cleaned = query.strip()
         if not cleaned:
             return ToolResult(
@@ -111,14 +138,18 @@ def _create_web_search_tools(provider: SearchProvider, cache: SearchCache) -> li
                 hint="Provide a search query describing what to look up.",
             )
 
-        max_results = settings.web_search_max_results
-        cache_key = SearchCache.make_key(provider.name, cleaned, max_results)
+        # Clamped rather than rejected: a model asking for 50 wants "lots", and
+        # spending a turn on a validation error teaches it nothing useful.
+        requested = settings.web_search_max_results if max_results is None else max_results
+        resolved = max(_MIN_RESULTS, min(requested, _MAX_RESULTS))
+
+        cache_key = SearchCache.make_key(provider.name, cleaned, resolved, freshness)
         cached = await cache.get(cache_key)
         if cached is not None:
             return ToolResult(content=_format_results(cached, cleaned))
 
         try:
-            records = await provider.search(cleaned, max_results=max_results)
+            records = await provider.search(cleaned, max_results=resolved, freshness=freshness)
         except SearchUnavailableError as exc:
             logger.warning("Web search backend unavailable: query=%r reason=%s", cleaned, exc)
             return ToolResult(

--- a/backend/app/integrations/web_search/protocol.py
+++ b/backend/app/integrations/web_search/protocol.py
@@ -29,4 +29,20 @@ class SearchProvider(Protocol):
     name: str
     display_name: str
 
-    async def search(self, query: str, *, max_results: int = 5) -> list[dict[str, Any]]: ...
+    async def search(
+        self,
+        query: str,
+        *,
+        max_results: int = 3,
+        freshness: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Run *query* and return the provider's own result records.
+
+        ``freshness`` is a best-effort recency hint (``pd``/``pw``/``pm``/``py``
+        for past day/week/month/year). It is on the seam rather than buried in
+        one backend because recency is a property of the question, not of the
+        vendor: a material price wants the last month, a building code from 2023
+        wants no filter at all. A provider that cannot express it ignores it,
+        which degrades to today's behavior rather than failing.
+        """
+        ...

--- a/backend/app/integrations/web_search/render.py
+++ b/backend/app/integrations/web_search/render.py
@@ -12,11 +12,12 @@ The two transformations applied are markup removal (in the provider, where
 ``<strong>`` highlight tags are stripped) and skipping keys whose value is null
 or an empty string, neither of which carries anything the model could use.
 
-The size of a response is therefore set by one number the operator can reason
-about, ``WEB_SEARCH_MAX_RESULTS``, rather than by a character budget hidden in
-here. A live Brave result runs roughly 2,000 characters, so the default of five
-lands near 10,000. If that is ever too much, the fix is to ask for fewer
-results, not to serve half of each one.
+The size of a response is therefore set by the result count, rather than by a
+character budget hidden in here. A live Brave result runs roughly 2,000
+characters, so the default of three lands near 6,000 and the ceiling of twenty
+near 40,000. ``WEB_SEARCH_MAX_RESULTS`` sets the count for a call that does not
+ask for one; the agent picks per call otherwise. If that is ever too much, the
+fix is to ask for fewer results, not to serve half of each one.
 """
 
 from typing import Any

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -303,7 +303,7 @@ If that is too much for your deployment, lower `WEB_SEARCH_MAX_RESULTS`. That tr
 
 ### Swapping the search provider
 
-The provider seam is one method wide (`search(query, max_results) -> list[SearchResult]`). To add a backend, write a module in `backend/app/integrations/web_search/` satisfying the `SearchProvider` protocol, add it to `_PROVIDERS` in that package's `factory.py`, and point `WEB_SEARCH_PROVIDER` at it. The cache, retry policy, error handling, and result formatting are provider-agnostic and need no changes.
+The provider seam is one method wide (`search(query, *, max_results, freshness) -> list[dict[str, Any]]`). To add a backend, write a module in `backend/app/integrations/web_search/` satisfying the `SearchProvider` protocol, add it to `_PROVIDERS` in that package's `factory.py`, and point `WEB_SEARCH_PROVIDER` at it. A backend that cannot express `freshness` ignores it and returns unfiltered results. The cache, retry policy, error handling, and result formatting are provider-agnostic and need no changes.
 
 
 ## HTTP timeouts

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -278,9 +278,16 @@ ServiceTitan uses OAuth 2.0 client credentials, one set per tenant. The operator
 | `WEB_SEARCH_PROVIDER` | `brave` | Search backend. `brave` is the only one implemented today |
 | `WEB_SEARCH_TIMEOUT_SECONDS` | `10` | Per-request timeout. Kept short because searches run inside a live message loop |
 | `WEB_SEARCH_CACHE_TTL_SECONDS` | `900` | How long an identical query is served from an in-memory cache, to control cost |
-| `WEB_SEARCH_MAX_RESULTS` | `5` | Results requested per search. This is the only lever on response size, see below |
+| `WEB_SEARCH_MAX_RESULTS` | `3` | Results returned when the agent does not ask for a specific count. See result size below |
 
 The agent gets one specialist tool here: `web_search`, which takes a natural-language query and returns ranked results with titles, snippets, and source URLs. The agent writes its own queries and uses it for material prices, product specs, building code requirements, and anything else outside its training data.
+
+Two optional parameters are chosen per call by the agent rather than fixed by configuration, because both depend on the question rather than the deployment:
+
+- `max_results` (1 to 20) trades cost against breadth. Checking one fact needs fewer results than comparing prices across suppliers. Values outside the range are clamped rather than rejected, since a rejected call costs a turn and teaches the agent nothing.
+- `freshness` (`pd`, `pw`, `pm`, `py` for past day/week/month/year) restricts results by age. A material price wants the past month; a 2023 code requirement wants no filter at all, because the correct answer is years old and filtering would hide it. Omitted by default.
+
+Without a freshness filter most results carry no publication date at all, so the agent cannot tell a page from last week from one from 2019. Asking for `pm` on a price query is the difference between an undated snippet and one stamped `3 weeks ago`.
 
 Without `WEB_SEARCH_API_KEY` the tool is not registered, so it never reaches the model's schema. The agent is told web search is unconfigured and answers from what it knows instead, saying so; nothing else degrades.
 
@@ -290,9 +297,9 @@ Results are search snippets and can be stale. The agent is instructed to cite th
 
 Results are passed through as the provider returned them. Nothing is truncated and no fields are dropped, because a search tool that quietly serves half a result is indistinguishable from one that is broken, and the field most likely to go missing is the one a specific answer depends on. An earlier revision of this integration mapped results onto a fixed set of fields and silently discarded the structured product price, which is exactly that failure.
 
-The cost is real and worth knowing before tuning. Measured against Brave with `WEB_SEARCH_MAX_RESULTS=5`, a single search renders to roughly 4,000 tokens for a product query and 8,500 for a broad research query. At `3` those fall to about 2,400 and 5,500. A request that fans out across many items multiplies accordingly: a nine-item materials list runs near 50,000 tokens at the default.
+The cost is real and worth knowing before tuning. Measured against Brave, a single search renders to roughly 2,600 tokens at three results and 4,000 at five, rising to about 16,000 at the ceiling of twenty. A request that fans out across many items multiplies accordingly.
 
-If that is too much for your deployment, lower the result count. That trades away whole results, which the agent can see and reason about, rather than trimming fields out of the ones it keeps.
+If that is too much for your deployment, lower `WEB_SEARCH_MAX_RESULTS`. That trades away whole results, which the agent can see and reason about, rather than trimming fields out of the ones it keeps. Note that the agent can request more than the default on a given call, so this sets the usual case rather than a hard budget.
 
 ### Swapping the search provider
 

--- a/tests/test_web_search_tools.py
+++ b/tests/test_web_search_tools.py
@@ -10,14 +10,14 @@ The search API is mocked throughout; no test makes a network call.
 """
 
 import asyncio
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from backend.app.agent.tools.base import Tool
+from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.integrations.web_search.brave import BraveSearchProvider, _clean
 from backend.app.integrations.web_search.cache import SearchCache
 from backend.app.integrations.web_search.errors import SearchUnavailableError
@@ -373,11 +373,20 @@ class TestSearchCache:
     def test_make_key_normalizes_query(self) -> None:
         """A reworded-but-identical query should hit, so casing and runs of
         whitespace must not produce distinct keys."""
-        assert SearchCache.make_key("brave", "  Copper   PIPE ", 5) == "brave:copper pipe:5"
+        assert SearchCache.make_key("brave", "  Copper   PIPE ", 5) == "brave:copper pipe:5:any"
 
     def test_make_key_separates_providers_and_sizes(self) -> None:
         assert SearchCache.make_key("brave", "q", 5) != SearchCache.make_key("other", "q", 5)
         assert SearchCache.make_key("brave", "q", 5) != SearchCache.make_key("brave", "q", 10)
+
+    def test_make_key_separates_freshness(self) -> None:
+        """Otherwise a search restricted to the past month is served an older
+        unfiltered hit, which is the staleness the caller asked to avoid."""
+        unfiltered = SearchCache.make_key("brave", "q", 5)
+        assert unfiltered != SearchCache.make_key("brave", "q", 5, "pm")
+        assert SearchCache.make_key("brave", "q", 5, "pm") != SearchCache.make_key(
+            "brave", "q", 5, "pd"
+        )
 
     def test_clear(self) -> None:
         cache = SearchCache()
@@ -653,6 +662,170 @@ class TestRendering:
         assert "omitted" not in out
         for i in range(12):
             assert f"url: https://example.com/{i}" in out
+
+
+class TestSearchParameters:
+    """max_results and freshness are chosen per call by the agent."""
+
+    def _tool(self, provider: AsyncMock) -> Callable[..., Awaitable[ToolResult]]:
+        from backend.app.integrations.web_search.factory import _create_web_search_tools
+
+        return _create_web_search_tools(provider, SearchCache())[0].function
+
+    def _provider(self) -> AsyncMock:
+        provider = AsyncMock(spec=BraveSearchProvider)
+        provider.name = "brave"
+        provider.search = AsyncMock(return_value=[_record()])
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_omitted_max_results_uses_the_configured_default(self) -> None:
+        provider = self._provider()
+        with patch("backend.app.integrations.web_search.factory.settings") as mock_settings:
+            mock_settings.web_search_max_results = 3
+            await self._tool(provider)(query="q")
+
+        assert provider.search.call_args.kwargs["max_results"] == 3
+
+    @pytest.mark.asyncio
+    async def test_agent_supplied_max_results_wins(self) -> None:
+        provider = self._provider()
+        with patch("backend.app.integrations.web_search.factory.settings") as mock_settings:
+            mock_settings.web_search_max_results = 3
+            await self._tool(provider)(query="q", max_results=10)
+
+        assert provider.search.call_args.kwargs["max_results"] == 10
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("asked", "expected"), [(50, 20), (0, 1), (-5, 1), (20, 20)])
+    async def test_max_results_is_clamped_not_rejected(self, asked: int, expected: int) -> None:
+        """A model asking for 50 wants "lots". Spending a turn on a validation
+        error teaches it nothing, and Brave 422s above 20."""
+        provider = self._provider()
+        with patch("backend.app.integrations.web_search.factory.settings") as mock_settings:
+            mock_settings.web_search_max_results = 3
+            result = await self._tool(provider)(query="q", max_results=asked)
+
+        assert not result.is_error
+        assert provider.search.call_args.kwargs["max_results"] == expected
+
+    @pytest.mark.asyncio
+    async def test_freshness_is_passed_through(self) -> None:
+        provider = self._provider()
+        with patch("backend.app.integrations.web_search.factory.settings") as mock_settings:
+            mock_settings.web_search_max_results = 3
+            await self._tool(provider)(query="q", freshness="pm")
+
+        assert provider.search.call_args.kwargs["freshness"] == "pm"
+
+    @pytest.mark.asyncio
+    async def test_freshness_defaults_to_unfiltered(self) -> None:
+        """Codes and standards have old but correct answers; filtering by
+        default would hide them."""
+        provider = self._provider()
+        with patch("backend.app.integrations.web_search.factory.settings") as mock_settings:
+            mock_settings.web_search_max_results = 3
+            await self._tool(provider)(query="q")
+
+        assert provider.search.call_args.kwargs["freshness"] is None
+
+    @pytest.mark.asyncio
+    async def test_different_freshness_does_not_share_a_cache_entry(self) -> None:
+        """Serving a filtered query from an unfiltered hit reintroduces exactly
+        the staleness the caller asked to avoid."""
+        provider = self._provider()
+        tool_fn = self._tool(provider)
+        with patch("backend.app.integrations.web_search.factory.settings") as mock_settings:
+            mock_settings.web_search_max_results = 3
+            await tool_fn(query="copper pipe")
+            await tool_fn(query="copper pipe", freshness="pm")
+
+        assert provider.search.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_different_result_counts_do_not_share_a_cache_entry(self) -> None:
+        provider = self._provider()
+        tool_fn = self._tool(provider)
+        with patch("backend.app.integrations.web_search.factory.settings") as mock_settings:
+            mock_settings.web_search_max_results = 3
+            await tool_fn(query="copper pipe", max_results=3)
+            await tool_fn(query="copper pipe", max_results=10)
+
+        assert provider.search.call_count == 2
+
+    def test_schema_offers_freshness_as_an_enum(self) -> None:
+        """A free-text field would let the model invent a value Brave 422s on."""
+        from backend.app.agent.tools.base import tool_to_function_schema
+        from backend.app.integrations.web_search.factory import _create_web_search_tools
+
+        provider = AsyncMock(spec=BraveSearchProvider)
+        provider.name = "brave"
+        tool = _create_web_search_tools(provider, SearchCache())[0]
+        schema = tool_to_function_schema(tool)
+
+        freshness = schema["input_schema"]["properties"]["freshness"]
+        allowed = {v for branch in freshness["anyOf"] for v in branch.get("enum", [])}
+        assert allowed == {"pd", "pw", "pm", "py"}
+
+    def test_only_query_is_required(self) -> None:
+        """Both new parameters are optional, so existing behavior is unchanged
+        when the model omits them."""
+        from backend.app.agent.tools.base import tool_to_function_schema
+        from backend.app.integrations.web_search.factory import _create_web_search_tools
+
+        provider = AsyncMock(spec=BraveSearchProvider)
+        provider.name = "brave"
+        tool = _create_web_search_tools(provider, SearchCache())[0]
+        schema = tool_to_function_schema(tool)
+
+        assert schema["input_schema"]["required"] == ["query"]
+
+
+class TestBraveParameterMapping:
+    @pytest.mark.asyncio
+    async def test_count_and_freshness_reach_the_request(self) -> None:
+        provider = BraveSearchProvider(api_key="k")
+        client = _mock_client([_make_httpx_response(200, _make_brave_response())])
+
+        with _patch_client(client):
+            await provider.search("test", max_results=7, freshness="pm")
+
+        params = client.get.call_args.kwargs["params"]
+        assert params["count"] == "7"
+        assert params["freshness"] == "pm"
+
+    @pytest.mark.asyncio
+    async def test_freshness_is_omitted_when_unset(self) -> None:
+        provider = BraveSearchProvider(api_key="k")
+        client = _mock_client([_make_httpx_response(200, _make_brave_response())])
+
+        with _patch_client(client):
+            await provider.search("test")
+
+        assert "freshness" not in client.get.call_args.kwargs["params"]
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_freshness_is_dropped_rather_than_sent(self) -> None:
+        """Brave 422s on an invalid value. An unfiltered search is the better
+        fallback: the question may have an old but correct answer."""
+        provider = BraveSearchProvider(api_key="k")
+        client = _mock_client([_make_httpx_response(200, _make_brave_response())])
+
+        with _patch_client(client):
+            await provider.search("test", freshness="last-tuesday")
+
+        assert "freshness" not in client.get.call_args.kwargs["params"]
+
+    @pytest.mark.asyncio
+    async def test_count_is_clamped_to_the_api_ceiling(self) -> None:
+        """Brave returns 422 for count above 20."""
+        provider = BraveSearchProvider(api_key="k")
+        client = _mock_client([_make_httpx_response(200, _make_brave_response())])
+
+        with _patch_client(client):
+            await provider.search("test", max_results=999)
+
+        assert client.get.call_args.kwargs["params"]["count"] == "20"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Adds two optional `web_search` parameters the agent chooses per call, because both depend on the question rather than the deployment.

**`freshness`** (`pd`/`pw`/`pm`/`py`) is the more valuable of the two. Without it Brave returns results with no publication date at all, so the agent cannot tell a page from last week from one from 2019. Measured on one query:

| `freshness` | Result ages |
|---|---|
| omitted | `-`, `-`, `-` |
| `pm` | 1 week ago, 3 weeks ago, 4 weeks ago |

That is the staleness problem at its root; the prompt framing could only manage it after the fact. Omitted by default, because a 2023 code requirement has an old but correct answer that filtering would hide.

**`max_results`** (1-20) trades cost against breadth. Out-of-range values are clamped rather than rejected: a model asking for 50 wants "lots", and a validation error costs a turn and teaches it nothing. 20 is Brave's own ceiling (30 returns 422).

The default drops from 5 to 3, taking a product search from roughly 4,000 tokens to 2,600. `WEB_SEARCH_MAX_RESULTS` now sets the usual case rather than a hard budget, since the agent can ask for more.

`freshness` joins the cache key. Without that a search restricted to the past month would be served an older unfiltered hit, which is the staleness the caller asked to avoid. It sits on the provider seam rather than inside the Brave module because recency is a property of the question, not the vendor; a backend that cannot express it ignores it.

Both parameters are optional, so a call that omits them behaves exactly as before.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`)
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [ ] Bug fixes include regression tests

18 new tests covering clamping, pass-through, cache-key separation for both parameters, the schema exposing `freshness` as an enum rather than free text, and `query` remaining the only required field. Suite 4030 passed; `ty`, ruff, and no OpenAPI drift. Behavior verified against the live Brave API before the tests were written.

## AI Usage
- [x] AI-assisted (describe how)
- [ ] No AI used

Implemented by Claude Opus 5 via the Claude Code CLI, through back-and-forth with @njbrake. The decision to make these agent-chosen rather than configured, and the default of 3, are his; the code and prose are the model's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added optional per-call controls for web search result count and freshness.
- Clamped `max_results` to 1–20 and changed the default from 5 to 3.
- Updated caching to separate results by freshness and result count.
- Updated the provider interface and Brave integration.
- Updated configuration guidance and added tests for validation, caching, parameter handling, and schema behavior.

## Benefits

Agents can balance search depth, token use, and result freshness for each request. Existing calls remain unchanged when these options are omitted.

## Potential Follow-up

Other search providers can add native freshness support. Providers without that support will continue to return unfiltered results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->