### PR TITLE
feat(admin): list models through an endpoint, and let an operator test one

### DIFF
--- a/backend/app/middleware/admin_config_guard.py
+++ b/backend/app/middleware/admin_config_guard.py
@@ -44,7 +44,6 @@ _PROTECTED_PREFIXES: tuple[str, ...] = ("/api/user/model/endpoints",)
 # and integration wiring, so it sits behind the same admin gate.
 _GET_PROTECTED_PATHS: set[str] = {
     "/api/user/model/config",
-    "/api/user/model/endpoints",
     "/api/user/conversation/system-prompt",
 }
 

--- a/backend/app/middleware/admin_config_guard.py
+++ b/backend/app/middleware/admin_config_guard.py
@@ -29,9 +29,12 @@ _PUT_PROTECTED_PATHS: set[str] = {
     "/api/user/channels/config",
 }
 
-# Prefixes whose every write is admin-only. An LLM endpoint is a credential
-# and a destination for the whole deployment's traffic, so it is guarded like
-# the model config it feeds, and by prefix because the name is in the path.
+# Prefixes under which every method is admin-only. An LLM endpoint is a
+# credential and a destination for the whole deployment's traffic, so it is
+# guarded like the model config it feeds, and by prefix because the name is in
+# the path. Reads are included: the sub-path GET enumerates models *through*
+# the endpoint, which spends the operator's credential on the caller's
+# request, and the exact-path GET lists which gateway the deployment uses.
 _PROTECTED_PREFIXES: tuple[str, ...] = ("/api/user/model/endpoints",)
 
 # Paths that only admins may read. The model config exposes the LLM
@@ -67,7 +70,7 @@ class AdminConfigGuardMiddleware:
         is_protected = (
             (method == "PUT" and path in _PUT_PROTECTED_PATHS)
             or (method == "GET" and path in _GET_PROTECTED_PATHS)
-            or (method in ("PUT", "POST", "DELETE") and path.startswith(_PROTECTED_PREFIXES))
+            or path.startswith(_PROTECTED_PREFIXES)
         )
         if not is_protected:
             await self.app(scope, receive, send)

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -1,8 +1,12 @@
 """Endpoints for user profile management."""
 
 import datetime
+import logging
+import time
 from typing import cast
 
+from any_llm import amessages
+from any_llm.exceptions import MissingApiKeyError
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import CursorResult, delete, select, update
 from sqlalchemy import func as sa_func
