### PR TITLE
feat(admin): browse evaluation runs across every user

### DIFF
--- a/backend/app/routers/admin_llm_eval.py
+++ b/backend/app/routers/admin_llm_eval.py
@@ -16,7 +16,8 @@ drill-down is masked.
 Endpoints:
 
 - ``POST /admin/llm-eval/users/{user_id}/runs`` starts a run.
-- ``GET  /admin/llm-eval/users/{user_id}/runs`` lists that user's runs.
+- ``GET  /admin/llm-eval/runs`` lists runs, newest first, across every user
+  or one of them (``?user_id=``).
 - ``GET  /admin/llm-eval/runs/{run_id}`` returns a run plus its per-turn
   evidence, worst turns first.
 - ``POST /admin/llm-eval/runs/{run_id}/cancel`` stops an in-flight run.
@@ -98,9 +99,13 @@ def _summary_of(run: LLMEvalRun) -> AdminLLMEvalSummary | None:
     return AdminLLMEvalSummary.model_validate(run.summary_json)
 
 
-def _run_item(run: LLMEvalRun) -> AdminLLMEvalRunItem:
+def _run_item(
+    run: LLMEvalRun, *, user_email: str = "", user_consented: bool = True
+) -> AdminLLMEvalRunItem:
     return AdminLLMEvalRunItem(
         id=run.public_id,
+        user_email=user_email,
+        user_consented=user_consented,
         user_id=run.user_id,
         baseline_provider=run.baseline_provider,
         baseline_model=run.baseline_model,
@@ -303,29 +308,67 @@ async def start_run(
     return _run_item(run)
 
 
-@router.get("/users/{user_id}/runs", response_model=AdminLLMEvalRunListResponse)
+@router.get("/runs", response_model=AdminLLMEvalRunListResponse)
 async def list_runs(
-    user_id: str,
+    user_id: str | None = Query(default=None),
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
     ctx: AdminAuditContext = Depends(audit_admin(AdminAction.VIEW_LLM_EVAL_RUNS)),
     db: AsyncSession = Depends(get_async_db),
 ) -> AdminLLMEvalRunListResponse:
-    """List this user's evaluation runs, newest first."""
-    user = await _consenting_user(user_id, db)
-    ctx.target_user_id = user.id
-    runs = (
-        (
+    """Evaluation runs, newest first, across every user or one of them.
+
+    Unfiltered by default so the console can answer "what has been evaluated
+    lately", which is how an operator finds a run again weeks later without
+    remembering whose it was. ``user_id`` narrows it to one user for the run
+    form beside it.
+
+    No consent gate here, unlike the report: a row is run metadata (which
+    models, what verdict, how many turns), not the user's conversations. Each
+    row carries ``user_consented`` so the console can show that a run's
+    evidence is no longer readable rather than offering a link that 403s.
+    """
+    query = select(LLMEvalRun).order_by(desc(LLMEvalRun.created_at))
+    total_query = select(sa_func.count()).select_from(LLMEvalRun)
+    if user_id is not None:
+        # Existence still matters: a typo'd id should 404 rather than quietly
+        # return an empty list that reads as "this user has never been run".
+        user = (await db.execute(select(User).where(User.id == user_id))).scalar_one_or_none()
+        if user is None:
+            raise HTTPException(status_code=404, detail="User not found")
+        ctx.target_user_id = user.id
+        query = query.where(LLMEvalRun.user_id == user_id)
+        total_query = total_query.where(LLMEvalRun.user_id == user_id)
+
+    runs = (await db.execute(query.limit(limit).offset(offset))).scalars().all()
+    total = await db.scalar(total_query) or 0
+
+    # One query for the identities on this page rather than one per row.
+    owner_ids = {r.user_id for r in runs}
+    emails: dict[str, str] = {}
+    consented: dict[str, bool] = {}
+    if owner_ids:
+        rows = (
             await db.execute(
-                select(LLMEvalRun)
-                .where(LLMEvalRun.user_id == user_id)
-                .order_by(desc(LLMEvalRun.created_at))
-                .limit(50)
+                select(User.id, User.data_sharing_consent, Subscription.email)
+                .outerjoin(Subscription, Subscription.user_id == User.id)
+                .where(User.id.in_(owner_ids))
             )
-        )
-        .scalars()
-        .all()
-    )
+        ).all()
+        for owner_id, consent, email in rows:
+            emails[owner_id] = email or ""
+            consented[owner_id] = bool(consent)
+
     return AdminLLMEvalRunListResponse(
-        runs=[_run_item(r) for r in runs],
+        runs=[
+            _run_item(
+                r,
+                user_email=emails.get(r.user_id, ""),
+                user_consented=consented.get(r.user_id, False),
+            )
+            for r in runs
+        ],
+        total=total,
         max_samples=settings.llm_eval_max_samples,
         min_turns_for_verdict=MIN_TURNS_FOR_VERDICT,
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1820,6 +1820,16 @@ class AdminLLMEvalRunItem(BaseModel):
     """The run's ``public_id``. Its report is addressed by this, not by the row id."""
 
     user_id: str
+    user_email: str = ""
+    """Whose run this is, for the cross-user listing. Empty when unknown."""
+
+    user_consented: bool = True
+    """Whether this run's evidence is still readable.
+
+    A run survives its user withdrawing data-sharing consent, but the report
+    endpoint refuses it from then on. The listing says so rather than offering
+    a link that 403s.
+    """
     baseline_provider: str
     baseline_model: str
     candidate_provider: str
@@ -1849,6 +1859,9 @@ class AdminLLMEvalRunListResponse(BaseModel):
     """
 
     runs: list[AdminLLMEvalRunItem]
+    total: int
+    """Runs matching the query, not just this page, so the console can page."""
+
     max_samples: int
     min_turns_for_verdict: int
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3872,22 +3872,54 @@
             }
           }
         }
-      },
+      }
+    },
+    "/api/admin/llm-eval/runs": {
       "get": {
         "tags": [
           "admin"
         ],
         "summary": "List Runs",
-        "description": "List this user's evaluation runs, newest first.",
-        "operationId": "list_runs_api_admin_llm_eval_users__user_id__runs_get",
+        "description": "Evaluation runs, newest first, across every user or one of them.\n\nUnfiltered by default so the console can answer \"what has been evaluated\nlately\", which is how an operator finds a run again weeks later without\nremembering whose it was. ``user_id`` narrows it to one user for the run\nform beside it.\n\nNo consent gate here, unlike the report: a row is run metadata (which\nmodels, what verdict, how many turns), not the user's conversations. Each\nrow carries ``user_consented`` so the console can show that a run's\nevidence is no longer readable rather than offering a link that 403s.",
+        "operationId": "list_runs_api_admin_llm_eval_runs_get",
         "parameters": [
           {
             "name": "user_id",
-            "in": "path",
-            "required": true,
+            "in": "query",
+            "required": false,
             "schema": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 25,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
             }
           }
         ],
@@ -5599,6 +5631,16 @@
             "type": "string",
             "title": "User Id"
           },
+          "user_email": {
+            "type": "string",
+            "title": "User Email",
+            "default": ""
+          },
+          "user_consented": {
+            "type": "boolean",
+            "title": "User Consented",
+            "default": true
+          },
           "baseline_provider": {
             "type": "string",
             "title": "Baseline Provider"
@@ -5709,6 +5751,10 @@
             "type": "array",
             "title": "Runs"
           },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
           "max_samples": {
             "type": "integer",
             "title": "Max Samples"
@@ -5721,6 +5767,7 @@
         "type": "object",
         "required": [
           "runs",
+          "total",
           "max_samples",
           "min_turns_for_verdict"
         ],

--- a/frontend/src/extensions/admin/admin-api.ts
+++ b/frontend/src/extensions/admin/admin-api.ts
@@ -1338,6 +1338,9 @@ export interface EvalRun {
   /** The run's public id, which is also its report URL segment. */
   id: string;
   user_id: string;
+  user_email: string;
+  /** False once the user withdraws consent: the report is no longer readable. */
+  user_consented: boolean;
   baseline_provider: string;
   baseline_model: string;
   candidate_provider: string;
@@ -1399,15 +1402,24 @@ export interface EvalReport {
 
 export interface EvalRunList {
   runs: EvalRun[];
+  /** Runs matching the query, not just this page. */
+  total: number;
   /** LLM_EVAL_MAX_SAMPLES: the largest run the API will start. */
   max_samples: number;
   /** Below this many compared turns a run reports inconclusive, not a pass. */
   min_turns_for_verdict: number;
 }
 
-export async function listEvalRuns(userId: string): Promise<EvalRunList> {
+/** Runs across every user, or one user's when ``userId`` is given. */
+export async function listEvalRuns(
+  opts: { userId?: string; limit?: number; offset?: number } = {},
+): Promise<EvalRunList> {
+  const params = new URLSearchParams();
+  if (opts.userId) params.set('user_id', opts.userId);
+  params.set('limit', String(opts.limit ?? 25));
+  if (opts.offset) params.set('offset', String(opts.offset));
   const { data, error } = await client.GET(
-    `/api/admin/llm-eval/users/${encodeURIComponent(userId)}/runs` as never,
+    `/api/admin/llm-eval/runs?${params.toString()}` as never,
   );
   if (error) throwApiError(error, 'Failed to load evaluation runs');
   return data as EvalRunList;

--- a/frontend/src/extensions/admin/tabs/model-eval-fixtures.ts
+++ b/frontend/src/extensions/admin/tabs/model-eval-fixtures.ts
@@ -72,6 +72,8 @@ export function run(overrides: Partial<EvalRun> = {}): EvalRun {
   return {
     id: 'run-0001',
     user_id: 'user-1',
+    user_email: 'consenting@example.com',
+    user_consented: true,
     baseline_provider: 'anthropic',
     baseline_model: 'incumbent',
     candidate_provider: 'anthropic',
@@ -132,6 +134,12 @@ export function report(overrides: Partial<EvalReport> = {}): EvalReport {
 // ``listEvalRuns`` returns the run list plus the bounds the sample slider has
 // to respect, so a mock has to carry them or the slider falls back to its own
 // defaults and the test stops exercising the wired value.
-export function runList(runs: EvalRun[] = [], overrides: Partial<EvalRunList> = {}) {
-  return { runs, max_samples: 200, min_turns_for_verdict: 20, ...overrides };
+export function runList(runs: EvalRun[] = [], overrides: Partial<EvalRunList> = {}): EvalRunList {
+  return {
+    runs,
+    total: runs.length,
+    max_samples: 200,
+    min_turns_for_verdict: 20,
+    ...overrides,
+  };
 }

--- a/frontend/src/extensions/admin/tabs/model-eval.test.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval.test.tsx
@@ -117,6 +117,96 @@ describe('ModelEvalTab', () => {
     expect(await screen.findByText(/reports inconclusive/)).toBeInTheDocument();
   });
 
+  it('lists runs across every user before one is picked', async () => {
+    // The table is how a run is found again weeks later, when nobody
+    // remembers whose it was.
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(
+      runList([
+        run(),
+        run({
+          id: 'run-0002',
+          user_id: 'user-2',
+          user_email: 'other@example.com',
+          candidate_model: 'other-candidate',
+        }),
+      ]),
+    );
+    renderTab();
+
+    expect(await screen.findByText('Recent evaluations')).toBeInTheDocument();
+    expect(await screen.findByText('other@example.com')).toBeInTheDocument();
+    expect(screen.getByText('other-candidate')).toBeInTheDocument();
+    // Unfiltered: the API is asked for every user's runs.
+    expect(api.listEvalRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: undefined }),
+    );
+  });
+
+  it('narrows the table to the selected user', async () => {
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
+    renderTab();
+
+    await screen.findByRole('option', { name: 'consenting@example.com' });
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
+
+    await waitFor(() =>
+      expect(api.listEvalRuns).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-1' })),
+    );
+    expect(await screen.findByText('Runs for this user')).toBeInTheDocument();
+  });
+
+  it('does not offer a report for a run whose user withdrew consent', async () => {
+    // The run row survives, because it is metadata rather than conversation
+    // content, but its evidence is no longer readable and the link would 403.
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(
+      runList([run({ user_consented: false })]),
+    );
+    renderTab();
+
+    expect(await screen.findByText('consent withdrawn')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /ago|2026/ })).not.toBeInTheDocument();
+  });
+
+  it('pages the run table', async () => {
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()], { total: 60 }));
+    renderTab();
+
+    expect(await screen.findByText('1 of 60')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Show more runs' }));
+    await waitFor(() =>
+      expect(api.listEvalRuns).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 50 })),
+    );
+  });
+
+  it('lets a run start while another user has one in flight', async () => {
+    // start_run allows one active run per user, so someone else's run in the
+    // unfiltered table must not disable this form.
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(
+      runList([
+        run({
+          id: 'run-0009',
+          user_id: 'user-2',
+          user_email: 'other@example.com',
+          status: 'running',
+          summary: null,
+        }),
+      ]),
+    );
+    renderTab();
+
+    await screen.findByRole('option', { name: 'consenting@example.com' });
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
+    await userEvent.type(screen.getByLabelText('provider'), 'anthropic');
+    await userEvent.type(screen.getByLabelText('model'), 'candidate');
+
+    expect(screen.getByRole('button', { name: 'Run analysis' })).not.toBeDisabled();
+  });
+
   it('links each past run to its own report URL', async () => {
     // The report is a page an operator returns to and shares, so the row has
     // to carry a real, copyable link rather than only a click handler.

--- a/frontend/src/extensions/admin/tabs/model-eval.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval.tsx
@@ -35,6 +35,10 @@ const SAMPLE_STEP = 5;
 const SAMPLE_MAX_FALLBACK = 200;
 const SAMPLE_DEFAULT = 100;
 
+// Rows per page in the run table. Each row is one run's metadata, so this is
+// about scanning, not cost.
+const RUN_PAGE_SIZE = 25;
+
 
 // ---------------------------------------------------------------------------
 // Page
@@ -54,6 +58,8 @@ export default function ModelEvalTab() {
   const [judgeEnabled, setJudgeEnabled] = useState(true);
 
   const [runs, setRuns] = useState<EvalRun[]>([]);
+  const [runTotal, setRunTotal] = useState(0);
+  const [runsShown, setRunsShown] = useState(RUN_PAGE_SIZE);
 
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -68,14 +74,14 @@ export default function ModelEvalTab() {
       .finally(() => setUsersLoading(false));
   }, []);
 
-  const refreshRuns = useCallback(async (id: string) => {
-    if (!id) {
-      setRuns([]);
-      return;
-    }
+  // Unfiltered when no user is picked: the table's job is answering "what has
+  // been evaluated lately" so a run can be found again without remembering
+  // whose it was. Picking a user in the form above narrows it.
+  const refreshRuns = useCallback(async (id: string, limit: number) => {
     try {
-      const list = await listEvalRuns(id);
+      const list = await listEvalRuns({ userId: id || undefined, limit });
       setRuns(list.runs);
+      setRunTotal(list.total);
       setSampleMax(list.max_samples);
       setMinTurnsForVerdict(list.min_turns_for_verdict);
       // A cap below the current selection would leave the thumb pinned past
@@ -87,10 +93,15 @@ export default function ModelEvalTab() {
   }, []);
 
   useEffect(() => {
-    void refreshRuns(userId);
-  }, [userId, refreshRuns]);
+    void refreshRuns(userId, runsShown);
+  }, [userId, runsShown, refreshRuns]);
 
-  const activeRun = runs.find(r => ACTIVE_STATUSES.has(r.status));
+  // Scoped to the selected user on purpose. ``start_run`` allows one active
+  // run per user, so another tenant's run in the unfiltered list must not
+  // disable this form.
+  const activeRun = runs.find(
+    r => ACTIVE_STATUSES.has(r.status) && (!userId || r.user_id === userId),
+  );
 
   // One interval, restarted whenever what we are watching changes. While a run
   // is active we re-read the list so progress advances; once it settles the
@@ -100,11 +111,11 @@ export default function ModelEvalTab() {
   useEffect(() => {
     if (pollRef.current) clearInterval(pollRef.current);
     if (activeRunId == null || !userId) return;
-    pollRef.current = setInterval(() => void refreshRuns(userId), POLL_MS);
+    pollRef.current = setInterval(() => void refreshRuns(userId, runsShown), POLL_MS);
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
     };
-  }, [activeRunId, userId, refreshRuns]);
+  }, [activeRunId, userId, runsShown, refreshRuns]);
 
   async function handleStart() {
     setError(null);
@@ -285,18 +296,35 @@ export default function ModelEvalTab() {
         </section>
       ) : null}
 
-      {/* Past runs */}
-      {runs.length > 0 ? (
-        <section className="rounded-[--radius-lg] border border-border bg-card">
-          <h3 className="border-b border-border p-3 text-sm font-semibold text-foreground">
-            Runs for this user
+      {/* The run browser. Present whether or not a user is selected: with no
+          selection it is every run, newest first, which is how a run gets
+          found again weeks later. */}
+      <section className="rounded-[--radius-lg] border border-border bg-card">
+        <div className="flex flex-wrap items-baseline justify-between gap-2 border-b border-border p-3">
+          <h3 className="text-sm font-semibold text-foreground">
+            {userId ? 'Runs for this user' : 'Recent evaluations'}
           </h3>
+          <p className="text-xs text-muted-foreground">
+            {runTotal > runs.length
+              ? `${runs.length} of ${runTotal}`
+              : `${runTotal} run${runTotal === 1 ? '' : 's'}`}
+          </p>
+        </div>
+        {runs.length === 0 ? (
+          <p className="p-3 text-sm text-muted-foreground">
+            {userId
+              ? 'No evaluations for this user yet.'
+              : 'No evaluations yet. Pick a user above to run the first one.'}
+          </p>
+        ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="p-3">Started</th>
+                  {userId ? null : <th className="p-3">User</th>}
                   <th className="p-3">Candidate</th>
+                  <th className="p-3">Incumbent</th>
                   <th className="p-3">Turns</th>
                   <th className="p-3">Status</th>
                   <th className="p-3">Verdict</th>
@@ -305,32 +333,55 @@ export default function ModelEvalTab() {
               <tbody>
                 {runs.map(run => {
                   const copy = RECOMMENDATION_COPY[run.recommendation as EvalRecommendation];
+                  const href = `${adminPath('model-eval')}/${run.id}`;
                   return (
                     <tr
                       key={run.id}
-                      onClick={() => navigate(`${adminPath('model-eval')}/${run.id}`)}
-                      className="cursor-pointer border-t border-border hover:bg-panel"
+                      onClick={() => {
+                        // A run whose user withdrew consent has no readable
+                        // report, so the row is not a way into one.
+                        if (run.user_consented) navigate(href);
+                      }}
+                      className={`border-t border-border ${
+                        run.user_consented ? 'cursor-pointer hover:bg-panel' : 'opacity-60'
+                      }`}
                     >
-                      <td className="p-3 text-muted-foreground">
-                        {/* A real link in the first cell, so the row is
-                            keyboard reachable and its URL is copyable, while
-                            the row click stays the large target. */}
-                        <Link
-                          to={`${adminPath('model-eval')}/${run.id}`}
-                          className="text-primary hover:underline"
-                          onClick={e => e.stopPropagation()}
-                        >
-                          {formatRelative(run.created_at)}
-                        </Link>
+                      <td className="whitespace-nowrap p-3 text-muted-foreground">
+                        {run.user_consented ? (
+                          // A real link, so the row is keyboard reachable and
+                          // its URL is copyable.
+                          <Link
+                            to={href}
+                            className="text-primary hover:underline"
+                            onClick={e => e.stopPropagation()}
+                          >
+                            {formatRelative(run.created_at)}
+                          </Link>
+                        ) : (
+                          formatRelative(run.created_at)
+                        )}
                       </td>
-                      <td className="p-3 font-mono text-xs text-foreground">
+                      {userId ? null : (
+                        <td className="whitespace-nowrap p-3 text-muted-foreground">
+                          {run.user_email || run.user_id}
+                          {run.user_consented ? null : (
+                            <span className="ml-2 text-xs text-warning-text">
+                              consent withdrawn
+                            </span>
+                          )}
+                        </td>
+                      )}
+                      <td className="whitespace-nowrap p-3 font-mono text-xs text-foreground">
                         {run.candidate_model}
+                      </td>
+                      <td className="whitespace-nowrap p-3 font-mono text-xs text-muted-foreground">
+                        {run.baseline_model}
                       </td>
                       <td className="p-3 text-muted-foreground">
                         {run.progress_total || run.requested_samples}
                       </td>
-                      <td className="p-3 text-muted-foreground">{run.status}</td>
-                      <td className="p-3">
+                      <td className="whitespace-nowrap p-3 text-muted-foreground">{run.status}</td>
+                      <td className="whitespace-nowrap p-3">
                         {copy ? (
                           <span className={`rounded-full px-2 py-0.5 text-xs ${copy.className}`}>
                             {copy.label}
@@ -345,8 +396,19 @@ export default function ModelEvalTab() {
               </tbody>
             </table>
           </div>
-        </section>
-      ) : null}
+        )}
+        {runTotal > runs.length ? (
+          <div className="border-t border-border p-3">
+            <button
+              type="button"
+              onClick={() => setRunsShown(n => n + RUN_PAGE_SIZE)}
+              className="rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
+            >
+              Show more runs
+            </button>
+          </div>
+        ) : null}
+      </section>
 
     </div>
   );

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -2191,11 +2191,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /**
-         * List Runs
-         * @description List this user's evaluation runs, newest first.
-         */
-        get: operations["list_runs_api_admin_llm_eval_users__user_id__runs_get"];
+        get?: never;
         put?: never;
         /**
          * Start Run
@@ -2206,6 +2202,36 @@ export interface paths {
          *     same history would double the provider load for no extra information.
          */
         post: operations["start_run_api_admin_llm_eval_users__user_id__runs_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/llm-eval/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Runs
+         * @description Evaluation runs, newest first, across every user or one of them.
+         *
+         *     Unfiltered by default so the console can answer "what has been evaluated
+         *     lately", which is how an operator finds a run again weeks later without
+         *     remembering whose it was. ``user_id`` narrows it to one user for the run
+         *     form beside it.
+         *
+         *     No consent gate here, unlike the report: a row is run metadata (which
+         *     models, what verdict, how many turns), not the user's conversations. Each
+         *     row carries ``user_consented`` so the console can show that a run's
+         *     evidence is no longer readable rather than offering a link that 403s.
+         */
+        get: operations["list_runs_api_admin_llm_eval_runs_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -3174,6 +3200,16 @@ export interface components {
             id: string;
             /** User Id */
             user_id: string;
+            /**
+             * User Email
+             * @default
+             */
+            user_email: string;
+            /**
+             * User Consented
+             * @default true
+             */
+            user_consented: boolean;
             /** Baseline Provider */
             baseline_provider: string;
             /** Baseline Model */
@@ -3218,6 +3254,8 @@ export interface components {
         AdminLLMEvalRunListResponse: {
             /** Runs */
             runs: components["schemas"]["AdminLLMEvalRunItem"][];
+            /** Total */
+            total: number;
             /** Max Samples */
             max_samples: number;
             /** Min Turns For Verdict */
@@ -8253,37 +8291,6 @@ export interface operations {
             };
         };
     };
-    list_runs_api_admin_llm_eval_users__user_id__runs_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminLLMEvalRunListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     start_run_api_admin_llm_eval_users__user_id__runs_post: {
         parameters: {
             query?: never;
@@ -8306,6 +8313,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AdminLLMEvalRunItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_runs_api_admin_llm_eval_runs_get: {
+        parameters: {
+            query?: {
+                user_id?: string | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminLLMEvalRunListResponse"];
                 };
             };
             /** @description Validation Error */

--- a/tests/multi_user/test_llm_eval_routes.py
+++ b/tests/multi_user/test_llm_eval_routes.py
@@ -234,13 +234,84 @@ def _make_run(db: Session, user_id: str, **overrides: object) -> LLMEvalRun:
     return run
 
 
-def test_list_runs_returns_the_users_runs(
+def test_list_runs_spans_every_user_by_default(
     admin_client: TestClient, consenting_user: User, db_session: Session
 ) -> None:
+    """Unfiltered is the useful default: it is how a run is found again.
+
+    An operator looking for last week's evaluation does not necessarily
+    remember which user it was against.
+    """
+    other = User(id=str(uuid.uuid4()), user_id="other-user")
+    db_session.add(other)
+    db_session.commit()
+    # The email lives on Subscription, and the base fixture user has no row,
+    # so both sides of the join are covered: one with an email, one without.
+    db_session.add(Subscription(user_id=other.id, email="other@example.com"))
+    db_session.commit()
     _make_run(db_session, consenting_user.id)
-    response = admin_client.get(f"{BASE}/users/{consenting_user.id}/runs")
-    assert response.status_code == 200
-    assert len(response.json()["runs"]) == 1
+    _make_run(db_session, other.id)
+
+    body = admin_client.get(f"{BASE}/runs").json()
+    assert body["total"] == 2
+    owners = {r["user_id"] for r in body["runs"]}
+    assert owners == {consenting_user.id, other.id}
+    # The listing names whose run each row is, or the table cannot be read.
+    # A user with no subscription row reports an empty email rather than
+    # dropping out of the listing.
+    assert {r["user_email"] for r in body["runs"]} == {"other@example.com", ""}
+
+
+def test_list_runs_filters_to_one_user(
+    admin_client: TestClient, consenting_user: User, db_session: Session
+) -> None:
+    other = User(id=str(uuid.uuid4()), user_id="other-user")
+    db_session.add(other)
+    db_session.commit()
+    _make_run(db_session, consenting_user.id)
+    _make_run(db_session, other.id)
+
+    body = admin_client.get(f"{BASE}/runs?user_id={consenting_user.id}").json()
+    assert body["total"] == 1
+    assert body["runs"][0]["user_id"] == consenting_user.id
+
+
+def test_list_runs_404s_an_unknown_user_filter(admin_client: TestClient) -> None:
+    """An empty page would read as "never evaluated" rather than "no such user"."""
+    assert admin_client.get(f"{BASE}/runs?user_id={uuid.uuid4()}").status_code == 404
+
+
+def test_list_runs_pages(
+    admin_client: TestClient, consenting_user: User, db_session: Session
+) -> None:
+    for _ in range(3):
+        _make_run(db_session, consenting_user.id)
+
+    body = admin_client.get(f"{BASE}/runs?limit=2").json()
+    assert len(body["runs"]) == 2
+    assert body["total"] == 3
+    assert len(admin_client.get(f"{BASE}/runs?limit=2&offset=2").json()["runs"]) == 1
+
+
+def test_list_runs_keeps_a_run_whose_user_withdrew_consent_and_says_so(
+    admin_client: TestClient, consenting_user: User, db_session: Session
+) -> None:
+    """A row is run metadata, not conversation content, so it survives.
+
+    The report does not: it is consent-gated, which is why the row carries the
+    flag rather than the console offering a link that 403s.
+    """
+    run = _make_run(db_session, consenting_user.id)
+    user = db_session.get(User, consenting_user.id)
+    assert user is not None
+    user.data_sharing_consent = False
+    db_session.commit()
+
+    body = admin_client.get(f"{BASE}/runs").json()
+    assert [r["id"] for r in body["runs"]] == [run.public_id]
+    assert body["runs"][0]["user_consented"] is False
+    # And the evidence really is refused.
+    assert admin_client.get(f"{BASE}/runs/{run.public_id}").status_code == 403
 
 
 def test_a_run_is_addressed_by_a_public_id_not_its_row_id(
@@ -268,7 +339,7 @@ def test_list_runs_reports_the_bounds_the_run_form_has_to_respect(
     a client guessing the cap offers sizes the API rejects with a bare 422.
     """
     with patch.object(settings, "llm_eval_max_samples", 40):
-        response = admin_client.get(f"{BASE}/users/{consenting_user.id}/runs")
+        response = admin_client.get(f"{BASE}/runs?user_id={consenting_user.id}")
     assert response.status_code == 200
     body = response.json()
     assert body["max_samples"] == 40


### PR DESCRIPTION
## Description

The run table only appeared once a user was picked, and only ever held that user's runs, so finding an evaluation again meant remembering whose it was.

`GET /admin/llm-eval/runs` lists runs newest first across every user, paged, with an optional `user_id` filter, and replaces the per-user route rather than sitting beside it. Rows carry the owner's email so the table can be read, and a `user_consented` flag: a run survives its user withdrawing consent, because a row is metadata rather than conversation content, but the report is refused from then on, so the console labels the row instead of offering a link that 403s.

The active-run guard is now scoped to the selected user. `start_run` allows one active run per user, so another tenant's run in the unfiltered table must not disable the form.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`): 4103 passed, plus 392 frontend
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): built by Claude Opus 5 in a Claude Code session with njbrake, who asked for a browsable table of past evaluations.
- [ ] No AI used

Checked in a browser against a real multi_user server in both themes, with three runs across three users: the unfiltered table names each owner, the consent-withdrawn row is dimmed, labelled, and carries no link, and picking a user swaps the heading and drops the User column.

_Note: this description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._
