### PR TITLE
chore(web): drop the Beta badge

### DIFF
--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
-import { BetaBadge } from '@/extensions/header-badge';
 import '@/styles/marketing.css';
 
 /**
@@ -106,7 +105,6 @@ export default function LoginPage() {
             <img src="/clawbolt-white.svg" alt="" className="w-16 h-16" />
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-bold font-display text-white">Clawbolt</h1>
-              <BetaBadge variant="dark" />
             </div>
           </Link>
           <p className="text-sm text-white/60 mt-1">AI assistant for the trades</p>

--- a/frontend/src/extensions/header-badge.tsx
+++ b/frontend/src/extensions/header-badge.tsx
@@ -1,30 +1,15 @@
 import type { ReactNode } from 'react';
 
 /**
- * Premium override of the OSS header-badge hook plus the shared BetaBadge
- * component used by MarketingLayout, DocsLayout, and LoginPage to tag the
- * hosted clawbolt.ai deployment.
+ * Implementation of the OSS ``renderHeaderBadge`` extension hook
+ * (mozilla-ai/clawbolt#1395), called by ``AppShell``.
  *
- * Requires OSS extension hook: renderHeaderBadge (mozilla-ai/clawbolt#1395).
+ * clawbolt.ai is out of beta, so it badges nothing. The hook stays because it
+ * is the seam a deployment uses to tag its own header, and the next thing
+ * worth saying there ("Preview", "Maintenance") is one return statement away.
+ * Returning null here is what "no badge" looks like; AppShell renders whatever
+ * this gives it.
  */
 export function renderHeaderBadge(): ReactNode {
-  return <BetaBadge variant="light" />;
-}
-
-type BetaBadgeVariant = 'light' | 'dark';
-
-const VARIANT_CLASSES: Record<BetaBadgeVariant, string> = {
-  light: 'bg-primary/15 text-primary border-primary/25',
-  dark: 'bg-white/15 text-white border-white/20',
-};
-
-export function BetaBadge({ variant = 'light' }: { variant?: BetaBadgeVariant }) {
-  return (
-    <span
-      aria-label="Beta release"
-      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium uppercase tracking-wide border ${VARIANT_CLASSES[variant]}`}
-    >
-      Beta
-    </span>
-  );
+  return null;
 }

--- a/frontend/src/layouts/DocsLayout.tsx
+++ b/frontend/src/layouts/DocsLayout.tsx
@@ -1,7 +1,6 @@
 import { Outlet, Link } from 'react-router-dom';
 import DocsSidebar from '@/pages/docs/DocsSidebar';
 import { LOGIN_PATH } from '@/extensions/routes';
-import { BetaBadge } from '@/extensions/header-badge';
 import '@/styles/marketing.css';
 
 export default function DocsLayout() {
@@ -37,7 +36,6 @@ export default function DocsLayout() {
           >
             <img src="/clawbolt-white.svg" alt="" className="w-10 h-10" />
             Clawbolt
-            <BetaBadge variant="dark" />
           </Link>
           <div className="flex items-center gap-5 text-sm">
             <Link to="/docs/guide" className="text-white/80 hover:text-white transition-colors">

--- a/frontend/src/layouts/MarketingLayout.tsx
+++ b/frontend/src/layouts/MarketingLayout.tsx
@@ -1,6 +1,5 @@
 import { Outlet, Link } from 'react-router-dom';
 import { LOGIN_PATH } from '@/extensions/routes';
-import { BetaBadge } from '@/extensions/header-badge';
 import '@/styles/marketing.css';
 
 export default function MarketingLayout() {
@@ -30,7 +29,6 @@ export default function MarketingLayout() {
           <Link to="/" className="flex items-center gap-3 text-3xl font-bold font-display text-white">
             <img src="/clawbolt-white.svg" alt="" className="w-14 h-14" />
             Clawbolt
-            <BetaBadge variant="dark" />
           </Link>
           <Link
             to={LOGIN_PATH}


### PR DESCRIPTION
## Description

clawbolt.ai is out of beta. The badge came off the app shell header, the marketing and docs headers, and the login page.

The `renderHeaderBadge` hook stays and returns null. It is the seam a deployment uses to tag its own header, and the next thing worth saying there ("Preview", "Maintenance") is one return statement away.

The Terms keep their "alpha, beta, pre-release or unpaid version" clause. That is conditional boilerplate, not a claim about the current release.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`): frontend 387 passed; no backend surface touched
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality (n/a: removal, and no test asserted the badge)
- [x] Bug fixes include regression tests (n/a)

## AI Usage
- [x] AI-assisted (describe how): removal by Claude Opus 5 in a Claude Code session with njbrake.
- [ ] No AI used

Checked in a browser on all four surfaces, logged out and logged in: no `[aria-label="Beta release"]` node and no stray "Beta" text on the login page, the marketing header, the docs header, or the app shell.

_Note: this description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the Beta badge from the login, marketing, documentation, and app shell headers.
- Kept `renderHeaderBadge` as a deployment customization point. It now returns `null`.
- Preserved all login behavior and Terms pre-release wording.

## Benefits

- Shows that clawbolt.ai is no longer in beta.
- Keeps deployment-specific header customization available.
- Removes unused badge code and simplifies the affected components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->