### PR TITLE
fix(admin): make the model eval pages readable on a phone

### DIFF
--- a/frontend/src/extensions/admin/tabs/model-eval-report.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval-report.tsx
@@ -167,7 +167,7 @@ function SummaryGrid({ summary }: { summary: EvalSummary }) {
   // not imply "free".
   const costKnown = summary.candidate.pricing_available && summary.baseline.pricing_available;
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
       <Stat
         label="Blocking findings"
         value={String(safetyTotal)}
@@ -260,9 +260,13 @@ function DecisionColumn({ title, decision }: { title: string; decision: EvalDeci
           {decision.tool_calls.length > 0 ? (
             <ul className="mb-2 space-y-1">
               {decision.tool_calls.map((call, index) => (
+                // ``break-all``: a serialized argument payload is one
+                // unbroken token, so without it the line runs past the card
+                // and the tail is clipped away rather than wrapped. On a
+                // phone that hid most of every call.
                 <li
                   key={`${call.name}-${index}`}
-                  className="rounded-[--radius-sm] bg-panel px-2 py-1 font-mono text-xs text-foreground"
+                  className="break-all rounded-[--radius-sm] bg-panel px-2 py-1 font-mono text-xs text-foreground"
                 >
                   <span className="font-semibold">{call.name}</span>
                   <span className="text-muted-foreground">
@@ -305,7 +309,13 @@ function TurnCard({ turn }: { turn: EvalTurn }) {
         className="flex w-full items-start gap-3 p-3 text-left"
       >
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm text-foreground">{turn.user_message}</p>
+          {/* One line while collapsed, so a list of turns stays scannable.
+              Expanding is the only place the question is shown in full: it is
+              not repeated in the diff below, and one truncated line is about
+              six words on a phone. */}
+          <p className={`text-sm text-foreground ${open ? 'break-words' : 'truncate'}`}>
+            {turn.user_message}
+          </p>
           <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
             <span className="text-muted-foreground">
               {AGREEMENT_COPY[turn.agreement] ?? turn.agreement}
@@ -391,7 +401,7 @@ function TurnCard({ turn }: { turn: EvalTurn }) {
                 {turn.historic_reply}
               </p>
               {turn.historic_tool_names.length > 0 ? (
-                <p className="mt-1 font-mono text-xs text-muted-foreground">
+                <p className="mt-1 break-all font-mono text-xs text-muted-foreground">
                   {turn.historic_tool_names.join(', ')}
                 </p>
               ) : null}
@@ -535,15 +545,15 @@ export default function ModelEvalReportPage({ runId }: { runId: string }) {
 
       {isActive ? (
         <section className="rounded-[--radius-lg] border border-border bg-card p-4">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-sm text-foreground">
+          <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="min-w-0 break-words text-sm text-foreground">
               Replaying {run.progress_completed} of {run.progress_total || '?'} turns against{' '}
               {run.candidate_model}
             </p>
             <button
               type="button"
               onClick={() => void handleCancel()}
-              className="rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
+              className="shrink-0 rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
             >
               Cancel
             </button>

--- a/frontend/src/extensions/admin/tabs/model-eval.test.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import ModelEvalTab from './model-eval';
@@ -31,6 +31,18 @@ vi.mock('../llm-picker', () => ({
     <input aria-label="model" value={value} onChange={e => onChange(e.target.value)} />
   ),
 }));
+
+// The run history renders twice: a card list up to ``xl`` and a table above
+// it, swapped by a CSS media query that jsdom does not evaluate. So a query
+// naming a run matches once per layout. Tests that are not about the layouts
+// themselves go through these; the layouts are checked against each other in
+// "shows every run in both layouts".
+const listed = (text: string) => screen.queryAllByText(text).length;
+const deleteControl = (model: string) => {
+  const [control] = screen.getAllByRole('button', { name: `Delete run against ${model}` });
+  if (!control) throw new Error(`no delete control for ${model}`);
+  return control;
+};
 
 function renderTab() {
   return render(
@@ -137,8 +149,8 @@ describe('ModelEvalTab', () => {
     renderTab();
 
     expect(await screen.findByText('Recent evaluations')).toBeInTheDocument();
-    expect(await screen.findByText('other@example.com')).toBeInTheDocument();
-    expect(screen.getByText('other-candidate')).toBeInTheDocument();
+    await screen.findAllByText('other@example.com');
+    expect(listed('other-candidate')).toBeGreaterThan(0);
     // Unfiltered: the API is asked for every user's runs.
     expect(api.listEvalRuns).toHaveBeenCalledWith(
       expect.objectContaining({ userId: undefined }),
@@ -168,7 +180,7 @@ describe('ModelEvalTab', () => {
     );
     renderTab();
 
-    expect(await screen.findByText('consent withdrawn')).toBeInTheDocument();
+    await screen.findAllByText('consent withdrawn');
     expect(screen.queryByRole('link', { name: /ago|2026/ })).not.toBeInTheDocument();
   });
 
@@ -219,8 +231,13 @@ describe('ModelEvalTab', () => {
     await screen.findByRole('option', { name: 'consenting@example.com' });
     await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
 
-    const link = await screen.findByRole('link', { name: /ago|2026/ });
-    expect(link).toHaveAttribute('href', '/app/admin/model-eval/run-0001');
+    // One per layout, and both have to point at the run: a card whose
+    // timestamp went nowhere would strand every phone visitor on the list.
+    const links = await screen.findAllByRole('link', { name: /ago|2026/ });
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', '/app/admin/model-eval/run-0001');
+    }
   });
 
   it('does not render a report inline', async () => {
@@ -232,7 +249,7 @@ describe('ModelEvalTab', () => {
 
     await screen.findByRole('option', { name: 'consenting@example.com' });
     await userEvent.selectOptions(screen.getByRole('combobox', { name: 'User' }), 'user-1');
-    await screen.findByText('candidate');
+    await screen.findAllByText('candidate');
 
     expect(api.getEvalReport).not.toHaveBeenCalled();
     expect(screen.queryByText('Turns, most concerning first')).not.toBeInTheDocument();
@@ -258,6 +275,50 @@ describe('ModelEvalTab', () => {
     );
   });
 
+  it('shows every run in both layouts', async () => {
+    // Two pieces of markup for one row can drift, and the direction it drifts
+    // is invisible to whoever changed it: a column added to the table and
+    // forgotten on the card costs nothing on a desktop and hides the field on
+    // every phone. So whatever the table says about a run, the card says too.
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
+    renderTab();
+
+    const table = await screen.findByRole('table');
+    const cards = screen.getByRole('list');
+
+    for (const layout of [table, cards]) {
+      expect(within(layout).getByText('candidate')).toBeInTheDocument();
+      expect(within(layout).getByText(/incumbent/)).toBeInTheDocument();
+      expect(within(layout).getByText('consenting@example.com')).toBeInTheDocument();
+      expect(within(layout).getByText('Safe to switch')).toBeInTheDocument();
+      expect(within(layout).getByText(/completed/)).toBeInTheDocument();
+      expect(within(layout).getByText(/\b40\b/)).toBeInTheDocument();
+      expect(within(layout).getByRole('link', { name: /ago|2026/ })).toBeInTheDocument();
+      expect(
+        within(layout).getByRole('button', { name: 'Delete run against candidate' }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('keeps the table scroller a containing block', async () => {
+    // Not styling. The header's "Actions" label is ``sr-only``, which is
+    // absolutely positioned, so without a positioned ancestor its containing
+    // block is the viewport rather than this scroller. It then escapes the
+    // clip, sits at the far edge of a table wider than the screen, and drags
+    // the document out to match, at which point a phone renders the whole
+    // page zoomed out to fit. That was the original mobile bug here, and it
+    // came back the moment the class was dropped. jsdom has no layout engine,
+    // so the class is the only part of this that can be asserted.
+    const api = await import('../admin-api');
+    vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
+    renderTab();
+
+    const scroller = (await screen.findByRole('table')).parentElement;
+    expect(scroller).toHaveClass('overflow-x-auto');
+    expect(scroller).toHaveClass('relative');
+  });
+
   it('will not delete a run until the confirmation is accepted', async () => {
     // The gate is the whole feature: the row itself navigates to the report,
     // so a delete control that fired on the first click would be one stray
@@ -266,9 +327,8 @@ describe('ModelEvalTab', () => {
     vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
     renderTab();
 
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Delete run against candidate' }),
-    );
+    await screen.findAllByText('candidate');
+    await userEvent.click(deleteControl('candidate'));
     expect(api.deleteEvalRun).not.toHaveBeenCalled();
 
     const dialog = await screen.findByRole('dialog');
@@ -286,13 +346,13 @@ describe('ModelEvalTab', () => {
     );
     renderTab();
 
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Delete run against candidate' }),
-    );
+    await screen.findAllByText('candidate');
+    await userEvent.click(deleteControl('candidate'));
     await userEvent.click(screen.getByRole('button', { name: 'Delete run' }));
 
-    await waitFor(() => expect(screen.queryByText('candidate')).not.toBeInTheDocument());
-    expect(screen.getByText('other-candidate')).toBeInTheDocument();
+    // Gone from both layouts, not just the one the click went through.
+    await waitFor(() => expect(listed('candidate')).toBe(0));
+    expect(listed('other-candidate')).toBeGreaterThan(0);
     expect(vi.mocked(api.listEvalRuns).mock.calls.length).toBe(1);
   });
 
@@ -301,13 +361,12 @@ describe('ModelEvalTab', () => {
     vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
     renderTab();
 
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Delete run against candidate' }),
-    );
+    await screen.findAllByText('candidate');
+    await userEvent.click(deleteControl('candidate'));
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(api.deleteEvalRun).not.toHaveBeenCalled();
-    expect(screen.getByText('candidate')).toBeInTheDocument();
+    expect(listed('candidate')).toBeGreaterThan(0);
   });
 
   it('offers no delete control while a run is still going', async () => {
@@ -318,10 +377,11 @@ describe('ModelEvalTab', () => {
     );
     renderTab();
 
-    await screen.findByText('candidate');
-    expect(
-      screen.queryByRole('button', { name: 'Delete run against candidate' }),
-    ).not.toBeInTheDocument();
+    await screen.findAllByText('candidate');
+    // In neither layout, so a phone cannot reach what the table withholds.
+    expect(screen.queryAllByRole('button', { name: 'Delete run against candidate' })).toHaveLength(
+      0,
+    );
   });
 
   it('keeps the delete control on a run whose user withdrew consent', async () => {
@@ -332,8 +392,8 @@ describe('ModelEvalTab', () => {
     renderTab();
 
     expect(
-      await screen.findByRole('button', { name: 'Delete run against candidate' }),
-    ).toBeInTheDocument();
+      await screen.findAllByRole('button', { name: 'Delete run against candidate' }),
+    ).toHaveLength(2);
   });
 
   it('surfaces a failed delete and keeps the row', async () => {
@@ -344,12 +404,11 @@ describe('ModelEvalTab', () => {
     );
     renderTab();
 
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Delete run against candidate' }),
-    );
+    await screen.findAllByText('candidate');
+    await userEvent.click(deleteControl('candidate'));
     await userEvent.click(screen.getByRole('button', { name: 'Delete run' }));
 
     expect(await screen.findByText(/Cancel it before deleting/)).toBeInTheDocument();
-    expect(screen.getByText('candidate')).toBeInTheDocument();
+    expect(listed('candidate')).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/extensions/admin/tabs/model-eval.test.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval.test.tsx
@@ -38,6 +38,9 @@ vi.mock('../llm-picker', () => ({
 // themselves go through these; the layouts are checked against each other in
 // "shows every run in both layouts".
 const listed = (text: string) => screen.queryAllByText(text).length;
+// The card's. Both layouts render the same ``DeleteRunButton``, so a test
+// about the delete flow rather than about the layouts gets nothing from
+// clicking each one.
 const deleteControl = (model: string) => {
   const [control] = screen.getAllByRole('button', { name: `Delete run against ${model}` });
   if (!control) throw new Error(`no delete control for ${model}`);
@@ -280,12 +283,21 @@ describe('ModelEvalTab', () => {
     // is invisible to whoever changed it: a column added to the table and
     // forgotten on the card costs nothing on a desktop and hides the field on
     // every phone. So whatever the table says about a run, the card says too.
+    //
+    // The field list below catches a field dropped from either layout. It
+    // cannot catch one added to only the table, since it never asked about
+    // that field, hence the column count: a ninth column fails here until
+    // whoever added it decides where it goes on the card.
     const api = await import('../admin-api');
     vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
     renderTab();
 
     const table = await screen.findByRole('table');
-    const cards = screen.getByRole('list');
+    const cards = screen.getByRole('list', { name: 'Evaluation runs' });
+
+    // Started, User, Candidate, Incumbent, Turns, Status, Verdict, actions.
+    // The list is unfiltered here, so the User column is present.
+    expect(within(table).getAllByRole('columnheader')).toHaveLength(8);
 
     for (const layout of [table, cards]) {
       expect(within(layout).getByText('candidate')).toBeInTheDocument();
@@ -302,14 +314,11 @@ describe('ModelEvalTab', () => {
   });
 
   it('keeps the table scroller a containing block', async () => {
-    // Not styling. The header's "Actions" label is ``sr-only``, which is
-    // absolutely positioned, so without a positioned ancestor its containing
-    // block is the viewport rather than this scroller. It then escapes the
-    // clip, sits at the far edge of a table wider than the screen, and drags
-    // the document out to match, at which point a phone renders the whole
-    // page zoomed out to fit. That was the original mobile bug here, and it
-    // came back the moment the class was dropped. jsdom has no layout engine,
-    // so the class is the only part of this that can be asserted.
+    // Not styling: dropping this class stretches the document past the
+    // viewport and the browser zooms the page out to fit. See the comment on
+    // the wrapper for the mechanism. jsdom has no layout engine, so the class
+    // is the only part of it that can be asserted here; the widths are in the
+    // commit message.
     const api = await import('../admin-api');
     vi.mocked(api.listEvalRuns).mockResolvedValue(runList([run()]));
     renderTab();

--- a/frontend/src/extensions/admin/tabs/model-eval.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval.tsx
@@ -403,7 +403,18 @@ export default function ModelEvalTab() {
                 Both layouts sit in the DOM and CSS picks one. Choosing in JS
                 would need a media query, which is only readable after mount,
                 so the first paint would show the wrong one and then jump. */}
-            <ul className="grid gap-2 p-3 sm:grid-cols-2 xl:hidden">
+            <ul
+              aria-label="Evaluation runs"
+              // ``grid-cols-1`` is not redundant. Without an explicit track
+              // the single implicit column is sized to max-content, and the
+              // card's nowrap user line then sets the card's width instead of
+              // the reverse: ``truncate`` never fires, the card grows past
+              // the viewport, and the delete control ends up off-screen. At
+              // 320px with a 47-character email that was a 420px card in a
+              // 320px window. ``main`` absorbs the overflow, so the document
+              // width stays honest and only the scroller shows it.
+              className="grid grid-cols-1 gap-2 p-3 sm:grid-cols-2 xl:hidden"
+            >
               {runs.map(run => {
                 const href = `${adminPath('model-eval')}/${run.id}`;
                 return (
@@ -415,7 +426,7 @@ export default function ModelEvalTab() {
                       if (run.user_consented) navigate(href);
                     }}
                     className={`space-y-1 rounded-[--radius-md] border border-border p-3 ${
-                      run.user_consented ? '' : 'opacity-60'
+                      run.user_consented ? 'cursor-pointer hover:bg-panel' : 'opacity-60'
                     }`}
                   >
                     <div className="flex items-start justify-between gap-2">
@@ -447,12 +458,12 @@ export default function ModelEvalTab() {
                     <div className="flex items-end justify-between gap-2">
                       <div className="min-w-0 text-xs text-muted-foreground">
                         {userId ? null : (
-                          <p className="truncate">
-                            {run.user_email || run.user_id}
+                          <>
+                            <p className="truncate">{run.user_email || run.user_id}</p>
                             {run.user_consented ? null : (
-                              <span className="ml-2 text-warning-text">consent withdrawn</span>
+                              <p className="text-warning-text">consent withdrawn</p>
                             )}
-                          </p>
+                          </>
                         )}
                         <p>
                           {run.status} | {run.progress_total || run.requested_samples} turns
@@ -469,10 +480,16 @@ export default function ModelEvalTab() {
                 ``sr-only`` span is absolutely positioned, so without a
                 positioned ancestor its containing block is the viewport
                 rather than this scroller. It then escapes the clip, sits at
-                the far edge of a table wider than the screen, and stretches
-                the document to match, at which point the browser renders the
-                whole page zoomed out to fit. Nothing else about the page
-                looks wrong, which is what made it hard to find. */}
+                the far edge of the table, and stretches the document to
+                match, at which point the browser renders the whole page
+                zoomed out to fit. Nothing else about the page looks wrong,
+                which is what made it hard to find.
+
+                It still matters at the widths this table is shown at, not
+                only at the phone widths that first surfaced it: whenever the
+                table exceeds this scroller, dropping the class stretches the
+                document. Measured at 1280px with a long user email, where the
+                table wants 1112px in a 1006px box. */}
             <div className="relative hidden overflow-x-auto xl:block">
               <table className="w-full text-sm">
                 <thead>

--- a/frontend/src/extensions/admin/tabs/model-eval.tsx
+++ b/frontend/src/extensions/admin/tabs/model-eval.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import {
   deleteEvalRun,
@@ -41,6 +41,50 @@ const SAMPLE_DEFAULT = 100;
 // about scanning, not cost.
 const RUN_PAGE_SIZE = 25;
 
+
+// ---------------------------------------------------------------------------
+// Row pieces, shared by the two layouts
+// ---------------------------------------------------------------------------
+
+/** The run's verdict, or *empty* when it has none.
+ *
+ * The table passes a dash: a blank cell in a column of pills reads as a
+ * rendering fault. A card has no column to keep aligned, so it passes
+ * nothing and lets the status line carry "running" or "cancelled".
+ */
+function VerdictPill({ run, empty = null }: { run: EvalRun; empty?: ReactNode }) {
+  const copy = RECOMMENDATION_COPY[run.recommendation as EvalRecommendation];
+  if (!copy) return <>{empty}</>;
+  return <span className={`rounded-full px-2 py-0.5 text-xs ${copy.className}`}>{copy.label}</span>;
+}
+
+/** Withheld while the run is in flight, since the API refuses to delete an
+ *  active run and wants it cancelled first.
+ *
+ * Present on every settled run, including one whose user withdrew consent:
+ * its report can no longer be opened, which makes it the row most worth
+ * clearing out.
+ */
+function DeleteRunButton({ run, onPick }: { run: EvalRun; onPick: (run: EvalRun) => void }) {
+  if (ACTIVE_STATUSES.has(run.status)) return null;
+  return (
+    <button
+      type="button"
+      aria-label={`Delete run against ${run.candidate_model}`}
+      onClick={e => {
+        // The row and the card both navigate to the report.
+        e.stopPropagation();
+        onPick(run);
+      }}
+      // A 44px target on the card, compact in the table row. DESIGN.md sets
+      // the density for a phone held in gloves, and on the card this button
+      // sits inside a tap area that navigates to the report.
+      className="min-h-11 shrink-0 rounded-[--radius-md] border border-border px-3 text-xs text-muted-foreground hover:bg-error-bg hover:text-error-text xl:min-h-0 xl:px-2 xl:py-1"
+    >
+      Delete
+    </button>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Page
@@ -300,14 +344,14 @@ export default function ModelEvalTab() {
           this user already has a run going before they try to start one. */}
       {activeRun ? (
         <section className="rounded-[--radius-lg] border border-border bg-card p-4">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-sm text-foreground">
+          <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="min-w-0 break-words text-sm text-foreground">
               Replaying {activeRun.progress_completed} of {activeRun.progress_total || '?'} turns
               against {activeRun.candidate_model}
             </p>
             <Link
               to={`${adminPath('model-eval')}/${activeRun.id}`}
-              className="rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
+              className="shrink-0 rounded-[--radius-md] border border-border px-3 py-1 text-sm text-muted-foreground"
             >
               Open report
             </Link>
@@ -346,109 +390,177 @@ export default function ModelEvalTab() {
               : 'No evaluations yet. Pick a user above to run the first one.'}
           </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="p-3">Started</th>
-                  {userId ? null : <th className="p-3">User</th>}
-                  <th className="p-3">Candidate</th>
-                  <th className="p-3">Incumbent</th>
-                  <th className="p-3">Turns</th>
-                  <th className="p-3">Status</th>
-                  <th className="p-3">Verdict</th>
-                  <th className="p-3">
-                    <span className="sr-only">Actions</span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {runs.map(run => {
-                  const copy = RECOMMENDATION_COPY[run.recommendation as EvalRecommendation];
-                  const href = `${adminPath('model-eval')}/${run.id}`;
-                  return (
-                    <tr
-                      key={run.id}
-                      onClick={() => {
-                        // A run whose user withdrew consent has no readable
-                        // report, so the row is not a way into one.
-                        if (run.user_consented) navigate(href);
-                      }}
-                      className={`border-t border-border ${
-                        run.user_consented ? 'cursor-pointer hover:bg-panel' : 'opacity-60'
-                      }`}
-                    >
-                      <td className="whitespace-nowrap p-3 text-muted-foreground">
-                        {run.user_consented ? (
-                          // A real link, so the row is keyboard reachable and
-                          // its URL is copyable.
-                          <Link
-                            to={href}
-                            className="text-primary hover:underline"
-                            onClick={e => e.stopPropagation()}
-                          >
-                            {formatRelative(run.created_at)}
-                          </Link>
-                        ) : (
-                          formatRelative(run.created_at)
+          <>
+            {/* Cards up to the width where the table below fits. Eight
+                columns of it measure 990px, and the sidebar leaves 750px at
+                1024px of viewport, so the switch is ``xl``: anything narrower
+                showed Started and User and hid the verdict and the delete
+                control behind a sideways scroll inside the card, which is the
+                same complaint on a laptop as on a phone. Two-up from ``sm``,
+                since one column of cards across a 1200px window is mostly
+                empty space.
+
+                Both layouts sit in the DOM and CSS picks one. Choosing in JS
+                would need a media query, which is only readable after mount,
+                so the first paint would show the wrong one and then jump. */}
+            <ul className="grid gap-2 p-3 sm:grid-cols-2 xl:hidden">
+              {runs.map(run => {
+                const href = `${adminPath('model-eval')}/${run.id}`;
+                return (
+                  <li
+                    key={run.id}
+                    onClick={() => {
+                      // A run whose user withdrew consent has no readable
+                      // report, so the card is not a way into one.
+                      if (run.user_consented) navigate(href);
+                    }}
+                    className={`space-y-1 rounded-[--radius-md] border border-border p-3 ${
+                      run.user_consented ? '' : 'opacity-60'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      {run.user_consented ? (
+                        <Link
+                          to={href}
+                          className="text-sm text-primary hover:underline"
+                          onClick={e => e.stopPropagation()}
+                        >
+                          {formatRelative(run.created_at)}
+                        </Link>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">
+                          {formatRelative(run.created_at)}
+                        </span>
+                      )}
+                      <VerdictPill run={run} />
+                    </div>
+                    {/* ``break-all`` rather than a truncation: a
+                        gateway-qualified model id is one unbroken 40-character
+                        token whose tail is the part that identifies it, and it
+                        is the reason an operator opened this list. */}
+                    <p className="break-all font-mono text-xs text-foreground">
+                      {run.candidate_model}
+                    </p>
+                    <p className="break-all font-mono text-xs text-muted-foreground">
+                      against {run.baseline_model}
+                    </p>
+                    <div className="flex items-end justify-between gap-2">
+                      <div className="min-w-0 text-xs text-muted-foreground">
+                        {userId ? null : (
+                          <p className="truncate">
+                            {run.user_email || run.user_id}
+                            {run.user_consented ? null : (
+                              <span className="ml-2 text-warning-text">consent withdrawn</span>
+                            )}
+                          </p>
                         )}
-                      </td>
-                      {userId ? null : (
+                        <p>
+                          {run.status} | {run.progress_total || run.requested_samples} turns
+                        </p>
+                      </div>
+                      <DeleteRunButton run={run} onPick={setDeleteTarget} />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+
+            {/* ``relative`` is load-bearing, not decoration. The header's
+                ``sr-only`` span is absolutely positioned, so without a
+                positioned ancestor its containing block is the viewport
+                rather than this scroller. It then escapes the clip, sits at
+                the far edge of a table wider than the screen, and stretches
+                the document to match, at which point the browser renders the
+                whole page zoomed out to fit. Nothing else about the page
+                looks wrong, which is what made it hard to find. */}
+            <div className="relative hidden overflow-x-auto xl:block">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="p-3">Started</th>
+                    {userId ? null : <th className="p-3">User</th>}
+                    <th className="p-3">Candidate</th>
+                    <th className="p-3">Incumbent</th>
+                    <th className="p-3">Turns</th>
+                    <th className="p-3">Status</th>
+                    <th className="p-3">Verdict</th>
+                    <th className="p-3">
+                      <span className="sr-only">Actions</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {runs.map(run => {
+                    const href = `${adminPath('model-eval')}/${run.id}`;
+                    return (
+                      <tr
+                        key={run.id}
+                        onClick={() => {
+                          if (run.user_consented) navigate(href);
+                        }}
+                        className={`border-t border-border ${
+                          run.user_consented ? 'cursor-pointer hover:bg-panel' : 'opacity-60'
+                        }`}
+                      >
                         <td className="whitespace-nowrap p-3 text-muted-foreground">
-                          {run.user_email || run.user_id}
-                          {run.user_consented ? null : (
-                            <span className="ml-2 text-xs text-warning-text">
-                              consent withdrawn
-                            </span>
+                          {run.user_consented ? (
+                            // A real link, so the row is keyboard reachable
+                            // and its URL is copyable.
+                            <Link
+                              to={href}
+                              className="text-primary hover:underline"
+                              onClick={e => e.stopPropagation()}
+                            >
+                              {formatRelative(run.created_at)}
+                            </Link>
+                          ) : (
+                            formatRelative(run.created_at)
                           )}
                         </td>
-                      )}
-                      <td className="whitespace-nowrap p-3 font-mono text-xs text-foreground">
-                        {run.candidate_model}
-                      </td>
-                      <td className="whitespace-nowrap p-3 font-mono text-xs text-muted-foreground">
-                        {run.baseline_model}
-                      </td>
-                      <td className="p-3 text-muted-foreground">
-                        {run.progress_total || run.requested_samples}
-                      </td>
-                      <td className="whitespace-nowrap p-3 text-muted-foreground">{run.status}</td>
-                      <td className="whitespace-nowrap p-3">
-                        {copy ? (
-                          <span className={`rounded-full px-2 py-0.5 text-xs ${copy.className}`}>
-                            {copy.label}
-                          </span>
-                        ) : (
-                          <span className="text-muted-foreground">-</span>
+                        {userId ? null : (
+                          <td className="whitespace-nowrap p-3 text-muted-foreground">
+                            {run.user_email || run.user_id}
+                            {run.user_consented ? null : (
+                              <span className="ml-2 text-xs text-warning-text">
+                                consent withdrawn
+                              </span>
+                            )}
+                          </td>
                         )}
-                      </td>
-                      {/* Present on every row, including a withdrawn-consent
-                          one whose report cannot be opened: that is the row
-                          most worth clearing out. Withheld only while the run
-                          is in flight, since the API wants it cancelled
-                          first. */}
-                      <td className="whitespace-nowrap p-3 text-right">
-                        {ACTIVE_STATUSES.has(run.status) ? null : (
-                          <button
-                            type="button"
-                            aria-label={`Delete run against ${run.candidate_model}`}
-                            onClick={e => {
-                              // The row itself navigates to the report.
-                              e.stopPropagation();
-                              setDeleteTarget(run);
-                            }}
-                            className="rounded-[--radius-md] border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-error-bg hover:text-error-text"
-                          >
-                            Delete
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                        {/* Wrapping, unlike every other column. A
+                            gateway-qualified model id runs past 40 characters
+                            and two of them held on one line pushed Verdict
+                            and the delete control off the right edge of the
+                            card at 1440px, where the only way to reach them
+                            was to scroll the table sideways. */}
+                        <td className="break-all p-3 font-mono text-xs text-foreground">
+                          {run.candidate_model}
+                        </td>
+                        <td className="break-all p-3 font-mono text-xs text-muted-foreground">
+                          {run.baseline_model}
+                        </td>
+                        <td className="p-3 text-muted-foreground">
+                          {run.progress_total || run.requested_samples}
+                        </td>
+                        <td className="whitespace-nowrap p-3 text-muted-foreground">
+                          {run.status}
+                        </td>
+                        <td className="whitespace-nowrap p-3">
+                          <VerdictPill
+                            run={run}
+                            empty={<span className="text-muted-foreground">-</span>}
+                          />
+                        </td>
+                        <td className="whitespace-nowrap p-3 text-right">
+                          <DeleteRunButton run={run} onPick={setDeleteTarget} />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
         {runTotal > runs.length ? (
           <div className="border-t border-border p-3">


### PR DESCRIPTION
## Description

Fixes a bug from #1537. The runs table header's `sr-only` "Actions" label is absolutely positioned; the scroll wrapper was `static`, so its containing block was the viewport rather than the scroller. It escaped the clip, sat at the far edge of the table, and stretched the document to 1567px against a 390px viewport. The browser then zoomed the page out to its 0.25 minimum scale to fit, so every control was about a quarter size with three quarters of the screen blank. `relative` on the wrapper contains it. It still earns its place at the widths the table is shown at: at 1280px with a long user email the table wants 1112px in a 1006px scroller, and forcing `static` back on stretches the document to 1293px.

Below `xl` the runs render as cards, one column on a phone and two from `sm`. Eight table columns measure 1001px and the sidebar leaves 750px at a 1024px viewport, so under `xl` the table showed Started and User and hid the candidate, the verdict and the delete control behind a sideways scroll inside the card. Both layouts render with CSS picking one, following `users.tsx:317-410`, which is the pattern this admin surface already uses and what AGENTS.md asks for over a JS layout swap.

The table's two model columns now wrap, cutting it from 1618px to 1001px, so Verdict and Delete are reachable at 1440px. They were not, with real gateway-qualified model ids.

On the report: tool-call arguments serialize to one unbroken token and were being clipped rather than wrapped, hiding most of every call including the `workspace_write_file` payload an unrequested-mutation finding is about. Summary tiles go two-up. The turn's question shows in full once expanded, since it appears nowhere else on the page.

### Second commit

Review caught the card layout reintroducing this PR's own symptom. `grid` with no base track sizes its single implicit column to max-content, and the card's `truncate` user line is `white-space: nowrap`, so that line set the card's width: at 320px with a 47-character email the card was 420px in a 320px window with Delete at x=436. It passed the first round of verification because `main` carries `overflow-x: auto` and absorbs the overflow, so `documentElement.scrollWidth` stayed honest. The scroller is what needs measuring.

Also in that commit: `cursor-pointer` and hover on a card that navigates on tap, the "consent withdrawn" marker out of the truncating paragraph that was clipping it, and a column-count assertion so the parity test catches a column added to only the table (the field list alone did not, though the first commit claimed it did).

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] CI/CD
- [ ] Documentation

## Checklist
- [x] Tests pass (`uv run pytest -v`) | frontend 414 passed; no backend change in this PR
- [x] Lint passes (`ruff check backend/ && ruff format --check backend/`) | no backend change; `npm run typecheck` and `npm run deadcode` green
- [x] New tests added for new functionality | two layout guards, each shown failing without its fix
- [x] Bug fixes include regression tests | the scroller containing-block guard, and the column-count guard for layout drift

Also green: `npm run test`, `npm run build`, `node scripts/audit-contrast.mjs`. No schema change, so no OpenAPI regeneration.

Verified in a browser at 320, 390, 768, 1024, 1180, 1280, 1440 and 1920, with operator emails of 6, 28 and 47 characters: no document or scroller overflow, one layout in the accessibility tree at each width, and the delete control on screen everywhere. Reviewed by a separate agent that had only the PR and the repo, which is what found the card-grid defect.

## AI Usage
- [x] AI-assisted (drafted by Claude Opus 5 via back-and-forth with @njbrake)
- [ ] No AI used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved mobile readability on admin model evaluation pages.
- Replaced the mobile runs table with responsive cards while retaining the desktop table.
- Added consistent fields and actions across both layouts.
- Improved text wrapping for model names, tool-call arguments, questions, and report content.
- Prevented card overflow and kept actions reachable.
- Added regression and layout tests for responsive behavior and table/card consistency.

## Benefits

- Makes evaluation results easier to read on phones and tablets.
- Keeps Verdict and Delete actions accessible on narrow screens.
- Reduces clipping and overflow for long content.
- Confirms responsive behavior through automated tests and verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->