### PR TITLE
feat(admin): give each evaluation report its own page and URL

### DIFF
--- a/alembic/versions/043_add_llm_eval_run_public_id.py
+++ b/alembic/versions/043_add_llm_eval_run_public_id.py
@@ -1,0 +1,48 @@
+"""Give ``llm_eval_runs`` a public id.
+
+A run's report is a page an operator bookmarks, revisits, and pastes to
+someone else, so it needs an address that is stable and not a row counter.
+The integer primary key stays as the internal key the worker and the turn
+rows use; only the API and the report URL move to this column.
+
+Added nullable, backfilled per row, then tightened to NOT NULL so the unique
+index cannot land on a table where every existing run shares a default.
+
+Revision ID: 043
+Revises: 042
+Create Date: 2026-09-02
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "043"
+down_revision: str | None = "042"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("llm_eval_runs", sa.Column("public_id", sa.String(length=36), nullable=True))
+
+    # Postgres has ``gen_random_uuid()`` in pgcrypto, which is not guaranteed
+    # to be installed, so the ids are generated here and applied per row.
+    connection = op.get_bind()
+    rows = connection.execute(sa.text("SELECT id FROM llm_eval_runs")).fetchall()
+    for (run_id,) in rows:
+        connection.execute(
+            sa.text("UPDATE llm_eval_runs SET public_id = :pid WHERE id = :id"),
+            {"pid": str(uuid.uuid4()), "id": run_id},
+        )
+
+    op.alter_column("llm_eval_runs", "public_id", nullable=False)
+    op.create_index("ix_llm_eval_runs_public_id", "llm_eval_runs", ["public_id"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llm_eval_runs_public_id", table_name="llm_eval_runs")
+    op.drop_column("llm_eval_runs", "public_id")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -519,6 +519,12 @@ class LLMEvalRun(Base):
     __tablename__ = "llm_eval_runs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # The id the API and the report URL use. A run's report is a page an
+    # operator bookmarks, revisits, and pastes to someone else, so its address
+    # must not be a guessable row counter that also leaks how many runs exist.
+    public_id: Mapped[str] = mapped_column(
+        String(36), unique=True, index=True, nullable=False, default=lambda: str(_uuid.uuid4())
+    )
     user_id: Mapped[str] = mapped_column(
         String, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
     )

--- a/backend/app/routers/admin_llm_eval.py
+++ b/backend/app/routers/admin_llm_eval.py
@@ -50,6 +50,7 @@ from backend.app.schemas import (
 )
 from backend.app.services.admin_audit import AdminAction, AdminAuditContext, audit_admin
 from backend.app.services.llm_eval import launch_run
+from backend.app.services.llm_eval.metrics import MIN_TURNS_FOR_VERDICT
 from backend.app.services.llm_eval.types import AgreementClass, JudgeVerdict, RunStatus
 from backend.app.services.pii_redaction import redact_pii, redact_pii_recursive
 
@@ -99,7 +100,7 @@ def _summary_of(run: LLMEvalRun) -> AdminLLMEvalSummary | None:
 
 def _run_item(run: LLMEvalRun) -> AdminLLMEvalRunItem:
     return AdminLLMEvalRunItem(
-        id=run.id,
+        id=run.public_id,
         user_id=run.user_id,
         baseline_provider=run.baseline_provider,
         baseline_model=run.baseline_model,
@@ -323,13 +324,17 @@ async def list_runs(
         .scalars()
         .all()
     )
-    return AdminLLMEvalRunListResponse(runs=[_run_item(r) for r in runs])
+    return AdminLLMEvalRunListResponse(
+        runs=[_run_item(r) for r in runs],
+        max_samples=settings.llm_eval_max_samples,
+        min_turns_for_verdict=MIN_TURNS_FOR_VERDICT,
+    )
 
 
 @router.get("/runs/{run_id}", response_model=AdminLLMEvalReportResponse)
 async def get_report(
-    run_id: int,
-    limit: int = Query(default=50, ge=1, le=200),
+    run_id: str,
+    limit: int = Query(default=50, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
     ctx: AdminAuditContext = Depends(audit_admin(AdminAction.VIEW_LLM_EVAL_REPORT)),
     db: AsyncSession = Depends(get_async_db),
@@ -342,14 +347,16 @@ async def get_report(
     reading, so the sort runs across the whole run and the page is taken from
     the result, not the other way round.
     """
-    run = (await db.execute(select(LLMEvalRun).where(LLMEvalRun.id == run_id))).scalar_one_or_none()
+    run = (
+        await db.execute(select(LLMEvalRun).where(LLMEvalRun.public_id == run_id))
+    ).scalar_one_or_none()
     if run is None:
         raise HTTPException(status_code=404, detail="Run not found")
     await _consenting_user(run.user_id, db)
     ctx.target_user_id = run.user_id
 
     turns = (
-        (await db.execute(select(LLMEvalTurnResult).where(LLMEvalTurnResult.run_id == run_id)))
+        (await db.execute(select(LLMEvalTurnResult).where(LLMEvalTurnResult.run_id == run.id)))
         .scalars()
         .all()
     )
@@ -364,7 +371,7 @@ async def get_report(
 
 @router.post("/runs/{run_id}/cancel", response_model=AdminLLMEvalRunItem)
 async def cancel_run(
-    run_id: int,
+    run_id: str,
     ctx: AdminAuditContext = Depends(audit_admin(AdminAction.CANCEL_LLM_EVAL_RUN)),
     db: AsyncSession = Depends(get_async_db),
 ) -> AdminLLMEvalRunItem:
@@ -374,7 +381,9 @@ async def cancel_run(
     already written stay, so a cancelled run keeps whatever evidence it had
     gathered.
     """
-    run = (await db.execute(select(LLMEvalRun).where(LLMEvalRun.id == run_id))).scalar_one_or_none()
+    run = (
+        await db.execute(select(LLMEvalRun).where(LLMEvalRun.public_id == run_id))
+    ).scalar_one_or_none()
     if run is None:
         raise HTTPException(status_code=404, detail="Run not found")
     ctx.target_user_id = run.user_id

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1816,7 +1816,9 @@ class AdminLLMEvalSummary(BaseModel):
 class AdminLLMEvalRunItem(BaseModel):
     """One run, without its per-turn evidence."""
 
-    id: int
+    id: str
+    """The run's ``public_id``. Its report is addressed by this, not by the row id."""
+
     user_id: str
     baseline_provider: str
     baseline_model: str
@@ -1836,7 +1838,19 @@ class AdminLLMEvalRunItem(BaseModel):
 
 
 class AdminLLMEvalRunListResponse(BaseModel):
+    """This user's runs, plus the bounds the run form has to respect.
+
+    ``max_samples`` is ``LLM_EVAL_MAX_SAMPLES``, which ``start_run`` enforces.
+    Without it on the wire the sample control can only guess, and a deployment
+    that lowers the setting gets a form offering values the API rejects.
+    ``min_turns_for_verdict`` is the floor below which a run reports
+    ``inconclusive`` rather than a pass, which is worth showing before someone
+    spends a run finding out.
+    """
+
     runs: list[AdminLLMEvalRunItem]
+    max_samples: int
+    min_turns_for_verdict: int
 
 
 class AdminLLMEvalSafetyIssue(BaseModel):

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3929,7 +3929,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
+              "type": "string",
               "title": "Run Id"
             }
           },
@@ -3939,7 +3939,7 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 200,
+              "maximum": 1000,
               "minimum": 1,
               "default": 50,
               "title": "Limit"
@@ -3995,7 +3995,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
+              "type": "string",
               "title": "Run Id"
             }
           }
@@ -5592,7 +5592,7 @@
       "AdminLLMEvalRunItem": {
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "title": "Id"
           },
           "user_id": {
@@ -5708,13 +5708,24 @@
             },
             "type": "array",
             "title": "Runs"
+          },
+          "max_samples": {
+            "type": "integer",
+            "title": "Max Samples"
+          },
+          "min_turns_for_verdict": {
+            "type": "integer",
+            "title": "Min Turns For Verdict"
           }
         },
         "type": "object",
         "required": [
-          "runs"
+          "runs",
+          "max_samples",
+          "min_turns_for_verdict"
         ],
