### PR TITLE
fix(admin): stop an evaluation run when the provider keeps failing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,11 @@ Three invariants, each of which the feature is worthless without:
   follows automatically; keep it that way.
 - **Safety findings are never averaged into a quality score.** `metrics.py`
   keeps them in their own tier, and one occurrence forces `do_not_switch`.
+- **A failing provider stops the run.** `MAX_CONSECUTIVE_CALL_FAILURES`
+  consecutive errored turns end it with `FAILED`, the evidence already
+  gathered, and `inconclusive` stamped on both the column and the summary. A
+  run competes with live traffic at the same gateway, so it must not spend a
+  200-sample budget rediscovering that the provider is down.
 
 Consent-gated like `/admin/shared-data`: a run reads real conversations and the
 report renders them back, so both require `User.data_sharing_consent`. Content is

--- a/backend/app/services/llm_eval/runner.py
+++ b/backend/app/services/llm_eval/runner.py
@@ -8,7 +8,11 @@ through should leave behind the evidence it already gathered instead of
 nothing.
 
 Turn failures are recorded, not raised. One provider hiccup on turn 40 must
-not discard the 39 comparisons before it.
+not discard the 39 comparisons before it. Sustained failure is different: a
+dead provider, a rejected key, or an exhausted quota fails every remaining
+turn the same way, so after ``MAX_CONSECUTIVE_CALL_FAILURES`` turns in a row
+come back with an error the run stops, keeps what it gathered, and reports
+why rather than spending the rest of the samples proving the point.
 """
 
 from __future__ import annotations
@@ -89,6 +93,14 @@ async def _load_run(run_id: int) -> LLMEvalRun | None:
 # per turn to read one column that changes at most once per run. A second of
 # lag on a job measured in minutes is not worth that.
 _CANCEL_POLL_SECONDS = 1.0
+
+
+# Consecutive turns whose provider calls failed before the run gives up. A
+# dead provider, a bad key, or an exhausted quota fails every remaining turn
+# identically, and a 200-turn run would make 400 more calls discovering that.
+# Counted consecutively rather than in total so one flaky call in a long run
+# does not end it: any turn that comes back resets the count.
+MAX_CONSECUTIVE_CALL_FAILURES = 3
 
 
 class _CancellationWatcher:
@@ -316,13 +328,20 @@ async def execute_run(run_id: int, *, concurrency: int) -> None:
     semaphore = asyncio.Semaphore(max(1, concurrency))
     comparisons: list[TurnComparison] = []
     completed = 0
+    consecutive_failures = 0
+    breaker_error = ""
     lock = asyncio.Lock()
 
     async def worker(sample: ReplaySample) -> None:
-        nonlocal completed
+        nonlocal completed, consecutive_failures, breaker_error
         async with semaphore:
             if await cancellation.is_cancelled():
                 raise asyncio.CancelledError
+            if breaker_error:
+                # The provider is failing every call. Return rather than
+                # raise: the turns that already landed are the run's evidence
+                # and ``gather`` must not discard the bookkeeping for them.
+                return
             try:
                 comparison = await _compare_turn(run, fixture, sample)
             except Exception as exc:
@@ -350,9 +369,20 @@ async def execute_run(run_id: int, *, concurrency: int) -> None:
                     safety_issues=[SafetyIssue(finding=SafetyFinding.CALL_FAILED, detail=detail)],
                     judge_verdict=JudgeVerdict.NOT_JUDGED,
                 )
+        failure = comparison.baseline.error or comparison.candidate.error
         async with lock:
             comparisons.append(comparison)
             completed += 1
+            if failure:
+                consecutive_failures += 1
+                if consecutive_failures >= MAX_CONSECUTIVE_CALL_FAILURES and not breaker_error:
+                    breaker_error = (
+                        f"stopped after {consecutive_failures} consecutive provider "
+                        f"failures: {failure}"
+                    )
+                    logger.warning("LLM eval run %d %s", run_id, breaker_error)
+            else:
+                consecutive_failures = 0
         async with db_session_async() as db:
             db.add(_turn_row(run_id, comparison))
             # Incremented in SQL rather than written from the Python counter.
@@ -375,6 +405,25 @@ async def execute_run(run_id: int, *, concurrency: int) -> None:
 
     comparisons.sort(key=lambda c: c.sample.seq)
     aggregate = metrics.aggregate(comparisons)
+    if breaker_error:
+        # The evidence gathered before the provider went down is kept and
+        # still readable, but it cannot endorse a switch: the run stopped
+        # early, so whatever it measured is a fraction of what was asked for.
+        # Both the column and the summary are stamped, or the report's banner
+        # would contradict the run's status.
+        aggregate.recommendation = Recommendation.INCONCLUSIVE
+        aggregate.reasons = [breaker_error]
+        await _finish(
+            run_id,
+            RunStatus.FAILED,
+            recommendation=str(Recommendation.INCONCLUSIVE),
+            summary=_summary_payload(aggregate),
+            error=breaker_error,
+        )
+        logger.info(
+            "LLM eval run %d abandoned after %d turn(s): %s", run_id, completed, breaker_error
+        )
+        return
     await _finish(
         run_id,
         RunStatus.COMPLETED,

--- a/frontend/src/extensions/admin/tabs/model-eval-report.test.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval-report.test.tsx
@@ -128,6 +128,27 @@ describe('ModelEvalReportPage', () => {
     await waitFor(() => expect(api.cancelEvalRun).toHaveBeenCalledWith('run-0001'));
   });
 
+  it('shows why a run stopped early, beside its partial verdict', async () => {
+    // A run the provider killed still carries a summary, so the reason has to
+    // be its own line: an "inconclusive" banner alone reads as "we looked and
+    // could not tell" rather than "the provider was down".
+    const api = await import('../admin-api');
+    vi.mocked(api.getEvalReport).mockResolvedValue(
+      report({
+        run: run({
+          status: 'failed',
+          error: 'stopped after 3 consecutive provider failures: APIStatusError: 503',
+          recommendation: 'inconclusive',
+          summary: summary({ recommendation: 'inconclusive', reasons: ['stopped after 3'] }),
+        }),
+      }),
+    );
+    renderReport();
+
+    expect(await screen.findByText(/3 consecutive provider failures/)).toBeInTheDocument();
+    expect(screen.getByText('Inconclusive')).toBeInTheDocument();
+  });
+
   it('offers a way back when the id in the URL is not a run', async () => {
     // A pasted link with a stale id is the common failure here, and a red
     // banner with no exit is a dead end.

--- a/frontend/src/extensions/admin/tabs/model-eval-report.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval-report.tsx
@@ -392,6 +392,15 @@ export default function ModelEvalReportPage({ runId }: { runId: string }) {
         </section>
       ) : null}
 
+      {/* A run that stopped early still has a summary, so this cannot live in
+          the no-summary branch below: without it the reason the run gave up
+          would be invisible behind an "inconclusive" banner. */}
+      {run.error ? (
+        <div className="rounded-[--radius-md] bg-error-bg px-3 py-2 text-sm text-error-text">
+          {run.error}
+        </div>
+      ) : null}
+
       {run.summary ? (
         <>
           <VerdictBanner summary={run.summary} userId={run.user_id} />
@@ -411,7 +420,7 @@ export default function ModelEvalReportPage({ runId }: { runId: string }) {
         <p className="text-sm text-muted-foreground">
           {isActive
             ? 'The verdict is written when the run finishes. Turns appear below as they land.'
-            : `This run has no summary${run.error ? `: ${run.error}` : '.'}`}
+            : 'This run has no summary.'}
         </p>
       )}
 

--- a/tests/multi_user/test_llm_eval_runner.py
+++ b/tests/multi_user/test_llm_eval_runner.py
@@ -375,8 +375,10 @@ async def test_run_stops_after_consecutive_provider_failures(
     # A run that stopped early cannot endorse a switch, and the banner reads
     # the summary rather than the column, so both have to say so.
     assert run.recommendation == str(Recommendation.INCONCLUSIVE)
-    assert run.summary_json["recommendation"] == str(Recommendation.INCONCLUSIVE)
-    assert "consecutive provider failures" in run.summary_json["reasons"][0]
+    summary = run.summary_json
+    assert summary is not None
+    assert summary["recommendation"] == str(Recommendation.INCONCLUSIVE)
+    assert "consecutive provider failures" in summary["reasons"][0]
 
 
 @pytest.mark.asyncio()

--- a/tests/multi_user/test_llm_eval_runner.py
+++ b/tests/multi_user/test_llm_eval_runner.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.agent.tools.base import Tool, ToolResult
 from backend.app.models import LLMEvalRun, LLMEvalTurnResult, User
-from backend.app.services.llm_eval.runner import execute_run
+from backend.app.services.llm_eval.runner import MAX_CONSECUTIVE_CALL_FAILURES, execute_run
 from backend.app.services.llm_eval.sampling import ReplayFixture
 from backend.app.services.llm_eval.types import (
     ModelCallResult,
@@ -335,3 +335,73 @@ async def test_user_with_no_turns_completes_as_inconclusive(
     assert run.status == RunStatus.COMPLETED
     assert run.recommendation == Recommendation.INCONCLUSIVE
     assert "no replayable turns" in run.error
+
+
+@pytest.mark.asyncio()
+async def test_run_stops_after_consecutive_provider_failures(
+    db_session: Session, test_user: User
+) -> None:
+    """A dead provider must not cost the whole sample budget.
+
+    Every remaining turn would fail identically, so the run stops, keeps the
+    turns it wrote, and says why.
+    """
+    run_id = _make_run(db_session, test_user.id, samples=20)
+    failing = ModelCallResult(provider="anthropic", model="m", error="APIStatusError: 503")
+
+    patches = _patched_run(
+        samples=_samples(20),
+        call_side_effect=lambda *a, **k: failing,
+    )
+    with patches[0], patches[1], patches[2], patches[3] as call:
+        await execute_run(run_id, concurrency=1)
+
+    run = db_session.get(LLMEvalRun, run_id)
+    assert run is not None
+    assert run.status == str(RunStatus.FAILED)
+    assert "consecutive provider failures" in run.error
+    assert "503" in run.error
+
+    turns = (
+        db_session.execute(select(LLMEvalTurnResult).where(LLMEvalTurnResult.run_id == run_id))
+        .scalars()
+        .all()
+    )
+    # The three that failed are kept as evidence; the other seventeen are not
+    # attempted, which is the point.
+    assert len(turns) == MAX_CONSECUTIVE_CALL_FAILURES
+    assert call.await_count == MAX_CONSECUTIVE_CALL_FAILURES * 2
+
+    # A run that stopped early cannot endorse a switch, and the banner reads
+    # the summary rather than the column, so both have to say so.
+    assert run.recommendation == str(Recommendation.INCONCLUSIVE)
+    assert run.summary_json["recommendation"] == str(Recommendation.INCONCLUSIVE)
+    assert "consecutive provider failures" in run.summary_json["reasons"][0]
+
+
+@pytest.mark.asyncio()
+async def test_an_intermittent_failure_does_not_stop_the_run(
+    db_session: Session, test_user: User
+) -> None:
+    """The count is consecutive, so a flaky call in a long run is survivable."""
+    run_id = _make_run(db_session, test_user.id, samples=6)
+    ok = _result(text="fine")
+    bad = ModelCallResult(provider="anthropic", model="m", error="APIStatusError: 429")
+    # Two calls per turn: alternate whole turns rather than individual calls.
+    outcomes = [bad, bad, ok, ok, bad, bad, ok, ok, bad, bad, ok, ok]
+    calls = iter(outcomes)
+
+    patches = _patched_run(samples=_samples(6), call_side_effect=lambda *a, **k: next(calls))
+    with patches[0], patches[1], patches[2], patches[3]:
+        await execute_run(run_id, concurrency=1)
+
+    run = db_session.get(LLMEvalRun, run_id)
+    assert run is not None
+    assert run.status == str(RunStatus.COMPLETED)
+    assert run.error == ""
+    turns = (
+        db_session.execute(select(LLMEvalTurnResult).where(LLMEvalTurnResult.run_id == run_id))
+        .scalars()
+        .all()
+    )
+    assert len(turns) == 6


### PR DESCRIPTION
## Description

A dead provider, a rejected key, or an exhausted quota fails every turn identically. The run recorded each failure and carried on, so a 200-sample budget was spent making 400 more calls to discover the same thing, against the same gateway the user's live traffic goes through.

Three consecutive errored turns now end the run: status `FAILED`, the turns already written kept as evidence, and the reason in `error`. The count is consecutive, so one flaky call in a long run resets it rather than ending it. Workers return rather than raise when the breaker trips, so the bookkeeping for turns already in flight is not discarded.

A run that stopped early cannot endorse a switch, so `inconclusive` is stamped on both the run column and the summary payload. The report banner reads the summary, and the two disagreeing would be worse than either. The report page shows the stop reason on its own line, since a run that stopped early still has a summary and would otherwise show an unexplained "inconclusive".

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`): 4101 passed, plus 388 frontend
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

## AI Usage
- [x] AI-assisted (describe how): written by Claude Opus 5 in a Claude Code session with njbrake, who asked that a run not keep hammering a failing endpoint.
- [ ] No AI used

Not implemented: pause and resume. Stopping keeps the evidence and names the cause, which is what makes the failure legible; resuming a half-finished run needs state this feature does not have yet. Say if you want it.

_Note: this description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Stops evaluation runs after three consecutive provider failures.
- Marks stopped runs as `FAILED` and `inconclusive`.
- Preserves completed turns and records the provider error in the run and summary.
- Resets the failure count after a successful or non-error turn.
- Displays the stop reason in a separate report banner.
- Adds coverage for consecutive and intermittent provider failures.

This prevents repeated failed calls, preserves useful evidence, and gives users a clear explanation for inconclusive results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->