@@ -29,6 +33,7 @@ from backend.app.database import get_async_db
 from backend.app.models import ChannelRoute, HeartbeatLog, LLMUsageLog, User
 from backend.app.query_helpers import get_or_404_async
 from backend.app.schemas import (
+    AdminLLMModelsResponse,
     ChannelConfigResponse,
     ChannelConfigUpdate,
     ChannelRouteListResponse,
@@ -41,6 +46,8 @@ from backend.app.schemas import (
     HeartbeatLogListResponse,
     LLMEndpointItem,
     LLMEndpointListResponse,
+    LLMEndpointTestRequest,
+    LLMEndpointTestResult,
     LLMEndpointUpsert,
     LLMUsageByPurpose,
     LLMUsageSummary,
@@ -56,8 +63,10 @@ from backend.app.services.llm_endpoints import (
     delete_endpoint,
     endpoint_delete_blockers,
     endpoint_item,
+    get_endpoint,
     list_endpoints,
     missing_endpoints,
+    resolve_target,
     upsert_endpoint,
 )
 from backend.app.services.llm_service import (
@@ -65,6 +74,8 @@ from backend.app.services.llm_service import (
     get_models,
     is_local_provider,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -565,6 +576,148 @@ async def upsert_llm_endpoint(
         },
     )
     return endpoint_item(row)
+
+
+@router.get(
+    "/user/model/endpoints/{name}/models",
+    response_model=AdminLLMModelsResponse,
+)
+async def list_llm_endpoint_models(
+    name: str,
+    _current_user: User = Depends(get_current_user),
+) -> AdminLLMModelsResponse:
+    """Enumerate the models a configured endpoint serves.
+
+    The provider-scoped listing route deliberately refuses a caller-supplied
+    ``api_base``, because honoring one would make the server deliver a
+    provider key from its environment to whatever host the caller named. That
+    objection does not reach here: the caller names an endpoint, not a URL,
+    and the base and credential come from the stored row. Nothing about the
+    destination is caller-controlled.
+
+    Without this the model field falls back to free text whenever an endpoint
+    is selected, which is the one case where the operator is least likely to
+    know the exact model id by heart.
+
+    Never raises for "this endpoint cannot list models" or "the call failed".
+    Both are ordinary states the form has to render, and a 502 would leave it
+    with nothing to say.
+    """
+    row = await get_endpoint(name)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Endpoint {name!r} not found")
+
+    try:
+        models = await get_models(
+            row.dialect,
+            api_key=row.api_key or None,
+            api_base=row.base_url or None,
+        )
+    except NotImplementedError as exc:
+        return AdminLLMModelsResponse(
+            provider=row.dialect,
+            models=[],
+            supports_listing=False,
+            error=str(exc) or "This endpoint's dialect does not support listing models.",
+        )
+    except MissingApiKeyError as exc:
+        return AdminLLMModelsResponse(
+            provider=row.dialect, models=[], supports_listing=True, error=str(exc)
+        )
+    except Exception as exc:
+        logger.warning("Listing models for endpoint %r failed: %s", name, exc)
+        return AdminLLMModelsResponse(
+            provider=row.dialect,
+            models=[],
+            supports_listing=True,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    return AdminLLMModelsResponse(provider=row.dialect, models=models, supports_listing=True)
+
+
+# A tool schema small enough to be free and real enough to be refused. The
+# failure this probe exists to catch only appears when tools and reasoning are
+# on the same request: at least one gateway-served model accepts either alone
+# and rejects the pair on ``/v1/chat/completions``, so a reachability check
+# that sent no tools would pass while every agent turn 400s.
+_PROBE_TOOL = {
+    "name": "noop",
+    "description": "Does nothing. Present only so the request carries a tool.",
+    "input_schema": {"type": "object", "properties": {}},
+}
+
+
+@router.post(
+    "/user/model/endpoints/{name}/test",
+    response_model=LLMEndpointTestResult,
+)
+async def test_llm_endpoint(
+    name: str,
+    body: LLMEndpointTestRequest,
+    _current_user: User = Depends(get_current_user),
+) -> LLMEndpointTestResult:
+    """Send one minimal request through an endpoint and report what came back.
+
+    Shaped like a real agent turn rather than a ping: same reasoning
+    parameter the endpoint's ``reasoning`` column produces, and a tool
+    attached. Both halves matter, and only together. An endpoint can answer a
+    bare completion perfectly and still refuse every request the agent
+    actually makes.
+
+    ``model`` is optional. Left empty, the endpoint is asked what it serves
+    and the first answer is used, which is the common case right after
+    creating one. Failures come back as ``ok: false`` with the provider's own
+    text, because "your gateway rejected this" is the answer the operator
+    needs to read, not a 502.
+    """
+    row = await get_endpoint(name)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Endpoint {name!r} not found")
+
+    target = await resolve_target(endpoint=name, provider="", model=body.model)
+    model = body.model
+    if not model:
+        try:
+            listed = await get_models(
+                row.dialect, api_key=row.api_key or None, api_base=row.base_url or None
+            )
+        except Exception:
+            listed = []
+        if not listed:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Endpoint {name!r} could not be asked what it serves, so the probe "
+                    "needs a model id."
+                ),
+            )
+        model = listed[0]
+        target = await resolve_target(endpoint=name, provider="", model=model)
+
+    reasoning = target.reasoning_kwargs(settings.reasoning_effort)
+    started = time.monotonic()
+    try:
+        await amessages(
+            **target.connection_kwargs(),
+            messages=[{"role": "user", "content": "Reply with the single word: ok"}],
+            tools=[dict(_PROBE_TOOL)],
+            max_tokens=16,
+            **reasoning,
+        )
+    except Exception as exc:
+        return LLMEndpointTestResult(
+            ok=False,
+            model=model,
+            detail=f"{type(exc).__name__}: {exc}",
+            latency_ms=(time.monotonic() - started) * 1000,
+            reasoning=str(reasoning) if reasoning else "(none)",
+        )
+    return LLMEndpointTestResult(
+        ok=True,
+        model=model,
+        latency_ms=(time.monotonic() - started) * 1000,
+        reasoning=str(reasoning) if reasoning else "(none)",
+    )
 
 
 @router.delete("/user/model/endpoints/{name}", status_code=204)

--- a/backend/app/routers/user_profile.py
+++ b/backend/app/routers/user_profile.py
@@ -1,9 +1,10 @@
 """Endpoints for user profile management."""
 
+import asyncio
 import datetime
 import logging
 import time
-from typing import cast
+from typing import Any, cast
 
 from any_llm import amessages
 from any_llm.exceptions import MissingApiKeyError
@@ -70,6 +71,7 @@ from backend.app.services.llm_endpoints import (
     upsert_endpoint,
 )
 from backend.app.services.llm_service import (
+    LLMTarget,
     get_configured_providers,
     get_models,
     is_local_provider,
@@ -608,10 +610,13 @@ async def list_llm_endpoint_models(
         raise HTTPException(status_code=404, detail=f"Endpoint {name!r} not found")
 
     try:
-        models = await get_models(
-            row.dialect,
-            api_key=row.api_key or None,
-            api_base=row.base_url or None,
+        models = await asyncio.wait_for(
+            get_models(
+                row.dialect,
+                api_key=row.api_key or None,
+                api_base=row.base_url or None,
+            ),
+            timeout=_LIST_TIMEOUT_SECONDS,
         )
     except NotImplementedError as exc:
         return AdminLLMModelsResponse(
@@ -646,6 +651,47 @@ _PROBE_TOOL = {
     "input_schema": {"type": "object", "properties": {}},
 }
 
+# The smallest thinking budget the Anthropic API accepts.
+_PROBE_THINKING_BUDGET = 1024
+
+# A gateway that accepts the connection and never answers would otherwise hold
+# the request for the provider SDK's own default, which is ten minutes, with
+# the Test button disabled the whole time and no way to cancel it.
+_PROBE_TIMEOUT_SECONDS = 60.0
+_LIST_TIMEOUT_SECONDS = 30.0
+
+
+def _probe_call_shape(target: LLMTarget) -> tuple[dict[str, Any], int, str]:
+    """Reasoning kwargs, ``max_tokens``, and a label, for one probe request.
+
+    A thinking budget must be *smaller* than ``max_tokens``; the Anthropic SDK
+    states the rule on ``ThinkingConfigEnabledParam``. Pairing a fixed tiny
+    ``max_tokens`` with a configured budget therefore manufactures a 400 on a
+    perfectly healthy endpoint, and the probe reports the gateway broken for a
+    rule the probe itself broke. Every effort level trips it, since the
+    smallest budget is 1024.
+
+    The budget is clamped to that minimum rather than tracking
+    ``reasoning_effort``. What this probe answers is whether the endpoint
+    accepts reasoning *and tools on the same request*, which is a question
+    about the parameter's shape rather than its size, and a probe that spent a
+    32768-token budget per click would be too expensive to click freely.
+    """
+    reasoning = target.reasoning_kwargs(settings.reasoning_effort)
+    thinking = reasoning.get("thinking")
+    if isinstance(thinking, dict) and thinking.get("type") == "enabled":
+        budget = _PROBE_THINKING_BUDGET
+        return (
+            {"thinking": {"type": "enabled", "budget_tokens": budget}},
+            budget + 64,
+            f"thinking, clamped to a {budget}-token budget",
+        )
+    if "reasoning_effort" in reasoning:
+        return reasoning, 256, f"effort={reasoning['reasoning_effort']}"
+    if thinking:
+        return reasoning, 64, "thinking disabled"
+    return {}, 64, "none"
+
 
 @router.post(
     "/user/model/endpoints/{name}/test",
@@ -654,7 +700,7 @@ _PROBE_TOOL = {
 async def test_llm_endpoint(
     name: str,
     body: LLMEndpointTestRequest,
-    _current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> LLMEndpointTestResult:
     """Send one minimal request through an endpoint and report what came back.
 
@@ -674,12 +720,12 @@ async def test_llm_endpoint(
     if row is None:
         raise HTTPException(status_code=404, detail=f"Endpoint {name!r} not found")
 
-    target = await resolve_target(endpoint=name, provider="", model=body.model)
     model = body.model
     if not model:
         try:
-            listed = await get_models(
-                row.dialect, api_key=row.api_key or None, api_base=row.base_url or None
+            listed = await asyncio.wait_for(
+                get_models(row.dialect, api_key=row.api_key or None, api_base=row.base_url or None),
+                timeout=_LIST_TIMEOUT_SECONDS,
             )
         except Exception:
             listed = []
@@ -692,31 +738,42 @@ async def test_llm_endpoint(
                 ),
             )
         model = listed[0]
-        target = await resolve_target(endpoint=name, provider="", model=model)
 
-    reasoning = target.reasoning_kwargs(settings.reasoning_effort)
+    target = await resolve_target(endpoint=name, provider="", model=model)
+    reasoning, max_tokens, label = _probe_call_shape(target)
     started = time.monotonic()
     try:
-        await amessages(
-            **target.connection_kwargs(),
-            messages=[{"role": "user", "content": "Reply with the single word: ok"}],
-            tools=[dict(_PROBE_TOOL)],
-            max_tokens=16,
-            **reasoning,
+        await asyncio.wait_for(
+            amessages(
+                **target.connection_kwargs(),
+                messages=[{"role": "user", "content": "Reply with the single word: ok"}],
+                tools=[dict(_PROBE_TOOL)],
+                max_tokens=max_tokens,
+                **reasoning,
+            ),
+            timeout=_PROBE_TIMEOUT_SECONDS,
         )
+        ok, detail = True, ""
+    except TimeoutError:
+        ok, detail = False, f"No answer within {_PROBE_TIMEOUT_SECONDS:.0f}s."
     except Exception as exc:
-        return LLMEndpointTestResult(
-            ok=False,
-            model=model,
-            detail=f"{type(exc).__name__}: {exc}",
-            latency_ms=(time.monotonic() - started) * 1000,
-            reasoning=str(reasoning) if reasoning else "(none)",
-        )
+        ok, detail = False, f"{type(exc).__name__}: {exc}"
+
+    latency_ms = (time.monotonic() - started) * 1000
+    # Spends the operator's credential on an outbound request, so it leaves a
+    # record like the writes do. The provider's error text stays out of the
+    # trail: it goes to the caller, and the log is read by more people than
+    # can set a credential.
+    await record_admin_action(
+        action=AdminAction.TEST_LLM_ENDPOINT,
+        admin_user_id=current_user.id,
+        endpoint="POST /api/user/model/endpoints/{name}/test",
+        resource_type="llm_endpoint",
+        resource_id=name,
+        detail={"model": model, "ok": ok, "reasoning": label},
+    )
     return LLMEndpointTestResult(
-        ok=True,
-        model=model,
-        latency_ms=(time.monotonic() - started) * 1000,
-        reasoning=str(reasoning) if reasoning else "(none)",
+        ok=ok, model=model, detail=detail, latency_ms=latency_ms, reasoning=label
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -317,10 +317,9 @@ class LLMEndpointTestResult(BaseModel):
     detail: str = ""
     """Empty on success; the provider's own error text otherwise."""
     latency_ms: float = 0.0
-    sent_tools: bool = True
-    """Whether the probe carried a tool schema. See the handler for why."""
     reasoning: str = ""
-    """The reasoning parameter the endpoint's setting produced, or "(none)"."""
+    """How the probe asked for reasoning, in words. The probe always carries a
+    tool, so there is nothing to report about that."""
 
 
 class LLMEndpointUpsert(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -302,6 +302,27 @@ class LLMEndpointListResponse(BaseModel):
     items: list[LLMEndpointItem]
 
 
+class LLMEndpointTestRequest(BaseModel):
+    """Optional model to probe with. Empty asks the endpoint what it serves."""
+
+    model: str = Field(default="", max_length=128)
+
+
+class LLMEndpointTestResult(BaseModel):
+    """Outcome of one probe call against a configured endpoint."""
+
+    ok: bool
+    model: str = ""
+    """The model actually probed, which may have been chosen for the caller."""
+    detail: str = ""
+    """Empty on success; the provider's own error text otherwise."""
+    latency_ms: float = 0.0
+    sent_tools: bool = True
+    """Whether the probe carried a tool schema. See the handler for why."""
+    reasoning: str = ""
+    """The reasoning parameter the endpoint's setting produced, or "(none)"."""
+
+
 class LLMEndpointUpsert(BaseModel):
     """Create or replace one endpoint.
 

--- a/backend/app/services/admin_audit.py
+++ b/backend/app/services/admin_audit.py
@@ -85,6 +85,7 @@ class AdminAction(StrEnum):
     VIEW_LLM_CONFIG = "view_llm_config"
     UPDATE_LLM_CONFIG = "update_llm_config"
     UPSERT_LLM_ENDPOINT = "upsert_llm_endpoint"
+    TEST_LLM_ENDPOINT = "test_llm_endpoint"
     DELETE_LLM_ENDPOINT = "delete_llm_endpoint"
     VIEW_USER_LLM_OVERRIDE = "view_user_llm_override"
     UPDATE_USER_LLM_OVERRIDE = "update_user_llm_override"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -999,6 +999,96 @@
         }
       }
     },
+    "/api/user/model/endpoints/{name}/models": {
+      "get": {
+        "summary": "List Llm Endpoint Models",
+        "description": "Enumerate the models a configured endpoint serves.\n\nThe provider-scoped listing route deliberately refuses a caller-supplied\n``api_base``, because honoring one would make the server deliver a\nprovider key from its environment to whatever host the caller named. That\nobjection does not reach here: the caller names an endpoint, not a URL,\nand the base and credential come from the stored row. Nothing about the\ndestination is caller-controlled.\n\nWithout this the model field falls back to free text whenever an endpoint\nis selected, which is the one case where the operator is least likely to\nknow the exact model id by heart.\n\nNever raises for \"this endpoint cannot list models\" or \"the call failed\".\nBoth are ordinary states the form has to render, and a 502 would leave it\nwith nothing to say.",
+        "operationId": "list_llm_endpoint_models_api_user_model_endpoints__name__models_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminLLMModelsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/model/endpoints/{name}/test": {
+      "post": {
+        "summary": "Test Llm Endpoint",
+        "description": "Send one minimal request through an endpoint and report what came back.\n\nShaped like a real agent turn rather than a ping: same reasoning\nparameter the endpoint's ``reasoning`` column produces, and a tool\nattached. Both halves matter, and only together. An endpoint can answer a\nbare completion perfectly and still refuse every request the agent\nactually makes.\n\n``model`` is optional. Left empty, the endpoint is asked what it serves\nand the first answer is used, which is the common case right after\ncreating one. Failures come back as ``ok: false`` with the provider's own\ntext, because \"your gateway rejected this\" is the answer the operator\nneeds to read, not a 502.",
+        "operationId": "test_llm_endpoint_api_user_model_endpoints__name__test_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMEndpointTestRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMEndpointTestResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/user/providers": {
       "get": {
         "summary": "List Providers",
@@ -7927,6 +8017,58 @@
           "items"
         ],
         "title": "LLMEndpointListResponse"
+      },
+      "LLMEndpointTestRequest": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "Model",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "LLMEndpointTestRequest",
+        "description": "Optional model to probe with. Empty asks the endpoint what it serves."
+      },
+      "LLMEndpointTestResult": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model",
+            "default": ""
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "default": ""
+          },
+          "latency_ms": {
+            "type": "number",
+            "title": "Latency Ms",
+            "default": 0.0
+          },
+          "sent_tools": {
+            "type": "boolean",
+            "title": "Sent Tools",
+            "default": true
+          },
+          "reasoning": {
+            "type": "string",
+            "title": "Reasoning",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "ok"
+        ],
+        "title": "LLMEndpointTestResult",
+        "description": "Outcome of one probe call against a configured endpoint."
       },
       "LLMEndpointUpsert": {
         "properties": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8052,11 +8052,6 @@
             "title": "Latency Ms",
             "default": 0.0
           },
-          "sent_tools": {
-            "type": "boolean",
-            "title": "Sent Tools",
-            "default": true
-          },
           "reasoning": {
             "type": "string",
             "title": "Reasoning",

--- a/frontend/src/extensions/admin/admin-api.ts
+++ b/frontend/src/extensions/admin/admin-api.ts
@@ -516,6 +516,46 @@ export async function upsertLLMEndpoint(
   return data as LLMEndpointItem;
 }
 
+/** What a configured endpoint says it serves.
+ *
+ * Same shape as ``listProviderModels`` so the model field can render the
+ * "cannot list" and "call failed" states identically whichever way it asked.
+ */
+export async function listEndpointModels(name: string): Promise<ProviderModelsResult> {
+  const { data, error } = await client.GET(
+    `/api/user/model/endpoints/${encodeURIComponent(name)}/models` as never,
+  );
+  if (error) throwApiError(error, 'Failed to list endpoint models');
+  return data as ProviderModelsResult;
+}
+
+export interface LLMEndpointTestResult {
+  ok: boolean;
+  model: string;
+  detail: string;
+  latency_ms: number;
+  sent_tools: boolean;
+  reasoning: string;
+}
+
+/** Send one agent-shaped request through an endpoint and report the result.
+ *
+ *  Carries a tool and the endpoint's reasoning setting, because that pairing
+ *  is what a gateway is most likely to reject. A bare reachability check can
+ *  pass while every real turn fails.
+ */
+export async function testLLMEndpoint(
+  name: string,
+  model = '',
+): Promise<LLMEndpointTestResult> {
+  const { data, error } = await client.POST(
+    `/api/user/model/endpoints/${encodeURIComponent(name)}/test` as never,
+    { body: { model } } as never,
+  );
+  if (error) throwApiError(error, 'Failed to test endpoint');
+  return data as LLMEndpointTestResult;
+}
+
 export async function deleteLLMEndpoint(name: string): Promise<void> {
   const { error } = await client.DELETE(
     `/api/user/model/endpoints/${encodeURIComponent(name)}` as never,

--- a/frontend/src/extensions/admin/admin-api.ts
+++ b/frontend/src/extensions/admin/admin-api.ts
@@ -534,7 +534,6 @@ export interface LLMEndpointTestResult {
   model: string;
   detail: string;
   latency_ms: number;
-  sent_tools: boolean;
   reasoning: string;
 }
 

--- a/frontend/src/extensions/admin/llm-picker.test.tsx
+++ b/frontend/src/extensions/admin/llm-picker.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { LLMModelField } from './llm-picker';
+
+// The model field is the surface an operator picks a model from once an
+// endpoint is selected. Its branches decide between a usable dropdown and a
+// text box, and getting that wrong is silent: the form still submits.
+
+vi.mock('./admin-api', () => ({
+  listEndpointModels: vi.fn(),
+  listProviders: vi.fn().mockResolvedValue([]),
+  listProviderModels: vi.fn(),
+  invalidateProviderModels: vi.fn(),
+  listLLMEndpoints: vi.fn().mockResolvedValue([]),
+}));
+
+const noop = () => {};
+
+beforeEach(async () => {
+  const api = await import('./admin-api');
+  vi.mocked(api.listEndpointModels).mockReset();
+});
+
+describe('LLMModelField with an endpoint selected', () => {
+  it('offers what the endpoint says it serves', async () => {
+    const api = await import('./admin-api');
+    vi.mocked(api.listEndpointModels).mockResolvedValue({
+      provider: 'anthropic',
+      models: ['gw-sonnet', 'gw-haiku'],
+      supports_listing: true,
+      error: null,
+    });
+    render(<LLMModelField endpoint="otari" provider="" value="" onChange={noop} />);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    expect(
+      Array.from(screen.getByRole('combobox').querySelectorAll('option')).map(o => o.textContent),
+    ).toEqual(['gw-sonnet', 'gw-haiku']);
+  });
+
+  it('falls back to typing when the endpoint cannot be asked', async () => {
+    // A dropdown with nothing in it would be a dead end, so this is the one
+    // case where free text is the right answer rather than a cop-out.
+    const api = await import('./admin-api');
+    vi.mocked(api.listEndpointModels).mockResolvedValue({
+      provider: 'anthropic',
+      models: [],
+      supports_listing: false,
+      error: 'no listing here',
+    });
+    render(<LLMModelField endpoint="otari" provider="" value="" onChange={noop} />);
+
+    await waitFor(() => expect(screen.getByPlaceholderText('model id')).toBeInTheDocument());
+    expect(screen.getByText(/no listing here/)).toBeInTheDocument();
+  });
+
+  it('keeps a saved model the endpoint no longer lists', async () => {
+    // Dropping it would silently rewrite a working config on first render.
+    const api = await import('./admin-api');
+    vi.mocked(api.listEndpointModels).mockResolvedValue({
+      provider: 'anthropic',
+      models: ['gw-sonnet'],
+      supports_listing: true,
+      error: null,
+    });
+    render(<LLMModelField endpoint="otari" provider="" value="retired-model" onChange={noop} />);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    expect(screen.getByText(/retired-model \(saved, not in list\)/)).toBeInTheDocument();
+  });
+
+  it('ignores an answer that arrives after the endpoint changed', async () => {
+    // The slow first response must not fill the dropdown under the second
+    // endpoint's label, which would offer models it does not serve.
+    const api = await import('./admin-api');
+    let releaseFirst: (v: never) => void = () => {};
+    vi.mocked(api.listEndpointModels)
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            releaseFirst = resolve as never;
+          }),
+      )
+      .mockResolvedValueOnce({
+        provider: 'anthropic',
+        models: ['second-model'],
+        supports_listing: true,
+        error: null,
+      });
+
+    const { rerender } = render(
+      <LLMModelField endpoint="first" provider="" value="" onChange={noop} />,
+    );
+    rerender(<LLMModelField endpoint="second" provider="" value="" onChange={noop} />);
+    await waitFor(() => expect(screen.getByText('second-model')).toBeInTheDocument());
+
+    releaseFirst({
+      provider: 'anthropic',
+      models: ['first-model'],
+      supports_listing: true,
+      error: null,
+    } as never);
+
+    await waitFor(() => expect(screen.getByText('second-model')).toBeInTheDocument());
+    expect(screen.queryByText('first-model')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/extensions/admin/llm-picker.tsx
+++ b/frontend/src/extensions/admin/llm-picker.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   invalidateProviderModels,
+  listEndpointModels,
   listLLMEndpoints,
   listProviders,
   listProviderModels,
@@ -409,6 +410,27 @@ export function LLMModelField({
   allowEmpty,
   emptyLabel,
 }: LLMModelFieldProps) {
+  const [result, setResult] = useState<ProviderModelsResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(() => {
+    if (!endpoint) return;
+    setLoading(true);
+    listEndpointModels(endpoint)
+      .then(setResult)
+      .catch((e: Error) =>
+        setResult({ provider: '', models: [], supports_listing: true, error: e.message }),
+      )
+      .finally(() => setLoading(false));
+  }, [endpoint]);
+
+  useEffect(() => {
+    setResult(null);
+    load();
+  }, [load]);
+
+  // No endpoint: the provider knows its own models, and that path already
+  // handles every failure mode.
   if (!endpoint) {
     return (
       <LLMModelSelect
@@ -421,18 +443,60 @@ export function LLMModelField({
       />
     );
   }
+
+  if (loading || !result) {
+    return (
+      <select id={id} className={selectClass} disabled value="" onChange={() => {}}>
+        <option value="">Loading models...</option>
+      </select>
+    );
+  }
+
+  // The endpoint cannot be asked, or asking failed. Typing the id is the only
+  // way forward, so say why rather than showing an empty dropdown.
+  if (!result.supports_listing || result.error || result.models.length === 0) {
+    return (
+      <div>
+        <input
+          id={id}
+          className={inputClass}
+          placeholder="model id"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+        />
+        <p className="text-[11px] text-muted-foreground mt-1 flex items-center gap-2">
+          <span>
+            {result.error ||
+              (result.supports_listing
+                ? 'This endpoint returned no models.'
+                : 'This endpoint does not enumerate models.')}
+          </span>
+          <button type="button" onClick={load} className="text-primary hover:underline">
+            Retry
+          </button>
+        </p>
+      </div>
+    );
+  }
+
+  // A saved value the endpoint no longer lists is kept as an option, so the
+  // form does not silently rewrite it on the next render.
+  const showSaved = value && !result.models.includes(value);
+
   return (
-    <div>
-      <input
-        id={id}
-        className={inputClass}
-        placeholder="model id"
-        value={value}
-        onChange={e => onChange(e.target.value)}
-      />
-      <p className="text-[11px] text-muted-foreground mt-1">
-        An endpoint cannot be asked what it serves, so type the model id it exposes.
-      </p>
-    </div>
+    <select
+      id={id}
+      className={selectClass}
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    >
+      {allowEmpty && <option value="">{emptyLabel}</option>}
+      {showSaved && <option value={value}>{value} (saved, not in list)</option>}
+      {result.models.map(m => (
+        <option key={m} value={m}>
+          {m}
+        </option>
+      ))}
+    </select>
   );
 }

--- a/frontend/src/extensions/admin/llm-picker.tsx
+++ b/frontend/src/extensions/admin/llm-picker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   invalidateProviderModels,
   listEndpointModels,
@@ -384,11 +384,10 @@ export function ReasoningEffortSelect({
 // ---------------------------------------------------------------------------
 // Model field that copes with an endpoint being selected.
 //
-// Model enumeration goes through the provider, and the listing endpoint
-// deliberately refuses a caller-supplied base URL for a hosted provider, so
-// there is no way to ask a gateway what it serves. Rather than show a picker
-// stuck on "pick a provider first", an endpoint gets a free-text field: the
-// operator types the model id the gateway exposes.
+// A provider knows its own models; an endpoint is asked through its own base
+// URL and credential (``listEndpointModels``). Both end in a dropdown. The
+// free-text fallback is for the cases where asking genuinely cannot work: a
+// dialect that does not enumerate, or a call that failed.
 // ---------------------------------------------------------------------------
 
 interface LLMModelFieldProps {
@@ -412,16 +411,27 @@ export function LLMModelField({
 }: LLMModelFieldProps) {
   const [result, setResult] = useState<ProviderModelsResult | null>(null);
   const [loading, setLoading] = useState(false);
+  // Switching endpoints while a request is in flight would otherwise let the
+  // old one's answer land last and fill the dropdown with models the newly
+  // selected endpoint does not serve, silently, under the right label.
+  const ticket = useRef(0);
 
   const load = useCallback(() => {
     if (!endpoint) return;
+    const mine = ++ticket.current;
     setLoading(true);
     listEndpointModels(endpoint)
-      .then(setResult)
-      .catch((e: Error) =>
-        setResult({ provider: '', models: [], supports_listing: true, error: e.message }),
-      )
-      .finally(() => setLoading(false));
+      .then(r => {
+        if (mine === ticket.current) setResult(r);
+      })
+      .catch((e: Error) => {
+        if (mine === ticket.current) {
+          setResult({ provider: '', models: [], supports_listing: true, error: e.message });
+        }
+      })
+      .finally(() => {
+        if (mine === ticket.current) setLoading(false);
+      });
   }, [endpoint]);
 
   useEffect(() => {

--- a/frontend/src/extensions/admin/tabs/config.tsx
+++ b/frontend/src/extensions/admin/tabs/config.tsx
@@ -273,7 +273,9 @@ function LLMEndpointsSection({ onChanged }: { onChanged: () => void }) {
                     {results[item.name]?.ok
                       ? `Answered on ${results[item.name]?.model} in ${Math.round(
                           results[item.name]?.latency_ms ?? 0,
-                        )}ms, with a tool attached and reasoning ${results[item.name]?.reasoning}.`
+                        )}ms, with a tool attached and reasoning: ${
+                          results[item.name]?.reasoning
+                        }.`
                       : results[item.name]?.detail}
                   </p>
                 )}

--- a/frontend/src/extensions/admin/tabs/config.tsx
+++ b/frontend/src/extensions/admin/tabs/config.tsx
@@ -7,11 +7,13 @@ import {
   updateAdminLLMConfig,
   listLLMEndpoints,
   upsertLLMEndpoint,
+  testLLMEndpoint,
   deleteLLMEndpoint,
   SECRET_MASK,
   type AdminChannelConfig,
   type AdminLLMConfig,
   type LLMEndpointItem,
+  type LLMEndpointTestResult,
   type LLMEndpointUpsert,
 } from '../admin-api';
 import {
@@ -133,6 +135,10 @@ function LLMEndpointsSection({ onChanged }: { onChanged: () => void }) {
   // API reads as "leave the stored key alone".
   const [draft, setDraft] = useState<LLMEndpointUpsert | null>(null);
   const [saving, setSaving] = useState(false);
+  // Name of the endpoint currently being probed, so only its own button
+  // shows the pending state.
+  const [testing, setTesting] = useState<string | null>(null);
+  const [results, setResults] = useState<Record<string, LLMEndpointTestResult>>({});
 
   const load = useCallback(() => {
     setLoading(true);
@@ -174,6 +180,25 @@ function LLMEndpointsSection({ onChanged }: { onChanged: () => void }) {
       toast.error((e as Error).message);
     } finally {
       setSaving(false);
+    }
+  };
+
+  const test = async (name: string) => {
+    setTesting(name);
+    try {
+      const result = await testLLMEndpoint(name);
+      setResults(prev => ({ ...prev, [name]: result }));
+      if (result.ok) {
+        toast.success(`${name} answered on ${result.model}`);
+      } else {
+        // The provider's own text is the useful part, so it goes on the row
+        // where it can be read rather than only into a toast that vanishes.
+        toast.error(`${name} failed: ${result.detail}`);
+      }
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setTesting(null);
     }
   };
 
@@ -219,6 +244,14 @@ function LLMEndpointsSection({ onChanged }: { onChanged: () => void }) {
                 </span>
                 <button
                   type="button"
+                  className="px-2 py-1 text-xs rounded-[--radius-sm] border border-border hover:bg-panel disabled:opacity-50"
+                  onClick={() => void test(item.name)}
+                  disabled={testing === item.name}
+                >
+                  {testing === item.name ? 'Testing...' : 'Test'}
+                </button>
+                <button
+                  type="button"
                   className="px-2 py-1 text-xs rounded-[--radius-sm] border border-border hover:bg-panel"
                   onClick={() => edit(item)}
                 >
@@ -231,6 +264,19 @@ function LLMEndpointsSection({ onChanged }: { onChanged: () => void }) {
                 >
                   Delete
                 </button>
+                {results[item.name] && (
+                  <p
+                    className={`basis-full text-[11px] ${
+                      results[item.name]?.ok ? 'text-muted-foreground' : 'text-danger'
+                    }`}
+                  >
+                    {results[item.name]?.ok
+                      ? `Answered on ${results[item.name]?.model} in ${Math.round(
+                          results[item.name]?.latency_ms ?? 0,
+                        )}ms, with a tool attached and reasoning ${results[item.name]?.reasoning}.`
+                      : results[item.name]?.detail}
+                  </p>
+                )}
               </li>
             ))}
           </ul>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -4466,11 +4466,6 @@ export interface components {
              */
             latency_ms: number;
             /**
-             * Sent Tools
-             * @default true
-             */
-            sent_tools: boolean;
-            /**
              * Reasoning
              * @default
              */

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -672,6 +672,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/user/model/endpoints/{name}/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Llm Endpoint Models
+         * @description Enumerate the models a configured endpoint serves.
+         *
+         *     The provider-scoped listing route deliberately refuses a caller-supplied
+         *     ``api_base``, because honoring one would make the server deliver a
+         *     provider key from its environment to whatever host the caller named. That
+         *     objection does not reach here: the caller names an endpoint, not a URL,
+         *     and the base and credential come from the stored row. Nothing about the
+         *     destination is caller-controlled.
+         *
+         *     Without this the model field falls back to free text whenever an endpoint
+         *     is selected, which is the one case where the operator is least likely to
+         *     know the exact model id by heart.
+         *
+         *     Never raises for "this endpoint cannot list models" or "the call failed".
+         *     Both are ordinary states the form has to render, and a 502 would leave it
+         *     with nothing to say.
+         */
+        get: operations["list_llm_endpoint_models_api_user_model_endpoints__name__models_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/user/model/endpoints/{name}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Test Llm Endpoint
+         * @description Send one minimal request through an endpoint and report what came back.
+         *
+         *     Shaped like a real agent turn rather than a ping: same reasoning
+         *     parameter the endpoint's ``reasoning`` column produces, and a tool
+         *     attached. Both halves matter, and only together. An endpoint can answer a
+         *     bare completion perfectly and still refuse every request the agent
+         *     actually makes.
+         *
+         *     ``model`` is optional. Left empty, the endpoint is asked what it serves
+         *     and the first answer is used, which is the common case right after
+         *     creating one. Failures come back as ``ok: false`` with the provider's own
+         *     text, because "your gateway rejected this" is the answer the operator
+         *     needs to read, not a 502.
+         */
+        post: operations["test_llm_endpoint_api_user_model_endpoints__name__test_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/user/providers": {
         parameters: {
             query?: never;
@@ -4366,6 +4433,50 @@ export interface components {
             items: components["schemas"]["LLMEndpointItem"][];
         };
         /**
+         * LLMEndpointTestRequest
+         * @description Optional model to probe with. Empty asks the endpoint what it serves.
+         */
+        LLMEndpointTestRequest: {
+            /**
+             * Model
+             * @default
+             */
+            model: string;
+        };
+        /**
+         * LLMEndpointTestResult
+         * @description Outcome of one probe call against a configured endpoint.
+         */
+        LLMEndpointTestResult: {
+            /** Ok */
+            ok: boolean;
+            /**
+             * Model
+             * @default
+             */
+            model: string;
+            /**
+             * Detail
+             * @default
+             */
+            detail: string;
+            /**
+             * Latency Ms
+             * @default 0
+             */
+            latency_ms: number;
+            /**
+             * Sent Tools
+             * @default true
+             */
+            sent_tools: boolean;
+            /**
+             * Reasoning
+             * @default
+             */
+            reasoning: string;
+        };
+        /**
          * LLMEndpointUpsert
          * @description Create or replace one endpoint.
          *
@@ -6680,6 +6791,72 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_llm_endpoint_models_api_user_model_endpoints__name__models_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminLLMModelsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    test_llm_endpoint_api_user_model_endpoints__name__test_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LLMEndpointTestRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LLMEndpointTestResult"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/tests/multi_user/test_admin_config_guard.py
+++ b/tests/multi_user/test_admin_config_guard.py
@@ -360,6 +360,34 @@ class TestAdminConfigGuard:
         assert resp.status_code == 200
         assert resp.json() == {"items": []}
 
+    def test_admin_still_reaches_the_endpoint_sub_paths(
+        self,
+        jwt_client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        """The prefix rule is now the only thing separating these two cases.
+
+        A 404 from the handler is the pass: it means the request got past the
+        guard and reached a route that has no such endpoint configured.
+        """
+        db_session.add(
+            Subscription(user_id=test_user.id, role="admin", plan="free", status="active")
+        )
+        db_session.commit()
+        headers = {"Authorization": f"Bearer {create_access_token(test_user.id)}"}
+
+        assert (
+            jwt_client.get("/api/user/model/endpoints/nope/models", headers=headers).status_code
+            == 404
+        )
+        assert (
+            jwt_client.post(
+                "/api/user/model/endpoints/nope/test", headers=headers, json={}
+            ).status_code
+            == 404
+        )
+
     def test_non_admin_blocked_from_get_system_prompt(
         self,
         jwt_client: TestClient,

--- a/tests/multi_user/test_admin_config_guard.py
+++ b/tests/multi_user/test_admin_config_guard.py
@@ -319,6 +319,18 @@ class TestAdminConfigGuard:
         headers = {"Authorization": f"Bearer {token}"}
 
         assert jwt_client.get("/api/user/model/endpoints", headers=headers).status_code == 403
+        # Sub-path reads too: enumerating models goes *through* the endpoint,
+        # spending the operator's credential on the caller's request.
+        assert (
+            jwt_client.get("/api/user/model/endpoints/otari/models", headers=headers).status_code
+            == 403
+        )
+        assert (
+            jwt_client.post(
+                "/api/user/model/endpoints/otari/test", headers=headers, json={}
+            ).status_code
+            == 403
+        )
         assert (
             jwt_client.put(
                 "/api/user/model/endpoints/otari",

--- a/tests/test_llm_endpoint_routes.py
+++ b/tests/test_llm_endpoint_routes.py
@@ -260,6 +260,74 @@ class TestEndpointProbe:
         assert kwargs["reasoning_effort"] == "high"
         assert kwargs["api_base"] == "https://ai.example.test"
 
+    @pytest.mark.parametrize("reasoning", ["auto", "thinking"])
+    @pytest.mark.parametrize("effort", ["minimal", "medium", "high", "xhigh"])
+    def test_the_probe_leaves_room_for_the_thinking_budget_it_asks_for(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        reasoning: str,
+        effort: str,
+    ) -> None:
+        """A budget must be smaller than ``max_tokens``, or the call is invalid.
+
+        The probe used to send a fixed ``max_tokens=16`` beside whatever
+        budget the endpoint's reasoning produced. The smallest budget is
+        1024, so every effort level made the request invalid and a healthy
+        endpoint came back as failed, for a rule the probe itself broke.
+
+        ``auto`` is in the parameters because it is the default for a newly
+        created endpoint, and it resolves to the thinking shape.
+        """
+        client.put(f"{BASE}/otari", json=_body(reasoning=reasoning))
+        monkeypatch.setattr(settings, "reasoning_effort", effort)
+        sent = AsyncMock(return_value=object())
+        with patch("backend.app.routers.user_profile.amessages", new=sent):
+            resp = client.post(f"{BASE}/otari/test", json={"model": "gw-model"})
+
+        assert resp.status_code == 200
+        call = sent.await_args
+        assert call is not None
+        budget = call.kwargs["thinking"]["budget_tokens"]
+        assert call.kwargs["max_tokens"] > budget, (
+            f"max_tokens={call.kwargs['max_tokens']} must exceed budget={budget}"
+        )
+        # And the label reaching the UI is words, not a repr of a dict.
+        assert "{" not in resp.json()["reasoning"]
+
+    def test_the_probe_is_audited_without_recording_the_providers_words(
+        self, client: TestClient
+    ) -> None:
+        """It spends the operator's credential, so it leaves a trail.
+
+        The gateway's error text is not part of that trail: it goes to the
+        caller, and the log is read by more people than can set a credential.
+        """
+
+        async def _latest() -> AdminAuditLog | None:
+            async with db_session_async() as db:
+                return (
+                    (await db.execute(select(AdminAuditLog).order_by(AdminAuditLog.id.desc())))
+                    .scalars()
+                    .first()
+                )
+
+        client.put(f"{BASE}/otari", json=_body())
+        with patch(
+            "backend.app.routers.user_profile.amessages",
+            new=AsyncMock(side_effect=RuntimeError("gateway said no: secret-ish detail")),
+        ):
+            resp = client.post(f"{BASE}/otari/test", json={"model": "gw-model"})
+
+        assert resp.json()["ok"] is False
+        row = asyncio.run(_latest())
+        assert row is not None
+        assert row.action == "test_llm_endpoint"
+        assert row.resource_id == "otari"
+        assert row.detail is not None
+        assert row.detail["ok"] is False
+        assert "secret-ish" not in str(row.detail)
+
     def test_a_rejection_comes_back_as_a_result_not_an_error(self, client: TestClient) -> None:
         """The gateway's own words are the useful part of a failed test."""
         client.put(f"{BASE}/otari", json=_body())

--- a/tests/test_llm_endpoint_routes.py
+++ b/tests/test_llm_endpoint_routes.py
@@ -6,6 +6,7 @@ never come back out of the API, and re-submitting the form must not blank it.
 
 import asyncio
 from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -166,6 +167,147 @@ def test_names_are_restricted_to_a_slug(client: TestClient, name: str) -> None:
 def test_an_empty_name_does_not_reach_the_handler(client: TestClient) -> None:
     """``PUT /endpoints/`` is the collection path, which takes no PUT."""
     assert client.put(f"{BASE}/", json=_body(name="")).status_code == 405
+
+
+class TestEndpointModelListing:
+    """Enumerating models through a configured endpoint.
+
+    The provider-scoped route refuses a caller-supplied ``api_base`` because
+    honoring one would send a provider key from the server's environment to
+    whatever host the caller named. That objection does not reach here: the
+    caller names an endpoint, and the base and credential come from the row.
+    """
+
+    def test_models_are_listed_through_the_endpoints_own_base_and_key(
+        self, client: TestClient
+    ) -> None:
+        client.put(f"{BASE}/otari", json=_body(api_key="sk-secret"))
+        with patch(
+            "backend.app.routers.user_profile.get_models",
+            new=AsyncMock(return_value=["gw-model-a", "gw-model-b"]),
+        ) as listed:
+            resp = client.get(f"{BASE}/otari/models")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["models"] == ["gw-model-a", "gw-model-b"]
+        assert body["supports_listing"] is True
+        # The stored row supplies both, and nothing about them came from the
+        # request. That is what makes this safe where a URL parameter is not.
+        call = listed.await_args
+        assert call is not None
+        assert call.args[0] == "anthropic"
+        assert call.kwargs["api_base"] == "https://ai.example.test"
+        assert call.kwargs["api_key"] == "sk-secret"
+
+    def test_a_dialect_that_cannot_enumerate_is_reported_not_raised(
+        self, client: TestClient
+    ) -> None:
+        """The form has to render this, so a 502 would leave it nothing to say."""
+        client.put(f"{BASE}/otari", json=_body())
+        with patch(
+            "backend.app.routers.user_profile.get_models",
+            new=AsyncMock(side_effect=NotImplementedError("no listing here")),
+        ):
+            resp = client.get(f"{BASE}/otari/models")
+
+        assert resp.status_code == 200
+        assert resp.json()["supports_listing"] is False
+        assert "no listing" in resp.json()["error"]
+
+    def test_a_failed_call_is_reported_not_raised(self, client: TestClient) -> None:
+        client.put(f"{BASE}/otari", json=_body())
+        with patch(
+            "backend.app.routers.user_profile.get_models",
+            new=AsyncMock(side_effect=RuntimeError("gateway said no")),
+        ):
+            resp = client.get(f"{BASE}/otari/models")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+        assert "gateway said no" in resp.json()["error"]
+
+    def test_listing_an_unknown_endpoint_is_404(self, client: TestClient) -> None:
+        assert client.get(f"{BASE}/nope/models").status_code == 404
+
+
+class TestEndpointProbe:
+    """The Test button.
+
+    Shaped like an agent turn rather than a ping, because the failure worth
+    catching only appears when tools and reasoning ride the same request.
+    """
+
+    def test_the_probe_carries_a_tool_and_the_endpoints_reasoning_shape(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``reasoning: effort`` means the scalar rides along, which is the
+        # pairing at least one gateway rejects.
+        client.put(f"{BASE}/otari", json=_body(reasoning="effort"))
+        monkeypatch.setattr(settings, "reasoning_effort", "high")
+        sent = AsyncMock(return_value=object())
+        with patch("backend.app.routers.user_profile.amessages", new=sent):
+            resp = client.post(f"{BASE}/otari/test", json={"model": "gw-model"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["model"] == "gw-model"
+        call = sent.await_args
+        assert call is not None
+        kwargs = call.kwargs
+        assert kwargs["tools"], "a probe with no tool cannot catch the tools+reasoning refusal"
+        assert kwargs["reasoning_effort"] == "high"
+        assert kwargs["api_base"] == "https://ai.example.test"
+
+    def test_a_rejection_comes_back_as_a_result_not_an_error(self, client: TestClient) -> None:
+        """The gateway's own words are the useful part of a failed test."""
+        client.put(f"{BASE}/otari", json=_body())
+        with patch(
+            "backend.app.routers.user_profile.amessages",
+            new=AsyncMock(side_effect=RuntimeError("reasoning_effort not supported with tools")),
+        ):
+            resp = client.post(f"{BASE}/otari/test", json={"model": "gw-model"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is False
+        assert "not supported with tools" in body["detail"]
+
+    def test_an_omitted_model_is_chosen_from_what_the_endpoint_serves(
+        self, client: TestClient
+    ) -> None:
+        client.put(f"{BASE}/otari", json=_body())
+        with (
+            patch(
+                "backend.app.routers.user_profile.get_models",
+                new=AsyncMock(return_value=["first-model", "second"]),
+            ),
+            patch(
+                "backend.app.routers.user_profile.amessages", new=AsyncMock(return_value=object())
+            ) as sent,
+        ):
+            resp = client.post(f"{BASE}/otari/test", json={})
+
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "first-model"
+        call = sent.await_args
+        assert call is not None
+        assert call.kwargs["model"] == "first-model"
+
+    def test_an_endpoint_that_cannot_be_asked_needs_a_model(self, client: TestClient) -> None:
+        client.put(f"{BASE}/otari", json=_body())
+        with patch(
+            "backend.app.routers.user_profile.get_models",
+            new=AsyncMock(side_effect=NotImplementedError()),
+        ):
+            resp = client.post(f"{BASE}/otari/test", json={})
+
+        assert resp.status_code == 422
+        assert "needs a model id" in resp.json()["detail"]
+
+    def test_probing_an_unknown_endpoint_is_404(self, client: TestClient) -> None:
+        assert client.post(f"{BASE}/nope/test", json={}).status_code == 404
 
 
 def test_delete_removes_the_endpoint(client: TestClient) -> None:


### PR DESCRIPTION
## Description

Two gaps in the endpoint work from #1545, both reported after using it.

**Model auto-populate.** The model field fell back to free text whenever an endpoint was selected, which is the one case where an operator is least likely to know the model id by heart. The stated reason was that the provider-scoped listing route refuses a caller-supplied `api_base`, since honoring one would make the server deliver a provider key from its environment to whatever host the caller named. That objection does not reach an endpoint: the caller names a row, and the base and credential are read from it, so nothing about the destination is caller-controlled. `GET /api/user/model/endpoints/{name}/models` enumerates through the endpoint's own base and key.

**Test button.** Sends one request shaped like an agent turn rather than a ping: a tool attached, and the reasoning parameter the endpoint's own `reasoning` column produces. Both halves matter and only together, because the failure worth catching appears when tools and reasoning ride the same request; a reachability check that sent neither would pass while every real turn 400s. Rejections come back as a result carrying the gateway's own words, not a 502, and land on the row where they can be read.

Also: the endpoints prefix is now admin-gated for reads, not only writes. The new sub-path GET enumerates *through* the endpoint, spending the operator's credential on the caller's request, so leaving it open to any authenticated tenant would have been the same mistake in a new place.

## Type
- [x] Feature

## Checklist
- [x] Tests pass (3259 OSS, 989 multi_user, 421 frontend)
- [x] Lint passes (`ruff check` + `ruff format --check` + `ty` over `backend/ tests/ alembic/`)
- [x] New tests added for new functionality
- [x] Bug fixes include regression tests

Also: `npm run typecheck`, `deadcode`, `build`. Both features driven in a real browser against a seeded deployment.

## AI Usage
- [x] AI-assisted. Built with Claude Opus 5 via Claude Code, from feedback on the shipped feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJFvFeBvwV2qz6KHoqBVV6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added admin-only APIs to list models and test configured LLM endpoints.
- Added endpoint probes with tool support, reasoning settings, latency reporting, timeouts, auditing, and readable provider errors.
- Restored endpoint model dropdowns with loading, retry, fallback, and stale-response protection.
- Restricted all endpoint routes to administrators.
- Added backend and frontend tests for model listing, endpoint probes, access control, reasoning budgets, and model selection.

## Benefits

Administrators can verify endpoint configuration and select available models more easily. Provider errors now appear as useful results instead of generic gateway failures.

## Potential follow-up

Consider adding refresh controls or cached model lists to reduce repeated endpoint requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->