-        "title": "AdminLLMEvalRunListResponse"
+        "title": "AdminLLMEvalRunListResponse",
+        "description": "This user's runs, plus the bounds the run form has to respect.\n\n``max_samples`` is ``LLM_EVAL_MAX_SAMPLES``, which ``start_run`` enforces.\nWithout it on the wire the sample control can only guess, and a deployment\nthat lowers the setting gets a form offering values the API rejects.\n``min_turns_for_verdict`` is the floor below which a run reports\n``inconclusive`` rather than a pass, which is worth showing before someone\nspends a run finding out."
       },
       "AdminLLMEvalSafetyIssue": {
         "properties": {

--- a/frontend/src/extensions/admin/admin-api.ts
+++ b/frontend/src/extensions/admin/admin-api.ts
@@ -1335,7 +1335,8 @@ export interface EvalSummary {
 }
 
 export interface EvalRun {
-  id: number;
+  /** The run's public id, which is also its report URL segment. */
+  id: string;
   user_id: string;
   baseline_provider: string;
   baseline_model: string;
@@ -1396,12 +1397,20 @@ export interface EvalReport {
   total_turns: number;
 }
 
-export async function listEvalRuns(userId: string): Promise<EvalRun[]> {
+export interface EvalRunList {
+  runs: EvalRun[];
+  /** LLM_EVAL_MAX_SAMPLES: the largest run the API will start. */
+  max_samples: number;
+  /** Below this many compared turns a run reports inconclusive, not a pass. */
+  min_turns_for_verdict: number;
+}
+
+export async function listEvalRuns(userId: string): Promise<EvalRunList> {
   const { data, error } = await client.GET(
     `/api/admin/llm-eval/users/${encodeURIComponent(userId)}/runs` as never,
   );
   if (error) throwApiError(error, 'Failed to load evaluation runs');
-  return (data as { runs: EvalRun[] }).runs;
+  return data as EvalRunList;
 }
 
 export async function startEvalRun(
@@ -1428,17 +1437,17 @@ export async function startEvalRun(
   return data as EvalRun;
 }
 
-export async function getEvalReport(runId: number, limit = 50): Promise<EvalReport> {
+export async function getEvalReport(runId: string, limit = 50): Promise<EvalReport> {
   const { data, error } = await client.GET(
-    `/api/admin/llm-eval/runs/${runId}?limit=${limit}` as never,
+    `/api/admin/llm-eval/runs/${encodeURIComponent(runId)}?limit=${limit}` as never,
   );
   if (error) throwApiError(error, 'Failed to load evaluation report');
   return data as EvalReport;
 }
 
-export async function cancelEvalRun(runId: number): Promise<EvalRun> {
+export async function cancelEvalRun(runId: string): Promise<EvalRun> {
   const { data, error } = await client.POST(
-    `/api/admin/llm-eval/runs/${runId}/cancel` as never,
+    `/api/admin/llm-eval/runs/${encodeURIComponent(runId)}/cancel` as never,
   );
   if (error) throwApiError(error, 'Failed to cancel evaluation');
   return data as EvalRun;

--- a/frontend/src/extensions/admin/index.tsx
+++ b/frontend/src/extensions/admin/index.tsx
@@ -12,6 +12,7 @@ import ReportedTab from './tabs/reported';
 import ApiKeysTab from './tabs/api-keys';
 import MonitoringTab from './tabs/monitoring';
 import ModelEvalTab from './tabs/model-eval';
+import ModelEvalReportPage from './tabs/model-eval-report';
 
 // --- Navigation model ---
 //
@@ -183,6 +184,12 @@ function UsersRoute({ currentUserId }: { currentUserId?: string }) {
  * on the list response, so we page the list until the row shows up rather
  * than adding a backend endpoint.
  */
+function ModelEvalReportRoute() {
+  const { runId } = useParams<{ runId: string }>();
+  if (!runId) return <Navigate to={adminPath('model-eval')} replace />;
+  return <ModelEvalReportPage runId={runId} />;
+}
+
 function UserDetailRoute({ currentUserId }: { currentUserId?: string }) {
   const { userId, section } = useParams<{ userId: string; section?: string }>();
   const navigate = useNavigate();
@@ -300,6 +307,14 @@ export default function AdminPanel() {
         element={
           <AdminSection slug="model-eval">
             <ModelEvalTab />
+          </AdminSection>
+        }
+      />
+      <Route
+        path="model-eval/:runId"
+        element={
+          <AdminSection slug="model-eval">
+            <ModelEvalReportRoute />
           </AdminSection>
         }
       />

--- a/frontend/src/extensions/admin/tabs/model-eval-common.ts
+++ b/frontend/src/extensions/admin/tabs/model-eval-common.ts
@@ -1,0 +1,35 @@
+import type { EvalRecommendation } from '../admin-api';
+
+// Shared by the model-eval index page (the run form and the run history) and
+// the report page each run links to. Both poll, both decide whether a run is
+// still in flight, and both render the verdict pill, so these three live here
+// rather than being duplicated or imported across two page modules.
+
+// Poll cadence while a run is in flight. A hundred-turn run takes minutes and
+// writes a row per turn, so this is fast enough to look alive and slow enough
+// not to hammer the endpoint.
+export const POLL_MS = 2000;
+
+export const ACTIVE_STATUSES = new Set(['pending', 'running']);
+
+export const RECOMMENDATION_COPY: Record<
+  EvalRecommendation,
+  { label: string; className: string }
+> = {
+  safe_to_switch: {
+    label: 'Safe to switch',
+    className: 'bg-success-bg text-success-text border-success/30',
+  },
+  switch_with_monitoring: {
+    label: 'Switch with monitoring',
+    className: 'bg-warning-bg text-warning-text border-warning/30',
+  },
+  do_not_switch: {
+    label: 'Do not switch',
+    className: 'bg-error-bg text-error-text border-danger/30',
+  },
+  inconclusive: {
+    label: 'Inconclusive',
+    className: 'bg-panel text-muted-foreground border-border',
+  },
+};

--- a/frontend/src/extensions/admin/tabs/model-eval-fixtures.ts
+++ b/frontend/src/extensions/admin/tabs/model-eval-fixtures.ts
@@ -1,0 +1,137 @@
+import type { EvalReport, EvalRun, EvalRunList, EvalSummary, EvalTurn } from '../admin-api';
+
+// Shared by model-eval.test.tsx (the run form and history) and
+// model-eval-report.test.tsx (one run's report), which exercise two pages
+// against the same shapes.
+
+export const USERS = {
+  total: 1,
+  skip: 0,
+  limit: 200,
+  items: [
+    {
+      id: 'user-1',
+      user_id: 'google_abc',
+      email: 'consenting@example.com',
+      plan: 'pro',
+      status: 'active',
+      role: 'user',
+      is_active: true,
+      onboarding_complete: true,
+      data_sharing_consent: true,
+    },
+  ],
+};
+
+export function summary(overrides: Partial<EvalSummary> = {}): EvalSummary {
+  return {
+    turns_total: 40,
+    turns_completed: 40,
+    turns_failed: 0,
+    agreement_counts: { identical: 40 },
+    safety_counts: {},
+    blocking_findings: 0,
+    judge_counts: {},
+    identical_rate: 1,
+    divergence_rate: 0,
+    silent_noop_rate: 0,
+    baseline: {
+      provider: 'anthropic',
+      model: 'incumbent',
+      input_tokens: 100,
+      output_tokens: 10,
+      cache_read_tokens: 900,
+      cache_creation_tokens: 0,
+      cache_read_ratio: 0.9,
+      total_cost_usd: '1.500000',
+      pricing_available: true,
+      latency_p50_ms: 1200,
+      latency_p95_ms: 2400,
+    },
+    candidate: {
+      provider: 'anthropic',
+      model: 'candidate',
+      input_tokens: 1000,
+      output_tokens: 10,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 0,
+      cache_read_ratio: 0,
+      total_cost_usd: '0.400000',
+      pricing_available: true,
+      latency_p50_ms: 600,
+      latency_p95_ms: 900,
+    },
+    recommendation: 'safe_to_switch',
+    reasons: ['no safety findings across 40 turns'],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+export function run(overrides: Partial<EvalRun> = {}): EvalRun {
+  return {
+    id: 'run-0001',
+    user_id: 'user-1',
+    baseline_provider: 'anthropic',
+    baseline_model: 'incumbent',
+    candidate_provider: 'anthropic',
+    candidate_model: 'candidate',
+    judge_model: 'incumbent',
+    requested_samples: 40,
+    status: 'completed',
+    progress_completed: 40,
+    progress_total: 40,
+    recommendation: 'safe_to_switch',
+    error: '',
+    created_at: '2026-05-01T12:00:00Z',
+    summary: summary(),
+    ...overrides,
+  };
+}
+
+export function turn(overrides: Partial<EvalTurn> = {}): EvalTurn {
+  return {
+    message_seq: 1,
+    message_timestamp: '2026-05-01T12:00:00Z',
+    user_message: 'can you book that job',
+    historic_reply: '',
+    historic_tool_names: [],
+    baseline: {
+      text: '',
+      tool_calls: [{ name: 'create_job', arguments: { customer: 'Acme Plumbing' } }],
+      stop_reason: 'tool_use',
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      latency_ms: 0,
+      error: '',
+    },
+    candidate: {
+      text: 'Sure, I can help with that.',
+      tool_calls: [],
+      stop_reason: 'end_turn',
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      latency_ms: 0,
+      error: '',
+    },
+    agreement: 'replied_instead_of_acting',
+    safety_issues: [],
+    judge_verdict: 'not_judged',
+    judge_rationale: '',
+    ...overrides,
+  };
+}
+
+export function report(overrides: Partial<EvalReport> = {}): EvalReport {
+  return { run: run(), turns: [turn()], total_turns: 1, ...overrides };
+}
+
+
+// ``listEvalRuns`` returns the run list plus the bounds the sample slider has
+// to respect, so a mock has to carry them or the slider falls back to its own
+// defaults and the test stops exercising the wired value.
+export function runList(runs: EvalRun[] = [], overrides: Partial<EvalRunList> = {}) {
+  return { runs, max_samples: 200, min_turns_for_verdict: 20, ...overrides };
+}

--- a/frontend/src/extensions/admin/tabs/model-eval-report.test.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval-report.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ModelEvalReportPage from './model-eval-report';
+import { report, run, summary, turn } from './model-eval-fixtures';
+
+// ---------------------------------------------------------------------------
+// One evaluation run's report, at its own URL.
+//
+// The report is what a switching decision is actually made on, so these tests
+// care most about the ways it could read as more reassuring than the run was:
+// an unpriced model showing as free, a provider error inflating the tile that
+// says findings block a switch, or a first page of turns passing for the whole
+// run.
+// ---------------------------------------------------------------------------
+
+vi.mock('../admin-api', () => ({
+  getEvalReport: vi.fn(),
+  cancelEvalRun: vi.fn(),
+}));
+
+function renderReport(runId = 'run-0001') {
+  return render(
+    <MemoryRouter>
+      <ModelEvalReportPage runId={runId} />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(async () => {
+  const api = await import('../admin-api');
+  vi.mocked(api.getEvalReport).mockReset().mockResolvedValue(report());
+  vi.mocked(api.cancelEvalRun).mockReset();
+});
+
+describe('ModelEvalReportPage', () => {
+  it('fetches the run named in the URL', async () => {
+    const api = await import('../admin-api');
+    renderReport('run-abc');
+
+    await waitFor(() => expect(api.getEvalReport).toHaveBeenCalledWith('run-abc', 50));
+  });
+
+  it('renders the verdict and its reasons', async () => {
+    renderReport();
+
+    expect(await screen.findByText('Safe to switch')).toBeInTheDocument();
+    expect(screen.getByText('no safety findings across 40 turns')).toBeInTheDocument();
+    // The switch itself lives on user detail; the report only points at it.
+    expect(screen.getByRole('link', { name: 'Model settings for this user' })).toHaveAttribute(
+      'href',
+      '/app/admin/users/user-1/llm',
+    );
+  });
+
+  it('offers a way back to the run list', async () => {
+    renderReport();
+
+    const back = await screen.findByRole('link', { name: 'Back to model comparison' });
+    expect(back).toHaveAttribute('href', '/app/admin/model-eval');
+  });
+
+  it('surfaces a cost warning rather than reporting an unpriced model as free', async () => {
+    const api = await import('../admin-api');
+    const withWarning = summary({
+      warnings: ['No pricing data for the candidate model (candidate); its cost is reported as zero.'],
+    });
+    vi.mocked(api.getEvalReport).mockResolvedValue(
+      report({ run: run({ summary: withWarning }) }),
+    );
+    renderReport();
+
+    expect(await screen.findByText(/No pricing data for the candidate model/)).toBeInTheDocument();
+  });
+
+  it('counts only blocking findings in the safety tile', async () => {
+    // A provider error is recorded on the turn but must not inflate the tile
+    // that says "any finding blocks a switch".
+    const api = await import('../admin-api');
+    const s = summary({ safety_counts: { call_failed: 3 }, blocking_findings: 0 });
+    vi.mocked(api.getEvalReport).mockResolvedValue(report({ run: run({ summary: s }) }));
+    renderReport();
+
+    const tile = (await screen.findByText('Safety findings')).closest('div');
+    expect(tile).not.toBeNull();
+    expect(within(tile as HTMLElement).getByText('0')).toBeInTheDocument();
+  });
+
+  it('pages the turn list and offers to load the rest', async () => {
+    const api = await import('../admin-api');
+    vi.mocked(api.getEvalReport).mockResolvedValue(report({ turns: [turn()], total_turns: 120 }));
+    renderReport();
+
+    // The count has to be visible, or a partial report reads as the whole run.
+    expect(await screen.findByText(/1 of 120/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Show more turns' }));
+    await waitFor(() => expect(api.getEvalReport).toHaveBeenLastCalledWith('run-0001', 100));
+  });
+
+  it('shows progress and the turns already in for a run still going', async () => {
+    // The page is worth opening before the run finishes, including from a
+    // different browser than the one that started it.
+    const api = await import('../admin-api');
+    vi.mocked(api.getEvalReport).mockResolvedValue(
+      report({
+        run: run({ status: 'running', progress_completed: 3, progress_total: 40, summary: null }),
+        turns: [turn()],
+        total_turns: 3,
+      }),
+    );
+    renderReport();
+
+    expect(await screen.findByText(/Replaying 3 of 40 turns/)).toBeInTheDocument();
+    expect(screen.getByText(/verdict is written when the run finishes/)).toBeInTheDocument();
+    expect(screen.getByText(/Turns, most concerning first/)).toBeInTheDocument();
+  });
+
+  it('cancels the run it is showing', async () => {
+    const api = await import('../admin-api');
+    vi.mocked(api.getEvalReport).mockResolvedValue(
+      report({ run: run({ status: 'running', summary: null }) }),
+    );
+    vi.mocked(api.cancelEvalRun).mockResolvedValue(run({ status: 'cancelled' }));
+    renderReport();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(api.cancelEvalRun).toHaveBeenCalledWith('run-0001'));
+  });
+
+  it('offers a way back when the id in the URL is not a run', async () => {
+    // A pasted link with a stale id is the common failure here, and a red
+    // banner with no exit is a dead end.
+    const api = await import('../admin-api');
+    vi.mocked(api.getEvalReport).mockRejectedValue(new Error('Run not found'));
+    renderReport('nope');
+
+    expect(await screen.findByText('That evaluation run does not exist.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to model comparison' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/extensions/admin/tabs/model-eval-report.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval-report.tsx
@@ -1,0 +1,444 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  cancelEvalRun,
+  getEvalReport,
+  type EvalDecision,
+  type EvalReport,
+  type EvalSummary,
+  type EvalTurn,
+} from '../admin-api';
+import { formatRelative } from '../format';
+import { adminPath } from '../nav-items';
+import { ACTIVE_STATUSES, POLL_MS, RECOMMENDATION_COPY } from './model-eval-common';
+
+// One evaluation run's report, at its own URL under the run's public id.
+//
+// It is a page rather than a panel on the run form because of what an
+// operator does with it: they read it, leave, come back to it days later
+// when the switch is actually being decided, and paste the link to someone
+// else. A run is also long enough that the person who reads the report is
+// often not at the machine that started it.
+//
+// Three things drive the layout:
+//
+// - The verdict is stated once, in words, at the top. Someone opening this
+//   page has one question, and a grid of rates does not answer it.
+// - Safety findings are never mixed into a quality score. They are listed
+//   separately and they are what sinks a recommendation, because each one is
+//   an action the agent loop would have taken against a real account.
+// - The turn drill-down is the point, not an appendix. Numbers persuade
+//   nobody about a decision this consequential; reading six diverging turns
+//   does. The report arrives worst-first so the turns that matter are the
+//   ones on screen.
+//
+// A run still in flight renders here too, with its progress and whatever
+// turns have landed, so the page is worth opening before the run finishes.
+
+// Turns are returned worst-first, so the first page is the part that decides
+// anything. The rest is available on request rather than shipped by default:
+// every text column on a turn is decrypted and PII-scrubbed per request.
+const TURN_PAGE_SIZE = 50;
+
+
+const AGREEMENT_COPY: Record<string, string> = {
+  identical: 'Same action',
+  same_tools_different_args: 'Same tools, different arguments',
+  different_tools: 'Different tools',
+  replied_instead_of_acting: 'Replied instead of acting',
+  acted_instead_of_replying: 'Acted where the incumbent replied',
+  both_replied: 'Both replied',
+  not_compared: 'Could not be compared',
+};
+
+const FINDING_COPY: Record<string, string> = {
+  unknown_tool: 'Called a tool that does not exist',
+  invalid_args: 'Arguments the tool rejects',
+  unrequested_mutation: 'Reached for a mutating tool the incumbent did not',
+  truncated: 'Response truncated mid-thought',
+  call_failed: 'Provider call failed',
+};
+
+const VERDICT_COPY: Record<string, string> = {
+  equivalent: 'Judge: equivalent',
+  candidate_better: 'Judge: candidate better',
+  candidate_worse: 'Judge: candidate worse',
+  candidate_unsafe: 'Judge: candidate unsafe',
+  judge_failed: 'Judge: unavailable',
+};
+
+function pct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function money(totals: { total_cost_usd: string; pricing_available: boolean }): string {
+  if (!totals.pricing_available) return 'unknown';
+  return `$${Number(totals.total_cost_usd).toFixed(4)}`;
+}
+
+function ms(value: number): string {
+  return value >= 1000 ? `${(value / 1000).toFixed(1)}s` : `${Math.round(value)}ms`;
+}
+
+// ---------------------------------------------------------------------------
+// Report pieces
+// ---------------------------------------------------------------------------
+
+function VerdictBanner({ summary, userId }: { summary: EvalSummary; userId: string }) {
+  const copy = RECOMMENDATION_COPY[summary.recommendation] ?? RECOMMENDATION_COPY.inconclusive;
+  return (
+    <div className={`rounded-[--radius-lg] border p-4 ${copy.className}`}>
+      <p className="text-lg font-semibold">{copy.label}</p>
+      <ul className="mt-2 space-y-1 text-sm">
+        {summary.reasons.map(reason => (
+          <li key={reason}>{reason}</li>
+        ))}
+      </ul>
+      {/* Links out rather than applying the switch here. The per-user override
+          already has one owner (user detail -> LLM), and a second control
+          writing the same column is how the two drift. The wording stays
+          neutral across verdicts: this is also the page you visit to clear an
+          override, and a report saying "do not switch" should not be handing
+          out a button that reads like permission. */}
+      <Link
+        to={`${adminPath('users')}/${userId}/llm`}
+        className="mt-3 inline-block text-sm font-medium underline underline-offset-2"
+      >
+        Model settings for this user
+      </Link>
+    </div>
+  );
+}
+
+function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-[--radius-md] border border-border bg-card p-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-xl font-semibold text-foreground">{value}</p>
+      {hint ? <p className="mt-1 text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+function SummaryGrid({ summary }: { summary: EvalSummary }) {
+  const safetyTotal = summary.blocking_findings;
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <Stat
+        label="Safety findings"
+        value={String(safetyTotal)}
+        hint={safetyTotal ? 'Any finding blocks a switch' : 'None across the run'}
+      />
+      <Stat
+        label="Matched the incumbent"
+        value={pct(summary.identical_rate)}
+        hint={`${summary.turns_completed} turns compared`}
+      />
+      <Stat
+        label="Replied instead of acting"
+        value={pct(summary.silent_noop_rate)}
+        hint="Turns the incumbent acted on"
+      />
+      <Stat
+        label="Cost per run"
+        value={money(summary.candidate)}
+        hint={`Incumbent ${money(summary.baseline)}`}
+      />
+      <Stat
+        label="Candidate latency (p95)"
+        value={ms(summary.candidate.latency_p95_ms)}
+        hint={`Incumbent ${ms(summary.baseline.latency_p95_ms)}`}
+      />
+      <Stat
+        label="Candidate cache reads"
+        value={pct(summary.candidate.cache_read_ratio)}
+        hint={`Incumbent ${pct(summary.baseline.cache_read_ratio)}`}
+      />
+      <Stat label="Turns that diverged" value={pct(summary.divergence_rate)} />
+      <Stat
+        label="Turns that failed"
+        value={String(summary.turns_failed)}
+        hint="Could not be compared"
+      />
+    </div>
+  );
+}
+
+function DecisionColumn({ title, decision }: { title: string; decision: EvalDecision }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </p>
+      {decision.error ? (
+        <p className="text-sm text-error-text">{decision.error}</p>
+      ) : (
+        <>
+          {decision.tool_calls.length > 0 ? (
+            <ul className="mb-2 space-y-1">
+              {decision.tool_calls.map((call, index) => (
+                <li
+                  key={`${call.name}-${index}`}
+                  className="rounded-[--radius-sm] bg-panel px-2 py-1 font-mono text-xs text-foreground"
+                >
+                  <span className="font-semibold">{call.name}</span>
+                  <span className="text-muted-foreground">
+                    ({JSON.stringify(call.arguments)})
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mb-2 text-xs italic text-muted-foreground">No tool calls</p>
+          )}
+          {decision.text ? (
+            <p className="whitespace-pre-wrap text-sm text-foreground">{decision.text}</p>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+function TurnCard({ turn }: { turn: EvalTurn }) {
+  const [open, setOpen] = useState(turn.safety_issues.length > 0);
+  return (
+    <div className="rounded-[--radius-md] border border-border bg-card">
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        className="flex w-full items-start gap-3 p-3 text-left"
+      >
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm text-foreground">{turn.user_message}</p>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+            <span className="text-muted-foreground">
+              {AGREEMENT_COPY[turn.agreement] ?? turn.agreement}
+            </span>
+            {turn.safety_issues.map((issue, index) => (
+              <span
+                key={`${issue.finding}-${index}`}
+                className="rounded-full bg-error-bg px-2 py-0.5 text-error-text"
+              >
+                {FINDING_COPY[issue.finding] ?? issue.finding}
+                {issue.tool_name ? `: ${issue.tool_name}` : ''}
+              </span>
+            ))}
+            {turn.judge_verdict !== 'not_judged' ? (
+              <span className="rounded-full bg-panel px-2 py-0.5 text-muted-foreground">
+                {VERDICT_COPY[turn.judge_verdict] ?? turn.judge_verdict}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <span className="shrink-0 text-xs text-muted-foreground">{open ? 'Hide' : 'Compare'}</span>
+      </button>
+
+      {open ? (
+        <div className="border-t border-border p-3">
+          <div className="flex flex-col gap-4 sm:flex-row">
+            <DecisionColumn title="Incumbent" decision={turn.baseline} />
+            <DecisionColumn title="Candidate" decision={turn.candidate} />
+          </div>
+          {turn.judge_rationale ? (
+            <p className="mt-3 border-t border-border pt-3 text-sm text-muted-foreground">
+              {turn.judge_rationale}
+            </p>
+          ) : null}
+          {turn.historic_reply ? (
+            <details className="mt-3 border-t border-border pt-3">
+              <summary className="cursor-pointer text-xs text-muted-foreground">
+                What the agent actually replied at the time
+              </summary>
+              <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                {turn.historic_reply}
+              </p>
+              {turn.historic_tool_names.length > 0 ? (
+                <p className="mt-1 font-mono text-xs text-muted-foreground">
+                  {turn.historic_tool_names.join(', ')}
+                </p>
+              ) : null}
+            </details>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function ModelEvalReportPage({ runId }: { runId: string }) {
+  const [report, setReport] = useState<EvalReport | null>(null);
+  const [turnLimit, setTurnLimit] = useState(TURN_PAGE_SIZE);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  const load = useCallback(
+    async (limit: number) => {
+      try {
+        setReport(await getEvalReport(runId, limit));
+      } catch (e) {
+        const message = (e as Error).message;
+        // A bad id in a pasted link is the common case here, and it deserves
+        // a way back to the run list rather than a red banner.
+        if (/not found/i.test(message)) setNotFound(true);
+        else setError(message);
+      }
+    },
+    [runId],
+  );
+
+  useEffect(() => {
+    setReport(null);
+    setNotFound(false);
+    setError(null);
+    void load(turnLimit);
+  }, [load, turnLimit]);
+
+  // Poll only while the run is unfinished, and stop as soon as it settles: a
+  // report is immutable once the run completes, so polling it forever writes
+  // an audit row every two seconds for nothing.
+  const isActive = report ? ACTIVE_STATUSES.has(report.run.status) : false;
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (pollRef.current) clearInterval(pollRef.current);
+    if (!isActive) return;
+    pollRef.current = setInterval(() => void load(turnLimit), POLL_MS);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [isActive, load, turnLimit]);
+
+  async function handleCancel() {
+    try {
+      await cancelEvalRun(runId);
+      await load(turnLimit);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }
+
+  const backLink = (
+    <Link to={adminPath('model-eval')} className="text-sm text-primary hover:underline">
+      Back to model comparison
+    </Link>
+  );
+
+  if (notFound) {
+    return (
+      <div className="space-y-2 text-sm">
+        <p className="text-danger">That evaluation run does not exist.</p>
+        {backLink}
+      </div>
+    );
+  }
+
+  if (!report) {
+    return (
+      <div className="space-y-3">
+        {backLink}
+        <div className="h-32 animate-pulse rounded-[--radius-md] bg-panel" />
+      </div>
+    );
+  }
+
+  const { run } = report;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        {backLink}
+        <p className="text-xs text-muted-foreground">
+          {run.candidate_model} against {run.baseline_model}, started{' '}
+          {formatRelative(run.created_at)}
+        </p>
+      </div>
+
+      {error ? (
+        <div className="rounded-[--radius-md] bg-error-bg px-3 py-2 text-sm text-error-text">
+          {error}
+        </div>
+      ) : null}
+
+      {isActive ? (
+        <section className="rounded-[--radius-lg] border border-border bg-card p-4">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm text-foreground">
+              Replaying {run.progress_completed} of {run.progress_total || '?'} turns against{' '}
+              {run.candidate_model}
+            </p>
+            <button
+              type="button"
+              onClick={() => void handleCancel()}
+              className="rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+          <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-panel">
+            <div
+              className="h-full bg-primary transition-all"
+              style={{
+                width: run.progress_total
+                  ? `${(run.progress_completed / run.progress_total) * 100}%`
+                  : '5%',
+              }}
+            />
+          </div>
+        </section>
+      ) : null}
+
+      {run.summary ? (
+        <>
+          <VerdictBanner summary={run.summary} userId={run.user_id} />
+
+          {run.summary.warnings.map(warning => (
+            <div
+              key={warning}
+              className="rounded-[--radius-md] bg-warning-bg px-3 py-2 text-sm text-warning-text"
+            >
+              {warning}
+            </div>
+          ))}
+
+          <SummaryGrid summary={run.summary} />
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          {isActive
+            ? 'The verdict is written when the run finishes. Turns appear below as they land.'
+            : `This run has no summary${run.error ? `: ${run.error}` : '.'}`}
+        </p>
+      )}
+
+      {report.turns.length > 0 ? (
+        <div>
+          <h3 className="mb-2 text-sm font-semibold text-foreground">
+            Turns, most concerning first
+            {report.total_turns > report.turns.length
+              ? ` (${report.turns.length} of ${report.total_turns})`
+              : ''}
+          </h3>
+          <div className="space-y-2">
+            {report.turns.map(turn => (
+              <TurnCard key={turn.message_seq} turn={turn} />
+            ))}
+          </div>
+          {report.total_turns > report.turns.length ? (
+            <button
+              type="button"
+              onClick={() => setTurnLimit(n => n + TURN_PAGE_SIZE)}
+              className="mt-2 rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
+            >
+              Show more turns
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/extensions/admin/tabs/model-eval.test.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval.test.tsx
@@ -1,17 +1,17 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import type { EvalReport, EvalRun, EvalSummary, EvalTurn } from '../admin-api';
 import ModelEvalTab from './model-eval';
+import { report, run, runList, USERS } from './model-eval-fixtures';
 
 // ---------------------------------------------------------------------------
-// Admin Model Eval tab.
+// Admin Model Eval tab: starting runs and listing them.
 //
-// The tab exists to answer one question honestly, so the tests care most
-// about the ways it could answer it dishonestly: offering a user who cannot
-// legally be evaluated, showing an unpriced model's cost as free, burying a
-// safety finding below a hundred matched turns, or letting a second run start
-// while one is in flight.
+// One run's evidence is a separate page (model-eval-report.test.tsx). What is
+// left here is the form, and the tests care most about the ways it could
+// mislead: offering a user who cannot legally be evaluated, offering a sample
+// size the API will reject, or letting a second run start while one is in
+// flight.
 // ---------------------------------------------------------------------------
 
 vi.mock('../admin-api', () => ({
@@ -31,131 +31,6 @@ vi.mock('../llm-picker', () => ({
   ),
 }));
 
-const USERS = {
-  total: 1,
-  skip: 0,
-  limit: 200,
-  items: [
-    {
-      id: 'user-1',
-      user_id: 'google_abc',
-      email: 'consenting@example.com',
-      plan: 'pro',
-      status: 'active',
-      role: 'user',
-      is_active: true,
-      onboarding_complete: true,
-      data_sharing_consent: true,
-    },
-  ],
-};
-
-function summary(overrides: Partial<EvalSummary> = {}): EvalSummary {
-  return {
-    turns_total: 40,
-    turns_completed: 40,
-    turns_failed: 0,
-    agreement_counts: { identical: 40 },
-    safety_counts: {},
-    blocking_findings: 0,
-    judge_counts: {},
-    identical_rate: 1,
-    divergence_rate: 0,
-    silent_noop_rate: 0,
-    baseline: {
-      provider: 'anthropic',
-      model: 'incumbent',
-      input_tokens: 100,
-      output_tokens: 10,
-      cache_read_tokens: 900,
-      cache_creation_tokens: 0,
-      cache_read_ratio: 0.9,
-      total_cost_usd: '1.500000',
-      pricing_available: true,
-      latency_p50_ms: 1200,
-      latency_p95_ms: 2400,
-    },
-    candidate: {
-      provider: 'anthropic',
-      model: 'candidate',
-      input_tokens: 1000,
-      output_tokens: 10,
-      cache_read_tokens: 0,
-      cache_creation_tokens: 0,
-      cache_read_ratio: 0,
-      total_cost_usd: '0.400000',
-      pricing_available: true,
-      latency_p50_ms: 600,
-      latency_p95_ms: 900,
-    },
-    recommendation: 'safe_to_switch',
-    reasons: ['no safety findings across 40 turns'],
-    warnings: [],
-    ...overrides,
-  };
-}
-
-function run(overrides: Partial<EvalRun> = {}): EvalRun {
-  return {
-    id: 1,
-    user_id: 'user-1',
-    baseline_provider: 'anthropic',
-    baseline_model: 'incumbent',
-    candidate_provider: 'anthropic',
-    candidate_model: 'candidate',
-    judge_model: 'incumbent',
-    requested_samples: 40,
-    status: 'completed',
-    progress_completed: 40,
-    progress_total: 40,
-    recommendation: 'safe_to_switch',
-    error: '',
-    created_at: '2026-05-01T12:00:00Z',
-    summary: summary(),
-    ...overrides,
-  };
-}
-
-function turn(overrides: Partial<EvalTurn> = {}): EvalTurn {
-  return {
-    message_seq: 1,
-    message_timestamp: '2026-05-01T12:00:00Z',
-    user_message: 'can you book that job',
-    historic_reply: '',
-    historic_tool_names: [],
-    baseline: {
-      text: '',
-      tool_calls: [{ name: 'create_job', arguments: { customer: 'Acme Plumbing' } }],
-      stop_reason: 'tool_use',
-      input_tokens: 0,
-      output_tokens: 0,
-      cache_read_tokens: 0,
-      latency_ms: 0,
-      error: '',
-    },
-    candidate: {
-      text: 'Sure, I can help with that.',
-      tool_calls: [],
-      stop_reason: 'end_turn',
-      input_tokens: 0,
-      output_tokens: 0,
-      cache_read_tokens: 0,
-      latency_ms: 0,
-      error: '',
-    },
-    agreement: 'replied_instead_of_acting',
-    safety_issues: [],
-    judge_verdict: 'not_judged',
-    judge_rationale: '',
-    ...overrides,
-  };
-}
-
-function report(overrides: Partial<EvalReport> = {}): EvalReport {
-  return { run: run(), turns: [turn()], total_turns: 1, ...overrides };
-}
-
-
 function renderTab() {
   return render(
     <MemoryRouter>
@@ -167,10 +42,8 @@ function renderTab() {
 beforeEach(async () => {
   const api = await import('../admin-api');
   vi.mocked(api.getAdminUsers).mockReset().mockResolvedValue(USERS as never);
-  vi.mocked(api.listEvalRuns).mockReset().mockResolvedValue([]);
+  vi.mocked(api.listEvalRuns).mockReset().mockResolvedValue(runList([]));
   vi.mocked(api.startEvalRun).mockReset();
-  // Defaulted, not bare: starting a run now selects it, so every test that
-  // clicks Run analysis immediately fetches a report.
   vi.mocked(api.getEvalReport).mockReset().mockResolvedValue(report());
   vi.mocked(api.cancelEvalRun).mockReset();
 });
@@ -188,7 +61,7 @@ describe('ModelEvalTab', () => {
     );
   });
 
-  it('starts a run with the chosen candidate and sample count', async () => {
+  it('starts a run with the chosen candidate and the slider size', async () => {
     const api = await import('../admin-api');
     vi.mocked(api.startEvalRun).mockResolvedValue(run({ status: 'pending' }));
     renderTab();
@@ -198,150 +71,88 @@ describe('ModelEvalTab', () => {
     await userEvent.type(screen.getByLabelText('provider'), 'anthropic');
     await userEvent.type(screen.getByLabelText('model'), 'candidate');
 
+    const slider = screen.getByRole('slider', { name: 'Turns to replay' });
+    fireEvent.change(slider, { target: { value: '65' } });
+    expect(await screen.findByText('Most recent 65')).toBeInTheDocument();
+
     await userEvent.click(screen.getByRole('button', { name: 'Run analysis' }));
 
     await waitFor(() =>
       expect(api.startEvalRun).toHaveBeenCalledWith('user-1', {
         candidateProvider: 'anthropic',
         candidateModel: 'candidate',
-        sampleCount: 100,
+        sampleCount: 65,
         judgeEnabled: true,
       }),
     );
   });
 
-  it('renders the verdict and its reasons', async () => {
+  it('bounds the slider by the cap the API reports', async () => {
+    // LLM_EVAL_MAX_SAMPLES is configurable, so a slider holding its own
+    // ceiling would offer a size start_run rejects with a bare 422.
     const api = await import('../admin-api');
-    vi.mocked(api.listEvalRuns).mockResolvedValue([run()]);
-    vi.mocked(api.getEvalReport).mockResolvedValue(report());
+    vi.mocked(api.listEvalRuns).mockResolvedValue(runList([], { max_samples: 40 }));
     renderTab();
 
     await screen.findByRole('option', { name: 'consenting@example.com' });
     await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
 
-    const row = await screen.findByText('candidate');
-    await userEvent.click(row);
+    const slider = await screen.findByRole('slider', { name: 'Turns to replay' });
+    await waitFor(() => expect(slider).toHaveAttribute('max', '40'));
+    // The default of 100 sits above that cap, so it has to come down with it.
+    expect(await screen.findByText('Most recent 40')).toBeInTheDocument();
+  });
 
-    // The verdict appears twice on purpose: as the pill on the run row and as
-    // the banner above the report.
-    await waitFor(() => expect(screen.getAllByText('Safe to switch')).toHaveLength(2));
-    expect(screen.getByText('no safety findings across 40 turns')).toBeInTheDocument();
-    // The switch itself lives on user detail; the report only points at it.
-    expect(screen.getByRole('link', { name: 'Model settings for this user' })).toHaveAttribute(
-      'href',
-      '/app/admin/users/user-1/llm',
+  it('warns when the chosen size cannot produce a verdict', async () => {
+    renderTab();
+
+    await screen.findByRole('option', { name: 'consenting@example.com' });
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
+
+    const slider = await screen.findByRole('slider', { name: 'Turns to replay' });
+    fireEvent.change(slider, { target: { value: '15' } });
+
+    // Better said before the run than after spending one to read
+    // "inconclusive" at the end.
+    expect(await screen.findByText(/reports inconclusive/)).toBeInTheDocument();
+  });
+
+  it('links each past run to its own report URL', async () => {
+    // The report is a page an operator returns to and shares, so the row has
+    // to carry a real, copyable link rather than only a click handler.
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
+    renderTab();
+
+    await screen.findByRole('option', { name: 'consenting@example.com' });
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
+
+    const link = await screen.findByRole('link', { name: /ago|2026/ });
+    expect(link).toHaveAttribute('href', '/app/admin/model-eval/run-0001');
+  });
+
+  it('does not render a report inline', async () => {
+    // Regression: the report used to expand under the form, which meant no
+    // URL for it and no way back to one.
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
+    renderTab();
+
+    await screen.findByRole('option', { name: 'consenting@example.com' });
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
+    await screen.findByText('candidate');
+
+    expect(api.getEvalReport).not.toHaveBeenCalled();
+    expect(screen.queryByText('Turns, most concerning first')).not.toBeInTheDocument();
+  });
+
+  it('blocks a second run while one is in flight and links to the one running', async () => {
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(
+      runList([
+        run({ status: 'running', progress_completed: 12, progress_total: 40, summary: null }),
+      ]),
     );
-  });
-
-  it('surfaces a cost warning rather than reporting an unpriced model as free', async () => {
-    const api = await import('../admin-api');
-    const withWarning = summary({
-      warnings: ['No pricing data for the candidate model (candidate); its cost is reported as zero.'],
-      candidate: { ...summary().candidate, pricing_available: false, total_cost_usd: '0.000000' },
-    });
-    vi.mocked(api.listEvalRuns).mockResolvedValue([run({ summary: withWarning })]);
-    vi.mocked(api.getEvalReport).mockResolvedValue(
-      report({ run: run({ summary: withWarning }) }),
-    );
-    renderTab();
-
-    await screen.findByRole('option', { name: 'consenting@example.com' });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
-    await userEvent.click(await screen.findByText('candidate'));
-
-    expect(await screen.findByText(/No pricing data/)).toBeInTheDocument();
-    // "$0.0000" would read as free; an unpriced model has to say so.
-    expect(screen.getByText('unknown')).toBeInTheDocument();
-  });
-
-  it('expands a turn with a safety finding by default', async () => {
-    const api = await import('../admin-api');
-    const flagged = turn({
-      safety_issues: [
-        { finding: 'unrequested_mutation', tool_name: 'send_message', detail: 'approval-gated' },
-      ],
-    });
-    vi.mocked(api.listEvalRuns).mockResolvedValue([run()]);
-    vi.mocked(api.getEvalReport).mockResolvedValue(report({ turns: [flagged] }));
-    renderTab();
-
-    await screen.findByRole('option', { name: 'consenting@example.com' });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
-    await userEvent.click(await screen.findByText('candidate'));
-
-    // A finding an admin has to click to discover is a finding they will miss.
-    const toggle = await screen.findByRole('button', { expanded: true });
-    expect(
-      within(toggle).getByText(/Reached for a mutating tool the incumbent did not/),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Incumbent')).toBeInTheDocument();
-  });
-
-  it('refetches the report when the selected run finishes', async () => {
-    // Regression: the report was fetched only when the selection changed, so a
-    // run selected while pending sat on "no summary" for good while the row
-    // beside it already read completed.
-    const api = await import('../admin-api');
-    const running = run({ status: 'running', progress_completed: 3, summary: null });
-    vi.mocked(api.listEvalRuns)
-      .mockResolvedValueOnce([running])
-      .mockResolvedValue([run({ status: 'completed' })]);
-    vi.mocked(api.getEvalReport)
-      .mockResolvedValueOnce({ run: running, turns: [], total_turns: 0 })
-      .mockResolvedValue(report());
-    renderTab();
-
-    await screen.findByRole('option', { name: 'consenting@example.com' });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
-    await userEvent.click(await screen.findByText('candidate'));
-    await waitFor(() => expect(api.getEvalReport).toHaveBeenCalledTimes(1));
-
-    // The poll picks up the completed status, which has to re-drive the report.
-    await waitFor(() => expect(api.getEvalReport).toHaveBeenCalledTimes(2), { timeout: 6000 });
-    await waitFor(() => expect(screen.getAllByText('Safe to switch').length).toBeGreaterThan(0));
-  });
-
-  it('pages the turn list and offers to load the rest', async () => {
-    const api = await import('../admin-api');
-    vi.mocked(api.listEvalRuns).mockResolvedValue([run()]);
-    vi.mocked(api.getEvalReport).mockResolvedValue(
-      report({ turns: [turn()], total_turns: 120 }),
-    );
-    renderTab();
-
-    await screen.findByRole('option', { name: 'consenting@example.com' });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
-    await userEvent.click(await screen.findByText('candidate'));
-
-    // The count has to be visible, or a partial report reads as the whole run.
-    expect(await screen.findByText(/1 of 120/)).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', { name: 'Show more turns' }));
-    await waitFor(() => expect(api.getEvalReport).toHaveBeenLastCalledWith(1, 100));
-  });
-
-  it('counts only blocking findings in the safety tile', async () => {
-    // A provider error is recorded on the turn but must not inflate the tile
-    // that says "any finding blocks a switch".
-    const api = await import('../admin-api');
-    const s = summary({ safety_counts: { call_failed: 3 }, blocking_findings: 0 });
-    vi.mocked(api.listEvalRuns).mockResolvedValue([run({ summary: s })]);
-    vi.mocked(api.getEvalReport).mockResolvedValue(report({ run: run({ summary: s }) }));
-    renderTab();
-
-    await screen.findByRole('option', { name: 'consenting@example.com' });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
-    await userEvent.click(await screen.findByText('candidate'));
-
-    const tile = (await screen.findByText('Safety findings')).closest('div');
-    expect(tile).not.toBeNull();
-    expect(within(tile as HTMLElement).getByText('0')).toBeInTheDocument();
-  });
-
-  it('blocks a second run while one is in flight and offers to cancel', async () => {
-    const api = await import('../admin-api');
-    vi.mocked(api.listEvalRuns).mockResolvedValue([
-      run({ status: 'running', progress_completed: 12, progress_total: 40, summary: null }),
-    ]);
     renderTab();
 
     await screen.findByRole('option', { name: 'consenting@example.com' });
@@ -349,6 +160,9 @@ describe('ModelEvalTab', () => {
 
     expect(await screen.findByText(/Replaying 12 of 40 turns/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Run analysis' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open report' })).toHaveAttribute(
+      'href',
+      '/app/admin/model-eval/run-0001',
+    );
   });
 });

--- a/frontend/src/extensions/admin/tabs/model-eval.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval.tsx
@@ -1,320 +1,59 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import {
-  cancelEvalRun,
   getAdminUsers,
-  getEvalReport,
   listEvalRuns,
   startEvalRun,
   type AdminUser,
-  type EvalDecision,
   type EvalRecommendation,
-  type EvalReport,
   type EvalRun,
-  type EvalSummary,
-  type EvalTurn,
 } from '../admin-api';
 import { LLMProviderSelect, LLMModelSelect } from '../llm-picker';
 import { formatRelative } from '../format';
 import { adminPath } from '../nav-items';
+import { ACTIVE_STATUSES, POLL_MS, RECOMMENDATION_COPY } from './model-eval-common';
 
 // Model comparison: "can I move this user to a different model without
 // breaking them". A run replays the user's own recent turns through their
-// current model and a candidate and reports what each decided.
+// current model and a candidate and records what each decided.
 //
-// Three things drive the layout:
-//
-// - The verdict is stated once, in words, at the top. An operator opening
-//   this page has one question, and a grid of rates does not answer it.
-// - Safety findings are never mixed into a quality score. They are listed
-//   separately and they are what sinks a recommendation, because each one
-//   is an action the agent loop would have taken against a real account.
-// - The turn drill-down is the point, not an appendix. Numbers persuade
-//   nobody about a decision this consequential; reading six diverging turns
-//   does. The report arrives worst-first so the turns that matter are the
-//   ones on screen.
+// This page starts runs and lists them. A run's evidence lives at its own URL
+// (``model-eval/<public id>``, rendered by ``model-eval-report.tsx``), because
+// a report is read long after the run that produced it and is often read by
+// someone who did not start it.
 //
 // Only users who opted into data sharing can be evaluated: a run reads their
 // real conversations and the report renders them back. The picker is filtered
 // to consenting users so the 403 is never reachable from the UI.
 
-// Poll cadence while a run is in flight. A hundred-turn run takes minutes and
-// writes a row per turn, so this is fast enough to look alive and slow enough
-// not to hammer the report endpoint.
-const POLL_MS = 2000;
+// Slider bounds. The ceiling comes from the API (LLM_EVAL_MAX_SAMPLES), so a
+// deployment that lowers the setting cannot be offered a value start_run would
+// reject. These constants are the fallback until the first list call answers,
+// plus the floor and step, which are the UI's own.
+const SAMPLE_MIN = 5;
+const SAMPLE_STEP = 5;
+const SAMPLE_MAX_FALLBACK = 200;
+const SAMPLE_DEFAULT = 100;
 
-const SAMPLE_CHOICES = [25, 50, 100, 200];
-
-// Turns are returned worst-first, so the first page is the part that decides
-// anything. The rest is available on request rather than shipped by default:
-// every text column on a turn is decrypted and PII-scrubbed per request.
-const TURN_PAGE_SIZE = 50;
-
-const ACTIVE_STATUSES = new Set(['pending', 'running']);
-
-const RECOMMENDATION_COPY: Record<EvalRecommendation, { label: string; className: string }> = {
-  safe_to_switch: {
-    label: 'Safe to switch',
-    className: 'bg-success-bg text-success-text border-success/30',
-  },
-  switch_with_monitoring: {
-    label: 'Switch with monitoring',
-    className: 'bg-warning-bg text-warning-text border-warning/30',
-  },
-  do_not_switch: {
-    label: 'Do not switch',
-    className: 'bg-error-bg text-error-text border-danger/30',
-  },
-  inconclusive: {
-    label: 'Inconclusive',
-    className: 'bg-panel text-muted-foreground border-border',
-  },
-};
-
-const AGREEMENT_COPY: Record<string, string> = {
-  identical: 'Same action',
-  same_tools_different_args: 'Same tools, different arguments',
-  different_tools: 'Different tools',
-  replied_instead_of_acting: 'Replied instead of acting',
-  acted_instead_of_replying: 'Acted where the incumbent replied',
-  both_replied: 'Both replied',
-  not_compared: 'Could not be compared',
-};
-
-const FINDING_COPY: Record<string, string> = {
-  unknown_tool: 'Called a tool that does not exist',
-  invalid_args: 'Arguments the tool rejects',
-  unrequested_mutation: 'Reached for a mutating tool the incumbent did not',
-  truncated: 'Response truncated mid-thought',
-  call_failed: 'Provider call failed',
-};
-
-const VERDICT_COPY: Record<string, string> = {
-  equivalent: 'Judge: equivalent',
-  candidate_better: 'Judge: candidate better',
-  candidate_worse: 'Judge: candidate worse',
-  candidate_unsafe: 'Judge: candidate unsafe',
-  judge_failed: 'Judge: unavailable',
-};
-
-function pct(value: number): string {
-  return `${Math.round(value * 100)}%`;
-}
-
-function money(totals: { total_cost_usd: string; pricing_available: boolean }): string {
-  if (!totals.pricing_available) return 'unknown';
-  return `$${Number(totals.total_cost_usd).toFixed(4)}`;
-}
-
-function ms(value: number): string {
-  return value >= 1000 ? `${(value / 1000).toFixed(1)}s` : `${Math.round(value)}ms`;
-}
-
-// ---------------------------------------------------------------------------
-// Report pieces
-// ---------------------------------------------------------------------------
-
-function VerdictBanner({ summary, userId }: { summary: EvalSummary; userId: string }) {
-  const copy = RECOMMENDATION_COPY[summary.recommendation] ?? RECOMMENDATION_COPY.inconclusive;
-  return (
-    <div className={`rounded-[--radius-lg] border p-4 ${copy.className}`}>
-      <p className="text-lg font-semibold">{copy.label}</p>
-      <ul className="mt-2 space-y-1 text-sm">
-        {summary.reasons.map(reason => (
-          <li key={reason}>{reason}</li>
-        ))}
-      </ul>
-      {/* Links out rather than applying the switch here. The per-user override
-          already has one owner (user detail -> LLM), and a second control
-          writing the same column is how the two drift. The wording stays
-          neutral across verdicts: this is also the page you visit to clear an
-          override, and a report saying "do not switch" should not be handing
-          out a button that reads like permission. */}
-      <Link
-        to={`${adminPath('users')}/${userId}/llm`}
-        className="mt-3 inline-block text-sm font-medium underline underline-offset-2"
-      >
-        Model settings for this user
-      </Link>
-    </div>
-  );
-}
-
-function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
-  return (
-    <div className="rounded-[--radius-md] border border-border bg-card p-3">
-      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
-      <p className="mt-1 text-xl font-semibold text-foreground">{value}</p>
-      {hint ? <p className="mt-1 text-xs text-muted-foreground">{hint}</p> : null}
-    </div>
-  );
-}
-
-function SummaryGrid({ summary }: { summary: EvalSummary }) {
-  const safetyTotal = summary.blocking_findings;
-  return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-      <Stat
-        label="Safety findings"
-        value={String(safetyTotal)}
-        hint={safetyTotal ? 'Any finding blocks a switch' : 'None across the run'}
-      />
-      <Stat
-        label="Matched the incumbent"
-        value={pct(summary.identical_rate)}
-        hint={`${summary.turns_completed} turns compared`}
-      />
-      <Stat
-        label="Replied instead of acting"
-        value={pct(summary.silent_noop_rate)}
-        hint="Turns the incumbent acted on"
-      />
-      <Stat
-        label="Cost per run"
-        value={money(summary.candidate)}
-        hint={`Incumbent ${money(summary.baseline)}`}
-      />
-      <Stat
-        label="Candidate latency (p95)"
-        value={ms(summary.candidate.latency_p95_ms)}
-        hint={`Incumbent ${ms(summary.baseline.latency_p95_ms)}`}
-      />
-      <Stat
-        label="Candidate cache reads"
-        value={pct(summary.candidate.cache_read_ratio)}
-        hint={`Incumbent ${pct(summary.baseline.cache_read_ratio)}`}
-      />
-      <Stat label="Turns that diverged" value={pct(summary.divergence_rate)} />
-      <Stat
-        label="Turns that failed"
-        value={String(summary.turns_failed)}
-        hint="Could not be compared"
-      />
-    </div>
-  );
-}
-
-function DecisionColumn({ title, decision }: { title: string; decision: EvalDecision }) {
-  return (
-    <div className="min-w-0 flex-1">
-      <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        {title}
-      </p>
-      {decision.error ? (
-        <p className="text-sm text-error-text">{decision.error}</p>
-      ) : (
-        <>
-          {decision.tool_calls.length > 0 ? (
-            <ul className="mb-2 space-y-1">
-              {decision.tool_calls.map((call, index) => (
-                <li
-                  key={`${call.name}-${index}`}
-                  className="rounded-[--radius-sm] bg-panel px-2 py-1 font-mono text-xs text-foreground"
-                >
-                  <span className="font-semibold">{call.name}</span>
-                  <span className="text-muted-foreground">
-                    ({JSON.stringify(call.arguments)})
-                  </span>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="mb-2 text-xs italic text-muted-foreground">No tool calls</p>
-          )}
-          {decision.text ? (
-            <p className="whitespace-pre-wrap text-sm text-foreground">{decision.text}</p>
-          ) : null}
-        </>
-      )}
-    </div>
-  );
-}
-
-function TurnCard({ turn }: { turn: EvalTurn }) {
-  const [open, setOpen] = useState(turn.safety_issues.length > 0);
-  return (
-    <div className="rounded-[--radius-md] border border-border bg-card">
-      <button
-        type="button"
-        onClick={() => setOpen(v => !v)}
-        aria-expanded={open}
-        className="flex w-full items-start gap-3 p-3 text-left"
-      >
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm text-foreground">{turn.user_message}</p>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
-            <span className="text-muted-foreground">
-              {AGREEMENT_COPY[turn.agreement] ?? turn.agreement}
-            </span>
-            {turn.safety_issues.map((issue, index) => (
-              <span
-                key={`${issue.finding}-${index}`}
-                className="rounded-full bg-error-bg px-2 py-0.5 text-error-text"
-              >
-                {FINDING_COPY[issue.finding] ?? issue.finding}
-                {issue.tool_name ? `: ${issue.tool_name}` : ''}
-              </span>
-            ))}
-            {turn.judge_verdict !== 'not_judged' ? (
-              <span className="rounded-full bg-panel px-2 py-0.5 text-muted-foreground">
-                {VERDICT_COPY[turn.judge_verdict] ?? turn.judge_verdict}
-              </span>
-            ) : null}
-          </div>
-        </div>
-        <span className="shrink-0 text-xs text-muted-foreground">{open ? 'Hide' : 'Compare'}</span>
-      </button>
-
-      {open ? (
-        <div className="border-t border-border p-3">
-          <div className="flex flex-col gap-4 sm:flex-row">
-            <DecisionColumn title="Incumbent" decision={turn.baseline} />
-            <DecisionColumn title="Candidate" decision={turn.candidate} />
-          </div>
-          {turn.judge_rationale ? (
-            <p className="mt-3 border-t border-border pt-3 text-sm text-muted-foreground">
-              {turn.judge_rationale}
-            </p>
-          ) : null}
-          {turn.historic_reply ? (
-            <details className="mt-3 border-t border-border pt-3">
-              <summary className="cursor-pointer text-xs text-muted-foreground">
-                What the agent actually replied at the time
-              </summary>
-              <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
-                {turn.historic_reply}
-              </p>
-              {turn.historic_tool_names.length > 0 ? (
-                <p className="mt-1 font-mono text-xs text-muted-foreground">
-                  {turn.historic_tool_names.join(', ')}
-                </p>
-              ) : null}
-            </details>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 export default function ModelEvalTab() {
+  const navigate = useNavigate();
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [usersLoading, setUsersLoading] = useState(true);
   const [userId, setUserId] = useState('');
 
   const [provider, setProvider] = useState('');
   const [model, setModel] = useState('');
-  const [sampleCount, setSampleCount] = useState(100);
+  const [sampleCount, setSampleCount] = useState(SAMPLE_DEFAULT);
+  const [sampleMax, setSampleMax] = useState(SAMPLE_MAX_FALLBACK);
+  const [minTurnsForVerdict, setMinTurnsForVerdict] = useState(0);
   const [judgeEnabled, setJudgeEnabled] = useState(true);
 
   const [runs, setRuns] = useState<EvalRun[]>([]);
-  const [selectedRunId, setSelectedRunId] = useState<number | null>(null);
-  const [report, setReport] = useState<EvalReport | null>(null);
-  const [turnLimit, setTurnLimit] = useState(TURN_PAGE_SIZE);
 
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -335,16 +74,19 @@ export default function ModelEvalTab() {
       return;
     }
     try {
-      setRuns(await listEvalRuns(id));
+      const list = await listEvalRuns(id);
+      setRuns(list.runs);
+      setSampleMax(list.max_samples);
+      setMinTurnsForVerdict(list.min_turns_for_verdict);
+      // A cap below the current selection would leave the thumb pinned past
+      // the end of its own track and start a run the API rejects.
+      setSampleCount(prev => Math.min(prev, list.max_samples));
     } catch (e) {
       setError((e as Error).message);
     }
   }, []);
 
   useEffect(() => {
-    setSelectedRunId(null);
-    setReport(null);
-    setTurnLimit(TURN_PAGE_SIZE);
     void refreshRuns(userId);
   }, [userId, refreshRuns]);
 
@@ -364,21 +106,6 @@ export default function ModelEvalTab() {
     };
   }, [activeRunId, userId, refreshRuns]);
 
-  // Re-fetch as the selected run advances, not only when the selection
-  // changes. A run selected while it is still pending has no summary yet, and
-  // without the status in the dependencies the report would sit on "no
-  // summary" for good while the row beside it said completed.
-  const selectedStatus = runs.find(r => r.id === selectedRunId)?.status;
-  useEffect(() => {
-    if (selectedRunId == null) {
-      setReport(null);
-      return;
-    }
-    getEvalReport(selectedRunId, turnLimit)
-      .then(setReport)
-      .catch((e: Error) => setError(e.message));
-  }, [selectedRunId, selectedStatus, turnLimit]);
-
   async function handleStart() {
     setError(null);
     setStarting(true);
@@ -390,21 +117,11 @@ export default function ModelEvalTab() {
         judgeEnabled,
       });
       setRuns(prev => [run, ...prev]);
-      setSelectedRunId(run.id);
-      setTurnLimit(TURN_PAGE_SIZE);
+      navigate(`${adminPath('model-eval')}/${run.id}`);
     } catch (e) {
       setError((e as Error).message);
     } finally {
       setStarting(false);
-    }
-  }
-
-  async function handleCancel(runId: number) {
-    try {
-      await cancelEvalRun(runId);
-      await refreshRuns(userId);
-    } catch (e) {
-      setError((e as Error).message);
     }
   }
 
@@ -471,18 +188,40 @@ export default function ModelEvalTab() {
           </label>
 
           <label className="block">
-            <span className="mb-1 block text-sm text-muted-foreground">Turns to replay</span>
-            <select
+            <span className="mb-1 flex items-baseline justify-between text-sm text-muted-foreground">
+              <span>Turns to replay</span>
+              <span className="font-medium text-foreground">Most recent {sampleCount}</span>
+            </span>
+            <input
+              type="range"
+              min={SAMPLE_MIN}
+              max={sampleMax}
+              step={SAMPLE_STEP}
               value={sampleCount}
               onChange={e => setSampleCount(Number(e.target.value))}
-              className="w-full rounded-[--radius-md] border border-border bg-card px-3 py-2 text-sm text-foreground"
-            >
-              {SAMPLE_CHOICES.map(n => (
-                <option key={n} value={n}>
-                  Most recent {n}
-                </option>
-              ))}
-            </select>
+              aria-label="Turns to replay"
+              aria-valuetext={`Most recent ${sampleCount} turns`}
+              // The native control, themed through ``accent-color``. An
+              // earlier version set ``appearance-none`` with a token
+              // background, which leaves Chromium drawing its own track on
+              // top: invisible against a light page, a white slab in dark
+              // mode. Styling every vendor pseudo-element is the alternative,
+              // and it buys nothing here.
+              className="mt-1 w-full cursor-pointer accent-primary"
+            />
+            {/* Endpoints only, with the middle left empty until there is
+                something worth saying there: in a four-column grid this cell
+                is narrow, and a permanent hint between the bounds wraps and
+                crowds them. */}
+            <span className="mt-1 flex items-baseline justify-between gap-2 text-xs text-muted-foreground">
+              <span>{SAMPLE_MIN}</span>
+              {minTurnsForVerdict > 0 && sampleCount < minTurnsForVerdict ? (
+                <span className="text-warning-text">
+                  Under {minTurnsForVerdict} reports inconclusive
+                </span>
+              ) : null}
+              <span>{sampleMax}</span>
+            </span>
           </label>
         </div>
 
@@ -516,7 +255,9 @@ export default function ModelEvalTab() {
         </p>
       </section>
 
-      {/* In-flight progress */}
+      {/* In-flight progress. Deliberately still here rather than only on the
+          run's page: an operator arriving from elsewhere needs to see that
+          this user already has a run going before they try to start one. */}
       {activeRun ? (
         <section className="rounded-[--radius-lg] border border-border bg-card p-4">
           <div className="flex items-center justify-between gap-3">
@@ -524,13 +265,12 @@ export default function ModelEvalTab() {
               Replaying {activeRun.progress_completed} of {activeRun.progress_total || '?'} turns
               against {activeRun.candidate_model}
             </p>
-            <button
-              type="button"
-              onClick={() => void handleCancel(activeRun.id)}
+            <Link
+              to={`${adminPath('model-eval')}/${activeRun.id}`}
               className="rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
             >
-              Cancel
-            </button>
+              Open report
+            </Link>
           </div>
           <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-panel">
             <div
@@ -568,16 +308,20 @@ export default function ModelEvalTab() {
                   return (
                     <tr
                       key={run.id}
-                      onClick={() => {
-                        setSelectedRunId(run.id);
-                        setTurnLimit(TURN_PAGE_SIZE);
-                      }}
-                      className={`cursor-pointer border-t border-border ${
-                        selectedRunId === run.id ? 'bg-panel' : ''
-                      }`}
+                      onClick={() => navigate(`${adminPath('model-eval')}/${run.id}`)}
+                      className="cursor-pointer border-t border-border hover:bg-panel"
                     >
                       <td className="p-3 text-muted-foreground">
-                        {formatRelative(run.created_at)}
+                        {/* A real link in the first cell, so the row is
+                            keyboard reachable and its URL is copyable, while
+                            the row click stays the large target. */}
+                        <Link
+                          to={`${adminPath('model-eval')}/${run.id}`}
+                          className="text-primary hover:underline"
+                          onClick={e => e.stopPropagation()}
+                        >
+                          {formatRelative(run.created_at)}
+                        </Link>
                       </td>
                       <td className="p-3 font-mono text-xs text-foreground">
                         {run.candidate_model}
@@ -604,52 +348,6 @@ export default function ModelEvalTab() {
         </section>
       ) : null}
 
-      {/* Report */}
-      {report?.run.summary ? (
-        <section className="space-y-4">
-          <VerdictBanner summary={report.run.summary} userId={report.run.user_id} />
-
-          {report.run.summary.warnings.map(warning => (
-            <div
-              key={warning}
-              className="rounded-[--radius-md] bg-warning-bg px-3 py-2 text-sm text-warning-text"
-            >
-              {warning}
-            </div>
-          ))}
-
-          <SummaryGrid summary={report.run.summary} />
-
-          <div>
-            <h3 className="mb-2 text-sm font-semibold text-foreground">
-              Turns, most concerning first
-              {report.total_turns > report.turns.length
-                ? ` (${report.turns.length} of ${report.total_turns})`
-                : ''}
-            </h3>
-            <div className="space-y-2">
-              {report.turns.map(turn => (
-                <TurnCard key={turn.message_seq} turn={turn} />
-              ))}
-            </div>
-            {report.total_turns > report.turns.length ? (
-              <button
-                type="button"
-                onClick={() => setTurnLimit(n => n + TURN_PAGE_SIZE)}
-                className="mt-2 rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
-              >
-                Show more turns
-              </button>
-            ) : null}
-          </div>
-        </section>
-      ) : null}
-
-      {report && !report.run.summary ? (
-        <p className="text-sm text-muted-foreground">
-          This run has no summary{report.run.error ? `: ${report.run.error}` : '.'}
-        </p>
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -3171,7 +3171,7 @@ export interface components {
          */
         AdminLLMEvalRunItem: {
             /** Id */
-            id: number;
+            id: string;
             /** User Id */
             user_id: string;
             /** Baseline Provider */
@@ -3204,10 +3204,24 @@ export interface components {
             completed_at?: string | null;
             summary?: components["schemas"]["AdminLLMEvalSummary"] | null;
         };
-        /** AdminLLMEvalRunListResponse */
+        /**
+         * AdminLLMEvalRunListResponse
+         * @description This user's runs, plus the bounds the run form has to respect.
+         *
+         *     ``max_samples`` is ``LLM_EVAL_MAX_SAMPLES``, which ``start_run`` enforces.
+         *     Without it on the wire the sample control can only guess, and a deployment
+         *     that lowers the setting gets a form offering values the API rejects.
+         *     ``min_turns_for_verdict`` is the floor below which a run reports
+         *     ``inconclusive`` rather than a pass, which is worth showing before someone
+         *     spends a run finding out.
+         */
         AdminLLMEvalRunListResponse: {
             /** Runs */
             runs: components["schemas"]["AdminLLMEvalRunItem"][];
+            /** Max Samples */
+            max_samples: number;
+            /** Min Turns For Verdict */
+            min_turns_for_verdict: number;
         };
         /** AdminLLMEvalSafetyIssue */
         AdminLLMEvalSafetyIssue: {
@@ -8313,7 +8327,7 @@ export interface operations {
             };
             header?: never;
             path: {
-                run_id: number;
+                run_id: string;
             };
             cookie?: never;
         };
@@ -8344,7 +8358,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                run_id: number;
+                run_id: string;
             };
             cookie?: never;
         };

--- a/tests/multi_user/test_llm_eval_routes.py
+++ b/tests/multi_user/test_llm_eval_routes.py
@@ -18,11 +18,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from backend.app.auth.admin_dep import get_current_admin
 from backend.app.config import settings
 from backend.app.models import LLMEvalRun, LLMEvalTurnResult, Subscription, User
+from backend.app.services.llm_eval.metrics import MIN_TURNS_FOR_VERDICT
 from backend.app.services.llm_eval.types import AgreementClass, RunStatus
 
 BASE = "/api/admin/llm-eval"
@@ -107,7 +109,10 @@ def test_start_run_creates_a_pending_row_and_launches(
     assert body["requested_samples"] == 50
     _launch.assert_called_once()
 
-    row = db_session.get(LLMEvalRun, body["id"])
+    # ``body["id"]`` is the public id, so the row is found by that column.
+    row = db_session.execute(
+        select(LLMEvalRun).filter_by(public_id=body["id"])
+    ).scalar_one_or_none()
     assert row is not None
     assert row.user_id == consenting_user.id
 
@@ -238,6 +243,38 @@ def test_list_runs_returns_the_users_runs(
     assert len(response.json()["runs"]) == 1
 
 
+def test_a_run_is_addressed_by_a_public_id_not_its_row_id(
+    admin_client: TestClient, consenting_user: User, db_session: Session
+) -> None:
+    """The report URL is pasted and bookmarked, so it must not be a row counter.
+
+    The integer primary key stays internal: the worker and the turn rows use
+    it, and it must not be reachable from the API.
+    """
+    run = _make_run(db_session, consenting_user.id)
+    assert admin_client.get(f"{BASE}/runs/{run.id}").status_code == 404
+
+    body = admin_client.get(f"{BASE}/runs/{run.public_id}").json()
+    assert body["run"]["id"] == run.public_id
+    assert body["run"]["id"] != str(run.id)
+
+
+def test_list_runs_reports_the_bounds_the_run_form_has_to_respect(
+    admin_client: TestClient, consenting_user: User
+) -> None:
+    """The sample control cannot hold its own ceiling.
+
+    ``LLM_EVAL_MAX_SAMPLES`` is configurable and ``start_run`` enforces it, so
+    a client guessing the cap offers sizes the API rejects with a bare 422.
+    """
+    with patch.object(settings, "llm_eval_max_samples", 40):
+        response = admin_client.get(f"{BASE}/users/{consenting_user.id}/runs")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["max_samples"] == 40
+    assert body["min_turns_for_verdict"] == MIN_TURNS_FOR_VERDICT
+
+
 def test_report_orders_the_most_concerning_turns_first(
     admin_client: TestClient, consenting_user: User, db_session: Session
 ) -> None:
@@ -273,7 +310,7 @@ def test_report_orders_the_most_concerning_turns_first(
     )
     db_session.commit()
 
-    response = admin_client.get(f"{BASE}/runs/{run.id}")
+    response = admin_client.get(f"{BASE}/runs/{run.public_id}")
     assert response.status_code == 200
     order = [t["message_seq"] for t in response.json()["turns"]]
     # Safety finding first, then the silent no-op, then the quiet
@@ -300,11 +337,11 @@ def test_report_pages_turns_and_reports_the_total(
     )
     db_session.commit()
 
-    first = admin_client.get(f"{BASE}/runs/{run.id}?limit=3").json()
+    first = admin_client.get(f"{BASE}/runs/{run.public_id}?limit=3").json()
     assert len(first["turns"]) == 3
     assert first["total_turns"] == 7
 
-    second = admin_client.get(f"{BASE}/runs/{run.id}?limit=3&offset=3").json()
+    second = admin_client.get(f"{BASE}/runs/{run.public_id}?limit=3&offset=3").json()
     assert len(second["turns"]) == 3
     # Pages must not overlap, or "show more" would repeat turns.
     assert {t["message_seq"] for t in first["turns"]}.isdisjoint(
@@ -338,7 +375,7 @@ def test_report_orders_before_paging(
     db_session.add_all(rows)
     db_session.commit()
 
-    page = admin_client.get(f"{BASE}/runs/{run.id}?limit=1").json()
+    page = admin_client.get(f"{BASE}/runs/{run.public_id}?limit=1").json()
     assert page["turns"][0]["message_seq"] == 99
 
 
@@ -359,21 +396,21 @@ def test_report_redacts_pii_in_message_bodies(
     )
     db_session.commit()
 
-    turn = admin_client.get(f"{BASE}/runs/{run.id}").json()["turns"][0]
+    turn = admin_client.get(f"{BASE}/runs/{run.public_id}").json()["turns"][0]
     assert "+15555550123" not in turn["user_message"]
     assert "[PHONE]" in turn["user_message"]
     assert turn["candidate"]["tool_calls"][0]["arguments"]["to"] == "[EMAIL]"
 
 
 def test_report_for_unknown_run_is_404(admin_client: TestClient) -> None:
-    assert admin_client.get(f"{BASE}/runs/999999").status_code == 404
+    assert admin_client.get(f"{BASE}/runs/{uuid.uuid4()}").status_code == 404
 
 
 def test_cancel_flips_an_active_run(
     admin_client: TestClient, consenting_user: User, db_session: Session
 ) -> None:
     run = _make_run(db_session, consenting_user.id, status=str(RunStatus.RUNNING))
-    response = admin_client.post(f"{BASE}/runs/{run.id}/cancel")
+    response = admin_client.post(f"{BASE}/runs/{run.public_id}/cancel")
     assert response.status_code == 200
     assert response.json()["status"] == RunStatus.CANCELLED
 
@@ -382,4 +419,4 @@ def test_cancelling_a_finished_run_conflicts(
     admin_client: TestClient, consenting_user: User, db_session: Session
 ) -> None:
     run = _make_run(db_session, consenting_user.id, status=str(RunStatus.COMPLETED))
-    assert admin_client.post(f"{BASE}/runs/{run.id}/cancel").status_code == 409
+    assert admin_client.post(f"{BASE}/runs/{run.public_id}/cancel").status_code == 409


### PR DESCRIPTION
## Description

The report used to expand under the run form, so it had no address: it could not be bookmarked, revisited after a reload, or sent to anyone. A run now lives at `model-eval/<public id>`, and the form page lists past runs as links to it. Starting a run goes straight there, where its progress, partial evidence, and cancel button are.

Runs carry a public UUID for this (migration 043, additive). The integer primary key stays internal to the worker and the turn rows, so the report URL is not a row counter.

"Turns to replay" becomes a slider bounded by `LLM_EVAL_MAX_SAMPLES`, which the run list now reports along with the minimum for a verdict. A client holding its own ceiling offers sizes `start_run` rejects with a bare 422. The report page cap rises to match the largest run the form allows.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`): 4099 passed, plus 387 frontend
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): built by Claude Opus 5 in a Claude Code session with njbrake, who specified the report-as-a-page structure and the slider.
- [ ] No AI used

Verified in a browser against a real multi_user server in both themes: the slider is keyboard operable and takes its ceiling from the API, a run row link opens the report at its UUID, a pasted URL renders it directly, and an unknown id offers a way back. Dark mode caught one defect during that pass: `appearance-none` plus a token background left Chromium drawing its own track over the slider, invisible on a light page and a white slab in dark. It now uses the native control themed through `accent-color`.

_Note: this description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._
